### PR TITLE
[FIX] Use available balance in bank

### DIFF
--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -17,7 +17,6 @@ import player from "assets/icons/player.png";
 import { toWei } from "web3-utils";
 import { metamask } from "lib/blockchain/metamask";
 import { canWithdraw } from "../lib/bankUtils";
-import { getOnChainState } from "features/game/actions/onchain";
 
 import {
   getKeys,
@@ -37,25 +36,12 @@ export const WithdrawItems: React.FC<Props> = ({
   const { goblinService } = useContext(Context);
   const [goblinState] = useActor(goblinService);
 
-  const [isLoading, setIsLoading] = useState(true);
   const [inventory, setInventory] = useState<Inventory>({});
   const [selected, setSelected] = useState<Inventory>({});
 
   useEffect(() => {
-    setIsLoading(true);
-
-    const load = async () => {
-      const { game: state } = await getOnChainState({
-        id: goblinState.context.state.id as number,
-        farmAddress: goblinState.context.state.farmAddress as string,
-      });
-
-      setInventory(state.inventory);
-      setIsLoading(false);
-    };
-
+    setInventory(goblinState.context.state.inventory);
     setSelected({});
-    load();
   }, []);
 
   const withdraw = () => {
@@ -101,10 +87,6 @@ export const WithdrawItems: React.FC<Props> = ({
         }
       : details;
   };
-
-  if (isLoading) {
-    return <span className="text-shadow loading mt-2">Loading</span>;
-  }
 
   const inventoryItems = getKeys(inventory).filter((item) =>
     inventory[item]?.gt(0)

--- a/src/features/goblins/bank/components/WithdrawTokens.tsx
+++ b/src/features/goblins/bank/components/WithdrawTokens.tsx
@@ -20,7 +20,6 @@ import downArrow from "assets/icons/arrow_down.png";
 import lightning from "assets/icons/lightning.png";
 
 import { getTax } from "lib/utils/tax";
-import { getOnChainState } from "features/game/actions/onchain";
 
 interface Props {
   onWithdraw: (sfl: string) => void;
@@ -39,24 +38,7 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
   const [tax, setTax] = useState(0);
 
-  const [balance, setBalance] = useState<Decimal>(new Decimal(0));
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    setIsLoading(true);
-
-    const load = async () => {
-      const { game: onChainState } = await getOnChainState({
-        id: state.id as number,
-        farmAddress: state.farmAddress as string,
-      });
-
-      setBalance(onChainState.balance);
-      setIsLoading(false);
-    };
-
-    load();
-  }, []);
+  const balance = state.balance;
 
   useEffect(() => {
     // Use base 1000
@@ -109,10 +91,6 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
         setAmount((prevState) => safeAmount(prevState).minus(0.1));
     }
   };
-
-  if (isLoading) {
-    return <span className="text-shadow loading mt-2">Loading</span>;
-  }
 
   const enabled = authState.context.token?.userAccess.withdraw;
   const disableWithdraw =


### PR DESCRIPTION
# Description

The Goblin bank was showing items/tokens that had already been used in off chain - i.e. just showing the on chain value. This would cause an API error if attempting to withdraw these items.

**Solution** - Use the state that is stored on the goblin state.

See example below where Goblin Village only has 2995 but the bank displays 2999

<img width="417" alt="Screen Shot 2022-06-21 at 2 22 59 pm" src="https://user-images.githubusercontent.com/11745561/174715626-41f42255-620e-46da-805f-831133284015.png">

Fixes #issue

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
