### PR TITLE
[FEAT] Preload images / allow tx rejections

### DIFF
--- a/src/features/auth/components/StartFarm.tsx
+++ b/src/features/auth/components/StartFarm.tsx
@@ -4,10 +4,13 @@ import { useActor } from "@xstate/react";
 import * as Auth from "features/auth/lib/Provider";
 
 import { Button } from "components/ui/Button";
+import { useImagePreloader } from "../useImagePreloader";
+import { Loading } from "./Loading";
 
 export const StartFarm: React.FC = () => {
   const { authService } = useContext(Auth.Context);
   const [authState, send] = useActor(authService);
+  const { imagesPreloaded } = useImagePreloader();
 
   const start = () => {
     send("START_GAME");
@@ -23,12 +26,18 @@ export const StartFarm: React.FC = () => {
   return (
     <>
       <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
-      <Button onClick={start} className="overflow-hidden mb-2">
-        Lets go!
-      </Button>
-      <Button onClick={explore} className="overflow-hidden">
-        {`Explore a friend's farm`}
-      </Button>
+      {imagesPreloaded ? (
+        <>
+          <Button onClick={start} className="overflow-hidden mb-2">
+            Lets go!
+          </Button>
+          <Button onClick={explore} className="overflow-hidden">
+            {`Explore a friend's farm`}
+          </Button>
+        </>
+      ) : (
+        <Loading />
+      )}
     </>
   );
 };

--- a/src/features/auth/components/StartFarm.tsx
+++ b/src/features/auth/components/StartFarm.tsx
@@ -25,9 +25,9 @@ export const StartFarm: React.FC = () => {
 
   return (
     <>
-      <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
       {imagesPreloaded ? (
         <>
+          <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
           <Button onClick={start} className="overflow-hidden mb-2">
             Lets go!
           </Button>

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -168,7 +168,6 @@ export const authMachine = createMachine<
               },
             },
           },
-
           creatingFarm: {
             invoke: {
               src: "createFarm",

--- a/src/features/auth/useImagePreloader.tsx
+++ b/src/features/auth/useImagePreloader.tsx
@@ -7,7 +7,6 @@ import minting from "assets/npcs/minting.gif";
 import richBegger from "assets/npcs/rich_begger.gif";
 import syncing from "assets/npcs/syncing.gif";
 import background from "assets/land/background.png";
-import clouds from "assets/land/clouds.png";
 
 const IMAGE_LIST: string[] = [
   goblinDonation,
@@ -17,7 +16,6 @@ const IMAGE_LIST: string[] = [
   richBegger,
   syncing,
   background,
-  clouds,
 ];
 
 function preloadImage(src: string) {

--- a/src/features/auth/useImagePreloader.tsx
+++ b/src/features/auth/useImagePreloader.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+import goblinDonation from "assets/splash/goblin_donation.gif";
+import humanDeath from "assets/npcs/human_death.gif";
+import lightningDeath from "assets/npcs/lightning_death.gif";
+import minting from "assets/npcs/minting.gif";
+import richBegger from "assets/npcs/rich_begger.gif";
+import syncing from "assets/npcs/syncing.gif";
+import background from "assets/land/background.png";
+import clouds from "assets/land/clouds.png";
+
+const IMAGE_LIST: string[] = [
+  goblinDonation,
+  humanDeath,
+  lightningDeath,
+  minting,
+  richBegger,
+  syncing,
+  background,
+  clouds,
+];
+
+function preloadImage(src: string) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = function () {
+      resolve(img);
+    };
+    img.onerror = img.onabort = function () {
+      reject(src);
+    };
+    img.src = src;
+  });
+}
+
+export function useImagePreloader() {
+  const [imagesPreloaded, setImagesPreloaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function load() {
+      if (isCancelled) return;
+
+      const imagesPromiseList: Promise<any>[] = [];
+      for (const i of IMAGE_LIST) {
+        imagesPromiseList.push(preloadImage(i));
+      }
+
+      await Promise.all(imagesPromiseList);
+
+      if (isCancelled) return;
+
+      setImagesPreloaded(true);
+    }
+
+    load();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  return { imagesPreloaded };
+}

--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -1,17 +1,13 @@
-import React, { createRef, useContext, useEffect } from "react";
+import React, { useContext, useEffect } from "react";
 import { Modal } from "react-bootstrap";
 import { useActor } from "@xstate/react";
 import { useTour } from "@reactour/tour";
 
 import { Hud } from "features/hud/Hud";
 import { Crops } from "features/crops/Crops";
-import { Blacksmith } from "features/blacksmith/Blacksmith";
-import { Mail } from "features/mail/Mail";
 import { Water } from "features/water/Water";
 import { Loading } from "features/auth/components";
 import { Animals } from "features/animals/Animals";
-import { WishingWell } from "features/wishingWell/WishingWell";
-import { Bakery } from "features/bakery/Bakery";
 
 import { useInterval } from "lib/utils/useInterval";
 
@@ -29,7 +25,6 @@ import { Withdrawing } from "./components/Withdrawing";
 import { Quarry } from "features/quarry/Quarry";
 import { TeamDonation } from "features/teamDonation/TeamDonation";
 import { Forest } from "features/forest/Forest";
-import { Bank } from "features/bank/Bank";
 
 import { StateValues } from "./lib/gameMachine";
 import { Town } from "features/town/Town";

--- a/src/features/game/actions/sync.ts
+++ b/src/features/game/actions/sync.ts
@@ -1,5 +1,6 @@
 import { metamask } from "lib/blockchain/metamask";
 import { CONFIG } from "lib/config";
+import { ERRORS } from "lib/errors";
 
 type Request = {
   sessionId: string;
@@ -35,13 +36,21 @@ type Options = {
 export async function sync({ farmId, sessionId, token }: Options) {
   if (!API_URL) return;
 
-  const transaction = await signTransaction({
-    farmId,
-    sessionId,
-    token,
-  });
+  try {
+    const transaction = await signTransaction({
+      farmId,
+      sessionId,
+      token,
+    });
 
-  const session = await metamask.getSessionManager().sync(transaction);
+    const session = await metamask.getSessionManager().sync(transaction);
 
-  return session;
+    return session;
+  } catch (error: any) {
+    if (error.code === 4001) {
+      throw new Error(ERRORS.REJECTED_TRANSACTION);
+    }
+
+    throw error;
+  }
 }

--- a/src/features/game/actions/withdraw.ts
+++ b/src/features/game/actions/withdraw.ts
@@ -1,5 +1,6 @@
 import { metamask } from "lib/blockchain/metamask";
 import { CONFIG } from "lib/config";
+import { ERRORS } from "lib/errors";
 
 type Request = {
   sessionId: string;
@@ -51,16 +52,24 @@ export async function withdraw({
 }: Options) {
   if (!API_URL) return;
 
-  const transaction = await signTransaction({
-    farmId,
-    sessionId,
-    sfl,
-    ids,
-    amounts,
-    token,
-  });
+  try {
+    const transaction = await signTransaction({
+      farmId,
+      sessionId,
+      sfl,
+      ids,
+      amounts,
+      token,
+    });
 
-  const session = await metamask.getSessionManager().withdraw(transaction);
+    const session = await metamask.getSessionManager().withdraw(transaction);
 
-  return session;
+    return session;
+  } catch (error: any) {
+    if (error.code === 4001) {
+      throw new Error(ERRORS.REJECTED_TRANSACTION);
+    }
+
+    throw error;
+  }
 }

--- a/src/features/game/components/GameError.tsx
+++ b/src/features/game/components/GameError.tsx
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import deathAnimation from "assets/npcs/human_death.gif";
 
 export const GameError: React.FC = () => {
+  useEffect(() => {
+    const body = document.querySelector("body");
+
+    if (body) {
+      body.style.pointerEvents = "none";
+    }
+  }, []);
+
   return (
-    <div className="flex flex-col items-center p-2">
+    <div id="gameerror" className="flex flex-col items-center p-2">
       <span className="text-shadow text-center">Something went wrong!</span>
       <img src={deathAnimation} className="w-1/2 -mt-4 ml-8" />
       <span className="text-shadow text-xs text-center">

--- a/src/features/game/components/Withdrawing.tsx
+++ b/src/features/game/components/Withdrawing.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
 export const Withdrawing: React.FC = () => {
-  return <span>Withdrawing</span>;
+  return <span className="loading">Withdrawing</span>;
 };

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -387,9 +387,16 @@ export function startGame(authContext: Options) {
               sessionId: (_, event) => event.data.sessionId,
             }),
           },
-          onError: {
-            target: "error",
-          },
+          onError: [
+            {
+              target: "playing",
+              cond: (_, event: any) =>
+                event.data.message === ERRORS.REJECTED_TRANSACTION,
+            },
+            {
+              target: "error",
+            },
+          ],
         },
       },
       readonly: {},

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -14,6 +14,7 @@ import { LimitedItem } from "../types/craftables";
 import { sync } from "../actions/sync";
 import { withdraw } from "../actions/withdraw";
 import { getVisitState } from "../actions/visit";
+import { ERRORS } from "lib/errors";
 
 export type PastAction = GameEvent & {
   createdAt: Date;
@@ -351,9 +352,16 @@ export function startGame(authContext: Options) {
               sessionId: (_, event) => event.data.sessionId,
             }),
           },
-          onError: {
-            target: "error",
-          },
+          onError: [
+            {
+              target: "playing",
+              cond: (_, event: any) =>
+                event.data.message === ERRORS.REJECTED_TRANSACTION,
+            },
+            {
+              target: "error",
+            },
+          ],
         },
       },
       withdrawing: {

--- a/src/features/hud/components/Menu.tsx
+++ b/src/features/hud/components/Menu.tsx
@@ -96,11 +96,11 @@ export const Menu = () => {
   const syncOnChain = async () => {
     if (!canSync(metamask.myAccount as string)) {
       setShowComingSoon(true);
-      setMenuOpen(false);
       return;
     }
 
     gameService.send("SYNC");
+    setMenuOpen(false);
   };
 
   const autosave = async () => {

--- a/src/features/teamDonation/TeamDonation.tsx
+++ b/src/features/teamDonation/TeamDonation.tsx
@@ -15,6 +15,7 @@ import upArrow from "assets/icons/arrow_up.png";
 import downArrow from "assets/icons/arrow_down.png";
 import token from "assets/icons/token.png";
 import humanDeath from "assets/npcs/human_death.gif";
+import { ERRORS } from "lib/errors";
 
 type DonateEvent = {
   type: "DONATE";
@@ -66,7 +67,16 @@ const teamDonationMachine = createMachine<Context, Event, State>({
           target: "donated",
           actions: assign({ hasDonated: (_context, _event) => true }),
         },
-        onError: "error",
+        onError: [
+          {
+            target: "idle",
+            cond: (_, event: any) =>
+              event.data.message === ERRORS.REJECTED_TRANSACTION,
+          },
+          {
+            target: "error",
+          },
+        ],
       },
     },
     donated: {

--- a/src/features/wishingWell/components/WishingWellModal.tsx
+++ b/src/features/wishingWell/components/WishingWellModal.tsx
@@ -30,23 +30,23 @@ export const WishingWellModal: React.FC<Props> = () => {
     }
 
     if (machine.matches("loading")) {
-      return <span>Loading...</span>;
+      return <span className="loading">Loading</span>;
     }
 
     if (machine.matches("withdrawing")) {
-      return <span>Withdrawing...</span>;
+      return <span className="loading">Withdrawing</span>;
     }
 
     if (machine.matches("depositing")) {
-      return <span>Throwing in tokens...</span>;
+      return <span className="loading">Throwing in tokens</span>;
     }
 
     if (machine.matches("searching")) {
-      return <span>Searching...</span>;
+      return <span className="loading">Searching</span>;
     }
 
     if (machine.matches("approving")) {
-      return <span>Approving...</span>;
+      return <span className="loading">Approving</span>;
     }
 
     if (machine.matches("throwing")) {

--- a/src/lib/blockchain/metamask.ts
+++ b/src/lib/blockchain/metamask.ts
@@ -247,12 +247,20 @@ export class Metamask {
     console.log({ donation: CONFIG.DONATION_ADDRESS });
     const gasPrice = await estimateGasPrice(this.web3 as Web3);
 
-    await this.web3?.eth.sendTransaction({
-      from: metamask.myAccount as string,
-      to: CONFIG.DONATION_ADDRESS as string,
-      value: toHex(toWei(donation.toString(), "ether")),
-      gasPrice,
-    });
+    try {
+      await this.web3?.eth.sendTransaction({
+        from: metamask.myAccount as string,
+        to: CONFIG.DONATION_ADDRESS as string,
+        value: toHex(toWei(donation.toString(), "ether")),
+        gasPrice,
+      });
+    } catch (error: any) {
+      if (error.code === 4001) {
+        throw new Error(ERRORS.REJECTED_TRANSACTION);
+      }
+
+      throw error;
+    }
   }
 
   public getFarm() {


### PR DESCRIPTION
# Description
This PR add a preload hook for our modal images/gifs. This prevents the case where the modal doesn't have the image when it first opens which looks janky and makes the modal jump once the image does load.

I have also set up some handling that allows the user to cancel a sync, team donation and withdraw transaction and continue playing the game rather than showing the `Something went wrong` modal forcing the user to refresh.

I have also block the ability for a user to continue clicking around (after deleting modal from the dom) if a fatal error has occurred.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Run the app and see the images loaded during the during the `readyToStart` state.
- Go to the menu and hit `Sync on chain`
- The syncing image should show in the modal immediately
- Reject the tx in metamask. You should be able to continue playing the game

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
