### PR TITLE
[FEAT] Testnet button to burn land expansions

### DIFF
--- a/src/features/farming/hud/components/DEV_BurnLandButton.tsx
+++ b/src/features/farming/hud/components/DEV_BurnLandButton.tsx
@@ -185,26 +185,28 @@ export const DEV_BurnLandButton: React.FC = () => {
               </div>
               <hr />
               <hr />
-              {Object.entries(tokens).map(([id, checked], i) => (
-                <div key={`checkbox-${String(i)}`} className="flex">
-                  <input
-                    type="checkbox"
-                    id={String(id)}
-                    name="token"
-                    value={id}
-                    checked={checked}
-                    onChange={() =>
-                      setTokens({
-                        ...tokens,
-                        [Number(id)]: !tokens[Number(id)],
-                      })
-                    }
-                  />
-                  <label htmlFor={String(id)} className="text-xss">
-                    Level {i + 2}
-                  </label>
-                </div>
-              ))}
+              {Object.entries(tokens)
+                .sort(([id1], [id2]) => parseInt(id1) - parseInt(id2))
+                .map(([id, checked], i) => (
+                  <div key={`checkbox-${String(i)}`} className="flex">
+                    <input
+                      type="checkbox"
+                      id={String(id)}
+                      name="token"
+                      value={id}
+                      checked={checked}
+                      onChange={() =>
+                        setTokens({
+                          ...tokens,
+                          [Number(id)]: !tokens[Number(id)],
+                        })
+                      }
+                    />
+                    <label htmlFor={String(id)} className="text-xss">
+                      Level {i + 2}
+                    </label>
+                  </div>
+                ))}
               <hr />
               <Button onClick={() => burn(tokens)}>Burn!</Button>
             </>

--- a/src/features/farming/hud/components/DEV_BurnLandButton.tsx
+++ b/src/features/farming/hud/components/DEV_BurnLandButton.tsx
@@ -1,0 +1,197 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useActor } from "@xstate/react";
+import Web3 from "web3";
+import { AbiItem } from "web3-utils";
+
+import { Button } from "components/ui/Button";
+import { Context } from "features/auth/lib/Provider";
+
+const LAND_EXPANSION_ADDRESS = "0x1bAF4b9b954eD537c355469A47A995e3E4e31B48";
+
+const BALACE_OF_ABI: AbiItem = {
+  name: "balanceOf",
+  type: "function",
+  inputs: [
+    {
+      type: "address",
+      name: "owner",
+    },
+  ],
+};
+
+const TOKEN_OF_OWNER_BY_INDEX_ABI: AbiItem = {
+  name: "tokenOfOwnerByIndex",
+  type: "function",
+  inputs: [
+    {
+      type: "address",
+      name: "owner",
+    },
+    {
+      type: "uint256",
+      name: "index",
+    },
+  ],
+};
+
+const GAME_BURN_ABI: AbiItem = {
+  name: "gameBurn",
+  type: "function",
+  inputs: [
+    {
+      type: "uint256",
+      name: "tokenId",
+    },
+  ],
+};
+
+const loadExpansions = async (web3: Web3, address: string) => {
+  const balanceOf = web3.eth.abi.encodeFunctionCall(BALACE_OF_ABI, [address]);
+
+  const balance = await web3.eth.call({
+    to: LAND_EXPANSION_ADDRESS,
+    data: balanceOf,
+  });
+
+  const tokenOfOwnerByIndex = (index: number) =>
+    web3.eth.abi.encodeFunctionCall(TOKEN_OF_OWNER_BY_INDEX_ABI, [
+      address,
+      String(index),
+    ]);
+
+  const tokenIds = await Promise.all(
+    Array.from({ length: Number(balance) }, (_, i) =>
+      web3.eth.call({
+        to: LAND_EXPANSION_ADDRESS,
+        data: tokenOfOwnerByIndex(i),
+      })
+    )
+  );
+
+  return tokenIds.map(Number);
+};
+
+export const DEV_BurnLandButton: React.FC = () => {
+  const { authService } = useContext(Context);
+  const [
+    {
+      context: { address },
+    },
+  ] = useActor(authService);
+
+  const [showBurnForm, setShowBurnForm] = useState(false);
+  const [tokens, setTokens] = useState<Record<number, boolean>>();
+
+  const allSelected = Object.values(tokens ?? {}).every((token) => token);
+
+  useEffect(() => {
+    const web3 = new Web3((window as any).ethereum);
+
+    if (showBurnForm) {
+      (async () => {
+        const tokenIds = await loadExpansions(web3, String(address));
+        setTokens(
+          tokenIds.reduce((tokens, id) => ({ ...tokens, [id]: false }), {})
+        );
+      })();
+    } else {
+      setTokens(undefined);
+    }
+  }, [showBurnForm]);
+
+  const burn = async (tokens: Record<number, boolean>) => {
+    const web3 = new Web3((window as any).ethereum);
+    const account = (await web3.eth.getAccounts())[0];
+
+    const batch = new web3.BatchRequest();
+
+    const checkedTokens = Object.entries(tokens).filter(
+      ([id, checked]) => checked
+    );
+
+    let resolved = 0;
+
+    await new Promise((reject, resolve) => {
+      checkedTokens.forEach(([id]) =>
+        batch.add(
+          (web3.eth.sendTransaction as any).request(
+            {
+              from: account,
+              to: LAND_EXPANSION_ADDRESS,
+              data: web3.eth.abi.encodeFunctionCall(GAME_BURN_ABI, [id]),
+            },
+            () => ++resolved === checkedTokens.length && resolve()
+          )
+        )
+      );
+
+      batch.execute();
+    });
+
+    setShowBurnForm(false);
+
+    authService.send("REFRESH");
+  };
+
+  return (
+    <>
+      <Button onClick={() => setShowBurnForm(!showBurnForm)}>Burn Land</Button>
+
+      {showBurnForm && (
+        <div className="p-2">
+          {tokens === undefined ? (
+            <div className="loading">Loading</div>
+          ) : Object.entries(tokens).length > 0 ? (
+            <>
+              <div className="flex">
+                <input
+                  type="checkbox"
+                  id="select-all"
+                  name="token"
+                  checked={allSelected}
+                  onChange={() =>
+                    setTokens(
+                      Object.keys(tokens).reduce(
+                        (tokens, id) => ({ ...tokens, [id]: !allSelected }),
+                        {}
+                      )
+                    )
+                  }
+                />
+                <label htmlFor="select-all" className="text-xss">
+                  Select All
+                </label>
+              </div>
+              <hr />
+              <hr />
+              {Object.entries(tokens).map(([id, checked], i) => (
+                <div key={`checkbox-${String(i)}`} className="flex">
+                  <input
+                    type="checkbox"
+                    id={String(id)}
+                    name="token"
+                    value={id}
+                    checked={checked}
+                    onChange={() =>
+                      setTokens({
+                        ...tokens,
+                        [Number(id)]: !tokens[Number(id)],
+                      })
+                    }
+                  />
+                  <label htmlFor={String(id)} className="text-xss">
+                    Level {i + 2}
+                  </label>
+                </div>
+              ))}
+              <hr />
+              <Button onClick={() => burn(tokens)}>Burn!</Button>
+            </>
+          ) : (
+            "No Expansions"
+          )}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/features/farming/hud/components/DEV_BurnLandButton.tsx
+++ b/src/features/farming/hud/components/DEV_BurnLandButton.tsx
@@ -186,7 +186,7 @@ export const DEV_BurnLandButton: React.FC = () => {
               <hr />
               <hr />
               {Object.entries(tokens)
-                .sort(([id1], [id2]) => parseInt(id1) - parseInt(id2))
+                .sort(([id1], [id2]) => parseInt(id2) - parseInt(id1))
                 .map(([id, checked], i) => (
                   <div key={`checkbox-${String(i)}`} className="flex">
                     <input

--- a/src/features/farming/hud/components/Menu.tsx
+++ b/src/features/farming/hud/components/Menu.tsx
@@ -28,6 +28,7 @@ import goblin from "assets/npcs/goblin_head.png";
 
 import { useIsNewFarm } from "../lib/onboarding";
 import { GoblinVillageModal } from "features/farming/town/components/GoblinVillageModal";
+import { DEV_BurnLandButton } from "./DEV_BurnLandButton";
 
 /**
  * TODO:
@@ -149,6 +150,7 @@ export const Menu = () => {
             )}
           </Button>
         </div>
+        {CONFIG.NETWORK === "mumbai" && <DEV_BurnLandButton />}
         <div
           className={`transition-all ease duration-200 ${
             menuOpen ? "max-h-100" : "max-h-0"


### PR DESCRIPTION
# Description

This PR introduces an extra button on testnet to burn land expansions. 

The code has purposely been bundled into a single file,to prevent test code from leaking all over the code base.

The code does the following:

1. Get balance of land expansions
2. Get the token IDs of the land expansions (up to the balance)
3. Use the web3 batch APIs to approve multiple burn transactions

![burn](https://user-images.githubusercontent.com/41215134/181436583-dd5b41f6-29a5-436f-9578-9017b856bbbe.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
