### PR TITLE
[FIX]: Bug #343 ~IOS (Safari) Input & #341 ~Metamask Sign Overflow

### DIFF
--- a/src/lib/blockchain/metamask.ts
+++ b/src/lib/blockchain/metamask.ts
@@ -162,15 +162,10 @@ export class Metamask {
     address: string;
     nonce: number;
   }) {
-    const MESSAGE = [
-      "Welcome to Sunflower Land!",
-      "Click to sign in and accept the Sunflower Land Terms of Service: https://docs.sunflower-land.com/support/terms-of-service",
-      "This request will not trigger a blockchain transaction or cost any gas fees.",
-      "Your authentication status will reset after each session.",
-      `Wallet address: ${address}`,
-      `Nonce: ${nonce}`,
-    ].join("\n\n");
-
+    const MESSAGE = `🌻 Welcome to Sunflower Land! 🌻\n\nClick to sign in and accept the Sunflower Land\n📜 Terms of Service:\nhttps://docs.sunflower-land.com/support/terms-of-service\n\nThis request will not trigger a blockchain\ntransaction or cost any gas fees.\n\nYour authentication status will reset after\neach session.\n\n👛 Wallet address:\n${address.substring(
+      0,
+      19
+    )}...${address.substring(24)}\n\n🔑 Nonce: ${nonce}`;
     return MESSAGE;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -58,6 +58,9 @@ input[type="number"]::-webkit-inner-spin-button {
 
 input[type="number"] {
   -moz-appearance: textfield;
+  /* Enable user-select, for ios(Safari) compatibility */
+  -webkit-user-select: auto;
+  user-select: auto;
 }
 
 /*


### PR DESCRIPTION
## Fixes #343 & #341  😇 
- `#343` IOS (Safari) Input
   - this was css3 issue :)
   - added exclusion for `input` type `number` for:
   - `-webkit-user-select` & `user-select`
   - this will enable selection for `input` type `number`, only
   - **Effects:**
        - User selection is enabled for `input` type `number`, only

- `#341` Metamask Sign Overflow
   - use single string only with line breaks
   - optimized line breaks for default Metamask Window size
   - added some std emojies in message :)
   - line break for tos url is **not** added
      >ig we need to create `/tos` url :)

![fix-343-341](https://user-images.githubusercontent.com/55224033/156940943-3f650a0f-87f0-41e3-8504-31703bf4c604.png)


## Testing:
- `yarn test`
- Haven't tested input fix on real IOS device