### PR TITLE
[FEAT] Auto Hide - How To Play Guide 👶

### DIFF
--- a/src/features/hud/components/Menu.tsx
+++ b/src/features/hud/components/Menu.tsx
@@ -5,9 +5,11 @@ import ReCAPTCHA from "react-google-recaptcha";
 import { Button } from "components/ui/Button";
 import { OuterPanel, Panel } from "components/ui/Panel";
 
-import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import * as Auth from "features/auth/lib/Provider";
 import { Context } from "features/game/GameProvider";
+
+import { getLevel } from "features/game/types/skills";
+import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 
 import { Modal } from "react-bootstrap";
 import { Share } from "./Share";
@@ -43,6 +45,7 @@ export const Menu = () => {
   const { gameService } = useContext(Context);
   const [authState] = useActor(authService);
   const [gameState] = useActor(gameService);
+  const { state } = gameState.context;
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [scrollIntoView] = useScrollIntoView();
@@ -55,6 +58,14 @@ export const Menu = () => {
   const [menuLevel, setMenuLevel] = useState(MENU_LEVELS.ROOT);
 
   const ref = useRef<HTMLDivElement>(null);
+
+  const { gathering, farming } = state.skills;
+
+  const farmingLevel = getLevel(farming);
+  const toolLevel = getLevel(gathering);
+  const totalLevel = toolLevel + farmingLevel;
+
+  const isNoobPlayer: boolean = totalLevel < 4 ? true : false;
 
   const handleMenuClick = () => {
     setMenuOpen(!menuOpen);
@@ -188,16 +199,18 @@ export const Menu = () => {
                     </Button>
                   </li>
                 )}
-                <li className="p-1 flex">
-                  <Button onClick={handleHowToPlay}>
-                    <span className="sm:text-sm flex-1">How to play</span>
-                    <img
-                      src={questionMark}
-                      className="w-3 ml-2"
-                      alt="question-mark"
-                    />
-                  </Button>
-                </li>
+                {isNoobPlayer && (
+                  <li className="p-1 flex">
+                    <Button onClick={handleHowToPlay}>
+                      <span className="sm:text-sm flex-1">How to play</span>
+                      <img
+                        src={questionMark}
+                        className="w-3 ml-2"
+                        alt="question-mark"
+                      />
+                    </Button>
+                  </li>
+                )}
                 <li className="p-1">
                   <Button
                     className="flex justify-between"


### PR DESCRIPTION
# Description

Currently the **How to Play ?** button is shown for all players irrespective of their Skills XP (Farming & Gathering).
So this PR introduces feature to auto hide noob 👶  guide button from Menu by creating extra space for other functionalities as well it's redundant after player has acquired some XP in farming as well as Gathering.

The auto hide logic : `isNoobPlayer: boolean = totalLevel < 4 ? true : false`
where, `totalLevel = toolLevel + farmingLevel`

Assuming atleast `tooLevel = farmingLevel = 2`
*separate checks are not used, if it seems necessary we can add that...*

Added New FEAT :)

## Screenshots

| For player w/ totalLevel < 4 | totalLevel >= 4 |
| - | - |
| ![image](https://user-images.githubusercontent.com/55224033/165619802-62f125de-650c-4391-9ae7-025667285686.png) | ![image](https://user-images.githubusercontent.com/55224033/165620418-e02ce500-4a9b-49bf-9205-15579174f630.png) |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- manual testing
- `yarn test`
- `yarn tsc`

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
