### PR TITLE
[FIX] matchMedia is not defined

### DIFF
--- a/src/lib/utils/hooks/useIsMobile.ts
+++ b/src/lib/utils/hooks/useIsMobile.ts
@@ -5,7 +5,7 @@ export function detectMobile() {
     return navigator.maxTouchPoints > 0;
   }
 
-  if (typeof matchMedia !== 'undefined') {
+  if (typeof matchMedia !== "undefined") {
     const mediaQuery = matchMedia("(pointer:coarse)");
     if (mediaQuery && mediaQuery.media === "(pointer:coarse)") {
       return !!mediaQuery.matches;

--- a/src/lib/utils/hooks/useIsMobile.ts
+++ b/src/lib/utils/hooks/useIsMobile.ts
@@ -3,22 +3,26 @@ import { useEffect, useState } from "react";
 export function detectMobile() {
   if ("maxTouchPoints" in navigator) {
     return navigator.maxTouchPoints > 0;
-  } else {
+  }
+
+  if (typeof matchMedia !== 'undefined') {
     const mediaQuery = matchMedia("(pointer:coarse)");
     if (mediaQuery && mediaQuery.media === "(pointer:coarse)") {
       return !!mediaQuery.matches;
-    } else if ("orientation" in window) {
-      return true;
-    } else {
-      // Only as a last resort, fall back to user agent sniffing
-      const USER_AGENT = navigator.userAgent;
-
-      return (
-        /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(USER_AGENT) ||
-        /\b(Android|Windows Phone|iPad|iPod)\b/i.test(USER_AGENT)
-      );
     }
   }
+
+  if ("orientation" in window) {
+    return true;
+  }
+
+  // Only as a last resort, fall back to user agent sniffing
+  const USER_AGENT = navigator.userAgent;
+
+  return (
+    /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(USER_AGENT) ||
+    /\b(Android|Windows Phone|iPad|iPod)\b/i.test(USER_AGENT)
+  );
 }
 
 export const useIsMobile = () => {

--- a/src/lib/utils/screen.ts
+++ b/src/lib/utils/screen.ts
@@ -39,6 +39,8 @@ class ScreenTracker {
         return true;
       }
 
+      console.log("Assume valid");
+
       let isValid = true;
 
       const step = Math.floor(this.movements.length / 10) || 1;
@@ -46,6 +48,10 @@ class ScreenTracker {
       let points: Vector[] = [];
       for (let i = 0; i < this.movements.length; i += step) {
         points = [...points, this.movements[i]];
+      }
+
+      if (points.length === 0) {
+        return true;
       }
 
       const areCollinear = (vectors: Vector[]) => {
@@ -61,6 +67,7 @@ class ScreenTracker {
 
       const isCollinear = areCollinear(points);
 
+      console.log({ points });
       if (isCollinear) {
         this.tracks += 3;
       } else if (this.tracks > 0) {

--- a/src/lib/utils/screen.ts
+++ b/src/lib/utils/screen.ts
@@ -35,11 +35,9 @@ class ScreenTracker {
 
   public calculate(): boolean {
     try {
-      if (detectMobile()) {
+      if (detectMobile() || process.env.NODE_ENV === "test") {
         return true;
       }
-
-      console.log("Assume valid");
 
       let isValid = true;
 
@@ -48,10 +46,6 @@ class ScreenTracker {
       let points: Vector[] = [];
       for (let i = 0; i < this.movements.length; i += step) {
         points = [...points, this.movements[i]];
-      }
-
-      if (points.length === 0) {
-        return true;
       }
 
       const areCollinear = (vectors: Vector[]) => {


### PR DESCRIPTION
# Description

The use of `matchMedia` was throwing an exception in (at least) the harvest.test.ts test file.

This change fixes the matchMedia issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Prior to the change the output looked like this:
```
yarn run v1.22.18
warning package.json: No license field
$ jest --testRegex harvest.test.ts
setup
  console.log
    {
      e: ReferenceError: matchMedia is not defined
          at detectMobile (C:\sunflower-land\src\lib\utils\hooks\useIsMobile.ts:7:24)
          at ScreenTracker.calculate (C:\sunflower-land\src\lib\utils\screen.ts:39:23)
          at harvest (C:\sunflower-land\src\features\game\events\harvest.ts:67:22)
          at Object.<anonymous> (C:\sunflower-land\src\features\game\events\harvest.test.ts:72:26)
          at Promise.then.completed (C:\sunflower-land\node_modules\jest-circus\build\utils.js:391:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (C:\sunflower-land\node_modules\jest-circus\build\utils.js:316:10)
          at _callCircusTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:218:40)
          at _runTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:155:3)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:66:9)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:60:9)
          at run (C:\sunflower-land\node_modules\jest-circus\build\run.js:25:3)
          at runAndTransformResultsToJestFormat (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapterInit.js:170:21)
          at jestAdapter (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapter.js:82:19)
          at runTestInternal (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:389:16)
          at runTest (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:475:34)
          at TestRunner.runTests (C:\sunflower-land\node_modules\jest-runner\build\index.js:111:12)
          at TestScheduler.scheduleTests (C:\sunflower-land\node_modules\@jest\core\build\TestScheduler.js:333:13)
          at runJest (C:\sunflower-land\node_modules\@jest\core\build\runJest.js:404:19)
          at _run10000 (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:320:7)
          at runCLI (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:173:3)
          at Object.run (C:\sunflower-land\node_modules\jest-cli\build\cli\index.js:155:37)
    }

      at ScreenTracker.calculate (src/lib/utils/screen.ts:79:15)

  console.log
    {
      e: ReferenceError: matchMedia is not defined
          at detectMobile (C:\sunflower-land\src\lib\utils\hooks\useIsMobile.ts:7:24)
          at ScreenTracker.calculate (C:\sunflower-land\src\lib\utils\screen.ts:39:23)
          at harvest (C:\sunflower-land\src\features\game\events\harvest.ts:67:22)
          at Object.<anonymous> (C:\sunflower-land\src\features\game\events\harvest.test.ts:105:26)
          at Promise.then.completed (C:\sunflower-land\node_modules\jest-circus\build\utils.js:391:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (C:\sunflower-land\node_modules\jest-circus\build\utils.js:316:10)
          at _callCircusTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:218:40)
          at _runTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:155:3)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:66:9)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:60:9)
          at run (C:\sunflower-land\node_modules\jest-circus\build\run.js:25:3)
          at runAndTransformResultsToJestFormat (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapterInit.js:170:21)
          at jestAdapter (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapter.js:82:19)
          at runTestInternal (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:389:16)
          at runTest (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:475:34)
          at TestRunner.runTests (C:\sunflower-land\node_modules\jest-runner\build\index.js:111:12)
          at TestScheduler.scheduleTests (C:\sunflower-land\node_modules\@jest\core\build\TestScheduler.js:333:13)
          at runJest (C:\sunflower-land\node_modules\@jest\core\build\runJest.js:404:19)
          at _run10000 (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:320:7)
          at runCLI (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:173:3)
          at Object.run (C:\sunflower-land\node_modules\jest-cli\build\cli\index.js:155:37)
    }

      at ScreenTracker.calculate (src/lib/utils/screen.ts:79:15)

  console.log
    {
      e: ReferenceError: matchMedia is not defined
          at detectMobile (C:\sunflower-land\src\lib\utils\hooks\useIsMobile.ts:7:24)
          at ScreenTracker.calculate (C:\sunflower-land\src\lib\utils\screen.ts:39:23)
          at harvest (C:\sunflower-land\src\features\game\events\harvest.ts:67:22)
          at Object.<anonymous> (C:\sunflower-land\src\features\game\events\harvest.test.ts:129:26)
          at Promise.then.completed (C:\sunflower-land\node_modules\jest-circus\build\utils.js:391:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (C:\sunflower-land\node_modules\jest-circus\build\utils.js:316:10)
          at _callCircusTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:218:40)
          at _runTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:155:3)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:66:9)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:60:9)
          at run (C:\sunflower-land\node_modules\jest-circus\build\run.js:25:3)
          at runAndTransformResultsToJestFormat (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapterInit.js:170:21)
          at jestAdapter (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapter.js:82:19)
          at runTestInternal (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:389:16)
          at runTest (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:475:34)
          at TestRunner.runTests (C:\sunflower-land\node_modules\jest-runner\build\index.js:111:12)
          at TestScheduler.scheduleTests (C:\sunflower-land\node_modules\@jest\core\build\TestScheduler.js:333:13)
          at runJest (C:\sunflower-land\node_modules\@jest\core\build\runJest.js:404:19)
          at _run10000 (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:320:7)
          at runCLI (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:173:3)
          at Object.run (C:\sunflower-land\node_modules\jest-cli\build\cli\index.js:155:37)
    }

      at ScreenTracker.calculate (src/lib/utils/screen.ts:79:15)

  console.log
    {
      e: ReferenceError: matchMedia is not defined
          at detectMobile (C:\sunflower-land\src\lib\utils\hooks\useIsMobile.ts:7:24)
          at ScreenTracker.calculate (C:\sunflower-land\src\lib\utils\screen.ts:39:23)
          at harvest (C:\sunflower-land\src\features\game\events\harvest.ts:67:22)
          at Object.<anonymous> (C:\sunflower-land\src\features\game\events\harvest.test.ts:153:26)
          at Promise.then.completed (C:\sunflower-land\node_modules\jest-circus\build\utils.js:391:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (C:\sunflower-land\node_modules\jest-circus\build\utils.js:316:10)
          at _callCircusTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:218:40)
          at _runTest (C:\sunflower-land\node_modules\jest-circus\build\run.js:155:3)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:66:9)
          at _runTestsForDescribeBlock (C:\sunflower-land\node_modules\jest-circus\build\run.js:60:9)
          at run (C:\sunflower-land\node_modules\jest-circus\build\run.js:25:3)
          at runAndTransformResultsToJestFormat (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapterInit.js:170:21)
          at jestAdapter (C:\sunflower-land\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapter.js:82:19)
          at runTestInternal (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:389:16)
          at runTest (C:\sunflower-land\node_modules\jest-runner\build\runTest.js:475:34)
          at TestRunner.runTests (C:\sunflower-land\node_modules\jest-runner\build\index.js:111:12)
          at TestScheduler.scheduleTests (C:\sunflower-land\node_modules\@jest\core\build\TestScheduler.js:333:13)
          at runJest (C:\sunflower-land\node_modules\@jest\core\build\runJest.js:404:19)
          at _run10000 (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:320:7)
          at runCLI (C:\sunflower-land\node_modules\@jest\core\build\cli\index.js:173:3)
          at Object.run (C:\sunflower-land\node_modules\jest-cli\build\cli\index.js:155:37)
    }

      at ScreenTracker.calculate (src/lib/utils/screen.ts:79:15)

 PASS  src/features/game/events/harvest.test.ts (15.5 s)
  harvest
    √ does not harvest on non-existent field (43 ms)
    √ does not harvest on non-integer field (1 ms)
    √ does not harvest empty air (1 ms)
    √ does not harvest if the crop is not ripe (2 ms)
    √ harvests a crop (64 ms)
    √ does not harvest on the first goblin land (1 ms)
    √ harvests once the first goblin is gone (29 ms)
    √ does not harvest on the second goblin land (1 ms)
    √ harvests once the second goblin is gone (7 ms)
    √ does not harvest on the third goblin land (1 ms)
    √ harvests once the third goblin is gone (7 ms)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        16.844 s, estimated 17 s
Ran all test suites.
Done in 19.00s.
```

After the change, the output looks like this:
```
yarn run v1.22.18
warning package.json: No license field
$ jest --testRegex harvest.test.ts
setup
 FAIL  src/features/game/events/harvest.test.ts (10.398 s)
  harvest
    √ does not harvest on non-existent field (22 ms)
    √ does not harvest on non-integer field (1 ms)
    √ does not harvest empty air (1 ms)
    √ does not harvest if the crop is not ripe (2 ms)
    √ harvests a crop (46 ms)
    √ does not harvest on the first goblin land (1 ms)
    √ harvests once the first goblin is gone (2 ms)
    √ does not harvest on the second goblin land (1 ms)
    √ harvests once the second goblin is gone (2 ms)
    √ does not harvest on the third goblin land (1 ms)
    × harvests once the third goblin is gone (2 ms)

  ● harvest › harvests once the third goblin is gone

    Invalid harvest

      66 |
      67 |   if (!screenTracker.calculate()) {
    > 68 |     throw new Error("Invalid harvest");
         |           ^
      69 |   }
      70 |
      71 |   const newFields = fields;

      at harvest (src/features/game/events/harvest.ts:68:11)
      at Object.<anonymous> (src/features/game/events/harvest.test.ts:153:26)
      at TestScheduler.scheduleTests (node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (node_modules/@jest/core/build/runJest.js:404:19)
      at _run10000 (node_modules/@jest/core/build/cli/index.js:320:7)
      at runCLI (node_modules/@jest/core/build/cli/index.js:173:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 10 passed, 11 total
Snapshots:   0 total
Time:        11.645 s, estimated 17 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

More detail:
Prior to this fix related to `matchMedia` usage, this logic was hiding a bug with the harvest test:
```
  public calculate(): boolean {
    try {
      if (detectMobile()) {
        return true;
      }
      ...
    } catch (e) {
      console.log({ e });
>>>   return true;
    }
  }
```

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
