### PR TITLE
[FIX] Keep the current selected shortcut item in the case that item count is 0

### DIFF
--- a/src/features/crops/components/Field.tsx
+++ b/src/features/crops/components/Field.tsx
@@ -11,9 +11,7 @@ import { AppIconContext } from "features/crops/AppIconProvider";
 import { CropName } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
-import { getShortcuts } from "../../hud/lib/shortcuts";
 import { Soil } from "./Soil";
-import Decimal from "decimal.js-light";
 import { useTour } from "@reactour/tour";
 import { TourStep } from "features/game/lib/Tour";
 
@@ -43,7 +41,6 @@ export const Field: React.FC<Props> = ({
   const { updateHarvestable } = useContext(AppIconContext);
   const [game] = useActor(gameService);
   const clickedAt = useRef<number>(0);
-  const inventory = game.context.state.inventory;
   const field = game.context.state.fields[fieldIndex];
 
   const displayPopover = async (element: JSX.Element) => {
@@ -76,17 +73,6 @@ export const Field: React.FC<Props> = ({
           index: fieldIndex,
           item: selectedItem,
         });
-
-        if (selectedItem) {
-          if ((inventory[selectedItem] || new Decimal(0)).sub(1).equals(0)) {
-            const shortcuts = getShortcuts();
-            if ((inventory[shortcuts[1]] || 0) > 0) {
-              shortcutItem(shortcuts[1]);
-            } else if ((inventory[shortcuts[2]] || 0) > 0) {
-              shortcutItem(shortcuts[2]);
-            }
-          }
-        }
 
         displayPopover(
           <div className="flex items-center justify-center text-xs text-white text-shadow overflow-visible">
@@ -157,7 +143,7 @@ export const Field: React.FC<Props> = ({
           style={{
             opacity: 0.1,
           }}
-          className="absolute inset-0 w-full top-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 z-10 cursor-pointer"
+          className="absolute inset-0 w-full top-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 z-20 cursor-pointer"
           onClick={onClick}
         />
       )}


### PR DESCRIPTION
# Description

The selected shortcut item should not change even if it goes to 0. This would prevent players from accidentally planting the next seed in the shortcut item _if_ the current selected item is all used up. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Pick and buy a SINGLE seed and make sure you don't have any in the inventory.
2. Plant the seed.
3.  Make sure the selected seed is still at the top of the shortcut items.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]