### PR TITLE
[FIX] Show Farm NFT Address

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -115,6 +115,9 @@ export function startGame(authContext: AuthContext) {
                 throw new Error("NO_FARM");
               }
 
+              // add farm address
+              game.farmAddress = authContext.address;
+
               return {
                 state: game,
               };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -31,7 +31,7 @@ export type GameState = {
 
   // Session values
   id: number;
-  address?: string;
+  farmAddress?: string;
 };
 
 export interface Context {

--- a/src/features/hud/components/Address.tsx
+++ b/src/features/hud/components/Address.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState, useEffect } from "react";
+import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
-import { metamask } from "lib/blockchain/metamask";
 
 import { Context } from "features/game/GameProvider";
 
@@ -10,7 +9,6 @@ import { Panel } from "components/ui/Panel";
 import player from "assets/icons/player.png";
 import arrowLeft from "assets/icons/arrow_left.png";
 import arrowRight from "assets/icons/arrow_right.png";
-import context from "react-bootstrap/esm/AccordionContext";
 
 interface Props {}
 

--- a/src/features/hud/components/Address.tsx
+++ b/src/features/hud/components/Address.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { useActor } from "@xstate/react";
 import { metamask } from "lib/blockchain/metamask";
 
@@ -10,6 +10,7 @@ import { Panel } from "components/ui/Panel";
 import player from "assets/icons/player.png";
 import arrowLeft from "assets/icons/arrow_left.png";
 import arrowRight from "assets/icons/arrow_right.png";
+import context from "react-bootstrap/esm/AccordionContext";
 
 interface Props {}
 
@@ -25,15 +26,15 @@ export const Address: React.FC<Props> = () => {
     },
   ] = useActor(gameService);
 
-  const [tooltipMessage, setTooltipMessage] = useState("Click to copy");
+  const [tooltipMessage, setTooltipMessage] = useState("Click to copy farm address");
   const [showAddress, setShowAddress] = useState(true);
   const [showLabel, setShowLabel] = useState(false);
 
   const copyToClipboard = (): void => {
-    navigator.clipboard.writeText(state.address as string);
+    navigator.clipboard.writeText(state.farmAddress as string);
     setTooltipMessage("Copied!");
     setTimeout(() => {
-      setTooltipMessage("Click to copy");
+      setTooltipMessage("Click to copy farm address");
     }, 2000);
   };
 
@@ -66,7 +67,7 @@ export const Address: React.FC<Props> = () => {
                 : "scale-x-0 opacity-0 max-w-[0px] -mr-1"
             }`}
           >
-            {shortAddress(metamask.myAccount! || "XXXX")}
+            {shortAddress(state.farmAddress! || "XXXX")}
           </span>
 
           <img


### PR DESCRIPTION
# Description

This PR shows the Farm NFT address. Since almost all game progression is related to the farm, I think it's better to show farm address. This is also useful when farmers want to fund their farms from their wallets. Though it might be confusing at first (*why is the address different?*), I think the community will get used to the game's architecture.

Fixes # N/A (deemed as a Bug in Discord)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing

1. Load the game
2. Check address -- should be different from wallet
3. Click to copy -- should be copied in clipboard

![farm nft address](https://user-images.githubusercontent.com/89294757/153718359-f9788730-7933-44cb-94b5-45369277ab18.png)

https://user-images.githubusercontent.com/89294757/153718363-67533fa7-e607-48ca-8ef9-f88568b51b6a.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
