### PR TITLE
[FIX] Align Session ID's

### DIFF
--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -18,6 +18,8 @@ import {
 import { ERRORS } from "lib/errors";
 import { EMPTY } from "./constants";
 import { loadSession } from "../actions/loadSession";
+import { metamask } from "lib/blockchain/metamask";
+import { INITIAL_SESSION } from "./gameMachine";
 
 export type GoblinState = Omit<GameState, "skills">;
 
@@ -98,31 +100,40 @@ export function startGoblinVillage(authContext: AuthContext) {
       initial: "loading",
       context: {
         state: EMPTY,
-        sessionId: authContext.sessionId,
+        sessionId: INITIAL_SESSION,
         limitedItems: {},
       },
       states: {
         loading: {
           invoke: {
             src: async () => {
+              const farmId = authContext.farmId as number;
+
               const { game, limitedItems } = await getOnChainState({
                 farmAddress: authContext.address as string,
                 id: Number(authContext.farmId),
               });
 
+              // Load the Goblin Village
+              game.id = authContext.farmId as number;
+              game.id = farmId;
+
+              // Get session id
+              const sessionId = await metamask
+                .getSessionManager()
+                .getSessionId(farmId);
+
               const response = await loadSession({
-                farmId: Number(authContext.farmId),
-                sessionId: authContext.sessionId as string,
+                farmId,
+                sessionId,
                 token: authContext.rawToken as string,
               });
 
-              // Load the Goblin Village
-              game.id = authContext.farmId as number;
               game.fields = response?.game.fields || {};
 
               const limitedItemsById = makeLimitedItemsById(limitedItems);
 
-              return { state: game, limitedItems: limitedItemsById };
+              return { state: game, limitedItems: limitedItemsById, sessionId };
             },
             onDone: {
               target: "playing",
@@ -133,6 +144,7 @@ export function startGoblinVillage(authContext: AuthContext) {
                     LIMITED_ITEMS,
                     event.data.limitedItems
                   ),
+                sessionId: (_, event) => event.data.sessionId,
               }),
             },
             onError: {},

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -157,20 +157,11 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
   const Action = () => {
     if (soldOut) return null;
 
-    if (hasItemOnFarm)
-      return (
-        <div className="flex flex-col text-center mt-2 border-y border-white w-full">
-          <p className="text-[10px] sm:text-sm my-2">Already minted!</p>
-          <p className="text-[8px] sm:text-[10px] mb-2">
-            You can only have one of each rare item on your farm at a time.
-          </p>
-        </div>
-      );
-
     const secondsLeft = mintCooldown({
       cooldownSeconds: selected.cooldownSeconds,
       mintedAt: selected.mintedAt,
     });
+
     if (secondsLeft > 0) {
       return (
         <div className="mt-2 border-y border-white w-full">
@@ -202,6 +193,16 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
         </div>
       );
     }
+
+    if (hasItemOnFarm)
+      return (
+        <div className="flex flex-col text-center mt-2 border-y border-white w-full">
+          <p className="text-[10px] sm:text-sm my-2">Already minted!</p>
+          <p className="text-[8px] sm:text-[10px] mb-2">
+            You can only have one of each rare item on your farm at a time.
+          </p>
+        </div>
+      );
 
     if (selected.disabled) {
       return <span className="text-xs mt-2">Coming soon</span>;

--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -16,6 +16,7 @@ import { wishingWellMachine } from "./wishingWellMachine";
 import { fromWei } from "web3-utils";
 import { secondsToLongString } from "lib/utils/time";
 import { CONFIG } from "lib/config";
+import { Context } from "features/game/GoblinProvider";
 
 export const shortAddress = (address: string): string => {
   // check if there is an address
@@ -32,8 +33,15 @@ interface Props {
 
 export const WishingWellModal: React.FC<Props> = ({ isOpen, onClose }) => {
   const { authService } = useContext(Auth.Context);
+  const { goblinService } = useContext(Context);
   const [authState] = useActor(authService);
-  const [machine, send] = useMachine(wishingWellMachine(authState.context));
+  const [goblinState] = useActor(goblinService);
+  const [machine, send] = useMachine(
+    wishingWellMachine(
+      authState.context,
+      goblinState.context.sessionId as string
+    )
+  );
 
   const Content = () => {
     const { state: wishingWell, errorCode } = machine.context;

--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -49,7 +49,10 @@ export type MachineInterpreter = Interpreter<
   BlockchainState
 >;
 
-export const wishingWellMachine = (authContext: AuthContext) =>
+export const wishingWellMachine = (
+  authContext: AuthContext,
+  sessionId: string
+) =>
   createMachine<Context, BlockchainEvent, BlockchainState>(
     {
       id: "wishingWell",
@@ -130,7 +133,7 @@ export const wishingWellMachine = (authContext: AuthContext) =>
 
               await collectFromWell({
                 farmId: authContext.farmId as number,
-                sessionId: authContext.sessionId as string,
+                sessionId,
                 amount: tokensToPull.toString(),
                 token: authContext.rawToken as string,
                 captcha: (event as CaptchaEvent).captcha,

--- a/src/lib/utils/screen.ts
+++ b/src/lib/utils/screen.ts
@@ -36,6 +36,7 @@ class ScreenTracker {
   }
 
   private clicks: number[] = [];
+
   private clicked(event: MouseEvent) {
     this.clicks.push(Date.now());
 
@@ -44,7 +45,7 @@ class ScreenTracker {
 
     // World Record is 16 clicks per second
     if (this.clicks.length > 10) {
-      this.service?.send("REFRESH");
+      // this.service?.send("REFRESH");
     }
   }
 


### PR DESCRIPTION
# Description

This PR moves the sessionId from the auth machine context into the game/goblin machine context. The aim of this is to keep the sessionId's in sync between the two state machines.

There is also a reordering of the messaging for locking rare items from being minted. Cooldown state will take precedence.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
