### PR TITLE
[FIX ] Implement Wood Increase NFT Boost

### DIFF
--- a/src/features/game/events/chop.test.ts
+++ b/src/features/game/events/chop.test.ts
@@ -108,7 +108,7 @@ describe("chop", () => {
     expect(game.trees["1"].wood.toNumber()).toBeGreaterThan(2);
   });
 
-  it("gives 20% more wood when you have Woody the Beaver NFT", () => {
+  it("gives 20% more wood when you have Beaver NFT", () => {
     const game = chop({
       state: {
         ...GAME_STATE,

--- a/src/features/game/events/chop.test.ts
+++ b/src/features/game/events/chop.test.ts
@@ -107,4 +107,24 @@ describe("chop", () => {
     expect(game.trees["0"].wood.toNumber()).toBeGreaterThan(2);
     expect(game.trees["1"].wood.toNumber()).toBeGreaterThan(2);
   });
+
+  it("gives 20% more wood when you have Woody the Beaver NFT", () => {
+    const game = chop({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Axe: new Decimal(3),
+          "Woody the Beaver": new Decimal(1),
+        },
+      },
+      action: {
+        type: "tree.chopped",
+        item: "Axe",
+        index: 0,
+      } as ChopAction,
+    });
+
+    // placeholder per tree is 3 wood
+    expect(game.inventory.Wood).toEqual(new Decimal(3.6));
+  });
 });

--- a/src/features/game/events/chop.ts
+++ b/src/features/game/events/chop.ts
@@ -46,6 +46,21 @@ export function getRequiredAxeAmount(inventory: Inventory) {
   return new Decimal(1);
 }
 
+/**
+ * Returns multiplier based on Beaver boost
+ */
+export function getMultiplier(inventory: Inventory) {
+  if (
+    inventory["Woody the Beaver"]?.gte(1) ||
+    inventory["Apprentice Beaver"]?.gte(1) ||
+    inventory["Foreman Beaver"]?.gte(1)
+  ) {
+    return new Decimal(1.2);
+  }
+
+  return new Decimal(1);
+}
+
 export type ChopAction = {
   type: "tree.chopped";
   index: number;
@@ -90,7 +105,7 @@ export function chop({
     inventory: {
       ...state.inventory,
       Axe: axeAmount.sub(requiredAxes),
-      Wood: woodAmount.add(tree.wood),
+      Wood: woodAmount.add(tree.wood.mul(getMultiplier(state.inventory))),
     },
     trees: {
       ...state.trees,


### PR DESCRIPTION
# Description

This PR fixes/implements T1 Beaver boost which increases wood drops by 20%. Since the wood per tree values are generated server-side, only test using placeholders as seen in `chop.ts` LN 115.

```
// Placeholder, random numbers generated on server side
wood: new Decimal(3),
```

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`yarn test`
![image](https://user-images.githubusercontent.com/89294757/163519058-0d7e5d51-aca1-49d1-a331-4d27bf4335ea.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
