### PR TITLE
[FEAT] Add seconds to displaying plant time

### DIFF
--- a/src/features/bank/Bank.tsx
+++ b/src/features/bank/Bank.tsx
@@ -45,12 +45,7 @@ export const Bank: React.FC = () => {
           "hover:img-highlight": isNotReadOnly,
         })}
       >
-        <img
-          src={bank}
-          alt="bank"
-          onClick={openBank}
-          className="w-full"
-        />
+        <img src={bank} alt="bank" onClick={openBank} className="w-full" />
         {isNotReadOnly && (
           <Action
             className="absolute -bottom-6 left-2"

--- a/src/features/tailor/components/TailorSale.tsx
+++ b/src/features/tailor/components/TailorSale.tsx
@@ -38,7 +38,10 @@ export const TailorSale: React.FC<Props> = ({ onClose }) => {
         }}
       >
         <Rare items={FLAGS} onClose={onClose} hasAccess={true} />
-        <p className="text-xxs p-1 m-1 underline text-center">Max 2 flags per farm. Crafting flags will sync your farm to the blockchain.</p>
+        <p className="text-xxs p-1 m-1 underline text-center">
+          Max 2 flags per farm. Crafting flags will sync your farm to the
+          blockchain.
+        </p>
       </div>
     </Panel>
   );

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -1,6 +1,12 @@
 export function secondsToString(seconds: number) {
-  if (seconds <= 60) {
-    return "1min";
+  const secondsCeil = Math.ceil(seconds % 60);
+
+  if (secondsCeil < 60) {
+    return `${secondsCeil}sec`;
+  }
+
+  if (secondsCeil === 60) {
+    return `1min`;
   }
 
   // Less than 1 hour


### PR DESCRIPTION
# Description
- changes the default `1 min` to display seconds
- minor formatting `yarn format`

Fixes #issue

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`yarn test`
<img width="402" alt="Screen Shot 2022-03-24 at 12 08 12 AM" src="https://user-images.githubusercontent.com/18549210/159744364-45177a2a-a8a8-4496-a994-0bba4e6d9003.png">
`yarn dev`

https://user-images.githubusercontent.com/18549210/159744457-5dfe8afe-10cc-45c6-99ca-82a17d9b4368.mov


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
