### PR TITLE
[FIX] Insufficient Ingredient Highlight

### DIFF
--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
 import classNames from "classnames";
+import Decimal from "decimal.js-light";
 
 import token from "assets/icons/token.png";
 
@@ -125,8 +126,8 @@ export const CraftingItems: React.FC<Props> = ({ items, isBulk = false }) => {
           <div className="border-t border-white w-full mt-2 pt-1">
             {selected.ingredients.map((ingredient, index) => {
               const item = ITEM_DETAILS[ingredient.item];
-              const hasFunds =
-                (inventory[ingredient.item] || 0) >= ingredient.amount;
+              const lessIngredient =
+                new Decimal(inventory[ingredient.item] || 0).lessThan(ingredient.amount);
 
               return (
                 <div className="flex justify-center items-end" key={index}>
@@ -135,7 +136,7 @@ export const CraftingItems: React.FC<Props> = ({ items, isBulk = false }) => {
                     className={classNames(
                       "text-xs text-shadow text-center mt-2 ",
                       {
-                        "text-red-500": !hasFunds,
+                        "text-red-500": lessIngredient,
                       }
                     )}
                   >

--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useActor } from "@xstate/react";
 import classNames from "classnames";
+import Decimal from "decimal.js-light";
 
 import token from "assets/icons/token.png";
 
@@ -132,8 +133,8 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
           <div className="border-t border-white w-full mt-2 pt-1">
             {selected.ingredients.map((ingredient, index) => {
               const item = ITEM_DETAILS[ingredient.item];
-              const hasFunds =
-                (inventory[ingredient.item] || 0) >= ingredient.amount;
+              const lessIngredient =
+                new Decimal(inventory[ingredient.item] || 0).lessThan(ingredient.amount);
 
               return (
                 <div className="flex justify-center items-end" key={index}>
@@ -142,7 +143,7 @@ export const Rare: React.FC<Props> = ({ onClose }) => {
                     className={classNames(
                       "text-xs text-shadow text-center mt-2 ",
                       {
-                        "text-red-500": !hasFunds,
+                        "text-red-500": lessIngredient,
                       }
                     )}
                   >

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import Decimal from "decimal.js-light";
 
 import token from "assets/icons/token.png";
 
@@ -35,7 +36,7 @@ export const Plants: React.FC<Props> = ({}) => {
     setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
   };
 
-  const lessPlants = (amount = 1) => (inventory[selected.name] || 0) < amount;
+  const lessPlants = (amount = 1) => new Decimal(inventory[selected.name] || 0).lessThan(amount);
 
   return (
     <div className="flex">


### PR DESCRIPTION
# Description

This PR fixes the bug raised by @InuBakaBo in Discord where the ingredient has red highlight even if there are resources in the inventory. The cause was that expression for checking was not updated to use `decimal.js-light`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual Testing (localhost connected to testnet)

Before fix
![highlight-before](https://user-images.githubusercontent.com/89294757/153222827-23a61a04-feeb-4abb-a751-2f31ec921115.PNG)

After fix
![highlight-after](https://user-images.githubusercontent.com/89294757/153222881-3e2ea0d9-596f-4b66-841d-770458abdd11.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
