### PR TITLE
[FEAT] Flexible bulk seed selling

### DIFF
--- a/src/features/crops/components/CustomSellModal.tsx
+++ b/src/features/crops/components/CustomSellModal.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from "react";
+import { Modal } from "react-bootstrap";
+import Decimal from "decimal.js-light";
+
+import token from "assets/icons/token.gif";
+import { Panel } from "components/ui/Panel";
+import { Button } from "components/ui/Button";
+
+const INCREMENT_AMOUNTS = [1, 10, 50, 100];
+
+export interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSell: (amount: number) => void;
+  cropAmount: Decimal;
+  cropName: string;
+  cropImage: string;
+  cropSellPrice: Decimal;
+}
+
+export const CustomSellModal = ({
+  open,
+  onClose,
+  onSell,
+  cropAmount,
+  cropName,
+  cropImage,
+  cropSellPrice,
+}: Props) => {
+  const [sellAmount, setSellAmount] = useState(cropAmount);
+
+  useEffect(() => {
+    setSellAmount(cropAmount);
+  }, [open]);
+
+  const handleSell = () => onSell(sellAmount.toNumber());
+
+  const incrementSellAmount = (amount: number) => {
+    const newAmount = sellAmount.plus(amount);
+    setSellAmount(newAmount.greaterThan(cropAmount) ? cropAmount : newAmount);
+  };
+
+  const decrementSellAmount = (amount: number) => {
+    const newAmount = sellAmount.minus(amount);
+    setSellAmount(newAmount.lessThan(1) ? new Decimal(1) : newAmount);
+  };
+
+  const noCrop = cropAmount.equals(0);
+
+  return (
+    <Modal centered show={open} onHide={onClose}>
+      <Panel className="md:w-4/5 m-auto">
+        <div className="m-auto flex flex-col items-center">
+          <span className="text-sm text-center text-shadow">
+            How much of your {cropName} would you like to sell?
+          </span>
+          <div className="flex justify-center mt-3 mb-2">
+            <span className="text-lg text-center text-shadow mr-1">
+              {sellAmount.toNumber()}
+            </span>
+            <img src={cropImage} className="h-6" />
+          </div>
+          <div className="flex justify-center items-end mb-2">
+            <span className="text-xs text-shadow text-center mt-2 ">+</span>
+            <img src={token} className="h-5 mx-1" />
+            <span className="text-xs text-shadow text-center mt-2 ">
+              {`$${cropSellPrice.mul(sellAmount)}`}
+            </span>
+          </div>
+          <div className="flex items-center justify-center mt-1 mb-2 p-1">
+            {INCREMENT_AMOUNTS.map(
+              (amount) =>
+                cropAmount.greaterThan(amount) && (
+                  <div key={amount} className="mr-1">
+                    <Button
+                      disabled={cropAmount.minus(sellAmount).lessThan(amount)}
+                      className="text-xs mb-1"
+                      onClick={() => incrementSellAmount(amount)}
+                    >
+                      +{amount}
+                    </Button>
+                    <Button
+                      disabled={sellAmount.lessThanOrEqualTo(amount)}
+                      className="text-xs"
+                      onClick={() => decrementSellAmount(amount)}
+                    >
+                      -{amount}
+                    </Button>
+                  </div>
+                )
+            )}
+            <div className="min-w-50">
+              <Button
+                disabled={cropAmount.equals(sellAmount)}
+                className="text-xs mb-1 bg-brown-600"
+                onClick={() => setSellAmount(cropAmount)}
+              >
+                Max
+              </Button>
+              <Button
+                disabled={sellAmount.lessThanOrEqualTo(1)}
+                className="text-xs bg-brown-600"
+                onClick={() => setSellAmount(new Decimal(1))}
+              >
+                Min
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-content-around p-1">
+          <Button disabled={noCrop} className="text-xs" onClick={handleSell}>
+            Sell
+          </Button>
+          <Button disabled={noCrop} className="text-xs ml-2" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+      </Panel>
+    </Modal>
+  );
+};

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -76,7 +76,7 @@ export const Plants: React.FC = () => {
 
   useEffect(() => {
     setIsPriceBoosted(hasSellBoost(inventory));
-  }, [inventory, state.inventory]);
+  }, [inventory]);
 
   return (
     <div className="flex">

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -127,7 +127,7 @@ export const Plants: React.FC = () => {
             Sell All
           </Button>
           <Button
-            disabled={noCrop}
+            disabled={cropAmount.lessThanOrEqualTo(1)}
             className="text-xs mt-1 whitespace-nowrap"
             onClick={() => setShowCustomModal(true)}
           >

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -126,16 +126,14 @@ export const Plants: React.FC = () => {
           >
             Sell All
           </Button>
-          {
-            cropAmount.greaterThan(10) && (
-              <Button
-                className="text-xs mt-1 whitespace-nowrap"
-                onClick={() => setShowCustomModal(true)}
-              >
-                Custom
-              </Button>
-            )
-          }
+          {cropAmount.greaterThan(10) && (
+            <Button
+              className="text-xs mt-1 whitespace-nowrap"
+              onClick={() => setShowCustomModal(true)}
+            >
+              Custom
+            </Button>
+          )}
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -30,6 +30,14 @@ export const Plants: React.FC = () => {
   const [isPriceBoosted, setIsPriceBoosted] = useState(false);
 
   const inventory = state.inventory;
+  const cropAmount = new Decimal(inventory[selected.name] || 0);
+  const noCrop = cropAmount.equals(0);
+  const displaySellPrice = (crop: Crop) => getSellPrice(crop, inventory);
+  const [bulkSellAmount, setBulkSellAmount] = useState(cropAmount);
+
+  useEffect(() => {
+    setBulkSellAmount(cropAmount);
+  }, [selected.name]);
 
   const sell = (amount = 1) => {
     gameService.send("item.sell", {
@@ -41,16 +49,12 @@ export const Plants: React.FC = () => {
     });
   };
 
-  const cropAmount = new Decimal(inventory[selected.name] || 0);
-  const noCrop = cropAmount.equals(0);
-  const displaySellPrice = (crop: Crop) => getSellPrice(crop, inventory);
-
   const handleSellOne = () => {
     sell(1);
   };
 
   const handleSellAll = () => {
-    sell(cropAmount.toNumber());
+    sell(bulkSellAmount.toNumber());
     showSellAllModal(false);
   };
 
@@ -117,8 +121,31 @@ export const Plants: React.FC = () => {
             className="text-xs mt-1 whitespace-nowrap"
             onClick={openConfirmationModal}
           >
-            Sell All
+            Sell{" "}
+            {bulkSellAmount.equals(cropAmount)
+              ? "All"
+              : bulkSellAmount.toNumber()}
           </Button>
+          <div>
+            <input
+              className="
+                form-range
+                w-full
+                h-6
+                p-0
+                bg-transparent
+                focus:outline-none focus:ring-0 focus:shadow-none
+                slider-thumb
+              "
+              onChange={(e) => {
+                setBulkSellAmount(new Decimal(Number(e.target.value)));
+              }}
+              type="range"
+              min={1}
+              max={cropAmount.toNumber()}
+              value={bulkSellAmount.toNumber()}
+            />
+          </div>
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>
@@ -129,7 +156,7 @@ export const Plants: React.FC = () => {
               sell all your {selected.name}?
             </span>
             <span className="text-sm text-center text-shadow mt-1">
-              Total: {cropAmount.toNumber()}
+              Total: {bulkSellAmount.toNumber()}
             </span>
           </div>
           <div className="flex justify-content-around p-1">

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -126,13 +126,16 @@ export const Plants: React.FC = () => {
           >
             Sell All
           </Button>
-          <Button
-            disabled={cropAmount.lessThanOrEqualTo(1)}
-            className="text-xs mt-1 whitespace-nowrap"
-            onClick={() => setShowCustomModal(true)}
-          >
-            Custom
-          </Button>
+          {
+            cropAmount.greaterThan(10) && (
+              <Button
+                className="text-xs mt-1 whitespace-nowrap"
+                onClick={() => setShowCustomModal(true)}
+              >
+                Custom
+              </Button>
+            )
+          }
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -17,6 +17,8 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { getSellPrice, hasSellBoost } from "features/game/lib/boosts";
 
+const BULK_INCREMENT_AMOUNTS = [1, 10, 50];
+
 export const Plants: React.FC = () => {
   const [selected, setSelected] = useState<Crop>(CROPS().Sunflower);
   const { setToast } = useContext(ToastContext);
@@ -59,8 +61,6 @@ export const Plants: React.FC = () => {
     setToast({
       content: "SFL +$" + displaySellPrice(selected).mul(amount).toString(),
     });
-    // Immediately update bulkSell to prevent UI flashing between renders
-    setBulkSellAmount(cropAmount.minus(amount));
   };
 
   const handleSellOne = () => {
@@ -142,60 +142,64 @@ export const Plants: React.FC = () => {
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>
         <Panel className="md:w-4/5 m-auto">
-          <div className="m-auto flex flex-col">
+          <div className="m-auto flex flex-col items-center">
             <span className="text-sm text-center text-shadow">
               Are you sure you want to <br className="hidden md:block" />
               sell your {selected.name}?
             </span>
-            <div className="flex items-center justify-center ms-1 mt-1">
-              <div>
-                <Button
-                  disabled={bulkSellAmount.lessThanOrEqualTo(1)}
-                  className="flex-1 text-xs mt-1 w-70"
-                  onClick={() => decrementBulkSellAmount(1)}
-                >
-                  -1
-                </Button>
-                <Button
-                  disabled={bulkSellAmount.lessThanOrEqualTo(10)}
-                  className="flex-1 text-xs mt-1 w-70"
-                  onClick={() => decrementBulkSellAmount(10)}
-                >
-                  -10
-                </Button>
-              </div>
-              <div className="flex mx-2">
-                <span className="text-sm text-center text-shadow mr-1">
-                  {bulkSellAmount.toNumber()}
-                </span>
-                <img
-                  src={ITEM_DETAILS[selected.name].image}
-                  className="h-5 mr-1"
-                />
-              </div>
-              <div>
-                <Button
-                  disabled={cropAmount.minus(bulkSellAmount).lessThan(1)}
-                  className="flex-1 text-xs mt-1 w-70"
-                  onClick={() => incrementBulkSellAmount(1)}
-                >
-                  +1
-                </Button>
-                <Button
-                  disabled={cropAmount.minus(bulkSellAmount).lessThan(10)}
-                  className="flex-1 text-xs mt-1 w-70"
-                  onClick={() => incrementBulkSellAmount(10)}
-                >
-                  +10
-                </Button>
-              </div>
+            <div className="flex justify-center mt-3 mb-2">
+              <span className="text-lg text-center text-shadow mr-1">
+                {bulkSellAmount.toNumber()}
+              </span>
+              <img src={ITEM_DETAILS[selected.name].image} className="h-6" />
             </div>
-            <div className="flex justify-center items-end my-1">
+            <div className="flex justify-center items-end mb-2">
               <span className="text-xs text-shadow text-center mt-2 ">+</span>
               <img src={token} className="h-5 mx-1" />
               <span className="text-xs text-shadow text-center mt-2 ">
                 {`$${displaySellPrice(selected).mul(bulkSellAmount)}`}
               </span>
+            </div>
+            <div className="flex items-center justify-center mt-1 mb-2 w-4/6">
+              {BULK_INCREMENT_AMOUNTS.map(
+                (amount) =>
+                  cropAmount.greaterThan(amount) && (
+                    <div key={amount} className="mr-1 flex-1">
+                      <Button
+                        disabled={cropAmount
+                          .minus(bulkSellAmount)
+                          .lessThan(amount)}
+                        className="flex-1 text-xs mb-1"
+                        onClick={() => incrementBulkSellAmount(amount)}
+                      >
+                        +{amount}
+                      </Button>
+                      <Button
+                        disabled={bulkSellAmount.lessThanOrEqualTo(amount)}
+                        className="flex-1 text-xs"
+                        onClick={() => decrementBulkSellAmount(amount)}
+                      >
+                        -{amount}
+                      </Button>
+                    </div>
+                  )
+              )}
+              <div className="flex-1 max-w-70">
+                <Button
+                  disabled={cropAmount.equals(bulkSellAmount)}
+                  className="flex-1 text-xs mb-1 bg-brown-600"
+                  onClick={() => setBulkSellAmount(cropAmount)}
+                >
+                  Max
+                </Button>
+                <Button
+                  disabled={bulkSellAmount.lessThanOrEqualTo(1)}
+                  className="flex-1 text-xs bg-brown-600"
+                  onClick={() => setBulkSellAmount(new Decimal(1))}
+                >
+                  Min
+                </Button>
+              </div>
             </div>
           </div>
           <div className="flex justify-content-around p-1">

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -39,6 +39,10 @@ export const Plants: React.FC = () => {
     setBulkSellAmount(cropAmount);
   }, [selected.name]);
 
+  useEffect(() => {
+    setBulkSellAmount(cropAmount);
+  }, [cropAmount.toNumber()]);
+
   const sell = (amount = 1) => {
     gameService.send("item.sell", {
       item: selected.name,
@@ -47,6 +51,8 @@ export const Plants: React.FC = () => {
     setToast({
       content: "SFL +$" + displaySellPrice(selected).mul(amount).toString(),
     });
+    // Immediately update bulkSell to prevent UI flashing between renders
+    setBulkSellAmount(cropAmount.minus(amount));
   };
 
   const handleSellOne = () => {
@@ -56,7 +62,6 @@ export const Plants: React.FC = () => {
   const handleSellAll = () => {
     sell(bulkSellAmount.toNumber());
     showSellAllModal(false);
-    setBulkSellAmount(cropAmount.minus(bulkSellAmount));
   };
 
   // ask confirmation if crop supply is greater than 1
@@ -127,8 +132,9 @@ export const Plants: React.FC = () => {
               ? "All"
               : bulkSellAmount.toNumber()}
           </Button>
-          <div>
+          {cropAmount.gte(5) && (
             <input
+              disabled={noCrop}
               className="
                 form-range
                 w-full
@@ -142,11 +148,11 @@ export const Plants: React.FC = () => {
                 setBulkSellAmount(new Decimal(Number(e.target.value)));
               }}
               type="range"
-              min={1}
+              min={2}
               max={cropAmount.toNumber()}
               value={bulkSellAmount.toNumber()}
             />
-          </div>
+          )}
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -56,6 +56,7 @@ export const Plants: React.FC = () => {
   const handleSellAll = () => {
     sell(bulkSellAmount.toNumber());
     showSellAllModal(false);
+    setBulkSellAmount(cropAmount.minus(bulkSellAmount));
   };
 
   // ask confirmation if crop supply is greater than 1

--- a/src/features/crops/components/Plants.tsx
+++ b/src/features/crops/components/Plants.tsx
@@ -37,11 +37,19 @@ export const Plants: React.FC = () => {
 
   useEffect(() => {
     setBulkSellAmount(cropAmount);
-  }, [selected.name]);
+  }, [selected.name, isSellAllModalOpen]);
 
-  useEffect(() => {
-    setBulkSellAmount(cropAmount);
-  }, [cropAmount.toNumber()]);
+  const incrementBulkSellAmount = (amount: number) => {
+    const newAmount = bulkSellAmount.plus(amount);
+    setBulkSellAmount(
+      newAmount.greaterThan(cropAmount) ? cropAmount : newAmount
+    );
+  };
+
+  const decrementBulkSellAmount = (amount: number) => {
+    const newAmount = bulkSellAmount.minus(amount);
+    setBulkSellAmount(newAmount.lessThan(1) ? new Decimal(1) : newAmount);
+  };
 
   const sell = (amount = 1) => {
     gameService.send("item.sell", {
@@ -115,9 +123,10 @@ export const Plants: React.FC = () => {
               </span>
             </div>
           </div>
+
           <Button
             disabled={cropAmount.lessThan(1)}
-            className="text-xs mt-1"
+            className="flex-1 text-xs mt-1 w-70"
             onClick={handleSellOne}
           >
             Sell 1
@@ -127,32 +136,8 @@ export const Plants: React.FC = () => {
             className="text-xs mt-1 whitespace-nowrap"
             onClick={openConfirmationModal}
           >
-            Sell{" "}
-            {bulkSellAmount.equals(cropAmount)
-              ? "All"
-              : bulkSellAmount.toNumber()}
+            Sell All
           </Button>
-          {cropAmount.gte(5) && (
-            <input
-              disabled={noCrop}
-              className="
-                form-range
-                w-full
-                h-6
-                p-0
-                bg-transparent
-                focus:outline-none focus:ring-0 focus:shadow-none
-                slider-thumb
-              "
-              onChange={(e) => {
-                setBulkSellAmount(new Decimal(Number(e.target.value)));
-              }}
-              type="range"
-              min={2}
-              max={cropAmount.toNumber()}
-              value={bulkSellAmount.toNumber()}
-            />
-          )}
         </div>
       </OuterPanel>
       <Modal centered show={isSellAllModalOpen} onHide={closeConfirmationModal}>
@@ -160,11 +145,58 @@ export const Plants: React.FC = () => {
           <div className="m-auto flex flex-col">
             <span className="text-sm text-center text-shadow">
               Are you sure you want to <br className="hidden md:block" />
-              sell all your {selected.name}?
+              sell your {selected.name}?
             </span>
-            <span className="text-sm text-center text-shadow mt-1">
-              Total: {bulkSellAmount.toNumber()}
-            </span>
+            <div className="flex items-center justify-center ms-1 mt-1">
+              <div>
+                <Button
+                  disabled={bulkSellAmount.lessThanOrEqualTo(1)}
+                  className="flex-1 text-xs mt-1 w-70"
+                  onClick={() => decrementBulkSellAmount(1)}
+                >
+                  -1
+                </Button>
+                <Button
+                  disabled={bulkSellAmount.lessThanOrEqualTo(10)}
+                  className="flex-1 text-xs mt-1 w-70"
+                  onClick={() => decrementBulkSellAmount(10)}
+                >
+                  -10
+                </Button>
+              </div>
+              <div className="flex mx-2">
+                <span className="text-sm text-center text-shadow mr-1">
+                  {bulkSellAmount.toNumber()}
+                </span>
+                <img
+                  src={ITEM_DETAILS[selected.name].image}
+                  className="h-5 mr-1"
+                />
+              </div>
+              <div>
+                <Button
+                  disabled={cropAmount.minus(bulkSellAmount).lessThan(1)}
+                  className="flex-1 text-xs mt-1 w-70"
+                  onClick={() => incrementBulkSellAmount(1)}
+                >
+                  +1
+                </Button>
+                <Button
+                  disabled={cropAmount.minus(bulkSellAmount).lessThan(10)}
+                  className="flex-1 text-xs mt-1 w-70"
+                  onClick={() => incrementBulkSellAmount(10)}
+                >
+                  +10
+                </Button>
+              </div>
+            </div>
+            <div className="flex justify-center items-end my-1">
+              <span className="text-xs text-shadow text-center mt-2 ">+</span>
+              <img src={token} className="h-5 mx-1" />
+              <span className="text-xs text-shadow text-center mt-2 ">
+                {`$${displaySellPrice(selected).mul(bulkSellAmount)}`}
+              </span>
+            </div>
           </div>
           <div className="flex justify-content-around p-1">
             <Button


### PR DESCRIPTION
# Description

Add the option to sell custom amount of crops.

"Custom" button added below "Sell All" which allows farmers to use a range of increment/decrement buttons to adjust the amount they desire to sell. This button will show when farmer has > 10 crops to sell.

Addresses #693 

### Before

<img width="503" alt="image" src="https://user-images.githubusercontent.com/14039116/165296048-5ec1fc5a-01f8-47b7-ad3b-9a9ade88cd28.png">

### After

![bulkSell5](https://user-images.githubusercontent.com/14039116/166145985-6e81bc19-037c-456f-bb82-c183114ed296.gif)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

 - Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
