### PR TITLE
[FIX] Scroll into view for Easter Bunny, Nancy, and Kuebiko

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -590,6 +590,7 @@ export const BARN_ITEMS: Record<BarnItem, Craftable> = {
     ],
     supply: 100000,
     disabled: false,
+    section: Section["Easter Bunny"],
   },
 };
 

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -443,6 +443,7 @@ export const MARKET_ITEMS: Record<MarketItem, Craftable> = {
     ],
     supply: 200,
     disabled: true,
+    section: Section.Scarecrow,
   },
   "Golden Cauliflower": {
     name: "Golden Cauliflower",

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -401,6 +401,7 @@ export const MARKET_ITEMS: Record<MarketItem, Craftable> = {
       },
     ],
     supply: 50000,
+    section: Section.Scarecrow,
   },
   Scarecrow: {
     name: "Scarecrow",


### PR DESCRIPTION
# Description

In the inventory section most all NFTs when clicked on scroll to center them on the screen so the user can easily find them. Some NFTs were lacking this [easter bunny, nancy, kuebiko] and I felt it would be a nice addition to make the game more enjoyable and easy to navigate 😃 

Additionally, the groundwork for this was already laid out just not implemented yet

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Manual testing and running the test suite with `yarn test`
![Screenshot 2022-04-20 211604](https://user-images.githubusercontent.com/31779206/164352317-ca7cf15c-ebfc-45c7-bfa1-77960a467617.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
