### PR TITLE
[FEAT] hover effect for ressources

### DIFF
--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -6,7 +6,7 @@ import Decimal from "decimal.js-light";
 import token from "assets/icons/token.gif";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
+import { OuterPanel, InnerPanel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
@@ -14,6 +14,11 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Craftable } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { Stock } from "components/ui/Stock";
+
+
+
+const POPOVER_TIME_MS = 1000;
+const HOVER_TIMEOUT = 1000;
 
 interface Props {
   items: Partial<Record<InventoryItemName, Craftable>>;
@@ -116,6 +121,7 @@ export const CraftingItems: React.FC<Props> = ({
   };
 
   const stock = state.stock[selected.name] || new Decimal(0);
+  const [isHover, setIsHover] = useState(false);
 
   return (
     <div className="flex">
@@ -151,18 +157,52 @@ export const CraftingItems: React.FC<Props> = ({
               ).lessThan(ingredient.amount);
 
               return (
-                <div className="flex justify-center items-end" key={index}>
-                  <img src={item.image} className="h-5 me-2" />
-                  <span
+                <div
+                  className="relative"
+                  onMouseEnter={() => setIsHover(true)}
+                  onMouseLeave={() => setIsHover(false)}
+                >
+                  <div
                     className={classNames(
-                      "text-xs text-shadow text-center mt-2 ",
+                      "flex  justify-center items-end px-1",
                       {
-                        "text-red-500": lessIngredient,
+                        "px-1": isHover,
                       }
                     )}
                   >
-                    {ingredient.amount.toNumber()}
-                  </span>
+                    <div className="flex justify-center h-fit items-end " key={index}>
+                      <img src={item.image} className="h-5 me-2" />
+
+                      <span
+                        className={classNames(
+                          "text-xs text-shadow text-center mt-2 ",
+                          {
+                            "text-red-500": lessIngredient,
+                          }
+                        )}
+                      >
+                        {ingredient.amount.toNumber()}
+
+                        <InnerPanel
+          className={classNames(
+            "ml-10 transition-opacity absolute whitespace-nowrap bind sm:opacity-0 bottom-5 w-fit  z-20 pointer-events-none",
+            {
+              "opacity-100": isHover,
+              "opacity-0": !isHover,
+            }
+          )}
+        >
+          <div className="flex items-center justify-center text-xxs text-white text-shadow ml-2 mr-2">
+            <img src={item.image} className="w-6 mr-1" />
+            <span className="flex-1">
+              {item.name}
+              </span>
+          </div>
+        </InnerPanel>
+                        
+                      </span>
+                    </div>
+                  </div>
                 </div>
               );
             })}

--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -15,8 +15,6 @@ import { Craftable } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { Stock } from "components/ui/Stock";
 
-
-
 const POPOVER_TIME_MS = 1000;
 const HOVER_TIMEOUT = 1000;
 
@@ -170,7 +168,10 @@ export const CraftingItems: React.FC<Props> = ({
                       }
                     )}
                   >
-                    <div className="flex justify-center h-fit items-end " key={index}>
+                    <div
+                      className="flex justify-center h-fit items-end "
+                      key={index}
+                    >
                       <img src={item.image} className="h-5 me-2" />
 
                       <span
@@ -184,22 +185,19 @@ export const CraftingItems: React.FC<Props> = ({
                         {ingredient.amount.toNumber()}
 
                         <InnerPanel
-          className={classNames(
-            "ml-10 transition-opacity absolute whitespace-nowrap bind sm:opacity-0 bottom-5 w-fit  z-20 pointer-events-none",
-            {
-              "opacity-100": isHover,
-              "opacity-0": !isHover,
-            }
-          )}
-        >
-          <div className="flex items-center justify-center text-xxs text-white text-shadow ml-2 mr-2">
-            <img src={item.image} className="w-6 mr-1" />
-            <span className="flex-1">
-              {item.name}
-              </span>
-          </div>
-        </InnerPanel>
-                        
+                          className={classNames(
+                            "ml-10 transition-opacity absolute whitespace-nowrap bind sm:opacity-0 bottom-5 w-fit  z-20 pointer-events-none",
+                            {
+                              "opacity-100": isHover,
+                              "opacity-0": !isHover,
+                            }
+                          )}
+                        >
+                          <div className="flex items-center justify-center text-xxs text-white text-shadow ml-2 mr-2">
+                            <img src={item.image} className="w-6 mr-1" />
+                            <span className="flex-1">{item.name}</span>
+                          </div>
+                        </InnerPanel>
                       </span>
                     </div>
                   </div>

--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -156,11 +156,13 @@ export const CraftingItems: React.FC<Props> = ({
 
               return (
                 <div
+                  key={1}
                   className="relative"
                   onMouseEnter={() => setIsHover(true)}
                   onMouseLeave={() => setIsHover(false)}
                 >
                   <div
+                    key={2}
                     className={classNames(
                       "flex  justify-center items-end px-1",
                       {

--- a/src/features/blacksmith/components/CraftingItems.tsx
+++ b/src/features/blacksmith/components/CraftingItems.tsx
@@ -14,6 +14,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Craftable } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { Stock } from "components/ui/Stock";
+import { Label } from "components/ui/Label";
 
 const POPOVER_TIME_MS = 1000;
 const HOVER_TIMEOUT = 1000;
@@ -161,54 +162,40 @@ export const CraftingItems: React.FC<Props> = ({
                   onMouseEnter={() => setIsHover(true)}
                   onMouseLeave={() => setIsHover(false)}
                 >
-                  <div
-                    key={2}
-                    className={classNames(
-                      "flex  justify-center items-end px-1",
-                      {
-                        "px-1": isHover,
-                      }
-                    )}
-                  >
+                 
                     <div
-                      className="flex justify-center h-fit items-end "
+                      className="flex h-fit items-end "
                       key={index}
                     >
-                      <img src={item.image} className="h-5 me-2" />
-
+                      <img src={item.image} className="absolute left-8 h-6 mr-4" />
+                      <div className="flex  text-white text-shadow ml-20 mr-2">
+                            
+                            <span className="flex ">{item.name}</span>
+                          </div>
+                      <Label
+                    key={2}
+                    className="flex absolute  right-20 -bottom-2 h-5  z-10"
+  
+                  >
                       <span
                         className={classNames(
-                          "text-xs text-shadow text-center mt-2 ",
+                          "text-xs text-shadow text-center  ",
                           {
                             "text-red-500": lessIngredient,
                           }
                         )}
                       >
                         {ingredient.amount.toNumber()}
-
-                        <InnerPanel
-                          className={classNames(
-                            "ml-10 transition-opacity absolute whitespace-nowrap bind sm:opacity-0 bottom-5 w-fit  z-20 pointer-events-none",
-                            {
-                              "opacity-100": isHover,
-                              "opacity-0": !isHover,
-                            }
-                          )}
-                        >
-                          <div className="flex items-center justify-center text-xxs text-white text-shadow ml-2 mr-2">
-                            <img src={item.image} className="w-6 mr-1" />
-                            <span className="flex-1">{item.name}</span>
-                          </div>
-                        </InnerPanel>
+                        
                       </span>
-                    </div>
+                     </Label>
                   </div>
                 </div>
               );
             })}
 
-            <div className="flex justify-center items-end">
-              <img src={token} className="h-5 mr-1" />
+            <div className="flex justify-center items-end ">
+              <img src={token} className="h-6 mr-4" />
               <span
                 className={classNames("text-xs text-shadow text-center mt-2 ", {
                   "text-red-500": lessFunds(),

--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -63,7 +63,12 @@ const Items: React.FC<{
     </div>
   );
 };
-export const Rare: React.FC<Props> = ({ onClose, items, hasAccess, canCraft = true }) => {
+export const Rare: React.FC<Props> = ({
+  onClose,
+  items,
+  hasAccess,
+  canCraft = true,
+}) => {
   const [selected, setSelected] = useState<Craftable>(Object.values(items)[0]);
   const { gameService } = useContext(Context);
   const [

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -130,6 +130,7 @@ import { Section } from "lib/utils/hooks/useScrollIntoView";
 import { SKILL_TREE } from "./skills";
 
 export type ItemDetails = {
+  name: string;
   description: string;
   image: any;
   secondaryImage?: any;
@@ -239,38 +240,47 @@ export const ITEM_DETAILS: Items = {
   Wood: {
     ...RESOURCES["Wood"],
     image: wood,
+    name: "WOOD",
   },
   Stone: {
     ...RESOURCES["Stone"],
     image: stone,
+    name: "STONE",
   },
   Iron: {
     ...RESOURCES["Iron"],
     image: iron,
+    name: "IRON",
   },
   Gold: {
     ...RESOURCES["Gold"],
     image: gold,
+    name: "GOLD",
   },
   Egg: {
     ...RESOURCES["Egg"],
     image: egg,
+    name: "EGG",
   },
   Chicken: {
     ...RESOURCES["Chicken"],
     image: chicken,
+    name: "CHICKEN",
   },
   Cow: {
     ...RESOURCES["Chicken"],
     image: questionMark,
+    name: "COW",
   },
   Sheep: {
     ...RESOURCES["Chicken"],
     image: questionMark,
+    name: "SHEEP",
   },
   Pig: {
     ...RESOURCES["Chicken"],
     image: questionMark,
+    name: "PIG",
   },
 
   // TOOLS
@@ -391,34 +401,42 @@ export const ITEM_DETAILS: Items = {
   "Green Thumb": {
     description: SKILL_TREE["Green Thumb"].perks[0],
     image: greenThumb,
+    name: wood,
   },
   "Barn Manager": {
     description: SKILL_TREE["Barn Manager"].perks[0],
     image: barnManager,
+    name: wood,
   },
   "Seed Specialist": {
     description: SKILL_TREE["Seed Specialist"].perks[0],
     image: seedSpecialist,
+    name: wood,
   },
   Wrangler: {
     description: SKILL_TREE["Wrangler"].perks[0],
     image: wrangler,
+    name: wood,
   },
   Lumberjack: {
     description: SKILL_TREE["Lumberjack"].perks[0],
     image: lumberjack,
+    name: wood,
   },
   Prospector: {
     description: SKILL_TREE["Prospector"].perks[0],
     image: prospector,
+    name: wood,
   },
   Logger: {
     description: SKILL_TREE["Logger"].perks[0],
     image: logger,
+    name: wood,
   },
   "Gold Rush": {
     description: SKILL_TREE["Gold Rush"].perks[0],
     image: goldRush,
+    name: wood,
   },
 
   /**


### PR DESCRIPTION
# Description

To help new player's start with the ressource farming, I added the name of the ressources when you hover over them on the blacksmith for tools, because it's confusing to know which is which when you just start playing

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
yarn dev:
![Hover function](https://user-images.githubusercontent.com/98262339/161338841-26bfc8d2-a2fe-4a3d-82a5-4acacaf604cb.PNG)
![Hover function 2](https://user-images.githubusercontent.com/98262339/161338843-12ff2ef2-cb6c-465a-86fc-05db4aae60ff.PNG)


yarn format :
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
PS C:\Users\Z1kou\Documents\GitHub\sunflower-land> yarn test
yarn run v1.22.18
warning package.json: No license field
$ jest
setup
 PASS  src/features/game/events/plant.test.ts (34.269 s)
 PASS  src/features/game/events/harvest.test.ts (34.383 s)
 PASS  src/features/game/events/sell.test.ts (34.777 s)
 PASS  src/features/game/events/stoneMine.test.ts      
 PASS  src/features/game/events/goldMine.test.ts       
 PASS  src/lib/utils/hooks/__tests__/useStepper.test.ts (5.78 s)
 PASS  src/features/game/events/chop.test.ts
 PASS  src/features/game/events/ironMine.test.ts
 PASS  src/features/game/events/craft.test.ts

Test Suites: 9 passed, 9 total
Tests:       71 passed, 71 total
Snapshots:   0 total
Time:        50.589 s
Ran all test suites.
Done in 54.29s.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

