### PR TITLE
[FIX] Reveal Event

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -58,7 +58,7 @@ export type GameEvent =
   | RevealAction
   | FertiliseCropAction;
 
-type EventName = Extract<GameEvent, { type: string }>["type"];
+export type EventName = Extract<GameEvent, { type: string }>["type"];
 
 /**
  * Type which enables us to map the event name to the payload containing that event name


### PR DESCRIPTION
# Description

"expansion.revealed" is a UI only event. This PR excludes it from going to the API and causing an error.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How to test?

1. `yarn dev`
2. Expand your land
3. Wait for the autosave (no error should occur - the event will be filtered out)
