### PR TITLE
[FIX] Green Book Z-Index Overlap

### DIFF
--- a/src/features/game/components/Lore.tsx
+++ b/src/features/game/components/Lore.tsx
@@ -37,7 +37,7 @@ export const Lore: React.FC = () => {
     <>
       <img
         src={greenBook}
-        className="absolute hover:img-highlight cursor-pointer z-10"
+        className="absolute hover:img-highlight cursor-pointer z-5"
         onClick={onOpenGreenBook}
         style={{
           width: `${GRID_WIDTH_PX * 0.5}px`,


### PR DESCRIPTION
# Description
- This PR fixes green book overlapping the `TimeLeft` panel for stone recovery hover function.

Fixes #issue
<img width="268" alt="Screen Shot 2022-05-25 at 9 40 16 PM" src="https://user-images.githubusercontent.com/18549210/170283973-d4ccd844-ec58-498f-a88d-f0f702ce7c63.png">


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`yarn dev`

<img width="299" alt="Screen Shot 2022-05-25 at 10 07 18 PM" src="https://user-images.githubusercontent.com/18549210/170284081-6a2e6966-47d4-4356-8853-060afeb9dc57.png">

`yarn test`

<img width="402" alt="Screen Shot 2022-05-25 at 10 18 45 PM" src="https://user-images.githubusercontent.com/18549210/170284387-cae4a349-81a7-44f1-822c-1be9598ddf50.png">



# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
