### PR TITLE
[FEAT} Limit food crafting

### DIFF
--- a/src/features/bakery/components/Crafting.tsx
+++ b/src/features/bakery/components/Crafting.tsx
@@ -7,7 +7,7 @@ import { Panel } from "components/ui/Panel";
 import { Tab } from "components/ui/Tab";
 import { FOODS } from "features/game/types/craftables";
 
-import { CraftingItems } from "features/blacksmith/components/CraftingItems";
+import { CraftingItems } from "./CraftingItems";
 
 interface Props {
   onClose: () => void;
@@ -37,7 +37,7 @@ export const Crafting: React.FC<Props> = ({ onClose }) => {
           minHeight: "200px",
         }}
       >
-        {tab === "foods" && <CraftingItems items={FOODS} onClose={onClose} />}
+        {tab === "foods" && <CraftingItems items={FOODS} />}
       </div>
     </Panel>
   );

--- a/src/features/bakery/components/CraftingItems.tsx
+++ b/src/features/bakery/components/CraftingItems.tsx
@@ -1,0 +1,132 @@
+import React, { useContext, useState } from "react";
+import { useActor } from "@xstate/react";
+import classNames from "classnames";
+import Decimal from "decimal.js-light";
+
+import token from "assets/icons/token.gif";
+
+import { Box } from "components/ui/Box";
+import { OuterPanel } from "components/ui/Panel";
+import { Button } from "components/ui/Button";
+import { ToastContext } from "features/game/toast/ToastQueueProvider";
+import { Context } from "features/game/GameProvider";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { Craftable } from "features/game/types/craftables";
+import { InventoryItemName } from "features/game/types/game";
+
+interface Props {
+  items: Partial<Record<InventoryItemName, Craftable>>;
+}
+
+export const CraftingItems: React.FC<Props> = ({ items }) => {
+  const [selected, setSelected] = useState<Craftable>(Object.values(items)[0]);
+  const { setToast } = useContext(ToastContext);
+  const { gameService, shortcutItem } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
+  const inventory = state.inventory;
+
+  const lessIngredients = (amount = 1) =>
+    selected.ingredients.some((ingredient) =>
+      ingredient.amount.mul(amount).greaterThan(inventory[ingredient.item] || 0)
+    );
+  const lessFunds = (amount = 1) =>
+    state.balance.lessThan(selected.price.mul(amount));
+
+  const hasSelectedFood = Object.keys(inventory).includes(selected.name);
+  const canCraft = !(lessFunds() || lessIngredients());
+
+  const craft = (amount = 1) => {
+    gameService.send("item.crafted", {
+      item: selected.name,
+      amount,
+    });
+    setToast({ content: "SFL -$" + selected.price.mul(amount) });
+    selected.ingredients.map((ingredient, index) => {
+      setToast({
+        content:
+          "Item " + ingredient.item + " -" + ingredient.amount.mul(amount),
+      });
+    });
+
+    shortcutItem(selected.name);
+  };
+
+  return (
+    <div className="flex">
+      <div className="w-3/5 flex flex-wrap h-fit">
+        {Object.values(items).map((item) => (
+          <Box
+            isSelected={selected.name === item.name}
+            key={item.name}
+            onClick={() => setSelected(item)}
+            image={ITEM_DETAILS[item.name].image}
+            count={inventory[item.name]}
+          />
+        ))}
+      </div>
+      <OuterPanel className="flex-1 w-1/3">
+        <div className="flex flex-col justify-center items-center p-2 relative">
+          <span className="text-shadow text-center">{selected.name}</span>
+          <img
+            src={ITEM_DETAILS[selected.name].image}
+            className="h-16 img-highlight mt-1"
+            alt={selected.name}
+          />
+          <span className="text-shadow text-center mt-2 sm:text-sm">
+            {selected.description}
+          </span>
+
+          {!hasSelectedFood && 
+            <div className="border-t border-white w-full mt-2 pt-1">
+              {selected.ingredients.map((ingredient, index) => {
+                const item = ITEM_DETAILS[ingredient.item];
+                const lessIngredient = new Decimal(
+                  inventory[ingredient.item] || 0
+                ).lessThan(ingredient.amount);
+
+                return (
+                  <div className="flex justify-center items-end" key={index}>
+                    <img src={item.image} className="h-5 me-2" />
+                    <span
+                      className={classNames(
+                        "text-xs text-shadow text-center mt-2 ",
+                        {
+                          "text-red-500": lessIngredient,
+                        }
+                      )}
+                    >
+                      {ingredient.amount.toNumber()}
+                    </span>
+                  </div>
+                );
+              })}
+
+              <div className="flex justify-center items-end">
+                <img src={token} className="h-5 mr-1" />
+                <span
+                  className={classNames("text-xs text-shadow text-center mt-2 ", {
+                    "text-red-500": lessFunds(),
+                  })}
+                >
+                  {`$${selected.price.toNumber()}`}
+                </span>
+              </div>
+            </div>
+          }
+          <Button
+            disabled={hasSelectedFood ? false : !canCraft}
+            className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
+            onClick={() => craft()}
+          >
+            {hasSelectedFood ? "Already crafted" : "Craft"}
+          </Button>
+        </div>
+      </OuterPanel>
+    </div>
+  );
+};
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,6 +30,10 @@ body {
   font-size: 12px;
 }
 
+button:disabled {
+  cursor: not-allowed;
+}
+
 @media screen and (min-width: 480px) {
   body {
     font-size: 16px;


### PR DESCRIPTION
# Description

This PR imposes a one food item per account.

- removed stock counter as it will always be at 1 or 0

Closes #337 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- run locally
- check **Kitchen**

![image](https://user-images.githubusercontent.com/50954098/157233781-096a15fa-81ec-415d-8a83-7b56a33ac844.png)

![image](https://user-images.githubusercontent.com/50954098/157233871-f6f3a46a-5ef6-477f-8d8d-72dd111de1d8.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
