### PR TITLE
[FIX] Floor SFL balance to 18 decimal places after selling

### DIFF
--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -38,7 +38,7 @@ export function sell({ state, action }: Options): GameState {
 
   return {
     ...state,
-    balance: state.balance.add(price.mul(action.amount)),
+    balance: state.balance.add(price.mul(action.amount)).toDecimalPlaces(18, Decimal.ROUND_DOWN),
     inventory: {
       ...state.inventory,
       [crop.name]: cropCount.sub(1 * action.amount),


### PR DESCRIPTION
# Description

When acquiring the minimal amount of Wheat (meaning 1e-18 units) via trading, deposit works fine.  What does not work fine is selling the Wheat.  If you sell the Wheat (with or without NFTs), the sale price is 7e-19.  The Shop vendor happily does the transaction.  From there forward, Sync is broken for the farm for all attempts going forward.

The problem is that the in-game SFL balance can store more than 18 decimal places but the on-chain token support 18 so a Sync is impossible.

This change floors the SFL balance to 18 decimal places after completing a sell operation.  This prevents this issue in this case and similar cases that are likely to happen after a few halvings.

I'm hopeful it will also fix my currently un-sync-able farm in Polygon mainnet. :|

Screenshot of the Wheat about to be sold:
![image](https://user-images.githubusercontent.com/36871683/164396017-c805125b-bb1b-4a23-a9b9-0d47f0b6bb14.png)

Screenshot of the message after sale:
![image](https://user-images.githubusercontent.com/36871683/164396045-5f16811b-8021-491b-98f3-b76dd2909187.png)
The 20th and 21st decimal places are due to 5% from the Green Thumb skill.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Validated locally with 1 and 2 as the floor values.  I don't have a good way to test the Sync scenario though as it's not available on local.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
