### PR TITLE
[FIX] Remove onClick on Unlocked Wheat Goblin

### DIFF
--- a/src/features/crops/components/WheatGoblin.tsx
+++ b/src/features/crops/components/WheatGoblin.tsx
@@ -69,7 +69,6 @@ export const WheatGoblin: React.FC = () => {
             <img
               src={goblin}
               className="z-10 w-full"
-              onClick={() => setShowModal(true)}
               style={{
                 width: `${GRID_WIDTH_PX * 1}px`,
                 transform: "scaleX(-1)",


### PR DESCRIPTION
# Description

This PR removes the onClick handler when clicking unlocked wheat goblin

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`yarn tsc|test`

Manual testing

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
