### PR TITLE
[CHORE] Add note sync for minting flags

### DIFF
--- a/src/features/tailor/components/TailorSale.tsx
+++ b/src/features/tailor/components/TailorSale.tsx
@@ -38,7 +38,7 @@ export const TailorSale: React.FC<Props> = ({ onClose }) => {
         }}
       >
         <Rare items={FLAGS} onClose={onClose} hasAccess={true} />
-        <span className="text-xs p-2 underline">Max 2 flags per farm</span>
+        <p className="text-xxs p-1 m-1 underline text-center">Max 2 flags per farm. Crafting flags will sync your farm to the blockchain.</p>
       </div>
     </Panel>
   );


### PR DESCRIPTION
# Description
- Adds sync message note indicating that minting a flag would also result to a sync.

Fixes #issue
- Not many people know that minting flags would trigger sync, could be a missed opportunity for the seed stocks

## Type of change
- [x] Chore (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
<img width="404" alt="Screen Shot 2022-03-23 at 2 36 47 AM" src="https://user-images.githubusercontent.com/18549210/159552104-e50ed1fc-99db-4a35-9034-392c6478f4d7.png">

`yarn dev`
<img width="404" alt="Screen Shot 2022-03-23 at 2 36 47 AM" src="https://media.discordapp.net/attachments/908870536652816417/955895667786674216/Screen_Shot_2022-03-23_at_2.27.48_AM.png">


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
