### PR TITLE
[FEAT] Scroll to NFT in Map

### DIFF
--- a/src/features/animals/components/Chickens.tsx
+++ b/src/features/animals/components/Chickens.tsx
@@ -5,6 +5,7 @@ import coop from "assets/nfts/chicken_coop.png";
 
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
+import { Section } from "lib/utils/hooks/useScrollIntoView";
 
 export const Chickens: React.FC = () => {
   const { gameService, selectedItem } = useContext(Context);
@@ -24,6 +25,7 @@ export const Chickens: React.FC = () => {
             right: `${GRID_WIDTH_PX * 1.1}px`,
             top: `${GRID_WIDTH_PX * 0}px`,
           }}
+          id={Section["Chicken Coop"]}
           className="absolute"
         />
       )}

--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -18,6 +18,7 @@ import fountain from "assets/nfts/fountain.gif";
 
 import { GRID_WIDTH_PX } from "../lib/constants";
 import { Context } from "../GameProvider";
+import { Section } from "lib/utils/hooks/useScrollIntoView";
 
 export const Decorations: React.FC = () => {
   const { gameService, selectedItem } = useContext(Context);
@@ -36,6 +37,7 @@ export const Decorations: React.FC = () => {
             right: `${GRID_WIDTH_PX * 11.5}px`,
             top: `${GRID_WIDTH_PX * 22}px`,
           }}
+          id={Section["Sunflower Rock"]}
           className="absolute"
           src={sunflowerRock}
           alt="Sunflower rock"
@@ -49,6 +51,7 @@ export const Decorations: React.FC = () => {
             right: `${GRID_WIDTH_PX * 16}px`,
             top: `${GRID_WIDTH_PX * 1}px`,
           }}
+          id={Section["Christmas Tree"]}
           className="absolute"
           src={christmasTree}
           alt="Christmas Tree"
@@ -62,6 +65,7 @@ export const Decorations: React.FC = () => {
             left: `${GRID_WIDTH_PX * 45.5}px`,
             top: `${GRID_WIDTH_PX * 32}px`,
           }}
+          id={Section["Sunflower Statue"]}
           className="absolute"
           src={sunflowerStatue}
           alt="Sunflower Statue"
@@ -75,6 +79,7 @@ export const Decorations: React.FC = () => {
             left: `${GRID_WIDTH_PX * 52}px`,
             top: `${GRID_WIDTH_PX * 39}px`,
           }}
+          id={Section["Potato Statue"]}
           className="absolute"
           src={potatoStatue}
           alt="Potato Statue"
@@ -88,6 +93,7 @@ export const Decorations: React.FC = () => {
             left: `${GRID_WIDTH_PX * 30}px`,
             top: `${GRID_WIDTH_PX * 36.8}px`,
           }}
+          id={Section["Sunflower Tombstone"]}
           className="absolute"
           src={sunflowerTombstone}
           alt="Sunflower tombstone"
@@ -101,6 +107,7 @@ export const Decorations: React.FC = () => {
             right: `${GRID_WIDTH_PX * 39.28}px`,
             top: `${GRID_WIDTH_PX * 28.2}px`,
           }}
+          id={Section["Farm Cat"]}
           className="absolute"
           src={cat}
           alt="Farm cat"
@@ -114,6 +121,7 @@ export const Decorations: React.FC = () => {
             right: `${GRID_WIDTH_PX * 37.8}px`,
             top: `${GRID_WIDTH_PX * 32}px`,
           }}
+          id={Section["Farm Dog"]}
           className="absolute"
           src={dog}
           alt="Farm dog"
@@ -127,6 +135,7 @@ export const Decorations: React.FC = () => {
             right: "493px",
             top: "449px",
           }}
+          id={Section.Gnome}
           className="absolute"
           src={gnome}
           alt="Gnome"
@@ -140,6 +149,7 @@ export const Decorations: React.FC = () => {
             left: `${GRID_WIDTH_PX * 38.9}px`,
             top: `${GRID_WIDTH_PX * 34}px`,
           }}
+          id={Section.Scarecrow}
           className="absolute"
           src={scarecrow}
           alt="Scarecrow"
@@ -153,6 +163,7 @@ export const Decorations: React.FC = () => {
             left: `${GRID_WIDTH_PX * 36}px`,
             top: `${GRID_WIDTH_PX * 30}px`,
           }}
+          id={Section.Fountain}
           className="absolute"
           src={fountain}
           alt="Fountain"
@@ -166,6 +177,7 @@ export const Decorations: React.FC = () => {
             right: `${GRID_WIDTH_PX * 27.5}px`,
             bottom: `${GRID_WIDTH_PX * 5.5}px`,
           }}
+          id={Section["Goblin Crown"]}
           className="absolute"
           src={goblinKing}
           alt="GoblinKing"

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { SeedName, SEEDS } from "../types/crops";
 import { InventoryItemName } from "../types/game";
+import { Section } from "lib/utils/hooks/useScrollIntoView";
 
 export type CraftAction = {
   type: "item.crafted";
@@ -22,6 +23,7 @@ export type Craftable = {
   supply?: number;
   disabled?: boolean;
   requires?: InventoryItemName;
+  section?: Section;
 };
 
 export type LimitedItem =
@@ -198,6 +200,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     ],
     limit: 1,
     supply: 1000,
+    section: Section["Sunflower Statue"],
   },
   "Potato Statue": {
     name: "Potato Statue",
@@ -215,6 +218,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     ],
     limit: 1,
     supply: 5000,
+    section: Section["Potato Statue"],
   },
   Scarecrow: {
     name: "Scarecrow",
@@ -233,6 +237,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     limit: 1,
     supply: 5000,
     disabled: true,
+    section: Section.Scarecrow,
   },
   "Christmas Tree": {
     name: "Christmas Tree",
@@ -249,6 +254,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
       },
     ],
     supply: 0,
+    section: Section["Christmas Tree"],
   },
   "Chicken Coop": {
     name: "Chicken Coop",
@@ -270,6 +276,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     ],
     supply: 2000,
     limit: 1,
+    section: Section["Chicken Coop"],
   },
   "Farm Cat": {
     name: "Farm Cat",
@@ -277,6 +284,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     price: new Decimal(50),
     ingredients: [],
     supply: 0,
+    section: Section["Farm Cat"],
   },
   "Farm Dog": {
     name: "Farm Dog",
@@ -284,6 +292,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     price: new Decimal(75),
     ingredients: [],
     supply: 0,
+    section: Section["Farm Dog"],
   },
   Gnome: {
     name: "Gnome",
@@ -291,6 +300,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     price: new Decimal(10),
     ingredients: [],
     supply: 0,
+    section: Section.Gnome,
   },
   "Gold Egg": {
     name: "Gold Egg",
@@ -314,6 +324,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     price: new Decimal(0),
     ingredients: [],
     supply: 0,
+    section: Section["Sunflower Tombstone"],
   },
   "Golden Cauliflower": {
     name: "Golden Cauliflower",
@@ -346,6 +357,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
       },
     ],
     supply: 150,
+    section: Section["Sunflower Rock"],
   },
   "Goblin Crown": {
     name: "Goblin Crown",
@@ -353,6 +365,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
     price: new Decimal(5),
     ingredients: [],
     supply: 5000,
+    section: Section["Goblin Crown"],
   },
   Fountain: {
     name: "Fountain",
@@ -365,6 +378,7 @@ export const LimitedItems: Record<LimitedItem, Craftable> = {
       },
     ],
     supply: 10000,
+    section: Section.Fountain,
   },
   Beaver: {
     name: "Beaver",

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -63,11 +63,13 @@ import { InventoryItemName } from "./game";
 import { FOODS, LimitedItems, TOOLS } from "./craftables";
 import { CROPS, SEEDS } from "./crops";
 import { RESOURCES } from "./resources";
+import { Section } from "lib/utils/hooks/useScrollIntoView";
 
 export type ItemDetails = {
   description: string;
   image: any;
   secondaryImage?: any;
+  section?: Section;
 };
 
 type Items = Record<InventoryItemName, ItemDetails>;

--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -76,9 +76,11 @@ export const InventoryTabContent = ({
   const getCropHarvestTime = (crop = "") =>
     secondsToString(CROPS()[crop.split(" ")[0] as CropName].harvestSeconds);
 
-  const handleImageClick = () => {
-    if (selectedItem && ITEM_DETAILS[selectedItem].section) {
-      scrollIntoView(ITEM_DETAILS[selectedItem].section);
+  const handleItemClick = (item: InventoryItemName) => {
+    onClick(item);
+
+    if (item && ITEM_DETAILS[item].section) {
+      scrollIntoView(ITEM_DETAILS[item].section);
     }
   };
 
@@ -90,15 +92,7 @@ export const InventoryTabContent = ({
             style={{ minHeight: ITEM_CARD_MIN_HEIGHT }}
             className="flex flex-col justify-evenly items-center p-2"
           >
-            <span
-              className={classNames("text-center text-shadow", {
-                underline: !!ITEM_DETAILS[selectedItem].section,
-                "cursor-pointer": !!ITEM_DETAILS[selectedItem].section,
-              })}
-              onClick={() => handleImageClick()}
-            >
-              {selectedItem}
-            </span>
+            <span className="text-center text-shadow">{selectedItem}</span>
             <img
               src={ITEM_DETAILS[selectedItem].image}
               className="h-12"
@@ -137,9 +131,7 @@ export const InventoryTabContent = ({
                     count={inventory[item]}
                     isSelected={selectedItem === item}
                     key={item}
-                    onClick={() => {
-                      onClick(item);
-                    }}
+                    onClick={() => handleItemClick(item)}
                     image={ITEM_DETAILS[item].image}
                   />
                 ))}

--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -11,6 +11,7 @@ import timer from "assets/icons/timer.png";
 import { secondsToString } from "lib/utils/time";
 import classNames from "classnames";
 import { useShowScrollbar } from "lib/utils/hooks/useShowScrollbar";
+import { useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { Inventory, TabItems } from "./InventoryItems";
 
 const ITEM_CARD_MIN_HEIGHT = "148px";
@@ -38,6 +39,7 @@ export const InventoryTabContent = ({
 }: Props) => {
   const { ref: itemContainerRef, showScrollbar } =
     useShowScrollbar(TAB_CONTENT_HEIGHT);
+  const [scrollIntoView] = useScrollIntoView();
   const categories = Object.keys(tabItems) as InventoryItemName[];
 
   useEffect(() => {
@@ -74,6 +76,12 @@ export const InventoryTabContent = ({
   const getCropHarvestTime = (crop = "") =>
     secondsToString(CROPS()[crop.split(" ")[0] as CropName].harvestSeconds);
 
+  const handleImageClick = () => {
+    if (selectedItem && ITEM_DETAILS[selectedItem].section) {
+      scrollIntoView(ITEM_DETAILS[selectedItem].section);
+    }
+  };
+
   return (
     <div className="flex flex-col">
       <OuterPanel className="flex-1 mb-3">
@@ -82,7 +90,15 @@ export const InventoryTabContent = ({
             style={{ minHeight: ITEM_CARD_MIN_HEIGHT }}
             className="flex flex-col justify-evenly items-center p-2"
           >
-            <span className="text-center text-shadow">{selectedItem}</span>
+            <span
+              className={classNames("text-center text-shadow", {
+                underline: !!ITEM_DETAILS[selectedItem].section,
+                "cursor-pointer": !!ITEM_DETAILS[selectedItem].section,
+              })}
+              onClick={() => handleImageClick()}
+            >
+              {selectedItem}
+            </span>
             <img
               src={ITEM_DETAILS[selectedItem].image}
               className="h-12"

--- a/src/lib/utils/hooks/useScrollIntoView.ts
+++ b/src/lib/utils/hooks/useScrollIntoView.ts
@@ -4,10 +4,26 @@ export enum Section {
   Animals = "animals",
   Shop = "shop",
   Town = "town",
+
+  // NFT IDs
+  "Sunflower Statue" = "sunflower-statue",
+  "Potato Statue" = "potato-statue",
+  "Christmas Tree" = "christmas-tree",
+  Scarecrow = "scarecrow",
+  "Farm Cat" = "farm-cat",
+  "Farm Dog" = "farm-dog",
+  Gnome = "gnome",
+  "Chicken Coop" = "chicken-coop",
+  "Sunflower Tombstone" = "sunflower-tombstone",
+  "Sunflower Rock" = "sunflower-rock",
+  "Goblin Crown" = "goblin-crown",
+  Fountain = "fountain",
 }
 
 export const useScrollIntoView = () => {
-  const scrollIntoView = (id: Section) => {
+  const scrollIntoView = (id: Section | undefined) => {
+    if (!id) return;
+
     const el = document.getElementById(id);
 
     el?.scrollIntoView({


### PR DESCRIPTION
# Description

This PR implements scrolling to the NFT when clicked from Inventory modal. It uses the existing `scrollIntoView()` to navigate in background. If the NFT is viewable in the map, its name is underlined and can be clicked. It is subtle but it will not disrupt the layout as opposed to having a dynamically rendered button on the side.

Like @spencerdezartsmith also suggested, the modal is still open to not break the flow of viewing items. We can change this easily if most people would want the modal to close immediately.

Fixes #363 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing with edited `INITIAL_FARM.inventory` to perform actions.

Feature on PC

https://user-images.githubusercontent.com/89294757/158372164-a4f103e4-a0bd-4056-9de9-de462a62764d.mp4

Feature on Mobile-sized screens

https://user-images.githubusercontent.com/89294757/158372209-2a32eb5c-d75b-40a4-987f-9cff9931a32d.mp4

If an NFT is not rendered on the map e.g. Golden Cauliflower, the title looks normal
![scroll-none](https://user-images.githubusercontent.com/89294757/158372305-d31d3597-e0e7-482d-8e19-dd1d184459a2.PNG)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
