### PR TITLE
[FIX] Wishing well LP

### DIFF
--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -175,19 +175,10 @@ export const wishingWellMachine = createMachine<
       granting: {
         invoke: {
           src: async (context, event) => {
-            const tokensToPull = Math.min(
-              Number(context.state.lpTokens),
-              Number(context.state.totalTokensInWell)
-            );
-
-            if (tokensToPull === 0) {
-              throw new Error(ERRORS.NO_TOKENS);
-            }
-
             await collectFromWell({
               farmId: context.farmId as number,
               sessionId: context.sessionId as string,
-              amount: tokensToPull.toString(),
+              amount: context.state.myTokensInWell.toString(),
               token: context.token as string,
               captcha: (event as CaptchaEvent).captcha,
             });


### PR DESCRIPTION
# Description

This fix reverts the wishing well logic to a previous fix.

The amount of tokens in the well was incorrectly being passed to the API