### PR TITLE
[FIX] Show minting time for rare items that are also sold out

### DIFF
--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -155,8 +155,6 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
   const hasItemOnFarm = amountOfSelectedItemInInventory > 0;
 
   const Action = () => {
-    if (soldOut) return null;
-
     const secondsLeft = mintCooldown({
       cooldownSeconds: selected.cooldownSeconds,
       mintedAt: selected.mintedAt,
@@ -193,6 +191,8 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
         </div>
       );
     }
+
+    if (soldOut) return null;
 
     if (hasItemOnFarm)
       return (

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -160,6 +160,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
       mintedAt: selected.mintedAt,
     });
 
+    // Rare item is still in the cooldown period
     if (secondsLeft > 0) {
       return (
         <div className="mt-2 border-y border-white w-full">


### PR DESCRIPTION
# Description

This PR fixes the issue where a sold out rare item wasn't showing the cooldown timer for players. This was due to the render _ordering._

Fixes #issue

_This is a screenshot of a user who purchased Kuebiko on release_

![unknown](https://user-images.githubusercontent.com/17863697/168399485-428c1568-3940-4c22-9bc9-de50b430590e.png)

## Type of change


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
