### PR TITLE
[FIX] Apply Padding on Label className

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -9,7 +9,7 @@ export const Label: React.FC<Props> = ({ children, className }) => {
   return (
     <div
       className={classnames(
-        "bg-silver-300 ",
+        "bg-silver-300 text-white text-shadow text-xs object-contain justify-center items-center flex",
         className
       )}
       // Custom styles to get pixellated border effect
@@ -24,9 +24,7 @@ export const Label: React.FC<Props> = ({ children, className }) => {
         borderRadius: "15px",
       }}
     >
-      <div className="flex flex-col text-white text-shadow text-xs object-contain justify-center items-center text-center p-1">
-        {children}
-      </div>
+      {children}
     </div>
   );
 };

--- a/src/features/forest/components/Tree.tsx
+++ b/src/features/forest/components/Tree.tsx
@@ -32,6 +32,7 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
+const tool = "Axe";
 
 interface Props {
   treeIndex: number;
@@ -217,7 +218,7 @@ export const Tree: React.FC<Props> = ({ treeIndex }) => {
               showLabel ? "opacity-100" : "opacity-0"
             }`}
           >
-            <Label>Equip an axe first</Label>
+            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
           </div>
         </div>
       )}

--- a/src/features/quarry/components/Gold.tsx
+++ b/src/features/quarry/components/Gold.tsx
@@ -207,7 +207,7 @@ export const Gold: React.FC<Props> = ({ rockIndex }) => {
               showLabel ? "opacity-100" : "opacity-0"
             }`}
           >
-            <Label>Equip {tool.toLowerCase()}</Label>
+            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
           </div>
         </div>
       )}

--- a/src/features/quarry/components/Iron.tsx
+++ b/src/features/quarry/components/Iron.tsx
@@ -212,7 +212,7 @@ export const Iron: React.FC<Props> = ({ rockIndex }) => {
               showLabel ? "opacity-100" : "opacity-0"
             }`}
           >
-            <Label>Equip {tool.toLowerCase()}</Label>
+            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
           </div>
         </div>
       )}

--- a/src/features/quarry/components/Stone.tsx
+++ b/src/features/quarry/components/Stone.tsx
@@ -211,7 +211,7 @@ export const Stone: React.FC<Props> = ({ rockIndex }) => {
               showLabel ? "opacity-100" : "opacity-0"
             }`}
           >
-            <Label>Equip {tool.toLowerCase()}</Label>
+            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
           </div>
         </div>
       )}


### PR DESCRIPTION
# Description

This PR fixes the padding that is applied to `Label` component on #732 . It affected the label display of `Box` wherein numbers cover the image as seen below:

![image](https://user-images.githubusercontent.com/89294757/165891420-dd7a6e37-a428-4cd2-b30e-7be0b8b8b9c9.png)

![image](https://user-images.githubusercontent.com/89294757/165891815-4c324cc9-f405-4384-9c97-2786ad884640.png)

The ff changes include:
- Revert padding on `Label` children
- Apply padding on `Label` className on Tree, Stone, Iron, Gold
- Tree text display in line with other resources

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`yarn tsc|test`

Manual testing - local state

![image](https://user-images.githubusercontent.com/89294757/165891719-fe780472-ceae-455e-a3bf-e4021f53b345.png)
![image](https://user-images.githubusercontent.com/89294757/165891756-88473436-38f6-4b86-9c51-8eda5d349c52.png)
![image](https://user-images.githubusercontent.com/89294757/165891963-65517972-4e95-445b-9a9d-1ff436bb54e0.png)
![image](https://user-images.githubusercontent.com/89294757/165892024-3dbeb448-840b-4531-b8c7-07c99e0a170d.png)
![image](https://user-images.githubusercontent.com/89294757/165892070-236f445e-9d47-4666-9541-59b62916f1d5.png)
![image](https://user-images.githubusercontent.com/89294757/165892140-25ae2f9c-cfa8-46c3-8ab0-3179d78fc2ea.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
