### PR TITLE
[FEAT] Remove Progress Warnings

### DIFF
--- a/src/features/auth/components/Refreshing.tsx
+++ b/src/features/auth/components/Refreshing.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const Refreshing: React.FC = () => {
+  return <span className="text-shadow loading">Refreshing</span>;
+};

--- a/src/features/auth/components/Resetting.tsx
+++ b/src/features/auth/components/Resetting.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export const Resetting: React.FC = () => {
-  return <span className="text-shadow loading">Resetting</span>;
-};

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -166,7 +166,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -191,7 +191,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -210,7 +210,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -385,7 +385,7 @@ export const authMachine = createMachine<
               },
               LOGOUT: {
                 target: "#connecting",
-                actions: ["clearSession", "resetFarm"],
+                actions: ["clearSession", "refreshFarm"],
               },
             },
           },
@@ -394,7 +394,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -403,7 +403,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -418,7 +418,7 @@ export const authMachine = createMachine<
           },
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -446,7 +446,7 @@ export const authMachine = createMachine<
         on: {
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -458,11 +458,11 @@ export const authMachine = createMachine<
         on: {
           RETURN: {
             target: "connecting",
-            actions: ["resetFarm", "deleteFarmIdUrl"],
+            actions: ["refreshFarm", "deleteFarmIdUrl"],
           },
           ACCOUNT_CHANGED: {
             target: "connecting",
-            actions: "resetFarm",
+            actions: "refreshFarm",
           },
         },
       },
@@ -471,11 +471,11 @@ export const authMachine = createMachine<
     on: {
       CHAIN_CHANGED: {
         target: "connecting",
-        actions: "resetFarm",
+        actions: "refreshFarm",
       },
       REFRESH: {
         target: "connecting",
-        actions: "resetFarm",
+        actions: "refreshFarm",
       },
     },
   },
@@ -565,7 +565,7 @@ export const authMachine = createMachine<
       assignErrorMessage: assign<Context, any>({
         errorCode: (_context, event) => event.data.message,
       }),
-      resetFarm: assign<Context, any>({
+      refreshFarm: assign<Context, any>({
         farmId: () => undefined,
         address: () => undefined,
         token: () => undefined,

--- a/src/features/farming/hud/components/Settings.tsx
+++ b/src/features/farming/hud/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 
 import * as Auth from "features/auth/lib/Provider";
 
@@ -6,7 +6,7 @@ import { Modal } from "react-bootstrap";
 import { Button } from "components/ui/Button";
 import { Panel } from "components/ui/Panel";
 
-import alert from "assets/icons/expression_alerted.png";
+import questionMark from "assets/icons/expression_confused.png";
 import { Context } from "features/game/GameProvider";
 
 interface Props {
@@ -19,57 +19,32 @@ export const Settings: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const { gameService } = useContext(Context);
 
-  const [resetSessionConfirmation, setResetSessionConfirmation] =
-    useState(false);
-  // {Todo: Modify gameState and authMachine for Logout event}
-
   const onLogout = () => {
     onClose();
     authService.send("LOGOUT"); // hack used to avoid redundancy
   };
 
-  const onResetSession = () => {
-    setResetSessionConfirmation(true);
-  };
-
-  const onConfirmResetSession = () => {
+  const refreshSession = () => {
     onClose();
     gameService.send("RESET");
   };
 
   const Content = () => {
-    if (resetSessionConfirmation) {
-      return (
-        <>
-          <div className="flex items-center border-2 rounded-md border-black p-2 mb-2 bg-error">
-            <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
-            <span className="text-xs">
-              YOUR FARM WILL BE RESET TO THE LAST TIME YOU SYNCED ON CHAIN. YOU
-              WILL LOSE ANY NON SYNCED PROGRESS.
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <Button
-              className="mr-1"
-              onClick={() => setResetSessionConfirmation(false)}
-            >
-              No
-            </Button>
-            <Button className="ml-1" onClick={onConfirmResetSession}>
-              Yes
-            </Button>
-          </div>
-        </>
-      );
-    }
     return (
       <div className="flex flex-col">
         <Button className="col p-1" onClick={onLogout}>
           Logout
         </Button>
-        <Button className="col p-1 mt-2" onClick={onResetSession}>
-          Reset Session
+        <Button className="col p-1 mt-2" onClick={refreshSession}>
+          Refresh
         </Button>
+        <div className="flex items-start">
+          <img src={questionMark} className="w-12 pt-2 pr-2" />
+          <span className="text-xs mt-2">
+            Refresh your session to grab the latest changes from the Blockchain.
+            This is useful if you deposited items to your farm.
+          </span>
+        </div>
       </div>
     );
   };

--- a/src/features/farming/town/components/GoblinVillageModal.tsx
+++ b/src/features/farming/town/components/GoblinVillageModal.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import alert from "assets/icons/expression_alerted.png";
 import { Panel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 import goblinFence from "assets/land/goblin_fence.png";
@@ -28,21 +27,11 @@ export const GoblinVillageModal: React.FC<{ onClose: () => void }> = ({
           <span className="underline">on-chain</span> gameplay.
         </p>
         <p className="mb-4 text-sm">
-          If you transact with a greedy goblin be careful. They will steal any
-          SFL, resources & crops that are not synced to the blockchain.
-        </p>
-        <p className="mb-2 text-sm">
-          If you have any un-synced items it is recommended you{" "}
-          <span className="underline">sync on chain</span> before entering.
+          Goblins will only accept items that are on the Blockchain. Items that
+          are not synced will be hidden.
         </p>
       </div>
-      <div className="flex items-center border-2 rounded-md border-black p-2 mb-2 bg-error">
-        <img src={alert} alt="alert" className="mr-2 w-6" />
-        <span className="text-xs">
-          You may lose SFL or resources from your farm if they have not been
-          synced to the blockchain
-        </span>
-      </div>
+
       <div className="flex">
         <Button className="mr-1" onClick={onClose}>
           Close

--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -30,7 +30,7 @@ import { House } from "features/farming/house/House";
 import { Lore } from "./components/Lore";
 import { ClockIssue } from "./components/ClockIssue";
 import { screenTracker } from "lib/utils/screen";
-import { Resetting } from "features/auth/components/Resetting";
+import { Refreshing } from "features/auth/components/Refreshing";
 import { GoblinShovel } from "features/farming/crops/components/GoblinShovel";
 import { Announcements } from "features/announcements/Announcement";
 
@@ -44,7 +44,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   synced: true,
   error: true,
   levelling: false,
-  resetting: true,
+  refreshing: true,
 };
 
 export const Game: React.FC = () => {
@@ -96,7 +96,7 @@ export const Game: React.FC = () => {
 
           {gameState.matches("announcing") && <Announcements />}
 
-          {gameState.matches("resetting") && <Resetting />}
+          {gameState.matches("refreshing") && <Refreshing />}
           {gameState.matches("error") && (
             <ErrorMessage
               errorCode={gameState.context.errorCode as ErrorCode}

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -10,7 +10,7 @@ import * as AuthProvider from "features/auth/lib/Provider";
 import { ErrorCode } from "lib/errors";
 import { ErrorMessage } from "features/auth/ErrorMessage";
 import { screenTracker } from "lib/utils/screen";
-import { Resetting } from "features/auth/components/Resetting";
+import { Refreshing } from "features/auth/components/Refreshing";
 import { Context } from "../GameProvider";
 import { StateValues } from "../lib/gameMachine";
 import { ToastManager } from "../toast/ToastManager";
@@ -29,7 +29,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   synced: true,
   error: true,
   levelling: false,
-  resetting: true,
+  refreshing: true,
   announcing: true,
 };
 
@@ -116,7 +116,7 @@ export const Game: React.FC = () => {
       <Modal show={SHOW_MODAL[gameState.value as StateValues]} centered>
         <Panel className="text-shadow">
           {gameState.matches("loading") && <Loading />}
-          {gameState.matches("resetting") && <Resetting />}
+          {gameState.matches("refreshing") && <Refreshing />}
           {gameState.matches("error") && (
             <ErrorMessage
               errorCode={gameState.context.errorCode as ErrorCode}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -123,7 +123,7 @@ export type BlockchainState = {
     | "synced"
     | "levelling"
     | "error"
-    | "resetting";
+    | "refreshing";
   context: Context;
 };
 
@@ -276,7 +276,7 @@ export function startGame(authContext: Options) {
               })),
             },
             RESET: {
-              target: "resetting",
+              target: "refreshing",
             },
           },
         },
@@ -427,7 +427,7 @@ export function startGame(authContext: Options) {
             },
           },
         },
-        resetting: {
+        refreshing: {
           invoke: {
             src: async (context, event) => {
               // Autosave just in case

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -238,9 +238,6 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
           onExpired={() => setShowCaptcha(false)}
           className="w-full m-4 flex items-center justify-center"
         />
-        <p className="text-xxs p-1 m-1 text-center">
-          Crafting an item will sync your farm to the blockchain.
-        </p>
       </>
     );
   }

--- a/src/features/goblins/bank/components/Withdraw.tsx
+++ b/src/features/goblins/bank/components/Withdraw.tsx
@@ -9,8 +9,6 @@ import { Button } from "components/ui/Button";
 import { WithdrawTokens } from "./WithdrawTokens";
 import { WithdrawItems } from "./WithdrawItems";
 
-import alert from "assets/icons/expression_alerted.png";
-
 import { Context } from "features/game/GoblinProvider";
 
 interface Props {
@@ -92,13 +90,6 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
       <span className="text-shadow text-sm pb-2">
         You can only withdraw items that you have synced to the blockchain.
       </span>
-
-      <div className="flex items-center border-2 rounded-md border-black p-2 bg-error mb-3">
-        <img src={alert} alt="alert" className="mr-2 w-5 h-5/6" />
-        <span className="text-xs">
-          ANY PROGRESS THAT HAS NOT BEEN SYNCED ON CHAIN WILL BE LOST.
-        </span>
-      </div>
 
       <div className="flex">
         <Button className="mr-1" onClick={() => setPage("tokens")}>


### PR DESCRIPTION
# Description

Our latest smart contract improvements means that players no longer lose progress when:

- Resetting a session
- Minting items
- Withdrawing items

This PR focusses on removing these warnings from the game.

<img width="531" alt="Screen Shot 2022-06-24 at 12 01 58 pm" src="https://user-images.githubusercontent.com/11745561/175448129-3a68e5d4-6779-4fcb-a4b2-bb8039cc3c8e.png">
<img width="547" alt="Screen Shot 2022-06-24 at 12 05 10 pm" src="https://user-images.githubusercontent.com/11745561/175448135-3f37269b-88e0-4ad2-a2cd-ff4f1e94db04.png">

<img width="524" alt="Screen Shot 2022-06-24 at 12 09 46 pm" src="https://user-images.githubusercontent.com/11745561/175448170-d964f96d-06c5-4a7c-b337-964d5f08778c.png">

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
