### PR TITLE
[FIX] Allow trees to be spam clicked

### DIFF
--- a/src/features/farming/forest/components/Tree.tsx
+++ b/src/features/farming/forest/components/Tree.tsx
@@ -103,8 +103,6 @@ export const Tree: React.FC<Props> = ({ treeIndex }) => {
     (selectedItem === "Axe" || axesNeeded.eq(0)) && axeAmount.gte(axesNeeded);
 
   const shake = async () => {
-    shakeGif.current?.goToAndPlay(0);
-
     if (!hasAxes) {
       return;
     }

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -111,15 +111,15 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
     (selectedItem === "Axe" || axesNeeded.eq(0)) && axeAmount.gte(axesNeeded);
 
   const shake = async () => {
-    shakeGif.current?.goToAndPlay(0);
-
     if (!hasAxes) {
       return;
     }
 
     const isPlaying = shakeGif.current?.getInfo("isPlaying");
 
-    if (isPlaying) return;
+    if (isPlaying) {
+      return;
+    }
 
     chopAudio.play();
     shakeGif.current?.goToAndPlay(0);


### PR DESCRIPTION
# Description

A regression was introduced in the trees preventing them from being spam clicked: https://github.com/sunflower-land/sunflower-land/commit/8d10d176bc779b65d7df2008931c19c950949da9#diff-8cba0344fd15399a3c441fae297148a0c5c5e1bb54b6fc6c94d08777392c4f10

You can infinitely hit a tree.

This small PR ensure the tree animation does not reset when hit.

![spam](https://user-images.githubusercontent.com/41215134/185539934-c8de195a-a061-4d67-ae1b-437565ced318.gif)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
