### PR TITLE
[FEAT] Add Kitchen Button to Goblin Prompt

### DIFF
--- a/src/features/farming/crops/components/CropZoneFour.tsx
+++ b/src/features/farming/crops/components/CropZoneFour.tsx
@@ -13,7 +13,10 @@ import goblinHead from "assets/npcs/goblin_head.png";
 import cauliflowerRice from "assets/nfts/roasted_cauliflower.png";
 import close from "assets/icons/close.png";
 
+import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
+
 import { Field } from "./Field";
+import { Button } from "components/ui/Button";
 
 export const CropZoneFour: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
@@ -24,7 +27,15 @@ export const CropZoneFour: React.FC = () => {
     },
   ] = useActor(gameService);
 
+  const [scrollIntoView] = useScrollIntoView();
+
+  const goToKitchen = () => {
+    setShowModal(false);
+    scrollIntoView(Section.Town);
+  };
+
   const isUnlocked = state.inventory["Roasted Cauliflower"];
+
   return (
     <>
       {!isUnlocked ? (
@@ -100,8 +111,11 @@ export const CropZoneFour: React.FC = () => {
               </span>
               <img
                 src={cauliflowerRice}
-                className="w-8 img-highlight float-right mr-1"
+                className="w-8 img-highlight float-right mr-1 mb-2"
               />
+              <Button className="text-sm" onClick={goToKitchen}>
+                Go to the kitchen
+              </Button>
             </div>
           </div>
         </Panel>

--- a/src/features/farming/crops/components/CropZoneThree.tsx
+++ b/src/features/farming/crops/components/CropZoneThree.tsx
@@ -11,8 +11,12 @@ import goblin from "assets/npcs/goblin.gif";
 import goblinWatering from "assets/npcs/goblin_watering.gif";
 import goblinHead from "assets/npcs/goblin_head.png";
 import cabbageSoup from "assets/nfts/saurekrat_small.png";
+import close from "assets/icons/close.png";
+
+import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 
 import { Field } from "./Field";
+import { Button } from "components/ui/Button";
 
 export const CropZoneThree: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
@@ -22,6 +26,13 @@ export const CropZoneThree: React.FC = () => {
       context: { state },
     },
   ] = useActor(gameService);
+
+  const [scrollIntoView] = useScrollIntoView();
+
+  const goToKitchen = () => {
+    setShowModal(false);
+    scrollIntoView(Section.Town);
+  };
 
   const isUnlocked = state.inventory["Sauerkraut"];
 
@@ -89,6 +100,11 @@ export const CropZoneThree: React.FC = () => {
 
       <Modal centered show={showModal} onHide={() => setShowModal(false)}>
         <Panel>
+          <img
+            src={close}
+            className="h-6 top-4 right-4 absolute cursor-pointer"
+            onClick={() => setShowModal(false)}
+          />
           <div className="flex items-start">
             <img src={goblinHead} className="w-16 img-highlight mr-2" />
             <div className="flex-1">
@@ -97,8 +113,11 @@ export const CropZoneThree: React.FC = () => {
               </span>
               <img
                 src={cabbageSoup}
-                className="w-8 img-highlight float-right mr-1"
+                className="w-4 img-highlight float-right mr-1 mb-2"
               />
+              <Button className="text-sm" onClick={goToKitchen}>
+                Go to the kitchen
+              </Button>
             </div>
           </div>
         </Panel>

--- a/src/features/farming/crops/components/WheatGoblin.tsx
+++ b/src/features/farming/crops/components/WheatGoblin.tsx
@@ -14,6 +14,9 @@ import questionMark from "assets/icons/expression_confused.png";
 import heart from "assets/icons/heart.png";
 import close from "assets/icons/close.png";
 
+import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
+import { Button } from "components/ui/Button";
+
 export const WheatGoblin: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
   const { gameService } = useContext(Context);
@@ -22,6 +25,13 @@ export const WheatGoblin: React.FC = () => {
       context: { state },
     },
   ] = useActor(gameService);
+
+  const [scrollIntoView] = useScrollIntoView();
+
+  const goToKitchen = () => {
+    setShowModal(false);
+    scrollIntoView(Section.Town);
+  };
 
   return (
     <>
@@ -96,6 +106,9 @@ export const WheatGoblin: React.FC = () => {
                 src={radishPie}
                 className="w-8 img-highlight float-right mr-1 mb-1"
               />
+              <Button className="text-sm" onClick={goToKitchen}>
+                Go to the kitchen
+              </Button>
             </div>
           </div>
         </Panel>


### PR DESCRIPTION
# Description
- Added missing `Go to Kitchen` button on the 3 other goblin prompts
- Added missing `x` close button to one of the goblin prompts
- Resized sauerkraut inside goblin prompt to have the same width as the other recipes
- This is a continuation of @JacobSobolev 's PR : #640 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`yarn test`
<img width="415" alt="Screen Shot 2022-05-23 at 12 56 48 AM" src="https://user-images.githubusercontent.com/18549210/169706691-d48786eb-7af6-4855-840c-9f545efcbd48.png">

`yarn dev`
## Sauerkraut Goblin
**BEFORE**
<img width="499" alt="Screen Shot 2022-05-23 at 1 26 28 AM" src="https://user-images.githubusercontent.com/18549210/169707775-4e20f666-fc4a-43a3-9f82-49398242775c.png">

**AFTER**
<img width="500" alt="Screen Shot 2022-05-23 at 12 46 08 AM" src="https://user-images.githubusercontent.com/18549210/169706705-c34f6e52-033d-4e56-b6cd-9e3688e1b4f3.png">

## Roasted Cauliflower Goblin
**BEFORE**
<img width="500" alt="Screen Shot 2022-05-23 at 1 26 20 AM" src="https://user-images.githubusercontent.com/18549210/169707768-86107246-cc60-47ad-a51e-73366138533b.png">

**AFTER**
<img width="496" alt="Screen Shot 2022-05-23 at 12 46 17 AM" src="https://user-images.githubusercontent.com/18549210/169706703-2fb8d924-de05-404e-99cf-430d7f1ba771.png">

## Wheat Goblin
**BEFORE**
<img width="498" alt="Screen Shot 2022-05-23 at 1 26 37 AM" src="https://user-images.githubusercontent.com/18549210/169707779-1e5822f2-c761-49ef-9129-0ec04886fdd0.png">

**AFTER**
<img width="499" alt="Screen Shot 2022-05-23 at 1 21 54 AM" src="https://user-images.githubusercontent.com/18549210/169707679-4106dd67-f03a-40c0-9a88-765735f5866f.png">


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
