### PR TITLE
[FIX] Scarecrow withdraw issue

### DIFF
--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -17,6 +17,7 @@ import {
 } from "../actions/onchain";
 import { ERRORS } from "lib/errors";
 import { EMPTY } from "./constants";
+import { loadSession } from "../actions/loadSession";
 
 export type GoblinState = Omit<GameState, "skills">;
 
@@ -109,8 +110,15 @@ export function startGoblinVillage(authContext: AuthContext) {
                 id: Number(authContext.farmId),
               });
 
+              const response = await loadSession({
+                farmId: Number(authContext.farmId),
+                sessionId: authContext.sessionId as string,
+                token: authContext.rawToken as string,
+              });
+
               // Load the Goblin Village
               game.id = authContext.farmId as number;
+              game.fields = response?.game.fields || {};
 
               const limitedItemsById = makeLimitedItemsById(limitedItems);
 

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -140,15 +140,18 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
         <div className="flex flex-wrap h-fit -ml-1.5">
           {inventoryItems.map((itemName) => {
             const details = makeItemDetails(itemName);
+
             const withdrawable = canWithdraw({
               item: itemName,
               game: goblinState.context.state,
             });
+
             const cooldownInProgress =
               mintCooldown({
                 cooldownSeconds: details?.cooldownSeconds,
                 mintedAt: details?.mintedAt,
               }) > 0;
+
             const locked = !withdrawable || cooldownInProgress;
 
             return (


### PR DESCRIPTION
# Description

This PR fixes the issue where players were unable to withdraw their scarecrows. This was caused by us populating default crops (Sunflowers) when a player is not in an active game state ie Goblin Town. We are now reading from the server to see the planted state of a players crops and evaluating our conditions based on that data rather than the default data.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
