### PR TITLE
[FIX] Added ability to close hoarding modal.

### DIFF
--- a/src/features/game/components/Hoarding.tsx
+++ b/src/features/game/components/Hoarding.tsx
@@ -15,7 +15,11 @@ export const Hoarding: React.FC = () => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const [showCaptcha, setShowCaptcha] = useState(false);
+
   const maxedItem = gameState.context.maxedItem as InventoryItemName | "SFL";
+  const maxedItemImage =
+    maxedItem === "SFL" ? token : ITEM_DETAILS[maxedItem].image;
+  const itemName = maxedItem === "SFL" ? maxedItem : maxedItem.toLowerCase();
 
   const onCaptchaSolved = async (captcha: string | null) => {
     await new Promise((res) => setTimeout(res, 1000));
@@ -23,22 +27,28 @@ export const Hoarding: React.FC = () => {
     gameService.send("SYNC", { captcha });
   };
 
+  const onAcknowledge = () => {
+    gameService.send("ACKNOWLEDGE");
+  };
+
   const makeTitle = () => {
     const regex = new RegExp(/^[aeiou]/gi);
     const startsWithVowel = regex.test(maxedItem);
     const indefiniteArticle = startsWithVowel ? "an" : "a";
-    const item = maxedItem === "SFL" ? maxedItem : maxedItem.toLowerCase();
 
-    return `Are you ${indefiniteArticle} ${item} hoarder?!`;
+    return `Are you ${indefiniteArticle} ${itemName} hoarder?!`;
   };
-
-  const maxedItemImage =
-    maxedItem === "SFL" ? token : ITEM_DETAILS[maxedItem].image;
 
   return (
     <>
       {!showCaptcha ? (
-        <div>
+        <>
+          <img
+            src={close}
+            className="h-6 top-4 right-4 absolute cursor-pointer"
+            alt="Close Hoarding Modal"
+            onClick={onAcknowledge}
+          />
           <div className="flex flex-col items-center p-1">
             <span className="text-center text-sm sm:text-base">
               {makeTitle()}
@@ -48,7 +58,7 @@ export const Hoarding: React.FC = () => {
               {`Word is that Goblins are known to raid farms that have an abundance of resources.`}
             </p>
             <p className="text-xs sm:text-sm mb-1">
-              {`To protect yourself and keep those precious resources safe, please sync them on chain before continuing.`}
+              {`To protect yourself and keep those precious resources safe, please sync them on chain before gathering any more ${itemName}.`}
             </p>
             <div className="text-xs underline my-2 w-full">
               <a
@@ -61,7 +71,7 @@ export const Hoarding: React.FC = () => {
             </div>
           </div>
           <Button onClick={() => setShowCaptcha(true)}>Sync</Button>
-        </div>
+        </>
       ) : (
         <div>
           <img

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -655,6 +655,9 @@ export function startGame(authContext: Options) {
             SYNC: {
               target: "syncing",
             },
+            ACKNOWLEDGE: {
+              target: "playing",
+            },
           },
         },
         editing: {


### PR DESCRIPTION
# Description

Added ability to close hoarding modal in order to give players chance to prepare for sync.
Update modal text to specify that player cant gather that resource before sync.
![image](https://user-images.githubusercontent.com/9656961/186085724-91c83f7d-a31c-4202-b5dc-626ae5782efe.png)


Fixes #1354

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
