### PR TITLE
[FEAT] Connect FE & BE placeable logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint --ext .tsx,.ts .",
     "format": "yarn lint --fix",
     "preview": "vite preview",
-    "generate": "graphql-codegen",
     "test": "jest",
     "erc1155": "ts-node --project _scripts/node.tsconfig.json _scripts/erc1155Metadata.ts",
     "prepare": "husky install"
@@ -29,7 +28,6 @@
     "clipboard": "^2.0.11",
     "decimal.js-light": "^2.5.1",
     "events": "^3.3.0",
-    "graphql": "^16.2.0",
     "howler": "^2.2.3",
     "html2canvas": "^1.4.1",
     "jwt-decode": "^3.1.2",

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -8,6 +8,8 @@ import { Context } from "features/game/GameProvider";
 import confirm from "assets/icons/confirm.png";
 import cancel from "assets/icons/cancel.png";
 import Decimal from "decimal.js-light";
+import { BuildingName, BUILDINGS } from "features/game/types/buildings";
+import { CollectibleName } from "features/game/types/craftables";
 
 export const PlaceableController: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -16,7 +18,7 @@ export const PlaceableController: React.FC = () => {
 
   const [
     {
-      context: { collisionDetected, placeable },
+      context: { collisionDetected, placeable, coordinates },
     },
     send,
   ] = useActor(child);
@@ -25,9 +27,34 @@ export const PlaceableController: React.FC = () => {
     const inventoryCount = inventory[placeable] || new Decimal(0);
 
     if (inventoryCount.eq(0)) {
-      send("CONSTRUCT");
+      send({
+        type: "CONSTRUCT",
+        action: {
+          type: "building.constructed",
+          name: placeable as BuildingName,
+          coordinates,
+        },
+      });
     } else {
-      send("PLACE");
+      if (placeable in BUILDINGS) {
+        send({
+          type: "PLACE",
+          action: {
+            type: "building.placed",
+            name: placeable as BuildingName,
+            coordinates,
+          },
+        });
+      } else {
+        send({
+          type: "PLACE",
+          action: {
+            type: "collectible.placed",
+            name: placeable as CollectibleName,
+            coordinates,
+          },
+        });
+      }
     }
   };
 

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -22,9 +22,9 @@ export const PlaceableController: React.FC = () => {
   ] = useActor(child);
 
   const handleConfirmPlacement = () => {
-    const itemInInventory = inventory[placeable] || new Decimal(0);
+    const inventoryCount = inventory[placeable] || new Decimal(0);
 
-    if (itemInInventory.eq(0)) {
+    if (inventoryCount.eq(0)) {
       send("CONSTRUCT");
     } else {
       send("PLACE");

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -7,28 +7,20 @@ import { Context } from "features/game/GameProvider";
 
 import confirm from "assets/icons/confirm.png";
 import cancel from "assets/icons/cancel.png";
-import Decimal from "decimal.js-light";
 
 export const PlaceableController: React.FC = () => {
   const { gameService } = useContext(Context);
-  const { inventory } = gameService.state.context.state;
   const child = gameService.state.children.editing as MachineInterpreter;
 
   const [
     {
-      context: { collisionDetected, placeable },
+      context: { collisionDetected },
     },
     send,
   ] = useActor(child);
 
   const handleConfirmPlacement = () => {
-    const inventoryCount = inventory[placeable] || new Decimal(0);
-
-    if (inventoryCount.eq(0)) {
-      send("CONSTRUCT");
-    } else {
-      send("PLACE");
-    }
+    send("PLACE");
   };
 
   const handleCancelPlacement = () => {

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -7,6 +7,7 @@ import { Context } from "features/game/GameProvider";
 
 import confirm from "assets/icons/confirm.png";
 import cancel from "assets/icons/cancel.png";
+import Decimal from "decimal.js-light";
 
 export const PlaceableController: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -21,10 +22,12 @@ export const PlaceableController: React.FC = () => {
   ] = useActor(child);
 
   const handleConfirmPlacement = () => {
-    if (inventory[placeable]) {
-      send("PLACE");
+    const itemInInventory = inventory[placeable] || new Decimal(0);
+
+    if (itemInInventory.eq(0)) {
+      send("CONSTRUCT");
     } else {
-      send({ type: "PLACE", isConstruction: true });
+      send("PLACE");
     }
   };
 

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -8,8 +8,6 @@ import { Context } from "features/game/GameProvider";
 import confirm from "assets/icons/confirm.png";
 import cancel from "assets/icons/cancel.png";
 import Decimal from "decimal.js-light";
-import { BuildingName, BUILDINGS } from "features/game/types/buildings";
-import { CollectibleName } from "features/game/types/craftables";
 
 export const PlaceableController: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -18,7 +16,7 @@ export const PlaceableController: React.FC = () => {
 
   const [
     {
-      context: { collisionDetected, placeable, coordinates },
+      context: { collisionDetected, placeable },
     },
     send,
   ] = useActor(child);
@@ -27,34 +25,9 @@ export const PlaceableController: React.FC = () => {
     const inventoryCount = inventory[placeable] || new Decimal(0);
 
     if (inventoryCount.eq(0)) {
-      send({
-        type: "CONSTRUCT",
-        action: {
-          type: "building.constructed",
-          name: placeable as BuildingName,
-          coordinates,
-        },
-      });
+      send("CONSTRUCT");
     } else {
-      if (placeable in BUILDINGS) {
-        send({
-          type: "PLACE",
-          action: {
-            type: "building.placed",
-            name: placeable as BuildingName,
-            coordinates,
-          },
-        });
-      } else {
-        send({
-          type: "PLACE",
-          action: {
-            type: "collectible.placed",
-            name: placeable as CollectibleName,
-            coordinates,
-          },
-        });
-      }
+      send("PLACE");
     }
   };
 

--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -10,17 +10,22 @@ import cancel from "assets/icons/cancel.png";
 
 export const PlaceableController: React.FC = () => {
   const { gameService } = useContext(Context);
+  const { inventory } = gameService.state.context.state;
   const child = gameService.state.children.editing as MachineInterpreter;
 
   const [
     {
-      context: { collisionDetected },
+      context: { collisionDetected, placeable },
     },
     send,
   ] = useActor(child);
 
   const handleConfirmPlacement = () => {
-    send("PLACE");
+    if (inventory[placeable]) {
+      send("PLACE");
+    } else {
+      send({ type: "PLACE", isConstruction: true });
+    }
   };
 
   const handleCancelPlacement = () => {

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -11,12 +11,7 @@ import {
   getShortcuts,
 } from "features/farming/hud/lib/shortcuts";
 
-import {
-  startGame,
-  MachineInterpreter,
-  MachineState,
-  INITIAL_SESSION,
-} from "./lib/gameMachine";
+import { startGame, MachineInterpreter, MachineState } from "./lib/gameMachine";
 import { InventoryItemName } from "./types/game";
 import { useParams } from "react-router-dom";
 
@@ -61,7 +56,7 @@ export const GameProvider: React.FC = ({ children }) => {
   useLayoutEffect(() => {
     const savedShortcuts = getShortcuts();
 
-    if (sessionId !== INITIAL_SESSION && savedShortcuts.length === 0) {
+    if (savedShortcuts.length === 0) {
       const defaultItem: InventoryItemName = inventory["Shovel"]
         ? "Shovel"
         : "Rusty Shovel";

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -1,8 +1,8 @@
 /**
  * A wrapper that provides game state and dispatches events
  */
-import { useState, useCallback } from "react";
-import { useActor, useInterpret } from "@xstate/react";
+import { useState, useCallback, useLayoutEffect } from "react";
+import { useActor, useInterpret, useSelector } from "@xstate/react";
 import React, { useContext } from "react";
 
 import * as Auth from "features/auth/lib/Provider";
@@ -11,7 +11,12 @@ import {
   getShortcuts,
 } from "features/farming/hud/lib/shortcuts";
 
-import { startGame, MachineInterpreter } from "./lib/gameMachine";
+import {
+  startGame,
+  MachineInterpreter,
+  MachineState,
+  INITIAL_SESSION,
+} from "./lib/gameMachine";
 import { InventoryItemName } from "./types/game";
 import { useParams } from "react-router-dom";
 
@@ -22,6 +27,9 @@ interface GameContext {
 }
 
 export const Context = React.createContext<GameContext>({} as GameContext);
+
+const selectInventory = (state: MachineState) => state.context.state.inventory;
+const selectSessionId = (state: MachineState) => state.context.sessionId;
 
 export const GameProvider: React.FC = ({ children }) => {
   const { authService } = useContext(Auth.Context);
@@ -40,14 +48,29 @@ export const GameProvider: React.FC = ({ children }) => {
 
   // TODO - Typescript error
   const gameService = useInterpret(gameMachine) as MachineInterpreter;
-  const [shortcuts, setShortcuts] = useState<InventoryItemName[]>(
-    getShortcuts()
-  );
+  const inventory = useSelector(gameService, selectInventory);
+  const sessionId = useSelector(gameService, selectSessionId);
+  const [shortcuts, setShortcuts] = useState<InventoryItemName[]>([]);
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
     const items = cacheShortcuts(item);
+
     setShortcuts(items);
   }, []);
+
+  useLayoutEffect(() => {
+    const savedShortcuts = getShortcuts();
+
+    if (sessionId !== INITIAL_SESSION && savedShortcuts.length === 0) {
+      const defaultItem: InventoryItemName = inventory["Shovel"]
+        ? "Shovel"
+        : "Rusty Shovel";
+
+      shortcutItem(defaultItem);
+    } else {
+      setShortcuts(savedShortcuts);
+    }
+  }, [inventory, sessionId, shortcutItem]);
 
   const selectedItem = shortcuts.length > 0 ? shortcuts[0] : undefined;
 

--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -3,7 +3,7 @@ import { metamask } from "lib/blockchain/metamask";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { sanitizeHTTPResponse } from "lib/network";
-import { EventName } from "../events";
+import { GameEventName, PlacementEvent, PlayingEvent } from "../events";
 import { SellAction } from "../events/sell";
 import { PastAction } from "../lib/gameMachine";
 import { makeGame } from "../lib/transforms";
@@ -21,7 +21,9 @@ type Request = {
 
 const API_URL = CONFIG.API_URL;
 
-const EXCLUDED_EVENTS: EventName[] = ["expansion.revealed"];
+const EXCLUDED_EVENTS: GameEventName<PlayingEvent | PlacementEvent>[] = [
+  "expansion.revealed",
+];
 
 /**
  * Squashes similar events into a single event

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -43,7 +43,7 @@ import {
   ConstructBuildingAction,
 } from "./landExpansion/constructBuilding";
 
-export type GameEvent =
+export type PlayingEvent =
   | CraftAction
   | SellAction
   | PlantAction
@@ -70,20 +70,23 @@ export type GameEvent =
   | ConstructBuildingAction
   | PlaceBuildingAction;
 
-export type EventName = Extract<GameEvent, { type: string }>["type"];
+export type PlacementEvent = ConstructBuildingAction | PlaceBuildingAction;
+
+export type GameEvent = PlayingEvent | PlacementEvent;
+type GameEventName<T> = Extract<T, { type: string }>["type"];
 
 /**
  * Type which enables us to map the event name to the payload containing that event name
  */
-type Handlers = {
-  [Name in EventName]: (options: {
+type Handlers<T> = {
+  [Name in GameEventName<T>]: (options: {
     state: GameState;
     // Extract the correct event payload from the list of events
-    action: Extract<GameEvent, { type: Name }>;
+    action: Extract<GameEventName<T>, { type: Name }>;
   }) => GameState;
 };
 
-export const EVENTS: Handlers = {
+export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "item.planted": plant,
   "item.harvested": harvest,
   "item.crafted": craft,
@@ -107,6 +110,11 @@ export const EVENTS: Handlers = {
   "timber.chopped": landExpansionChop,
   "rock.mined": landExpansionMineStone,
   "item.fertilised": fertiliseCrop,
+};
+
+export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "building.constructed": constructBuilding,
   "building.placed": placeBuilding,
 };
+
+export const EVENTS = { ...PLAYING_EVENTS, ...PLACEMENT_EVENTS };

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -34,6 +34,14 @@ import { chopShrub, ChopShrubAction } from "./chopShrub";
 import { reveal, RevealAction } from "./revealExpansion";
 import { fertiliseCrop, FertiliseCropAction } from "./fertiliseCrop";
 import { claimAirdrop, ClaimAirdropAction } from "./claimAirdrop";
+import {
+  placeBuilding,
+  PlaceBuildingAction,
+} from "./landExpansion/placeBuilding";
+import {
+  constructBuilding,
+  ConstructBuildingAction,
+} from "./landExpansion/constructBuilding";
 
 export type GameEvent =
   | CraftAction
@@ -58,7 +66,9 @@ export type GameEvent =
   | ChopShrubAction
   | RevealAction
   | FertiliseCropAction
-  | ClaimAirdropAction;
+  | ClaimAirdropAction
+  | ConstructBuildingAction
+  | PlaceBuildingAction;
 
 export type EventName = Extract<GameEvent, { type: string }>["type"];
 
@@ -97,4 +107,6 @@ export const EVENTS: Handlers = {
   "timber.chopped": landExpansionChop,
   "rock.mined": landExpansionMineStone,
   "item.fertilised": fertiliseCrop,
+  "building.constructed": constructBuilding,
+  "building.placed": placeBuilding,
 };

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -73,7 +73,7 @@ export type PlayingEvent =
 export type PlacementEvent = ConstructBuildingAction | PlaceBuildingAction;
 
 export type GameEvent = PlayingEvent | PlacementEvent;
-type GameEventName<T> = Extract<T, { type: string }>["type"];
+export type GameEventName<T> = Extract<T, { type: string }>["type"];
 
 /**
  * Type which enables us to map the event name to the payload containing that event name

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -70,9 +70,7 @@ export type PlayingEvent =
   | ChopShrubAction
   | RevealAction
   | FertiliseCropAction
-  | ClaimAirdropAction
-  | ConstructBuildingAction
-  | PlaceBuildingAction;
+  | ClaimAirdropAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -42,6 +42,10 @@ import {
   constructBuilding,
   ConstructBuildingAction,
 } from "./landExpansion/constructBuilding";
+import {
+  placeCollectible,
+  PlaceCollectibleAction,
+} from "./landExpansion/placeCollectible";
 
 export type PlayingEvent =
   | CraftAction
@@ -70,7 +74,10 @@ export type PlayingEvent =
   | ConstructBuildingAction
   | PlaceBuildingAction;
 
-export type PlacementEvent = ConstructBuildingAction | PlaceBuildingAction;
+export type PlacementEvent =
+  | ConstructBuildingAction
+  | PlaceBuildingAction
+  | PlaceCollectibleAction;
 
 export type GameEvent = PlayingEvent | PlacementEvent;
 export type GameEventName<T> = Extract<T, { type: string }>["type"];
@@ -115,6 +122,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "building.constructed": constructBuilding,
   "building.placed": placeBuilding,
+  "collectible.placed": placeCollectible,
 };
 
 export const EVENTS = { ...PLAYING_EVENTS, ...PLACEMENT_EVENTS };

--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -14,7 +14,7 @@ describe("Construct building", () => {
         state: GAME_STATE,
         action: {
           type: "building.constructed",
-          building: "Workbench",
+          name: "Workbench",
           coordinates: {
             x: 0,
             y: 0,
@@ -30,7 +30,7 @@ describe("Construct building", () => {
         state: GAME_STATE,
         action: {
           type: "building.constructed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           coordinates: {
             x: 0,
             y: 0,
@@ -48,7 +48,7 @@ describe("Construct building", () => {
         },
         action: {
           type: "building.constructed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           coordinates: {
             x: 0,
             y: 0,
@@ -70,7 +70,7 @@ describe("Construct building", () => {
         },
         action: {
           type: "building.constructed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           coordinates: {
             x: 0,
             y: 0,
@@ -96,7 +96,7 @@ describe("Construct building", () => {
         },
         action: {
           type: "building.constructed",
-          building: "Workbench",
+          name: "Workbench",
           coordinates: {
             x: 0,
             y: 0,
@@ -122,7 +122,7 @@ describe("Construct building", () => {
         },
         action: {
           type: "building.constructed",
-          building: "Workbench",
+          name: "Workbench",
           coordinates: {
             x: 0,
             y: 0,
@@ -141,7 +141,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         coordinates: {
           x: 0,
           y: 0,
@@ -164,7 +164,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         coordinates: {
           x: 0,
           y: 0,
@@ -185,7 +185,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         coordinates: {
           x: 1,
           y: 2,
@@ -212,7 +212,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Workbench",
+        name: "Workbench",
         coordinates: {
           x: 1,
           y: 2,
@@ -235,7 +235,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Workbench",
+        name: "Workbench",
         coordinates: {
           x: 1,
           y: 2,
@@ -269,7 +269,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         coordinates: {
           x: 1,
           y: 2,
@@ -315,7 +315,7 @@ describe("Construct building", () => {
       },
       action: {
         type: "building.constructed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         coordinates: {
           x: 1,
           y: 2,

--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -196,7 +196,6 @@ describe("Construct building", () => {
 
     expect(state.buildings["Fire Pit"]).toHaveLength(1);
     expect(state.buildings["Fire Pit"]?.[0]).toEqual({
-      id: expect.any(String),
       coordinates: { x: 1, y: 2 },
       readyAt: date + 30 * 1000,
       createdAt: date,
@@ -243,7 +242,6 @@ describe("Construct building", () => {
         },
       },
     });
-    // previousInventory.Wood.sub(BUILDINGS.Workbench.ingredients)
     expect(state.inventory["Wood"]).toEqual(new Decimal(15));
     expect(state.inventory["Stone"]).toEqual(new Decimal(10));
   });
@@ -340,7 +338,6 @@ describe("Construct building", () => {
           },
           createdAt: date,
           readyAt: date + 30 * 1000,
-          id: expect.any(String),
         },
       ],
       Workbench: [

--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -1,0 +1,356 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "../../lib/constants";
+import { GameState } from "../../types/game";
+import { constructBuilding } from "./constructBuilding";
+
+const GAME_STATE: GameState = INITIAL_FARM;
+
+const date = Date.now();
+
+describe("Construct building", () => {
+  it("ensures Bumpkin level requirements for Workbench are met", () => {
+    expect(() =>
+      constructBuilding({
+        state: GAME_STATE,
+        action: {
+          type: "building.constructed",
+          building: "Workbench",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("Your Bumpkin does not meet the level requirements");
+  });
+
+  it("ensures Bumpkin level requirements for Fire Pit are met", () => {
+    expect(() =>
+      constructBuilding({
+        state: GAME_STATE,
+        action: {
+          type: "building.constructed",
+          building: "Fire Pit",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).not.toThrow("Your Bumpkin does not meet the level requirements");
+  });
+
+  it("does not craft Fire Pit if there is insufficient ingredients", () => {
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+        },
+        action: {
+          type: "building.constructed",
+          building: "Fire Pit",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("Insufficient ingredient: Wood");
+  });
+
+  it("crafts a Fire Pit if there is sufficient ingredients", () => {
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Wood: new Decimal(100),
+            Stone: new Decimal(100),
+          },
+        },
+        action: {
+          type: "building.constructed",
+          building: "Fire Pit",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).not.toThrow("Insufficient ingredient: Wood");
+  });
+
+  it("does not craft item with insufficient SFL", () => {
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Wood: new Decimal(100),
+            Stone: new Decimal(100),
+          },
+          bumpkin: {
+            level: 2,
+          },
+          balance: new Decimal(0),
+        },
+        action: {
+          type: "building.constructed",
+          building: "Workbench",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("Insufficient SFL");
+  });
+
+  it("crafts item with sufficient SFL", () => {
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Wood: new Decimal(100),
+            Stone: new Decimal(100),
+          },
+          bumpkin: {
+            level: 2,
+          },
+          balance: new Decimal(100),
+        },
+        action: {
+          type: "building.constructed",
+          building: "Workbench",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).not.toThrow("Insufficient SFL");
+  });
+
+  it("adds the building to the inventory", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: { Wood: new Decimal(20), Stone: new Decimal(100) },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Fire Pit",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.inventory["Fire Pit"]).toEqual(new Decimal(1));
+  });
+
+  it("does not affect existing inventory", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Wood: new Decimal(100),
+          Stone: new Decimal(100),
+          Radish: new Decimal(50),
+        },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Fire Pit",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.inventory["Fire Pit"]).toEqual(new Decimal(1));
+    expect(state.inventory["Radish"]).toEqual(new Decimal(50));
+  });
+
+  it("adds the building to the buildings data structure", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: { Wood: new Decimal(20), Stone: new Decimal(100) },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Fire Pit",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+      },
+      createdAt: date,
+    });
+
+    expect(state.buildings["Fire Pit"]).toHaveLength(1);
+    expect(state.buildings["Fire Pit"]?.[0]).toEqual({
+      id: expect.any(String),
+      coordinates: { x: 1, y: 2 },
+      readyAt: date + 30 * 1000,
+      createdAt: date,
+    });
+  });
+
+  it("burns SFL on construct building", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: { Wood: new Decimal(20), Stone: new Decimal(100) },
+        bumpkin: { level: 2 },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Workbench",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+      },
+    });
+    expect(state.balance).toEqual(new Decimal(99));
+  });
+
+  it("burns ingredients on construct building", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: {
+          Wood: new Decimal(20),
+          Stone: new Decimal(15),
+        },
+        bumpkin: { level: 2 },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Workbench",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+      },
+    });
+    // previousInventory.Wood.sub(BUILDINGS.Workbench.ingredients)
+    expect(state.inventory["Wood"]).toEqual(new Decimal(15));
+    expect(state.inventory["Stone"]).toEqual(new Decimal(10));
+  });
+
+  it("constructs multiple Fire Pits", () => {
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: {
+          Wood: new Decimal(20),
+          Stone: new Decimal(15),
+        },
+        bumpkin: { level: 2 },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 1, y: 1 },
+              createdAt: Date.now(),
+              readyAt: Date.now() + 30 * 1000,
+              id: "1",
+            },
+          ],
+        },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Fire Pit",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+      },
+      createdAt: 234567890,
+    });
+    expect(state.buildings["Fire Pit"]).toHaveLength(2);
+  });
+
+  it("does not affect existing Buildings when constructing new Fire Pit", () => {
+    const buildings = {
+      "Fire Pit": [
+        {
+          coordinates: { x: 1, y: 1 },
+          createdAt: date,
+          readyAt: date + 30 * 1000,
+          id: "1",
+        },
+      ],
+      Workbench: [
+        {
+          coordinates: { x: 2, y: 2 },
+          createdAt: date,
+          readyAt: date + 5 * 60 * 1000,
+          id: "2",
+        },
+      ],
+    };
+
+    const state = constructBuilding({
+      state: {
+        ...GAME_STATE,
+        balance: new Decimal(100),
+        inventory: {
+          Wood: new Decimal(20),
+          Stone: new Decimal(15),
+        },
+        bumpkin: { level: 2 },
+        buildings: {
+          ...buildings,
+        },
+      },
+      action: {
+        type: "building.constructed",
+        building: "Fire Pit",
+        coordinates: {
+          x: 1,
+          y: 2,
+        },
+      },
+      createdAt: date,
+    });
+    expect(state.buildings).toEqual({
+      "Fire Pit": [
+        {
+          coordinates: { x: 1, y: 1 },
+          createdAt: date,
+          readyAt: date + 30 * 1000,
+          id: "1",
+        },
+        {
+          coordinates: {
+            x: 1,
+            y: 2,
+          },
+          createdAt: date,
+          readyAt: date + 30 * 1000,
+          id: expect.any(String),
+        },
+      ],
+      Workbench: [
+        {
+          coordinates: { x: 2, y: 2 },
+          createdAt: date,
+          readyAt: date + 5 * 60 * 1000,
+          id: "2",
+        },
+      ],
+    });
+  });
+});

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "crypto";
+import Decimal from "decimal.js-light";
+import cloneDeep from "lodash.clonedeep";
+import { BuildingName, BUILDINGS } from "../../types/buildings";
+import { Building, GameState } from "../../types/game";
+
+// Generate a Unique ID for a building
+function generateBuildingId() {
+  return randomUUID();
+}
+
+export type ConstructBuildingAction = {
+  type: "building.constructed";
+  building: BuildingName;
+  coordinates: {
+    x: number;
+    y: number;
+  };
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: ConstructBuildingAction;
+  createdAt?: number;
+};
+
+export function constructBuilding({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  const stateCopy = cloneDeep(state);
+  const building = BUILDINGS[action.building];
+
+  if (stateCopy.bumpkin.level < building.levelRequired) {
+    throw new Error("Your Bumpkin does not meet the level requirements");
+  }
+
+  if (stateCopy.balance.lessThan(building.sfl)) {
+    throw new Error("Insufficient SFL");
+  }
+
+  const inventoryMinusIngredients = building.ingredients.reduce(
+    (inventory, ingredient) => {
+      const count = inventory[ingredient.item] || new Decimal(0);
+
+      if (count.lessThan(ingredient.amount)) {
+        throw new Error(`Insufficient ingredient: ${ingredient.item}`);
+      }
+
+      return {
+        ...inventory,
+        [ingredient.item]: count.sub(ingredient.amount),
+      };
+    },
+    stateCopy.inventory
+  );
+
+  const buildingInventory =
+    stateCopy.inventory[action.building] || new Decimal(0);
+  const placed = stateCopy.buildings[action.building] || [];
+
+  const newBuilding: Building = {
+    id: generateBuildingId(),
+    createdAt: createdAt,
+    coordinates: action.coordinates,
+    readyAt: createdAt + building.constructionSeconds * 1000,
+  };
+
+  return {
+    ...stateCopy,
+    balance: stateCopy.balance.sub(building.sfl),
+    inventory: {
+      ...inventoryMinusIngredients,
+      [action.building]: buildingInventory.add(1),
+    },
+    buildings: {
+      ...stateCopy.buildings,
+      [action.building]: [...placed, newBuilding],
+    },
+  };
+}

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -5,7 +5,7 @@ import { Building, GameState } from "../../types/game";
 
 export type ConstructBuildingAction = {
   type: "building.constructed";
-  building: BuildingName;
+  name: BuildingName;
   coordinates: {
     x: number;
     y: number;
@@ -24,7 +24,7 @@ export function constructBuilding({
   createdAt = Date.now(),
 }: Options): GameState {
   const stateCopy = cloneDeep(state);
-  const building = BUILDINGS[action.building];
+  const building = BUILDINGS[action.name];
 
   if (stateCopy.bumpkin.level < building.levelRequired) {
     throw new Error("Your Bumpkin does not meet the level requirements");
@@ -50,9 +50,8 @@ export function constructBuilding({
     stateCopy.inventory
   );
 
-  const buildingInventory =
-    stateCopy.inventory[action.building] || new Decimal(0);
-  const placed = stateCopy.buildings[action.building] || [];
+  const buildingInventory = stateCopy.inventory[action.name] || new Decimal(0);
+  const placed = stateCopy.buildings[action.name] || [];
 
   const newBuilding: Omit<Building, "id"> = {
     createdAt: createdAt,
@@ -65,11 +64,11 @@ export function constructBuilding({
     balance: stateCopy.balance.sub(building.sfl),
     inventory: {
       ...inventoryMinusIngredients,
-      [action.building]: buildingInventory.add(1),
+      [action.name]: buildingInventory.add(1),
     },
     buildings: {
       ...stateCopy.buildings,
-      [action.building]: [...placed, newBuilding],
+      [action.name]: [...placed, newBuilding],
     },
   };
 }

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
-import { Building, GameState } from "../../types/game";
+import { GameState, PlacedItem } from "../../types/game";
 
 export type ConstructBuildingAction = {
   type: "building.constructed";
@@ -53,7 +53,7 @@ export function constructBuilding({
   const buildingInventory = stateCopy.inventory[action.name] || new Decimal(0);
   const placed = stateCopy.buildings[action.name] || [];
 
-  const newBuilding: Omit<Building, "id"> = {
+  const newBuilding: Omit<PlacedItem, "id"> = {
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + building.constructionSeconds * 1000,

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -1,13 +1,7 @@
-import { randomUUID } from "crypto";
 import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
 import { Building, GameState } from "../../types/game";
-
-// Generate a Unique ID for a building
-function generateBuildingId() {
-  return randomUUID();
-}
 
 export type ConstructBuildingAction = {
   type: "building.constructed";
@@ -60,8 +54,7 @@ export function constructBuilding({
     stateCopy.inventory[action.building] || new Decimal(0);
   const placed = stateCopy.buildings[action.building] || [];
 
-  const newBuilding: Building = {
-    id: generateBuildingId(),
+  const newBuilding: Omit<Building, "id"> = {
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + building.constructionSeconds * 1000,

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -123,7 +123,6 @@ describe("Place building", () => {
       createdAt: date,
     });
     expect(state.buildings["Anvil"]?.[1]).toEqual({
-      id: expect.any(String),
       coordinates: { x: 0, y: 0 },
       readyAt: date + 5 * 60 * 1000,
       createdAt: date,

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -1,0 +1,156 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "../../lib/constants";
+import { BuildingName } from "../../types/buildings";
+import { GameState } from "../../types/game";
+import { placeBuilding } from "./placeBuilding";
+
+const date = Date.now();
+const GAME_STATE: GameState = INITIAL_FARM;
+describe("Place building", () => {
+  it("Requires a building is not already placed", () => {
+    expect(() =>
+      placeBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            "Fire Pit": new Decimal(1),
+          },
+          buildings: {
+            "Fire Pit": [
+              {
+                coordinates: {
+                  x: 1,
+                  y: 1,
+                },
+                createdAt: date,
+                id: "234",
+                readyAt: date + 10 * 1000,
+              },
+            ],
+          },
+        },
+
+        action: {
+          type: "building.placed",
+          building: "Fire Pit",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("This building is already placed");
+  });
+
+  it("Requires a building is on the inventory to be placed", () => {
+    expect(() =>
+      placeBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {},
+          buildings: {},
+        },
+
+        action: {
+          type: "building.placed",
+          building: "Fire Pit",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("You can't place a building that is not on the inventory");
+  });
+
+  it("Places a building", () => {
+    const state = placeBuilding({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Oven: new Decimal(1),
+        },
+        buildings: {},
+      },
+
+      action: {
+        type: "building.placed",
+        building: "Oven",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.buildings["Oven"]).toHaveLength(1);
+  });
+
+  it("Places multiple Anvils", () => {
+    const state = placeBuilding({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Anvil: new Decimal(2),
+        },
+        buildings: {
+          Anvil: [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              createdAt: date,
+              readyAt: date,
+            },
+          ],
+        },
+      },
+      createdAt: date,
+      action: {
+        type: "building.placed",
+        building: "Anvil",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.buildings["Anvil"]).toHaveLength(2);
+    expect(state.buildings["Anvil"]?.[0]).toEqual({
+      id: expect.any(String),
+      coordinates: { x: 1, y: 1 },
+      readyAt: date,
+      createdAt: date,
+    });
+    expect(state.buildings["Anvil"]?.[1]).toEqual({
+      id: expect.any(String),
+      coordinates: { x: 0, y: 0 },
+      readyAt: date + 5 * 60 * 1000,
+      createdAt: date,
+    });
+  });
+
+  it("Cannot place a crop", () => {
+    expect(() =>
+      placeBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Scarecrow: new Decimal(2),
+            Carrot: new Decimal(10),
+          },
+          buildings: {},
+        },
+
+        action: {
+          type: "building.placed",
+          building: "Carrot" as BuildingName,
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("You cannot place this item");
+  });
+});

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -32,7 +32,7 @@ describe("Place building", () => {
 
         action: {
           type: "building.placed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           coordinates: {
             x: 0,
             y: 0,
@@ -53,7 +53,7 @@ describe("Place building", () => {
 
         action: {
           type: "building.placed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           coordinates: {
             x: 0,
             y: 0,
@@ -75,7 +75,7 @@ describe("Place building", () => {
 
       action: {
         type: "building.placed",
-        building: "Oven",
+        name: "Oven",
         coordinates: {
           x: 0,
           y: 0,
@@ -107,7 +107,7 @@ describe("Place building", () => {
       createdAt: date,
       action: {
         type: "building.placed",
-        building: "Anvil",
+        name: "Anvil",
         coordinates: {
           x: 0,
           y: 0,
@@ -143,7 +143,7 @@ describe("Place building", () => {
 
         action: {
           type: "building.placed",
-          building: "Carrot" as BuildingName,
+          name: "Carrot" as BuildingName,
           coordinates: {
             x: 0,
             y: 0,

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,6 +1,6 @@
 import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
-import { GameState, Building } from "../../types/game";
+import { GameState, PlacedItem } from "../../types/game";
 
 export type PlaceBuildingAction = {
   type: "building.placed";
@@ -42,7 +42,7 @@ export function placeBuilding({
 
   const placed = stateCopy.buildings[action.name] || [];
 
-  const newBuilding: Omit<Building, "id"> = {
+  const newBuilding: Omit<PlacedItem, "id"> = {
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + 5 * 60 * 1000,

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -4,7 +4,7 @@ import { GameState, Building } from "../../types/game";
 
 export type PlaceBuildingAction = {
   type: "building.placed";
-  building: BuildingName;
+  name: BuildingName;
   coordinates: {
     x: number;
     y: number;
@@ -24,7 +24,7 @@ export function placeBuilding({
 }: Options): GameState {
   const stateCopy = cloneDeep(state);
 
-  const building = action.building;
+  const building = action.name;
   const buildingsItem = state.buildings[building];
   const inventoryItem = state.inventory[building];
 
@@ -40,7 +40,7 @@ export function placeBuilding({
     throw new Error("You cannot place this item");
   }
 
-  const placed = stateCopy.buildings[action.building] || [];
+  const placed = stateCopy.buildings[action.name] || [];
 
   const newBuilding: Omit<Building, "id"> = {
     createdAt: createdAt,

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,11 +1,6 @@
-import { randomUUID } from "crypto";
 import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
 import { GameState, Building } from "../../types/game";
-
-function generateBuildingId() {
-  return randomUUID();
-}
 
 export type PlaceBuildingAction = {
   type: "building.placed";
@@ -47,8 +42,7 @@ export function placeBuilding({
 
   const placed = stateCopy.buildings[action.building] || [];
 
-  const newBuilding: Building = {
-    id: generateBuildingId(),
+  const newBuilding: Omit<Building, "id"> = {
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + 5 * 60 * 1000,

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "crypto";
+import cloneDeep from "lodash.clonedeep";
+import { BuildingName, BUILDINGS } from "../../types/buildings";
+import { GameState, Building } from "../../types/game";
+
+function generateBuildingId() {
+  return randomUUID();
+}
+
+export type PlaceBuildingAction = {
+  type: "building.placed";
+  building: BuildingName;
+  coordinates: {
+    x: number;
+    y: number;
+  };
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: PlaceBuildingAction;
+  createdAt?: number;
+};
+
+export function placeBuilding({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  const stateCopy = cloneDeep(state);
+
+  const building = action.building;
+  const buildingsItem = state.buildings[building];
+  const inventoryItem = state.inventory[building];
+
+  if (!inventoryItem) {
+    throw new Error("You can't place a building that is not on the inventory");
+  }
+
+  if (buildingsItem && inventoryItem?.lessThanOrEqualTo(buildingsItem.length)) {
+    throw new Error("This building is already placed");
+  }
+
+  if (!(building in BUILDINGS)) {
+    throw new Error("You cannot place this item");
+  }
+
+  const placed = stateCopy.buildings[action.building] || [];
+
+  const newBuilding: Building = {
+    id: generateBuildingId(),
+    createdAt: createdAt,
+    coordinates: action.coordinates,
+    readyAt: createdAt + 5 * 60 * 1000,
+  };
+
+  return {
+    ...stateCopy,
+    buildings: {
+      ...stateCopy.buildings,
+      [building]: [...placed, newBuilding],
+    },
+  };
+}

--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -1,0 +1,157 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "../../lib/constants";
+import { CollectibleName } from "../../types/craftables";
+import { GameState } from "../../types/game";
+import { placeCollectible } from "./placeCollectible";
+
+const date = Date.now();
+const GAME_STATE: GameState = INITIAL_FARM;
+describe("Place Collectible", () => {
+  it("Requires a collectible is not already placed", () => {
+    expect(() =>
+      placeCollectible({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Scarecrow: new Decimal(1),
+          },
+          collectibles: {
+            Scarecrow: [
+              {
+                coordinates: {
+                  x: 1,
+                  y: 1,
+                },
+                createdAt: date,
+                id: "234",
+                readyAt: date + 10 * 1000,
+              },
+            ],
+          },
+        },
+
+        action: {
+          type: "collectible.placed",
+          name: "Scarecrow",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("This collectible is already placed");
+  });
+
+  it("Requires a collectible is on the inventory to be placed", () => {
+    expect(() =>
+      placeCollectible({
+        state: {
+          ...GAME_STATE,
+          inventory: {},
+          collectibles: {},
+        },
+
+        action: {
+          type: "collectible.placed",
+          name: "Scarecrow",
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("You can't place an item that is not on the inventory");
+  });
+
+  it("Places a collectible", () => {
+    const state = placeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Brazilian Flag": new Decimal(1),
+        },
+        collectibles: {},
+      },
+
+      action: {
+        type: "collectible.placed",
+        name: "Brazilian Flag",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.collectibles["Brazilian Flag"]).toHaveLength(1);
+  });
+
+  it("Places multiple scarecrows", () => {
+    const state = placeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Scarecrow: new Decimal(2),
+        },
+        collectibles: {
+          Scarecrow: [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              createdAt: date,
+              readyAt: date,
+            },
+          ],
+        },
+      },
+      createdAt: date,
+      action: {
+        type: "collectible.placed",
+        name: "Scarecrow",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    expect(state.collectibles["Scarecrow"]).toHaveLength(2);
+    expect(state.collectibles["Scarecrow"]?.[0]).toEqual({
+      id: expect.any(String),
+      coordinates: { x: 1, y: 1 },
+      readyAt: date,
+      createdAt: date,
+    });
+    expect(state.collectibles["Scarecrow"]?.[1]).toEqual({
+      id: expect.any(String),
+      coordinates: { x: 0, y: 0 },
+      readyAt: date + 5 * 60 * 1000,
+      createdAt: date,
+    });
+  });
+
+  it("Cannot place a building", () => {
+    expect(() =>
+      placeCollectible({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Scarecrow: new Decimal(2),
+            Carrot: new Decimal(10),
+            "Fire Pit": new Decimal(10),
+          },
+          collectibles: {},
+        },
+
+        action: {
+          type: "collectible.placed",
+          name: "Fire Pit" as CollectibleName,
+          coordinates: {
+            x: 0,
+            y: 0,
+          },
+        },
+      })
+    ).toThrow("You cannot place this item");
+  });
+});

--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -123,7 +123,6 @@ describe("Place Collectible", () => {
       createdAt: date,
     });
     expect(state.collectibles["Scarecrow"]?.[1]).toEqual({
-      id: expect.any(String),
       coordinates: { x: 0, y: 0 },
       readyAt: date + 5 * 60 * 1000,
       createdAt: date,

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -1,0 +1,64 @@
+import cloneDeep from "lodash.clonedeep";
+import {
+  CollectibleName,
+  COLLECTIBLES_DIMENSIONS,
+} from "../../types/craftables";
+import { GameState, Collectible } from "../../types/game";
+
+export type PlaceCollectibleAction = {
+  type: "collectible.placed";
+  name: CollectibleName;
+  coordinates: {
+    x: number;
+    y: number;
+  };
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: PlaceCollectibleAction;
+  createdAt?: number;
+};
+
+export function placeCollectible({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  console.log({ state });
+  const stateCopy = cloneDeep(state);
+  console.log({ collectible: action.name });
+  const collectible = action.name;
+  const collectibleItems = stateCopy.collectibles[collectible];
+  const inventoryItemBalance = stateCopy.inventory[collectible];
+
+  if (!inventoryItemBalance) {
+    throw new Error("You can't place an item that is not on the inventory");
+  }
+
+  if (
+    collectibleItems &&
+    inventoryItemBalance?.lessThanOrEqualTo(collectibleItems.length)
+  ) {
+    throw new Error("This collectible is already placed");
+  }
+
+  if (!(collectible in COLLECTIBLES_DIMENSIONS)) {
+    throw new Error("You cannot place this item");
+  }
+
+  const placed = stateCopy.collectibles[action.name] || [];
+  const newCollectiblePlacement: Omit<Collectible, "id"> = {
+    createdAt: createdAt,
+    coordinates: action.coordinates,
+    readyAt: createdAt + 5 * 60 * 1000,
+  };
+
+  return {
+    ...stateCopy,
+    collectibles: {
+      ...stateCopy.collectibles,
+      [collectible]: [...placed, newCollectiblePlacement],
+    },
+  };
+}

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -25,9 +25,7 @@ export function placeCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  console.log({ state });
   const stateCopy = cloneDeep(state);
-  console.log({ collectible: action.name });
   const collectible = action.name;
   const collectibleItems = stateCopy.collectibles[collectible];
   const inventoryItemBalance = stateCopy.inventory[collectible];

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -3,7 +3,7 @@ import {
   CollectibleName,
   COLLECTIBLES_DIMENSIONS,
 } from "../../types/craftables";
-import { GameState, Collectible } from "../../types/game";
+import { GameState, PlacedItem } from "features/game/types/game";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -46,7 +46,7 @@ export function placeCollectible({
   }
 
   const placed = stateCopy.collectibles[action.name] || [];
-  const newCollectiblePlacement: Omit<Collectible, "id"> = {
+  const newCollectiblePlacement: Omit<PlacedItem, "id"> = {
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + 5 * 60 * 1000,

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -234,7 +234,7 @@ export const Land: React.FC = () => {
                 height={height}
                 width={width}
               >
-                <div className="flex w-full h-full">
+                <div className="flex justify-center w-full h-full">
                   <img src={ITEM_DETAILS[name].image} alt={name} />
                 </div>
               </MapPlacement>

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -198,13 +198,13 @@ export const Land: React.FC = () => {
 
         {getKeys(buildings).flatMap((name) => {
           const items = buildings[name];
-          return items?.map((building) => {
+          return items?.map((building, index) => {
             const { x, y } = building.coordinates;
             const { width, height } = BUILDINGS_DIMENSIONS[name];
 
             return (
               <MapPlacement
-                key={building.id}
+                key={index}
                 x={x}
                 y={y}
                 height={height}
@@ -222,13 +222,13 @@ export const Land: React.FC = () => {
 
         {getKeys(collectibles).flatMap((name) => {
           const items = collectibles[name];
-          return items?.map((collectible) => {
+          return items?.map((collectible, index) => {
             const { x, y } = collectible.coordinates;
             const { width, height } = COLLECTIBLES_DIMENSIONS[name];
 
             return (
               <MapPlacement
-                key={collectible.id}
+                key={index}
                 x={x}
                 y={y}
                 height={height}

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -4,7 +4,7 @@ import { MapPlacement } from "./components/MapPlacement";
 import { useActor } from "@xstate/react";
 import { Context } from "../GameProvider";
 import { getTerrainImageByKey } from "../lib/getTerrainImageByKey";
-import { getKeys } from "../types/craftables";
+import { COLLECTIBLES_DIMENSIONS, getKeys } from "../types/craftables";
 import { Plot } from "features/farming/crops/components/landExpansion/Plot";
 import { Tree } from "./components/resources/Tree";
 import { Pebble } from "./components/resources/Pebble";
@@ -19,6 +19,7 @@ import { Stone } from "./components/resources/Stone";
 import { Placeable } from "./placeable/Placeable";
 import { BuildingName, BUILDINGS_DIMENSIONS } from "../types/buildings";
 import { Building } from "features/island/buildings/components/building/Building";
+import { ITEM_DETAILS } from "../types/images";
 
 type ExpansionProps = Pick<
   LandExpansion,
@@ -154,9 +155,7 @@ export const Land: React.FC = () => {
   const [gameState] = useActor(gameService);
   const { state } = gameState.context;
 
-  const { expansions } = state;
-
-  const buildings = gameState.context.state.buildings;
+  const { expansions, buildings, collectibles } = state;
 
   const [scrollIntoView] = useScrollIntoView();
 
@@ -216,6 +215,28 @@ export const Land: React.FC = () => {
                   building={building}
                   name={name as BuildingName}
                 />
+              </MapPlacement>
+            );
+          });
+        })}
+
+        {getKeys(collectibles).flatMap((name) => {
+          const items = collectibles[name];
+          return items?.map((collectible) => {
+            const { x, y } = collectible.coordinates;
+            const { width, height } = COLLECTIBLES_DIMENSIONS[name];
+
+            return (
+              <MapPlacement
+                key={collectible.id}
+                x={x}
+                y={y}
+                height={height}
+                width={width}
+              >
+                <div className="flex w-full h-full">
+                  <img src={ITEM_DETAILS[name].image} alt={name} />
+                </div>
               </MapPlacement>
             );
           });

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -17,7 +17,7 @@ import { TerrainPlacement } from "./components/TerrainPlacement";
 import { EXPANSION_ORIGINS } from "./lib/constants";
 import { Stone } from "./components/resources/Stone";
 import { Placeable } from "./placeable/Placeable";
-import { BuildingName, PLACEABLES_DIMENSIONS } from "../types/buildings";
+import { BuildingName, BUILDINGS_DIMENSIONS } from "../types/buildings";
 import { Building } from "features/island/buildings/components/building/Building";
 
 type ExpansionProps = Pick<
@@ -201,7 +201,7 @@ export const Land: React.FC = () => {
           const items = buildings[name];
           return items?.map((building) => {
             const { x, y } = building.coordinates;
-            const { width, height } = PLACEABLES_DIMENSIONS[name];
+            const { width, height } = BUILDINGS_DIMENSIONS[name];
 
             return (
               <MapPlacement

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -8,8 +8,9 @@ import Draggable from "react-draggable";
 import { detectCollision } from "./lib/collisionDetection";
 import classNames from "classnames";
 import { calculateZIndex, Coordinates } from "../components/MapPlacement";
-import { PLACEABLES_DIMENSIONS } from "features/game/types/buildings";
+import { BUILDINGS_DIMENSIONS } from "features/game/types/buildings";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 
 type Dimensions = {
   height: number;
@@ -29,7 +30,10 @@ export const Placeable: React.FC = () => {
   const [machine, send] = useActor(child);
 
   const { placeable, coordinates } = machine.context;
-  const { width, height } = PLACEABLES_DIMENSIONS[placeable];
+  const { width, height } = {
+    ...BUILDINGS_DIMENSIONS,
+    ...COLLECTIBLES_DIMENSIONS,
+  }[placeable];
   const { image } = ITEM_DETAILS[placeable];
 
   const handleImageLoad = (

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -60,21 +60,24 @@ export const Placeable: React.FC = () => {
 
   if (machine.matches("placed")) {
     return (
-      <div
-        className="absolute"
-        style={{
-          left: coordinates.x * GRID_WIDTH_PX,
-          top: -coordinates.y * GRID_WIDTH_PX,
-          height: imageDimensions.height * PIXEL_SCALE,
-          width: imageDimensions.width * PIXEL_SCALE,
-        }}
-      >
-        <img
-          draggable="false"
-          className="bulge h-full w-full"
-          src={image}
-          alt=""
-        />
+      <div className="absolute left-1/2 top-1/2">
+        <div
+          className="absolute"
+          style={{
+            left: coordinates.x * GRID_WIDTH_PX,
+            top: -coordinates.y * GRID_WIDTH_PX,
+            height: imageDimensions.height * PIXEL_SCALE,
+            width: imageDimensions.width * PIXEL_SCALE,
+          }}
+        >
+          <img
+            draggable="false"
+            className="bulge h-full w-full"
+            src={image}
+            alt=""
+            onLoad={handleImageLoad}
+          />
+        </div>
       </div>
     );
   }

--- a/src/features/game/expansion/placeable/editingMachine.ts
+++ b/src/features/game/expansion/placeable/editingMachine.ts
@@ -1,14 +1,12 @@
-import { PlacementEvent } from "features/game/events";
+import { GameEventName, PlacementEvent } from "features/game/events";
 import { BuildingName } from "features/game/types/buildings";
 import { CollectibleName } from "features/game/types/craftables";
 import { assign, createMachine, Interpreter, sendParent } from "xstate";
 import { Coordinates } from "../components/MapPlacement";
 
-export type PlaceableType = "building" | "collectible";
-
 export interface Context {
   placeable: BuildingName | CollectibleName;
-  placeableType: PlaceableType;
+  action: GameEventName<PlacementEvent>;
   coordinates: Coordinates;
   collisionDetected: boolean;
 }
@@ -21,12 +19,11 @@ type UpdateEvent = {
 
 type PlaceEvent = {
   type: "PLACE";
-  action: PlacementEvent;
 };
 
 type ConstructEvent = {
   type: "CONSTRUCT";
-  action: PlacementEvent;
+  actionName: PlacementEvent;
 };
 
 export type BlockchainEvent =
@@ -67,16 +64,15 @@ export const editingMachine = createMachine<
         DRAG: {
           target: "dragging",
         },
-        CONSTRUCT: {
-          target: "placed",
-          actions: sendParent<Context, ConstructEvent, PlacementEvent>(
-            (_, event) => event.action
-          ),
-        },
         PLACE: {
           target: "placed",
-          actions: sendParent<Context, ConstructEvent, PlacementEvent>(
-            (_, event) => event.action
+          actions: sendParent<Context, PlaceEvent, PlacementEvent>(
+            ({ placeable, action, coordinates: { x, y } }) =>
+              ({
+                type: action,
+                name: placeable,
+                coordinates: { x, y },
+              } as PlacementEvent)
           ),
         },
       },

--- a/src/features/game/expansion/placeable/editingMachine.ts
+++ b/src/features/game/expansion/placeable/editingMachine.ts
@@ -1,12 +1,13 @@
 import { GameEventName, PlacementEvent } from "features/game/events";
-import { BuildingName } from "features/game/types/buildings";
+import { BuildingName, BUILDINGS } from "features/game/types/buildings";
+import { CollectibleName } from "features/game/types/craftables";
 import { assign, createMachine, Interpreter, sendParent } from "xstate";
 import { Coordinates } from "../components/MapPlacement";
 
-export type PlaceableType = "building" | "collectable";
+export type PlaceableType = "building" | "collectible";
 
 export interface Context {
-  placeable: BuildingName;
+  placeable: BuildingName | CollectibleName;
   placeableType: PlaceableType;
   coordinates: Coordinates;
   collisionDetected: boolean;
@@ -39,6 +40,12 @@ export type BlockchainState = {
   context: Context;
 };
 
+function getTypedPlaceable(placeable: BuildingName | CollectibleName) {
+  if (placeable in BUILDINGS) return placeable as BuildingName;
+
+  return placeable as CollectibleName;
+}
+
 export type MachineInterpreter = Interpreter<
   Context,
   any,
@@ -68,8 +75,8 @@ export const editingMachine = createMachine<
           target: "placed",
           actions: sendParent<Context, ConstructEvent, PlacementEvent>(
             ({ placeable, placeableType, coordinates: { x, y } }) => ({
-              type: `${placeableType}.constructed` as GameEventName<PlacementEvent>,
-              name: placeable,
+              type: `${placeableType}.placed` as GameEventName<PlacementEvent>,
+              name: placeable as BuildingName,
               coordinates: { x, y },
             })
           ),

--- a/src/features/game/expansion/placeable/editingMachine.ts
+++ b/src/features/game/expansion/placeable/editingMachine.ts
@@ -66,7 +66,7 @@ export const editingMachine = createMachine<
         },
         PLACE: {
           target: "placed",
-          actions: sendParent<Context, PlaceEvent, PlacementEvent>(
+          actions: sendParent(
             ({ placeable, action, coordinates: { x, y } }) =>
               ({
                 type: action,

--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -7,7 +7,7 @@ import {
   isOverlapping,
 } from "./collisionDetection";
 
-describe("extractResourcePositions", () => {
+describe("extractResourceBoundingBoxes", () => {
   it("returns a list of all resource positions", () => {
     const position1: Position = { x: 1, y: 1, height: 1, width: 1 };
     const position2: Position = { x: 3, y: 1, height: 1, width: 1 };
@@ -128,6 +128,58 @@ describe("detectCollisions", () => {
       y: 3,
       width: 1,
       height: 1,
+    });
+
+    expect(hasCollision).toBe(true);
+  });
+
+  it("returns true if a collision is detected with a building", () => {
+    const state: GameState = cloneDeep(INITIAL_FARM);
+    state.buildings = {
+      "Fire Pit": [
+        {
+          id: "123",
+          coordinates: {
+            x: 3,
+            y: 3,
+          },
+          readyAt: 0,
+          createdAt: 0,
+        },
+      ],
+    };
+
+    const hasCollision = detectCollision(state, {
+      x: 3,
+      y: 3,
+      height: 1,
+      width: 1,
+    });
+
+    expect(hasCollision).toBe(true);
+  });
+
+  it("returns true if a collision is detected with a collectible", () => {
+    const state: GameState = cloneDeep(INITIAL_FARM);
+    state.collectibles = {
+      "Farm Cat": [
+        {
+          id: "123",
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+          readyAt: 0,
+          createdAt: 0,
+        },
+      ],
+    };
+
+    const hasCollision = detectCollision(state, {
+      x: 1,
+      y: 1,
+      height: 1,
+      width: 1,
     });
 
     expect(hasCollision).toBe(true);

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -342,6 +342,7 @@ export const INITIAL_FARM: GameState = {
       sfl: 3,
     },
   ],
+  collectibles: {},
 };
 
 export const EMPTY: GameState = {
@@ -371,4 +372,5 @@ export const EMPTY: GameState = {
   expansions: INITIAL_EXPANSIONS,
   bumpkin: { level: 1 },
   buildings: {},
+  collectibles: {},
 };

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -1,4 +1,10 @@
-import { createMachine, Interpreter, assign, TransitionsConfig } from "xstate";
+import {
+  createMachine,
+  Interpreter,
+  assign,
+  TransitionsConfig,
+  State,
+} from "xstate";
 import {
   PLAYING_EVENTS,
   PlacementEvent,
@@ -33,6 +39,7 @@ import { expand } from "../expansion/actions/expand";
 import { checkProgress, processEvent } from "./processEvent";
 import { editingMachine } from "../expansion/placeable/editingMachine";
 import { BuildingName } from "../types/buildings";
+import { Context } from "../GameProvider";
 
 export type PastAction = GameEvent & {
   createdAt: Date;
@@ -200,6 +207,8 @@ export type BlockchainState = {
 
 export type StateKeys = keyof Omit<BlockchainState, "context">;
 export type StateValues = BlockchainState[StateKeys];
+
+export type MachineState = State<Context, BlockchainEvent, BlockchainState>;
 
 export type MachineInterpreter = Interpreter<
   Context,

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -5,6 +5,7 @@ import {
   PLACEMENT_EVENTS,
   GameEvent,
   PlayingEvent,
+  GameEventName,
 } from "../events";
 
 import { Context as AuthContext } from "features/auth/lib/authMachine";
@@ -14,7 +15,7 @@ import { GameState, InventoryItemName } from "../types/game";
 import { loadSession, MintedAt } from "../actions/loadSession";
 import { INITIAL_FARM, EMPTY } from "./constants";
 import { autosave } from "../actions/autosave";
-import { LimitedItemName } from "../types/craftables";
+import { CollectibleName, LimitedItemName } from "../types/craftables";
 import { sync } from "../actions/sync";
 import { getOnChainState } from "../actions/onchain";
 import { ErrorCode, ERRORS } from "lib/errors";
@@ -30,10 +31,8 @@ import {
 import { OnChainEvent, unseenEvents } from "../actions/onChainEvents";
 import { expand } from "../expansion/actions/expand";
 import { checkProgress, processEvent } from "./processEvent";
-import {
-  editingMachine,
-  PlaceableType,
-} from "../expansion/placeable/editingMachine";
+import { editingMachine } from "../expansion/placeable/editingMachine";
+import { BuildingName } from "../types/buildings";
 
 export type PastAction = GameEvent & {
   createdAt: Date;
@@ -78,8 +77,8 @@ type SyncEvent = {
 };
 
 type EditEvent = {
-  placeable: string;
-  placeableType: PlaceableType;
+  placeable: BuildingName | CollectibleName;
+  action: GameEventName<PlacementEvent>;
   type: "EDIT";
 };
 
@@ -630,8 +629,7 @@ export function startGame(authContext: Options) {
             src: editingMachine,
             data: {
               placeable: (_: Context, event: EditEvent) => event.placeable,
-              placeableType: (_: Context, event: EditEvent) =>
-                event.placeableType,
+              action: (_: Context, event: EditEvent) => event.action,
               coordinates: { x: 0, y: 0 },
               collisionDetected: true,
             },

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -106,6 +106,7 @@ export function makeGame(farm: any): GameState {
     bumpkin: farm.bumpkin || { level: 1 },
     buildings: farm.buildings,
     airdrops: farm.airdrops,
+    collectibles: farm.collectibles,
   };
 }
 

--- a/src/features/game/types/buildings.ts
+++ b/src/features/game/types/buildings.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
-import { BlacksmithItem, getKeys, BarnItem, MarketItem } from "./craftables";
-import { Flag, FLAGS } from "./flags";
+import { BlacksmithItem, BarnItem, MarketItem, Dimensions } from "./craftables";
+import { Flag } from "./flags";
 import { InventoryItemName } from "./game";
 
 export type BuildingName =
@@ -116,68 +116,7 @@ export const BUILDINGS: Record<BuildingName, BuildingBluePrint> = {
   },
 };
 
-type Dimensions = { width: number; height: number };
-
-type Placeables = Record<PlaceableName, Dimensions>;
-
-const flagsDimension = getKeys(FLAGS).reduce(
-  (previous, flagName) => ({
-    ...previous,
-    [flagName]: {
-      height: 0,
-      width: 0,
-    },
-  }),
-  {} as Record<Flag, Dimensions>
-);
-
-export const PLACEABLES_DIMENSIONS: Placeables = {
-  // Salesman Items
-  "Wicker Man": { height: 1, width: 1 },
-  "Golden Bonsai": { height: 1, width: 1 },
-
-  // Flags
-  ...flagsDimension,
-
-  // Blacksmith Items
-  "Sunflower Statue": { width: 2, height: 2 },
-  "Potato Statue": { width: 1, height: 1 },
-  "Christmas Tree": { width: 2, height: 2 },
-  Gnome: { width: 1, height: 1 },
-  "Sunflower Tombstone": { width: 1, height: 1 },
-  "Sunflower Rock": { width: 4, height: 3 },
-  "Goblin Crown": { width: 1, height: 1 },
-  Fountain: { width: 2, height: 2 },
-  "Woody the Beaver": { width: 1, height: 1 },
-  "Apprentice Beaver": { width: 1, height: 1 },
-  "Foreman Beaver": { width: 1, height: 1 },
-  "Nyon Statue": { width: 2, height: 1 },
-  "Homeless Tent": { width: 2, height: 2 },
-  "Farmer Bath": { width: 2, height: 3 },
-  "Mysterious Head": { width: 2, height: 1 },
-  "Rock Golem": { width: 2, height: 3 },
-  "Tunnel Mole": { width: 1, height: 1 },
-  "Rocky the Mole": { width: 1, height: 1 },
-  Nugget: { width: 1, height: 1 },
-
-  // Market Items
-  Scarecrow: { height: 2, width: 2 },
-  Nancy: { width: 2, height: 2 },
-  Kuebiko: { width: 2, height: 2 },
-  "Golden Cauliflower": { width: 1, height: 1 },
-  "Mysterious Parsnip": { width: 1, height: 1 },
-  "Carrot Sword": { width: 1, height: 1 },
-
-  // Barn Items
-  "Farm Cat": { width: 1, height: 1 },
-  "Farm Dog": { width: 1, height: 1 },
-  "Chicken Coop": { width: 2, height: 2 },
-  "Gold Egg": { width: 1, height: 1 },
-  "Easter Bunny": { width: 2, height: 1 },
-  Rooster: { height: 1, width: 1 },
-  "Egg Basket": { height: 1, width: 1 },
-
-  // Buildings
+export const BUILDINGS_DIMENSIONS: Record<BuildingName, Dimensions> = {
   "Fire Pit": { height: 1, width: 1 },
   Oven: { height: 1, width: 1 },
   Bakery: { height: 3, width: 3 },

--- a/src/features/game/types/buildings.ts
+++ b/src/features/game/types/buildings.ts
@@ -47,7 +47,7 @@ export const BUILDINGS: Record<BuildingName, BuildingBluePrint> = {
         amount: new Decimal(3),
       },
     ],
-    sfl: new Decimal(2),
+    sfl: new Decimal(0),
     constructionSeconds: 30,
   },
   Oven: {

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -24,7 +24,7 @@ export type CraftableName =
   | Animal
   | Flag
   | Shovel
-  | TravellingSalesmanItem;
+  | TravelingSalesmanItem;
 
 export interface Craftable {
   name: CraftableName;
@@ -78,7 +78,7 @@ export interface LimitedItem extends CraftableItem {
 
 export type MOMEventItem = "Engine Core" | "Observatory";
 
-export type TravellingSalesmanItem = "Wicker Man" | "Golden Bonsai";
+export type TravelingSalesmanItem = "Wicker Man" | "Golden Bonsai";
 
 export type QuestItem =
   | "Goblin Key"
@@ -132,6 +132,13 @@ export type LimitedItemName =
   | MOMEventItem
   | QuestItem
   | MutantChicken;
+
+export type CollectibleName =
+  | BlacksmithItem
+  | BarnItem
+  | MarketItem
+  | Flag
+  | TravelingSalesmanItem;
 
 export type Tool =
   | "Axe"
@@ -544,7 +551,7 @@ export const QUEST_ITEMS: Record<QuestItem, LimitedItem> = {
   },
 };
 
-export const SALESMAN_ITEMS: Record<TravellingSalesmanItem, LimitedItem> = {
+export const SALESMAN_ITEMS: Record<TravelingSalesmanItem, LimitedItem> = {
   "Wicker Man": {
     name: "Wicker Man",
     description:
@@ -935,4 +942,64 @@ export const isLimitedItem = (itemName: any) => {
   return !!getKeys(LIMITED_ITEMS).find(
     (limitedItemName) => limitedItemName === itemName
   );
+};
+
+export type Dimensions = { width: number; height: number };
+
+const flagsDimension = getKeys(FLAGS).reduce(
+  (previous, flagName) => ({
+    ...previous,
+    [flagName]: {
+      height: 0,
+      width: 0,
+    },
+  }),
+  {} as Record<Flag, Dimensions>
+);
+
+export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
+  // Salesman Items
+  "Wicker Man": { height: 1, width: 1 },
+  "Golden Bonsai": { height: 1, width: 1 },
+
+  // Flags
+  ...flagsDimension,
+
+  // Blacksmith Items
+  "Sunflower Statue": { width: 2, height: 2 },
+  "Potato Statue": { width: 1, height: 1 },
+  "Christmas Tree": { width: 2, height: 2 },
+  Gnome: { width: 1, height: 1 },
+  "Sunflower Tombstone": { width: 1, height: 1 },
+  "Sunflower Rock": { width: 4, height: 3 },
+  "Goblin Crown": { width: 1, height: 1 },
+  Fountain: { width: 2, height: 2 },
+  "Woody the Beaver": { width: 1, height: 1 },
+  "Apprentice Beaver": { width: 1, height: 1 },
+  "Foreman Beaver": { width: 1, height: 1 },
+  "Nyon Statue": { width: 2, height: 1 },
+  "Homeless Tent": { width: 2, height: 2 },
+  "Farmer Bath": { width: 2, height: 3 },
+  "Mysterious Head": { width: 2, height: 2 },
+  "Rock Golem": { width: 2, height: 3 },
+  "Tunnel Mole": { width: 1, height: 1 },
+  "Rocky the Mole": { width: 1, height: 1 },
+  Nugget: { width: 1, height: 1 },
+
+  // Market Items
+  Scarecrow: { height: 2, width: 2 },
+  Nancy: { width: 2, height: 2 },
+  Kuebiko: { width: 2, height: 2 },
+  "Golden Cauliflower": { width: 1, height: 1 },
+  "Mysterious Parsnip": { width: 1, height: 1 },
+  "Carrot Sword": { width: 1, height: 1 },
+
+  // Barn Items
+  "Farm Cat": { width: 1, height: 1 },
+  "Farm Dog": { width: 1, height: 1 },
+  "Chicken Coop": { width: 2, height: 2 },
+  "Gold Egg": { width: 1, height: 1 },
+  "Easter Bunny": { width: 2, height: 1 },
+  Rooster: { height: 1, width: 1 },
+  "Egg Basket": { height: 1, width: 1 },
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1,11 +1,11 @@
 import { Decimal } from "decimal.js-light";
 
 import { CropName, SeedName } from "./crops";
-import { CraftableName, Food, Ingredient } from "./craftables";
+import { CollectibleName, CraftableName, Food, Ingredient } from "./craftables";
 import { ResourceName } from "./resources";
 import { SkillName } from "./skills";
 import { TerrainTypeEnum } from "../lib/getTerrainImageByKey";
-import { BuildingName, PlaceableName } from "./buildings";
+import { BuildingName } from "./buildings";
 import { GameEvent } from "../events";
 
 export type CropReward = {
@@ -196,9 +196,16 @@ export type Building = {
   createdAt: number;
 };
 
-export type Buildings = Partial<
-  Record<PlaceableName | BuildingName, Building[]>
->;
+export type Collectible = {
+  id: string;
+  coordinates: { x: number; y: number };
+  readyAt: number;
+  createdAt: number;
+};
+
+export type Buildings = Partial<Record<BuildingName, Building[]>>;
+
+export type Collectibles = Partial<Record<CollectibleName, Collectible[]>>;
 
 export type LandExpansion = {
   createdAt: number;
@@ -260,6 +267,7 @@ export interface GameState {
   expansionRequirements?: ExpansionRequirements;
   bumpkin: Bumpkin;
   buildings: Buildings;
+  collectibles: Collectibles;
 }
 
 export interface Context {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -189,23 +189,15 @@ export type LandExpansionPlot = {
   crop?: PlantedCrop;
 } & Position;
 
-export type Building = {
+export type PlacedItem = {
   id: string;
   coordinates: { x: number; y: number };
   readyAt: number;
   createdAt: number;
 };
 
-export type Collectible = {
-  id: string;
-  coordinates: { x: number; y: number };
-  readyAt: number;
-  createdAt: number;
-};
-
-export type Buildings = Partial<Record<BuildingName, Building[]>>;
-
-export type Collectibles = Partial<Record<CollectibleName, Collectible[]>>;
+export type Buildings = Partial<Record<BuildingName, PlacedItem[]>>;
+export type Collectibles = Partial<Record<CollectibleName, PlacedItem[]>>;
 
 export type LandExpansion = {
   createdAt: number;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1,5 +1,4 @@
 import { Decimal } from "decimal.js-light";
-import { GameEvent } from "../events";
 
 import { CropName, SeedName } from "./crops";
 import { CraftableName, Food, Ingredient } from "./craftables";
@@ -7,6 +6,7 @@ import { ResourceName } from "./resources";
 import { SkillName } from "./skills";
 import { TerrainTypeEnum } from "../lib/getTerrainImageByKey";
 import { BuildingName, PlaceableName } from "./buildings";
+import { GameEvent } from "../events";
 
 export type CropReward = {
   items: {

--- a/src/features/goblins/trader/buying/Buying.tsx
+++ b/src/features/goblins/trader/buying/Buying.tsx
@@ -27,7 +27,7 @@ export const Buying: React.FC = () => {
     return (
       <Idle
         visitingFarmId={machine.context.visitingFarmId}
-        vistingFarmSlots={machine.context.vistingFarmSlots}
+        vistingFarmSlots={machine.context.visitingFarmSlots}
         balance={goblinState.context.state.balance}
         onVisit={(farmId) => buyingService.send("LOAD_FARM", { farmId })}
         onPurchase={(listing) => buyingService.send("PURCHASE", { listing })}

--- a/src/features/goblins/trader/buying/lib/buyingMachine.ts
+++ b/src/features/goblins/trader/buying/lib/buyingMachine.ts
@@ -8,7 +8,7 @@ interface Context {
   token: string;
 
   visitingFarmId: number;
-  vistingFarmSlots: FarmSlot[];
+  visitingFarmSlots: FarmSlot[];
   purchasingListing: Listing;
 }
 
@@ -64,7 +64,7 @@ export const buyingMachine = createMachine<
           onDone: {
             target: "idle",
             actions: assign((_, event) => ({
-              vistingFarmSlots: event.data.farmSlots,
+              visitingFarmSlots: event.data.farmSlots,
             })),
           },
         },

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -2,8 +2,7 @@ import React, { useRef, useState } from "react";
 import classNames from "classnames";
 
 import { BuildingName } from "features/game/types/buildings";
-import { Building as IBuilding } from "features/game/types/game";
-
+import { PlacedItem as IBuilding } from "features/game/types/game";
 import { FirePit } from "./FirePit";
 import { TimeLeftOverlay } from "components/ui/TimeLeftOverlay";
 import { Bar } from "components/ui/ProgressBar";

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -18,7 +18,7 @@ type BuildingProp = {
   id: string;
 };
 
-const BUIDLING_COMPONENTS: Record<BuildingName, React.FC<BuildingProp>> = {
+const BUILDING_COMPONENTS: Record<BuildingName, React.FC<BuildingProp>> = {
   "Fire Pit": FirePit,
   Anvil: () => null,
   Bakery: () => null,
@@ -30,7 +30,7 @@ export const Building: React.FC<Prop> = ({ name, building, id }) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const BuildingPlaced = BUIDLING_COMPONENTS[name];
+  const BuildingPlaced = BUILDING_COMPONENTS[name];
 
   const inProgress = building.readyAt > Date.now();
 

--- a/src/features/island/buildings/components/ui/ModalContent.tsx
+++ b/src/features/island/buildings/components/ui/ModalContent.tsx
@@ -6,6 +6,7 @@ import { BuildingName } from "features/game/types/buildings";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { ListView } from "./ListView";
 import { DetailView } from "./DetailView";
+import Decimal from "decimal.js-light";
 
 export const ModalContent: React.FC<{ closeModal: () => void }> = ({
   closeModal,
@@ -16,12 +17,18 @@ export const ModalContent: React.FC<{ closeModal: () => void }> = ({
 
   const [selected, setSelected] = useState<BuildingName | null>(null);
 
-  const state = game.context.state;
+  const { state } = game.context;
+  const { inventory } = state;
 
   const handleBuild = () => {
+    if (!selected) return;
+
+    const inventoryCount = inventory[selected] || new Decimal(0);
+    const hasBuilding = inventoryCount.gt(0);
+
     gameService.send("EDIT", {
       placeable: selected,
-      placeableType: "building",
+      action: hasBuilding ? "building.placed" : "building.constructed",
     });
     closeModal();
     scrollIntoView(Section.GenesisBlock);

--- a/src/features/island/buildings/components/ui/ModalContent.tsx
+++ b/src/features/island/buildings/components/ui/ModalContent.tsx
@@ -19,7 +19,10 @@ export const ModalContent: React.FC<{ closeModal: () => void }> = ({
   const state = game.context.state;
 
   const handleBuild = () => {
-    gameService.send("EDIT", { placeable: selected });
+    gameService.send("EDIT", {
+      placeable: selected,
+      placeableType: "building",
+    });
     closeModal();
     scrollIntoView(Section.GenesisBlock);
   };

--- a/src/features/island/buildings/components/ui/ModalContent.tsx
+++ b/src/features/island/buildings/components/ui/ModalContent.tsx
@@ -6,7 +6,6 @@ import { BuildingName } from "features/game/types/buildings";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { ListView } from "./ListView";
 import { DetailView } from "./DetailView";
-import Decimal from "decimal.js-light";
 
 export const ModalContent: React.FC<{ closeModal: () => void }> = ({
   closeModal,
@@ -18,17 +17,13 @@ export const ModalContent: React.FC<{ closeModal: () => void }> = ({
   const [selected, setSelected] = useState<BuildingName | null>(null);
 
   const { state } = game.context;
-  const { inventory } = state;
 
   const handleBuild = () => {
     if (!selected) return;
 
-    const inventoryCount = inventory[selected] || new Decimal(0);
-    const hasBuilding = inventoryCount.gt(0);
-
     gameService.send("EDIT", {
       placeable: selected,
-      action: hasBuilding ? "building.placed" : "building.constructed",
+      action: "building.constructed",
     });
     closeModal();
     scrollIntoView(Section.GenesisBlock);

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { Box } from "components/ui/Box";
 import { OuterPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -6,7 +6,7 @@ import { GameState, InventoryItemName } from "features/game/types/game";
 
 import classNames from "classnames";
 import { useShowScrollbar } from "lib/utils/hooks/useShowScrollbar";
-import { useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
+import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import {
   getKeys,
   LimitedItemName,
@@ -16,16 +16,19 @@ import { getChestItems } from "./utils/inventory";
 import Decimal from "decimal.js-light";
 import { Button } from "components/ui/Button";
 import chest from "assets/npcs/synced.gif";
+import { Context } from "features/game/GameProvider";
 
 const ITEM_CARD_MIN_HEIGHT = "148px";
 
 interface Props {
   state: GameState;
+  closeModal: () => void;
 }
 
 const TAB_CONTENT_HEIGHT = 400;
 
-export const Chest: React.FC<Props> = ({ state }: Props) => {
+export const Chest: React.FC<Props> = ({ state, closeModal }: Props) => {
+  const { gameService } = useContext(Context);
   const { ref: itemContainerRef, showScrollbar } =
     useShowScrollbar(TAB_CONTENT_HEIGHT);
   const [scrollIntoView] = useScrollIntoView();
@@ -42,6 +45,15 @@ export const Chest: React.FC<Props> = ({ state }: Props) => {
   const [selected, setSelected] = useState<InventoryItemName>(
     getKeys(collectibles)[0]
   );
+
+  const handlePlace = () => {
+    gameService.send("EDIT", {
+      placeable: selected,
+      placeableType: "collectible",
+    });
+    closeModal();
+    scrollIntoView(Section.GenesisBlock);
+  };
 
   const handleItemClick = (item: InventoryItemName) => {
     setSelected(item);
@@ -85,7 +97,9 @@ export const Chest: React.FC<Props> = ({ state }: Props) => {
               <span className="text-xs text-shadow text-center mt-2 w-80">
                 {ITEM_DETAILS[selected].description}
               </span>
-              <Button className="text-xs w-2/4 mt-2">Place on Map</Button>
+              <Button className="text-xs w-full mt-2" onClick={handlePlace}>
+                Place on Map
+              </Button>
             </div>
           )}
         </OuterPanel>

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -49,7 +49,7 @@ export const Chest: React.FC<Props> = ({ state, closeModal }: Props) => {
   const handlePlace = () => {
     gameService.send("EDIT", {
       placeable: selected,
-      placeableType: "collectible",
+      action: "collectible.placed",
     });
     closeModal();
     scrollIntoView(Section.GenesisBlock);

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -55,7 +55,6 @@ export const Inventory: React.FC<Props> = ({
         <InventoryItems
           state={state}
           onClose={() => setIsOpen(false)}
-          shortcutItem={shortcutItem}
           isFarming={isFarming}
         />
       </Modal>

--- a/src/features/island/hud/components/inventory/InventoryItems.tsx
+++ b/src/features/island/hud/components/inventory/InventoryItems.tsx
@@ -8,118 +8,27 @@ import close from "assets/icons/close.png";
 import { Panel } from "components/ui/Panel";
 import { Tab } from "components/ui/Tab";
 
-import { SEEDS, CROPS } from "features/game/types/crops";
-import {
-  FOODS,
-  TOOLS,
-  FLAGS,
-  BLACKSMITH_ITEMS,
-  BARN_ITEMS,
-  MARKET_ITEMS,
-  ROCKET_ITEMS,
-  getKeys,
-  QUEST_ITEMS,
-  MUTANT_CHICKENS,
-  SHOVELS,
-  SALESMAN_ITEMS,
-} from "features/game/types/craftables";
-import { RESOURCES } from "features/game/types/resources";
-
 import Decimal from "decimal.js-light";
 import { Basket } from "./Basket";
-import { ITEM_DETAILS } from "features/game/types/images";
 import { Chest } from "./Chest";
 
 type Tab = "basket" | "chest";
 
 interface Props {
   state: GameState;
-  shortcutItem?: (item: InventoryItemName) => void;
   onClose: () => void;
   isFarming?: boolean;
 }
 
 export type TabItems = Record<string, { items: object }>;
 
-const BASKET_CATEGORIES: TabItems = {
-  Seeds: {
-    items: SEEDS(),
-  },
-  Tools: {
-    items: {
-      ...TOOLS,
-      ...SHOVELS,
-    },
-  },
-  Resources: {
-    items: RESOURCES,
-  },
-  Crops: {
-    items: CROPS(),
-  },
-};
-
-const COLLECTIBLE_CATEGORIES: TabItems = {
-  NFTs: {
-    items: {
-      ...BLACKSMITH_ITEMS,
-      ...BARN_ITEMS,
-      ...MARKET_ITEMS,
-      ...FLAGS,
-      ...ROCKET_ITEMS,
-      ...MUTANT_CHICKENS,
-      ...SALESMAN_ITEMS,
-    },
-  },
-  "Quest Items": {
-    items: QUEST_ITEMS,
-  },
-  Foods: {
-    items: FOODS(),
-  },
-  "Easter Eggs": {
-    items: {
-      "Pink Egg": ITEM_DETAILS["Pink Egg"],
-      "Purple Egg": ITEM_DETAILS["Purple Egg"],
-      "Red Egg": ITEM_DETAILS["Red Egg"],
-      "Blue Egg": ITEM_DETAILS["Blue Egg"],
-      "Orange Egg": ITEM_DETAILS["Orange Egg"],
-      "Green Egg": ITEM_DETAILS["Green Egg"],
-      "Yellow Egg": ITEM_DETAILS["Yellow Egg"],
-    },
-  },
-};
-
 export type Inventory = Partial<Record<InventoryItemName, Decimal>>;
 
-const makeInventoryItems = (inventory: Inventory) => {
-  const items = getKeys(inventory) as InventoryItemName[];
-  return items.filter(
-    (itemName) => !!inventory[itemName] && !inventory[itemName]?.equals(0)
-  );
-};
-
-export const InventoryItems: React.FC<Props> = ({
-  state,
-  onClose,
-  shortcutItem,
-}) => {
+export const InventoryItems: React.FC<Props> = ({ state, onClose }) => {
   const [currentTab, setCurrentTab] = useState<Tab>("basket");
-  const [inventoryItems] = useState<InventoryItemName[]>(
-    makeInventoryItems(state.inventory)
-  );
-  const [selectedItem, setSelectedItem] = useState<InventoryItemName>();
 
   const handleTabClick = (tab: Tab) => {
     setCurrentTab(tab);
-  };
-
-  const handleItemSelected = (item: InventoryItemName) => {
-    if (shortcutItem) {
-      shortcutItem(item);
-    }
-
-    setSelectedItem(item);
   };
 
   return (
@@ -155,7 +64,7 @@ export const InventoryItems: React.FC<Props> = ({
       </div>
 
       {currentTab === "basket" && <Basket />}
-      {currentTab === "chest" && <Chest state={state} />}
+      {currentTab === "chest" && <Chest state={state} closeModal={onClose} />}
     </Panel>
   );
 };

--- a/src/features/island/hud/components/inventory/chest.test.ts
+++ b/src/features/island/hud/components/inventory/chest.test.ts
@@ -9,7 +9,7 @@ describe("chest", () => {
   it("creates an empty chest", () => {
     const chest = getChestItems({
       ...GAME_STATE,
-      buildings: {},
+      collectibles: {},
     });
 
     expect(chest).toEqual({});
@@ -22,7 +22,7 @@ describe("chest", () => {
         "Farm Cat": new Decimal(2),
         "Woody the Beaver": new Decimal(1),
       },
-      buildings: {},
+      collectibles: {},
     });
 
     expect(chest).toEqual({
@@ -44,7 +44,7 @@ describe("chest", () => {
         "Fire Pit": new Decimal(1),
         "Foreman Beaver": new Decimal(1),
       },
-      buildings: {
+      collectibles: {
         Scarecrow: [
           {
             coordinates: { x: 1, y: 1 },
@@ -57,7 +57,6 @@ describe("chest", () => {
     });
 
     expect(chest).toEqual({
-      "Fire Pit": new Decimal(1),
       "Foreman Beaver": new Decimal(1),
     });
   });
@@ -70,7 +69,7 @@ describe("chest", () => {
         "Foreman Beaver": new Decimal(1),
         Scarecrow: new Decimal(1),
       },
-      buildings: {
+      collectibles: {
         Scarecrow: [
           {
             coordinates: { x: 1, y: 1 },
@@ -82,7 +81,6 @@ describe("chest", () => {
       },
     });
     expect(chest).toEqual({
-      "Fire Pit": new Decimal(1),
       "Foreman Beaver": new Decimal(1),
     });
   });

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -18,7 +18,10 @@ export const getBasketItems = (inventory: Inventory) => {
 
 export const getChestItems = (state: GameState) => {
   return getKeys(state.inventory).reduce((acc, itemName) => {
-    if (itemName in COLLECTIBLES_DIMENSIONS && !(itemName in state.buildings)) {
+    if (
+      itemName in COLLECTIBLES_DIMENSIONS &&
+      !(itemName in state.collectibles)
+    ) {
       return {
         ...acc,
         [itemName]: state.inventory[itemName],

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -1,11 +1,17 @@
 import { Inventory } from "components/InventoryItems";
+import { BUILDINGS_DIMENSIONS } from "features/game/types/buildings";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 
+const PLACEABLE_DIMENSIONS = {
+  ...BUILDINGS_DIMENSIONS,
+  ...COLLECTIBLES_DIMENSIONS,
+};
+
 export const getBasketItems = (inventory: Inventory) => {
   return getKeys(inventory).reduce((acc, itemName) => {
-    if (itemName in COLLECTIBLES_DIMENSIONS) {
+    if (itemName in PLACEABLE_DIMENSIONS) {
       return acc;
     }
 

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -1,11 +1,11 @@
 import { Inventory } from "components/InventoryItems";
-import { PLACEABLES_DIMENSIONS } from "features/game/types/buildings";
+import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 
 export const getBasketItems = (inventory: Inventory) => {
   return getKeys(inventory).reduce((acc, itemName) => {
-    if (itemName in PLACEABLES_DIMENSIONS) {
+    if (itemName in COLLECTIBLES_DIMENSIONS) {
       return acc;
     }
 
@@ -18,7 +18,7 @@ export const getBasketItems = (inventory: Inventory) => {
 
 export const getChestItems = (state: GameState) => {
   return getKeys(state.inventory).reduce((acc, itemName) => {
-    if (itemName in PLACEABLES_DIMENSIONS && !(itemName in state.buildings)) {
+    if (itemName in COLLECTIBLES_DIMENSIONS && !(itemName in state.buildings)) {
       return {
         ...acc,
         [itemName]: state.inventory[itemName],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8374,10 +8374,17 @@ xmlchars@^2.2.0:
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+<<<<<<< HEAD
 xstate@^4.33.1:
   version "4.33.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.1.tgz#07293258c78aa1cfaf798ca541e2ed7d71b6bb5b"
   integrity sha512-C9A3esyOuw/xRpwQUkG2e1Gjd8sZYh42t66COq8DaJgaaLOqmE8zWRH1ouL9mHtQ3WV//uT5Ki3ijHGSUdLiww==
+=======
+xstate@^4.33.0:
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.0.tgz#4377a11e92267ad01ea498c4fc69887f0eddf1c8"
+  integrity sha512-+oari/Nt2cBq79mklnGA9Tsb6kv7ln+cIMfrH6n642XpTEG6sMRHg4GkooAbGbcslG3Ff9uH2jmGRP+1uoZ/Xw==
+>>>>>>> b0100d8c (Update react package)
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8374,17 +8374,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-<<<<<<< HEAD
 xstate@^4.33.1:
   version "4.33.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.1.tgz#07293258c78aa1cfaf798ca541e2ed7d71b6bb5b"
   integrity sha512-C9A3esyOuw/xRpwQUkG2e1Gjd8sZYh42t66COq8DaJgaaLOqmE8zWRH1ouL9mHtQ3WV//uT5Ki3ijHGSUdLiww==
-=======
-xstate@^4.33.0:
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.0.tgz#4377a11e92267ad01ea498c4fc69887f0eddf1c8"
-  integrity sha512-+oari/Nt2cBq79mklnGA9Tsb6kv7ln+cIMfrH6n642XpTEG6sMRHg4GkooAbGbcslG3Ff9uH2jmGRP+1uoZ/Xw==
->>>>>>> b0100d8c (Update react package)
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
# Description

This PR connects all the placeable logic so we have a full flow for both buildings and collectibles. A user can now place a building and also go the `Chest` tab and place a collectible. Collision detection has been added for both buildings and collectibles also. As part of this work we have split events into two categories `PlayingEvents` and `PlacementEvents` as they are two different contexts. Some types have been updated to accommodate this change.

This PR also sets a default `shortcutItem` if none are found in local storage. This item will be set as either the `Shovel` or the `Rusty Shovel`, whichever one is found.

**NOTE** The sizing of placed collectibles is janky. This will be fixes once we build the components for these items. Right now we're just rendering images. 

Fixes #issue

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

To test this you will need to run it against the API PR.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
