### PR TITLE
Ensure Polygon when using Metamask

### DIFF
--- a/src/dapp/App.tsx
+++ b/src/dapp/App.tsx
@@ -1,29 +1,31 @@
+import "./App.css";
+
+import { useService } from "@xstate/react";
 import React from "react";
 import Modal from "react-bootstrap/Modal";
-import { useService } from "@xstate/react";
 
-import { Banner } from "./components/ui/HalveningBanner";
-import { service, Context, BlockchainEvent, BlockchainState } from "./machine";
-
-import { Donation } from "./types/contract";
-
+import Farm from "./components/farm/Farm";
 import {
   Charity,
   Connecting,
-  Welcome,
   Creating,
-  Saving,
   Error,
+  GasWarning,
+  SaveError,
+  Saving,
   TimerComplete,
   Unsupported,
-  SaveError,
-  GasWarning,
+  Welcome,
 } from "./components/modals";
-
-import Farm from "./components/farm/Farm";
-
-import "./App.css";
 import { Crafting } from "./components/modals/Crafting";
+import { Banner } from "./components/ui/HalveningBanner";
+import {
+  BlockchainEvent,
+  BlockchainState,
+  Context,
+  service,
+} from "./machine";
+import { Donation } from "./types/contract";
 
 export const App: React.FC = () => {
   const [machineState, send] = useService<

--- a/src/dapp/machine.ts
+++ b/src/dapp/machine.ts
@@ -1,12 +1,13 @@
 import {
+  assign,
   createMachine,
-  Interpreter,
   EventObject,
   interpret,
-  assign,
+  Interpreter,
 } from "xstate";
-import { Charity } from "./types/contract";
+
 import { BlockChain } from "./Blockchain";
+import { Charity } from "./types/contract";
 import { Recipe } from "./types/crafting";
 import { hasOnboarded } from "./utils/localStorage";
 
@@ -206,7 +207,7 @@ export const blockChainMachine = createMachine<
     },
     loading: {
       invoke: {
-        src: ({ blockChain }) => blockChain.initialise(),
+        src: ({ blockChain }) => blockChain.ensurePolygonNetwork(),
         onDone: [
           {
             target: "farming",

--- a/src/dapp/utils/metamask.ts
+++ b/src/dapp/utils/metamask.ts
@@ -1,0 +1,12 @@
+class Metamask {
+  public errors(): any {
+    const result = {
+      REQUESTED_CHAIN_MISSING: 4902,
+    };
+
+    return result;
+  }
+}
+
+export default Metamask;
+export { Metamask };


### PR DESCRIPTION
A fun new PR for dealing with blockchain wallet providers (e.g. – Metamask). This emulates the behaviour of some DEXs, in which it tries to recover Polygon chain access if migrated away. Useful for when working with multiple chains, or if the user is off making trades and comes back to a previous session in a separate tab/window of Sunflower Farmers.

In the below example, I show initialising the app using the wrong network (BSC). Additionally, it shows switching tabs, choosing a different network, and then returning to the actively-running Sunflower Farmers game context. In contrast to other implementations I've seen, this will _not_ nag the user if they switch to a different chain while Sunflower Farmers is in an inactive tab/window.

_NOTE:_ I have only tested this with Metamask using Metamask-provided globals. However, to my knowledge, not only is Metamask one of the most used browser-based providers, but its behaviour is also widely adopted by competitors.

#### Example:

https://user-images.githubusercontent.com/3837103/147839775-2cd97a4b-e11a-43ad-824c-8b08096b90f9.mp4
