### PR TITLE
[FIX] Add required items check on craft

### DIFF
--- a/src/features/farming/shop/Seeds.tsx
+++ b/src/features/farming/shop/Seeds.tsx
@@ -103,9 +103,8 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     );
   }
   const Action = () => {
-    // const isLocked = selected.requires && !inventory[selected.requires];
-    // if (isLocked || selected.disabled) {
-    if (selected.disabled) {
+    const isLocked = selected.requires && !inventory[selected.requires];
+    if (isLocked || selected.disabled) {
       return <span className="text-xs mt-1 text-shadow">Locked</span>;
     }
 

--- a/src/features/game/events/craft.test.ts
+++ b/src/features/game/events/craft.test.ts
@@ -215,4 +215,21 @@ describe("craft", () => {
   //     })
   //   ).toThrow("Not enough stock");
   // });
+
+  it("requires a certain item before crafting", () => {
+    expect(() =>
+      craft({
+        state: {
+          ...GAME_STATE,
+          balance: new Decimal(1),
+          inventory: { Wood: new Decimal(10) },
+        },
+        action: {
+          type: "item.crafted",
+          item: "Carrot Seed",
+          amount: 1,
+        },
+      })
+    ).toThrow("Missing Pumpkin Soup");
+  });
 });

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -74,6 +74,11 @@ export function craft({ state, action }: Options) {
   const price = getBuyPrice(item, state.inventory);
   const totalExpenses = price?.mul(action.amount);
 
+  const isLocked = item.requires && !state.inventory[item.requires];
+  if (isLocked) {
+    throw new Error(`Missing ${item.requires}`);
+  }
+
   if (totalExpenses && state.balance.lessThan(totalExpenses)) {
     throw new Error("Insufficient tokens");
   }


### PR DESCRIPTION
# Description

This PR adds the required items checks, this was removed on the latest Goblin Town POC merge.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
