### PR TITLE
[FIX] Remove Sell Price Boost on Cakes

### DIFF
--- a/src/features/game/events/sell.ts
+++ b/src/features/game/events/sell.ts
@@ -14,6 +14,7 @@ export type SellAction = {
 export type SellableName = CropName | Cake;
 
 export type SellableItem = {
+  name: SellableName;
   sellPrice: Decimal;
 };
 

--- a/src/features/game/lib/boosts.ts
+++ b/src/features/game/lib/boosts.ts
@@ -1,6 +1,9 @@
 import { Inventory, InventoryItemName } from "../types/game";
 import { isSeed } from "../events/plant";
 import { SellableItem } from "../events/sell";
+import { CROPS } from "../types/crops";
+
+const crops = CROPS();
 
 /**
  * How much SFL an item is worth
@@ -8,7 +11,8 @@ import { SellableItem } from "../events/sell";
 export const getSellPrice = (item: SellableItem, inventory: Inventory) => {
   let price = item.sellPrice;
 
-  if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
+  // apply Green Thumb boost to crops
+  if (item.name in crops && inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
     price = price.mul(1.05);
   }
 


### PR DESCRIPTION
# Description

This PR fixes the bug where selling cakes appear to be boosted by Green Thumb (+5%). As reported in [discord](https://discord.com/channels/880987707214544966/881648372249939980/1002166168628502588), syncing corrects the SFL balance.

Replicated on local

https://user-images.githubusercontent.com/89294757/181504921-89511c2d-5fa3-4242-8c43-a998f0b6323c.mp4

Fixes #issue N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing - local (edited inventory)

![image](https://user-images.githubusercontent.com/89294757/181505313-c93a4060-ae76-4374-98dc-68b6fbdb205e.png)

https://user-images.githubusercontent.com/89294757/181505325-55ca43ca-72f5-4dfe-a5b1-e4a3162c960c.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
