### PR TITLE
[FIX] Crop reward missing after 1st per plot

### DIFF
--- a/src/features/crops/components/CropReward.tsx
+++ b/src/features/crops/components/CropReward.tsx
@@ -41,6 +41,11 @@ export const CropReward: React.FC<Props> = ({
     gameService.send("reward.opened", { fieldIndex });
   };
 
+  const close = () => {
+    onCollected();
+    setOpened(false);
+  };
+
   return (
     <Modal centered show={true}>
       <Panel>
@@ -60,7 +65,7 @@ export const CropReward: React.FC<Props> = ({
                   </span>
                 </div>
               ))}
-              <Button onClick={onCollected} className="mt-4 w-28">
+              <Button onClick={close} className="mt-4 w-28">
                 Close
               </Button>
             </>


### PR DESCRIPTION
# Description

When clicking through the chest to claim a crop reward, the Close button was not clearing the "opened" flag.  This means that subsequent attempts to claim crop rewards would skip the chest opening and the rewards delivery entirely.

A user workaround is to choose Save and then refresh the browser _before_ applying the second "touch" to a harvestable plant.

This change corrects the Close button handling so that the user workaround is not needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Change the `Sunflower.harvestSeconds` to `1`
2. Add the following to Field.tsx before the `field?.reward` check:
```
if (field) {
    field.reward = {
        items = [{
            name: "Sunflower Seed",
            amount: 7,
        }]
    }
}
```
3. Click each of the 3 auto-filled plots to confirm reward flow works
4. Repeat step 3 to confirm that the reward flow still works

![image](https://user-images.githubusercontent.com/36871683/162896258-3aae30cf-8496-4765-babf-df577937a0b4.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Credit:

Investigation and fix based on theory by `beastrong23 | j923sneaks` on Discord.