### PR TITLE
[CHORE] Update goblin land balance after rewards collected.

### DIFF
--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -21,6 +21,7 @@ import { loadSession } from "../actions/loadSession";
 import { metamask } from "lib/blockchain/metamask";
 import { INITIAL_SESSION } from "./gameMachine";
 import { wishingWellMachine } from "features/goblins/wishingWell/wishingWellMachine";
+import Decimal from "decimal.js-light";
 
 export type GoblinState = Omit<GameState, "skills">;
 
@@ -53,6 +54,11 @@ type OpeningWishingWellEvent = {
   authState: AuthContext;
 };
 
+type UpdateBalance = {
+  type: "UPDATE_BALANCE";
+  newBalance: Decimal;
+};
+
 export type BlockchainEvent =
   | {
       type: "REFRESH";
@@ -68,7 +74,8 @@ export type BlockchainEvent =
     }
   | WithdrawEvent
   | MintEvent
-  | OpeningWishingWellEvent;
+  | OpeningWishingWellEvent
+  | UpdateBalance;
 
 export type BlockchainState = {
   value:
@@ -187,6 +194,16 @@ export function startGoblinVillage(authContext: AuthContext) {
             },
             onDone: {
               target: "playing",
+            },
+          },
+          on: {
+            UPDATE_BALANCE: {
+              actions: assign({
+                state: (context, event) => ({
+                  ...context.state,
+                  balance: (event as UpdateBalance).newBalance,
+                }),
+              }),
             },
           },
         },

--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -1,4 +1,10 @@
-import { createMachine, Interpreter, assign, DoneInvokeEvent } from "xstate";
+import {
+  createMachine,
+  Interpreter,
+  assign,
+  DoneInvokeEvent,
+  sendParent,
+} from "xstate";
 
 import { metamask } from "lib/blockchain/metamask";
 import { ERRORS } from "lib/errors";
@@ -199,11 +205,18 @@ export const wishingWellMachine = createMachine<
 
             const well = await loadWishingWell();
 
-            return { state: well, totalRewards };
+            return { state: well, totalRewards, newBalance };
           },
           onDone: {
             target: "granted",
-            actions: [assignWishingWellState, assignTotalRewards],
+            actions: [
+              assignWishingWellState,
+              assignTotalRewards,
+              sendParent((_, event) => ({
+                type: "UPDATE_BALANCE",
+                newBalance: event.data.newBalance,
+              })),
+            ],
           },
           onError: {
             target: "error",


### PR DESCRIPTION
# Description
This PR updates the SFL balance in goblin land after a player collects rewards from the wishing well. This provides a better UX as the player can now see the updated SFL balance without having to reload goblin land. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to goblin land
- Open the wishing well. If you don't have LP tokens then click on the `Mint testnet LP tokens` button. 
- Make a wish.
- You will then need to wait 3 minutes until you wish is ready.
- Grant wish
- Check that the balance is updated with the reward amount reported in the `Congratulations` modal.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
