### PR TITLE
[FIX] Refactor Counter and Increase Z-index of Progress Bar

### DIFF
--- a/src/features/crops/AppIconProvider.tsx
+++ b/src/features/crops/AppIconProvider.tsx
@@ -2,7 +2,7 @@
  * A wrapper that provides crops favicon harvestable items management
  */
 
-import React, { useContext } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import Tinycon from "tinycon";
 import { useActor } from "@xstate/react";
 import { CROPS } from "features/game/types/crops";
@@ -18,47 +18,22 @@ export const AppIconContext = React.createContext<AppIconContext>(
   {} as AppIconContext
 );
 
-/**
- * Checks if Field is harvestable
- *
- * @param field
- */
-const isHarvestable = (field: FieldItem): boolean => {
-  if (!field) {
-    return false;
-  }
-  const crop = CROPS()[field.name];
-  const timeLeft = getTimeLeft(field.plantedAt, crop.harvestSeconds);
-  return timeLeft <= 0;
-};
-/**
- * Apply debounce to function
- *
- * @param func
- * @param timeout
- */
-const debounce = (func: (...args: any) => void, timeout = 500) => {
-  let timer: NodeJS.Timeout;
-  return (...args: any[]) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      func.apply(this, args);
-    }, timeout);
-  };
-};
-
 export const AppIconProvider: React.FC = ({ children }) => {
-  const { gameService } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const [counter, setCounter] = useState<number>(0);
 
-  const updateHarvestable = debounce((): void => {
-    const total = Object.values(state.fields).filter(isHarvestable).length;
-    Tinycon.setBubble(total || null);
-  });
+  const updateHarvestable = (op: "plus" | "minus"): void => {
+    setCounter((prevCounter) => prevCounter + (op === "plus" ? 1 : -1));
+  };
+
+  // apply force update
+  useEffect(() => {
+    Tinycon.setOptions({ fallback: "force" });
+  }, []);
+
+  // need to be in useEffect
+  useEffect(() => {
+    Tinycon.setBubble(counter);
+  }, [counter]);
 
   return (
     <AppIconContext.Provider value={{ updateHarvestable }}>

--- a/src/features/crops/AppIconProvider.tsx
+++ b/src/features/crops/AppIconProvider.tsx
@@ -2,16 +2,11 @@
  * A wrapper that provides crops favicon harvestable items management
  */
 
-import React, { useContext, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import Tinycon from "tinycon";
-import { useActor } from "@xstate/react";
-import { CROPS } from "features/game/types/crops";
-import { Context } from "features/game/GameProvider";
-import { FieldItem } from "features/game/types/game";
-import { getTimeLeft } from "lib/utils/time";
 
 interface AppIconContext {
-  updateHarvestable: () => void;
+  updateHarvestable: (op: "plus" | "minus") => void;
 }
 
 export const AppIconContext = React.createContext<AppIconContext>(
@@ -25,7 +20,7 @@ export const AppIconProvider: React.FC = ({ children }) => {
     setCounter((prevCounter) => prevCounter + (op === "plus" ? 1 : -1));
   };
 
-  // apply force update
+  // apply force update (reverts to title update and not bubble)
   useEffect(() => {
     Tinycon.setOptions({ fallback: "force" });
   }, []);

--- a/src/features/crops/components/Field.tsx
+++ b/src/features/crops/components/Field.tsx
@@ -99,7 +99,7 @@ export const Field: React.FC<Props> = ({
       gameService.send("item.harvested", {
         index: fieldIndex,
       });
-      updateHarvestable();
+      updateHarvestable("minus");
 
       displayPopover(
         <div className="flex items-center justify-center text-xs text-white text-shadow overflow-visible">

--- a/src/features/crops/components/Soil.tsx
+++ b/src/features/crops/components/Soil.tsx
@@ -35,7 +35,7 @@ export const Soil: React.FC<Props> = ({ field }) => {
   }, [field]);
 
   React.useEffect(() => {
-    if (badgeUpdated) updateHarvestable();
+    if (badgeUpdated) updateHarvestable("plus");
   }, [badgeUpdated]);
 
   if (!field) {
@@ -53,7 +53,7 @@ export const Soil: React.FC<Props> = ({ field }) => {
     return (
       <div className="relative w-full h-full">
         <img src={lifecycle.seedling} className="w-full" />
-        <div className="absolute w-full -bottom-10 z-10">
+        <div className="absolute w-full -bottom-10 z-20">
           <ProgressBar percentage={percentage} seconds={timeLeft} />
         </div>
       </div>

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -74,3 +74,11 @@ export const INITIAL_FARM: GameState = {
   inventory: {},
   stock: INITIAL_STOCK,
 };
+
+export const EMPTY: GameState = {
+  id: 1,
+  balance: new Decimal(fromWei("0")),
+  fields: {},
+  inventory: {},
+  stock: {},
+};

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -7,7 +7,7 @@ import { metamask } from "../../../lib/blockchain/metamask";
 
 import { GameState } from "../types/game";
 import { loadSession } from "../actions/loadSession";
-import { INITIAL_FARM } from "./constants";
+import { INITIAL_FARM, EMPTY } from "./constants";
 import { autosave } from "../actions/autosave";
 import { mint } from "../actions/mint";
 import { LimitedItem } from "../types/craftables";
@@ -116,7 +116,7 @@ export function startGame(authContext: Options) {
     initial: "loading",
     context: {
       actions: [],
-      state: INITIAL_FARM,
+      state: EMPTY,
       sessionId: authContext.sessionId,
     },
     states: {


### PR DESCRIPTION
# Description

This PR covers the ff:
- refactor/fix the counter bug
- increase z-index of progress bar to avoid being covered by tall crop (Sunflower)

The implementation i decided was that `updateHarvestable` now triggers counter increment/decrement instead of looping `state.fields`. It is important to set a "force" option in `Tinycon` as well as do the `setBubble` whenever `counter` changes to display the correct value. I also included an `EMPTY` game state so at first load the counter won't execute.

the tradeoff however is that "force" changes the design from bubble to title update i.e. `(x) Sunflower Land`. [Tinycon github](https://github.com/tommoor/tinycon/blob/master/tinycon.js)

i also ignored the part in `INITIAL_FARM` where there are harvestable in locked plots. Given the game progression I dont see it happening unless the food somehow got deleted.

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing

Testnet
Steps
1. Load the game -- should correctly see harvestable counter
2. harvest -- counter should decrease
3. plant and wait -- counter should increase

https://user-images.githubusercontent.com/89294757/154871823-136385e8-8235-4c54-b99c-d3e96457e4b0.mp4

First Load

https://user-images.githubusercontent.com/89294757/154871832-ccf05f17-050c-4614-b306-523595e6f240.mp4

Progress Bar
![sfl-progress-bar-z](https://user-images.githubusercontent.com/89294757/154871850-558b84ab-3ada-4df6-9c45-ded37d218ccd.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
