### PR TITLE
[FIX] Refactor setToast method to prevent incorrect display of toasts (1035)

### DIFF
--- a/src/features/game/toast/ToastQueueProvider.tsx
+++ b/src/features/game/toast/ToastQueueProvider.tsx
@@ -17,22 +17,28 @@ export const ToastContext = createContext<{
   toastList: Toast[];
 }>({ removeToast: console.log, setToast: console.log, toastList: [] });
 
-const MAX_TOAST = 5;
+const MAX_TOAST = 6;
 
 export const ToastProvider: FC = ({ children }) => {
   const [toastList, setToastList] = useState<Toast[]>([]);
 
   const setToast: SetToast = (toast) => {
-    if (toastList.length > 4) {
-      setToastList(toastList.slice(0, MAX_TOAST));
-    }
     const id = `${Date.now()}-${toast.icon}`;
+    const newToast = { id: id, ...toast };
+
+    setToastList((toastList) => {
+      let toasts = [newToast, ...toastList];
+
+      if (toasts.length > MAX_TOAST) {
+        toasts = toasts.slice(0, MAX_TOAST);
+      }
+
+      return toasts;
+    });
 
     window.setTimeout(() => {
       removeToast(id);
     }, toast.timeout || 2000);
-    const newToast = { id: id, ...toast };
-    setToastList((toastList) => [newToast, ...toastList]);
   };
 
   const removeToast = (toastId: string) => {

--- a/src/features/game/toast/ToastQueueProvider.tsx
+++ b/src/features/game/toast/ToastQueueProvider.tsx
@@ -17,14 +17,14 @@ export const ToastContext = createContext<{
   toastList: Toast[];
 }>({ removeToast: console.log, setToast: console.log, toastList: [] });
 
-const MAX_TOAST = 6;
+const MAX_TOAST = 5;
 
 export const ToastProvider: FC = ({ children }) => {
   const [toastList, setToastList] = useState<Toast[]>([]);
 
   const setToast: SetToast = (toast) => {
     const id = `${Date.now()}-${toast.icon}`;
-    const newToast = { id: id, ...toast };
+    const newToast = { id, ...toast };
 
     setToastList((toastList) => {
       let toasts = [newToast, ...toastList];


### PR DESCRIPTION
# Description

Refactored setToast method to set state only once. 
Increased max toast amount to 6(from 5) since we have a lot of recipes that require 3 ingredients.

Fixes [#1035](https://github.com/sunflower-land/sunflower-land/issues/1035)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test, yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [n/a] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
