### PR TITLE
[FIX] Add hover highlight to Wicker man

### DIFF
--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -394,7 +394,7 @@ const WickerManAnimation: React.FC = () => {
   return (
     <div
       ref={containerRef}
-      className="absolute cursor-pointer"
+      className="absolute cursor-pointer hover:img-highlight z-10"
       onClick={burn}
       style={{
         width: `${PIXEL_SCALE * 19}px`,


### PR DESCRIPTION
# Description

Added the white outline upon hover to the Wicker Man so people can see he is clickable and will burn! 
<img width="126" alt="Screen Shot 2022-08-04 at 9 28 37 AM" src="https://user-images.githubusercontent.com/79071868/182996037-097877b3-4844-4b94-b39a-25823bdf5505.png">

<img width="110" alt="Screen Shot 2022-08-04 at 9 29 29 AM" src="https://user-images.githubusercontent.com/79071868/182996065-59a5f549-ede1-4b06-b9e4-ff32e157b14e.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added to initial farm constant and tested on localhost

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
