### PR TITLE
[FIX] Show blacklisted modal inside of visiting state

### DIFF
--- a/src/features/game/components/Blacklisted.tsx
+++ b/src/features/game/components/Blacklisted.tsx
@@ -13,22 +13,24 @@ export const Blacklisted: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center p-2">
-      <span className="text-shadow text-center">Something strange!</span>
-      <img src={suspiciousGoblin} className="w-1/4 mt-2" />
-      <span className="text-shadow text-xs text-center mt-2 mb-2">
-        The anti-bot detection system is relatively new and has picked up some
-        strange behaviour. Some actions may be temporarily restricted.
-      </span>
-      <a
-        href={`https://forms.gle/ajhNS6kr3c6U3YLT9`}
-        className="underline text-center text-xs hover:text-blue-500 mt-1 mb-2 block"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Share details to help us improve our system
-      </a>
+    <>
+      <div className="flex flex-col items-center p-2">
+        <span className="text-center">Something strange!</span>
+        <img src={suspiciousGoblin} className="w-16 mt-2" />
+        <span className="text-sm mt-2 mb-2">
+          The anti-bot detection system is relatively new and has picked up some
+          strange behaviour. Some actions may be temporarily restricted.
+        </span>
+        <a
+          href={`https://forms.gle/ajhNS6kr3c6U3YLT9`}
+          className="underline text-center text-sm hover:text-blue-500 mt-1 mb-2 block"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Share details to help us improve our system
+        </a>
+      </div>
       <Button onClick={continuePlaying}>Continue Playing</Button>
-    </div>
+    </>
   );
 };

--- a/src/features/game/lib/visitingMachine.ts
+++ b/src/features/game/lib/visitingMachine.ts
@@ -60,7 +60,7 @@ export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
             onDone: [
               {
                 target: "blacklisted",
-                cond: (context) => !!context.isBlacklisted,
+                cond: (_, event) => !!event.data.isBlacklisted,
                 actions: setFarmDetails,
               },
               {
@@ -73,7 +73,13 @@ export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
             },
           },
         },
-        blacklisted: {},
+        blacklisted: {
+          on: {
+            CONTINUE: {
+              target: "visiting",
+            },
+          },
+        },
         visiting: {},
         error: {},
       },

--- a/src/features/visiting/Blacklisted.tsx
+++ b/src/features/visiting/Blacklisted.tsx
@@ -1,26 +1,27 @@
 import React, { useContext } from "react";
 
-import * as AuthProvider from "features/auth/lib/Provider";
-
 import suspiciousGoblin from "assets/npcs/suspicious_goblin.gif";
 import { Button } from "components/ui/Button";
+import { Context } from "features/game/VisitingProvider";
 
 export const Blacklisted: React.FC = () => {
-  const { authService } = useContext(AuthProvider.Context);
+  const { gameService } = useContext(Context);
 
-  const goBack = () => {
-    authService.send("RETURN");
+  const continueVisiting = () => {
+    gameService.send("CONTINUE");
   };
 
   return (
-    <div className="flex flex-col items-center p-2">
-      <span className="text-shadow text-center mb-2">Something strange!</span>
-      <img src={suspiciousGoblin} className="w-[15%] mb-2" />
-      <span className="text-xs text-center mb-3">
-        The anti-bot detection system is relatively new and has picked up some
-        strange behaviour on this land.
-      </span>
-      <Button onClick={goBack}>Back</Button>
-    </div>
+    <>
+      <div className="flex flex-col items-center p-2">
+        <span className="text-center">Something strange!</span>
+        <img src={suspiciousGoblin} className="w-16 mt-2" />
+        <span className="text-sm mt-2 mb-2">
+          The anti-bot detection system is relatively new and has picked up some
+          strange behaviour on this land.
+        </span>
+      </div>
+      <Button onClick={continueVisiting}>Continue Visiting</Button>
+    </>
   );
 };

--- a/src/features/visiting/ReadOnlyGame.tsx
+++ b/src/features/visiting/ReadOnlyGame.tsx
@@ -18,9 +18,9 @@ import { Lore } from "features/game/components/Lore";
 import { Town } from "./town/Town";
 import { ErrorMessage } from "features/auth/ErrorMessage";
 import { ErrorCode } from "lib/errors";
-import { Blacklisted } from "./Blacklisted";
 import { TeamDonation } from "./teamDonation/TeamDonation";
 import { House } from "features/farming/house/House";
+import { Blacklisted } from "./Blacklisted";
 
 const SHOW_MODAL: Record<StateValues, boolean> = {
   loading: true,


### PR DESCRIPTION
# Description
This PR fixes an issue where a blacklisted farm was not showing as blacklisted when visiting it. 

<img width="400" alt="Screen Shot 2022-05-25 at 11 01 16 am" src="https://user-images.githubusercontent.com/17863697/170159613-bd58c674-8c56-48f6-9e98-976bcb3ef65f.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Blacklist a farm in the db
- Visit farm
- Confirm you see blacklisted modal

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
