### PR TITLE
[FIX] Deposit modal - highlight active instructions

### DIFF
--- a/src/features/bank/components/Deposit.tsx
+++ b/src/features/bank/components/Deposit.tsx
@@ -10,6 +10,7 @@ import farm from "assets/brand/nft.png";
 import alert from "assets/icons/expression_alerted.png";
 import { Label } from "components/ui/Label";
 import { Button } from "components/ui/Button";
+import classNames from "classnames";
 
 const EyeSvg = () => (
   <svg
@@ -109,7 +110,10 @@ const SFLItemsInstructions = () => (
 
 const TOOL_TIP_MESSAGE = "Copy Farm Address";
 
-type INSTRUCTION_TYPE = "token" | "item";
+enum Instructions {
+  "token",
+  "item",
+}
 
 export const Deposit: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -117,9 +121,7 @@ export const Deposit: React.FC = () => {
   const [showFullAddress, setShowFullAddress] = useState(false);
   const [tooltipMessage, setTooltipMessage] = useState(TOOL_TIP_MESSAGE);
   const [showLabel, setShowLabel] = useState(false);
-  const [instructions, setInstructions] = useState<INSTRUCTION_TYPE | null>(
-    null
-  );
+  const [instructions, setInstructions] = useState<Instructions | null>(null);
 
   const farmAddress = gameState.context.state?.farmAddress as string;
 
@@ -131,8 +133,8 @@ export const Deposit: React.FC = () => {
     }, 2000);
   };
 
-  const showTokenInstructions = instructions === "token";
-  const showItemInstructions = instructions === "item";
+  const showTokenInstructions = instructions === Instructions.token;
+  const showItemInstructions = instructions === Instructions.item;
 
   return (
     <div>
@@ -205,14 +207,18 @@ export const Deposit: React.FC = () => {
 
       <div className="flex mb-3">
         <Button
-          className={"mr-1 focus:bg-brown-300"}
-          onClick={() => setInstructions("token")}
+          className={classNames("mr-1", {
+            "bg-brown-300": showTokenInstructions,
+          })}
+          onClick={() => setInstructions(Instructions.token)}
         >
           SFL Token
         </Button>
         <Button
-          className="ml-1 focus:bg-brown-300"
-          onClick={() => setInstructions("item")}
+          className={classNames("ml-1", {
+            "bg-brown-300": showItemInstructions,
+          })}
+          onClick={() => setInstructions(Instructions.item)}
         >
           SFL Items
         </Button>


### PR DESCRIPTION
# Description

Instructions were highlighted only on focus, losing active background on click away. Now the button background is rendered based on state.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://user-images.githubusercontent.com/19366687/160707365-bbdff10e-e69a-4b08-94b0-995e0491aafe.mov

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
