### PR TITLE
[FIX] Fixes Negative SFL Withdraw bug

### DIFF
--- a/src/features/bank/components/WithdrawTokens.tsx
+++ b/src/features/bank/components/WithdrawTokens.tsx
@@ -60,8 +60,13 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
   };
 
   const withdraw = () => {
-    onWithdraw(toWei(amount.toString()));
+    if (amount > new Decimal(0)) {
+      onWithdraw(toWei(amount.toString()));
+    } else {
+      setAmount(new Decimal(0));
+    }
   };
+
   const onWithdrawChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value === "") {
       setAmount(new Decimal(0));
@@ -71,7 +76,7 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
   };
 
   const setMax = () => {
-    setAmount(balance);
+    setAmount(balance.minus(new Decimal(0.01)));
   };
 
   const incrementWithdraw = () => {
@@ -97,6 +102,8 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
   const tax = getTax(typeof amount !== "string" ? amount : new Decimal(0)) / 10;
 
   const enabled = authState.context.token?.userAccess.withdraw;
+  const disableWithdraw =
+    safeAmount(amount).gte(balance) || safeAmount(amount).lt(0);
 
   if (!enabled) {
     return <span>Available May 9th</span>;
@@ -188,7 +195,7 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
         </span>
       </div>
 
-      <Button onClick={withdraw} disabled={safeAmount(amount).gte(balance)}>
+      <Button onClick={withdraw} disabled={disableWithdraw}>
         Withdraw
       </Button>
     </>


### PR DESCRIPTION
# Description

Fixes Negative SFL Withdraw bug. Bonus: Also sets `MAX` to `balance - .01` so whole balance cannot be removed.

Fixes #665

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Locally during play and using `yarn test` + `yarn lint`.

Test Suites: 12 passed, 12 total
Tests:       103 passed, 103 total
Snapshots:   0 total
Time:        16.823 s
Ran all test suites.
Done in 17.79s.

https://user-images.githubusercontent.com/7065115/166403889-5a07f062-99a9-41d4-9238-cf421dc70e72.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
