### PR TITLE
[FIX] Land Expansion Resource Positioning offset

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -19,6 +19,16 @@ type ExpansionProps = Pick<
   "shrubs" | "plots" | "trees" | "terrains" | "pebbles" | "createdAt"
 >;
 
+const LAND_SIZE = 6;
+
+const EXPANSION_PLACEMENT: Record<number, Record<"x" | "y", number>> = {
+  0: { x: 0 * LAND_SIZE, y: 0 * LAND_SIZE },
+  1: { x: 1 * LAND_SIZE, y: 0 * LAND_SIZE },
+  2: { x: 1 * LAND_SIZE, y: 1 * LAND_SIZE },
+  3: { x: 0 * LAND_SIZE, y: 1 * LAND_SIZE },
+  4: { x: -1 * LAND_SIZE, y: 1 * LAND_SIZE },
+};
+
 const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
   shrubs,
   plots,
@@ -28,6 +38,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
   createdAt,
   expansionIndex,
 }) => {
+  const { x: xOffset, y: yOffset } = EXPANSION_PLACEMENT[expansionIndex];
+
   return (
     <>
       {shrubs &&
@@ -37,8 +49,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
           return (
             <MapPlacement
               key={`${createdAt}-shrub-${index}`}
-              x={x}
-              y={y}
+              x={x + xOffset}
+              y={y + yOffset}
               height={height}
               width={width}
             >
@@ -54,8 +66,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
           return (
             <MapPlacement
               key={`${createdAt}-pebble-${index}`}
-              x={x}
-              y={y}
+              x={x + xOffset}
+              y={y + yOffset}
               height={height}
               width={width}
             >
@@ -71,8 +83,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
           return (
             <MapPlacement
               key={`${createdAt}-terrain-${index}`}
-              x={x}
-              y={y}
+              x={x + xOffset}
+              y={y + yOffset}
               height={height}
               width={width}
             >
@@ -88,8 +100,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
           return (
             <MapPlacement
               key={`${createdAt}-plot-${index}`}
-              x={x}
-              y={y}
+              x={x + xOffset}
+              y={y + yOffset}
               height={height}
               width={width}
             >
@@ -105,8 +117,8 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
           return (
             <MapPlacement
               key={`${createdAt}-tree-${index}`}
-              x={x}
-              y={y}
+              x={x + xOffset}
+              y={y + yOffset}
               height={height}
               width={width}
             >

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -13,21 +13,12 @@ import { LandBase } from "./components/LandBase";
 import { Bumpkin } from "features/island/bumpkin/Bumpkin";
 import { UpcomingExpansion } from "./components/UpcomingExpansion";
 import { LandExpansion } from "../types/game";
+import { EXPANSION_ORIGINS } from "./lib/constants";
 
 type ExpansionProps = Pick<
   LandExpansion,
   "shrubs" | "plots" | "trees" | "terrains" | "pebbles" | "createdAt"
 >;
-
-const LAND_SIZE = 6;
-
-const EXPANSION_PLACEMENT: Record<number, Record<"x" | "y", number>> = {
-  0: { x: 0 * LAND_SIZE, y: 0 * LAND_SIZE },
-  1: { x: 1 * LAND_SIZE, y: 0 * LAND_SIZE },
-  2: { x: 1 * LAND_SIZE, y: 1 * LAND_SIZE },
-  3: { x: 0 * LAND_SIZE, y: 1 * LAND_SIZE },
-  4: { x: -1 * LAND_SIZE, y: 1 * LAND_SIZE },
-};
 
 const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
   shrubs,
@@ -38,7 +29,7 @@ const Expansion: React.FC<ExpansionProps & { expansionIndex: number }> = ({
   createdAt,
   expansionIndex,
 }) => {
-  const { x: xOffset, y: yOffset } = EXPANSION_PLACEMENT[expansionIndex];
+  const { x: xOffset, y: yOffset } = EXPANSION_ORIGINS[expansionIndex];
 
   return (
     <>
@@ -152,20 +143,22 @@ export const Land: React.FC = () => {
         <LandBase expansions={expansions} />
         <UpcomingExpansion gameState={state} />
 
-        {expansions.map(
-          ({ shrubs, pebbles, terrains, trees, plots, createdAt }, index) => (
-            <Expansion
-              createdAt={createdAt}
-              expansionIndex={index}
-              key={index}
-              shrubs={shrubs}
-              pebbles={pebbles}
-              terrains={terrains}
-              trees={trees}
-              plots={plots}
-            />
-          )
-        )}
+        {expansions
+          .filter((expansion) => expansion.readyAt < Date.now())
+          .map(
+            ({ shrubs, pebbles, terrains, trees, plots, createdAt }, index) => (
+              <Expansion
+                createdAt={createdAt}
+                expansionIndex={index}
+                key={index}
+                shrubs={shrubs}
+                pebbles={pebbles}
+                terrains={terrains}
+                trees={trees}
+                plots={plots}
+              />
+            )
+          )}
 
         <MapPlacement x={2} y={1}>
           <Bumpkin />

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -6,7 +6,7 @@ import { Panel } from "components/ui/Panel";
 import { GameState } from "features/game/types/game";
 import expandIcon from "assets/icons/expand.png";
 
-import { EXPANSION_ORIGINS } from "../lib/constants";
+import { EXPANSION_ORIGINS, LAND_SIZE } from "../lib/constants";
 import { UpcomingExpansionModal } from "./UpcomingExpansionModal";
 import { MapPlacement } from "./MapPlacement";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -36,9 +36,15 @@ export const UpcomingExpansion: React.FC<Props> = ({ gameState }) => {
 
   // Land is still being built
   if (latestLand.readyAt > Date.now()) {
-    const origin = EXPANSION_ORIGINS[gameState.expansions.length];
+    const origin = EXPANSION_ORIGINS[gameState.expansions.length - 1];
+
     return (
-      <MapPlacement x={origin.x} y={origin.y} height={6} width={6}>
+      <MapPlacement
+        x={origin.x - LAND_SIZE / 2}
+        y={origin.y + LAND_SIZE / 2}
+        height={LAND_SIZE}
+        width={LAND_SIZE}
+      >
         <Pontoon expansion={latestLand} />
       </MapPlacement>
     );
@@ -49,11 +55,16 @@ export const UpcomingExpansion: React.FC<Props> = ({ gameState }) => {
     setShowBumpkinModal(false);
   };
 
-  const nextPosition = EXPANSION_ORIGINS[gameState.expansions.length + 1];
+  const nextPosition = EXPANSION_ORIGINS[gameState.expansions.length];
 
   return (
     <>
-      <MapPlacement x={nextPosition.x} y={nextPosition.y} height={6} width={6}>
+      <MapPlacement
+        x={nextPosition.x - LAND_SIZE / 2}
+        y={nextPosition.y + LAND_SIZE / 2}
+        height={LAND_SIZE}
+        width={LAND_SIZE}
+      >
         <div
           className="w-full h-full flex items-center justify-center cursor-pointer opacity-60 hover:opacity-100"
           onClick={() => setShowBumpkinModal(true)}

--- a/src/features/game/expansion/lib/constants.ts
+++ b/src/features/game/expansion/lib/constants.ts
@@ -2,54 +2,23 @@ import Decimal from "decimal.js-light";
 import { Ingredient } from "features/game/types/craftables";
 import { Coordinates } from "../components/MapPlacement";
 
+export const LAND_SIZE = 6;
+
 /**
- * Bottom left hand corner of the land
+ * Top left hand corner of the land
  */
 export const EXPANSION_ORIGINS: Record<number, Coordinates> = {
-  1: {
-    x: -3,
-    y: 3,
-  },
-  2: {
-    x: 3,
-    y: 3,
-  },
-  3: {
-    x: 3,
-    y: 9,
-  },
-  4: {
-    x: -3,
-    y: 9,
-  },
-  5: {
-    x: -9,
-    y: 9,
-  },
-  6: {
-    x: -9,
-    y: 3,
-  },
-  7: {
-    x: -9,
-    y: -3,
-  },
-  8: {
-    x: -3,
-    y: -3,
-  },
-  9: {
-    x: 3,
-    y: -3,
-  },
-  10: {
-    x: 9,
-    y: -3,
-  },
-  11: {
-    x: 9,
-    y: 3,
-  },
+  0: { x: 0 * LAND_SIZE, y: 0 * LAND_SIZE },
+  1: { x: 1 * LAND_SIZE, y: 0 * LAND_SIZE },
+  2: { x: 1 * LAND_SIZE, y: 1 * LAND_SIZE },
+  3: { x: 0 * LAND_SIZE, y: 1 * LAND_SIZE },
+  4: { x: -1 * LAND_SIZE, y: 1 * LAND_SIZE },
+  5: { x: -1 * LAND_SIZE, y: 0 * LAND_SIZE },
+  6: { x: -1 * LAND_SIZE, y: -1 * LAND_SIZE },
+  7: { x: 0 * LAND_SIZE, y: -1 * LAND_SIZE },
+  8: { x: 1 * LAND_SIZE, y: -1 * LAND_SIZE },
+  9: { x: 2 * LAND_SIZE, y: -1 * LAND_SIZE },
+  10: { x: 2 * LAND_SIZE, y: 0 * LAND_SIZE },
 };
 
 export type LandRequirements = {

--- a/src/features/game/expansion/lib/constants.ts
+++ b/src/features/game/expansion/lib/constants.ts
@@ -4,9 +4,6 @@ import { Coordinates } from "../components/MapPlacement";
 
 export const LAND_SIZE = 6;
 
-/**
- * Top left hand corner of the land
- */
 export const EXPANSION_ORIGINS: Record<number, Coordinates> = {
   0: { x: 0 * LAND_SIZE, y: 0 * LAND_SIZE },
   1: { x: 1 * LAND_SIZE, y: 0 * LAND_SIZE },


### PR DESCRIPTION
# Description

This PR adds a lookup for positioning expansion resources

Co-authored-by: @c-py 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
