### PR TITLE
[FIX] VIP door when visiting

### DIFF
--- a/src/features/game/components/Vip.tsx
+++ b/src/features/game/components/Vip.tsx
@@ -24,9 +24,11 @@ const VIP_ITEMS: InventoryItemName[] = [
   "Nugget",
   "Golden Cauliflower",
 ];
+
 export const VipArea: React.FC<Props> = ({ inventory }) => {
   const { authService } = useContext(Auth.Context);
   const [authState] = useActor(authService);
+  const visiting = authState.matches("visiting");
 
   const [state, setState] = useState<
     "idle" | "noAccess" | "noDiscord" | "welcome" | "joining" | "joined"
@@ -123,7 +125,17 @@ export const VipArea: React.FC<Props> = ({ inventory }) => {
 
   const showModal = state !== "idle";
 
-  return (
+  return visiting ? (
+    <img
+      src={doorway}
+      className="absolute"
+      style={{
+        top: `${GRID_WIDTH_PX * 2.1}px`,
+        left: `${GRID_WIDTH_PX * 20}px`,
+        width: `${GRID_WIDTH_PX * 2}px`,
+      }}
+    />
+  ) : (
     <>
       <img
         src={doorway}


### PR DESCRIPTION
# Description

Disable the VIP doors when you are visiting another farm.

Fixes #1082

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

https://user-images.githubusercontent.com/13154028/174493691-7fed18cd-6fa3-44ea-8554-ad63b9500a72.mov

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
