### PR TITLE
[FIX] Output multiplier for Kuebiko should be 1.2

### DIFF
--- a/src/features/game/events/plant.ts
+++ b/src/features/game/events/plant.ts
@@ -90,7 +90,10 @@ function getMultiplier({ crop, inventory }: GetFieldArgs): number {
     multiplier *= 2;
   }
 
-  if (inventory.Scarecrow?.gte(1)) {
+  if (
+    inventory.Scarecrow?.gte(1) ||
+    inventory.Kuebiko?.gte(1)
+  ) {
     multiplier *= 1.2;
   }
 


### PR DESCRIPTION
# Description

When upgrading from Scarecrow (level 3) to Kuebiko (level 3), the crop output multiplier lowers from 1.2 to 1.  This is not intended behavior.

This change updates the `getMultiplier()` function to include Keubiko in the 1.2 adjustment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Start a new farm on local (which has Scarecrow)
2. Sell some initial materials at the Shop
3. Buy 1 sunflower seed
4. Plant sunflower seed
5. Harvest Sunflower (note: it has to be a new plant rather than one of the initial 3 sunflowers)
=> 1.2 output
6. Remove Scarecrow from `INITIAL_FARM.inventory`
7. Add Kuebiko to `INITIAL_FARM.inventory`
8. Repeat steps 1-5
=> 1.0 output
9. Apply this PR
10. Repeat steps 1-5
=> 1.2 output

![image](https://user-images.githubusercontent.com/36871683/162900758-fbce732a-c156-4f4c-b6ce-4b31079ae847.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
