### PR TITLE
[FIX] Click area of Crop

### DIFF
--- a/src/features/crops/components/Field.tsx
+++ b/src/features/crops/components/Field.tsx
@@ -111,8 +111,7 @@ export const Field: React.FC<Props> = ({
 
   return (
     <div
-      onClick={onClick}
-      className={classNames("relative group cursor-pointer", className)}
+      className={classNames("relative group", className)}
       style={{
         width: `${GRID_WIDTH_PX}px`,
         height: `${GRID_WIDTH_PX}px`,
@@ -137,7 +136,8 @@ export const Field: React.FC<Props> = ({
         style={{
           opacity: 0.1,
         }}
-        className="absolute inset-0 w-full top-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 z-10"
+        className="absolute inset-0 w-full top-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 z-10 cursor-pointer"
+        onClick={onClick}
       />
     </div>
   );


### PR DESCRIPTION
# Description

This moves the `onClick` trigger from the whole Field div to the `selectBox` image. With this, users will need to hover around the bottom part (select box / hole) to plant or harvest. If this is not acceptable behavior, will close this PR no worries :)

Fixes #232 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing
1. Hover on crop body and click -- unclickable
2. Hover slightly above crop body and click -- unclickable (raised issue)
3. Hover around crop soil / bottom and click -- triggers plant / harvest

https://user-images.githubusercontent.com/89294757/153004457-1c7b0a80-4ef8-498f-bddb-d66c852591c9.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
