### PR TITLE
[FIX] Audio: Save music settings to local storage.

### DIFF
--- a/src/components/ui/AudioPlayer.tsx
+++ b/src/components/ui/AudioPlayer.tsx
@@ -54,11 +54,11 @@ export const AudioPlayer: React.FC<Props> = ({ isFarming }) => {
     min: 0,
   });
   const [visible, setIsVisible] = useState<boolean>(false);
-  const [audioMmuted, setAudioMuted] = useState<boolean>(
+  const [audioMuted, setAudioMuted] = useState<boolean>(
     getCachedAudioSetting<boolean>(AudioLocalStorageKeys.audioMuted, false)
   );
   const [musicPaused, setMusicPaused] = useState<boolean>(
-    getCachedAudioSetting<boolean>(AudioLocalStorageKeys.musicPaused, true)
+    getCachedAudioSetting<boolean>(AudioLocalStorageKeys.musicPaused, false)
   );
   const [songIndex, setSongIndex] = useState<number>(0);
   const musicPlayer = useRef<any>(null);
@@ -75,9 +75,9 @@ export const AudioPlayer: React.FC<Props> = ({ isFarming }) => {
   const song = isFarming ? getFarmingSong(songIndex) : getGoblinSong(songIndex);
 
   useEffect(() => {
-    Howler.mute(audioMmuted);
-    cacheAudioSetting(AudioLocalStorageKeys.audioMuted, audioMmuted);
-  }, [audioMmuted]);
+    Howler.mute(audioMuted);
+    cacheAudioSetting(AudioLocalStorageKeys.audioMuted, audioMuted);
+  }, [audioMuted]);
 
   useEffect(() => {
     if (musicPaused) {
@@ -174,9 +174,9 @@ export const AudioPlayer: React.FC<Props> = ({ isFarming }) => {
           visible ? "translate-x-1.5" : ""
         } -left-20 sm:-left-24 bottom-0 transition-all duration-500 ease-in-out w-fit z-50 flex gap-2 align-items-center overflow-hidden`}
       >
-        <Button onClick={() => setAudioMuted(!audioMmuted)}>
+        <Button onClick={() => setAudioMuted(!audioMuted)}>
           <img
-            src={audioMmuted ? volume_down : volume_up}
+            src={audioMuted ? volume_down : volume_up}
             alt="mute/unmute ingame audio"
             className="w-4 h-4 sm:w-6 sm:h-5"
           />


### PR DESCRIPTION
# Description
Issue:
Each time user opens/reloads game in non chromium browser music starts playing.
Solution:
I have added musicPaused and musicVolume to local storage, next to audioMuted setting.

Fixes #1086

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test in firefox and chrome browsers.
yarn test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [n/a] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
