### PR TITLE
[FIX] truncate address on withdraw modal

### DIFF
--- a/src/features/hud/components/Withdraw.tsx
+++ b/src/features/hud/components/Withdraw.tsx
@@ -16,6 +16,7 @@ import upArrow from "assets/icons/arrow_up.png";
 import downArrow from "assets/icons/arrow_down.png";
 import { withdraw } from "features/game/actions/withdraw";
 import { toWei } from "web3-utils";
+import { shortAddress } from "features/hud/components/Address";
 
 interface Props {
   isOpen: boolean;
@@ -192,7 +193,7 @@ export const Withdraw: React.FC<Props> = ({ isOpen, onClose }) => {
             </div>
           </h1>
 
-          <h1 className="text-shadow mt-4">Your address: {to}</h1>
+          <h1 className="text-shadow mt-4">Your address: {shortAddress(to! || "XXXX")}</h1>
           <span className="text-xs">TODO: disclaimer</span>
           <Button onClick={onWithdraw}>Withdraw</Button>
         </>


### PR DESCRIPTION
# Description

Truncates wallet address on withdraw modal.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 

# How Has This Been Tested?

**Locally**

Before:
![image](https://user-images.githubusercontent.com/50954098/153719048-a7211e4c-c6ab-4d4f-a1da-4e8b6243b7a7.png)

After:
![image](https://user-images.githubusercontent.com/50954098/153719072-eab57eeb-cd47-4acb-ba14-94fcc49a24e0.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
