### PR TITLE
[FIX] Laying chicken withdraw

### DIFF
--- a/src/features/farming/animals/components/MutantChickenModal.tsx
+++ b/src/features/farming/animals/components/MutantChickenModal.tsx
@@ -46,9 +46,9 @@ export const MutantChickenModal = ({
           <div className="flex my-4 justify-center">
             <img src={mutants[type].image} style={{ width: "50px" }} />
           </div>
-          <p className="text-sm mb-4">{`Congratulations, your chicken has laid a very rare mutant chicken!`}</p>
+          <p className="text-sm mb-2">{`Congratulations, your chicken has laid a very rare mutant chicken!`}</p>
           {showDescrition && (
-            <p className="text-sm mb-3">{mutants[type].description}</p>
+            <p className="text-sm mb-2">{mutants[type].description}</p>
           )}
         </div>
 

--- a/src/features/farming/town/components/GoblinVillageModal.tsx
+++ b/src/features/farming/town/components/GoblinVillageModal.tsx
@@ -26,7 +26,7 @@ export const GoblinVillageModal: React.FC<{ onClose: () => void }> = ({
           Goblin Village offers rare items and{" "}
           <span className="underline">on-chain</span> gameplay.
         </p>
-        <p className="mb-4 text-sm">
+        <p className="mb-2 text-sm">
           Goblins will only accept items that are on the Blockchain. Items that
           are not synced will be hidden.
         </p>

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -155,6 +155,7 @@ export function updateGame(
       iron: updateRocks(oldGameState.iron, newGameState.iron),
       gold: updateRocks(oldGameState.gold, newGameState.gold),
       skills: newGameState.skills,
+      chickens: newGameState.chickens,
     };
   } catch (e) {
     console.log({ e });

--- a/src/features/goblins/bank/components/BankModal.tsx
+++ b/src/features/goblins/bank/components/BankModal.tsx
@@ -35,15 +35,8 @@ export const BankModal: React.FC<Props> = ({ onClose }) => {
           onClick={onClose}
         />
       </div>
-
-      <div
-        style={{
-          minHeight: "200px",
-        }}
-      >
-        {tab === "deposit" && <Deposit />}
-        {tab === "withdraw" && <Withdraw onClose={onClose} />}
-      </div>
+      {tab === "deposit" && <Deposit />}
+      {tab === "withdraw" && <Withdraw onClose={onClose} />}
     </Panel>
   );
 };

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -32,6 +32,7 @@ function hasFedChickens(game: GoblinState): boolean {
   const hasFedChickens = Object.values(game.chickens).some(
     (chicken) => Date.now() - chicken.fedAt < CHICKEN_TIME_TO_EGG
   );
+
   return hasFedChickens;
 }
 
@@ -90,7 +91,12 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
     return !cropIsPlanted({ item: "Parsnip", game });
   }
 
-  if (item === "Chicken Coop") {
+  if (
+    item === "Chicken Coop" ||
+    item === "Fat Chicken" ||
+    item === "Speed Chicken" ||
+    item === "Rich Chicken"
+  ) {
     return !hasFedChickens(game);
   }
 


### PR DESCRIPTION
# Description

This PR limits the player from being able to withdraw chickens that are in the process of laying an egg. It also blocks the withdrawal of mutant chickens if chickens are laying eggs. I have also fixed an issue where the chickens weren't updating in the return value when autosaving after being fed. 

Some minor styling fixes as well.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Feed some chickens and then try to withdraw while they're in the laying process

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
