### PR TITLE
[FIX] Set overflow scroll class

### DIFF
--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -106,7 +106,8 @@ export const InventoryTabContent = ({
       </OuterPanel>
       <div
         ref={itemContainerRef}
-        className={classNames("h-96 overflow-y-scroll", {
+        className={classNames("h-96", {
+          "overflow-y-scroll": showScrollbar,
           scrollable: showScrollbar,
         })}
       >


### PR DESCRIPTION
# Description

This PR fixes default scroll display even if inventory items fit the given height. `overflow-y-scroll` now depends on `showScrollbar` property

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing w/ local farm state. Device specs are PC and brave browser (maximized)

Show scroll if exceeds height
![inventory-scroll-with](https://user-images.githubusercontent.com/89294757/158067481-4145421f-d823-49c4-bd42-49d217a6f73b.PNG)

Hide scroll if within height
![inventory-scroll-none](https://user-images.githubusercontent.com/89294757/158067492-1f3f3cd1-649e-4a6b-9627-6026a76ce0dc.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
