### PR TITLE
[FIX] Display All Skill Badges in House

### DIFF
--- a/src/features/farming/house/House.tsx
+++ b/src/features/farming/house/House.tsx
@@ -8,6 +8,7 @@ import {
   getLevel,
   getRequiredXpToLevelUp,
   upgradeAvailable,
+  SKILL_TREE,
 } from "features/game/types/skills";
 
 import house from "assets/buildings/house.png";
@@ -69,16 +70,9 @@ export const House: React.FC = () => {
   const farmingRequiredXp = getRequiredXpToLevelUp(farmingLevel);
 
   const Badges = () => {
-    const BADGES: InventoryItemName[] = [
-      "Green Thumb",
-      "Barn Manager",
-      "Seed Specialist",
-      "Wrangler",
-      "Lumberjack",
-      "Prospector",
-      "Logger",
-      "Gold Rush",
-    ];
+    const BADGES: InventoryItemName[] = Object.keys(SKILL_TREE).map(
+      (badge) => badge as InventoryItemName
+    );
 
     const badges = BADGES.map((badge) => {
       if (gameState.context.state.inventory[badge]) {


### PR DESCRIPTION
# Description

This PR implements display of contributor badges in House Modal Badges section. it takes `SKILL_TREE` keys to iterate if farmer has the item in inventory

![image](https://user-images.githubusercontent.com/89294757/168428571-e354f3ba-58a4-4e60-b5d5-61b480c8136c.png)

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual - local with edited `INITIAL_FARM` inventory
![image](https://user-images.githubusercontent.com/89294757/168428535-22f015b0-3b3b-48ab-a282-21a89558563b.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
