### PR TITLE
[CHORE] initialize empty variables in visit

### DIFF
--- a/src/features/game/actions/visit.ts
+++ b/src/features/game/actions/visit.ts
@@ -5,7 +5,7 @@ import Decimal from "decimal.js-light";
 import { balancesToInventory, populateFields } from "lib/utils/visitUtils";
 
 import { GameState } from "../types/game";
-import { INITIAL_TREES } from "../lib/constants";
+import { EMPTY } from "../lib/constants";
 
 export async function getVisitState(farmAddress: string): Promise<GameState> {
   const balance = await metamask.getToken().balanceOf(farmAddress);
@@ -14,13 +14,10 @@ export async function getVisitState(farmAddress: string): Promise<GameState> {
   const fields = populateFields(inventory);
 
   return {
+    ...EMPTY,
     balance: new Decimal(fromWei(balance)),
     farmAddress,
     fields,
     inventory,
-    trees: INITIAL_TREES,
-    stock: {},
-    // unused
-    id: 1000,
   };
 }

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -99,10 +99,11 @@ export const INITIAL_FARM: GameState = {
 };
 
 export const EMPTY: GameState = {
-  id: 1,
   balance: new Decimal(fromWei("0")),
   fields: {},
   inventory: {},
   stock: {},
   trees: INITIAL_TREES,
+  // unused
+  id: 1000,
 };


### PR DESCRIPTION
# Description

This PR initializes visit state variables with `EMPTY` before overwriting with correct values. This is to avoid breaking the game (due to initialization errors) whenever new features are added *as long as `EMPTY` is updated properly*

### Side note
I think disabling actions on visit / readonly is and will be tedious as observed when Trees feature was added. Each feature component needs to have `isNotReadOnly` logic to disable `hover` and `onClick` attributes. I do not know the best approach which can cover succeeding releases 😞 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No difference in game. Visit farm should still function

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
