### PR TITLE
[FEAT] Add rocket repair placeholder

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -77,7 +77,8 @@ export type BlacksmithItem =
   | "Nyon Statue"
   | "Homeless Tent"
   | "Egg Basket"
-  | "Farmer Bath";
+  | "Farmer Bath"
+  | "Rocket Repair";
 
 export type BarnItem =
   | "Farm Cat"
@@ -326,6 +327,11 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, LimitedItem> = {
   "Egg Basket": {
     name: "Egg Basket",
     description: "Gives access to the Easter Egg Hunt",
+    type: LimitedItemType.BlacksmithItem,
+  },
+  "Rocket Repair": {
+    name: "Rocket Repair",
+    description: "Equipment used to repair a rocket",
     type: LimitedItemType.BlacksmithItem,
   },
 };

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -702,4 +702,9 @@ export const ITEM_DETAILS: Items = {
     description: "A purple easter egg",
     image: purpleEgg,
   },
+
+  "Rocket Repair": {
+    description: "Equipment used to repair a rocket",
+    image: questionMark,
+  },
 };

--- a/src/features/game/types/index.ts
+++ b/src/features/game/types/index.ts
@@ -143,6 +143,7 @@ export const KNOWN_IDS: Record<InventoryItemName, number> = {
   "Orange Egg": 907,
   "Green Egg": 908,
   "Easter Bunny": 909,
+  "Rocket Repair": 910,
 };
 
 // The reverse of above


### PR DESCRIPTION
# Description

Adds the placeholder ID for the rocket repair item

**Excludes**

- Image for the rocket repair


<img width="520" alt="Screen Shot 2022-05-19 at 1 57 26 pm" src="https://user-images.githubusercontent.com/11745561/169201359-4156d2ec-adf4-4f7b-8e27-af6755291098.png">

