### PR TITLE
[FIX] Disable Coop Withdrawal on Timer

### DIFF
--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -1,6 +1,7 @@
 import { canChop } from "features/game/events/chop";
 import { isSeed } from "features/game/events/plant";
 import { canMine } from "features/game/events/stoneMine";
+import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import { FOODS, getKeys, QUEST_ITEMS } from "features/game/types/craftables";
 import { SEEDS } from "features/game/types/crops";
@@ -23,6 +24,15 @@ function cropIsPlanted({ item, game }: CanWithdrawArgs): boolean {
 
 function hasSeeds(inventory: Inventory) {
   return getKeys(inventory).some((name) => name in SEEDS());
+}
+
+function hasFedChickens(game: GoblinState): boolean {
+  if (!game.chickens) return false;
+
+  const hasFedChickens = Object.values(game.chickens).some(
+    (chicken) => Date.now() - chicken.fedAt < CHICKEN_TIME_TO_EGG
+  );
+  return hasFedChickens;
 }
 
 export function canWithdraw({ item, game }: CanWithdrawArgs) {
@@ -78,6 +88,10 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
 
   if (item === "Mysterious Parsnip") {
     return !cropIsPlanted({ item: "Parsnip", game });
+  }
+
+  if (item === "Chicken Coop") {
+    return !hasFedChickens(game);
   }
 
   const stoneReady = Object.values(game?.stones).every((stone) =>

--- a/src/features/visiting/animals/components/Chickens.tsx
+++ b/src/features/visiting/animals/components/Chickens.tsx
@@ -38,7 +38,7 @@ export const Chickens: React.FC = () => {
           style={{
             width: `${GRID_WIDTH_PX * 2}px`,
             right: `${GRID_WIDTH_PX * 1.1}px`,
-            top: `${GRID_WIDTH_PX * 0}px`,
+            top: `${GRID_WIDTH_PX * -1}px`,
           }}
           id={Section["Chicken Coop"]}
           className="absolute"


### PR DESCRIPTION
# Description

This PR disables Chicken Coop withdrawal when a chicken has an active timer. This is to avoid boost exploit where coop can be passed between "friend" farms before feeding chickens. Hopefully this will also mitigate the rate at which coops are minted because withdrawal has no condition.

Also fixes coop position on visit

![image](https://user-images.githubusercontent.com/89294757/174992286-5b709813-15e1-4e9b-b34a-3323a155d581.png)

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing - local with edited `INITIAL_FARM` chickens and inventory

![image](https://user-images.githubusercontent.com/89294757/174991780-335a68fe-e4fb-4676-a373-c0e1035cda52.png)

No / Full timers

https://user-images.githubusercontent.com/89294757/174991930-5a8e1b67-b70c-43dc-82c6-fcd0ee0740b6.mp4

Active timer

https://user-images.githubusercontent.com/89294757/174991971-9575fe91-c65d-44d9-a266-30a61fa6b301.mp4

Visit farm

![image](https://user-images.githubusercontent.com/89294757/174992413-ce824b6c-ddd7-4556-9854-d9fc5e17d58d.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
