### PR TITLE
[FIX] Manure Misspelling

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -447,7 +447,7 @@ export const ANIMALS: Record<Animal, Craftable> = {
   },
   Pig: {
     name: "Pig",
-    description: "Produces maneure. Requires wheat for feeding",
+    description: "Produces manure. Requires wheat for feeding",
     price: new Decimal(20),
     ingredients: [],
     disabled: true,


### PR DESCRIPTION
# Description
- Fix misspelling for `manure`

Fixes #issue (raised in discord chat)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
<img width="407" alt="Screen Shot 2022-03-19 at 10 11 10 PM" src="https://user-images.githubusercontent.com/18549210/159124497-7a541517-f194-4445-a052-e8d283f601e3.png">
`yarn dev`
<img width="493" alt="Screen Shot 2022-03-19 at 10 12 37 PM" src="https://user-images.githubusercontent.com/18549210/159124559-df501915-2e28-423e-a2eb-2bf9674d27ec.png">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
