### PR TITLE
[FIX] Refactor state machine. Move all connected states to child machine.

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -16,7 +16,12 @@ export const Navigation: React.FC = () => {
   const [authState, send] = useActor(authService);
 
   useEffect(() => {
-    if (!(authState.matches("authorised") || authState.matches("visiting"))) {
+    if (
+      !(
+        authState.matches({ connected: "authorised" }) ||
+        authState.matches("visiting")
+      )
+    ) {
       return;
     }
     // Start with crops centered
@@ -46,7 +51,8 @@ export const Navigation: React.FC = () => {
   }, [send]);
 
   const showGame =
-    authState.matches("authorised") || authState.matches("visiting");
+    authState.matches({ connected: "authorised" }) ||
+    authState.matches("visiting");
 
   return (
     <>

--- a/src/features/auth/Auth.tsx
+++ b/src/features/auth/Auth.tsx
@@ -16,7 +16,7 @@ export const Auth: React.FC = () => {
   const [authState] = useActor(authService);
 
   return (
-    <Modal centered show={!authState.matches("authorised") && !authState.matches('visiting')} backdrop={false}>
+    <Modal centered show={!authState.matches({ connected: "authorised" }) && !authState.matches('visiting')} backdrop={false}>
       <div className="relative">
         <img
           id="curly"
@@ -30,7 +30,7 @@ export const Auth: React.FC = () => {
           {authState.matches({ connected: "noFarmLoaded" }) && <CreateFarm />}
           {authState.matches({ connected: "signing" }) && <Loading text="Signing" />}
           {authState.matches({ connected: "creatingFarm" }) && <CreatingFarm />}
-          {authState.matches("readyToStart") && <StartFarm />}
+          {authState.matches({ connected: "readyToStart" }) && <StartFarm />}
           {authState.matches("unauthorised") && <Unauthorised />}
         </Panel>
       </div>


### PR DESCRIPTION
# Description

The PR addresses a previous change that moved the `sign` transaction before the `createFarm` transaction. The `sign` step for folks that already have a farm was removed which caused a break. I have refactored the state machine a bit to make more logical sense. All states that happen when a user is `connected` now live inside of the `connected` child machine. 

I think this is the one 😅 

<img width="927" alt="Screen Shot 2022-02-08 at 5 06 44 pm" src="https://user-images.githubusercontent.com/17863697/152928186-ba6f01fb-3c7a-411e-8ba9-c08758e97cfc.png">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Load the game on an account with no farm 
- Click on `Create Farm` you should see the sign step before completing the transaction for donating. 
**NOTE: I am experiencing a 500 from the server so I haven't been able to test the successful farm creation**
- Load the game on an account with a farm
- Click `Let's Go` you should see the sign step before being taken to your farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
