### PR TITLE
[FIX] Remove easter egg location logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,25 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "plugin:prettier/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier",
-        "plugin:prettier/recommended",
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
-}
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["react", "@typescript-eslint"],
+  rules: {
+    "no-console": "error",
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,5 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["react", "@typescript-eslint"],
-  rules: {
-    "no-console": "warn",
-  },
+  rules: {},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,6 @@ module.exports = {
   },
   plugins: ["react", "@typescript-eslint"],
   rules: {
-    "no-console": "error",
+    "no-console": "warn",
   },
 };

--- a/src/features/easter/Area.tsx
+++ b/src/features/easter/Area.tsx
@@ -66,9 +66,7 @@ export const EasterEggHunt: React.FC = () => {
   useEffect(() => {
     // check inventory
     const collectibleEgg = availableEgg();
-    console.log({ collectibleEgg, inventory: state.inventory });
     if (!state.inventory[collectibleEgg] && state.inventory["Egg Basket"]) {
-      console.log("render egg");
       setEgg(collectibleEgg);
       const randomPosition = Math.floor(Math.random() * 29);
       setPosition(positions[randomPosition]);
@@ -78,8 +76,6 @@ export const EasterEggHunt: React.FC = () => {
   if (!egg) {
     return null;
   }
-
-  console.log({ position });
 
   return (
     <div className="w-full h-full absolute top-0 left-0">

--- a/src/features/game/components/Lore.tsx
+++ b/src/features/game/components/Lore.tsx
@@ -16,21 +16,21 @@ export const Lore: React.FC = () => {
   const [showTombstone, setShowTombstone] = useState(false);
 
   const onOpenGreenBook = () => {
-      setShowGreenBook(true)
-      battleAudio.play()
-  }  
-  
+    setShowGreenBook(true);
+    battleAudio.play();
+  };
+
   const onOpenYellowBook = () => {
-      setShowYellowBook(true)
-      diaryAudio.play()
-  }
+    setShowYellowBook(true);
+    diaryAudio.play();
+  };
 
   const onCloseBook = () => {
-    setShowYellowBook(false)
-    setShowGreenBook(false)
-    battleAudio.stop()
-    diaryAudio.stop()
-  }
+    setShowYellowBook(false);
+    setShowGreenBook(false);
+    battleAudio.stop();
+    diaryAudio.stop();
+  };
 
   return (
     <>
@@ -45,11 +45,7 @@ export const Lore: React.FC = () => {
         }}
       />
       {showGreenBook && (
-        <Modal
-          centered
-          show={showGreenBook}
-          onHide={() => onCloseBook()}
-        >
+        <Modal centered show={showGreenBook} onHide={() => onCloseBook()}>
           <Panel>
             <div className="flex items-start">
               <img src={greenBook} className="w-12 img-highlight mr-2" />
@@ -79,11 +75,7 @@ export const Lore: React.FC = () => {
         }}
       />
       {showYellowBook && (
-        <Modal
-          centered
-          show={showYellowBook}
-          onHide={() => onCloseBook()}
-        >
+        <Modal centered show={showYellowBook} onHide={() => onCloseBook()}>
           <Panel>
             <div className="flex items-start">
               <img src={yellowBook} className="w-12 img-highlight mr-2" />

--- a/src/lib/utils/sfx.ts
+++ b/src/lib/utils/sfx.ts
@@ -19,7 +19,6 @@ import barnMp3 from "../../assets/sound-effects/barn.mp3";
 import battleMp3 from "../../assets/sound-effects/battle.mp3";
 import diaryMp3 from "../../assets/sound-effects/diary.mp3";
 
-
 export const harvestAudio = new Howl({
   src: [harvestMp3],
   volume: 0.2,


### PR DESCRIPTION
# Description

The easter egg locations are being dumped to the console. It takes away a lot of the mystery when you can see the locations easily by opening the console.

<img width="392" alt="image" src="https://user-images.githubusercontent.com/3408480/164330497-00eb1777-9b81-4bc5-b43a-b4b14feea31c.png">


* Also added an eslint rule to disallow logging like this (without fixing any of the other current logging warnings)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran `npx tsc` locally with no compile errors

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
