### PR TITLE
[FIX] Wheat cake ingredients 

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -399,11 +399,7 @@ export const CAKES: () => Record<Cake, Craftable> = () => ({
     ingredients: [
       {
         item: "Wheat",
-        amount: new Decimal(25),
-      },
-      {
-        item: "Wheat",
-        amount: new Decimal(10),
+        amount: new Decimal(35),
       },
       {
         item: "Egg",


### PR DESCRIPTION
# Description

Wheat cake incorrectly shows as all requirements met when a farmer has 25-34 wheat 
![image](https://user-images.githubusercontent.com/79071868/180691702-36a44a2f-cca0-4314-9d6b-af29dc2341a3.png)

I simplified the recipe to 35 wheat to fix this 
<img width="215" alt="Screen Shot 2022-07-24 at 10 06 10 PM" src="https://user-images.githubusercontent.com/79071868/180691771-d185d3e7-673f-4e69-9959-8b064f76da9d.png">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Above screenshots

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
