### PR TITLE
[FIX] Limited Item Amount Left

### DIFF
--- a/src/features/auth/components/StartFarm.tsx
+++ b/src/features/auth/components/StartFarm.tsx
@@ -29,7 +29,7 @@ export const StartFarm: React.FC = () => {
         <>
           <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
           <Button onClick={start} className="overflow-hidden mb-2">
-            Lets farm!
+            Let's farm!
           </Button>
           <Button onClick={explore} className="overflow-hidden">
             {`Explore a friend's farm`}

--- a/src/features/auth/components/StartFarm.tsx
+++ b/src/features/auth/components/StartFarm.tsx
@@ -29,7 +29,7 @@ export const StartFarm: React.FC = () => {
         <>
           <p className="text-shadow text-small mb-2 px-1">Farm ID: {farmId}</p>
           <Button onClick={start} className="overflow-hidden mb-2">
-            Let's farm!
+            Let&apos;s farm!
           </Button>
           <Button onClick={explore} className="overflow-hidden">
             {`Explore a friend's farm`}

--- a/src/features/blacksmith/components/Rare.tsx
+++ b/src/features/blacksmith/components/Rare.tsx
@@ -20,6 +20,7 @@ import { useShowScrollbar } from "lib/utils/hooks/useShowScrollbar";
 import { KNOWN_IDS } from "features/game/types";
 import { mintCooldown } from "../lib/mintUtils";
 import { secondsToString } from "lib/utils/time";
+import { getAmountLeft } from "features/game/lib/amountLeft";
 
 const TAB_CONTENT_HEIGHT = 360;
 
@@ -122,7 +123,7 @@ export const Rare: React.FC<Props> = ({
 
   let amountLeft = 0;
   if (supply && selected.supply) {
-    amountLeft = selected.supply - supply[selected.name]?.toNumber();
+    amountLeft = getAmountLeft(supply, selected);
   }
 
   const soldOut = amountLeft <= 0;

--- a/src/features/game/lib/amountLeft.test.ts
+++ b/src/features/game/lib/amountLeft.test.ts
@@ -1,0 +1,50 @@
+import Decimal from "decimal.js-light";
+import { getAmountLeft } from "./amountLeft";
+import {
+  Craftable,
+  BLACKSMITH_ITEMS,
+  MARKET_ITEMS,
+  TOOLS,
+} from "../types/craftables";
+
+const supply = {
+  "Woody the Beaver": new Decimal(4000), // (50k - 4k) - 100 - 1 = 45899 left
+  "Apprentice Beaver": new Decimal(100), // (5k - 100) - 1 = 4899 left
+  "Foreman Beaver": new Decimal(1), // (300 - 1) = 299 left
+  Nancy: new Decimal(10000), // (50k - 10k) - 123 - 90 = 39787 left
+  Scarecrow: new Decimal(123), // (5k - 123) - 90 = 4787 left
+  Kuebiko: new Decimal(90), // (200 - 90) = 110 left
+  "Sunflower Statue": new Decimal(100),
+};
+
+describe("amountLeft", () => {
+  it("should return `Infinity` when there is no `supply` prop", () => {
+    const selected = TOOLS.Axe;
+
+    expect(getAmountLeft(supply, selected)).toEqual(Infinity);
+  });
+
+  it("should ignore `upgradeSupply` when non existent", () => {
+    const selected: Craftable = BLACKSMITH_ITEMS["Sunflower Statue"];
+
+    expect(getAmountLeft(supply, selected)).toEqual(900);
+  });
+
+  it("should subtract `upgradeSupply` when limited item is required on higher tier crafting", () => {
+    const woody = BLACKSMITH_ITEMS["Woody the Beaver"];
+    const apprentice = BLACKSMITH_ITEMS["Apprentice Beaver"];
+    const foreman = BLACKSMITH_ITEMS["Foreman Beaver"];
+
+    expect(getAmountLeft(supply, woody)).toEqual(45899);
+    expect(getAmountLeft(supply, apprentice)).toEqual(4899);
+    expect(getAmountLeft(supply, foreman)).toEqual(299);
+
+    const nancy = MARKET_ITEMS.Nancy;
+    const scarecrow = MARKET_ITEMS.Scarecrow;
+    const kuebiko = MARKET_ITEMS.Kuebiko;
+
+    expect(getAmountLeft(supply, nancy)).toEqual(39787);
+    expect(getAmountLeft(supply, scarecrow)).toEqual(4787);
+    expect(getAmountLeft(supply, kuebiko)).toEqual(110);
+  });
+});

--- a/src/features/game/lib/amountLeft.ts
+++ b/src/features/game/lib/amountLeft.ts
@@ -1,0 +1,24 @@
+import { Craftable } from "../types/craftables";
+import Decimal from "decimal.js-light";
+
+/**
+ * Subtract higher tier item supplies from the selected's amount left
+ * @param itemSupply onchain supply of all items
+ * @param selected selected item
+ */
+export const getAmountLeft = (
+  itemSupply: Record<any, Decimal>,
+  selected: Craftable
+) => {
+  const { name, supply, upgrades } = selected;
+
+  if (!supply) return Infinity; // avoid sold out logic
+
+  const amountLeft = supply - itemSupply[name]?.toNumber();
+  const upgradeSupply =
+    upgrades
+      ?.map((upgrade) => itemSupply[upgrade]?.toNumber())
+      .reduce((sum, amount) => sum + amount) || 0;
+
+  return amountLeft - upgradeSupply;
+};

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -34,6 +34,7 @@ export type Craftable = {
   disabled?: boolean;
   requires?: InventoryItemName;
   section?: Section;
+  upgrades?: CraftableName[]; // used for getting amount left
 };
 
 export type BlacksmithItem =
@@ -393,6 +394,7 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, Craftable> = {
     ],
     supply: 50000,
     section: Section.Beaver,
+    upgrades: ["Apprentice Beaver", "Foreman Beaver"],
   },
   "Apprentice Beaver": {
     name: "Apprentice Beaver",
@@ -411,6 +413,7 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, Craftable> = {
     supply: 5000,
     section: Section.Beaver,
     disabled: true,
+    upgrades: ["Foreman Beaver"],
   },
   "Foreman Beaver": {
     name: "Foreman Beaver",
@@ -446,6 +449,7 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, Craftable> = {
     ],
     supply: 100000,
     disabled: true,
+    upgrades: ["Easter Bunny"],
   },
 };
 
@@ -466,6 +470,7 @@ export const MARKET_ITEMS: Record<MarketItem, Craftable> = {
     ],
     supply: 50000,
     section: Section.Scarecrow,
+    upgrades: ["Scarecrow", "Kuebiko"],
   },
   Scarecrow: {
     name: "Scarecrow",
@@ -489,6 +494,7 @@ export const MARKET_ITEMS: Record<MarketItem, Craftable> = {
     supply: 5000,
     disabled: true,
     section: Section.Scarecrow,
+    upgrades: ["Kuebiko"],
   },
   Kuebiko: {
     name: "Kuebiko",


### PR DESCRIPTION
# Description

This PR fixes the amount left displayed on lower tier items that are used on crafting higher tier ones. **Unless intended**, it should also consider the supply of the crafted higher tier items e.g. `Woody` amount left should consider `Apprentice` and `Foreman` beaver supplies.

Items affected:
- Egg Basket
- Woody the Beaver
- Apprentice Beaver
- Nancy
- Scarecrow

For future items, add `upgrades` prop on `craftables.ts`.

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`yarn tsc`
![image](https://user-images.githubusercontent.com/89294757/165025348-36b267cb-aefe-4111-8f10-226d84a91e2c.png)

`yarn test`
![image](https://user-images.githubusercontent.com/89294757/165025474-228a28e7-657a-4172-88dc-b227278fc91f.png)
![image](https://user-images.githubusercontent.com/89294757/165025490-e93c4c44-4812-41cf-9721-fd4b2bafd933.png)

`yarn format`
![image](https://user-images.githubusercontent.com/89294757/165025707-b74ccd5c-b9d8-4660-828e-82681cbedec3.png)

Manual testing - connected to Testnet but stubbed `supply` state

Rare.tsx
```ts
  const load = async () => {
  let supply = await metamask.getInventory().totalSupply();
  supply = {
    ...supply,
    "Woody the Beaver": new Decimal(4000), // (50k - 4k) - 100 - 1 = 45899 left
    "Apprentice Beaver": new Decimal(100), // (5k - 100) - 1 = 4899 left
    "Foreman Beaver": new Decimal(1), // (300 - 1) = 299 left
    Nancy: new Decimal(10000), // (50k - 10k) - 123 - 90 = 39787 left
    Scarecrow: new Decimal(123), // (5k - 123) - 90 = 4787 left
    Kuebiko: new Decimal(90), // (200 - 90) = 110 left
    "Egg Basket": new Decimal(12000), // (100k - 12k) - 41k = 47k left
    "Easter Bunny": new Decimal(41000), // (100k - 41k) = 59k left
  };
  setSupply(supply);
  setIsLoading(false);
};
```

https://user-images.githubusercontent.com/89294757/165025297-2e3b9c0c-543a-4f2a-bab1-b50bc5153e81.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
