### PR TITLE
[FEAT] Constructing building

### DIFF
--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -14,7 +14,7 @@ interface Props {
   seconds: number;
 }
 
-export const Bar: React.FC<Props> = ({ percentage }) => {
+export const Bar: React.FC<{ percentage: number }> = ({ percentage }) => {
   if (percentage >= 100) {
     return <img src={progressFull} className="w-10" />;
   }

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -45,7 +45,7 @@ export const ProgressBar: React.FC<Props> = ({ percentage, seconds }) => {
           {secondsToString(seconds)}
         </span>
       )}
-      <Bar percentage={percentage} seconds={seconds} />
+      <Bar percentage={percentage} />
     </div>
   );
 };

--- a/src/features/farming/animals/components/Chicken.tsx
+++ b/src/features/farming/animals/components/Chicken.tsx
@@ -335,10 +335,7 @@ export const Chicken: React.FC<Props> = ({ index, position }) => {
           className="absolute w-2/5 bottom-1 left-4"
           style={{ zIndex: index + 1 }}
         >
-          <Bar
-            percentage={percentageComplete}
-            seconds={CHICKEN_TIME_TO_EGG / 1000}
-          />
+          <Bar percentage={percentageComplete} />
         </div>
       )}
       {showMutantModal && (

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -322,28 +322,7 @@ export const INITIAL_FARM: GameState = {
 
   expansions: INITIAL_EXPANSIONS,
   bumpkin: { level: 1 },
-  buildings: {
-    "Fire Pit": [
-      {
-        id: "123",
-        coordinates: {
-          x: 1,
-          y: 1,
-        },
-        createdAt: 0,
-        readyAt: 0,
-      },
-      {
-        id: "123",
-        coordinates: {
-          x: 1,
-          y: 2,
-        },
-        createdAt: Date.now(),
-        readyAt: Date.now() + 5 * 1000,
-      },
-    ],
-  },
+  buildings: {},
 };
 
 export const EMPTY: GameState = {

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -322,7 +322,28 @@ export const INITIAL_FARM: GameState = {
 
   expansions: INITIAL_EXPANSIONS,
   bumpkin: { level: 1 },
-  buildings: {},
+  buildings: {
+    "Fire Pit": [
+      {
+        id: "123",
+        coordinates: {
+          x: 1,
+          y: 1,
+        },
+        createdAt: 0,
+        readyAt: 0,
+      },
+      {
+        id: "123",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+        createdAt: Date.now(),
+        readyAt: Date.now() + 5 * 1000,
+      },
+    ],
+  },
 };
 
 export const EMPTY: GameState = {

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -1,7 +1,12 @@
+import React, { useRef, useState } from "react";
+import classNames from "classnames";
+
 import { BuildingName } from "features/game/types/buildings";
 import { Building as IBuilding } from "features/game/types/game";
-import React from "react";
+
 import { FirePit } from "./FirePit";
+import { TimeLeftOverlay } from "components/ui/TimeLeftOverlay";
+import { Bar } from "components/ui/ProgressBar";
 
 interface Prop {
   name: BuildingName;
@@ -22,12 +27,46 @@ const BUIDLING_COMPONENTS: Record<BuildingName, React.FC<BuildingProp>> = {
 };
 
 export const Building: React.FC<Prop> = ({ name, building, id }) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+
   const BuildingPlaced = BUIDLING_COMPONENTS[name];
 
-  // TODO in progress
-  return (
-    <div>
-      <BuildingPlaced id={id} />
-    </div>
-  );
+  const inProgress = building.readyAt > Date.now();
+
+  if (inProgress) {
+    const totalSeconds = (building.readyAt - building.createdAt) / 1000;
+    const secondsLeft = Math.floor((building.readyAt - Date.now()) / 1000);
+
+    return (
+      <>
+        <div
+          className="w-full h-full cursor-pointer"
+          ref={overlayRef}
+          onMouseEnter={() => setShowTooltip(true)}
+          onMouseLeave={() => setShowTooltip(false)}
+        >
+          <div
+            className={classNames("w-full h-full pointer-events-none", {
+              "opacity-50": inProgress,
+            })}
+          >
+            <BuildingPlaced id={id} />
+          </div>
+          <div className="absolute bottom-0 w-8 left-1/2 -translate-x-1/2">
+            <Bar percentage={(1 - secondsLeft / totalSeconds) * 100} />
+          </div>
+        </div>
+        {overlayRef.current && (
+          <TimeLeftOverlay
+            target={overlayRef.current}
+            timeLeft={secondsLeft}
+            showTimeLeft={showTooltip}
+          />
+        )}
+      </>
+    );
+  }
+
+  return <BuildingPlaced id={id} />;
 };

--- a/src/features/island/hud/components/BumpkinHUD.tsx
+++ b/src/features/island/hud/components/BumpkinHUD.tsx
@@ -42,7 +42,7 @@ export const BumpkinHUD: React.FC = () => {
         </div>
         <div className="flex  ml-1 items-center">
           <img src={stamina} className="w-4 mr-1" />
-          <Bar percentage={60} seconds={20} />
+          <Bar percentage={60} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

While a building is being constructed, show it in 'construction mode'.

In construction mode, the image will have half opacity and a progress bar below. Hovering shows the time left.

<img width="187" alt="Screen Shot 2022-08-12 at 2 02 15 pm" src="https://user-images.githubusercontent.com/11745561/184283455-05e117ae-1d52-4838-9e66-136f7700f53f.png">
<img width="272" alt="Screen Shot 2022-08-12 at 2 06 02 pm" src="https://user-images.githubusercontent.com/11745561/184283457-22e1176a-075c-45cc-ae0b-22a1abec062f.png">

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How to test?

Enter UI mode and add the following to the `INITIAL_FARM` constant

```
buildings: {
    "Fire Pit": [
      {
        id: "123",
        coordinates: {
          x: 1,
          y: 1,
        },
        createdAt: 0,
        readyAt: 0,
      },
      {
        id: "123",
        coordinates: {
          x: 1,
          y: 2,
        },
        createdAt: Date.now(),
        readyAt: Date.now() + 5 * 1000,
      },
    ],
  },
```