### PR TITLE
[CHORE] Ignore Saving on Development environment

### DIFF
--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -11,6 +11,8 @@ type Request = {
 const API_URL = import.meta.env.VITE_API_URL;
 
 export async function autosave(request: Request) {
+  if (process.env.NODE_ENV === 'development') return;
+
   // Serialize values before sending
   const actions = request.actions.map((action) => ({
     ...action,


### PR DESCRIPTION
# Description

Ignores saving when in development since there is no `VITE_API_URL` to call. Covers auto and manual saves. Error occurs when an action is taken (e.g. plant) then waiting for autosave.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Plant then wait for autosave interval. GameError modal should not appear when running in local.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
