### PR TITLE
[FIX] Toggle showGame based on authMachine state

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -46,15 +46,12 @@ export const Navigation: React.FC = () => {
   }, [send]);
 
   useEffect(() => {
-    if (
-      authState.matches({ connected: "authorised" }) ||
-      authState.matches("visiting")
-    ) {
-      // TODO: look into this further
-      // This is to prevent a modal clash when the authmachine switches
-      // to the game machine.
-      setTimeout(() => setShowGame(true), 20);
-    }
+    const _showGame = authState.matches({ connected: "authorised" }) || authState.matches("visiting");
+
+    // TODO: look into this further
+    // This is to prevent a modal clash when the authmachine switches
+    // to the game machine.
+    setTimeout(() => setShowGame(_showGame), 20);
   }, [authState.value]);
 
   return (


### PR DESCRIPTION
# Description

Fixes a bug that when visiting then clicking Back, the farm still shows while connecting modal appears.
![image](https://user-images.githubusercontent.com/89294757/154426375-62119f9c-be43-4bd8-9880-51ac1812a176.png)

Steps:
1. Visit a farm
2. Click Back -- ERROR: farm still shows, proceeds to connect and load new farm only in data BUT does not refresh render
3. Load your farm -- ERROR: own farm doesn't load in the game

Expected:
On step 2, should redirect to splash screen

Fixes (#issue) N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing

Steps:

1. Visit a farm
2. Click Back -- should redirect to Splash screen

https://user-images.githubusercontent.com/89294757/154427552-75f899f7-e1dd-4cb3-8c4a-9fc0b8f93b46.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
