### PR TITLE
[FIX] Disable button if already crafted

### DIFF
--- a/src/features/bakery/components/CraftingItems.tsx
+++ b/src/features/bakery/components/CraftingItems.tsx
@@ -120,7 +120,7 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
             </div>
           )}
           <Button
-            disabled={hasSelectedFood ? true : !canCraft}
+            disabled={hasSelectedFood || !canCraft}
             className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
             onClick={() => craft()}
           >

--- a/src/features/bakery/components/CraftingItems.tsx
+++ b/src/features/bakery/components/CraftingItems.tsx
@@ -120,7 +120,7 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
             </div>
           )}
           <Button
-            disabled={hasSelectedFood ? false : !canCraft}
+            disabled={hasSelectedFood ? true : !canCraft}
             className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
             onClick={() => craft()}
           >


### PR DESCRIPTION
# Description
- disabled button in kitchen if it is `already crafted`

Fixes #issue: raised in discord chat

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
<img width="346" alt="Screen Shot 2022-04-22 at 5 12 17 PM" src="https://user-images.githubusercontent.com/18549210/164675616-b3ad1c49-de38-456a-857a-e722ea0f5e78.png">

`yarn dev`
## Before:
<img width="496" alt="Screen Shot 2022-04-22 at 4 46 33 PM" src="https://user-images.githubusercontent.com/18549210/164675446-002f480d-be4e-4ec3-898a-302a1f21bc13.png">

## After:
<img width="500" alt="Screen Shot 2022-04-22 at 4 56 06 PM" src="https://user-images.githubusercontent.com/18549210/164675538-5bb74d34-d710-4654-a5e4-0f06e59b95e5.png">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
