### PR TITLE
[Fix] Update Selling Price With Skills

### DIFF
--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -41,7 +41,7 @@ export const Plants: React.FC = () => {
      }
       else
      {
-      setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
+       setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
     }
   };
 

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -29,20 +29,17 @@ export const Plants: React.FC = () => {
 
   const inventory = state.inventory;
 
+
+
   const sell = (amount = 1) => {
     gameService.send("item.sell", {
       item: selected.name,
       amount,
     })
-      
-    if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) 
-     {
-       setToast({ content: "SFL +$" + selected.sellPrice.mul(1.05*amount).toString() });
-     }
-      else
-     {
-       setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
-    }
+      {
+        setToast({ content: "SFL +$" +   displaySellPrice(selected).mul(cropAmount).toString() });
+      }
+
   };
 
   const cropAmount = new Decimal(inventory[selected.name] || 0);

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -33,8 +33,16 @@ export const Plants: React.FC = () => {
     gameService.send("item.sell", {
       item: selected.name,
       amount,
-    });
-    setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
+    })
+      
+    if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) 
+     {
+       setToast({ content: "SFL +$" + selected.sellPrice.mul(1.05*amount).toString() });
+     }
+      else
+     {
+      setToast({ content: "SFL +$" + selected.sellPrice.mul(amount).toString() });
+    }
   };
 
   const cropAmount = new Decimal(inventory[selected.name] || 0);

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -36,10 +36,7 @@ export const Plants: React.FC = () => {
       item: selected.name,
       amount,
     })
-      {
         setToast({ content: "SFL +$" +   displaySellPrice(selected).mul(cropAmount).toString() });
-      }
-
   };
 
   const cropAmount = new Decimal(inventory[selected.name] || 0);

--- a/src/features/game/lib/pricing.ts
+++ b/src/features/game/lib/pricing.ts
@@ -8,7 +8,7 @@ export const getSellPrice = (crop: Crop, inventory: Inventory) => {
   let price = crop.sellPrice;
 
   if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
-    price = price.mul(1.1);
+    price = price.mul(1.05);
   }
 
   return price;

--- a/src/features/game/lib/pricing.ts
+++ b/src/features/game/lib/pricing.ts
@@ -7,7 +7,7 @@ import { Crop } from "../types/crops";
 export const getSellPrice = (crop: Crop, inventory: Inventory) => {
   let price = crop.sellPrice;
 
-  if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
+  if (inventory["Sunflower Seed"]?.greaterThanOrEqualTo(1)) {
     price = price.mul(1.05);
   }
 

--- a/src/features/game/lib/pricing.ts
+++ b/src/features/game/lib/pricing.ts
@@ -7,7 +7,7 @@ import { Crop } from "../types/crops";
 export const getSellPrice = (crop: Crop, inventory: Inventory) => {
   let price = crop.sellPrice;
 
-  if (inventory["Sunflower Seed"]?.greaterThanOrEqualTo(1)) {
+  if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
     price = price.mul(1.05);
   }
 


### PR DESCRIPTION
# Description

The green thumb effect was giving 10%price increase instead of 5% stated in the game, also tried fixing the popup modul of selling when you have the skill, you will still get the updated amount but the pop over still showed the old value of before the skill


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Yarn dev
![Yarn dev Sunflower with skill](https://user-images.githubusercontent.com/98262339/160649850-67c63088-875d-4272-8d64-1102a754ef1c.P
![Yarn dev sunflower](https://user-images.githubusercontent.com/98262339/160649866-718ada70-6b3b-43f2-b208-8ac74ffb3f33.PNG)
NG)

Yarn test 
![Yarn test Skill](https://user-images.githubusercontent.com/98262339/160648855-0b621e61-3fb3-4c10-a986-a13b38a34d94.PNG)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

