### PR TITLE
[FIX] Added links to Announcements

### DIFF
--- a/src/features/announcements/Announcement.tsx
+++ b/src/features/announcements/Announcement.tsx
@@ -85,7 +85,7 @@ export const Announcement: React.FC<{ announcement: IAnnouncement }> = ({
         href={announcement.link}
         target="_blank"
         rel="noreferrer"
-        className="text-xxs"
+        className="text-xs"
       >
         Read more
       </a>

--- a/src/features/announcements/index.ts
+++ b/src/features/announcements/index.ts
@@ -18,7 +18,7 @@ export interface Announcement {
  */
 export const ANNOUNCEMENTS: Announcement[] = [
   {
-    date: new Date("2022-07-24T00:00:00"),
+    date: new Date("2022-07-21T00:00:00"),
     title: "Shovel",
     notes: [
       "The shovel is now available!",

--- a/src/features/announcements/index.ts
+++ b/src/features/announcements/index.ts
@@ -18,13 +18,15 @@ export interface Announcement {
  */
 export const ANNOUNCEMENTS: Announcement[] = [
   {
-    date: new Date("2022-07-21T00:00:00"),
+    date: new Date("2022-07-24T00:00:00"),
     title: "Shovel",
     notes: [
       "The shovel is now available!",
-      "Used to remove unwanted crops",
-      "Craft at the Blacksmith",
+      "Use it to remove unwanted crops.",
+      "Double tap crops to remove them.",
+      "Craft it at the Blacksmith.",
     ],
+    link: "https://docs.sunflower-land.com/player-guides/crop-farming#tools",
     image: shovel,
   },
   {
@@ -32,39 +34,44 @@ export const ANNOUNCEMENTS: Announcement[] = [
     title: "Rooster",
     notes: [
       "The rooster is now available!",
-      "Increase mutant chicken chance",
-      "Craft at Goblin Village",
+      "Doubles the chance of dropping a mutant chicken.",
+      "Craft it at Goblin Village.",
     ],
+    link: "https://docs.sunflower-land.com/player-guides/rare-and-limited-items#boosts-1",
     image: rooster,
   },
   {
     date: new Date("2022-06-26T23:57:05.618Z"),
     title: "Cakes",
     notes: [
-      "Craft a new cake weekly",
-      "Collect them all",
+      "Craft a new cake weekly!",
+      "Collect them all!",
       "Will you win the great bake off?",
     ],
+    link: "https://docs.sunflower-land.com/fundamentals/special-events/the-great-sunflower-bakeoff",
     image: cakes,
   },
   {
     date: new Date("2022-06-22T06:27:20.861Z"),
     title: "Travelling Salesman",
     notes: [
-      "Find weekly offers",
-      "Trade resources for items",
-      "What would be the next offer?",
+      "Find weekly offers.",
+      "Trade resources for items.",
+      "What will be the next offer?",
     ],
+    // link:
+    // Need documentation
     image: nomad,
   },
   {
     date: new Date("Mon, 20 Jun 2022 22:30:00 GMT"),
     title: "Nugget is open for crafting!",
     notes: [
-      "Gives a 25% increase to Gold Mines",
+      "Gives a 25% increase to Gold Mines.",
       "Price: 50 Gold, 300 SFL",
       "Supply: 1000",
     ],
+    link: "https://docs.sunflower-land.com/player-guides/rare-and-limited-items#boosts",
     image: nugget,
   },
   {
@@ -73,9 +80,9 @@ export const ANNOUNCEMENTS: Announcement[] = [
     ),
     title: "Chickens",
     notes: [
-      "Craft chickens at the Barn",
-      "Feed chickens wheat and collect eggs",
-      "Craft a rare Chicken Coop to grow your egg empire",
+      "Craft chickens at the Barn.",
+      "Feed chickens wheat and collect eggs.",
+      "Craft a rare Chicken Coop to grow your egg empire.",
       "Will you be lucky enough to find a mutant chicken in an egg?",
     ],
     link: "https://docs.sunflower-land.com/crafting-guide/farming-and-gathering#animals",

--- a/src/features/visiting/forest/components/Tree.tsx
+++ b/src/features/visiting/forest/components/Tree.tsx
@@ -19,8 +19,8 @@ export const Tree: React.FC = () => {
             imageRendering: "pixelated",
           }}
           image={shakeSheet}
-          widthFrame={266}
-          heightFrame={168}
+          widthFrame={266 / 4}
+          heightFrame={168 / 4}
           fps={24}
           steps={11}
           direction={`forward`}


### PR DESCRIPTION
# Description

After Shovel documentation update (thx @stevew00dy) I added the link as well as adding links to the other announcements for consistency and future reference at town crier.

Docs -  TO DOs (non-blocking):

- [ ] Add Traveling Salesman to Docs (will play with wording and propose to have someone add)

- [ ] Add Nugget to https://docs.sunflower-land.com/player-guides/rare-and-limited-items#boosts
     -  I added the link to the announcement just need to add him to that section.


I also adjusted the `Read More` to be xs instead of xxs for more clean look with the text:

xs:
<img width="480" alt="Screen Shot 2022-07-25 at 4 54 35 PM" src="https://user-images.githubusercontent.com/79071868/180881196-568a26d9-7a11-4d98-8edf-7f35ad99a6a5.png">

xxs:
<img width="465" alt="Screen Shot 2022-07-25 at 5 06 24 PM" src="https://user-images.githubusercontent.com/79071868/180881891-35155190-f8e8-48be-9acb-8d2924b2e899.png">

And finally made some grammar and consistency changes to all announcements.

++ @j923sneaks change of tree size on visiting 

https://discord.com/channels/880987707214544966/905567246452129873/1001344719583977593

Fixes #1219 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

- [X] This change requires a documentation update

# How Has This Been Tested?

Looked at both announcement modal and crier on testnet.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
