### PR TITLE
[FIX] Provider: do not cast authMachine to any

### DIFF
--- a/src/features/auth/lib/Provider.tsx
+++ b/src/features/auth/lib/Provider.tsx
@@ -9,8 +9,7 @@ interface AuthContext {
 export const Context = React.createContext<AuthContext>({} as AuthContext);
 
 export const Provider: React.FC = ({ children }) => {
-  // TODO - Typescript error
-  const authService = useInterpret(authMachine as any) as MachineInterpreter;
+  const authService = useInterpret(authMachine) as MachineInterpreter;
 
   return (
     <Context.Provider value={{ authService }}>{children}</Context.Provider>


### PR DESCRIPTION
# Description

In `auth/lib/Provider.tsx` do not cast `authMachine` to any type. It seems to work now.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran `yarn build` and it built successfully.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
