### PR TITLE
[FIX] Rearrange supply reached order

### DIFF
--- a/src/features/auth/components/SupplyReached.tsx
+++ b/src/features/auth/components/SupplyReached.tsx
@@ -1,12 +1,34 @@
-import React from "react";
+import { metamask } from "lib/blockchain/metamask";
+import React, { useEffect, useState } from "react";
 
 export const SupplyReached: React.FC = () => {
+  const [supply, setSupply] = useState<number>();
+
+  useEffect(() => {
+    const load = async () => {
+      const amount = await metamask.getFarm().getTotalSupply();
+
+      setSupply(amount);
+    };
+
+    load();
+  }, []);
+
+  if (!supply) {
+    return (
+      <div className="flex flex-col text-center text-shadow items-center p-1">
+        <p className="loading">Loading</p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col text-center text-shadow items-center p-1">
+      <p className="text-center text-xl">{supply}</p>
       <p className="text-center mb-3">Supply reached!</p>
 
       <p className="text-center mb-4 text-xs">
-        {`100,000 farms have already been minted for open beta. More spots are opening soon!`}
+        {`We are currently in Beta and all of the spots are currently taken. We will be opening more spots soon, join us on Twitter and Discord to hear more.`}
       </p>
     </div>
   );

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -231,7 +231,7 @@ export const authMachine = createMachine<
                   cond: "hasFarm",
                 },
 
-                { target: "checkingAccess" },
+                { target: "checkingSupply" },
               ],
               onError: {
                 target: "#unauthorised",
@@ -254,27 +254,6 @@ export const authMachine = createMachine<
               ],
             },
           },
-          checkingAccess: {
-            id: "checkingAccess",
-            invoke: {
-              src: async (context) => {
-                return {
-                  hasAccess: context.token?.userAccess.createFarm,
-                };
-              },
-              onDone: [
-                {
-                  target: "noFarmLoaded",
-                  cond: (_, event) => event.data.hasAccess,
-                },
-                { target: "checkingSupply" },
-              ],
-              onError: {
-                target: "#unauthorised",
-                actions: "assignErrorMessage",
-              },
-            },
-          },
           checkingSupply: {
             id: "checkingSupply",
             invoke: {
@@ -291,7 +270,7 @@ export const authMachine = createMachine<
                   cond: (context, event) =>
                     Number(event.data.totalSupply) >= 150000,
                 },
-                { target: "noFarmLoaded" },
+                { target: "checkingAccess" },
               ],
               onError: {
                 target: "#unauthorised",
@@ -299,6 +278,25 @@ export const authMachine = createMachine<
               },
             },
           },
+          checkingAccess: {
+            id: "checkingAccess",
+            invoke: {
+              src: async (context) => {
+                return {
+                  hasAccess: context.token?.userAccess.createFarm,
+                };
+              },
+              onDone: {
+                target: "noFarmLoaded",
+              },
+
+              onError: {
+                target: "#unauthorised",
+                actions: "assignErrorMessage",
+              },
+            },
+          },
+
           donating: {
             on: {
               CREATE_FARM: {


### PR DESCRIPTION
# Description

The API no longer requites Discord auth and users can always create a farm. This meant that `createFarm` was always true and `checkingSupply` was never entered.

This fix rearranges the state to ensure that we always check the total supply.

To make it clear for users, we also show the total supply on the SupplyReached.tsx component


- [X] Bug fix (non-breaking change which fixes an issue)
