### PR TITLE
[FIX] Splash.tsx breaks on local

### DIFF
--- a/src/features/auth/components/Splash.tsx
+++ b/src/features/auth/components/Splash.tsx
@@ -59,7 +59,7 @@ export const Splash: React.FC = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {releaseVersion.split("-")[0]}
+              {releaseVersion?.split("-")[0]}
             </a>
           </p>
         </InnerPanel>


### PR DESCRIPTION
# Description

On "pure local" (no Testnet), the game doesn't load.

This change handles the unset `releaseVersion` properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Game now loads.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
