### PR TITLE
[FEAT] Increase Parsnip Seed Limit to 60

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -47,7 +47,7 @@ export const INITIAL_STOCK: Inventory = {
   "Cabbage Seed": new Decimal(90),
   "Beetroot Seed": new Decimal(80),
   "Cauliflower Seed": new Decimal(80),
-  "Parsnip Seed": new Decimal(40),
+  "Parsnip Seed": new Decimal(60),
   "Radish Seed": new Decimal(40),
   "Wheat Seed": new Decimal(40),
 

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -30,7 +30,7 @@ const maxItems: Inventory = {
   "Cabbage Seed": new Decimal(100),
   "Beetroot Seed": new Decimal(90),
   "Cauliflower Seed": new Decimal(90),
-  "Parsnip Seed": new Decimal(50),
+  "Parsnip Seed": new Decimal(70),
   "Radish Seed": new Decimal(50),
   "Wheat Seed": new Decimal(50),
 


### PR DESCRIPTION
# Description

This PR increases the parsnip seed limit to 60. Parsnips currently take half the time of wheat but have the same supply.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
