### PR TITLE
[TYPO] Update Deposit.tsx

### DIFF
--- a/src/features/bank/components/Deposit.tsx
+++ b/src/features/bank/components/Deposit.tsx
@@ -92,7 +92,7 @@ const SFLItemsInstructions = () => (
           target="_blank"
           rel="noreferrer"
         >
-          Sunflower Land Collection
+          Sunflower Land Collectibles
         </a>
       </span>
     </div>


### PR DESCRIPTION
Changes text in deposit menu from "Sunflower Land Collection" to "Sunflower Land Collectibles" to match actual OpenSea name.

# Description

While training someone new to crypto games how to play, I emphasized she has to be very careful of scammers.  She noticed the in game title of the OpenSea collection didn't match the actual name.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [X] Typo fix

# How Has This Been Tested?

No testing required.

# Checklist:

N/A
