### PR TITLE
[FIX] Round Down Fractional Chickens

### DIFF
--- a/src/features/farming/animals/components/Chickens.tsx
+++ b/src/features/farming/animals/components/Chickens.tsx
@@ -44,7 +44,11 @@ export const Chickens: React.FC = () => {
     },
   ] = useActor(gameService);
 
-  const chickenCount = state.inventory.Chicken?.toNumber() || 0;
+  /**
+   * Round down if the player has fractional amount of chickens
+   * 3.000000000000000001 chickens should show 3 chickens.
+   */
+  const chickenCount = Math.floor(state.inventory.Chicken?.toNumber() ?? 0);
 
   const chickens = new Array(chickenCount).fill(null);
   const maxChickens = getMaxChickens(state.inventory);


### PR DESCRIPTION
# Description

If players have fractional quantities of chickens, it can cause the game UI to display a blank page, as `Array(0.1)` throws an `Invalid array length` exception.

This PR ensures that fractional amount of chickens can safely be displayed in the UI by rounding down to the nearest whole integer.

This bug was raised by @Z1kou and @0xSacul.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested by updating state to have fractional chickens.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
