### PR TITLE
[FEAT] Popup Before Quitting

### DIFF
--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -31,8 +31,11 @@ export const Game: React.FC = () => {
   useInterval(() => send("SAVE"), AUTO_SAVE_INTERVAL);
 
   useEffect(() => {
-    const handleBeforeUnload = (event: Event) => {
-      event.returnValue = gameState.context.actions.length === 0;
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (gameState.context.actions.length === 0) return;
+
+      event.preventDefault();
+      event.returnValue = '';
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);

--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { Modal } from "react-bootstrap";
 import { useActor } from "@xstate/react";
 
@@ -29,6 +29,19 @@ export const Game: React.FC = () => {
   const [gameState, send] = useActor(gameService);
 
   useInterval(() => send("SAVE"), AUTO_SAVE_INTERVAL);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: Event) => {
+      event.returnValue = gameState.context.actions.length === 0;
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    // cleanup on every gameState update
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [gameState]);
 
   return (
     <>


### PR DESCRIPTION
# Description

My attempt at implementing browser popup whenever user closes the game (tab/window exit, back, etc). as @fightingpisces recommended, use `beforeunload` event to check for unsaved actions. Couple of points:

- Popup string is not customizable
- Using `event.preventDefault()` to display dialog is recommended I but cannot make it to work. Used `event.returnValue` instead
- It is recommended to avoid adding listener unconditionally (not confident on my implementation of this)
- It seems like closing mobile browsers doesn't trigger `beforeunload` (need help testing)
- Cannot test closing after actions are saved

References:
https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#browser_compatibility
https://developers.google.com/web/updates/2018/07/page-lifecycle-api?hl=de#the-beforeunload-event

~~Fixes~~ Implements #240 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing (video does not capture browser popup)
![Popup on beforeunload](https://user-images.githubusercontent.com/89294757/153148386-731f5404-8d0f-48b3-bdaf-1d59c3e9547b.PNG)

Desktop - Brave / Chrome
1. Open the game
2. Close the tab -- expected: no popup
3. Open the game
4. Plant / Harvest / Buy / Sell 
5. Try to closing the tab -- expected: browser popup should appear

Android - Brave
1. Visit any page e.g. Youtube
2. Visit the game on the same tab
4. Plant / Harvest / Buy / Sell 
5. Try browser back -- expected: browser popup should appear

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
