### PR TITLE
[FIX] Bakery UX

### DIFF
--- a/src/features/farming/cakeStall/CakeStall.tsx
+++ b/src/features/farming/cakeStall/CakeStall.tsx
@@ -1,18 +1,28 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
+import Decimal from "decimal.js-light";
+import { useActor } from "@xstate/react";
+
+import token from "assets/icons/token.gif";
+import tokenStatic from "assets/icons/token.png";
+import questionMark from "assets/icons/expression_confused.png";
+
+import { Box } from "components/ui/Box";
+import { OuterPanel, Panel } from "components/ui/Panel";
+import { Button } from "components/ui/Button";
+
+import { Context } from "features/game/GameProvider";
+
+import { ITEM_DETAILS } from "features/game/types/images";
+import { ToastContext } from "features/game/toast/ToastQueueProvider";
+import { CAKES, Craftable } from "features/game/types/craftables";
 import { Modal } from "react-bootstrap";
 
-import stall from "assets/buildings/cake_stall.png";
-import goblin from "assets/npcs/goblin.gif";
-
-import { GRID_WIDTH_PX } from "features/game/lib/constants";
-import { Context } from "features/game/GameProvider";
-import { useActor } from "@xstate/react";
-import { CAKES } from "features/game/types/craftables";
-import { isExpired } from "features/game/lib/stock";
-import { ITEM_DETAILS } from "features/game/types/images";
-import { CakeSale } from "./components/CakeSale";
-
-export const CakeStall: React.FC = () => {
+export const Cakes: React.FC = () => {
+  const [selected, setSelected] = useState<Craftable>(
+    CAKES()["Sunflower Cake"]
+  );
+  const [isSellModalOpen, showSellModal] = React.useState(false);
+  const { setToast } = useContext(ToastContext);
   const { gameService } = useContext(Context);
   const [
     {
@@ -20,67 +30,111 @@ export const CakeStall: React.FC = () => {
     },
   ] = useActor(gameService);
 
-  const [showModal, setShowModal] = React.useState(false);
+  const inventory = state.inventory;
 
-  const openCakeModal = () => {
-    setShowModal(true);
+  const sell = () => {
+    gameService.send("item.sell", {
+      item: selected.name,
+      amount: 1,
+    });
+    setToast({
+      icon: tokenStatic,
+      content: `+$${selected.sellPrice?.toString()}`,
+    });
   };
 
-  const closeCakeModal = () => {
-    setShowModal(false);
+  const amount = new Decimal(inventory[selected.name] || 0); 
+  const noCake = amount.equals(0);
+
+  const handleSell = () => {
+    sell();
+    showSellModal(false);
   };
 
-  const specialCake = Object.values(CAKES()).find(
-    (item) =>
-      !isExpired({ name: item.name, stockExpiry: state.stockExpiry }) &&
-      state.inventory[item.name]
-  );
+  // ask confirmation for  selling
+  const openConfirmationModal = () => {
+      showSellModal(true);
+  };
+
+  const closeConfirmationModal = () => {
+    showSellModal(false);
+  };
 
   return (
-    <div
-      className="z-10 absolute"
-      // TODO some sort of coordinate system
-      style={{
-        width: `${GRID_WIDTH_PX * 6}px`,
-        right: `${GRID_WIDTH_PX * 11}px`,
-        top: `${GRID_WIDTH_PX * 4}px`,
-      }}
-    >
-      <div className="cursor-pointer hover:img-highlight">
-        <img
-          src={stall}
-          alt="bakery"
-          onClick={openCakeModal}
-          className="w-full"
-        />
-        {specialCake && (
-          <>
-            <img
-              src={ITEM_DETAILS[specialCake.name].image}
-              className="absolute"
-              style={{
-                width: `${GRID_WIDTH_PX * 0.71}px`,
-                right: `${GRID_WIDTH_PX * 3.07}px`,
-                top: `${GRID_WIDTH_PX * 2.59}px`,
-              }}
-              onClick={openCakeModal}
-            />
-            <img
-              src={goblin}
-              className="absolute"
-              style={{
-                width: `${GRID_WIDTH_PX}px`,
-                right: `${GRID_WIDTH_PX * 1.95}px`,
-                top: `${GRID_WIDTH_PX * 2.5}px`,
-                transform: "scaleX(-1)",
-              }}
-              onClick={openCakeModal}
-            />
-          </>
-        )}
+    <div className="flex">
+      <div className="w-3/5 flex flex-wrap h-fit">
+        {Object.values(CAKES()).map((item) => (
+          <Box
+            isSelected={selected.name === item.name}
+            key={item.name}
+            onClick={() => setSelected(item)}
+            image={
+              inventory[item.name]?.gte(1)
+                ? ITEM_DETAILS[item.name].image
+                : questionMark
+            }
+            count={inventory[item.name]}
+          />
+        ))}
       </div>
-      <Modal centered show={showModal} onHide={closeCakeModal}>
-        <CakeSale onClose={closeCakeModal} />
+      <OuterPanel className="flex-1 w-1/3">
+        <div className="flex flex-col justify-center items-center p-2 ">
+          <span className="text-shadow text-center">{selected.name}</span>
+          <img
+            src={
+              amount.gte(1) ? ITEM_DETAILS[selected.name].image : questionMark
+            }
+            className="h-16 img-highlight mt-1"
+            alt={selected.name}
+          />
+          <span className="text-shadow text-center mt-2 sm:text-sm">
+            {selected.description}
+          </span>
+
+          <div className="border-t border-white w-full mt-2 pt-1">
+            <div className="flex justify-center items-end">
+              <img src={token} className="h-5 mr-1" />
+              <span className="text-xs text-shadow text-center mt-2 ">
+                {`$${selected.sellPrice}`}
+              </span>
+            </div>
+          </div>
+          {amount.gte(1) && (
+            <Button
+              disabled={amount.lessThan(1)}
+              className="text-xs mt-1"
+              onClick={openConfirmationModal}
+            >
+              Sell
+            </Button>
+          )}
+        </div>
+      </OuterPanel>
+      <Modal centered show={isSellModalOpen} onHide={closeConfirmationModal}>
+        <Panel className="md:w-4/5 m-auto">
+          <div className="m-auto flex flex-col">
+            <span className="text-sm text-center text-shadow">
+              Are you sure you want to <br className="hidden md:block" />
+              sell your {selected.name}?
+            </span>
+          </div>
+          <div className="flex justify-content-around p-1">
+            <Button
+              disabled={noCake}
+              className="text-xs"
+              onClick={handleSell}
+            >
+              Yes
+            </Button>
+            <Button
+              disabled={noCake}
+              className="text-xs ml-2"
+              onClick={closeConfirmationModal}
+            >
+              No
+            </Button>
+          </div>
+        </Panel>
       </Modal>
     </div>
   );

--- a/src/features/farming/cakeStall/CakeStall.tsx
+++ b/src/features/farming/cakeStall/CakeStall.tsx
@@ -43,7 +43,7 @@ export const Cakes: React.FC = () => {
     });
   };
 
-  const amount = new Decimal(inventory[selected.name] || 0); 
+  const amount = new Decimal(inventory[selected.name] || 0);
   const noCake = amount.equals(0);
 
   const handleSell = () => {
@@ -53,7 +53,7 @@ export const Cakes: React.FC = () => {
 
   // ask confirmation for  selling
   const openConfirmationModal = () => {
-      showSellModal(true);
+    showSellModal(true);
   };
 
   const closeConfirmationModal = () => {
@@ -119,11 +119,7 @@ export const Cakes: React.FC = () => {
             </span>
           </div>
           <div className="flex justify-content-around p-1">
-            <Button
-              disabled={noCake}
-              className="text-xs"
-              onClick={handleSell}
-            >
+            <Button disabled={noCake} className="text-xs" onClick={handleSell}>
               Yes
             </Button>
             <Button


### PR DESCRIPTION
This commit fixes a problem of User Experience (UX) where players can accidentally sell their cakes

# Description

Players can accidentally sell their cakes by clciking on Sell button, since there is no Confirmation Screen, people can simply sell their cakes by accident.
Since people can't withdraw a cake, and can't craft a second cake without selling the first one, the sell button shoulded act the same as a Sell All button from Crops sell tab.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
![cake selling](https://user-images.githubusercontent.com/32925592/177536708-a0fac546-974d-494a-9f0f-68ca30e17aec.gif)

