### PR TITLE
[FIX] Changing lets go to lets farm !

### DIFF
--- a/src/features/auth/components/StartFarm.tsx
+++ b/src/features/auth/components/StartFarm.tsx
@@ -29,7 +29,7 @@ export const StartFarm: React.FC = () => {
         <>
           <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
           <Button onClick={start} className="overflow-hidden mb-2">
-            Lets go!
+            Lets farm!
           </Button>
           <Button onClick={explore} className="overflow-hidden">
             {`Explore a friend's farm`}


### PR DESCRIPTION
# Description

Saw a suggestion in #suggestion discord from @ZikOos_WF and I liked it since it fists the spirit of the game

Fixes #issue
Changed letsgo shown at the start of the game after you sign to your farm to lets farm!


## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Yarn dev & Yarn test
# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

