### PR TITLE
[FIX] Get Messages on Modal Open

### DIFF
--- a/src/features/mail/Mail.tsx
+++ b/src/features/mail/Mail.tsx
@@ -5,39 +5,38 @@ import { Inbox } from "./components/Inbox";
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
 
 import { Message } from "./types/message";
-import { cleanupCache, getInbox, getReadMessages, updateCache } from "./lib/mail";
+import {
+  cleanupCache,
+  getInbox,
+  getReadMessages,
+  updateCache,
+} from "./lib/mail";
 
 import baldMan from "assets/npcs/bald_man.png";
 import alerted from "assets/icons/expression_alerted.png";
 
 export const Mail: React.FC = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [inbox, setInbox] = useState<Message[]>([]);
   const [hasUnread, setHasUnread] = useState<boolean>(false);
 
-  useEffect(() => {
+  const getMessages = async () => {
+    setIsLoading(true);
+
     const readMessages = getReadMessages();
 
-    const initialize = async () => {
-      let _inbox: any = await getInbox();
+    let _inbox: any = await getInbox();
 
-      _inbox = _inbox.map((msg: Message) => ({
-        ...msg,
-        unread: !readMessages?.includes(msg.id),
-      }));
+    _inbox = _inbox.map((msg: Message) => ({
+      ...msg,
+      unread: !readMessages?.includes(msg.id),
+    }));
 
-      setInbox(_inbox);
-      cleanupCache(_inbox);
-    };
-
-    initialize();
-  }, []);
-
-  useEffect(() => {
-    const _hasUnread = inbox.some((msg) => msg.unread);
-
-    setHasUnread(_hasUnread);
-  }, [inbox]);
+    setInbox(_inbox);
+    cleanupCache(_inbox);
+    setIsLoading(false);
+  };
 
   const onRead = (index: number) => {
     if (!inbox[index].unread) return;
@@ -49,6 +48,23 @@ export const Mail: React.FC = () => {
 
     updateCache(newInbox[index].id);
   };
+
+  useEffect(() => {
+    getMessages();
+  }, []);
+
+  // refresh data
+  useEffect(() => {
+    if (isOpen) {
+      getMessages();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const _hasUnread = inbox.some((msg) => msg.unread);
+
+    setHasUnread(_hasUnread);
+  }, [inbox]);
 
   return (
     <div
@@ -68,7 +84,7 @@ export const Mail: React.FC = () => {
       />
       <span className="npc-shadow" />
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
-        <Inbox inbox={inbox} onRead={onRead} />
+        <Inbox inbox={inbox} isLoading={isLoading} onRead={onRead} />
       </Modal>
     </div>
   );

--- a/src/features/mail/components/Inbox.tsx
+++ b/src/features/mail/components/Inbox.tsx
@@ -9,13 +9,16 @@ import alerted from "assets/icons/expression_alerted.png";
 
 interface Props {
   inbox: Message[];
+  isLoading: boolean;
   onRead: (index: number) => void;
 }
 
-export const Inbox: React.FC<Props> = ({ inbox, onRead }) => {
+export const Inbox: React.FC<Props> = ({ inbox, isLoading, onRead }) => {
   return (
     <OuterPanel className="relative">
-      {inbox.length ? (
+      {isLoading ? (
+        <InnerPanel>Loading...</InnerPanel>
+      ) : inbox.length ? (
         <Accordion>
           {inbox.map(({ title, body, unread }, index) => (
             <Accordion.Item
@@ -41,7 +44,7 @@ export const Inbox: React.FC<Props> = ({ inbox, onRead }) => {
           ))}
         </Accordion>
       ) : (
-        <span>No messages</span>
+        <InnerPanel>No messages</InnerPanel>
       )}
     </OuterPanel>
   );

--- a/src/features/mail/lib/mail.ts
+++ b/src/features/mail/lib/mail.ts
@@ -43,7 +43,7 @@ export async function getInbox() {
       title: "SFL Supply",
       body: `Total SFL: ${sflBalance.toDecimalPlaces(3, Decimal.ROUND_DOWN)}  
         &nbsp;  
-        Note: this value is read from the Blockchain. Farmers may not have synced yet.
+        Note: this value is read from the Blockchain. Other farmers may not have synced yet.
       `,
     },
     {


### PR DESCRIPTION
# Description

This PR implements getting data once the modal is open. To test loading display, i added buffer in `getInbox()`.

```js
export async function getInbox() {
  // for testing
  await new Promise((res) => setTimeout(res, 1000));

  const sflBalance = await getSFLSupply();

  return [ ... ];
}
```

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing - Testnet. with added timeout to delay return value

https://user-images.githubusercontent.com/89294757/160225920-04283651-2132-4c94-9afb-acbe2c618754.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
