### PR TITLE
[Feat] Bulk withdraw items

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -7,6 +7,7 @@ import selectBox from "assets/ui/select/select_box.png";
 import { Label } from "./Label";
 import timer from "assets/icons/timer.png";
 import cancel from "assets/icons/cancel.png";
+import { useLongPress } from "lib/utils/hooks/useLongPress";
 
 export interface BoxProps {
   image?: any;
@@ -16,6 +17,7 @@ export interface BoxProps {
   onClick?: () => void;
   disabled?: boolean;
   locked?: boolean;
+  canBeLongPressed?: boolean;
   /**
    * When an NFT is minted it enters into a cooldown period where is cannot be withdrawn from the farm. We communicate
    * this as if the NFT is under construction.
@@ -54,6 +56,7 @@ export const Box: React.FC<BoxProps> = ({
   onClick,
   disabled,
   locked,
+  canBeLongPressed,
   cooldownInProgress,
 }) => {
   const [isHover, setIsHover] = useState(false);
@@ -63,6 +66,19 @@ export const Box: React.FC<BoxProps> = ({
   useEffect(() => setShortCount(shortenCount(count)), [count]);
 
   const canClick = !locked && !disabled;
+
+  const longPressEvents = useLongPress(
+    (e) => (canClick ? onClick?.() : undefined),
+    count,
+    {
+      delay: 500,
+      interval: 20,
+    }
+  );
+
+  const clickEvents = canBeLongPressed
+    ? longPressEvents
+    : { onClick: canClick ? onClick : undefined };
 
   return (
     <div
@@ -80,10 +96,9 @@ export const Box: React.FC<BoxProps> = ({
             "cursor-pointer": canClick,
           }
         )}
-        onClick={canClick ? onClick : undefined}
+        {...clickEvents}
         // Custom styles to get pixellated border effect
         style={{
-          // border: "6px solid transparent",
           borderStyle: "solid",
           borderWidth: "6px",
           borderImage: `url(${darkBorder}) 30 stretch`,

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -163,6 +163,7 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
                 onClick={() => onAdd(itemName)}
                 image={details.image}
                 locked={locked}
+                canBeLongPressed={true}
                 cooldownInProgress={cooldownInProgress}
               />
             );
@@ -183,6 +184,7 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
                   count={selected[itemName]}
                   key={itemName}
                   onClick={() => onRemove(itemName)}
+                  canBeLongPressed={true}
                   image={ITEM_DETAILS[itemName].image}
                 />
               );

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -28,8 +28,12 @@ import { mintCooldown } from "features/goblins/blacksmith/lib/mintUtils";
 
 interface Props {
   onWithdraw: (ids: number[], amounts: string[]) => void;
+  allowLongpressWithdrawal?: boolean;
 }
-export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
+export const WithdrawItems: React.FC<Props> = ({
+  onWithdraw,
+  allowLongpressWithdrawal = true,
+}) => {
   const { goblinService } = useContext(Context);
   const [goblinState] = useActor(goblinService);
 
@@ -163,7 +167,7 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
                 onClick={() => onAdd(itemName)}
                 image={details.image}
                 locked={locked}
-                canBeLongPressed={true}
+                canBeLongPressed={allowLongpressWithdrawal}
                 cooldownInProgress={cooldownInProgress}
               />
             );
@@ -184,7 +188,7 @@ export const WithdrawItems: React.FC<Props> = ({ onWithdraw }) => {
                   count={selected[itemName]}
                   key={itemName}
                   onClick={() => onRemove(itemName)}
-                  canBeLongPressed={true}
+                  canBeLongPressed={allowLongpressWithdrawal}
                   image={ITEM_DETAILS[itemName].image}
                 />
               );

--- a/src/lib/utils/hooks/useLongPress.ts
+++ b/src/lib/utils/hooks/useLongPress.ts
@@ -25,8 +25,10 @@ export const useLongPress = (
 
   const clear = useCallback(
     (e: React.MouseEvent | React.TouchEvent, shouldTriggerClick = true) => {
+      // Clear timeout and timer
       timeout.current && clearTimeout(timeout.current);
       timer.current && clearInterval(timer.current);
+      // Perform normal click if longpress didnt happen or after we hit the limit
       shouldTriggerClick && !longPressTriggered && onClick(e);
       setLongPressTriggered(false);
       if (shouldPreventDefault && target.current) {
@@ -45,7 +47,9 @@ export const useLongPress = (
         target.current = e.target;
       }
       timeout.current = setTimeout(() => {
+        // Remember remaining items count on longpress start
         let remaining = count.toNumber();
+        // Call onClick in a loop until we run out of items or longpress is canceled
         timer.current = setInterval(() => {
           if (remaining <= 1) {
             clear(e, false);
@@ -60,6 +64,7 @@ export const useLongPress = (
     [onClick, delay, interval, count, clear, shouldPreventDefault]
   );
 
+  // Return event handlers
   return {
     onMouseDown: (e: React.MouseEvent) => start(e),
     onTouchStart: (e: React.TouchEvent) => start(e),


### PR DESCRIPTION
# Description

Currently it is allowed to withdraw items by clicking on them. But it becomes a problem when you have 2k sunflowers to withdraw.

I made it possible to select multiple items for withdraw by long pressing mouse button.

https://user-images.githubusercontent.com/9656961/173187356-0801fe25-f899-4c8c-938b-3727c9b69c1b.mp4


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual test and 'yarn test' smd

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
