### PR TITLE
[FEAT] Progress bars now display 1 decimal place

### DIFF
--- a/src/lib/utils/time.test.ts
+++ b/src/lib/utils/time.test.ts
@@ -17,13 +17,21 @@ describe("time", () => {
       expect(secondsToString(2 * ONE_SEC)).toBe("2secs");
       expect(secondsToString(59 * ONE_SEC)).toBe("59secs");
       expect(secondsToString(ONE_MIN)).toBe("1min");
-      expect(secondsToString(ONE_MIN + ONE_SEC)).toBe("2mins");
+      expect(secondsToString(ONE_MIN + ONE_SEC)).toBe("1.1mins");
+      expect(secondsToString(2 * ONE_MIN - 6 * ONE_SEC)).toBe("1.9mins");
+      expect(secondsToString(2 * ONE_MIN - ONE_SEC)).toBe("2mins");
+      expect(secondsToString(2 * ONE_MIN)).toBe("2mins");
       expect(secondsToString(59 * ONE_MIN)).toBe("59mins");
       expect(secondsToString(ONE_HR)).toBe("1hr");
-      expect(secondsToString(ONE_HR + ONE_SEC)).toBe("2hrs");
+      expect(secondsToString(ONE_HR + ONE_SEC)).toBe("1.1hrs");
+      expect(secondsToString(2 * ONE_HR - 6 * ONE_MIN)).toBe("1.9hrs");
+      expect(secondsToString(2 * ONE_HR - ONE_SEC)).toBe("2hrs");
+      expect(secondsToString(2 * ONE_HR)).toBe("2hrs");
       expect(secondsToString(23 * ONE_HR)).toBe("23hrs");
       expect(secondsToString(ONE_DAY)).toBe("1day");
-      expect(secondsToString(ONE_DAY + ONE_SEC)).toBe("2days");
+      expect(secondsToString(ONE_DAY + ONE_SEC)).toBe("1.1days");
+      expect(secondsToString(2 * ONE_DAY - 3 * ONE_HR)).toBe("1.9days");
+      expect(secondsToString(2 * ONE_DAY)).toBe("2days");
     });
   });
 

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -31,16 +31,16 @@ export function secondsToString(seconds: number) {
   }
 
   if (seconds < ONE_HR) {
-    const minutesCeil = Math.ceil(seconds / ONE_MIN);
+    const minutesCeil = Math.ceil((seconds * 10) / ONE_MIN) / 10;
     return timeToStr(minutesCeil, "min");
   }
 
   if (seconds < ONE_DAY) {
-    const hoursCeil = Math.ceil(seconds / ONE_HR);
+    const hoursCeil = Math.ceil((seconds * 10) / ONE_HR) / 10;
     return timeToStr(hoursCeil, "hr");
   }
 
-  const daysCeil = Math.ceil(seconds / ONE_DAY);
+  const daysCeil = Math.ceil((seconds * 10) / ONE_DAY) / 10;
   return timeToStr(daysCeil, "day");
 }
 


### PR DESCRIPTION
# Description

Concerns:
1. The progress bar timers are "weird" around the value of 1.  The "1min" progress is displayed for exactly 1 second.
2. When upgrading with Nancy, the alignment with integer units drops so Sunflower duration is "51s" and similarly for other crops.
3. For longer duration items like without-Woody trees, "1.4hrs" is more useful than showing "2hrs" for a full hour.

This change introduces 1 decimal place to resource progress bars.

For example, Potato's initial progress bar with Nancy is now "4.3mins" instead of "5min"

Crop examples:
![image](https://user-images.githubusercontent.com/36871683/166990777-1824f62c-08df-48a5-a17d-7a77c81a227f.png)

Wood examples:
![image](https://user-images.githubusercontent.com/36871683/166991030-d999afe5-3061-454c-8847-76ef8b02a555.png)
![image](https://user-images.githubusercontent.com/36871683/166998356-5c0a73b8-d752-416a-9ed5-d3d957bb7d6a.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Watching the timers for various crops to ensure that the values look correct and the transitions across time units behavior properly.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
