### PR TITLE
[FIX] Salesman Visibility after Offer expiration

### DIFF
--- a/src/features/farming/salesman/Salesman.tsx
+++ b/src/features/farming/salesman/Salesman.tsx
@@ -38,6 +38,9 @@ export const Salesman: React.FC = () => {
 
   // Don't show the salesman because there is no trade available
   if (!state.tradeOffer) return null;
+  // Don't show the salesman because the trade offer has expired
+  if (Date.now() > new Date(state.tradeOffer.endAt as string).getTime())
+    return null;
 
   const handleOpenModal = () => {
     if (hasAlreadyTraded(state)) {


### PR DESCRIPTION
# Description

As shown in Issue [1252](https://github.com/sunflower-land/sunflower-land/issues/1252) the salesman was staying on the map and showing negative time after offer expiration (until I assume the offer was deleted).

I added a conditional that if the current date time is higher than the offer expiration, don't show the salesman.

Before: 

https://user-images.githubusercontent.com/79071868/180074166-9130d050-0a74-4501-aa89-6d14e01356ae.mov

After:

https://user-images.githubusercontent.com/79071868/180074216-3ac571d9-b49d-488b-8710-a9153c4cadd5.mov


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tests demonstrated above. He disappeared in desktop view automatically, and disappeared upon clicking in mobile view (firefox). I added an INITIAL_FARM constant trade to test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
