### PR TITLE
[FEAT]: Added true balance viewing 💰

### DIFF
--- a/src/features/hud/components/Balance.tsx
+++ b/src/features/hud/components/Balance.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
 
 import { InnerPanel } from "components/ui/Panel";
@@ -11,14 +11,23 @@ import Decimal from "decimal.js-light";
 export const Balance: React.FC = () => {
   const { gameService } = useContext(Context);
   const [game] = useActor(gameService);
+  const [isShown, setIsShown] = useState(false);
 
   return (
     <InnerPanel className="fixed top-2 right-2 z-50 flex items-center shadow-lg">
       <img src={token} className="w-8 img-highlight" />
-      <span className="text-white text-sm text-shadow ml-2">
-        {game.context.state.balance
-          .toDecimalPlaces(2, Decimal.ROUND_DOWN)
-          .toString()}
+      <span
+        className="text-white text-sm text-shadow ml-2"
+        onMouseEnter={() => setIsShown(true)}
+        onMouseLeave={() => setIsShown(false)}
+      >
+        {isShown === false ? (
+          game.context.state.balance
+            .toDecimalPlaces(2, Decimal.ROUND_DOWN)
+            .toString()
+        ) : (
+          <small>{game.context.state.balance.toString()}</small>
+        )}
       </span>
     </InnerPanel>
   );

--- a/src/features/hud/components/Balance.tsx
+++ b/src/features/hud/components/Balance.tsx
@@ -14,7 +14,7 @@ export const Balance: React.FC = () => {
   const [isShown, setIsShown] = useState(false);
 
   return (
-    <InnerPanel className="fixed top-2 right-2 z-50 flex items-center shadow-lg">
+    <InnerPanel className="fixed top-2 right-2 z-50 flex items-center shadow-lg cursor-pointer">
       <img src={token} className="w-8 img-highlight" />
       <span
         className="text-white text-sm text-shadow ml-2"


### PR DESCRIPTION
# Description

Added feature to view the **True Balance** of the player. Currently the balance is shown by rounding up to 2 dec places which sometimes confuses player when they want to Buy some resources in game.
So, in `Balance.tsx` added **`onMouseEnter`** and **`onMouseLeave`** to span which shows rounded balance such that, _when user **hovers** over the Balance Area it gets **expanded** and shows True Balance in **smaller font**- (for better visibility on mobile devices)._ Ref. screenshots.

#### Why this functionality?
=> Players won't be confused while Buying Or Selling resources also they'll have more grasp over their **True Balance**
Below screenshots show some scenarios where knowing True Balance seems necessary.

<details><summary><b>Screenshots</b></summary>
<ul>
<li>Before
<img src="https://user-images.githubusercontent.com/55224033/151022150-a4bdb617-6d91-4895-a42d-db76036066b3.PNG" />
</li>
<li>After
<img src="https://user-images.githubusercontent.com/55224033/151022428-bf3d2153-4208-46ac-a9ce-052d3313bcc0.PNG" />
</li>
<li>Before
<img src="https://user-images.githubusercontent.com/55224033/151023378-a78af142-f460-4d6b-a983-4180a352e487.PNG" />
</li>
<li>After
<img src="https://user-images.githubusercontent.com/55224033/151023490-e625640c-31e2-4f98-a422-cf220912e9d4.PNG" />
</ul>

<li>Before
<img src="https://user-images.githubusercontent.com/55224033/151024174-aef41312-a4e0-4822-8c14-ad3a50dd8c97.png" height="500px"/>
</li>
<li>After
<img src="https://user-images.githubusercontent.com/55224033/151024257-03e5c387-4259-4a83-b660-24dca26dfcc3.png" height="500px"/>
</ul>
</details>

Fixes --

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
