### PR TITLE
[FIX] Woddy -> Woody in the alt text for Woody the Beaver

### DIFF
--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -168,7 +168,7 @@ export const Beavers: React.FC<{ inventory: Inventory }> = ({ inventory }) => {
           width: `${GRID_WIDTH_PX * 1.2}px`,
         }}
         src={beaver}
-        alt="Woddy the Beaver"
+        alt="Woody the Beaver"
       />
     );
   }


### PR DESCRIPTION
# Description

The alt text for Woody the Beaver is misspelled! I'm not sure if this ever actually gets used though.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Check alt text for the image.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
