### PR TITLE
Support dynamic prices

### DIFF
--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -30,22 +30,22 @@ export const CraftingItems: React.FC<Props> = ({ items, isBulk = false }) => {
   const inventory = state.inventory;
 
   const lessIngredients = (amount = 1) =>
-    selected.ingredients.some(
-      (ingredient) =>
-        (inventory[ingredient.item] || 0) < ingredient.amount * amount
+    selected.ingredients.some((ingredient) =>
+      ingredient.amount.mul(amount).greaterThan(inventory[ingredient.item] || 0)
     );
   const lessFunds = (amount = 1) =>
-    state.balance.lessThan(selected.price * amount);
+    state.balance.lessThan(selected.price.mul(amount));
 
   const craft = (amount = 1) => {
     gameService.send("item.crafted", {
       item: selected.name,
       amount,
     });
-    setToast({ content: "SFL -$" + selected.price * amount });
+    setToast({ content: "SFL -$" + selected.price.mul(amount) });
     selected.ingredients.map((ingredient, index) => {
       setToast({
-        content: "Item " + ingredient.item + " -" + ingredient.amount * amount,
+        content:
+          "Item " + ingredient.item + " -" + ingredient.amount.mul(amount),
       });
     });
 
@@ -139,7 +139,7 @@ export const CraftingItems: React.FC<Props> = ({ items, isBulk = false }) => {
                       }
                     )}
                   >
-                    {ingredient.amount}
+                    {ingredient.amount.toNumber()}
                   </span>
                 </div>
               );
@@ -152,7 +152,7 @@ export const CraftingItems: React.FC<Props> = ({ items, isBulk = false }) => {
                   "text-red-500": lessFunds(),
                 })}
               >
-                {`$${selected.price}`}
+                {`$${selected.price.toNumber()}`}
               </span>
             </div>
           </div>

--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -10,11 +10,7 @@ import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
-import {
-  Craftable,
-  CRAFTABLES,
-  LimitedItems,
-} from "features/game/types/craftables";
+import { Craftable, LimitedItems } from "features/game/types/craftables";
 import { Inventory, InventoryItemName } from "features/game/types/game";
 import { metamask } from "lib/blockchain/metamask";
 import { ItemSupply } from "lib/blockchain/Inventory";
@@ -48,12 +44,11 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
   const inventory = state.inventory;
 
   const lessIngredients = (amount = 1) =>
-    selected.ingredients.some(
-      (ingredient) =>
-        (inventory[ingredient.item] || 0) < ingredient.amount * amount
+    selected.ingredients.some((ingredient) =>
+      ingredient.amount.mul(amount).greaterThan(inventory[ingredient.item] || 0)
     );
   const lessFunds = (amount = 1) =>
-    state.balance.lessThan(selected.price * amount);
+    state.balance.lessThan(selected.price.mul(amount));
 
   const craft = () => {
     console.log("Craft it!");
@@ -87,7 +82,7 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
     return (
       <>
         <Button
-          //disabled={lessFunds() || lessIngredients()}
+          disabled={lessFunds() || lessIngredients()}
           className="text-xs mt-1"
           onClick={() => craft()}
         >
@@ -151,7 +146,7 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
                       }
                     )}
                   >
-                    {ingredient.amount}
+                    {ingredient.amount.toNumber()}
                   </span>
                 </div>
               );
@@ -164,7 +159,7 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
                   "text-red-500": lessFunds(),
                 })}
               >
-                {`$${selected.price}`}
+                {`$${selected.price.toNumber()}`}
               </span>
             </div>
           </div>

--- a/src/features/crops/AppIconProvider.tsx
+++ b/src/features/crops/AppIconProvider.tsx
@@ -27,7 +27,7 @@ const isHarvestable = (field: FieldItem): boolean => {
   if (!field) {
     return false;
   }
-  const crop = CROPS[field.name];
+  const crop = CROPS()[field.name];
   const timeLeft = getTimeLeft(field.plantedAt, crop.harvestSeconds);
   return timeLeft <= 0;
 };

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -11,12 +11,12 @@ import { Context } from "features/game/GameProvider";
 import { Crop, CROPS } from "features/game/types/crops";
 import { useActor } from "@xstate/react";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { ToastContext } from 'features/game/toast/ToastQueueProvider';
+import { ToastContext } from "features/game/toast/ToastQueueProvider";
 
 interface Props {}
 
 export const Plants: React.FC<Props> = ({}) => {
-  const [selected, setSelected] = useState<Crop>(CROPS.Sunflower);
+  const [selected, setSelected] = useState<Crop>(CROPS().Sunflower);
   const { setToast } = useContext(ToastContext);
   const { gameService } = useContext(Context);
   const [
@@ -32,7 +32,7 @@ export const Plants: React.FC<Props> = ({}) => {
       item: selected.name,
       amount,
     });
-    setToast({content: "SFL +$"+(selected.sellPrice*amount)});
+    setToast({ content: "SFL +$" + selected.sellPrice * amount });
   };
 
   const lessPlants = (amount = 1) => (inventory[selected.name] || 0) < amount;
@@ -40,7 +40,7 @@ export const Plants: React.FC<Props> = ({}) => {
   return (
     <div className="flex">
       <div className="w-3/5 flex  flex-wrap h-fit">
-        {Object.values(CROPS).map((item) => (
+        {Object.values(CROPS()).map((item) => (
           <Box
             isSelected={selected.name === item.name}
             key={item.name}

--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -15,12 +15,14 @@ import { Context } from "features/game/GameProvider";
 import { Craftable } from "features/game/types/craftables";
 import { CropName, CROPS, SEEDS } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { ToastContext } from 'features/game/toast/ToastQueueProvider';
+import { ToastContext } from "features/game/toast/ToastQueueProvider";
 
 interface Props {}
 
 export const Seeds: React.FC<Props> = ({}) => {
-  const [selected, setSelected] = useState<Craftable>(SEEDS["Sunflower Seed"]);
+  const [selected, setSelected] = useState<Craftable>(
+    SEEDS()["Sunflower Seed"]
+  );
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
   const [
@@ -36,7 +38,7 @@ export const Seeds: React.FC<Props> = ({}) => {
       item: selected.name,
       amount,
     });
-    setToast({content: "SFL -$"+(selected.price*amount)});
+    setToast({ content: "SFL -$" + selected.price * amount });
     shortcutItem(selected.name);
   };
 
@@ -44,7 +46,7 @@ export const Seeds: React.FC<Props> = ({}) => {
     state.balance.lessThan(selected.price * amount);
 
   const cropName = selected.name.split(" ")[0] as CropName;
-  const crop = CROPS[cropName];
+  const crop = CROPS()[cropName];
 
   const Action = () => {
     const isLocked = selected.requires && !inventory[selected.requires];

--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -77,7 +77,7 @@ export const Seeds: React.FC<Props> = ({}) => {
   return (
     <div className="flex">
       <div className="w-3/5 flex flex-wrap h-fit">
-        {Object.values(SEEDS).map((item: Craftable) => (
+        {Object.values(SEEDS()).map((item: Craftable) => (
           <Box
             isSelected={selected.name === item.name}
             key={item.name}

--- a/src/features/crops/components/Soil.tsx
+++ b/src/features/crops/components/Soil.tsx
@@ -42,7 +42,7 @@ export const Soil: React.FC<Props> = ({ field }) => {
     return <img src={soil} className="w-full" />;
   }
 
-  const crop = CROPS[field.name];
+  const crop = CROPS()[field.name];
   const lifecycle = LIFECYCLE[field.name];
   const timeLeft = getTimeLeft(field.plantedAt, crop.harvestSeconds);
 

--- a/src/features/game/events/craft.test.ts
+++ b/src/features/game/events/craft.test.ts
@@ -1,4 +1,6 @@
 import Decimal from "decimal.js-light";
+import { CRAFTABLES } from "../types/craftables";
+import { CROPS, SEEDS } from "../types/crops";
 import { GameState } from "../types/game";
 import { craft } from "./craft";
 
@@ -41,7 +43,7 @@ describe("craft", () => {
       craft({
         state: {
           ...GAME_STATE,
-          balance: new Decimal(0.005),
+          balance: new Decimal(0.0000005),
         },
         action: {
           type: "item.crafted",
@@ -82,7 +84,9 @@ describe("craft", () => {
       },
     });
 
-    expect(state.balance).toEqual(new Decimal(0.99));
+    expect(state.balance).toEqual(
+      new Decimal(1).minus(SEEDS()["Sunflower Seed"].price)
+    );
     expect(state.inventory["Sunflower Seed"]).toEqual(new Decimal(1));
   });
 
@@ -152,7 +156,9 @@ describe("craft", () => {
       },
     });
 
-    expect(state.balance).toEqual(new Decimal(0.5));
+    expect(state.balance).toEqual(
+      new Decimal(1).sub(SEEDS()["Carrot Seed"].price)
+    );
     expect(state.inventory["Carrot Seed"]).toEqual(new Decimal(1));
   });
 
@@ -169,7 +175,9 @@ describe("craft", () => {
       },
     });
 
-    expect(state.balance).toEqual(new Decimal(0));
+    expect(state.balance).toEqual(
+      new Decimal(0.1).sub(SEEDS()["Sunflower Seed"].price.mul(10))
+    );
     expect(state.inventory["Sunflower Seed"]).toEqual(new Decimal(10));
   });
 

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -47,7 +47,7 @@ export function craft({ state, action, available }: Options) {
     throw new Error("Invalid amount");
   }
 
-  const totalExpenses = item.price * action.amount;
+  const totalExpenses = item.price.mul(action.amount);
 
   const isLocked = item.requires && !state.inventory[item.requires];
   if (isLocked) {
@@ -61,7 +61,7 @@ export function craft({ state, action, available }: Options) {
   const subtractedInventory = item.ingredients.reduce(
     (inventory, ingredient) => {
       const count = inventory[ingredient.item] || new Decimal(0);
-      const totalAmount = ingredient.amount * action.amount;
+      const totalAmount = ingredient.amount.mul(action.amount);
 
       if (count.lessThan(totalAmount)) {
         throw new Error(`Insufficient ingredient: ${ingredient.item}`);

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -15,7 +15,7 @@ export type CraftAction = {
  */
 const VALID_ITEMS = Object.keys({
   ...TOOLS,
-  ...SEEDS,
+  ...SEEDS(),
   ...FOODS,
 }) as CraftableName[];
 
@@ -37,7 +37,7 @@ export function craft({ state, action, available }: Options) {
     throw new Error(`This item is not craftable: ${action.item}`);
   }
 
-  const item = CRAFTABLES[action.item];
+  const item = CRAFTABLES()[action.item];
 
   if (item.disabled) {
     throw new Error("This item is disabled");

--- a/src/features/game/events/harvest.ts
+++ b/src/features/game/events/harvest.ts
@@ -57,7 +57,7 @@ export function harvest({ state, action, createdAt = Date.now() }: Options) {
     throw new Error("Nothing was planted");
   }
 
-  const crop = CROPS[field.name];
+  const crop = CROPS()[field.name];
 
   if (createdAt - field.plantedAt < crop.harvestSeconds * 1000) {
     throw new Error("Not ready");

--- a/src/features/game/events/sell.test.ts
+++ b/src/features/game/events/sell.test.ts
@@ -127,7 +127,7 @@ describe("sell", () => {
       },
     });
 
-    expect(state.balance).toEqual(new Decimal(CROPS.Cauliflower.sellPrice));
+    expect(state.balance).toEqual(new Decimal(CROPS().Cauliflower.sellPrice));
   });
 
   it("sells a cauliflower for a double the price if they have golden cauliflower", () => {
@@ -146,6 +146,8 @@ describe("sell", () => {
       },
     });
 
-    expect(state.balance).toEqual(new Decimal(CROPS.Cauliflower.sellPrice * 2));
+    expect(state.balance).toEqual(
+      new Decimal(CROPS().Cauliflower.sellPrice * 2)
+    );
   });
 });

--- a/src/features/game/events/sell.test.ts
+++ b/src/features/game/events/sell.test.ts
@@ -72,7 +72,9 @@ describe("sell", () => {
     });
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(4));
-    expect(state.balance).toEqual(new Decimal(0.02));
+    expect(state.balance).toEqual(
+      GAME_STATE.balance.add(CROPS().Sunflower.sellPrice)
+    );
   });
 
   it("sell an item in bulk given sufficient quantity", () => {
@@ -91,7 +93,9 @@ describe("sell", () => {
     });
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(1));
-    expect(state.balance).toEqual(new Decimal(0.2));
+    expect(state.balance).toEqual(
+      GAME_STATE.balance.add(CROPS().Sunflower.sellPrice.mul(10))
+    );
   });
 
   it("does not sell an item in bulk given insufficient quantity", () => {
@@ -147,7 +151,7 @@ describe("sell", () => {
     });
 
     expect(state.balance).toEqual(
-      new Decimal(CROPS().Cauliflower.sellPrice * 2)
+      new Decimal(CROPS().Cauliflower.sellPrice.mul(2))
     );
   });
 });

--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -9,7 +9,7 @@ export type SellAction = {
 };
 
 function isCrop(crop: InventoryItemName): crop is CropName {
-  return crop in CROPS;
+  return crop in CROPS();
 }
 
 type Options = {
@@ -25,7 +25,7 @@ export function sell({ state, action }: Options): GameState {
     throw new Error("Invalid amount");
   }
 
-  const crop = CROPS[action.item];
+  const crop = CROPS()[action.item];
 
   const cropCount = state.inventory[action.item] || new Decimal(0);
 

--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -38,12 +38,12 @@ export function sell({ state, action }: Options): GameState {
     crop.name === "Cauliflower" &&
     state.inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)
   ) {
-    price = price * 2;
+    price = price.mul(2);
   }
 
   return {
     ...state,
-    balance: state.balance.add(price * action.amount),
+    balance: state.balance.add(price.mul(action.amount)),
     inventory: {
       ...state.inventory,
       [crop.name]: cropCount.sub(1 * action.amount),

--- a/src/features/game/lib/halvening.ts
+++ b/src/features/game/lib/halvening.ts
@@ -1,0 +1,35 @@
+import Decimal from "decimal.js-light";
+
+function getHalveningRate() {
+  const now = new Date().getTime();
+
+  /**
+   * Estimated Block number + timestamp
+   * (Sunday, 17 April 2022)
+   * Will be updated closer to halvening
+   */
+  if (now < 1650204736000) {
+    return 0.05;
+  }
+
+  /**
+   * Estimated Block number + timestamp
+   * (Friday, 17 June 2022)
+   * Will be updated closer to halvening
+   */
+  if (now < 1655475136000) {
+    return 0.025;
+  }
+
+  return 0.0125;
+}
+
+/**
+ * Gets the market rate of an item based on demand
+ * In future consider using Decimal as the halvening rate gets more precise
+ */
+export function marketRate(value: number) {
+  const rate = getHalveningRate();
+
+  return value * rate;
+}

--- a/src/features/game/lib/halvening.ts
+++ b/src/features/game/lib/halvening.ts
@@ -9,7 +9,7 @@ function getHalveningRate() {
    * Will be updated closer to halvening
    */
   if (now < 1650204736000) {
-    return 0.05;
+    return 0.2;
   }
 
   /**
@@ -18,10 +18,10 @@ function getHalveningRate() {
    * Will be updated closer to halvening
    */
   if (now < 1655475136000) {
-    return 0.025;
+    return 0.1;
   }
 
-  return 0.0125;
+  return 0.05;
 }
 
 /**
@@ -30,6 +30,5 @@ function getHalveningRate() {
  */
 export function marketRate(value: number) {
   const rate = getHalveningRate();
-
-  return value * rate;
+  return new Decimal(value).mul(rate);
 }

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -345,9 +345,9 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   },
 };
 
-export const CRAFTABLES: Record<CraftableName, Craftable> = {
+export const CRAFTABLES: () => Record<CraftableName, Craftable> = () => ({
   ...TOOLS,
   ...LimitedItems,
-  ...SEEDS,
+  ...SEEDS(),
   ...FOODS,
-};
+});

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { SeedName, SEEDS } from "../types/crops";
 import { InventoryItemName } from "../types/game";
 
@@ -12,10 +13,10 @@ export type CraftableName = LimitedItem | Tool | SeedName | Food;
 export type Craftable = {
   name: CraftableName;
   description: string;
-  price: number;
+  price: Decimal;
   ingredients: {
     item: InventoryItemName;
-    amount: number;
+    amount: Decimal;
   }[];
   limit?: number;
   supply?: number;
@@ -55,11 +56,11 @@ export const FOODS: Record<Food, Craftable> = {
   "Pumpkin Soup": {
     name: "Pumpkin Soup",
     description: "A creamy soup that goblins love",
-    price: 5,
+    price: new Decimal(5),
     ingredients: [
       {
         item: "Pumpkin",
-        amount: 5,
+        amount: new Decimal(5),
       },
     ],
     limit: 1,
@@ -67,33 +68,33 @@ export const FOODS: Record<Food, Craftable> = {
   Flour: {
     name: "Flour",
     description: "Ground Wheat",
-    price: 0.1,
+    price: new Decimal(0.1),
     ingredients: [
       {
         item: "Wheat",
-        amount: 3,
+        amount: new Decimal(3),
       },
     ],
   },
   "Roasted Cauliflower": {
     name: "Roasted Cauliflower",
     description: "A Goblin's favourite",
-    price: 0.1,
+    price: new Decimal(0.1),
     ingredients: [
       {
         item: "Cauliflower",
-        amount: 3,
+        amount: new Decimal(3),
       },
     ],
   },
   Sauerkraut: {
     name: "Sauerkraut",
     description: "Fermented cabbage",
-    price: 0.1,
+    price: new Decimal(0.1),
     ingredients: [
       {
         item: "Cabbage",
-        amount: 3,
+        amount: new Decimal(3),
       },
     ],
   },
@@ -103,62 +104,62 @@ export const TOOLS: Record<Tool, Craftable> = {
   Axe: {
     name: "Axe",
     description: "Used to collect wood",
-    price: 1,
+    price: new Decimal(1),
     ingredients: [],
   },
   Pickaxe: {
     name: "Pickaxe",
     description: "Used to collect stone",
-    price: 1,
+    price: new Decimal(1),
     ingredients: [
       {
         item: "Wood",
-        amount: 2,
+        amount: new Decimal(2),
       },
     ],
   },
   "Stone Pickaxe": {
     name: "Stone Pickaxe",
     description: "Used to collect iron",
-    price: 2,
+    price: new Decimal(2),
     ingredients: [
       {
         item: "Wood",
-        amount: 3,
+        amount: new Decimal(3),
       },
       {
         item: "Stone",
-        amount: 3,
+        amount: new Decimal(3),
       },
     ],
   },
   "Iron Pickaxe": {
     name: "Iron Pickaxe",
     description: "Used to collect gold",
-    price: 5,
+    price: new Decimal(5),
     ingredients: [
       {
         item: "Wood",
-        amount: 5,
+        amount: new Decimal(5),
       },
       {
         item: "Iron",
-        amount: 3,
+        amount: new Decimal(3),
       },
     ],
   },
   Hammer: {
     name: "Hammer",
     description: "Used to construct buildings",
-    price: 5,
+    price: new Decimal(5),
     ingredients: [
       {
         item: "Wood",
-        amount: 5,
+        amount: new Decimal(5),
       },
       {
         item: "Iron",
-        amount: 2,
+        amount: new Decimal(2),
       },
     ],
     disabled: true,
@@ -166,11 +167,11 @@ export const TOOLS: Record<Tool, Craftable> = {
   Rod: {
     name: "Rod",
     description: "Used to fish trout",
-    price: 10,
+    price: new Decimal(10),
     ingredients: [
       {
         item: "Wood",
-        amount: 50,
+        amount: new Decimal(50),
       },
     ],
     disabled: true,
@@ -181,15 +182,15 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Sunflower Statue": {
     name: "Sunflower Statue",
     description: "Earn beta access to new features",
-    price: 5,
+    price: new Decimal(5),
     ingredients: [
       {
         item: "Sunflower",
-        amount: 1000,
+        amount: new Decimal(1000),
       },
       {
         item: "Stone",
-        amount: 50,
+        amount: new Decimal(50),
       },
     ],
     limit: 1,
@@ -198,15 +199,15 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Potato Statue": {
     name: "Potato Statue",
     description: "The OG potato hustler flex",
-    price: 0,
+    price: new Decimal(0),
     ingredients: [
       {
         item: "Potato",
-        amount: 100,
+        amount: new Decimal(100),
       },
       {
         item: "Stone",
-        amount: 20,
+        amount: new Decimal(20),
       },
     ],
     limit: 1,
@@ -215,15 +216,15 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   Scarecrow: {
     name: "Scarecrow",
     description: "Grow wheat faster",
-    price: 50,
+    price: new Decimal(50),
     ingredients: [
       {
         item: "Wheat",
-        amount: 10,
+        amount: new Decimal(10),
       },
       {
         item: "Wood",
-        amount: 10,
+        amount: new Decimal(10),
       },
     ],
     limit: 1,
@@ -233,15 +234,15 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Christmas Tree": {
     name: "Christmas Tree",
     description: "Receieve a Santa Airdrop on Christmas day",
-    price: 50,
+    price: new Decimal(50),
     ingredients: [
       {
         item: "Wood",
-        amount: 100,
+        amount: new Decimal(100),
       },
       {
         item: "Stone",
-        amount: 50,
+        amount: new Decimal(50),
       },
     ],
     supply: 0,
@@ -249,19 +250,19 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Chicken Coop": {
     name: "Chicken Coop",
     description: "Collect 3x the amount of eggs",
-    price: 50,
+    price: new Decimal(50),
     ingredients: [
       {
         item: "Wood",
-        amount: 10,
+        amount: new Decimal(10),
       },
       {
         item: "Stone",
-        amount: 10,
+        amount: new Decimal(10),
       },
       {
         item: "Gold",
-        amount: 10,
+        amount: new Decimal(10),
       },
     ],
     supply: 1856,
@@ -270,36 +271,36 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Farm Cat": {
     name: "Farm Cat",
     description: "Keep the rats away",
-    price: 50,
+    price: new Decimal(50),
     ingredients: [],
     supply: 0,
   },
   "Farm Dog": {
     name: "Farm Dog",
     description: "Herd sheep 4x faster",
-    price: 75,
+    price: new Decimal(75),
     ingredients: [],
     supply: 0,
   },
   Gnome: {
     name: "Gnome",
     description: "A lucky gnome",
-    price: 10,
+    price: new Decimal(10),
     ingredients: [],
     supply: 0,
   },
   "Gold Egg": {
     name: "Gold Egg",
     description: "A rare egg, what lays inside?",
-    price: 0,
+    price: new Decimal(0),
     ingredients: [
       {
         item: "Egg",
-        amount: 150,
+        amount: new Decimal(150),
       },
       {
         item: "Gold",
-        amount: 50,
+        amount: new Decimal(50),
       },
     ],
     supply: 82,
@@ -307,22 +308,22 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Sunflower Tombstone": {
     name: "Sunflower Tombstone",
     description: "In memory of Sunflower Farmers",
-    price: 0,
+    price: new Decimal(0),
     ingredients: [],
     supply: 0,
   },
   "Golden Cauliflower": {
     name: "Golden Cauliflower",
     description: "Double the rewards from cauliflowers",
-    price: 100,
+    price: new Decimal(100),
     ingredients: [
       {
         item: "Cauliflower",
-        amount: 100,
+        amount: new Decimal(100),
       },
       {
         item: "Gold",
-        amount: 10,
+        amount: new Decimal(10),
       },
     ],
     supply: 100,
@@ -330,15 +331,15 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
   "Sunflower Rock": {
     name: "Sunflower Rock",
     description: "The game that broke Polygon",
-    price: 100,
+    price: new Decimal(100),
     ingredients: [
       {
         item: "Sunflower",
-        amount: 10000,
+        amount: new Decimal(10000),
       },
       {
         item: "Iron",
-        amount: 100,
+        amount: new Decimal(100),
       },
     ],
     supply: 150,

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { marketRate } from "../lib/halvening";
 import { Craftable } from "./craftables";
 
@@ -14,8 +15,8 @@ export type CropName =
   | "Wheat";
 
 export type Crop = {
-  buyPrice: number;
-  sellPrice: number;
+  buyPrice: Decimal;
+  sellPrice: Decimal;
   harvestSeconds: number;
   name: CropName;
   description: string;
@@ -28,7 +29,7 @@ export type Crop = {
 export const CROPS: () => Record<CropName, Crop> = () => ({
   Sunflower: {
     buyPrice: marketRate(0.01),
-    sellPrice: 0.02,
+    sellPrice: marketRate(0.02),
     harvestSeconds: 1 * 60,
     name: "Sunflower",
     description: "A sunny flower",

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -1,3 +1,4 @@
+import { marketRate } from "../lib/halvening";
 import { Craftable } from "./craftables";
 
 export type CropName =
@@ -24,45 +25,45 @@ export type Crop = {
  * Crops and their original prices
  * TODO - use crop name from GraphQL API
  */
-export const CROPS: Record<CropName, Crop> = {
+export const CROPS: () => Record<CropName, Crop> = () => ({
   Sunflower: {
-    buyPrice: 0.01,
+    buyPrice: marketRate(0.01),
     sellPrice: 0.02,
     harvestSeconds: 1 * 60,
     name: "Sunflower",
     description: "A sunny flower",
   },
   Potato: {
-    buyPrice: 0.1,
-    sellPrice: 0.14,
+    buyPrice: marketRate(0.1),
+    sellPrice: marketRate(0.14),
     harvestSeconds: 5 * 60,
     name: "Potato",
     description: "A nutrious crop for any diet",
   },
   Pumpkin: {
-    buyPrice: 0.2,
-    sellPrice: 0.4,
+    buyPrice: marketRate(0.2),
+    sellPrice: marketRate(0.4),
     harvestSeconds: 30 * 60,
     name: "Pumpkin",
     description: "A nutrious crop for any diet",
   },
   Carrot: {
-    buyPrice: 0.5,
-    sellPrice: 0.8,
+    buyPrice: marketRate(0.5),
+    sellPrice: marketRate(0.8),
     harvestSeconds: 60 * 60,
     name: "Carrot",
     description: "A nutrious crop for any diet",
   },
   Cabbage: {
-    buyPrice: 1,
-    sellPrice: 1.5,
+    buyPrice: marketRate(1),
+    sellPrice: marketRate(1.5),
     harvestSeconds: 2 * 60 * 60,
     name: "Cabbage",
     description: "A nutrious crop for any diet",
   },
   Beetroot: {
-    buyPrice: 2,
-    sellPrice: 2.8,
+    buyPrice: marketRate(2),
+    sellPrice: marketRate(2.8),
     harvestSeconds: 4 * 60 * 60,
 
     name: "Beetroot",
@@ -70,103 +71,103 @@ export const CROPS: Record<CropName, Crop> = {
     description: "A nutrious crop for any diet",
   },
   Cauliflower: {
-    buyPrice: 3,
-    sellPrice: 4.25,
+    buyPrice: marketRate(3),
+    sellPrice: marketRate(4.25),
     harvestSeconds: 8 * 60 * 60,
     name: "Cauliflower",
     description: "A nutrious crop for any diet",
   },
   Parsnip: {
-    buyPrice: 5,
-    sellPrice: 6.5,
+    buyPrice: marketRate(5),
+    sellPrice: marketRate(6.5),
     harvestSeconds: 12 * 60 * 60,
     name: "Parsnip",
     description: "A nutrious crop for any diet",
   },
   Radish: {
-    buyPrice: 7,
-    sellPrice: 9.5,
+    buyPrice: marketRate(7),
+    sellPrice: marketRate(9.5),
     harvestSeconds: 24 * 60 * 60,
     name: "Radish",
     description: "A nutrious crop for any diet",
   },
   Wheat: {
-    buyPrice: 0.1,
-    sellPrice: 0.14,
+    buyPrice: marketRate(0.1),
+    sellPrice: marketRate(0.14),
     harvestSeconds: 5 * 60,
     name: "Wheat",
     description: "A nutrious crop for any diet",
   },
-};
+});
 
 export type SeedName = `${CropName} Seed`;
 
-export const SEEDS: Record<SeedName, Craftable> = {
+export const SEEDS: () => Record<SeedName, Craftable> = () => ({
   "Sunflower Seed": {
     name: "Sunflower Seed",
-    price: 0.01,
+    price: marketRate(0.01),
     ingredients: [],
     description: "A sunny flower",
   },
   "Potato Seed": {
     name: "Potato Seed",
-    price: 0.1,
+    price: marketRate(0.1),
     ingredients: [],
     description: "A nutrious crop for any diet",
   },
   "Pumpkin Seed": {
     name: "Pumpkin Seed",
     description: "A nutrious crop for any diet",
-    price: 0.2,
+    price: marketRate(0.2),
     ingredients: [],
   },
   "Carrot Seed": {
     name: "Carrot Seed",
     description: "A nutrious crop for any diet",
-    price: 0.5,
+    price: marketRate(0.5),
     ingredients: [],
     requires: "Pumpkin Soup",
   },
   "Cabbage Seed": {
     name: "Cabbage Seed",
     description: "A nutrious crop for any diet",
-    price: 1,
+    price: marketRate(1),
     ingredients: [],
     requires: "Pumpkin Soup",
   },
   "Beetroot Seed": {
     name: "Beetroot Seed",
     description: "A nutrious crop for any diet",
-    price: 2,
+    price: marketRate(2),
     ingredients: [],
     requires: "Sauerkraut",
   },
   "Cauliflower Seed": {
     name: "Cauliflower Seed",
     description: "A nutrious crop for any diet",
-    price: 3,
+    price: marketRate(3),
     ingredients: [],
     requires: "Sauerkraut",
   },
   "Parsnip Seed": {
     name: "Parsnip Seed",
     description: "A nutrious crop for any diet",
-    price: 5,
+    price: marketRate(5),
     ingredients: [],
     requires: "Roasted Cauliflower",
   },
   "Radish Seed": {
     name: "Radish Seed",
     description: "A nutrious crop for any diet",
-    price: 7,
+    price: marketRate(7),
     ingredients: [],
     requires: "Roasted Cauliflower",
   },
   "Wheat Seed": {
     name: "Wheat Seed",
     description: "A nutrious crop for any diet",
-    price: 2,
+    price: marketRate(2),
     ingredients: [],
     requires: "Pumpkin Soup",
   },
-};
+});

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -68,88 +68,90 @@ export type ItemDetails = {
 
 type Items = Record<InventoryItemName, ItemDetails>;
 
+const crops = CROPS();
+const seeds = SEEDS();
 export const ITEM_DETAILS: Items = {
   // Crops
   Sunflower: {
-    ...CROPS.Sunflower,
+    ...crops.Sunflower,
     image: sunflowerCrop,
   },
   Potato: {
-    ...CROPS.Potato,
+    ...crops.Potato,
     image: potatoCrop,
   },
   Pumpkin: {
-    ...CROPS.Pumpkin,
+    ...crops.Pumpkin,
     image: pumpkinCrop,
   },
   Carrot: {
-    ...CROPS.Carrot,
+    ...crops.Carrot,
     image: carrotCrop,
   },
   Cabbage: {
-    ...CROPS.Cabbage,
+    ...crops.Cabbage,
     image: cabbageCrop,
   },
   Beetroot: {
-    ...CROPS.Beetroot,
+    ...crops.Beetroot,
     image: beetrootCrop,
   },
   Cauliflower: {
-    ...CROPS.Cauliflower,
+    ...crops.Cauliflower,
     image: cauliflowerCrop,
   },
   Parsnip: {
-    ...CROPS.Parsnip,
+    ...crops.Parsnip,
     image: parsnipCrop,
   },
   Radish: {
-    ...CROPS.Radish,
+    ...crops.Radish,
     image: radishCrop,
   },
   Wheat: {
-    ...CROPS.Wheat,
+    ...crops.Wheat,
     image: wheatCrop,
   },
 
   // Seeds
   "Sunflower Seed": {
-    ...SEEDS["Sunflower Seed"],
+    ...seeds["Sunflower Seed"],
     image: sunflowerSeed,
   },
   "Potato Seed": {
-    ...SEEDS["Potato Seed"],
+    ...seeds["Potato Seed"],
     image: potatoSeed,
   },
   "Pumpkin Seed": {
-    ...SEEDS["Pumpkin Seed"],
+    ...seeds["Pumpkin Seed"],
     image: pumpkinSeed,
   },
   "Carrot Seed": {
-    ...SEEDS["Carrot Seed"],
+    ...seeds["Carrot Seed"],
     image: carrotSeed,
   },
   "Cabbage Seed": {
-    ...SEEDS["Cabbage Seed"],
+    ...seeds["Cabbage Seed"],
     image: cabbageSeed,
   },
   "Beetroot Seed": {
-    ...SEEDS["Beetroot Seed"],
+    ...seeds["Beetroot Seed"],
     image: beetrootSeed,
   },
   "Cauliflower Seed": {
-    ...SEEDS["Cauliflower Seed"],
+    ...seeds["Cauliflower Seed"],
     image: cauliflowerSeed,
   },
   "Parsnip Seed": {
-    ...SEEDS["Parsnip Seed"],
+    ...seeds["Parsnip Seed"],
     image: parsnipSeed,
   },
   "Radish Seed": {
-    ...SEEDS["Radish Seed"],
+    ...seeds["Radish Seed"],
     image: radishSeed,
   },
   "Wheat Seed": {
-    ...SEEDS["Wheat Seed"],
+    ...seeds["Wheat Seed"],
     image: wheatSeed,
   },
 


### PR DESCRIPTION
# Description

This PR adds in the dynamic prices support to the UI. It uses a thunk so it will ensure as soon as the millisecond passes the prices will update (on next render). This means a user does not have to refresh the page and there is a very small likelihood of errors


- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Manually tested against a temporary API