### PR TITLE
[FIX] polish visit feature

### DIFF
--- a/src/features/forest/components/Tree.tsx
+++ b/src/features/forest/components/Tree.tsx
@@ -71,6 +71,11 @@ export const Tree: React.FC<Props> = ({ treeIndex }) => {
   };
 
   const shake = async () => {
+    if (game.matches("readonly")) {
+      shakeGif.current?.goToAndPlay(0);
+      return;
+    }
+
     if (selectedItem !== "Axe") {
       return;
     }
@@ -132,14 +137,14 @@ export const Tree: React.FC<Props> = ({ treeIndex }) => {
   };
 
   const handleHover = () => {
-    if (selectedItem === "Axe" && game.context.state.inventory.Axe?.gte(1))
+    if (game.matches("readonly") || selectedItem === "Axe" && game.context.state.inventory.Axe?.gte(1))
       return;
     treeRef.current?.classList["add"]("cursor-not-allowed");
     setShowLabel((prev) => !prev);
   };
 
   const handleMouseLeave = () => {
-    if (selectedItem === "Axe" && game.context.state.inventory.Axe?.gte(1))
+    if (game.matches("readonly") || selectedItem === "Axe" && game.context.state.inventory.Axe?.gte(1))
       return;
     treeRef.current?.classList["remove"]("cursor-not-allowed");
     setShowLabel((prev) => !prev);

--- a/src/features/hud/components/InventoryItems.tsx
+++ b/src/features/hud/components/InventoryItems.tsx
@@ -136,7 +136,10 @@ export const InventoryItems: React.FC<Props> = ({ onClose }) => {
         <div className="w-3/5 flex flex-wrap h-fit">
           {!selectedItem ? (
             <span className="text-white text-shadow">
-              You have no {currentTab} in your inventory.
+              {game.matches("readonly") 
+                ? `Farm ${game.context.state.id} has no ${currentTab} in their inventory` 
+                : `You have no ${currentTab} in your inventory`
+              }
             </span>
           ) : (
             validItems.map(
@@ -147,7 +150,7 @@ export const InventoryItems: React.FC<Props> = ({ onClose }) => {
                     isSelected={selectedItem === itemName}
                     key={itemName}
                     onClick={() => {
-                      shortcutItem(itemName);
+                      game.matches("readonly") ? null : shortcutItem(itemName);
                       setSelectedItem(itemName);
                     }}
                     image={ITEM_DETAILS[itemName].image}


### PR DESCRIPTION
# Description

- Remove "equip axe" popup on trees when visiting
- Visitors can shake trees on other farms
- Don't set `shortcutItem` on "readonly" state (fixes #328) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
