### PR TITLE
[FEAT] queue on plating from shortcuts

### DIFF
--- a/src/features/crops/components/Field.tsx
+++ b/src/features/crops/components/Field.tsx
@@ -48,14 +48,15 @@ export const Field: React.FC<Props> = ({ field, selectedItem, className }) => {
           item: selectedItem,
         });
 
-        const seedCount = inventory[selectedItem]-1 || 0;
-        if (seedCount  == 0) {
-          const shortcuts = getShortcuts();
-          if (inventory[shortcuts[1]] > 0) {
-            shortcutItem(shortcuts[1]);
-          } else if (inventory[shortcuts[2]] > 0) {
-            shortcutItem(shortcuts[2]);
-          }          
+        if (selectedItem) {
+          if (((inventory[selectedItem] || 0)-1) == 0) {
+            const shortcuts = getShortcuts();
+            if ((inventory[shortcuts[1]] || 0) > 0) {
+               shortcutItem(shortcuts[1]);
+            } else if ((inventory[shortcuts[2]] || 0) > 0) {
+              shortcutItem(shortcuts[2]);
+            }
+          }
         }
 
         displayPopover(

--- a/src/features/crops/components/Field.tsx
+++ b/src/features/crops/components/Field.tsx
@@ -1,15 +1,17 @@
 import React, { useContext, useState } from "react";
+import { useActor } from "@xstate/react";
 import classNames from "classnames";
 
 import selectBox from "assets/ui/select/select_box.png";
 
 import { Context } from "features/game/GameProvider";
-import { FieldItem, InventoryItemName } from "features/game/types/game";
+import { GameState, FieldItem, InventoryItemName } from "features/game/types/game";
 import { AppIconContext } from "features/crops/AppIconProvider";
 
 import { CropName } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/items";
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
+import { getShortcuts } from "../../hud/lib/shortcuts";
 
 import { Soil } from "./Soil";
 
@@ -24,8 +26,10 @@ interface Props {
 export const Field: React.FC<Props> = ({ field, selectedItem, className }) => {
   const [showPopover, setShowPopover] = useState(true);
   const [popover, setPopover] = useState<JSX.Element | null>(null);
-  const { gameService } = useContext(Context);
+  const { gameService, shortcutItem } = useContext(Context);
   const { incrementHarvestable } = useContext(AppIconContext);
+  const [game] = useActor(gameService);
+  const inventory = game.context.state.inventory;
 
   const displayPopover = async (element: JSX.Element) => {
     setPopover(element);
@@ -43,6 +47,16 @@ export const Field: React.FC<Props> = ({ field, selectedItem, className }) => {
           index: field.fieldIndex,
           item: selectedItem,
         });
+
+        const seedCount = inventory[selectedItem]-1 || 0;
+        if (seedCount  == 0) {
+          const shortcuts = getShortcuts();
+          if (inventory[shortcuts[1]] > 0) {
+            shortcutItem(shortcuts[1]);
+          } else if (inventory[shortcuts[2]] > 0) {
+            shortcutItem(shortcuts[2]);
+          }          
+        }
 
         displayPopover(
           <div className="flex items-center justify-center text-xs text-white text-shadow overflow-visible">


### PR DESCRIPTION
# Description

When you go out seed from selected plant on shortcuts its select automatically the next shortcuts with seed available to plant

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on local

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

https://user-images.githubusercontent.com/61994/150690964-acf540e8-dcbf-4f09-9731-23fd2811bce2.mp4
