### PR TITLE
[FIX] Correct withdrawal of non integer values.

### DIFF
--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -29,6 +29,37 @@ interface Props {
   onWithdraw: (ids: number[], amounts: string[]) => void;
   allowLongpressWithdrawal?: boolean;
 }
+
+function transferItem(
+  itemName: InventoryItemName,
+  setFrom: React.Dispatch<
+    React.SetStateAction<Partial<Record<InventoryItemName, Decimal>>>
+  >,
+  setTo: React.Dispatch<
+    React.SetStateAction<Partial<Record<InventoryItemName, Decimal>>>
+  >
+) {
+  let amount = 1;
+
+  // Subtract 1 or remaining
+  setFrom((prev) => {
+    const remaining = prev[itemName]!.toNumber();
+    if (remaining < 1) {
+      amount = remaining;
+    }
+    return {
+      ...prev,
+      [itemName]: prev[itemName]?.minus(amount),
+    };
+  });
+
+  // Add 1 or remaining
+  setTo((prev) => ({
+    ...prev,
+    [itemName]: (prev[itemName] || new Decimal(0)).add(amount),
+  }));
+}
+
 export const WithdrawItems: React.FC<Props> = ({
   onWithdraw,
   allowLongpressWithdrawal = true,
@@ -54,27 +85,13 @@ export const WithdrawItems: React.FC<Props> = ({
   };
 
   const onAdd = (itemName: InventoryItemName) => {
-    setSelected((prev) => ({
-      ...prev,
-      [itemName]: (prev[itemName] || new Decimal(0)).add(1),
-    }));
-
-    setInventory((prev) => ({
-      ...prev,
-      [itemName]: prev[itemName]?.minus(1),
-    }));
+    // Transfer from inventory to selected
+    transferItem(itemName, setInventory, setSelected);
   };
 
   const onRemove = (itemName: InventoryItemName) => {
-    setInventory((prev) => ({
-      ...prev,
-      [itemName]: (prev[itemName] || new Decimal(0)).add(1),
-    }));
-
-    setSelected((prev) => ({
-      ...prev,
-      [itemName]: prev[itemName]?.minus(1),
-    }));
+    // Transfer from selected to inventory
+    transferItem(itemName, setSelected, setInventory);
   };
 
   const makeItemDetails = (itemName: InventoryItemName) => {


### PR DESCRIPTION
# Description

Test case:
I have 1.6 sunflowers and want to withdraw them, as a result I end up with incorrect values
Steps:
1. Initial - 1.6 in inventory, 0 in selected
2. After first click on sunflowers we get 0.6 in inventory and 1 in selected
3. After second click we get -0.4 in inventory and 2 in selected 
![image](https://user-images.githubusercontent.com/9656961/174768607-cdbdee49-da07-424c-86fe-54b6ebf28534.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual check of withdrawal on different amounts
![image](https://user-images.githubusercontent.com/9656961/174768194-008a3b6f-3ffd-431e-b676-5f53a40b220a.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
