### PR TITLE
[FIX] Salesman-timeLeft UX harmonization with cake

### DIFF
--- a/src/features/farming/salesman/Salesman.tsx
+++ b/src/features/farming/salesman/Salesman.tsx
@@ -14,6 +14,7 @@ import { Offer } from "./component/Offer";
 import { TradeOffer } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { secondsToString } from "lib/utils/time";
+import stopwatch from "assets/icons/stopwatch.png";
 
 const Content: React.FC<{ title: string }> = ({ title, children }) => {
   return (
@@ -121,13 +122,17 @@ export const Salesman: React.FC = () => {
             I travel all over these lands collecting items to trade.
           </p>
           <p className="sm:text-sm p-2">
-            What I have to offer you today will only be available until{" "}
-            {endDateLocale} (
-            {secondsToString(secondsLeft as number, {
-              separator: " ",
-            })}{" "}
-            left).
+            What I have to offer you today is available for a limited time.
           </p>
+          <span className="bg-blue-600 border flex text-[8px] sm:text-xxs items-center p-[3px] rounded-md whitespace-nowrap  mb-2">
+            <img src={stopwatch} className="w-3 left-0 -top-4 mr-1" />
+            <span className="mt-[2px]">{`${secondsToString(
+              secondsLeft as number,
+              {
+                separator: " ",
+              }
+            )} left`}</span>
+          </span>
           <Button onClick={() => setModalState("showOffer")}>
             {`Let's trade!`}
           </Button>


### PR DESCRIPTION
# Description

As an enhancement to my previous [PR 1192](https://github.com/sunflower-land/sunflower-land/pull/1192) requested and vetted by the community / @c-py 

<img width="581" alt="Screen Shot 2022-07-15 at 1 09 15 PM" src="https://user-images.githubusercontent.com/79071868/179285859-8ca7925b-e309-45a2-a88f-f51f21be37b4.png">

I changed the time left text to use the blue box used in cakes and reworked the wording to make it simple and look cleaner.

BEFORE: 
![image](https://user-images.githubusercontent.com/79071868/179286380-3f877dc6-ec48-4439-8876-73221af77cfb.png)

AFTER:
<img width="506" alt="Screen Shot 2022-07-15 at 12 43 21 PM" src="https://user-images.githubusercontent.com/79071868/179286465-e79ce87d-a13e-457b-b4d5-6840c34b75e1.png">


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
   
   An appearance issue :)

# How Has This Been Tested?

Run locally on testnet to confirm UX appearance (screenshot above)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
