### PR TITLE
[CHORE] Fix package.json license warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "sunflower-land",
   "version": "0.0.0",
   "author": "developer@sunflower-land.com",
+  "license": "UNLICENSED",
+  "private": true,
   "scripts": {
     "dev": "set NODE_ENV=development && vite --port 3000 --host",
     "build": "tsc && vite build",
@@ -10,7 +12,7 @@
     "preview": "vite preview",
     "generate": "graphql-codegen",
     "test": "jest",
-    "erc1155": "ts-node --project _scripts/node.tsconfig.json _scripts/erc1155Metadata.ts ",
+    "erc1155": "ts-node --project _scripts/node.tsconfig.json _scripts/erc1155Metadata.ts",
     "prepare": "husky install"
   },
   "browserslist": [


### PR DESCRIPTION
# Description

Fixed the license warnings of the `package.json` when running the `yarn install` command, by adding a license according to the [npm docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license). Also added the [private](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#private) flag to not publish the repository on npm.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running `yarn install` command, we get license warnings as the license is not specified in `package.json`.

```
❯ yarn install
yarn install v1.22.19
warning package.json: No license field
warning sunflower-land@0.0.0: No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @xstate/inspect@0.6.2" has unmet peer dependency "ws@^8.0.0".
warning " > @rollup/plugin-inject@4.0.4" has unmet peer dependency "rollup@^1.20.0 || ^2.0.0".
warning "@rollup/plugin-inject > @rollup/pluginutils@3.1.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning " > autoprefixer@10.4.2" has unmet peer dependency "postcss@^8.1.0".
warning " > tailwindcss@3.0.13" has unmet peer dependency "postcss@^8.0.9".
warning "tailwindcss > postcss-js@4.0.0" has unmet peer dependency "postcss@^8.3.3".
warning "tailwindcss > postcss-nested@5.0.6" has unmet peer dependency "postcss@^8.2.14".
[4/4] Building fresh packages...
$ husky install
husky - Git hooks installed
Done in 19.45s.
```

Added the `UNLICENSED` license and now there's no more warning.

```
❯ yarn install
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @xstate/inspect@0.6.2" has unmet peer dependency "ws@^8.0.0".
warning " > @rollup/plugin-inject@4.0.4" has unmet peer dependency "rollup@^1.20.0 || ^2.0.0".
warning "@rollup/plugin-inject > @rollup/pluginutils@3.1.0" has unmet peer dependency "rollup@^1.20.0||^2.0.0".
warning " > autoprefixer@10.4.2" has unmet peer dependency "postcss@^8.1.0".
warning " > tailwindcss@3.0.13" has unmet peer dependency "postcss@^8.0.9".
warning "tailwindcss > postcss-js@4.0.0" has unmet peer dependency "postcss@^8.3.3".
warning "tailwindcss > postcss-nested@5.0.6" has unmet peer dependency "postcss@^8.2.14".
[4/4] Building fresh packages...
$ husky install
husky - Git hooks installed
Done in 11.12s.
```

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules