### PR TITLE
[FIX] Crafting 10: Fix 'Yes' Button not closing in Confirmation Modal

### DIFF
--- a/src/features/farming/blacksmith/components/CraftingItems.tsx
+++ b/src/features/farming/blacksmith/components/CraftingItems.tsx
@@ -103,6 +103,7 @@ export const CraftingItems: React.FC<Props> = ({
   };
   const handleCraftTen = () => {
     craft(10);
+    closeConfirmationModal();
   };
   if (showCaptcha) {
     return (


### PR DESCRIPTION
# Description

This PR fixes the Confirmation Modal of Craft 10 that was merged 3 days ago. The bug is that the confirmation modal will not close when 'Yes' Button is clicked by the user.  Thanks to @AzaroQL for letting me know about this oversight.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Before:
Clicking 'Yes' button in the confirmation modal won't close the modal itself. This can result to unintended issue where players will think that they still haven't crafted 10 tools.

After:
Clicking 'Yes' button will craft 10 tools and close the confirmation modal.
# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
