### PR TITLE
[FIX] Stuck descriptions from other farms inventory.

### DIFF
--- a/src/features/farming/hud/components/InventoryTabContent.tsx
+++ b/src/features/farming/hud/components/InventoryTabContent.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Box } from "components/ui/Box";
 import { OuterPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { InventoryItemName } from "features/game/types/game";
 
 import { SEEDS, CropName } from "features/game/types/crops";
+
+import { useActor } from "@xstate/react";
+import { Context } from "features/game/GameProvider";
 
 import timer from "assets/icons/timer.png";
 import lightning from "assets/icons/lightning.png";
@@ -47,6 +50,9 @@ export const InventoryTabContent = ({
   const [scrollIntoView] = useScrollIntoView();
   const categories = getKeys(tabItems) as InventoryItemName[];
   const [isTimeBoosted, setIsTimeBoosted] = useState(false);
+  
+  const { gameService } = useContext(Context);
+  const [game] = useActor(gameService);
 
   const inventoryMapping = inventoryItems.reduce((acc, curr) => {
     const category = categories.find(
@@ -67,15 +73,15 @@ export const InventoryTabContent = ({
       (category) => !!inventoryMapping[category]?.length
     );
 
-    const defaultSelectedItem =
-      getShortcuts()[0] ||
-      // Fallback for when a no active item selected
-      (firstCategoryWithItem && inventoryMapping[firstCategoryWithItem][0]);
+    const firstItemInventory = firstCategoryWithItem && inventoryMapping[firstCategoryWithItem][0];
 
-    if (defaultSelectedItem) {
-      setDefaultSelectedItem(defaultSelectedItem);
-    }
-  }, [categories, inventoryMapping, setDefaultSelectedItem]);
+    if (game.matches('readonly')){
+      setDefaultSelectedItem(firstItemInventory);
+    } else { 
+      const cachedSelectedItem = getShortcuts()[0] || firstItemInventory;
+      setDefaultSelectedItem(cachedSelectedItem);
+    }	
+  }, []);
 
   useEffect(
     () =>


### PR DESCRIPTION
# Description

Clicking items from other farms inventory doesn't change the description. Description gets stuck with the last item interacted from user farm. This PR aims to fix that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open your own farm item inventory, click different items, description gets changed.
Do the same in somebody else farm. Description is stuck on last item clicked from user farm.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
