### PR TITLE
[FIX] Duplicate key warning for eslint-plugin-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-plugin-unused-imports": "^2.0.0",


### PR DESCRIPTION
# Description

When invoking `yarn dev` a warning is emitted.  This change resolves the warning.

```
C:\sunflower-land>yarn dev
yarn run v1.22.18
warning package.json: No license field
$ set NODE_ENV=development && vite --port 3000 --host
 > package.json:67:4: warning: Duplicate key "eslint-plugin-react" in object literal
    67 │     "eslint-plugin-react": "^7.29.4",
       ╵     ~~~~~~~~~~~~~~~~~~~~~
   package.json:66:4: note: The original "eslint-plugin-react" is here
    66 │     "eslint-plugin-react": "^7.28.0",
       ╵     ~~~~~~~~~~~~~~~~~~~~~
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Rerun `yarn dev`.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
