### PR TITLE
[CHORE] Hide HUD elements

### DIFF
--- a/src/components/ui/AudioPlayer.tsx
+++ b/src/components/ui/AudioPlayer.tsx
@@ -61,7 +61,7 @@ export const AudioPlayer: React.FC = () => {
     <div
       className={`position-fixed ${
         visible ? "-right-6 sm:right-10" : "right-2"
-      } sm:right-2 bottom-20 z-50 w-48 h-fit  sm:-translate-x-50 transition-all duration-500 ease-in-out`}
+      } sm:right-2 bottom-4 z-50 w-48 h-fit  sm:-translate-x-50 transition-all duration-500 ease-in-out`}
       style={{
         transform: `translateX(${visible ? 0 : "calc(100% + 8px)"})`,
       }}

--- a/src/features/hud/Hud.tsx
+++ b/src/features/hud/Hud.tsx
@@ -4,9 +4,7 @@ import { metamask } from "lib/blockchain/metamask";
 import { Balance } from "./components/Balance";
 import { Inventory } from "./components/Inventory";
 import { Menu } from "./components/Menu";
-import { Address } from "./components/Address";
 import { AudioPlayer } from "components/ui/AudioPlayer";
-import { ScreenshotButton } from "./components/ScreenshotButton";
 import { VisitBanner } from "./components/VisitBanner";
 
 /**
@@ -19,10 +17,8 @@ export const Hud: React.FC = () => {
       <Menu />
       <Balance />
       <Inventory />
-      <ScreenshotButton />
       <AudioPlayer />
       <VisitBanner />
-      {metamask.myAccount && <Address />}
     </div>
   );
 };


### PR DESCRIPTION
# Description

This PR hides the following from the HUD:

- Screenshot button
- Farm Address

Both of these buttons were causing confusion during Beta. Until we can solve this properly, we will hide for Beta. The less features and simpler the game is, the easier the adoption will be for users.

@Pranav-yadav @spencerdezartsmith Tagging you for visibility