### PR TITLE
[FIX] Add singular time unit display

### DIFF
--- a/src/lib/utils/time.test.ts
+++ b/src/lib/utils/time.test.ts
@@ -15,10 +15,13 @@ describe("time", () => {
     it("should return correct string", () => {
       expect(secondsToString(ONE_SEC)).toBe("1sec");
       expect(secondsToString(2 * ONE_SEC)).toBe("2secs");
+      expect(secondsToString(59 * ONE_SEC)).toBe("59secs");
       expect(secondsToString(ONE_MIN)).toBe("1min");
       expect(secondsToString(ONE_MIN + ONE_SEC)).toBe("2mins");
+      expect(secondsToString(59 * ONE_MIN)).toBe("59mins");
       expect(secondsToString(ONE_HR)).toBe("1hr");
       expect(secondsToString(ONE_HR + ONE_SEC)).toBe("2hrs");
+      expect(secondsToString(23 * ONE_HR)).toBe("23hrs");
       expect(secondsToString(ONE_DAY)).toBe("1day");
       expect(secondsToString(ONE_DAY + ONE_SEC)).toBe("2days");
     });

--- a/src/lib/utils/time.test.ts
+++ b/src/lib/utils/time.test.ts
@@ -1,0 +1,43 @@
+import { secondsToMidString, secondsToLongString } from "./time";
+
+const ONE_SEC = 1;
+const ONE_MIN = ONE_SEC * 60;
+const ONE_HR = ONE_MIN * 60;
+const ONE_DAY = ONE_HR * 24;
+
+describe("time", () => {
+  describe("secondsToMidString", () => {
+    it("should return correct string", () => {
+      expect(secondsToMidString(ONE_SEC)).toBe("1sec");
+      expect(secondsToMidString(2 * ONE_SEC)).toBe("2secs");
+      expect(secondsToMidString(ONE_MIN)).toBe("1min");
+      expect(secondsToMidString(2 * ONE_MIN)).toBe("2mins");
+      expect(secondsToMidString(ONE_HR)).toBe("1hr");
+      expect(secondsToMidString(2 * ONE_HR)).toBe("2hrs");
+      expect(secondsToMidString(ONE_DAY)).toBe("1day");
+      expect(secondsToMidString(2 * ONE_DAY)).toBe("2days");
+
+      expect(secondsToMidString(ONE_MIN + 30 * ONE_SEC)).toBe("1min 30secs");
+      expect(secondsToMidString(2 * ONE_HR + 11 * ONE_MIN + 50 * ONE_SEC)).toBe(
+        "2hrs 11mins"
+      );
+      expect(secondsToMidString(2 * ONE_DAY + ONE_HR + 20 * ONE_MIN)).toBe(
+        "2days 1hr"
+      );
+    });
+  });
+
+  describe("secondsToLongString", () => {
+    it("should return correct string", () => {
+      expect(secondsToLongString(2 * ONE_DAY + ONE_MIN + 30 * ONE_SEC)).toBe(
+        "2days 1min 30secs"
+      );
+      expect(secondsToLongString(ONE_HR + 20 * ONE_MIN + 5 * ONE_SEC)).toBe(
+        "1hr 20mins 5secs"
+      );
+      expect(secondsToLongString(2 * ONE_DAY + ONE_HR + 20 * ONE_MIN)).toBe(
+        "2days 1hr 20mins"
+      );
+    });
+  });
+});

--- a/src/lib/utils/time.test.ts
+++ b/src/lib/utils/time.test.ts
@@ -1,4 +1,9 @@
-import { secondsToMidString, secondsToLongString } from "./time";
+import {
+  secondsToMidString,
+  secondsToLongString,
+  secondsToString,
+  getTimeLeft,
+} from "./time";
 
 const ONE_SEC = 1;
 const ONE_MIN = ONE_SEC * 60;
@@ -6,6 +11,19 @@ const ONE_HR = ONE_MIN * 60;
 const ONE_DAY = ONE_HR * 24;
 
 describe("time", () => {
+  describe("secondsToString", () => {
+    it("should return correct string", () => {
+      expect(secondsToString(ONE_SEC)).toBe("1sec");
+      expect(secondsToString(2 * ONE_SEC)).toBe("2secs");
+      expect(secondsToString(ONE_MIN)).toBe("1min");
+      expect(secondsToString(ONE_MIN + ONE_SEC)).toBe("2mins");
+      expect(secondsToString(ONE_HR)).toBe("1hr");
+      expect(secondsToString(ONE_HR + ONE_SEC)).toBe("2hrs");
+      expect(secondsToString(ONE_DAY)).toBe("1day");
+      expect(secondsToString(ONE_DAY + ONE_SEC)).toBe("2days");
+    });
+  });
+
   describe("secondsToMidString", () => {
     it("should return correct string", () => {
       expect(secondsToMidString(ONE_SEC)).toBe("1sec");
@@ -38,6 +56,37 @@ describe("time", () => {
       expect(secondsToLongString(2 * ONE_DAY + ONE_HR + 20 * ONE_MIN)).toBe(
         "2days 1hr 20mins"
       );
+    });
+  });
+
+  describe("getTimeLeft", () => {
+    const RealDate = Date;
+
+    const getTimestamp = (datetime: string) => new Date(datetime).getTime();
+
+    beforeAll(() => {
+      global.Date.now = jest.fn(() => getTimestamp("2022-04-17T00:00:00"));
+    });
+
+    it("should return 0 if elapsed", () => {
+      expect(getTimeLeft(getTimestamp("2022-04-15T11:00:00"), ONE_DAY)).toBe(0);
+      expect(getTimeLeft(getTimestamp("2022-04-16T00:00:00"), ONE_DAY)).toBe(0);
+    });
+
+    it("should return correct time left", () => {
+      expect(getTimeLeft(getTimestamp("2022-04-16T01:00:00"), ONE_DAY)).toBe(
+        ONE_HR
+      );
+      expect(getTimeLeft(getTimestamp("2022-04-16T23:59:30"), ONE_MIN)).toBe(
+        30 * ONE_SEC
+      );
+      expect(getTimeLeft(getTimestamp("2022-04-16T23:30:00"), ONE_HR)).toBe(
+        30 * ONE_MIN
+      );
+    });
+
+    afterAll(() => {
+      global.Date = RealDate;
     });
   });
 });

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -1,14 +1,26 @@
-function getTimeUnits(time: number) {
-  const seconds = Math.ceil(time % 60);
-  const minutes = Math.floor((time / 60) % 60);
-  const hours = Math.floor((time / 60 / 60) % 24);
-  const days = Math.floor(time / 60 / 60 / 24);
+const ONE_SEC = 1;
+const ONE_MIN = ONE_SEC * 60;
+const ONE_HR = ONE_MIN * 60;
+const ONE_DAY = ONE_HR * 24;
+
+type TimeUnit = "sec" | "min" | "hr" | "day";
+
+function timeToStr(amount: number, unit: TimeUnit) {
+  const pluralizedUnit = amount === 1 ? unit : `${unit}s`;
+  return `${amount}${pluralizedUnit}`;
+}
+
+function getTimeUnits(seconds: number) {
+  const secondsPart = Math.ceil(seconds % ONE_MIN);
+  const minutesPart = Math.floor((seconds / ONE_MIN) % ONE_MIN);
+  const hoursPart = Math.floor((seconds / ONE_HR) % 24);
+  const daysPart = Math.floor(seconds / ONE_DAY);
 
   return [
-    days && `${days}days`,
-    hours && `${hours}hrs`,
-    minutes && `${minutes}mins`,
-    seconds && `${seconds}secs`,
+    daysPart && timeToStr(daysPart, "day"),
+    hoursPart && timeToStr(hoursPart, "hr"),
+    minutesPart && timeToStr(minutesPart, "min"),
+    secondsPart && timeToStr(secondsPart, "sec"),
   ].filter(Boolean);
 }
 

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -26,49 +26,38 @@ function getTimeUnits(seconds: number) {
 
 export function secondsToString(seconds: number) {
   const secondsCeil = Math.ceil(seconds);
-
-  if (secondsCeil < 60) {
-    return `${secondsCeil}secs`;
+  if (secondsCeil < ONE_MIN) {
+    return timeToStr(secondsCeil, "sec");
   }
 
-  if (secondsCeil === 60) {
-    return `1min`;
+  if (seconds < ONE_HR) {
+    const minutesCeil = Math.ceil(seconds / ONE_MIN);
+    return timeToStr(minutesCeil, "min");
   }
 
-  // Less than 1 hour
-  if (seconds < 60 * 60) {
-    return `${Math.ceil(seconds / 60)}mins`;
+  if (seconds < ONE_DAY) {
+    const hoursCeil = Math.ceil(seconds / ONE_HR);
+    return timeToStr(hoursCeil, "hr");
   }
 
-  if (seconds === 60 * 60) {
-    return "1hr";
-  }
-
-  if (seconds < 60 * 60 * 24) {
-    return `${Math.ceil(seconds / 60 / 60)}hrs`;
-  }
-
-  if (seconds === 60 * 60 * 24) {
-    return "1day";
-  }
-
-  return `${Math.ceil(seconds / 60 / 60 / 24)}days`;
+  const daysCeil = Math.ceil(seconds / ONE_DAY);
+  return timeToStr(daysCeil, "day");
 }
 
 // first 2 units
-export function secondsToMidString(time: number) {
-  return getTimeUnits(time).slice(0, 2).join(" ");
+export function secondsToMidString(seconds: number) {
+  return getTimeUnits(seconds).slice(0, 2).join(" ");
 }
 
-export function secondsToLongString(time: number) {
-  return getTimeUnits(time).join(" ");
+export function secondsToLongString(seconds: number) {
+  return getTimeUnits(seconds).join(" ");
 }
 
-export function getTimeLeft(createdAt: number, totalTime: number) {
+export function getTimeLeft(createdAt: number, totalTimeInSeconds: number) {
   const millisecondsElapsed = Date.now() - createdAt;
-  if (millisecondsElapsed > totalTime * 1000) {
+  if (millisecondsElapsed > totalTimeInSeconds * 1000) {
     return 0;
   }
 
-  return totalTime - millisecondsElapsed / 1000;
+  return totalTimeInSeconds - millisecondsElapsed / 1000;
 }


### PR DESCRIPTION
# Description

Displays time with singular unit when exactly one amount. 

Before:  `1secs, 1mins, 1hrs, 1days`
After: `1sec, 1min, 1hr, 1day`

Also adds missing unit tests for all the time utils.

Example before:
<img width="205" alt="image" src="https://user-images.githubusercontent.com/14039116/163714866-83968062-f7f3-4759-a8aa-f5c8377e3303.png">

Example after:
<img width="210" alt="image" src="https://user-images.githubusercontent.com/14039116/163714793-dadc4289-f19d-46ac-973b-a0e64defaee1.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually & unit tests

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
