### PR TITLE
[FIX] add close icon and modal hide for sync captcha modal

### DIFF
--- a/src/features/hud/components/Menu.tsx
+++ b/src/features/hud/components/Menu.tsx
@@ -22,6 +22,7 @@ import water from "assets/icons/expression_working.png";
 import timer from "assets/icons/timer.png";
 import wood from "assets/resources/wood.png";
 import leftArrow from "assets/icons/arrow_left.png";
+import close from "assets/icons/close.png";
 
 import { isNewFarm } from "../lib/onboarding";
 
@@ -313,8 +314,14 @@ export const Menu = () => {
       />
 
       {showCaptcha && (
-        <Modal show={showCaptcha} centered>
+        <Modal show={showCaptcha} onHide={() => setShowCaptcha(false)} centered>
           <Panel>
+            <img
+              src={close}
+              className="h-6 top-3 right-4 absolute cursor-pointer"
+              alt="Close Logout Confirmation Modal"
+              onClick={() => setShowCaptcha(false)}
+            />
             <ReCAPTCHA
               sitekey="6Lfqm6MeAAAAAFS5a0vwAfTGUwnlNoHziyIlOl1s"
               onChange={onCaptchaSolved}


### PR DESCRIPTION
# Description

I add a close icon and modal close event on modal mask to provide a way the user can close the captcha modal

Feat #577 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Open the menu
2. Click the sync to chain
3. Try to close the captcha modal by close icon or modal mask

![image](https://user-images.githubusercontent.com/59650459/163703717-c11ff3ef-9bd6-4b4f-b5f9-58723e470231.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
