### PR TITLE
[FIX] Farm Address Copy on Metamask (Android)

### DIFF
--- a/src/features/farming/hud/components/Address.tsx
+++ b/src/features/farming/hud/components/Address.tsx
@@ -30,8 +30,8 @@ export const Address: React.FC = () => {
   const [showAddress, setShowAddress] = useState(true);
   const [showLabel, setShowLabel] = useState(false);
 
-  const copyToClipboard = (): void => {
-    navigator.clipboard.writeText(state.farmAddress as string);
+  const copyToClipboard = async (): Promise<void> => {
+    await navigator.clipboard.writeText(state.farmAddress as string);
     setTooltipMessage("Copied!");
     setTimeout(() => {
       setTooltipMessage("Click to copy farm address");


### PR DESCRIPTION
# Description
Reported on discord: Copy farm address not working on metamask (android). 

This [stack overflow](https://stackoverflow.com/questions/69438702/why-does-navigator-clipboard-writetext-not-copy-text-to-clipboard-if-it-is-pro) post pointed out the the `writeText` fn returns a promise which needs to be awaited. This was causing an issue on android. I have fixed this in this PR.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
