### PR TITLE
[FIX] Separate TOOL and SHOVEL entities.

### DIFF
--- a/src/features/farming/blacksmith/components/Crafting.tsx
+++ b/src/features/farming/blacksmith/components/Crafting.tsx
@@ -6,7 +6,7 @@ import close from "assets/icons/close.png";
 import { Panel } from "components/ui/Panel";
 import { Tab } from "components/ui/Tab";
 
-import { TOOLS } from "features/game/types/craftables";
+import { SHOVELS, TOOLS } from "features/game/types/craftables";
 
 import { CraftingItems } from "./CraftingItems";
 
@@ -39,7 +39,11 @@ export const Crafting: React.FC<Props> = ({ onClose }) => {
         }}
       >
         {tab === "craft" && (
-          <CraftingItems items={TOOLS} isBulk onClose={onClose} />
+          <CraftingItems
+            items={{ ...TOOLS, ...SHOVELS }}
+            isBulk
+            onClose={onClose}
+          />
         )}
       </div>
     </Panel>

--- a/src/features/farming/blacksmith/components/CraftingItems.tsx
+++ b/src/features/farming/blacksmith/components/CraftingItems.tsx
@@ -32,10 +32,11 @@ export const CraftingItems: React.FC<Props> = ({
   onClose,
   isBulk = false,
 }) => {
-  const [selected, setSelected] = useState<CraftableItem>(
-    Object.values(items)[0]
-  );
-  const [isCraftTenModalOpen, showCraftTenModal] = React.useState(false);
+  // Convert to array and filter out hidden from crafting items
+  const craftableItems = Object.values(items).filter((item) => !item.hidden);
+
+  const [selected, setSelected] = useState<CraftableItem>(craftableItems[0]);
+  const [isCraftTenModalOpen, showCraftTenModal] = useState(false);
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
   const [showCaptcha, setShowCaptcha] = useState(false);
@@ -199,7 +200,7 @@ export const CraftingItems: React.FC<Props> = ({
   return (
     <div className="flex">
       <div className="w-3/5 flex flex-wrap h-fit">
-        {Object.values(items).map((item) => (
+        {craftableItems.map((item) => (
           <Box
             isSelected={selected.name === item.name}
             key={item.name}

--- a/src/features/game/events/craft.test.ts
+++ b/src/features/game/events/craft.test.ts
@@ -198,24 +198,39 @@ describe("craft", () => {
     ).toThrow("Insufficient ingredient: Wood");
   });
 
-  // it("does not craft an item that is not in stock", () => {
-  //   expect(() =>
-  //     craft({
-  //       state: {
-  //         ...GAME_STATE,
-  //         stock: {
-  //           "Sunflower Seed": new Decimal(0),
-  //         },
-  //         balance: new Decimal(10),
-  //       },
-  //       action: {
-  //         type: "item.crafted",
-  //         item: "Sunflower Seed",
-  //         amount: 1,
-  //       },
-  //     })
-  //   ).toThrow("Not enough stock");
-  // });
+  it("does not craft an item that is hidden", () => {
+    expect(() =>
+      craft({
+        state: {
+          ...GAME_STATE,
+        },
+        action: {
+          type: "item.crafted",
+          item: "Rusty Shovel",
+          amount: 1,
+        },
+      })
+    ).toThrow("This item is hidden from crafting");
+  });
+
+  it("does not craft an item that is not in stock", () => {
+    expect(() =>
+      craft({
+        state: {
+          ...GAME_STATE,
+          stock: {
+            "Sunflower Seed": new Decimal(0),
+          },
+          balance: new Decimal(10),
+        },
+        action: {
+          type: "item.crafted",
+          item: "Sunflower Seed",
+          amount: 1,
+        },
+      })
+    ).toThrow("Not enough stock");
+  });
 
   it("requires a certain item before crafting", () => {
     expect(() =>

--- a/src/features/game/events/craft.ts
+++ b/src/features/game/events/craft.ts
@@ -6,6 +6,7 @@ import {
   CraftableName,
   CRAFTABLES,
   FOODS,
+  SHOVELS,
   TOOLS,
 } from "../types/craftables";
 import { SEEDS } from "../types/crops";
@@ -24,6 +25,7 @@ export type CraftAction = {
  */
 const VALID_ITEMS = Object.keys({
   ...TOOLS,
+  ...SHOVELS,
   ...SEEDS(),
   ...FOODS(),
   ...ANIMALS(),
@@ -66,6 +68,10 @@ export function craft({ state, action }: Options) {
 
   if (item.disabled) {
     throw new Error("This item is disabled");
+  }
+
+  if (item.hidden) {
+    throw new Error("This item is hidden from crafting");
   }
 
   if (action.amount < 1) {

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -53,6 +53,8 @@ export interface CraftableItem {
   tokenAmount?: Decimal;
   ingredients?: Ingredient[];
   disabled?: boolean;
+  // Hidden for crafting
+  hidden?: boolean;
   requires?: InventoryItemName;
   /**
    * When enabled, description and price will display as "?"
@@ -62,12 +64,6 @@ export interface CraftableItem {
 }
 
 export type MutantChicken = "Speed Chicken" | "Rich Chicken" | "Fat Chicken";
-
-export type RustyShovel = "Rusty Shovel";
-
-export type ShovelTool = "Shovel";
-
-export type Shovel = RustyShovel | ShovelTool;
 
 export interface LimitedItem extends CraftableItem {
   maxSupply?: number;
@@ -160,8 +156,9 @@ export type Tool =
   | "Stone Pickaxe"
   | "Iron Pickaxe"
   | "Hammer"
-  | "Rod"
-  | ShovelTool;
+  | "Rod";
+
+export type Shovel = "Rusty Shovel" | "Shovel";
 
 export type Food =
   | "Pumpkin Soup"
@@ -432,28 +429,6 @@ export const CAKES: () => Record<Cake, Craftable> = () => ({
   },
 });
 
-export const SHOVEL_TOOLS: () => Record<ShovelTool, CraftableItem> = () => ({
-  Shovel: {
-    name: "Shovel",
-    description: "Used to remove unwanted crops",
-    tokenAmount: new Decimal(0),
-    ingredients: [
-      {
-        item: "Rusty Shovel",
-        amount: new Decimal(1),
-      },
-      {
-        item: "Iron",
-        amount: new Decimal(10),
-      },
-      {
-        item: "Wood",
-        amount: new Decimal(20),
-      },
-    ],
-  },
-});
-
 export const TOOLS: Record<Tool, CraftableItem> = {
   Axe: {
     name: "Axe",
@@ -530,7 +505,6 @@ export const TOOLS: Record<Tool, CraftableItem> = {
     ],
     disabled: true,
   },
-  ...SHOVEL_TOOLS(),
 };
 
 export const SHOVELS: Record<Shovel, CraftableItem> = {
@@ -538,8 +512,27 @@ export const SHOVELS: Record<Shovel, CraftableItem> = {
     name: "Rusty Shovel",
     description: "It's old and rusty, but still harvests crops",
     ingredients: [],
+    hidden: true,
   },
-  ...SHOVEL_TOOLS(),
+  Shovel: {
+    name: "Shovel",
+    description: "Used to remove unwanted crops",
+    tokenAmount: new Decimal(0),
+    ingredients: [
+      {
+        item: "Rusty Shovel",
+        amount: new Decimal(1),
+      },
+      {
+        item: "Iron",
+        amount: new Decimal(10),
+      },
+      {
+        item: "Wood",
+        amount: new Decimal(20),
+      },
+    ],
+  },
 };
 
 export const QUEST_ITEMS: Record<QuestItem, LimitedItem> = {
@@ -910,6 +903,7 @@ type Craftables = Record<CraftableName, CraftableItem>;
 
 export const CRAFTABLES: () => Craftables = () => ({
   ...TOOLS,
+  ...SHOVELS,
   ...BLACKSMITH_ITEMS,
   ...BARN_ITEMS,
   ...MARKET_ITEMS,
@@ -920,7 +914,6 @@ export const CRAFTABLES: () => Craftables = () => ({
   ...ROCKET_ITEMS,
   ...QUEST_ITEMS,
   ...MUTANT_CHICKENS,
-  ...SHOVELS,
   ...SALESMAN_ITEMS,
   ...WAR_BANNERS,
   ...WAR_TENT_ITEMS,

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -193,6 +193,7 @@ import {
   FOODS,
   CAKES,
   TOOLS,
+  SHOVELS,
   FLAGS,
   BLACKSMITH_ITEMS,
   MARKET_ITEMS,
@@ -201,7 +202,6 @@ import {
   CRAFTABLES,
   LimitedItem,
   MUTANT_CHICKENS,
-  SHOVELS,
   SALESMAN_ITEMS,
 } from "./craftables";
 import { CROPS, SEEDS } from "./crops";
@@ -353,7 +353,7 @@ export const ITEM_DETAILS: Items = {
     image: questionMark,
   },
 
-  // TOOLS
+  // Tools
   Axe: {
     ...TOOLS["Axe"],
     image: axe,
@@ -378,6 +378,8 @@ export const ITEM_DETAILS: Items = {
     ...TOOLS["Rod"],
     image: rod,
   },
+
+  // Shovels
   "Rusty Shovel": {
     ...SHOVELS["Rusty Shovel"],
     image: rustyShovel,
@@ -388,7 +390,6 @@ export const ITEM_DETAILS: Items = {
   },
 
   // NFTs
-
   "Sunflower Statue": {
     ...BLACKSMITH_ITEMS["Sunflower Statue"],
     image: sunflowerStatue,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -69,8 +69,6 @@ export const Basket: React.FC = () => {
 
   const allTools = [...tools, ...shovels];
 
-  const hastools = tools.length !== 0 || shovels.length !== 0;
-
   return (
     <div className="flex flex-col">
       {!basketIsEmpty && (
@@ -162,7 +160,7 @@ export const Basket: React.FC = () => {
             </div>
           </div>
         )}
-        {hastools && (
+        {!!allTools.length && (
           <div className="flex flex-col pl-2" key={"Tools"}>
             {<p className="mb-2 underline">Tools</p>}
             <div className="flex mb-2 flex-wrap -ml-1.5">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3744,11 +3744,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-graphql@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.2.0.tgz"
-  integrity sha512-MuQd7XXrdOcmfwuLwC2jNvx0n3rxIuNYOxUtiee5XOmfrWo613ar2U8pE7aHAKh8VwfpifubpD9IP+EdEAEOsA==
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"


### PR DESCRIPTION
# Description

Noticed that in land expansion two shovels are displayed in inventory.
![image](https://user-images.githubusercontent.com/9656961/185790089-38dccc01-3cc7-40af-8e84-96e80c6196be.png)

This is due to the fact that Shovel exists in both TOOL and SHOVEL dicts. I separated those entities and added new flag to exclude "Rusty Shovel" from crafting.

This will simplify things going forward and prevent bugs like this from happening.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [n/a] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
