### PR TITLE
[FIX] Set TAB_CONTENT_HEIGHT to a value that can fit all item types

### DIFF
--- a/src/components/InventoryTabContent.tsx
+++ b/src/components/InventoryTabContent.tsx
@@ -31,7 +31,7 @@ interface Props {
   isFarming?: boolean;
 }
 
-const TAB_CONTENT_HEIGHT = 384;
+const TAB_CONTENT_HEIGHT = 400;
 
 const isSeed = (selectedItem: InventoryItemName) => selectedItem in SEEDS();
 


### PR DESCRIPTION
# Description

Increase TAB_CONTENT_HEIGHT to fit a row of each item type. Logic is unchanged, so if someone has more than 1 row of items in any of the types he will see scrollbar. 

Before the fix:
![image](https://user-images.githubusercontent.com/9656961/170827846-d538729d-6bf0-46c0-bf99-87021c4ae71f.png)

After the fix:
![image](https://user-images.githubusercontent.com/9656961/170827857-411f705b-232c-4605-9416-21d296ed842e.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
