### PR TITLE
[FIX] Move gold rock - Out of Cook hitbox + Formatting Issues

### DIFF
--- a/src/features/auth/components/VisitFarm.tsx
+++ b/src/features/auth/components/VisitFarm.tsx
@@ -36,7 +36,7 @@ export const VisitFarm: React.FC = () => {
         />
         <div className="flex">
           <Button
-            className="overflow-hidden" 
+            className="overflow-hidden"
             onClick={() => authService.send("LOAD_FARM")}
           >
             Back

--- a/src/features/bakery/components/Crafting.tsx
+++ b/src/features/bakery/components/Crafting.tsx
@@ -10,35 +10,35 @@ import { FOODS } from "features/game/types/craftables";
 import { CraftingItems } from "features/blacksmith/components/CraftingItems";
 
 interface Props {
-    onClose: () => void;
+  onClose: () => void;
 }
 
 export const Crafting: React.FC<Props> = ({ onClose }) => {
-    const [tab, setTab] = useState<"foods">("foods");
+  const [tab, setTab] = useState<"foods">("foods");
 
-    return (
-        <Panel className="pt-5 relative">
-            <div className="flex justify-between absolute top-1.5 left-0.5 right-0 items-center">
-                <div className="flex">
-                    <Tab isActive={tab === "foods"} onClick={() => setTab("foods")}>
-                        <img src={food} className="h-5 mr-2" />
-                        <span className="text-sm text-shadow">Food</span>
-                    </Tab>
-                </div>
-                <img
-                    src={close}
-                    className="h-6 cursor-pointer mr-2 mb-1"
-                    onClick={onClose}
-                />
-            </div>
+  return (
+    <Panel className="pt-5 relative">
+      <div className="flex justify-between absolute top-1.5 left-0.5 right-0 items-center">
+        <div className="flex">
+          <Tab isActive={tab === "foods"} onClick={() => setTab("foods")}>
+            <img src={food} className="h-5 mr-2" />
+            <span className="text-sm text-shadow">Food</span>
+          </Tab>
+        </div>
+        <img
+          src={close}
+          className="h-6 cursor-pointer mr-2 mb-1"
+          onClick={onClose}
+        />
+      </div>
 
-            <div
-                style={{
-                    minHeight: "200px",
-                }}
-            >
-                {tab === "foods" && <CraftingItems items={FOODS} />}
-            </div>
-        </Panel>
-    );
+      <div
+        style={{
+          minHeight: "200px",
+        }}
+      >
+        {tab === "foods" && <CraftingItems items={FOODS} />}
+      </div>
+    </Panel>
+  );
 };

--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -34,7 +34,7 @@ export function sell({ state, action }: Options): GameState {
     throw new Error("Insufficient crops to sell");
   }
 
-  let price = getSellPrice(crop, state.inventory);
+  const price = getSellPrice(crop, state.inventory);
 
   return {
     ...state,

--- a/src/features/game/lib/pricing.ts
+++ b/src/features/game/lib/pricing.ts
@@ -2,14 +2,17 @@ import { Inventory } from "../types/game";
 import { Crop } from "../types/crops";
 
 /**
- * TODO 
+ * TODO
  *  - find better way to check inventory w/o passing it each time
  *  - add more conditions
  */
 export const getSellPrice = (crop: Crop, inventory: Inventory) => {
-  if (crop.name === "Cauliflower" && inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)) {
+  if (
+    crop.name === "Cauliflower" &&
+    inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)
+  ) {
     return crop.sellPrice.mul(2);
   }
 
   return crop.sellPrice;
-}
+};

--- a/src/features/quarry/Quarry.tsx
+++ b/src/features/quarry/Quarry.tsx
@@ -16,7 +16,7 @@ export const Quarry: React.FC = () => {
       style={{
         height: `${GRID_WIDTH_PX * 6}px`,
         width: `${GRID_WIDTH_PX * 6}px`,
-        left: `calc(50% +  ${GRID_WIDTH_PX * 16}px)`,
+        left: `calc(50% +  ${GRID_WIDTH_PX * 17}px)`,
         top: `calc(50% -  ${GRID_WIDTH_PX * 17}px)`,
       }}
       className="absolute "

--- a/src/features/quarry/Quarry.tsx
+++ b/src/features/quarry/Quarry.tsx
@@ -16,7 +16,7 @@ export const Quarry: React.FC = () => {
       style={{
         height: `${GRID_WIDTH_PX * 6}px`,
         width: `${GRID_WIDTH_PX * 6}px`,
-        left: `calc(50% +  ${GRID_WIDTH_PX * 15}px)`,
+        left: `calc(50% +  ${GRID_WIDTH_PX * 16}px)`,
         top: `calc(50% -  ${GRID_WIDTH_PX * 17}px)`,
       }}
       className="absolute "


### PR DESCRIPTION
# Description
- Moves gold rock a bit to the right. (Out of cook hitbox)
- Also fixed some linting issues.

Fixes #issue (Discord)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn dev`
![image](https://user-images.githubusercontent.com/18549210/155141074-114ad170-c6cf-4e66-bcc7-83f4e8cadf57.png)

`yarn test`
<img width="370" alt="Screen Shot 2022-02-22 at 9 20 12 PM" src="https://user-images.githubusercontent.com/18549210/155140506-a877374d-7178-4925-abea-4f8a9684ba5b.png">



# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
