### PR TITLE
[FEAT] Buy remaining seed stock button when less than 10 remaining

### DIFF
--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -140,6 +140,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
         </Button>
         {bulkSeedBuyAmount > 1 && (
           <Button
+            disabled={lessFunds(bulkSeedBuyAmount)}
             className="text-xs mt-1"
             onClick={() => buy(bulkSeedBuyAmount)}
           >

--- a/src/features/crops/components/Seeds.tsx
+++ b/src/features/crops/components/Seeds.tsx
@@ -24,6 +24,7 @@ import { hasBoost } from "features/game/lib/boosts";
 import { getBuyPrice } from "features/game/events/craft";
 import { getCropTime } from "features/game/events/plant";
 import { INITIAL_STOCK } from "features/game/lib/constants";
+import { makeBulkSeedBuyAmount } from "../lib/makeBulkSeedBuyAmount";
 
 interface Props {
   onClose: () => void;
@@ -55,14 +56,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     shortcutItem(selected.name);
   };
 
-  const handlBuyOne = () => {
-    buy();
-  };
-
-  const handleBuyTen = () => {
-    buy(10);
-  };
-
   const restock = () => {
     setShowCaptcha(true);
   };
@@ -82,6 +75,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
   const crop = CROPS()[cropName];
 
   const stock = state.stock[selected.name] || new Decimal(0);
+  const bulkSeedBuyAmount = makeBulkSeedBuyAmount(stock);
 
   useEffect(
     () =>
@@ -140,17 +134,18 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
         <Button
           disabled={lessFunds() || stock?.lessThan(1)}
           className="text-xs mt-1"
-          onClick={handlBuyOne}
+          onClick={() => buy(1)}
         >
           Buy 1
         </Button>
-        <Button
-          disabled={lessFunds(10) || stock?.lessThan(10)}
-          className="text-xs mt-1"
-          onClick={() => buy(10)}
-        >
-          Buy 10
-        </Button>
+        {bulkSeedBuyAmount > 1 && (
+          <Button
+            className="text-xs mt-1"
+            onClick={() => buy(bulkSeedBuyAmount)}
+          >
+            Buy {bulkSeedBuyAmount}
+          </Button>
+        )}
       </>
     );
   };

--- a/src/features/crops/lib/makeBulkSeedBuyAmount.ts
+++ b/src/features/crops/lib/makeBulkSeedBuyAmount.ts
@@ -1,0 +1,11 @@
+import { Decimal } from "decimal.js-light";
+
+export const MAX_BULK_SEED_BUY_AMOUNT = 10;
+
+export function makeBulkSeedBuyAmount(stock: Decimal) {
+  const amount = stock.lessThan(MAX_BULK_SEED_BUY_AMOUNT)
+    ? stock.toDecimalPlaces(0, Decimal.ROUND_DOWN)
+    : new Decimal(MAX_BULK_SEED_BUY_AMOUNT);
+
+  return amount.toNumber();
+}

--- a/src/features/crops/lib/makeBulkSeedBuyAmount.ts
+++ b/src/features/crops/lib/makeBulkSeedBuyAmount.ts
@@ -3,9 +3,9 @@ import { Decimal } from "decimal.js-light";
 export const MAX_BULK_SEED_BUY_AMOUNT = 10;
 
 export function makeBulkSeedBuyAmount(stock: Decimal) {
-  const amount = stock.lessThan(MAX_BULK_SEED_BUY_AMOUNT)
-    ? stock.toDecimalPlaces(0, Decimal.ROUND_DOWN)
-    : new Decimal(MAX_BULK_SEED_BUY_AMOUNT);
+  if (stock.lessThan(MAX_BULK_SEED_BUY_AMOUNT)) {
+    return stock.toDecimalPlaces(0, Decimal.ROUND_DOWN).toNumber();
+  }
 
-  return amount.toNumber();
+  return MAX_BULK_SEED_BUY_AMOUNT;
 }

--- a/src/features/crops/lib/makeBulkSeedByAmount.test.ts
+++ b/src/features/crops/lib/makeBulkSeedByAmount.test.ts
@@ -1,0 +1,34 @@
+import Decimal from "decimal.js-light";
+import {
+  makeBulkSeedBuyAmount,
+  MAX_BULK_SEED_BUY_AMOUNT,
+} from "./makeBulkSeedBuyAmount";
+
+describe("makeBulkSeedBuyAmount", () => {
+  it("should return the the MAX if enough stock", () => {
+    expect(makeBulkSeedBuyAmount(new Decimal(200))).toBe(
+      MAX_BULK_SEED_BUY_AMOUNT
+    );
+    expect(makeBulkSeedBuyAmount(new Decimal(11))).toBe(
+      MAX_BULK_SEED_BUY_AMOUNT
+    );
+  });
+
+  it("should return remaining stock if less than MAX bulk buy amount", () => {
+    expect(
+      makeBulkSeedBuyAmount(new Decimal(MAX_BULK_SEED_BUY_AMOUNT - 1))
+    ).toBe(MAX_BULK_SEED_BUY_AMOUNT - 1);
+    expect(
+      makeBulkSeedBuyAmount(new Decimal(MAX_BULK_SEED_BUY_AMOUNT - 4))
+    ).toBe(MAX_BULK_SEED_BUY_AMOUNT - 4);
+  });
+
+  it("should round down if stock some how not integer", () => {
+    expect(
+      makeBulkSeedBuyAmount(new Decimal(MAX_BULK_SEED_BUY_AMOUNT - 0.3))
+    ).toBe(MAX_BULK_SEED_BUY_AMOUNT - 1);
+    expect(
+      makeBulkSeedBuyAmount(new Decimal(MAX_BULK_SEED_BUY_AMOUNT - 1.5))
+    ).toBe(MAX_BULK_SEED_BUY_AMOUNT - 2);
+  });
+});


### PR DESCRIPTION
# Description

Small UX improvement when bulk buying seeds ("buy 10" button).

Instead of disabling the button when stock < 10, the button now buys the remaining stock. When only one stock remaining, show only the single buy button.

### **Before:**

<img width="525" alt="image" src="https://user-images.githubusercontent.com/14039116/165004020-9aa3faca-298e-4903-8d17-b15ced57565d.png">

### **After:**

![sunflower_bulkbuy](https://user-images.githubusercontent.com/14039116/165003900-f78cba09-c851-482a-82ef-4eb176760f5a.gif)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Unit test & manual testing

To test:
- Deplete stock of seed and observe bulk buy button change to remaining stock once below 10.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
