### PR TITLE
[FIX] Fix Level Up when clock has drifted 

### DIFF
--- a/src/features/game/actions/levelUp.ts
+++ b/src/features/game/actions/levelUp.ts
@@ -10,6 +10,7 @@ type Request = {
   token: string;
   fingerprint: string;
   skill: SkillName;
+  offset: number;
 };
 
 const API_URL = CONFIG.API_URL;
@@ -24,7 +25,7 @@ export async function levelUp(request: Request) {
       {
         type: "skill.learned",
         skill: request.skill,
-        createdAt: new Date().toISOString(),
+        createdAt: new Date(Date.now() + request.offset).toISOString(),
       },
     ],
   });

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -404,6 +404,7 @@ export function startGame(authContext: Options) {
                 token: authContext.rawToken as string,
                 fingerprint: context.fingerprint as string,
                 skill: (event as LevelUpEvent).skill,
+                offset: context.offset,
               });
 
               return {


### PR DESCRIPTION
# Description

This change adds the time offset to the `levelup` API. For players with incorrectly set clocks, the `levelup` API could fail.

Fixes [#1046 ](https://github.com/sunflower-land/sunflower-land/issues/1046)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual test against testnet.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
