### PR TITLE
[FEAT] Visit via URL query

### DIFF
--- a/src/features/auth/Auth.tsx
+++ b/src/features/auth/Auth.tsx
@@ -39,14 +39,14 @@ export const Auth: React.FC = () => {
         />
         <img src={jumpingGoblin} className="absolute w-52 -top-[83px] -z-10" />
         <Panel>
-          {authState.matches({ connected: "loadingFarm" }) && <Loading />}
+          {(authState.matches({ connected: "loadingFarm" }) ||
+            authState.matches("checkFarm")) && <Loading />}
           {authState.matches("connecting") && <Loading text="Connecting" />}
           {authState.matches("signing") && <Signing />}
           {authState.matches({ connected: "noFarmLoaded" }) && <CreateFarm />}
           {authState.matches({ connected: "creatingFarm" }) && <CreatingFarm />}
           {authState.matches({ connected: "readyToStart" }) && <StartFarm />}
-          {(authState.matches("exploring") ||
-            authState.matches("checkFarm")) && <VisitFarm />}
+          {authState.matches("exploring") && <VisitFarm />}
           {authState.matches("unauthorised") && <Unauthorised />}
         </Panel>
       </div>

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -10,6 +10,14 @@ import { CharityAddress } from "../components/Donation";
 const INITIAL_SESSION =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
+const getFarmUrl = () => {
+  const farmId = new URLSearchParams(window.location.search).get('farmId');
+
+  return parseInt(farmId!);
+};
+
+const deleteFarmUrl = () => (window.history.pushState({}, '', window.location.pathname));
+
 type Farm = {
   farmId: number;
   sessionId: string;
@@ -105,7 +113,13 @@ export const authMachine = createMachine<
         id: "connecting",
         invoke: {
           src: "initMetamask",
-          onDone: "signing",
+          onDone: [
+            {
+              target: "checkFarm",
+              cond: "hasFarmIdUrl",
+            },
+            { target: "signing" },
+          ],
           onError: {
             target: "unauthorised",
             actions: "assignErrorMessage",
@@ -223,7 +237,7 @@ export const authMachine = createMachine<
         on: {
           RETURN: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: ["resetFarm", "deleteFarmIdUrl"],
           },
         },
       },
@@ -299,7 +313,7 @@ export const authMachine = createMachine<
         context: Context,
         event: any
       ): Promise<Farm | undefined> => {
-        const farmId = (event as VisitEvent).farmId;
+        const farmId = getFarmUrl() || (event as VisitEvent).farmId;
         const farmAccount = await metamask.getFarm()?.getFarm(farmId);
 
         return {
@@ -326,6 +340,7 @@ export const authMachine = createMachine<
         address: (_context, event) => undefined,
         sessionId: (_context, event) => undefined,
       }),
+      deleteFarmIdUrl: () => deleteFarmUrl(),
     },
     guards: {
       hasFarm: (context: Context, event: any) => {
@@ -339,6 +354,7 @@ export const authMachine = createMachine<
 
         return !!context.farmId;
       },
+      hasFarmIdUrl: () => !isNaN(getFarmUrl()),
     },
   }
 );


### PR DESCRIPTION
# Description

This PR implements visiting a farm via url query. For example, `http://localhost:3000/?farmId=12` will automatically load Farm ID 12. This skips the signing transaction since the user's farm will not be loaded.

Note for general users: `?` is important for it to be considered as query param.

Fixes (#issue) N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing

Steps:
1. login and load your farm
2. in browser url, append `?farmId=1` and enter -- Farm ID 1 should load and the game in `visiting` state
3. Click `Back` -- the farmId param in browser will be deleted, the game goes back to connecting state and prompts signing

https://user-images.githubusercontent.com/89294757/154623816-41fa8e6c-23b5-4c3a-8a04-ba59e847a4d9.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
