### PR TITLE
[FIX] cramped text on "equip X" pop ups on resource nodes

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -9,7 +9,7 @@ export const Label: React.FC<Props> = ({ children, className }) => {
   return (
     <div
       className={classnames(
-        "bg-silver-300 text-white text-shadow text-xs object-contain justify-center items-center flex ",
+        "bg-silver-300 ",
         className
       )}
       // Custom styles to get pixellated border effect
@@ -24,7 +24,9 @@ export const Label: React.FC<Props> = ({ children, className }) => {
         borderRadius: "15px",
       }}
     >
-      {children}
+      <div className="flex flex-col text-white text-shadow text-xs object-contain justify-center items-center text-center p-1">
+        {children}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Description

The text was way too cramped on the resource nodes which told the user to equip a tool.
the text itself was overlapping with the white border of the panel.

![image](https://user-images.githubusercontent.com/9072434/165858279-603e239b-370b-480e-ac4b-dd91db38d12e.png)
![image](https://user-images.githubusercontent.com/9072434/165858253-1eb4fd85-6a57-41c5-a1f3-f6986ef9cc2f.png)
![image](https://user-images.githubusercontent.com/9072434/165858309-fa81a902-6160-49d1-983c-a3c254507014.png)
![image](https://user-images.githubusercontent.com/9072434/165858333-160e7113-6d18-4121-b1d3-c880a5c646c5.png)

so I encapsulated the children in the Label class and gave it some padding and centered the text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn test`
![image](https://user-images.githubusercontent.com/9072434/165858763-4fb1eae0-ff9f-461d-8ae2-641b1a37989e.png)

### UI after the change
![image](https://user-images.githubusercontent.com/9072434/165858635-ffc312ea-e58b-4b3c-a54f-5392a870ee1a.png)
![image](https://user-images.githubusercontent.com/9072434/165858653-60f51276-c97c-4d86-8f39-aefaf5a7ba6d.png)
![image](https://user-images.githubusercontent.com/9072434/165858670-545fd6fb-58a9-409d-a466-2f1bcf865d12.png)
![image](https://user-images.githubusercontent.com/9072434/165858690-4dbf62b8-cb22-45ac-8322-06170226e396.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
