### PR TITLE
[FIX] kbd (up, down, left and right) were working when any modal is open

### DIFF
--- a/src/features/game/lib/mapMovement.ts
+++ b/src/features/game/lib/mapMovement.ts
@@ -47,7 +47,7 @@ const keyDownListener = (event: KeyboardEvent) => {
   }
 };
 
-//no fix for keyup, as a movement began before the opening of the modal needs to be stopped when the key is released
+//no fix for keyup, as the movement began before the opening of the modal, it needs to be stopped when the key is released
 const keyUpListener = (event: KeyboardEvent) => {
   const key = event.key.toLowerCase();
   if (container) {

--- a/src/features/game/lib/mapMovement.ts
+++ b/src/features/game/lib/mapMovement.ts
@@ -47,9 +47,10 @@ const keyDownListener = (event: KeyboardEvent) => {
   }
 };
 
+//no fix for keyup, as a movement began before the opening of the modal needs to be stopped when the key is released
 const keyUpListener = (event: KeyboardEvent) => {
   const key = event.key.toLowerCase();
-  if (container && event.target === document.body) {
+  if (container) {
     if (key === "w" || key === "arrowup") {
       if (movementIntervals.moveUp !== undefined) {
         clearInterval(movementIntervals.moveUp);

--- a/src/features/game/lib/mapMovement.ts
+++ b/src/features/game/lib/mapMovement.ts
@@ -14,7 +14,7 @@ const initialCoordinates = [1024, 1214];
 
 const keyDownListener = (event: KeyboardEvent) => {
   const key = event.key.toLowerCase();
-  if (container) {
+  if (container && event.target === document.body) {
     if (key === "w" || key === "arrowup") {
       if (movementIntervals.moveUp === undefined) {
         movementIntervals.moveUp = setInterval(() => {
@@ -49,7 +49,7 @@ const keyDownListener = (event: KeyboardEvent) => {
 
 const keyUpListener = (event: KeyboardEvent) => {
   const key = event.key.toLowerCase();
-  if (container) {
+  if (container && event.target === document.body) {
     if (key === "w" || key === "arrowup") {
       if (movementIntervals.moveUp !== undefined) {
         clearInterval(movementIntervals.moveUp);


### PR DESCRIPTION
# Description
 _kbd(upm down left and right are working when any modal is open)_

 **fixed by checking if the event target is the document.body for the keydownevent so the event of scrolling only fire when no modals are open.
--the window will only stop scrolling when the key is released though, this is a quick and temporary fix, still better than what it was previously

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1-launch the website
2-check if the keys related to the action are working while a modal is open, and while a modal is not opened.
3-check on google chrome
4-check on mozilla
5-check on brave

list of tests passed :
 PASS  src/features/game/events/plant.test.ts (29.97 s)
 PASS  src/features/game/events/craft.test.ts (30.557 s)
 PASS  src/features/bank/lib/bankUtil.test.ts (30.736 s)
 PASS  src/features/game/events/harvest.test.ts
 PASS  src/features/game/events/stoneMine.test.ts
 PASS  src/lib/utils/time.test.ts
 PASS  src/features/game/events/sell.test.ts
 PASS  src/features/game/events/goldMine.test.ts
 PASS  src/features/game/events/ironMine.test.ts
 PASS  src/features/game/events/chop.test.ts
 PASS  src/lib/utils/hooks/__tests__/useStepper.test.ts

Test Suites: 11 passed, 11 total
Tests:       90 passed, 90 total
Snapshots:   0 total

# Checklist:

- [✅] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] New and existing unit tests pass locally with my changes
- [✅] My changes generate no new warnings
