### PR TITLE
[FIX] Sell All Modal UI Spacing

### DIFF
--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -113,22 +113,27 @@ export const Plants: React.FC = () => {
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>
-        <Panel>
-          <span className="text-sm text-shadow">
-            Are you sure you want to sell all your
-            {` (${cropAmount.toNumber()}) ${selected.name}`}?
-          </span>
-          <div className="flex">
+        <Panel className="md:w-4/5 m-auto">
+          <div className="m-auto flex flex-col">
+            <span className="text-sm text-center text-shadow">
+              Are you sure you want to <br className="hidden md:block" />
+              sell all your {selected.name}?
+            </span>
+            <span className="text-sm text-center text-shadow mt-1">
+              Total: {cropAmount.toNumber()}
+            </span>
+          </div>
+          <div className="flex justify-content-around p-1">
             <Button
               disabled={noCrop}
-              className="text-xs mt-1 whitespace-nowrap"
+              className="text-xs"
               onClick={() => handleSellAll()}
             >
               Yes
             </Button>
             <Button
               disabled={noCrop}
-              className="text-xs mt-1 whitespace-nowrap"
+              className="text-xs ml-2"
               onClick={closeConfirmationModal}
             >
               No


### PR DESCRIPTION
# Description
- fixes alignment of texts and buttons on "Sell All" modal
- minimized width of the modal in wide devices 

Fixes #issue (suggested on discord chat)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
<img width="403" alt="Screen Shot 2022-03-20 at 1 00 37 PM" src="https://user-images.githubusercontent.com/18549210/159148923-27a5ea3c-80e5-4a65-93b2-39afb0e55722.png">

`yarn dev`
## Desktop:
<img width="497" alt="Screen Shot 2022-03-20 at 12 44 56 PM" src="https://user-images.githubusercontent.com/18549210/159148947-a4b56573-2d52-4d10-b973-e269d43295fc.png">

## Mobile:
<img width="392" alt="Screen Shot 2022-03-20 at 12 44 41 PM" src="https://user-images.githubusercontent.com/18549210/159148938-17945f4f-404a-4435-8ee3-857107df4c08.png">

## Mobile: (smaller)
<img width="373" alt="Screen Shot 2022-03-20 at 1 02 39 PM" src="https://user-images.githubusercontent.com/18549210/159148958-0e4340c8-0e35-4598-a00b-3202913fe460.png">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
