### PR TITLE
[FEAT] add close icon to Nyon Statue

### DIFF
--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -5,6 +5,8 @@ import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
 import Modal from "react-bootstrap/Modal";
 
+import close from "assets/icons/close.png";
+
 import sunflowerRock from "assets/nfts/sunflower_rock.png";
 import sunflowerTombstone from "assets/nfts/sunflower_tombstone.png";
 import sunflowerStatue from "assets/nfts/sunflower_statue.png";
@@ -138,6 +140,11 @@ export const NyonStatue: React.FC = () => {
       />
       <Modal centered show={showNyonLore} onHide={() => setShowNyonLore(false)}>
         <Panel>
+          <img
+            src={close}
+            className="h-6 top-4 right-4 absolute cursor-pointer"
+            onClick={() => setShowNyonLore(false)}
+          />
           <div className="flex flex-col items-cetner justify-content-between">
             <div className="flex justify-content m-2">
               <img


### PR DESCRIPTION
# Description

based on PR #640 
added a close icon to the Nyon statue.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`yarn test`
![image](https://user-images.githubusercontent.com/9072434/165849018-3f9f46e1-0895-4894-9d74-4ba1ab1dde80.png)

### the model with the close icon:
![image](https://user-images.githubusercontent.com/9072434/165849139-d1e87a30-19fd-4cc0-a71c-f2d095bd767e.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
