### PR TITLE
[FIX] - Inventory modal cutoff when screen height less than modal

### DIFF
--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -106,7 +106,8 @@ export const InventoryTabContent = ({
       </OuterPanel>
       <div
         ref={itemContainerRef}
-        className={classNames("h-96 overflow-y-scroll", {
+        style={{ maxHeight: TAB_CONTENT_HEIGHT }}
+        className={classNames("overflow-y-scroll", {
           scrollable: showScrollbar,
         })}
       >

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,11 @@ input[type="number"] {
   border: none;
 }
 
+/* If modal content overflows the screen height then allow the window to scroll */
+.modal-dialog-scrollable .modal-content {
+  overflow: initial;
+}
+
 .carousel-control-next,
 .carousel-control-prev {
   opacity: 1;


### PR DESCRIPTION
# Description

This PR fixes a bug where the inventory modal was cutoff and not scrollable if the height of the window was less than the modal. 


https://user-images.githubusercontent.com/17863697/158093339-9042bd9a-bf7b-4ec3-a9b6-035ec82f3f8e.mov


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
