### PR TITLE
[CHORE] Use the ERRORS enum instead of strings in `src/features/auth/ErrorMessage.tsx`

### DIFF
--- a/src/features/auth/ErrorMessage.tsx
+++ b/src/features/auth/ErrorMessage.tsx
@@ -12,7 +12,7 @@ import { Blocked } from "./components/Blocked";
 import { DuplicateUser } from "./components/DuplicateUser";
 import { Congestion } from "./components/Congestion";
 import { SessionExpired } from "./components/SessionExpired";
-import { ErrorCode } from "lib/errors";
+import { ErrorCode, ERRORS } from "lib/errors";
 import { TooManyRequests } from "./components/TooManyRequests";
 import { Maintenance } from "./components/Maintenance";
 
@@ -38,43 +38,43 @@ export const ErrorMessage: React.FC<Props> = ({ errorCode }) => {
   }, []);
 
   console.log({ errorCode });
-  if (errorCode === "NO_WEB3") {
+  if (errorCode === ERRORS.NO_WEB3) {
     return <Web3Missing />;
   }
 
-  if (errorCode === "WRONG_CHAIN") {
+  if (errorCode === ERRORS.WRONG_CHAIN) {
     return <WrongChain />;
   }
 
-  if (errorCode === "REJECTED_TRANSACTION") {
+  if (errorCode === ERRORS.REJECTED_TRANSACTION) {
     return <RejectedSignTransaction onTryAgain={() => send("REFRESH")} />;
   }
 
-  if (errorCode === "NO_FARM") {
+  if (errorCode === ERRORS.NO_FARM) {
     return <Beta />;
   }
 
-  if (errorCode === "BLOCKED") {
+  if (errorCode === ERRORS.BLOCKED) {
     return <Blocked />;
   }
 
-  if (errorCode === "DISCORD_USER_EXISTS") {
+  if (errorCode === ERRORS.DISCORD_USER_EXISTS) {
     return <DuplicateUser />;
   }
 
-  if (errorCode === "NETWORK_CONGESTED") {
+  if (errorCode === ERRORS.NETWORK_CONGESTED) {
     return <Congestion />;
   }
 
-  if (errorCode === "SESSION_EXPIRED") {
+  if (errorCode === ERRORS.SESSION_EXPIRED) {
     return <SessionExpired />;
   }
 
-  if (errorCode === "TOO_MANY_REQUESTS") {
+  if (errorCode === ERRORS.TOO_MANY_REQUESTS) {
     return <TooManyRequests />;
   }
 
-  if (errorCode === "MAINTENANCE") {
+  if (errorCode === ERRORS.MAINTENANCE) {
     return <Maintenance />;
   }
 


### PR DESCRIPTION
# Description

These strings are already in the ERRORS enum so I replaced them with the enum values.

## Type of change

This is a small code change that doesn't affect any functionality.

# How Has This Been Tested?

Check https://github.com/sunflower-land/sunflower-land/blob/main/src/lib/errors.ts and compare it to the if statements in https://github.com/sunflower-land/sunflower-land/blob/main/src/features/auth/ErrorMessage.tsx and you'll see they're all in the enum.

The CI should pass with this change.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
