### PR TITLE
[FIX] call handleInitialState on CONTINUE event

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -553,7 +553,7 @@ export function startGame(authContext: Options) {
         },
         blacklisted: {
           on: {
-            CONTINUE: "playing",
+            CONTINUE: handleInitialState(),
           },
         },
         synced: {


### PR DESCRIPTION
# Description

This PR fixes the incorrect transition from `blacklisted` to `playing` when visiting a farm. refer to this bug [report](https://discord.com/channels/880987707214544966/944746072247504936/970174283777212476). 

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Untested - no known blacklisted farms in Testnet

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
