### PR TITLE
[FIX] Add wheat toast when feeding chicken. Fix stopwatch alignment

### DIFF
--- a/src/features/farming/animals/components/Chicken.tsx
+++ b/src/features/farming/animals/components/Chicken.tsx
@@ -163,6 +163,11 @@ export const Chicken: React.FC<Props> = ({ index, position }) => {
       timeToEgg: getSecondsToEgg(chicken.fedAt),
       isFed: true,
     });
+
+    setToast({
+      icon: wheat,
+      content: `-${wheatRequired}`,
+    });
   };
 
   const handleCollect = () => {

--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -15,9 +15,9 @@ import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { CAKES, CraftableItem } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
-import { CONFIG } from "lib/config";
-import { isExpired } from "features/game/lib/stock";
 import { secondsToString } from "lib/utils/time";
+import { isExpired } from "features/game/lib/stock";
+import { CONFIG } from "lib/config";
 
 interface Props {
   items: Partial<Record<InventoryItemName, CraftableItem>>;
@@ -149,14 +149,18 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
           />
         ))}
       </div>
+
       <OuterPanel className="flex-1 w-1/3">
         <div className="flex flex-col justify-center items-center p-2 relative">
           {expiryTime && (
-            <span className="bg-blue-600 border flex text-[8px] sm:text-xxs items-center absolute -top-4 p-1 rounded-md whitespace-nowrap">
-              <img src={stopwatch} className="w-3 sm:w-4 left-0 -top-4 mr-1" />
-              {`${secondsToString(secondsLeft as number, {
-                separator: " ",
-              })} left`}
+            <span className="bg-blue-600 border flex text-[8px] sm:text-xxs items-center absolute -top-4 p-[3px] rounded-md whitespace-nowrap">
+              <img src={stopwatch} className="w-3 left-0 -top-4 mr-1" />
+              <span className="mt-[2px]">{`${secondsToString(
+                secondsLeft as number,
+                {
+                  separator: " ",
+                }
+              )} left`}</span>
             </span>
           )}
 


### PR DESCRIPTION
# Description
This PR adds a wheat toast when feeding a chicken. It also fixes the alignment of the expiry time banner for the available cake.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
