### PR TITLE
[FIX] Add animal skill boosts to chickens

### DIFF
--- a/src/features/game/events/feedChicken.ts
+++ b/src/features/game/events/feedChicken.ts
@@ -1,7 +1,9 @@
 import Decimal from "decimal.js-light";
 import {
+  BARN_MANAGER_BOOST_AMOUNT,
   CHICKEN_TIME_TO_EGG,
   MUTANT_CHICKEN_BOOST_AMOUNT,
+  WRANGLER_BOOST_AMOUNT,
 } from "../lib/constants";
 import { GameState, Inventory } from "../types/game";
 
@@ -16,15 +18,20 @@ type Options = {
   createdAt?: number;
 };
 
-interface ChickenInfo {
-  multiplier: number;
-  maxChickens: number;
-}
-
 const makeFedAt = (inventory: Inventory, createdAt: number) => {
-  const hasSpeedChicken = inventory["Speed Chicken"]?.gt(0);
+  if (inventory["Wrangler"]?.gt(0) && inventory["Speed Chicken"]?.gt(0)) {
+    return (
+      createdAt -
+      CHICKEN_TIME_TO_EGG *
+        (WRANGLER_BOOST_AMOUNT + MUTANT_CHICKEN_BOOST_AMOUNT)
+    );
+  }
 
-  if (hasSpeedChicken) {
+  if (inventory["Wrangler"]?.gt(0)) {
+    return createdAt - CHICKEN_TIME_TO_EGG * WRANGLER_BOOST_AMOUNT;
+  }
+
+  if (inventory["Speed Chicken"]?.gt(0)) {
     return createdAt - CHICKEN_TIME_TO_EGG * MUTANT_CHICKEN_BOOST_AMOUNT;
   }
 
@@ -43,19 +50,21 @@ export const getWheatRequiredToFeed = (inventory: Inventory) => {
 };
 
 function getMultiplier(inventory: Inventory) {
-  if (inventory["Chicken Coop"] && inventory["Rich Chicken"]) {
-    return 2 + MUTANT_CHICKEN_BOOST_AMOUNT;
+  let multiplier = 1;
+
+  if (inventory["Chicken Coop"]?.gt(0)) {
+    multiplier += 1;
   }
 
-  if (inventory["Chicken Coop"]) {
-    return 2;
+  if (inventory["Barn Manager"]?.gt(0)) {
+    multiplier += BARN_MANAGER_BOOST_AMOUNT;
   }
 
-  if (inventory["Rich Chicken"]) {
-    return 1 + MUTANT_CHICKEN_BOOST_AMOUNT;
+  if (inventory["Rich Chicken"]?.gt(0)) {
+    multiplier += MUTANT_CHICKEN_BOOST_AMOUNT;
   }
 
-  return 1;
+  return Number(multiplier.toFixed(1));
 }
 
 export function getMaxChickens(inventory: Inventory) {

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -3,8 +3,11 @@ import { fromWei } from "web3-utils";
 import { GameState, Inventory } from "../types/game";
 
 export const GRID_WIDTH_PX = 42;
-export const CHICKEN_TIME_TO_EGG = 1000 * 60 * 60 * 24 * 2; // 48 hours
+export const CHICKEN_TIME_TO_EGG = 1000 * 20; // 48 hours
 export const MUTANT_CHICKEN_BOOST_AMOUNT = 0.1;
+
+export const BARN_MANAGER_BOOST_AMOUNT = 0.1;
+export const WRANGLER_BOOST_AMOUNT = 0.1;
 
 export const POPOVER_TIME_MS = 1000;
 
@@ -144,6 +147,10 @@ export const INITIAL_FARM: GameState = {
     Sunflower: new Decimal(5),
     Potato: new Decimal(12),
     "Roasted Cauliflower": new Decimal(1),
+    "Barn Manager": new Decimal(1),
+    Wrangler: new Decimal(1),
+    Chicken: new Decimal(1),
+    Wheat: new Decimal(1),
   },
   stock: INITIAL_STOCK,
   trees: INITIAL_TREES,


### PR DESCRIPTION
# Description
This PR applies the animal skill boosts to chickens. There are currently two animal skills ie Barn Manager and Wrangler.

There skills are as follows:

Barn Manager:
10% more produce
Increase mutant chance

Wrangler:
10% speed boost
Increase mutant chance

The increase mutant chance is 10% and it doesn't stack.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
