### PR TITLE
[FEAT] Add warning to Withdraw Modal

### DIFF
--- a/src/features/bank/components/Withdraw.tsx
+++ b/src/features/bank/components/Withdraw.tsx
@@ -88,7 +88,7 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
       <div className="flex items-center border-2 rounded-md border-black p-2 bg-[#e43b44]">
         <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
         <span className="text-xs">
-          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED ON CHAIN WILL BE LOST.
         </span>
       </div>
 

--- a/src/features/bank/components/Withdraw.tsx
+++ b/src/features/bank/components/Withdraw.tsx
@@ -8,6 +8,8 @@ import { Button } from "components/ui/Button";
 import { WithdrawTokens } from "./WithdrawTokens";
 import { WithdrawItems } from "./WithdrawItems";
 
+import alert from "assets/icons/expression_alerted.png";
+
 interface Props {
   onClose: () => void;
 }
@@ -79,12 +81,16 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
 
   return (
     <div className="p-2 flex flex-col justify-center">
-      <span className="text-shadow text-sm text-center">
+      <span className="text-shadow text-sm text-center pb-2">
         You can only withdraw items that you have synced to the blockchain.
       </span>
-      <span className="text-shadow text-sm text-center mt-4 block">
-        Any progress that has not been synced will be lost.
-      </span>
+
+      <div className="flex items-center border-2 rounded-md border-black p-2 bg-[#e43b44]">
+        <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
+        <span className="text-xs">
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+        </span>
+      </div>
 
       <div className="flex mt-4">
         <Button className="mr-1" onClick={() => setPage("tokens")}>

--- a/src/features/bank/components/WithdrawItems.tsx
+++ b/src/features/bank/components/WithdrawItems.tsx
@@ -19,6 +19,8 @@ import { metamask } from "lib/blockchain/metamask";
 import { canWithdraw } from "../lib/bankUtils";
 import { getOnChainState } from "features/game/actions/visit";
 
+import alert from "assets/icons/expression_alerted.png";
+
 interface Props {
   onWithdraw: (ids: number[], amounts: string[]) => void;
 }
@@ -153,6 +155,13 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
       <span className="text-center text-xs mb-4">
         Once withdrawn, you will be able to view your items on Open Sea.
       </span>
+
+      <div className="flex items-center border-2 rounded-md border-black p-2 mt-2 mb-2 bg-[#e43b44]">
+        <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
+        <span className="text-xs">
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+        </span>
+      </div>
 
       <Button onClick={withdraw} disabled={selectedItems.length <= 0}>
         Withdraw

--- a/src/features/bank/components/WithdrawItems.tsx
+++ b/src/features/bank/components/WithdrawItems.tsx
@@ -159,7 +159,7 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
       <div className="flex items-center border-2 rounded-md border-black p-2 mt-2 mb-2 bg-[#e43b44]">
         <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
         <span className="text-xs">
-          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED ON CHAIN WILL BE LOST.
         </span>
       </div>
 

--- a/src/features/bank/components/WithdrawTokens.tsx
+++ b/src/features/bank/components/WithdrawTokens.tsx
@@ -20,6 +20,8 @@ import downArrow from "assets/icons/arrow_down.png";
 import { getTax } from "lib/utils/tax";
 import { getOnChainState } from "features/game/actions/visit";
 
+import alert from "assets/icons/expression_alerted.png";
+
 interface Props {
   onWithdraw: (sfl: string) => void;
 }
@@ -177,6 +179,13 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
             {shortAddress(metamask.myAccount || "XXXX")}
           </p>
         </div>
+      </div>
+
+      <div className="flex items-center border-2 rounded-md border-black p-2 mt-2 mb-2 bg-[#e43b44]">
+        <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
+        <span className="text-xs">
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+        </span>
       </div>
 
       <Button onClick={withdraw} disabled={safeAmount(amount).gte(balance)}>

--- a/src/features/bank/components/WithdrawTokens.tsx
+++ b/src/features/bank/components/WithdrawTokens.tsx
@@ -184,7 +184,7 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
       <div className="flex items-center border-2 rounded-md border-black p-2 mt-2 mb-2 bg-[#e43b44]">
         <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
         <span className="text-xs">
-          ANY PROGRESS THAT HAS NOT BEEN SYNCED WILL BE LOST.
+          ANY PROGRESS THAT HAS NOT BEEN SYNCED ON CHAIN WILL BE LOST.
         </span>
       </div>
 


### PR DESCRIPTION
# Description
- added warning to withdraw modal since a lot of people have lost their progress.

Fixes #issue raised on discord

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`yarn test`
<img width="348" alt="Screen Shot 2022-04-15 at 4 24 44 PM" src="https://user-images.githubusercontent.com/18549210/163546001-a7864d38-5cb8-4b9e-a0bf-beb271953ca4.png">

`yarn dev`
<img width="497" alt="Screen Shot 2022-04-16 at 3 31 05 PM" src="https://user-images.githubusercontent.com/18549210/163666197-12784f4e-633b-490d-8846-0b72d3dc9efd.png">

`withdraw SFL TOKEN`
<img width="497" alt="Screen Shot 2022-04-16 at 3 31 16 PM" src="https://user-images.githubusercontent.com/18549210/163666206-57cb0f51-7dd4-4bbe-bd11-88e7c6278096.png">

`withdraw SFL ITEMS`
<img width="496" alt="Screen Shot 2022-04-16 at 3 31 30 PM" src="https://user-images.githubusercontent.com/18549210/163666216-6cfd0238-fe9e-44a0-9ad1-3c7013457914.png">


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
