### PR TITLE
[FIX] Only show onboarding modal to newly created farms

### DIFF
--- a/src/features/hud/components/Menu.tsx
+++ b/src/features/hud/components/Menu.tsx
@@ -45,7 +45,9 @@ export const Menu = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [scrollIntoView] = useScrollIntoView();
 
-  const [showHowToPlay, setShowHowToPlay] = React.useState(isNewFarm());
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [showComingSoon, setShowComingSoon] = useState(false);
+  const [showHowToPlay, setShowHowToPlay] = useState(isNewFarm());
   const [farmURL, setFarmURL] = useState("");
   const [menuLevel, setMenuLevel] = useState(MENU_LEVELS.ROOT);
 

--- a/src/features/hud/components/Menu.tsx
+++ b/src/features/hud/components/Menu.tsx
@@ -20,7 +20,7 @@ import water from "assets/icons/expression_working.png";
 import timer from "assets/icons/timer.png";
 import wood from "assets/resources/wood.png";
 
-import { hasOnboarded } from "../lib/onboarding";
+import { isNewFarm } from "../lib/onboarding";
 
 export const Menu = () => {
   const { authService } = useContext(Auth.Context);
@@ -33,7 +33,7 @@ export const Menu = () => {
 
   const [showShareModal, setShowShareModal] = React.useState(false);
   const [showComingSoon, setShowComingSoon] = React.useState(false);
-  const [showHowToPlay, setShowHowToPlay] = React.useState(!hasOnboarded());
+  const [showHowToPlay, setShowHowToPlay] = React.useState(isNewFarm());
 
   // farm link (URL)
   const farmURL = authState.context.farmId

--- a/src/features/hud/components/howToPlay/HowToPlay.tsx
+++ b/src/features/hud/components/howToPlay/HowToPlay.tsx
@@ -10,8 +10,8 @@ import close from "assets/icons/close.png";
 import { HowToFarm } from "./HowToFarm";
 import { HowToUpgrade } from "./HowToUpgrade";
 import { HowToSync } from "./HowToSync";
-import { finishOnboarding, hasOnboarded } from "features/hud/lib/onboarding";
 import { LetsGo } from "./LetsGo";
+import { isNewFarm } from "features/hud/lib/onboarding";
 
 enum Steps {
   HowToFarm = 1,
@@ -38,10 +38,9 @@ export const HowToPlay: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const finish = () => {
     onClose();
-    finishOnboarding();
   };
 
-  const canClose = hasOnboarded();
+  const canClose = !isNewFarm();
 
   return (
     <Modal show={isOpen} onHide={canClose ? onClose : undefined} centered>

--- a/src/features/hud/lib/onboarding.ts
+++ b/src/features/hud/lib/onboarding.ts
@@ -1,9 +1,14 @@
-const LOCAL_STORAGE_KEY = "onboarded_at";
+import { useActor } from "@xstate/react";
+import { Context } from "features/auth/lib/Provider";
+import { useContext } from "react";
 
-export function hasOnboarded() {
-  return !!localStorage.getItem(LOCAL_STORAGE_KEY);
-}
+export function isNewFarm() {
+  const { authService } = useContext(Context);
+  const [{ history }] = useActor(authService);
 
-export function finishOnboarding() {
-  localStorage.setItem(LOCAL_STORAGE_KEY, new Date().toISOString());
+  if (history?.event.type === "CREATE_FARM") {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
# Description

- This PR fixes the bug where even old farms can see the tutorial modal. It shows the modal based on the prev auth event


### Reported from discord:
![image](https://user-images.githubusercontent.com/50954098/159152019-7d2a8418-a253-41aa-9d31-db5d49593136.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Old farm**

https://user-images.githubusercontent.com/50954098/159152120-39eb5af5-7f4c-408b-a67f-8c598d471c21.mp4

**New farm** - shows tutorial modal after creating farm.

https://user-images.githubusercontent.com/50954098/159152123-4a96bcd2-8338-4602-a9d7-14289d50cf16.mp4

**When visiting a farm**

https://user-images.githubusercontent.com/50954098/159152124-798990c6-2ee6-4c0b-9652-113deedb3686.mp4



# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
