### PR TITLE
[FIX] Don't show items with 0 count in inventory

### DIFF
--- a/src/features/hud/components/InventoryItems.tsx
+++ b/src/features/hud/components/InventoryItems.tsx
@@ -62,7 +62,7 @@ export const InventoryItems: React.FC<Props> = ({ onClose }) => {
 
   const tabSequence = Object.keys(CATEGORIES) as Tab[];
   const items = Object.keys(inventory) as InventoryItemName[];
-  const validItems = items.filter((itemName) => !!inventory[itemName]);
+  const validItems = items.filter((itemName) => !!inventory[itemName] && !inventory[itemName]?.equals(0));
   const isCategoryEmpty = !validItems.some(
     (itemName) => itemName in CATEGORIES[currentTab].items
   );


### PR DESCRIPTION
# Description

Inventory UI improvement to only show items that have `> 0` count. This issue can be especially seen when planting all your seeds then going back to the inventory, the seed would still show up there.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Tested manually

**Before:**

https://user-images.githubusercontent.com/50954098/154691709-37c3b732-d877-4417-bd5d-400d052a4cf0.mp4

**After:**

https://user-images.githubusercontent.com/50954098/154691758-a0b5c98a-13fd-42b1-b5d5-5df899bdfc92.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
