### PR TITLE
[FIX[ Visit Farm ID missing

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -155,6 +155,8 @@ export function startGame(authContext: Options) {
             if (authContext.address) {
               const game = await getVisitState(authContext.address as string);
 
+              game.id = authContext.farmId as number;
+
               return { state: game };
             }
 


### PR DESCRIPTION
# Description

This PR reverts the removed code that stores farm id when visiting.

Fixes #354 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing (testnet)
Steps:
1. Visit farm via url e.g. `?farmId=12`
2. Load the game -- Visit banner should display farm id 12
![visit farm id](https://user-images.githubusercontent.com/89294757/157257694-ae9cd39b-e320-41bd-9708-abcd68b551e4.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
