### PR TITLE
[FEAT] Retain Draft on Confirm Back

### DIFF
--- a/src/features/goblins/trader/selling/Selling.tsx
+++ b/src/features/goblins/trader/selling/Selling.tsx
@@ -49,6 +49,7 @@ export const Selling: React.FC = () => {
         slotId={machine.context.draftingSlotId}
         itemLimits={tradingPostState.context.itemLimits}
         inventory={goblinState.context.state.inventory}
+        draft={machine.context.draft}
         onBack={() => send("BACK")}
         onUpdate={(slotId, draft) =>
           sellingService.send("UPDATE_DRAFT", { slotId, draft })

--- a/src/features/goblins/trader/selling/components/Drafting.tsx
+++ b/src/features/goblins/trader/selling/components/Drafting.tsx
@@ -20,6 +20,7 @@ interface DraftingProps {
   slotId: number;
   itemLimits: ItemLimits;
   inventory: Inventory;
+  draft?: Draft;
   onBack: () => void;
   onUpdate: (slotId: number, draft: Draft) => void;
   onConfirm: () => void;
@@ -29,6 +30,7 @@ export const Drafting: React.FC<DraftingProps> = ({
   slotId,
   itemLimits,
   inventory,
+  draft,
   onBack,
   onUpdate,
   onConfirm,
@@ -44,6 +46,15 @@ export const Drafting: React.FC<DraftingProps> = ({
   const [selected, setSelected] = useState<InventoryItemName>(
     inventoryItems[0]
   );
+
+  // Execute on first load. draft will have value if backing from Confirming component
+  useEffect(() => {
+    if (draft) {
+      setSelected(draft.resourceName);
+      setResourceAmount(draft.resourceAmount);
+      setSflAmount(draft.sfl);
+    }
+  }, []);
 
   useEffect(() => {
     onUpdate(slotId, {

--- a/src/features/goblins/trader/selling/lib/sellingMachine.ts
+++ b/src/features/goblins/trader/selling/lib/sellingMachine.ts
@@ -65,7 +65,13 @@ export const sellingMachine = createMachine<
       },
       drafting: {
         on: {
-          BACK: { target: "idle" },
+          BACK: {
+            target: "idle",
+            // delete current draft
+            actions: assign<Context, any>(() => ({
+              draft: undefined,
+            })),
+          },
           CONFIRM: { target: "confirming" },
           UPDATE_DRAFT: {
             actions: assign((_, event) => ({
@@ -77,7 +83,14 @@ export const sellingMachine = createMachine<
       },
       confirming: {
         on: {
-          BACK: { target: "drafting" },
+          BACK: {
+            target: "drafting",
+            // store current draft
+            actions: assign<Context, any>((context) => ({
+              draftingSlotId: context.draftingSlotId,
+              draft: context.draft,
+            })),
+          },
           CONFIRM: {
             actions: sendParent((context) => ({
               type: "LIST",


### PR DESCRIPTION
# Description

This PR stores current draft in confirming state so when a user goes back to drafting, it will populate the selected item and fields. the motivation for this is usually the sfl amount is most likely to be changed when editing the draft. there were instances of listing sunflowers since the user forgot to re select the intended item (including me 😅 )

Fixes #issue N/A

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`yarn tsc|test`

Manual testing - testnet
1. Select Radishes and fill amount and sfl amount
2. Click List Trade to see Confirming component
3. Click BACK -- **Expected:** Drafting component should pre-select Radish and the same amounts
4. Click Back
5. Click any available slot  -- **Expected:** Drafting component should load defaults

https://user-images.githubusercontent.com/89294757/178868636-5c768d9f-5d6d-4f06-b2d2-a4d2f089e8d9.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
