### PR TITLE
Change display decimals

### DIFF
--- a/src/dapp/components/farm/Farm.tsx
+++ b/src/dapp/components/farm/Farm.tsx
@@ -281,7 +281,7 @@ export const Farm: React.FC = () => {
           <div id="inner">
             <img src={coin} />
             {machineState.context.blockChain.isConnected &&
-              safeBalance.toFixed(3)}
+              safeBalance.toFixed(5)}
           </div>
         </Panel>
       </div>


### PR DESCRIPTION
On the farm screen, the decimal points for the SSF are less which is confusing (specially for new farmers `such as me` as they are not able to understand how much they have). Change that to show more decimal points.

Before Change:
![image](https://user-images.githubusercontent.com/16634228/148599487-cca369d9-b9bb-4b3c-9fb8-6fe91ad6dba2.png)


After Change: 
![image](https://user-images.githubusercontent.com/16634228/148599334-485bab63-98de-4025-b07e-a1023d752f9d.png)

Another point to highlight, because of the incorrect rounding, not able to calculate the coins to farm effectively.
Also this might be helpful as the upcoming halvening will reduce the base price of sunflower even more to 0.0001 so that means using the old UI, anyone will need to harvest 5 sunflowers to see some change in balance.
