### PR TITLE
[FIX] Undefined Error on Account Change

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -256,12 +256,15 @@ export const authMachine = createMachine<
     on: {
       ACCOUNT_CHANGED: {
         target: "connecting",
+        actions: "resetFarm",
       },
       NETWORK_CHANGED: {
         target: "connecting",
+        actions: "resetFarm",
       },
       REFRESH: {
         target: "connecting",
+        actions: "resetFarm",
       },
     },
   },


### PR DESCRIPTION
# Description

This PR fixes the undefined error when switching to an account that has no farm by resetting Farm variables in context to undefined.

Fixes #267 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual Testing (Metamask popup not captured on video)
Given:
Account A - has farm
Account B - no farm

Steps:

1. Connect Account A in metamask and sign transaction
2. When farm is ready (farm ID shows), switch to Account B and sign transaction -- should now display "Create a Farm" option and does not log undefined error in console

https://user-images.githubusercontent.com/89294757/155312513-3320b11a-4ee4-471e-bcdb-5cf91387aa11.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
