### PR TITLE
[FIX] META tag for viewport syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/src/assets/brand/icon.png" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=0"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
     />
     <title>Sunflower Land</title>
 


### PR DESCRIPTION
# Description

The current implementation of the HTML tag `<meta name="viewport">` has a syntax error and is throwing errors and warnings to the browser. This resolves that and resolves these warnings and errors.

- The value "1maximum-scale" for key "initial-scale" was truncated to its numeric prefix.
- The key "1" is not recognized and ignored.

I wrote a support ticket for this a couple of days ago but I finally got the nerve to dive in.  Even if it is a simple little thing.

Fixes #issue
https://sunflowerland.freshdesk.com/support/tickets/714

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via live debugging of the site. I don't know how to run the site locally so will need someone else to just do a quick confirmation.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
