### PR TITLE
[FIX] Resource refresh bug

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -15,6 +15,7 @@ import { sync } from "../actions/sync";
 import { withdraw } from "../actions/withdraw";
 import { getVisitState } from "../actions/visit";
 import { ERRORS } from "lib/errors";
+import { updateGame } from "./transforms";
 
 export type PastAction = GameEvent & {
   createdAt: Date;
@@ -242,16 +243,7 @@ export function startGame(authContext: Options) {
                     (action) =>
                       action.createdAt.getTime() > event.data.saveAt.getTime()
                   ),
-                  state: event.data.farm
-                    ? {
-                        ...context.state,
-                        // Update any random numbers from the server
-                        trees: event.data.farm.trees,
-                        stones: event.data.farm.stones,
-                        iron: event.data.farm.iron,
-                        gold: event.data.farm.gold,
-                      }
-                    : context.state,
+                  state: updateGame(event.data.farm, context.state),
                 })),
               },
             ],

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -66,6 +66,25 @@ export function makeGame(farm: any): GameState {
   };
 }
 
+type Rocks = Record<number, Rock>;
+
+/**
+ * Updates a rock with the new amount of mineral inside of it
+ */
+function updateRocks(oldRocks: Rocks, newRocks: Rocks): Rocks {
+  return Object.keys(oldRocks).reduce((rocks, rockId) => {
+    const id = Number(rockId);
+    const rock = oldRocks[id];
+    return {
+      ...rocks,
+      [id]: {
+        ...rock,
+        amount: newRocks[id].amount,
+      } as Rock,
+    };
+  }, {} as Record<number, Rock>);
+}
+
 /**
  * Merges in server side changes into the local state
  */
@@ -80,7 +99,7 @@ export function updateGame(
   // Only update random number values generated from the server
   return {
     ...oldGameState,
-    // Update any random numbers from the server
+    // Update tree with the random amount of wood from the server
     trees: Object.keys(oldGameState.trees).reduce((trees, treeId) => {
       const id = Number(treeId);
       const tree = oldGameState.trees[id];
@@ -92,38 +111,8 @@ export function updateGame(
         },
       };
     }, {} as Record<number, Tree>),
-    stones: Object.keys(oldGameState.stones).reduce((stones, treeId) => {
-      const id = Number(treeId);
-      const rock = oldGameState.stones[id];
-      return {
-        ...stones,
-        [id]: {
-          ...rock,
-          amount: newGameState.stones[id].amount,
-        } as Rock,
-      };
-    }, {} as Record<number, Rock>),
-    iron: Object.keys(oldGameState.iron).reduce((iron, treeId) => {
-      const id = Number(treeId);
-      const rock = oldGameState.iron[id];
-      return {
-        ...iron,
-        [id]: {
-          ...rock,
-          amount: newGameState.iron[id].amount,
-        } as Rock,
-      };
-    }, {} as Record<number, Rock>),
-    gold: Object.keys(oldGameState.gold).reduce((gold, treeId) => {
-      const id = Number(treeId);
-      const rock = oldGameState.gold[id];
-      return {
-        ...gold,
-        [id]: {
-          ...rock,
-          amount: newGameState.gold[id].amount,
-        } as Rock,
-      };
-    }, {} as Record<number, Rock>),
+    stones: updateRocks(oldGameState.stones, newGameState.stones),
+    iron: updateRocks(oldGameState.iron, newGameState.iron),
+    gold: updateRocks(oldGameState.gold, newGameState.gold),
   };
 }

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -65,3 +65,65 @@ export function makeGame(farm: any): GameState {
     id: farm.id,
   };
 }
+
+/**
+ * Merges in server side changes into the local state
+ */
+export function updateGame(
+  newGameState: GameState,
+  oldGameState: GameState
+): GameState {
+  if (!newGameState) {
+    return oldGameState;
+  }
+
+  // Only update random number values generated from the server
+  return {
+    ...oldGameState,
+    // Update any random numbers from the server
+    trees: Object.keys(oldGameState.trees).reduce((trees, treeId) => {
+      const id = Number(treeId);
+      const tree = oldGameState.trees[id];
+      return {
+        ...trees,
+        [id]: {
+          ...tree,
+          wood: newGameState.trees[id].wood,
+        },
+      };
+    }, {} as Record<number, Tree>),
+    stones: Object.keys(oldGameState.stones).reduce((stones, treeId) => {
+      const id = Number(treeId);
+      const rock = oldGameState.stones[id];
+      return {
+        ...stones,
+        [id]: {
+          ...rock,
+          amount: newGameState.stones[id].amount,
+        } as Rock,
+      };
+    }, {} as Record<number, Rock>),
+    iron: Object.keys(oldGameState.iron).reduce((iron, treeId) => {
+      const id = Number(treeId);
+      const rock = oldGameState.iron[id];
+      return {
+        ...iron,
+        [id]: {
+          ...rock,
+          amount: newGameState.iron[id].amount,
+        } as Rock,
+      };
+    }, {} as Record<number, Rock>),
+    gold: Object.keys(oldGameState.gold).reduce((gold, treeId) => {
+      const id = Number(treeId);
+      const rock = oldGameState.gold[id];
+      return {
+        ...gold,
+        [id]: {
+          ...rock,
+          amount: newGameState.gold[id].amount,
+        } as Rock,
+      };
+    }, {} as Record<number, Rock>),
+  };
+}


### PR DESCRIPTION
# Description

This PR fixes the issue that a resource would randomly reappear after being mined/chopped.

Fixes #361 

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Throttle your internet to make it slow. Click save and then begin chop a tree. By the time the game saves the tree should remain chopped
