### PR TITLE
[FIX] Disable close modals while onboarding

### DIFF
--- a/src/features/crops/components/Market.tsx
+++ b/src/features/crops/components/Market.tsx
@@ -94,7 +94,11 @@ export const Market: React.FC = () => {
           onClick={() => handleMarketClick()}
         />
       )}
-      <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
+      <Modal
+        centered
+        show={isOpen}
+        onHide={() => (tourIsOpen ? null : setIsOpen(false))}
+      >
         <MarketItems onClose={() => setIsOpen(false)} />
       </Modal>
     </div>

--- a/src/features/crops/components/Market.tsx
+++ b/src/features/crops/components/Market.tsx
@@ -97,7 +97,7 @@ export const Market: React.FC = () => {
       <Modal
         centered
         show={isOpen}
-        onHide={() => (tourIsOpen ? null : setIsOpen(false))}
+        onHide={tourIsOpen ? undefined : () => setIsOpen(false)}
       >
         <MarketItems onClose={() => setIsOpen(false)} />
       </Modal>

--- a/src/features/crops/components/MarketItems.tsx
+++ b/src/features/crops/components/MarketItems.tsx
@@ -49,7 +49,7 @@ export const MarketItems: React.FC<Props> = ({ onClose }) => {
         <img
           src={close}
           className="h-6 cursor-pointer mr-2 mb-1"
-          onClick={() => (tourIsOpen ? null : onClose)}
+          onClick={tourIsOpen ? undefined : () => onClose()}
         />
       </div>
 

--- a/src/features/crops/components/MarketItems.tsx
+++ b/src/features/crops/components/MarketItems.tsx
@@ -49,7 +49,7 @@ export const MarketItems: React.FC<Props> = ({ onClose }) => {
         <img
           src={close}
           className="h-6 cursor-pointer mr-2 mb-1"
-          onClick={onClose}
+          onClick={() => (tourIsOpen ? null : onClose)}
         />
       </div>
 

--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -60,6 +60,14 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     }
   };
 
+  const handleBuyTen = () => {
+    buy(10);
+    if (tourIsOpen && currentTourStep === TourStep.buy) {
+      setCurrentTourStep(TourStep.plant);
+      onClose();
+    }
+  };
+
   const restock = () => {
     gameService.send("SYNC");
 
@@ -108,7 +116,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
         <Button
           disabled={lessFunds(10) || stock?.lessThan(10)}
           className="text-xs mt-1"
-          onClick={() => buy(10)}
+          onClick={() => handleBuyTen()}
         >
           Buy 10
         </Button>

--- a/src/features/hud/components/Inventory.tsx
+++ b/src/features/hud/components/Inventory.tsx
@@ -58,8 +58,14 @@ export const Inventory: React.FC = () => {
         <Label className="hidden sm:block absolute -bottom-7">Inventory</Label>
       </div>
 
-      <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
-        <InventoryItems onClose={() => setIsOpen(false)} />
+      <Modal
+        centered
+        show={isOpen}
+        onHide={() => (tourIsOpen ? null : setIsOpen(false))}
+      >
+        <InventoryItems
+          onClose={() => (tourIsOpen ? null : setIsOpen(false))}
+        />
       </Modal>
 
       {!game.matches("readonly") && (

--- a/src/features/hud/components/Inventory.tsx
+++ b/src/features/hud/components/Inventory.tsx
@@ -61,7 +61,7 @@ export const Inventory: React.FC = () => {
       <Modal
         centered
         show={isOpen}
-        onHide={() => (tourIsOpen ? null : setIsOpen(false))}
+        onHide={tourIsOpen ? undefined : () => setIsOpen(false)}
       >
         <InventoryItems
           onClose={() => (tourIsOpen ? null : setIsOpen(false))}


### PR DESCRIPTION
# Description

This PR will disable closing modals while onboarding.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Create a new farm
* Start onboarding 
* Try closing modals (inventory and market) while onboarding

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
