### PR TITLE
[FIX] Decimal handling of selling all crops

### DIFF
--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -31,7 +31,7 @@ export const Plants: React.FC = () => {
 
   const inventory = state.inventory;
 
-  const sell = (amount = 1) => {
+  const sell = (amount = new Decimal(1)) => {
     gameService.send("item.sell", {
       item: selected.name,
       amount,
@@ -46,11 +46,11 @@ export const Plants: React.FC = () => {
   const displaySellPrice = (crop: Crop) => getSellPrice(crop, inventory);
 
   const handleSellOne = () => {
-    sell(1);
+    sell(new Decimal(1));
   };
 
   const handleSellAll = () => {
-    sell(cropAmount.toNumber());
+    sell(cropAmount);
     showSellAllModal(false);
   };
 
@@ -129,7 +129,7 @@ export const Plants: React.FC = () => {
               sell all your {selected.name}?
             </span>
             <span className="text-sm text-center text-shadow mt-1">
-              Total: {cropAmount.toNumber()}
+              Total: {cropAmount.toString()}
             </span>
           </div>
           <div className="flex justify-content-around p-1">

--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -192,7 +192,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
                   "text-red-500": lessFunds(),
                 })}
               >
-                {`$${price}`}
+                {`$${price.toString()}`}
               </span>
             </div>
           </div>

--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -37,6 +37,10 @@ import { screenTracker } from "lib/utils/screen";
 import { Withdrawn } from "./components/Withdrawn";
 import { EasterEggHunt } from "features/easter/Area";
 import { Resetting } from "features/auth/components/Resetting";
+import Decimal from 'decimal.js-light';
+
+const DECIMAL_PRECISION = 78;
+Decimal.set({ precision: DECIMAL_PRECISION });
 
 const AUTO_SAVE_INTERVAL = 1000 * 30; // autosave every 30 seconds
 const SHOW_MODAL: Record<StateValues, boolean> = {

--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -35,7 +35,7 @@ function squashEvents(events: PastAction[]): PastAction[] {
           {
             ...event,
             amount:
-              (previous as SellAction | CraftAction).amount + event.amount,
+              (previous as SellAction | CraftAction).amount.add(event.amount),
           } as PastAction,
         ];
       }

--- a/src/features/game/events/craft.test.ts
+++ b/src/features/game/events/craft.test.ts
@@ -14,7 +14,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Sunflower Statue",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("This item is not craftable: Sunflower");
@@ -27,7 +27,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Rod",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("This item is disabled");
@@ -38,12 +38,12 @@ describe("craft", () => {
       craft({
         state: {
           ...GAME_STATE,
-          balance: new Decimal(0.0000005),
+          balance: new Decimal('0.0000005'),
         },
         action: {
           type: "item.crafted",
           item: "Sunflower Seed",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("Insufficient tokens");
@@ -60,7 +60,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Pickaxe",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("Insufficient ingredient: Wood");
@@ -75,7 +75,7 @@ describe("craft", () => {
       action: {
         type: "item.crafted",
         item: "Sunflower Seed",
-        amount: 1,
+        amount: new Decimal(1),
       },
     });
 
@@ -95,7 +95,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Sunflower Seed",
-          amount: 0.2,
+          amount: new Decimal('0.2'),
         },
       })
     ).toThrow("Invalid amount");
@@ -111,7 +111,7 @@ describe("craft", () => {
       action: {
         type: "item.crafted",
         item: "Pickaxe",
-        amount: 1,
+        amount: new Decimal(1),
       },
     });
 
@@ -131,7 +131,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Carrot Seed",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("Missing Pumpkin Soup");
@@ -147,7 +147,7 @@ describe("craft", () => {
       action: {
         type: "item.crafted",
         item: "Carrot Seed",
-        amount: 1,
+        amount: new Decimal(1),
       },
     });
 
@@ -161,12 +161,12 @@ describe("craft", () => {
     const state = craft({
       state: {
         ...GAME_STATE,
-        balance: new Decimal(0.1),
+        balance: new Decimal('0.1'),
       },
       action: {
         type: "item.crafted",
         item: "Sunflower Seed",
-        amount: 10,
+        amount: new Decimal(10),
       },
     });
 
@@ -186,7 +186,7 @@ describe("craft", () => {
       action: {
         type: "item.crafted",
         item: "Pickaxe",
-        amount: 10,
+        amount: new Decimal(10),
       },
     });
 
@@ -206,7 +206,7 @@ describe("craft", () => {
         action: {
           type: "item.crafted",
           item: "Pickaxe",
-          amount: 10,
+          amount: new Decimal(10),
         },
       })
     ).toThrow("Insufficient ingredient: Wood");

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -58,7 +58,7 @@ export function craft({ state, action, available }: Options) {
     throw new Error("This item is disabled");
   }
 
-  if (action.amount < 1) {
+  if (action.amount < new Decimal(1)) {
     throw new Error("Invalid amount");
   }
 

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -14,7 +14,7 @@ import { isSeed } from "./plant";
 export type CraftAction = {
   type: "item.crafted";
   item: CraftableName;
-  amount: number;
+  amount: Decimal;
 };
 
 /**

--- a/src/features/game/events/sell.test.ts
+++ b/src/features/game/events/sell.test.ts
@@ -21,7 +21,7 @@ describe("sell", () => {
         action: {
           type: "item.sell",
           item: "Axe",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("Not for sale");
@@ -39,7 +39,7 @@ describe("sell", () => {
         action: {
           type: "item.sell",
           item: "Sunflower",
-          amount: 0,
+          amount: new Decimal(0),
         },
       })
     ).toThrow("Invalid amount");
@@ -52,7 +52,7 @@ describe("sell", () => {
         action: {
           type: "item.sell",
           item: "Sunflower",
-          amount: 1,
+          amount: new Decimal(1),
         },
       })
     ).toThrow("Insufficient crops to sell");
@@ -69,7 +69,7 @@ describe("sell", () => {
       action: {
         type: "item.sell",
         item: "Sunflower",
-        amount: 1,
+        amount: new Decimal(1),
       },
     });
 
@@ -90,7 +90,7 @@ describe("sell", () => {
       action: {
         type: "item.sell",
         item: "Sunflower",
-        amount: 10,
+        amount: new Decimal(10),
       },
     });
 
@@ -112,7 +112,7 @@ describe("sell", () => {
         action: {
           type: "item.sell",
           item: "Sunflower",
-          amount: 10,
+          amount: new Decimal(10),
         },
       })
     ).toThrow("Insufficient crops to sell");
@@ -129,7 +129,7 @@ describe("sell", () => {
       action: {
         type: "item.sell",
         item: "Cauliflower",
-        amount: 1,
+        amount: new Decimal(1),
       },
     });
 

--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -6,7 +6,7 @@ import { getSellPrice } from "../lib/boosts";
 export type SellAction = {
   type: "item.sell";
   item: InventoryItemName;
-  amount: number;
+  amount: Decimal;
 };
 
 function isCrop(crop: InventoryItemName): crop is CropName {
@@ -22,7 +22,7 @@ export function sell({ state, action }: Options): GameState {
     throw new Error("Not for sale");
   }
 
-  if (action.amount <= 0) {
+  if (action.amount <= new Decimal(0)) {
     throw new Error("Invalid amount");
   }
 
@@ -43,7 +43,7 @@ export function sell({ state, action }: Options): GameState {
       .toDecimalPlaces(18, Decimal.ROUND_DOWN),
     inventory: {
       ...state.inventory,
-      [crop.name]: cropCount.sub(1 * action.amount),
+      [crop.name]: cropCount.sub(action.amount),
     },
   };
 }

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -10,7 +10,7 @@ export { FLAGS };
 export type CraftAction = {
   type: "item.crafted";
   item: InventoryItemName;
-  amount: number;
+  amount: Decimal;
 };
 
 export type CraftableName =


### PR DESCRIPTION
# Description

Fixes #637 

Casting a "Decimal.js" number to a "number" javascript primitive causes a floating point precision loss that, in some cases, can prevent crops to be sold ( see example in #637 )

Fixed by adding a global precision setting and using `Decimal` instead of `number`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested the scenario proposed in #637

1. Change `cropCount` of `harvest.ts` to the testing number `new Decimal('1843.399999999999999999')`
2. Start a new farm
3. Harvest a crop
4. Open market
5. Navigate to 'Sell' tab
6. Select the crop type harvested in (3)
7. Press 'Sell all' button
8. Confirm the modal
9. Observe that the bug is fixed and crops can be successfully sold

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
