### PR TITLE
Block minting if a user already has one of the item in inventory

### DIFF
--- a/src/features/farming/blacksmith/components/CraftingItems.tsx
+++ b/src/features/farming/blacksmith/components/CraftingItems.tsx
@@ -117,7 +117,7 @@ export const CraftingItems: React.FC<Props> = ({
       <>
         <Button
           disabled={lessFunds() || lessIngredients() || stock?.lessThan(1)}
-          className="text-xs mt-1"
+          className="text-xxs sm:text-xs mt-1 whitespace-nowrap"
           onClick={() => craft()}
         >
           Craft {isBulk && "1"}
@@ -127,7 +127,7 @@ export const CraftingItems: React.FC<Props> = ({
             disabled={
               lessFunds(10) || lessIngredients(10) || stock?.lessThan(10)
             }
-            className="text-xs mt-1 whitespace-nowrap"
+            className="text-xxs sm:text-xs mt-1 whitespace-nowrap"
             onClick={() => craft(10)}
           >
             Craft 10

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -162,7 +162,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
         <div className="flex flex-col text-center mt-2 border-y border-white w-full">
           <p className="text-sm my-2">Already minted!</p>
           <p className="text-[10px] mb-2">
-            You can only have one of each rare item on a farm at a time.
+            You can only have one of each rare item on your farm at a time.
           </p>
         </div>
       );

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -150,11 +150,22 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
   }
 
   const soldOut = amountLeft <= 0;
+  const amountOfSelectedItemInInventory =
+    inventory[selected.name]?.toNumber() || 0;
+  const hasItemOnFarm = amountOfSelectedItemInInventory > 0;
 
   const Action = () => {
-    if (soldOut) {
-      return null;
-    }
+    if (soldOut) return null;
+
+    if (hasItemOnFarm)
+      return (
+        <div className="flex flex-col text-center mt-2 border-y border-white w-full">
+          <p className="text-sm my-2">Already minted!</p>
+          <p className="text-[10px] mb-2">
+            You can only have one of each rare item on a farm at a time.
+          </p>
+        </div>
+      );
 
     const secondsLeft = mintCooldown({
       cooldownSeconds: selected.cooldownSeconds,
@@ -163,11 +174,11 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
     if (secondsLeft > 0) {
       return (
         <div className="mt-2 border-y border-white w-full">
-          <div className="mt-3 flex items-center justify-center">
+          <div className="mt-2 flex items-center justify-center">
             <img src={busyGoblin} alt="not available" className="w-12" />
           </div>
           <div className="text-center">
-            <p className="text-[10px] mb-[-2px]">Ready in</p>
+            <p className="text-[10px] mb-2">Ready in</p>
             <p className="text-[10px]">
               <ProgressBar
                 seconds={secondsLeft}
@@ -238,12 +249,12 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
       <OuterPanel className="flex-1 min-w-[42%] flex flex-col justify-between items-center">
         <div className="flex flex-col justify-center items-center p-2 relative w-full">
           {soldOut && (
-            <span className="bg-blue-600 text-shadow border text-xxs absolute left-0 -top-4 p-1 rounded-md">
+            <span className="bg-blue-600 border text-xxs absolute left-0 -top-4 p-1 rounded-md">
               Sold out
             </span>
           )}
           {!!selected.maxSupply && amountLeft > 0 && (
-            <span className="bg-blue-600 text-shadow border  text-xxs absolute left-0 -top-4 p-1 rounded-md">
+            <span className="bg-blue-600 border  text-xxs absolute left-0 -top-4 p-1 rounded-md">
               {`${amountLeft} left`}
             </span>
           )}
@@ -259,7 +270,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
           </span>
 
           {canCraft && (
-            <div className="border-t border-white w-full mt-2 pt-1">
+            <div className="border-t border-white w-full mt-2 pt-1 mb-2">
               {selected.ingredients?.map((ingredient, index) => {
                 const item = ITEM_DETAILS[ingredient.item];
                 const lessIngredient = new Decimal(

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -160,8 +160,8 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
     if (hasItemOnFarm)
       return (
         <div className="flex flex-col text-center mt-2 border-y border-white w-full">
-          <p className="text-sm my-2">Already minted!</p>
-          <p className="text-[10px] mb-2">
+          <p className="text-[10px] sm:text-sm my-2">Already minted!</p>
+          <p className="text-[8px] sm:text-[10px] mb-2">
             You can only have one of each rare item on your farm at a time.
           </p>
         </div>

--- a/src/features/goblins/bank/Bank.tsx
+++ b/src/features/goblins/bank/Bank.tsx
@@ -29,7 +29,7 @@ export const Bank: React.FC = () => {
       <div className="cursor-pointer hover:img-highlight">
         <img src={bank} alt="bank" onClick={openBank} className="w-full" />
         <Action
-          className="absolute -bottom-6 left-3"
+          className="absolute -bottom-6 left-5"
           text="Bank"
           icon={token}
           onClick={openBank}


### PR DESCRIPTION
# Description

You are unable to mint a rare item if you're already holding that item on your farm. This was not happening in the UI. This PR adds this restriction to the UI.

<img width="334" alt="Screen Shot 2022-05-11 at 12 01 36 pm" src="https://user-images.githubusercontent.com/17863697/167757897-e0c0b1eb-e237-4d0e-a00f-fbc969dabb22.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
