### PR TITLE
[FIX] Fix chicken timer from getting out of sync

### DIFF
--- a/src/features/farming/animals/components/Chicken.tsx
+++ b/src/features/farming/animals/components/Chicken.tsx
@@ -20,7 +20,6 @@ import {
   MachineInterpreter,
   MachineState,
 } from "../chickenMachine";
-import { getSecondsToEgg } from "features/game/events/collectEgg";
 import Spritesheet from "components/animation/SpriteAnimator";
 import {
   CHICKEN_TIME_TO_EGG,
@@ -100,8 +99,7 @@ export const Chicken: React.FC<Props> = ({ index, position }) => {
   const percentageComplete = getPercentageComplete(chicken?.fedAt);
 
   const chickenContext: Partial<ChickenContext> | undefined = chicken && {
-    timeToEgg: chicken && getSecondsToEgg(chicken.fedAt),
-    isFed: true,
+    fedAt: chicken.fedAt,
   };
 
   // useInterpret returns a static reference (to just the interpreted machine) which will not rerender when its state changes
@@ -160,8 +158,7 @@ export const Chicken: React.FC<Props> = ({ index, position }) => {
     const chicken = chickens[index];
 
     service.send("FEED", {
-      timeToEgg: getSecondsToEgg(chicken.fedAt),
-      isFed: true,
+      fedAt: chicken.fedAt,
     });
 
     setToast({

--- a/src/features/game/events/collectEgg.ts
+++ b/src/features/game/events/collectEgg.ts
@@ -7,14 +7,6 @@ export type CollectAction = {
   index: number;
 };
 
-export const getSecondsToEgg = (fedAt: number) => {
-  const timePassedSinceFed = Date.now() - fedAt;
-
-  if (timePassedSinceFed >= CHICKEN_TIME_TO_EGG) return 0;
-
-  return Math.ceil((CHICKEN_TIME_TO_EGG - timePassedSinceFed) / 1000);
-};
-
 type Options = {
   state: GameState;
   action: CollectAction;


### PR DESCRIPTION
# Description

This PR fixes an issue that was originally reported in discord by a community dev which you can read [here](https://discord.com/channels/880987707214544966/905567246452129873/991975583590395924).

Basically the chicken timer was getting out of sync if the browser was left open for a period of time. The `chickenMachine` has a `setInterval` running which is counting the `timeElapsed` by incrementing a counter on each tick. This meant that when a blocking action happened in the browser then the tick started again it continued counting but longer than a second had passed. Over long periods of time this meant the timer was getting further out of sync as time passed. 

[This](https://abhi9bakshi.medium.com/why-javascript-timer-is-unreliable-and-how-can-you-fix-it-9ff5e6d34ee0) resource offered a few alternative solution of which I went with the first. Now on each tick we work out the time that has passed by comparing `now` and `fedAt`. The is then set as the `timeElapsed` value. 

You can see in this video. I have implemented a simulated thread blocking behaviour and you can see the timer stop and then when it runs again it calculated the time passed correctly.

https://user-images.githubusercontent.com/17863697/177026649-2082f10c-d2b3-4f03-b9e8-97e084e3786c.mov

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Simulated a thread block and run the timer. I have tested at 1, 2, and 5 minuted timers. I have left the browser open and also tested refreshing the browser multiple times as well. All works.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
