### PR TITLE
[FIX] Goblin Shovel Modal

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -62,7 +62,15 @@ export function checkProgress({ state, action, onChain }: checkProgressArgs): {
   valid: boolean;
   maxedItem?: InventoryItemName | "SFL";
 } {
-  const newState = processEvent({ state, action });
+  let newState: GameState;
+
+  try {
+    newState = processEvent({ state, action });
+  } catch {
+    // Not our responsibility to catch events, pass on to the next handler
+    return { valid: true };
+  }
+
   const progress = newState.balance.sub(onChain.balance);
 
   /**


### PR DESCRIPTION
# Description

The Goblin Shovel was not showing because the new `hoarding` action was not bubbling up the event and was throwing a state transition error when the Missing Shovel got thrown