### PR TITLE
[FIX] Engine Core and observatory inventory fix.

### DIFF
--- a/src/components/InventoryItems.tsx
+++ b/src/components/InventoryItems.tsx
@@ -16,6 +16,7 @@ import {
   BLACKSMITH_ITEMS,
   BARN_ITEMS,
   MARKET_ITEMS,
+  ROCKET_ITEMS,
   getKeys,
 } from "features/game/types/craftables";
 import { RESOURCES } from "features/game/types/resources";
@@ -64,7 +65,13 @@ const BASKET_CATEGORIES: TabItems = {
 const COLLECTIBLE_CATEGORIES: TabItems = {
   NFTs: {
     img: nft,
-    items: { ...BLACKSMITH_ITEMS, ...BARN_ITEMS, ...MARKET_ITEMS, ...FLAGS },
+    items: {
+      ...BLACKSMITH_ITEMS,
+      ...BARN_ITEMS,
+      ...MARKET_ITEMS,
+      ...FLAGS,
+      ...ROCKET_ITEMS,
+    },
   },
   Foods: {
     img: food,


### PR DESCRIPTION
# Description

Engine Core and Observatory were not showing in player farm inventories. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Engine Core was already minted on my Testnet farm. After bugfix, I confirmed visually fixed.
- For the observatory, I manually added some temp code to "fake add" the item to my gameState's inventory. I confirmed visually that the observatory is showing in inventory after this.

![rocket-core-and-observatory-in-inventory](https://user-images.githubusercontent.com/103600068/171069205-eeb97432-05d7-44dd-85c0-18b519cbbca7.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
