### PR TITLE
[FIX] Fix label on-hover clipping issue within modal

### DIFF
--- a/src/features/hud/components/InventoryTabContent.tsx
+++ b/src/features/hud/components/InventoryTabContent.tsx
@@ -153,10 +153,10 @@ export const InventoryTabContent = ({
         })}
       >
         {categories.map((category) => (
-          <div className="flex flex-col" key={category}>
+          <div className="flex flex-col pl-2" key={category}>
             {<p className="mb-2 underline">{category}</p>}
             {findIfItemsExistForCategory(category) ? (
-              <div className="flex mb-2 flex-wrap">
+              <div className="flex mb-2 flex-wrap pl-1.5">
                 {inventoryMapping[category].map((item) => (
                   <Box
                     count={inventory[item]}
@@ -168,7 +168,7 @@ export const InventoryTabContent = ({
                 ))}
               </div>
             ) : (
-              <p className="text-white text-xs text-shadow mb-2">
+              <p className="text-white text-xs text-shadow mb-2 pl-2.5">
                 {`No ${category} in inventory`}
               </p>
             )}


### PR DESCRIPTION
# Description

When you hover-over an inventory item with a large quantity within a modal, the "number label" will expand to show the entire number. However, there is a UI clipping bug whenever that inventory item is on the left side of the container. I noticed this bug as I reached a high wood count within my own farm.

To solve this, I added some simple padding on a few of the nested componenets.

See clipping issue:
![clipped-inventory-count-for-box](https://user-images.githubusercontent.com/103600068/164537858-e425089b-4e14-4e8c-8d02-e6d4392a6747.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since this is a UI bug, I validated visually. I chose padding based on what seemed to make the most sense to my eye. While testing locally, I manually created many inventory items with high inventory counts. Please see screenshots below...

**PLEASE NOTE - Clipping starts to occur again once 100K+ count.**

Inventory basket with small item count:
![inventory-basket-with-small-items](https://user-images.githubusercontent.com/103600068/164539237-93ab8946-70be-45b2-9dc1-e5bed8b78f27.png)

Inventory basket with large item count:
![inventory-basket-with-many-items](https://user-images.githubusercontent.com/103600068/164539375-a0f28b7a-ec1c-4b4d-94c3-fd571a9938bf.png)

Inventory collectibles with small item count:
![inventory-collectibles-with-small-items](https://user-images.githubusercontent.com/103600068/164539448-97e54ea4-e2af-4684-b989-e8744bf68595.png)

Inventory collectibles with large item count:
![inventory-collectibles-with-many-items](https://user-images.githubusercontent.com/103600068/164539491-1108d44e-269c-40f6-8063-68885910be90.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
