### PR TITLE
[CHORE] update CONTRIBUTING.md file missing & wrong links

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ In this guide you will get an overview of the contribution workflow from opening
 
 ## New contributor guide
 
-To get an overview of the project, read the [README](README.md). Here are some resources to help you get started with open source contributions:
+To get an overview of the project, read the [README](../README.md). Here are some resources to help you get started with open source contributions:
 
 ### Disclaimer
 
@@ -14,7 +14,7 @@ By contributing to this repository you provide Sunflower Land the rights to use 
 
 ## Getting started
 
-Please read the README.md for details on how to setup and run the repo locally.
+Please read the [README.md](../README.md) for details on how to setup and run the repo locally.
 
 ### Issues
 
@@ -24,7 +24,7 @@ If you spot a problem with the docs, [search if an issue already exists](https:/
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/github/docs/issues) to find one that interests you. You can narrow down the search using `labels` as filters. See [Labels](/contributing/how-to-use-labels.md) for more information.
+Scan through our [existing issues](https://github.com/sunflower-land/sunflower-land/issues) to find one that interests you. You can narrow down the search using `labels` as filters. See [Labels](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests#filtering-issues-and-pull-requests-by-labels) for more information.
 
 As a general rule, we assign features with deadlines to core team members. If a ticket is already assigned and you are passionate about it, please reach out to the developer on the issue comments and help them out.
 


### PR DESCRIPTION
# Description
<img width="1479" alt="Screen Shot 2022-02-05 at 1 42 30 AM" src="https://user-images.githubusercontent.com/18549210/152576966-017af460-7cfa-4cd9-8df6-f617a699ff14.png">

Updates:
- fixed [README] URL relative path
- added README.md link on Getting started section
- updated [existing issues] URL (wrong link)
- updated [Labels] URL (updated link)

## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

Tested on VS Code:
<img width="239" alt="Screen Shot 2022-02-05 at 1 45 29 AM" src="https://user-images.githubusercontent.com/18549210/152577434-b223f417-f7bc-4b30-9e38-c144d88b6d39.png">
<img width="658" alt="Screen Shot 2022-02-05 at 1 45 39 AM" src="https://user-images.githubusercontent.com/18549210/152577442-7004e801-d554-408f-906e-6625a1373c1f.png">


# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X]  My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
