### PR TITLE
[FIX] Add createdAt when learning skills

### DIFF
--- a/src/features/game/actions/levelUp.ts
+++ b/src/features/game/actions/levelUp.ts
@@ -24,6 +24,7 @@ export async function levelUp(request: Request) {
       {
         type: "skill.learned",
         skill: request.skill,
+        createdAt: new Date().toISOString(),
       },
     ],
   });


### PR DESCRIPTION
# Description

Validation is failing because `createdAt` is not being passed when learning skills. This PR adds `createdAt` to the `skill.learned` event.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was manually tested by checking the network inspector for the new attribute.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
