### PR TITLE
[FIX] Goblin shovel thief modal

### DIFF
--- a/src/features/farming/crops/components/GoblinShovel.tsx
+++ b/src/features/farming/crops/components/GoblinShovel.tsx
@@ -12,7 +12,10 @@ import { isShovelStolen } from "features/game/events/harvest";
 
 import { Button } from "components/ui/Button";
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
-import { recoverShovel } from "features/game/lib/goblinShovelStorage";
+import {
+  addToHarvestCount,
+  recoverShovel,
+} from "features/game/lib/goblinShovelStorage";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 
 type Position = {
@@ -69,6 +72,7 @@ export const GoblinShovel: React.FC = () => {
 
     gameService.onEvent((event) => {
       if (event.type == "item.harvested") {
+        addToHarvestCount(1);
         detectGoblins();
       }
     });

--- a/src/features/game/events/harvest.ts
+++ b/src/features/game/events/harvest.ts
@@ -2,11 +2,7 @@ import { FieldItem, GameState, Inventory } from "../types/game";
 import { Crop, CROPS } from "../types/crops";
 import Decimal from "decimal.js-light";
 import { screenTracker } from "lib/utils/screen";
-import {
-  addToHarvestCount,
-  getGoblinCount,
-  getHarvestCount,
-} from "../lib/goblinShovelStorage";
+import { getGoblinCount, getHarvestCount } from "../lib/goblinShovelStorage";
 import cloneDeep from "lodash.clonedeep";
 
 export type HarvestAction = {
@@ -18,6 +14,12 @@ type Options = {
   state: Readonly<GameState>;
   action: HarvestAction;
   createdAt?: number;
+};
+
+export const isShovelStolen = () => {
+  const goblinThreshold = getGoblinCount().add(1).pow(3).mul(57);
+
+  return getHarvestCount().greaterThanOrEqualTo(goblinThreshold);
 };
 
 export function isReadyToHarvest(
@@ -73,6 +75,7 @@ export function harvest({ state, action, createdAt = Date.now() }: Options) {
   }
 
   const field = fields[action.index];
+
   if (!field) {
     throw new Error("Nothing was planted");
   }
@@ -98,16 +101,9 @@ export function harvest({ state, action, createdAt = Date.now() }: Options) {
     [field.name]: cropCount.add(multiplier),
   };
 
-  addToHarvestCount(1);
-
   return {
     ...stateCopy,
     fields: newFields,
     inventory,
   } as GameState;
 }
-
-export const isShovelStolen = () => {
-  const goblinThreshold = getGoblinCount().add(1).pow(3).mul(57);
-  return getHarvestCount().greaterThanOrEqualTo(goblinThreshold);
-};

--- a/src/lib/utils/screen.ts
+++ b/src/lib/utils/screen.ts
@@ -77,7 +77,6 @@ class ScreenTracker {
 
       const isCollinear = areCollinear(points);
 
-      console.log({ points });
       if (isCollinear) {
         this.tracks += 3;
       } else if (this.tracks > 0) {


### PR DESCRIPTION
# Description

This PR fixes an issue where the goblin modal wasn't showing. 

**Cause**

With our previous fix for the maxItems we needed to `processEvent` first (without a state update) to test whether the event would push maxItems over the threshold and if it didn't then we would `processEvent` again with a state update this time.

The incrementing `harvestCount` was being updated inside of the action which meant our first test `processEvent` was incrementing this count as well therefore for each harvest we were incrementing the `harvestCount` by two even though only one `item.harvested` event fired. 

The `GoblinShovel` was listening for the `item.harvested` event and when it fired it was running some logic to determine whether the shovel was stolen. 

**Example**

For the first steal when the harvest count was 1 before the first threshold the next harvest event runs the action once (maxItems test) which increments to the first threshold and then because we don't go over maxItems it immediately calls the action again which errors out on:

```
 if (isShovelStolen()) {
  throw new Error("Missing shovel!");
}
```
Therefore the `GoblinShovel` is never re-rendered so we don't get the modal showing. 

**Fix**

IMO the incrementing of the `harvestCount` shouldn't be inside the action. This is a technically a "side effect" of the action. I think we should aim to keep the actions pure. I have moved the `addToHarvest` call inside of the `GoblinShovel` component and invoked this when the `item.harvested` event is fired.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
