### PR TITLE
[FIX]: Replace View All Skills link with btn :)

### DIFF
--- a/src/features/house/House.tsx
+++ b/src/features/house/House.tsx
@@ -31,6 +31,7 @@ import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { SkillUpgrade } from "./components/SkillUpgrade";
 import { SkillTree } from "./components/SkillTree";
 import { homeDoorAudio } from "lib/utils/sfx";
+import { Button } from "components/ui/Button";
 
 export const House: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -186,12 +187,9 @@ export const House: React.FC = () => {
               })}
               <span>{toolLevel}</span>
             </div>
-            <span
-              className="underline text-xs cursor-pointer"
-              onClick={openSkillTree}
-            >
+            <Button className="text-xs mt-3" onClick={openSkillTree}>
               View all skills
-            </span>
+            </Button>
           </div>
         </div>
 
@@ -216,7 +214,7 @@ export const House: React.FC = () => {
         className="relative cursor-pointer hover:img-highlight"
         onClick={() => open()}
       >
-        {isUpgradeAvailable && 
+        {isUpgradeAvailable && (
           <img
             className="animate-float"
             src={alert}
@@ -227,7 +225,7 @@ export const House: React.FC = () => {
               bottom: `${GRID_WIDTH_PX * 4.571}px`,
             }}
           />
-        }
+        )}
         <img src={house} alt="house" className="w-full" />
         <img
           src={smoke}


### PR DESCRIPTION
# Description

Replaced "View All Skills" span with **Button**, inside Home rfc


## Screenshots

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/55224033/163579246-3ebf06bf-d0db-44b2-9e92-ce5a2cce2678.png) | ![image](https://user-images.githubusercontent.com/55224033/163579392-c53eebf8-a6ea-4d4d-b616-c40fc7ca8345.png) |
| ![image](https://user-images.githubusercontent.com/55224033/163579655-a38f22f1-9cd2-492b-88c9-8be8ad227b01.png) | ![image](https://user-images.githubusercontent.com/55224033/163579931-9c5666f0-9995-4830-ab2e-684794956181.png) |

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`yarn test`

![](https://img.shields.io/static/v1?label=Tests&message=Passed&color=#198754)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
