### PR TITLE
[FIX] Remove craft button after crafting 2 flags

### DIFF
--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -17,6 +17,7 @@ import { metamask } from "lib/blockchain/metamask";
 import { ItemSupply } from "lib/blockchain/Inventory";
 import { useShowScrollbar } from "lib/utils/hooks/useShowScrollbar";
 import { KNOWN_IDS } from "features/game/types";
+import { FLAGS } from "features/game/types/flags";
 
 const TAB_CONTENT_HEIGHT = 360;
 
@@ -110,6 +111,10 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
 
   const soldOut = amountLeft <= 0;
 
+  const maxFlags = Object.values(FLAGS).filter(
+    (flag) => flag.name in items && flag.name in state.inventory
+  ).length === 2;
+
   const Action = () => {
     if (soldOut) {
       return null;
@@ -136,6 +141,8 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
         </div>
       );
     }
+
+    if (maxFlags) return;
 
     return (
       <>
@@ -188,6 +195,8 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
                   inventory[ingredient.item] || 0
                 ).lessThan(ingredient.amount);
 
+                if (maxFlags) return;
+
                 return (
                   <div className="flex justify-center items-end" key={index}>
                     <img src={item.image} className="h-5 me-2" />
@@ -205,19 +214,21 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
                 );
               })}
 
-              <div className="flex justify-center items-end">
-                <img src={token} className="h-5 mr-1" />
-                <span
-                  className={classNames(
-                    "text-xs text-shadow text-center mt-2 ",
-                    {
-                      "text-red-500": lessFunds(),
-                    }
-                  )}
-                >
-                  {`$${selected.price.toNumber()}`}
-                </span>
-              </div>
+              {!maxFlags && (
+                <div className="flex justify-center items-end">
+                  <img src={token} className="h-5 mr-1" />
+                  <span
+                    className={classNames(
+                      "text-xs text-shadow text-center mt-2 ",
+                      {
+                        "text-red-500": lessFunds(),
+                      }
+                    )}
+                  >
+                    {`${selected.price.toNumber()}`}
+                  </span>
+                </div>
+              )}
             </div>
           ) : (
             <span>?</span>

--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -25,6 +25,7 @@ interface Props {
   onClose: () => void;
   items: Partial<Record<InventoryItemName, Craftable>>;
   hasAccess: boolean;
+  canCraft?: boolean;
 }
 
 const Items: React.FC<{
@@ -62,7 +63,7 @@ const Items: React.FC<{
     </div>
   );
 };
-export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
+export const Rare: React.FC<Props> = ({ onClose, items, hasAccess, canCraft = true }) => {
   const [selected, setSelected] = useState<Craftable>(Object.values(items)[0]);
   const { gameService } = useContext(Context);
   const [
@@ -111,10 +112,6 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
 
   const soldOut = amountLeft <= 0;
 
-  const maxFlags = Object.values(FLAGS).filter(
-    (flag) => flag.name in items && flag.name in state.inventory
-  ).length === 2;
-
   const Action = () => {
     if (soldOut) {
       return null;
@@ -142,7 +139,7 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
       );
     }
 
-    if (maxFlags) return;
+    if (!canCraft) return;
 
     return (
       <>
@@ -195,7 +192,7 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
                   inventory[ingredient.item] || 0
                 ).lessThan(ingredient.amount);
 
-                if (maxFlags) return;
+                if (!canCraft) return;
 
                 return (
                   <div className="flex justify-center items-end" key={index}>
@@ -214,7 +211,7 @@ export const Rare: React.FC<Props> = ({ onClose, items, hasAccess }) => {
                 );
               })}
 
-              {!maxFlags && (
+              {canCraft && (
                 <div className="flex justify-center items-end">
                   <img src={token} className="h-5 mr-1" />
                   <span

--- a/src/features/tailor/components/TailorSale.tsx
+++ b/src/features/tailor/components/TailorSale.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 
 import close from "assets/icons/close.png";
 import flag from "assets/nfts/flags/sunflower_flag.gif";
@@ -8,12 +8,20 @@ import { Tab } from "components/ui/Tab";
 import { FLAGS } from "features/game/types/craftables";
 import { Rare } from "features/blacksmith/components/Rare";
 import { Flag } from "features/game/types/flags";
+import { useActor } from "@xstate/react";
+import { Context } from "features/game/GameProvider";
 
 interface Props {
   onClose: () => void;
 }
 
 export const TailorSale: React.FC<Props> = ({ onClose }) => {
+  const { gameService } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
   const [tab, setTab] = useState<"flags">("flags");
 
   // Alphabetically sort the flags
@@ -23,6 +31,10 @@ export const TailorSale: React.FC<Props> = ({ onClose }) => {
       obj[key] = FLAGS[key];
       return obj;
     }, {} as typeof FLAGS);
+
+  const maxFlags = Object.values(FLAGS).filter(
+    (flag) => flag.name in state.inventory
+  ).length === 2;
 
   return (
     <Panel className="pt-5 relative">
@@ -45,7 +57,7 @@ export const TailorSale: React.FC<Props> = ({ onClose }) => {
           minHeight: "200px",
         }}
       >
-        <Rare items={sortedFlags} onClose={onClose} hasAccess={true} />
+        <Rare items={sortedFlags} onClose={onClose} hasAccess={true} canCraft={!maxFlags} />
         <p className="text-xxs p-1 m-1 underline text-center">
           Max 2 flags per farm. Crafting flags will sync your farm to the
           blockchain.


### PR DESCRIPTION
# Description

Removes craft button and ingredients after reaching flag crafting limit.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

![image](https://user-images.githubusercontent.com/50954098/160668770-e5a53880-1d7b-41f3-9851-9baf2ebb535f.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
