### PR TITLE
[FEAT] Store Audio Settings in Local Storage

### DIFF
--- a/src/components/ui/AudioPlayer.tsx
+++ b/src/components/ui/AudioPlayer.tsx
@@ -11,13 +11,25 @@ import { Button } from "components/ui/Button";
 import { getSong, getSongCount } from "assets/songs/playlist";
 import { Panel } from "components/ui/Panel";
 import { useStepper } from "lib/utils/hooks/useStepper";
+import { useLocalStorage } from "lib/utils/hooks/useLocalStorage";
 
 export const AudioPlayer: React.FC = () => {
-  const volume = useStepper({ initial: 0.1, step: 0.1, max: 1, min: 0 });
   const [visible, setIsVisible] = useState<boolean>(false);
-  const [muted, setMuted] = useState<boolean>(false);
-  const [isPlaying, setPlaying] = useState<boolean>(true);
   const [songIndex, setSongIndex] = useState<number>(0);
+  const [muted, setMuted] = useLocalStorage<boolean>(
+    "audioplayer.muted",
+    false
+  );
+  const [isPlaying, setPlaying] = useLocalStorage<boolean>(
+    "audioplayer.playing",
+    true
+  );
+  const [lsVolume, setLsVolume] = useLocalStorage<number>(
+    "audioplayer.volume",
+    0.1
+  );
+  const volume = useStepper({ initial: lsVolume, step: 0.1, max: 1, min: 0 });
+
   const musicPlayer = useRef<any>(null);
 
   const handlePlayState = () => {
@@ -45,6 +57,7 @@ export const AudioPlayer: React.FC = () => {
 
   useEffect(() => {
     musicPlayer.current.volume = volume.value;
+    setLsVolume(volume.value);
   }, [volume.value]);
 
   useEffect(() => {
@@ -72,7 +85,7 @@ export const AudioPlayer: React.FC = () => {
           onPlay={() => setPlaying(!musicPlayer.current.paused)}
           src={song.path}
           className="d-none"
-          autoPlay
+          autoPlay={isPlaying}
           controls
         />
         <div className="p-1 sm:mr-2 relative">

--- a/src/lib/utils/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/lib/utils/hooks/__tests__/useLocalStorage.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import { useLocalStorage } from "../useLocalStorage";
 
 describe("useLocalStorage hook", () => {
@@ -61,7 +61,10 @@ describe("useLocalStorage hook", () => {
     const { result } = renderHook(() => useLocalStorage(key, defaultValue));
     const [, setValue] = result.current;
 
-    setValue(updatedValue);
+    act(() => {
+      setValue(updatedValue);
+    });
+
     const [value] = result.current;
 
     expect(value).toBe(updatedValue);
@@ -73,7 +76,10 @@ describe("useLocalStorage hook", () => {
     const { result } = renderHook(() => useLocalStorage("key", defaultValue));
     const [, setValue] = result.current;
 
-    setValue(updatedValue);
+    act(() => {
+      setValue(updatedValue);
+    });
+
     const [value] = result.current;
 
     expect(value).toBe(updatedValue);
@@ -85,7 +91,10 @@ describe("useLocalStorage hook", () => {
     const { result } = renderHook(() => useLocalStorage("key", defaultValue));
     const [, setValue] = result.current;
 
-    setValue(updatedValue);
+    act(() => {
+      setValue(updatedValue);
+    });
+
     const [value] = result.current;
 
     expect(value).toBe(updatedValue);
@@ -100,8 +109,27 @@ describe("useLocalStorage hook", () => {
     const { result } = renderHook(() => useLocalStorage("key", defaultValue));
     const [, setValue] = result.current;
 
-    setValue(updatedValue);
+    act(() => {
+      setValue(updatedValue);
+    });
     const [value] = result.current;
+
+    expect(value).toStrictEqual(updatedValue);
+  });
+
+  it("starts with stored value", () => {
+    const defaultValue = "defaultValue";
+    const updatedValue = "updatedValue";
+
+    const hook1 = renderHook(() => useLocalStorage("key", defaultValue));
+    const [, setValue] = hook1.result.current;
+
+    act(() => {
+      setValue(updatedValue);
+    });
+
+    const hook2 = renderHook(() => useLocalStorage("key", defaultValue));
+    const [value] = hook2.result.current;
 
     expect(value).toStrictEqual(updatedValue);
   });

--- a/src/lib/utils/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/lib/utils/hooks/__tests__/useLocalStorage.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useLocalStorage } from "../useLocalStorage";
+
+describe("useLocalStorage hook", () => {
+  let localStorage: { [key: string]: string } = {};
+  const key = "key";
+
+  beforeAll(() => {
+    global.Storage.prototype.setItem = jest.fn((key, value) => {
+      localStorage[key] = value;
+    });
+    global.Storage.prototype.getItem = jest.fn((key) => localStorage[key]);
+  });
+
+  beforeEach(() => {
+    localStorage = {};
+  });
+
+  afterAll(() => {
+    (global.Storage.prototype.setItem as jest.Mock).mockReset();
+    (global.Storage.prototype.getItem as jest.Mock).mockReset();
+  });
+
+  it("starts with a default string", () => {
+    const defaultValue = "defaultValue";
+
+    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+    const [value] = result.current;
+
+    expect(value).toBe(defaultValue);
+  });
+  it("starts with a default number", () => {
+    const defaultValue = 123;
+
+    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+    const [value] = result.current;
+
+    expect(value).toBe(123);
+  });
+  it("starts with a default boolean", () => {
+    const defaultValue = true;
+
+    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+    const [value] = result.current;
+
+    expect(value).toBe(defaultValue);
+  });
+  it("starts with a default object", () => {
+    const defaultValue = { defaultKey: ["1", 2] };
+
+    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+    const [value] = result.current;
+
+    expect(value).toStrictEqual(defaultValue);
+  });
+
+  it("updates a string", () => {
+    const defaultValue = "defaultValue";
+    const updatedValue = "updatedValue";
+
+    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+    const [, setValue] = result.current;
+
+    setValue(updatedValue);
+    const [value] = result.current;
+
+    expect(value).toBe(updatedValue);
+  });
+  it("updates a number", () => {
+    const defaultValue = 123;
+    const updatedValue = 456;
+
+    const { result } = renderHook(() => useLocalStorage("key", defaultValue));
+    const [, setValue] = result.current;
+
+    setValue(updatedValue);
+    const [value] = result.current;
+
+    expect(value).toBe(updatedValue);
+  });
+  it("updates a boolean", () => {
+    const defaultValue = true;
+    const updatedValue = false;
+
+    const { result } = renderHook(() => useLocalStorage("key", defaultValue));
+    const [, setValue] = result.current;
+
+    setValue(updatedValue);
+    const [value] = result.current;
+
+    expect(value).toBe(updatedValue);
+  });
+  it("updates an object", () => {
+    type StringStore = { [key: string]: string[] };
+    const defaultValue: StringStore = { defaultKey: ["defaultValue"] };
+    const updatedValue: StringStore = {
+      updatedKey: ["updatedValue1", "updatedValue1"],
+    };
+
+    const { result } = renderHook(() => useLocalStorage("key", defaultValue));
+    const [, setValue] = result.current;
+
+    setValue(updatedValue);
+    const [value] = result.current;
+
+    expect(value).toStrictEqual(updatedValue);
+  });
+});

--- a/src/lib/utils/hooks/useLocalStorage.ts
+++ b/src/lib/utils/hooks/useLocalStorage.ts
@@ -1,0 +1,17 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+export const useLocalStorage = <T>(
+  key: string,
+  defaultValue: T
+): [T, Dispatch<SetStateAction<T>>] => {
+  const [value, setValue] = useState<T>(() => {
+    const item = localStorage.getItem(key);
+    return item ? JSON.parse(item) : defaultValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+};


### PR DESCRIPTION
# Description

Refreshing the browser resets the audio volume and game sound settings. 

This change updates the audio player to store configured audio settings in browser local storage. This allows the settings to persist across browser refresh.

The changes introduce a new react hook, `useLocalStorage` to replace the current usage of `useState` in the audio player.

## Changes

- Introduces a new hook, `useLocalStorage`
- Updates the `AudioPlayer.tsx` hooks from `useState` to `useLocalStorage`.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests have been created in `useLocalStorage.test.ts`. The tests cover use cases for storing strings, booleans, numbers and JSON objects.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
