### PR TITLE
[FIX] Moles still act as tiered on Bank Withdraw

### DIFF
--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -367,21 +367,7 @@ describe("canWithdraw", () => {
     expect(enabled).toBeTruthy();
   });
 
-  it("prevents a user from withdrawing Rocky the Mole while they have replenishing stones or iron", () => {
-    const stone = canWithdraw({
-      item: "Rocky the Mole",
-      game: {
-        ...INITIAL_FARM,
-        stones: {
-          0: {
-            // Just been mined
-            minedAt: Date.now(),
-            amount: new Decimal(3),
-          },
-        },
-      },
-    });
-
+  it("prevents a user from withdrawing Rocky the Mole while they have replenishing iron", () => {
     const iron = canWithdraw({
       item: "Rocky the Mole",
       game: {
@@ -396,24 +382,10 @@ describe("canWithdraw", () => {
       },
     });
 
-    expect(stone).toBeFalsy();
     expect(iron).toBeFalsy();
   });
 
-  it("enable a user to withdraw Rocky the Mole while they dont have stones replenishing", () => {
-    const stone = canWithdraw({
-      item: "Rocky the Mole",
-      game: {
-        ...INITIAL_FARM,
-        stones: {
-          0: {
-            // Available to mine
-            minedAt: 0,
-            amount: new Decimal(3),
-          },
-        },
-      },
-    });
+  it("enable a user to withdraw Rocky the Mole while they dont have irons replenishing", () => {
     const iron = canWithdraw({
       item: "Rocky the Mole",
       game: {
@@ -428,39 +400,10 @@ describe("canWithdraw", () => {
       },
     });
 
-    expect(stone).toBeTruthy();
     expect(iron).toBeTruthy();
   });
 
-  it("prevents a user from withdrawing Nugget while they have replenishing stones, iron or gold", () => {
-    const stone = canWithdraw({
-      item: "Nugget",
-      game: {
-        ...INITIAL_FARM,
-        stones: {
-          0: {
-            // Just been mined
-            minedAt: Date.now(),
-            amount: new Decimal(3),
-          },
-        },
-      },
-    });
-
-    const iron = canWithdraw({
-      item: "Nugget",
-      game: {
-        ...INITIAL_FARM,
-        iron: {
-          0: {
-            // Just been mined
-            minedAt: Date.now(),
-            amount: new Decimal(2),
-          },
-        },
-      },
-    });
-
+  it("prevents a user from withdrawing Nugget while they have replenishing gold", () => {
     const gold = canWithdraw({
       item: "Nugget",
       game: {
@@ -475,40 +418,10 @@ describe("canWithdraw", () => {
       },
     });
 
-    expect(stone).toBeFalsy();
-    expect(iron).toBeFalsy();
     expect(gold).toBeFalsy();
   });
 
   it("enable a user to withdraw Nugget while they dont have stones replenishing", () => {
-    const stone = canWithdraw({
-      item: "Nugget",
-      game: {
-        ...INITIAL_FARM,
-        stones: {
-          0: {
-            // Available to mine
-            minedAt: 0,
-            amount: new Decimal(3),
-          },
-        },
-      },
-    });
-
-    const iron = canWithdraw({
-      item: "Nugget",
-      game: {
-        ...INITIAL_FARM,
-        iron: {
-          0: {
-            // Available to mine
-            minedAt: 0,
-            amount: new Decimal(2),
-          },
-        },
-      },
-    });
-
     const gold = canWithdraw({
       item: "Nugget",
       game: {
@@ -523,8 +436,6 @@ describe("canWithdraw", () => {
       },
     });
 
-    expect(stone).toBeTruthy();
-    expect(iron).toBeTruthy();
     expect(gold).toBeTruthy();
   });
 

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -112,7 +112,7 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
 
   const goldReady = Object.values(game?.gold).every((gold) => canMine(gold));
 
-  // Make sure golds are not replenishing
+  // Make sure gold is not replenishing
   if (item === "Nugget") {
     return goldReady;
   }

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -98,23 +98,23 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
     canMine(stone)
   );
 
-  // Make sure no stones are replenishing
+  // Make sure stones are not replenishing
   if (item === "Tunnel Mole") {
     return stoneReady;
   }
 
   const ironReady = Object.values(game?.iron).every((iron) => canMine(iron));
 
-  // Make sure no stones or iron are replenishing
+  // Make sure irons are not replenishing
   if (item === "Rocky the Mole") {
-    return ironReady && stoneReady;
+    return ironReady;
   }
 
   const goldReady = Object.values(game?.gold).every((gold) => canMine(gold));
 
-  // Make sure no stones, iron or gold are replenishing
+  // Make sure golds are not replenishing
   if (item === "Nugget") {
-    return ironReady && stoneReady && goldReady;
+    return goldReady;
   }
 
   // Tools, Crops, Resources

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -96,7 +96,9 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
 
   // Make sure stones are not replenishing
   if (item === "Tunnel Mole") {
-    const stoneReady = Object.values(game?.stones).every((stone) => canMine(stone));
+    const stoneReady = Object.values(game?.stones).every((stone) =>
+      canMine(stone)
+    );
     return stoneReady;
   }
 

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -94,26 +94,21 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
     return !hasFedChickens(game);
   }
 
-  const stoneReady = Object.values(game?.stones).every((stone) =>
-    canMine(stone)
-  );
-
   // Make sure stones are not replenishing
   if (item === "Tunnel Mole") {
+    const stoneReady = Object.values(game?.stones).every((stone) => canMine(stone));
     return stoneReady;
   }
 
-  const ironReady = Object.values(game?.iron).every((iron) => canMine(iron));
-
   // Make sure irons are not replenishing
   if (item === "Rocky the Mole") {
+    const ironReady = Object.values(game?.iron).every((iron) => canMine(iron));
     return ironReady;
   }
 
-  const goldReady = Object.values(game?.gold).every((gold) => canMine(gold));
-
   // Make sure gold is not replenishing
   if (item === "Nugget") {
+    const goldReady = Object.values(game?.gold).every((gold) => canMine(gold));
     return goldReady;
   }
 


### PR DESCRIPTION
Moles got their buffs split, but the withdraw function from bank didn't get updated, so as example, Nugget or Rocky the Mole can't be withdraw if there is a stone being replenished, while they should be withdrawable
Some server-sided changes might be needed.

# Description

I have removed the checks for the wrong ores from mole on bankUtils and bankUtils.test

Fixes #1163

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I didn't test those changes at all, I don't know how I would be able to withdraw moles on testnet, since I don't have em in there.

# Checklist:
(tbh idk if I should mark all of those)

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
