### PR TITLE
[CHORE] Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,19 @@
       window.process = process;
       window.EventEmitter = EventEmitter;
     </script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-CYBHD0NMGP"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-CYBHD0NMGP");
+    </script>
   </head>
   <body class="h-full w-full">
     <div id="root" class="h-full w-full"></div>


### PR DESCRIPTION
# Description

Google Analytics is being used on the landing page but for some reason in the last couple months it got removed from this repo thus making it hard to track usage of the `/play` endpoint.

As per our terms and services analytics was always a part of conditions, it looks like it was just accidentally removed from this repo.