### PR TITLE
[FEAT] Box Count Display Updates

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -15,29 +15,26 @@ export interface BoxProps {
   disabled?: boolean;
 }
 
-// scoped to this component?
-Decimal.set({
-  rounding: Decimal.ROUND_FLOOR,
-});
-
 /**
  * Format like in shortAddress
  * Rules/Limits:
- * - rounded down via Decimal.set
+ * - rounded down explicitly
  * - denominate by k, m for now
  */
 const shortenCount = (count: Decimal | undefined): string => {
   if (!count) return "";
 
-  if (count.lessThan(1)) return count.toDecimalPlaces(2).toString();
+  if (count.lessThan(1))
+    return count.toDecimalPlaces(2, Decimal.ROUND_FLOOR).toString();
 
-  if (count.lessThan(1000)) return count.toInteger().toString();
+  if (count.lessThan(1000))
+    return count.toDecimalPlaces(0, Decimal.ROUND_FLOOR).toString();
 
   const isThousand = count.lessThan(1e6);
 
   return `${count
     .div(isThousand ? 1000 : 1e6)
-    .toDecimalPlaces(1)
+    .toDecimalPlaces(1, Decimal.ROUND_FLOOR)
     .toString()}${isThousand ? "k" : "m"}`;
 };
 


### PR DESCRIPTION
# Description

This PR aims to implement suggestions to shorten count value to be readable on modals. There are cases where a label overlaps another e.g. `888.4k` nothing we can about that unless adjust spacing between items.

![image](https://user-images.githubusercontent.com/89294757/161035108-31fdd1dd-f947-42e2-8003-77239e97e93f.png)

Note:
- this PR does **NOT** solve the bug where label clips on Inventory modal. this is due to `overflow-y-auto` which forces x axis to `auto` instead of `visible` 

![image](https://user-images.githubusercontent.com/89294757/161035380-3aaf20f9-e61d-4ed7-9576-911883d5be6c.png)

Fixes #issue N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing - Local state with edited `INITIAL_FARM` inventory

https://user-images.githubusercontent.com/89294757/161035862-6be3bb1e-ea22-45aa-9d98-9fa0a4866610.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
