### PR TITLE
[FIX] Change deprecated networkChanged to chainChanged event

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -35,7 +35,7 @@ export const Navigation: React.FC = () => {
    */
   useEffect(() => {
     if (window.ethereum) {
-      window.ethereum.on("networkChanged", () => {
+      window.ethereum.on("chainChanged", () => {
         send("NETWORK_CHANGED");
       });
 

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -30,13 +30,13 @@ export const Navigation: React.FC = () => {
   }, [showGame]);
 
   /**
-   * Listen to web3 account/network changes
+   * Listen to web3 account/chain changes
    * TODO: move into a hook
    */
   useEffect(() => {
     if (window.ethereum) {
       window.ethereum.on("chainChanged", () => {
-        send("NETWORK_CHANGED");
+        send("CHAIN_CHANGED");
       });
 
       window.ethereum.on("accountsChanged", function () {

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -82,7 +82,7 @@ export type BlockchainEvent =
   | CreateFarmEvent
   | LoadFarmEvent
   | {
-      type: "NETWORK_CHANGED";
+      type: "CHAIN_CHANGED";
     }
   | {
       type: "ACCOUNT_CHANGED";
@@ -557,7 +557,7 @@ export const authMachine = createMachine<
       },
     },
     on: {
-      NETWORK_CHANGED: {
+      CHAIN_CHANGED: {
         target: "connecting",
         actions: "resetFarm",
       },


### PR DESCRIPTION
# Description

`networkChanged` event is deprecated in favor of `chainChanged` (https://eips.ethereum.org/EIPS/eip-1193#networkchanged-deprecated). Metamask shows a warning in console that says `networkChanged` may be removed in the future.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It didn't break the game, and chainChanged event is received.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
