### PR TITLE
[FIX] Goblin position is unset on first page load

### DIFF
--- a/src/features/farming/crops/components/GoblinShovel.tsx
+++ b/src/features/farming/crops/components/GoblinShovel.tsx
@@ -51,6 +51,9 @@ export const GoblinShovel: React.FC = () => {
 
   useEffect(() => {
     const detectGoblins = () => {
+      const randomPosition = Math.floor(Math.random() * 19);
+      setGoblinPosition(positions[randomPosition]);
+
       const isStolen = isShovelStolen();
       setShowModal(isStolen);
       setShowGoblin(isStolen);
@@ -58,8 +61,6 @@ export const GoblinShovel: React.FC = () => {
 
     gameService.onEvent((event) => {
       if (event.type == "item.harvested") {
-        const randomPosition = Math.floor(Math.random() * 19);
-        setGoblinPosition(positions[randomPosition]);
         detectGoblins();
       }
     });


### PR DESCRIPTION
# Description

It's possible for the goblin thief to spawn in the top leftmost corner of the map. This is because the goblin theif's coordinates are not initialised when the page is first rendered.

![](https://user-images.githubusercontent.com/41215134/169413346-91a4f3b3-5711-40bb-9b4f-5bb04c87138c.png)

This regression was introduced when the goblin thief was updated to move location each time crops are harvested here:
https://github.com/sunflower-land/sunflower-land/pull/944/files#diff-7d868dcf55884c6df306f2490a3a8af95c48fb666268ea9bdd0a81718e4b672fR61

The change removed the initial position from the goblin thief. This PR reintroduces the initial position.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested manually by triggering a goblin theif, and then refreshing the page to unset it's coordinates.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
