### PR TITLE
[FIX] Sunflower Farmers contract addresses fix for testnet

### DIFF
--- a/src/lib/blockchain/SunflowerFarmers.ts
+++ b/src/lib/blockchain/SunflowerFarmers.ts
@@ -1,11 +1,18 @@
+import { CONFIG } from "lib/config";
 import Web3 from "web3";
 import { AbiItem } from "web3-utils";
 import SunflowerFarmersABI from "./abis/SunflowerFarmers.json";
 import TokenABI from "./abis/Token.json";
 import { parseMetamaskError } from "./utils";
 
-const farmContractAddress = "0x6e5Fa679211d7F6b54e14E187D34bA547c5d3fe0"; //"0xd7952E176fe0B77cAAb2465b04F1422518Fb9643"; //;
-const farmTokenAddress = "0xdf9B4b57865B403e08c85568442f95c26b7896b0"; //"0x1D24F82b5d9d72450C2ed065F51827Eb280FFA38"; // ;
+const farmContractAddress =
+  CONFIG.NETWORK === "mainnet"
+    ? "0x6e5Fa679211d7F6b54e14E187D34bA547c5d3fe0"
+    : "0xd7952E176fe0B77cAAb2465b04F1422518Fb9643";
+const farmTokenAddress =
+  CONFIG.NETWORK === "mainnet"
+    ? "0xdf9B4b57865B403e08c85568442f95c26b7896b0"
+    : "0x1D24F82b5d9d72450C2ed065F51827Eb280FFA38";
 
 /**
  * Farm NFT contract


### PR DESCRIPTION
# Description

I was not able to mint a farm on Mumbai testnet, nor able to get to load the game at all on mumbai testnet. From my debugging, it's clear that it's because of these hardcoded mainnet contract addresses (when the game checks if I have v1Data, it fails the login process). This bug seems to have been introduced when the migrating feature was introduced.

**IMPORTANT NOTE - PLEASE DOUBLE CHECK ADDRESSES ARE CORRECT IN CODE**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

![fix-hardcoded-strings-test](https://user-images.githubusercontent.com/103600068/166154843-1c3a4e23-f10e-4d8a-9ec9-4d4546804440.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes