### PR TITLE
[FIX] Change position of Mining Tooltips

### DIFF
--- a/src/features/quarry/components/Gold.tsx
+++ b/src/features/quarry/components/Gold.tsx
@@ -156,7 +156,7 @@ export const Gold: React.FC<Props> = ({ rockIndex }) => {
         </div>
       )}
       <div
-        className={`absolute bottom-20 -right-[1rem] transition pointer-events-none w-28 ${
+        className={`absolute top-8 transition pointer-events-none w-28 ${
           showLabel ? "opacity-100" : "opacity-0"
         }`}
       >

--- a/src/features/quarry/components/Iron.tsx
+++ b/src/features/quarry/components/Iron.tsx
@@ -155,7 +155,7 @@ export const Iron: React.FC<Props> = ({ rockIndex }) => {
         </div>
       )}
       <div
-        className={`absolute bottom-20 -right-[1rem] transition pointer-events-none w-28 ${
+        className={`absolute top-5 transition pointer-events-none w-28 ${
           showLabel ? "opacity-100" : "opacity-0"
         }`}
       >

--- a/src/features/quarry/components/Stone.tsx
+++ b/src/features/quarry/components/Stone.tsx
@@ -155,7 +155,7 @@ export const Stone: React.FC<Props> = ({ rockIndex }) => {
         </div>
       )}
       <div
-        className={`absolute bottom-20 -right-[1rem] transition pointer-events-none w-28 ${
+        className={`absolute top-10 transition pointer-events-none w-28 ${
           showLabel ? "opacity-100" : "opacity-0"
         }`}
       >


### PR DESCRIPTION
# Description

Please PR changes the position of mining tooltips to be closer to the nodes (slightly above).

Fixes #342 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing
Steps:
1. Load the game
2. Do not select pickaxes in your shortcuts
3. Hover on stone, iron, and gold nodes -- Mining tooltips should be closer to the images

![mining-tooltip-gold](https://user-images.githubusercontent.com/89294757/156921912-227e0eb1-9d73-489b-b277-da5b1262b108.png)
![mining-tooltip-iron](https://user-images.githubusercontent.com/89294757/156921913-f6dc642b-3075-4535-b1e0-fca9fd9c30a3.png)
![mining-tooltip-stone](https://user-images.githubusercontent.com/89294757/156921914-76da6aef-218a-42fb-b289-cf1f94290b81.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
