### PR TITLE
[FIX] Inventory scrollbar in Windows

### DIFF
--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -117,7 +117,7 @@ export const InventoryTabContent = ({
       <div
         ref={itemContainerRef}
         style={{ maxHeight: TAB_CONTENT_HEIGHT }}
-        className={classNames("overflow-y-scroll", {
+        className={classNames("overflow-y-auto", {
           scrollable: showScrollbar,
         })}
       >


### PR DESCRIPTION
# Description

This PR fixes the always visible scrollbar observed in Windows devices by using `overflow-y-auto` instead.

![sfl-scrollbar-windows-before](https://user-images.githubusercontent.com/89294757/159150533-8a2134bb-afb3-42aa-be98-d11082064d5a.PNG)

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing on PC
Specs:
OS - Windows 10
Browser - Brave

![sfl-scrollbar-windows-after](https://user-images.githubusercontent.com/89294757/159150526-97bb3edb-d546-459e-bd0f-3d1f9a67f5c5.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
