### PR TITLE
[FIX] Scroll and Map positions of NFTs

### DIFF
--- a/src/features/farming/teamDonation/TeamDonation.tsx
+++ b/src/features/farming/teamDonation/TeamDonation.tsx
@@ -157,7 +157,7 @@ export const TeamDonation: React.FC = () => {
         <img
           id="begger"
           src={begger}
-          className="absolute hover:cursor-pointer hover:img-highlight z-10"
+          className="absolute hover:cursor-pointer hover:img-highlight z-20"
           style={{
             width: `${GRID_WIDTH_PX * 1.8}px`,
           }}
@@ -167,7 +167,7 @@ export const TeamDonation: React.FC = () => {
         <img
           id="rich_begger"
           src={richBegger}
-          className="absolute hover:cursor-pointer hover:img-highlight z-10"
+          className="absolute hover:cursor-pointer hover:img-highlight z-20"
           style={{
             width: `${GRID_WIDTH_PX * 1.8}px`,
           }}

--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -501,7 +501,7 @@ export const Decorations: React.FC<Props> = ({ state }) => (
         style={{
           width: `${GRID_WIDTH_PX * 3}px`,
           right: `${GRID_WIDTH_PX * 27.5}px`,
-          bottom: `${GRID_WIDTH_PX * 5.5}px`,
+          top: `${GRID_WIDTH_PX * 92.5}px`,
         }}
         id={Section["Goblin Crown"]}
         className="absolute"

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -329,7 +329,7 @@ export const BLACKSMITH_ITEMS: Record<BlacksmithItem, LimitedItem> = {
   "Nyon Statue": {
     name: "Nyon Statue",
     description: "In memory of Nyon Lann",
-    // TODO: Add section
+    section: Section["Nyon Statue"],
     type: LimitedItemType.BlacksmithItem,
   },
   "Farmer Bath": {

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -156,6 +156,7 @@ import {
   BLACKSMITH_ITEMS,
   MARKET_ITEMS,
   BARN_ITEMS,
+  ROCKET_ITEMS,
   CRAFTABLES,
   LimitedItem,
 } from "./craftables";
@@ -742,6 +743,7 @@ export const ITEM_DETAILS: Items = {
     image: momCoreEngine,
   },
   Observatory: {
+    ...ROCKET_ITEMS["Observatory"],
     description: "Reach the stars and increase XP",
     image: observatory,
   },

--- a/src/features/visiting/teamDonation/TeamDonation.tsx
+++ b/src/features/visiting/teamDonation/TeamDonation.tsx
@@ -154,7 +154,7 @@ export const TeamDonation: React.FC = () => {
         <img
           id="begger"
           src={begger}
-          className="absolute hover:cursor-pointer hover:img-highlight z-10"
+          className="absolute hover:cursor-pointer hover:img-highlight z-20"
           style={{
             width: `${GRID_WIDTH_PX * 1.8}px`,
           }}
@@ -164,7 +164,7 @@ export const TeamDonation: React.FC = () => {
         <img
           id="rich_begger"
           src={richBegger}
-          className="absolute hover:cursor-pointer hover:img-highlight z-10"
+          className="absolute hover:cursor-pointer hover:img-highlight z-20"
           style={{
             width: `${GRID_WIDTH_PX * 1.8}px`,
           }}


### PR DESCRIPTION
# Description

This PR fixes the bug where scroll observatory and goblin crown don't work (for crown, the image element was out of viewport) as reported in [discord](https://discord.com/channels/880987707214544966/929861853201436713/983207407805149244)

Note: will defer position fix to the team if not aligned with software used.

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing - edited `INITIAL_FARM` inventory

Fixed Goblin Crown `top` position
![goblin-crown-top-position](https://user-images.githubusercontent.com/89294757/172098821-740ff622-28c5-4128-91e6-eab7f9586906.PNG)

Scroll Demo

https://user-images.githubusercontent.com/89294757/172098847-92c9607b-d068-40d1-92ea-0f3c6ff34bc4.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
