### PR TITLE
[FIX]Green book overlap with time left model

### DIFF
--- a/src/features/game/components/Lore.tsx
+++ b/src/features/game/components/Lore.tsx
@@ -36,7 +36,7 @@ export const Lore: React.FC = () => {
     <>
       <img
         src={greenBook}
-        className="absolute hover:img-highlight cursor-pointer z-10"
+        className="absolute hover:img-highlight cursor-pointer"
         onClick={() => onOpenGreenBook()}
         style={{
           width: `${GRID_WIDTH_PX * 0.5}px`,


### PR DESCRIPTION
# Description

**Issue:** 
when you harvest the stone near the green book and hover your mouse to see the time left model 
the green book is on top of that model

So, I removed the z-10 class from the green book.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
![image](https://user-images.githubusercontent.com/9072434/164553483-0490dccc-a71f-4b48-bb33-9bfd3e18ab78.png)

### before
![image](https://user-images.githubusercontent.com/9072434/164553509-c95eff17-14b6-47bb-bf4a-a1dc9ba47672.png)

### after
![image](https://user-images.githubusercontent.com/9072434/164553542-c321fa2c-9a6f-4b1f-8dd3-741701721a5c.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
