### PR TITLE
[FIX] Rusty Shovel Unit Conversion on Visit / Wicker Man Scroll

### DIFF
--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -402,6 +402,7 @@ const WickerManAnimation: React.FC = () => {
         left: `${GRID_WIDTH_PX * 82}px`,
         top: `${GRID_WIDTH_PX * 21}px`,
       }}
+      id={Section["Wicker Man"]}
     >
       <Spritesheet
         className="absolute group-hover:img-highlight pointer-events-none z-10"

--- a/src/features/game/lib/conversion.ts
+++ b/src/features/game/lib/conversion.ts
@@ -1,5 +1,5 @@
 import { InventoryItemName } from "../types/game";
-import { TOOLS } from "../types/craftables";
+import { SHOVELS, TOOLS } from "../types/craftables";
 import { CROPS, SEEDS } from "../types/crops";
 import { RESOURCES } from "../types/resources";
 
@@ -12,7 +12,8 @@ export function getItemUnit(name: InventoryItemName) {
     name in CROPS() ||
     name in RESOURCES ||
     name in SEEDS() ||
-    name in TOOLS
+    name in TOOLS ||
+    name in SHOVELS
   ) {
     return "ether";
   }


### PR DESCRIPTION
# Description

This PR fixes the bug where `Rusty Shovel` shows as `10^18` when visiting

![image](https://user-images.githubusercontent.com/89294757/182156209-29bd1f5c-e8b6-42aa-bf4e-d385d3c9a8d7.png)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing - testnet

![image](https://user-images.githubusercontent.com/89294757/182156334-a8bd5c2a-e51a-48e2-bd63-543821d691b7.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
