### PR TITLE
[FIX] Tree recovery from Apprentice Beaver should also apply to Foreman Beaver

### DIFF
--- a/src/features/game/events/chop.ts
+++ b/src/features/game/events/chop.ts
@@ -24,7 +24,10 @@ type GetChoppedAtAtgs = {
  * Set a chopped in the past to make it replenish faster
  */
 function getChoppedAt({ inventory, createdAt }: GetChoppedAtAtgs): number {
-  if (inventory["Apprentice Beaver"]?.gte(1)) {
+  if (
+    inventory["Apprentice Beaver"]?.gte(1) ||
+    inventory["Foreman Beaver"]?.gte(1)
+  ) {
     return createdAt - (TREE_RECOVERY_SECONDS / 2) * 1000;
   }
 


### PR DESCRIPTION
# Description

When upgrading from Apprentice Beaver (level 2) to Foreman Beaver (level 3), the tree recovery effect is no longer applied.  This is not intended behavior.

This change updates the `getChoppedAt()` function to include Foreman Beaver when applying the effect.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Start a new farm on local (which has Scarecrow)
2. Chop a tree
=> Observe 2 hour cooldown
3. Add "Apprentice Beaver" to `INITIAL_FARM.inventory`
4. Repeat steps 1-2
=> Observe 60 minute cooldown
5. Change "Apprentice Beaver" to "Foreman Beaver" in `INITIAL_FARM.inventory`
6. Repeat steps 1-2
=> Observe 2 hour cooldown
7. Apply this PR
8. Repeat steps 1-2
=> Observe 60 minute cooldown

When running `yarn test`, the output includes `PASS` for `src/features/game/events/chop.test.ts`.

There are other failures reported for other tests:
`e: ReferenceError: matchMedia is not defined`

These errors occur for the `main` branch (i.e. without this PR) as well.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
