### PR TITLE
[FIX] Remove "Item" on Popup when crafting

### DIFF
--- a/src/features/bakery/components/CraftingItems.tsx
+++ b/src/features/bakery/components/CraftingItems.tsx
@@ -47,8 +47,7 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
     setToast({ content: "SFL -$" + selected.price.mul(amount) });
     selected.ingredients.map((ingredient, index) => {
       setToast({
-        content:
-          ingredient.item + " -" + ingredient.amount.mul(amount),
+        content: ingredient.item + " -" + ingredient.amount.mul(amount),
       });
     });
 

--- a/src/features/bakery/components/CraftingItems.tsx
+++ b/src/features/bakery/components/CraftingItems.tsx
@@ -48,7 +48,7 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
     selected.ingredients.map((ingredient, index) => {
       setToast({
         content:
-          "Item " + ingredient.item + " -" + ingredient.amount.mul(amount),
+          ingredient.item + " -" + ingredient.amount.mul(amount),
       });
     });
 

--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -52,7 +52,7 @@ export const CraftingItems: React.FC<Props> = ({
     selected.ingredients.map((ingredient, index) => {
       setToast({
         content:
-          "Item " + ingredient.item + " -" + ingredient.amount.mul(amount),
+          ingredient.item + " -" + ingredient.amount.mul(amount),
       });
     });
 

--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -51,8 +51,7 @@ export const CraftingItems: React.FC<Props> = ({
     setToast({ content: "SFL -$" + selected.price.mul(amount) });
     selected.ingredients.map((ingredient, index) => {
       setToast({
-        content:
-          ingredient.item + " -" + ingredient.amount.mul(amount),
+        content: ingredient.item + " -" + ingredient.amount.mul(amount),
       });
     });
 


### PR DESCRIPTION
# Description
- Removes word "Item" on popup

Fixes #issue raised by @ ChickenCX on discord
<img width="632" alt="Screen Shot 2022-03-25 at 5 16 03 AM" src="https://user-images.githubusercontent.com/18549210/160011891-f0a86a79-1c0e-457b-8eda-0dd55d8e201a.png">


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
<img width="414" alt="Screen Shot 2022-03-25 at 5 05 03 AM" src="https://user-images.githubusercontent.com/18549210/160012061-a230d032-ec4a-4d7b-85a7-42b1e4360063.png">

`yarn dev`
<img width="192" alt="Screen Shot 2022-03-25 at 5 14 07 AM" src="https://user-images.githubusercontent.com/18549210/160012077-2e21ec12-e1bf-441b-8990-c3dca8c2f58f.png">

Instructions to replicate:
1. Craft a pickaxe. (Check popup)
2. Craft food. (Check popup)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
