### PR TITLE
[FIX] Disabling the ability to craft egg basket

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -327,6 +327,7 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, LimitedItem> = {
     name: "Egg Basket",
     description: "Gives access to the Easter Egg Hunt",
     type: LimitedItemType.BlacksmithItem,
+    disabled: true,
   },
 };
 


### PR DESCRIPTION
One line addition to disable Egg Basket; it's not craft-able outside of the event.

# Description

The easter egg basket is no longer craft-able, but the users are able to try to craft it because it is not disabled.

It is an one line addition to src/features/game/types/craftables.ts to disable it.

Fixes #930 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

yarn tested only.
![image](https://user-images.githubusercontent.com/105506388/168586826-4d047dd9-82f7-433c-81ee-03d0d9f5f3bc.png)

Sorry, I don't have testnet access. Someone will need to confirm this works for me please!

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
