### PR TITLE
[FIX] Plant boosts should not be compounding

### DIFF
--- a/src/features/game/events/plant.ts
+++ b/src/features/game/events/plant.ts
@@ -92,19 +92,19 @@ type GetFieldArgs = {
 function getMultiplier({ crop, inventory }: GetFieldArgs): number {
   let multiplier = 1;
   if (crop === "Cauliflower" && inventory["Golden Cauliflower"]?.gte(1)) {
-    multiplier *= 2;
+    multiplier += 1; // 100%
   }
 
   if (crop === "Carrot" && inventory["Easter Bunny"]?.gte(1)) {
-    multiplier *= 1.2;
+    multiplier += 0.2; // 20%
   }
 
   if (inventory.Scarecrow?.gte(1) || inventory.Kuebiko?.gte(1)) {
-    multiplier *= 1.2;
+    multiplier += 0.2; // 20%
   }
 
   if (inventory.Coder?.gte(1)) {
-    multiplier *= 1.2;
+    multiplier += 0.2; // 20%
   }
 
   return multiplier;


### PR DESCRIPTION
# Description

This PR prevents the plant boosts from compounding to be in line with the rest of the boosts.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
