### PR TITLE
[FIX] Update README.md to remove broken link to aha.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ First Read the FAQ's here: [FAQ's](https://sunflowerland.freshdesk.com/support/s
 
 Still not satisfied? Submit a support ticket here: [Submit a ticket](https://sunflowerland.freshdesk.com/support/tickets/new)
 
-### ‼️ Have a suggestion/proposal/cool idea ?
-
-Please add a new idea for the community to vote on, here: [SFL Idea Portal](https://sunflower-land.ideas.aha.io/)
-
 # 👶 Getting Started
 
 Firstly, you will need to clone the repo locally. Once you have it ready navigate into the directory and run the following commands:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ First Read the FAQ's here: [FAQ's](https://sunflowerland.freshdesk.com/support/s
 
 Still not satisfied? Submit a support ticket here: [Submit a ticket](https://sunflowerland.freshdesk.com/support/tickets/new)
 
+### ‼️ Have a suggestion/proposal/cool idea ?
+
+Please add a new Github issue for your idea [here](https://github.com/sunflower-land/sunflower-land/issues).
+
 # 👶 Getting Started
 
 Firstly, you will need to clone the repo locally. Once you have it ready navigate into the directory and run the following commands:


### PR DESCRIPTION
# Description

This link is broken! I believe suggestions have moved to Github issues.

https://sunflower-land.ideas.aha.io/

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Read the README.md

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
