### PR TITLE
[FIX] Allow default visit state for development

### DIFF
--- a/src/features/game/lib/visitingMachine.ts
+++ b/src/features/game/lib/visitingMachine.ts
@@ -55,6 +55,7 @@ export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
     {
       id: "visitingMachine",
       context: { state: EMPTY, isBlacklisted: undefined },
+      // Allow a development playground if there is now API_URL env variable
       initial: API_URL ? "loading" : "visiting",
       states: {
         loading: {

--- a/src/features/game/lib/visitingMachine.ts
+++ b/src/features/game/lib/visitingMachine.ts
@@ -1,4 +1,5 @@
 import { metamask } from "lib/blockchain/metamask";
+import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { createMachine, assign, Interpreter } from "xstate";
 import { getOnChainState, isFarmBlacklisted } from "../actions/onchain";
@@ -47,12 +48,14 @@ const setFarmDetails = assign<Context, any>({
   state: (_, event) => event.data.state,
 });
 
+const API_URL = CONFIG.API_URL;
+
 export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
   return createMachine<Context, Event, State>(
     {
       id: "visitingMachine",
       context: { state: EMPTY, isBlacklisted: undefined },
-      initial: "loading",
+      initial: API_URL ? "loading" : "visiting",
       states: {
         loading: {
           invoke: {


### PR DESCRIPTION
# Description
Community devs were able to enter into a visiting state when no `API_URL` was defined in their `.env`. This PR allows this conditional to flow through to the `visitingMachine` so devs can continue to access this fallback dev environment.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes [#issue](https://discord.com/channels/880987707214544966/905567246452129873/978594089119399957)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Remove the `API_URL` environment variable from your `.env`
- Restart your local server
- You should be taken to a dev visiting state 

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
