### PR TITLE
[FIX] Remove duplicate parsnip logic in hasBoost()

### DIFF
--- a/src/features/game/lib/boosts.ts
+++ b/src/features/game/lib/boosts.ts
@@ -56,13 +56,6 @@ export const hasBoost = ({ item, inventory }: HasBoostArgs) => {
   }
 
   if (
-    item === "Parsnip Seed" &&
-    inventory["Mysterious Parsnip"]?.greaterThanOrEqualTo(1)
-  ) {
-    return true;
-  }
-
-  if (
     item === "Cauliflower Seed" &&
     inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)
   ) {


### PR DESCRIPTION
# Description

The hasBoost() function has two copies of the logic that handles Mysterious Parsnip.

This change removes the duplicate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
