### PR TITLE
[FEAT] Deep-Link to Farm Listings

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -354,6 +354,15 @@ export const authMachine = createMachine<
             },
           },
           readyToStart: {
+            invoke: {
+              src: async () => ({
+                skipSplash: window.location.hash.includes("goblins"),
+              }),
+              onDone: {
+                cond: (_, event) => event.data.skipSplash,
+                target: "authorised",
+              },
+            },
             on: {
               START_GAME: [
                 {
@@ -373,6 +382,8 @@ export const authMachine = createMachine<
           authorised: {
             id: "authorised",
             entry: (context, event) => {
+              if (window.location.hash.includes("goblins")) return;
+
               // When no 'screen' parameter is given to the event
               const defaultScreen = window.location.hash.includes("land")
                 ? "land"

--- a/src/features/goblins/trader/buying/Buying.tsx
+++ b/src/features/goblins/trader/buying/Buying.tsx
@@ -1,5 +1,6 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { useActor } from "@xstate/react";
+import { useSearchParams } from "react-router-dom";
 
 import alert from "assets/icons/expression_alerted.png";
 
@@ -22,6 +23,16 @@ export const Buying: React.FC = () => {
   const buyingService = tradingPostState.children
     .buying as BuyingMachineInterpreter;
   const [machine, send] = useActor(buyingService);
+
+  const [searchParams] = useSearchParams();
+
+  // Support deep-link to auto-visit a farm's listings
+  useEffect(() => {
+    const farmId = searchParams.get("viewListingsForLand") ?? "";
+    const isValidFarmId = /^\d+$/.test(farmId); // Ensure it's a valid farm ID before proceeding.
+    if (!isValidFarmId) return;
+    buyingService.send("LOAD_FARM", { farmId });
+  }, []);
 
   if (machine.matches("idle")) {
     return (

--- a/src/features/goblins/trader/buying/Buying.tsx
+++ b/src/features/goblins/trader/buying/Buying.tsx
@@ -32,7 +32,7 @@ export const Buying: React.FC = () => {
     const isValidFarmId = /^\d+$/.test(farmId); // Ensure it's a valid farm ID before proceeding.
     if (!isValidFarmId) return;
     buyingService.send("LOAD_FARM", { farmId });
-  }, []);
+  }, [searchParams]);
 
   if (machine.matches("idle")) {
     return (

--- a/src/features/goblins/trader/tradingPost/Trader.tsx
+++ b/src/features/goblins/trader/tradingPost/Trader.tsx
@@ -24,7 +24,7 @@ export const Trader: React.FC = () => {
     if (!searchParams.has("viewListingsForLand")) return;
     if (!goblinState.matches("playing")) return;
     openTrader();
-  }, [goblinState]);
+  }, [goblinState, searchParams]);
 
   const openTrader = () => {
     goblinService.send("OPEN_TRADING_POST");

--- a/src/features/goblins/trader/tradingPost/Trader.tsx
+++ b/src/features/goblins/trader/tradingPost/Trader.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { Context } from "features/game/GoblinProvider";
 
@@ -16,9 +17,25 @@ export const Trader: React.FC = () => {
 
   const [showModal, setShowModal] = useState(false);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Support deep-link to auto-open the trader
+  useEffect(() => {
+    if (!searchParams.has("viewListingsForLand")) return;
+    if (!goblinState.matches("playing")) return;
+    openTrader();
+  }, [goblinState]);
+
   const openTrader = () => {
     goblinService.send("OPEN_TRADING_POST");
     setShowModal(true);
+  };
+
+  const handleModalClose = () => {
+    const modifiedParams = Object.assign(searchParams, {});
+    modifiedParams.delete("viewListingsForLand");
+    setSearchParams(modifiedParams, { replace: true });
+    setShowModal(false);
   };
 
   return (
@@ -48,7 +65,13 @@ export const Trader: React.FC = () => {
       </div>
 
       {goblinState.matches("trading") && (
-        <TraderModal isOpen={showModal} onClose={() => setShowModal(false)} />
+        <TraderModal
+          isOpen={showModal}
+          initialTab={
+            searchParams.has("viewListingsForLand") ? "buying" : "selling"
+          }
+          onClose={handleModalClose}
+        />
       )}
     </>
   );

--- a/src/features/goblins/trader/tradingPost/Trader.tsx
+++ b/src/features/goblins/trader/tradingPost/Trader.tsx
@@ -32,7 +32,7 @@ export const Trader: React.FC = () => {
   };
 
   const handleModalClose = () => {
-    const modifiedParams = Object.assign(searchParams, {});
+    const modifiedParams = Object.assign({}, searchParams);
     modifiedParams.delete("viewListingsForLand");
     setSearchParams(modifiedParams, { replace: true });
     setShowModal(false);

--- a/src/features/goblins/trader/tradingPost/Trader.tsx
+++ b/src/features/goblins/trader/tradingPost/Trader.tsx
@@ -32,7 +32,7 @@ export const Trader: React.FC = () => {
   };
 
   const handleModalClose = () => {
-    const modifiedParams = Object.assign({}, searchParams);
+    const modifiedParams = new URLSearchParams(searchParams);
     modifiedParams.delete("viewListingsForLand");
     setSearchParams(modifiedParams, { replace: true });
     setShowModal(false);

--- a/src/features/goblins/trader/tradingPost/TraderModal.tsx
+++ b/src/features/goblins/trader/tradingPost/TraderModal.tsx
@@ -12,11 +12,13 @@ import { Tabs } from "./components/Tabs";
 
 interface TraderModalProps {
   isOpen: boolean;
+  initialTab?: "buying" | "selling";
   onClose: () => void;
 }
 
 export const TraderModal: React.FC<TraderModalProps> = ({
   isOpen,
+  initialTab = "selling",
   onClose,
 }) => {
   const { goblinService } = useContext(Context);
@@ -26,7 +28,7 @@ export const TraderModal: React.FC<TraderModalProps> = ({
 
   const [machine, send] = useActor(child);
 
-  const [isSelling, setIsSelling] = useState(true);
+  const [isSelling, setIsSelling] = useState(initialTab === "selling");
 
   const handleClose = () => {
     onClose();


### PR DESCRIPTION
# Description

This PR implements a deep-linking strategy to go directly to a farm's listings given a magic URL. This feature will help support third-party listing tools (like https://sfl.tools), allowing buyers to be taken directly to a farm's listings at the click of a button.

Fixes + Read More Here: https://github.com/sunflower-land/sunflower-land/issues/1366

Code works in the following way:
1. Enter a URL like the following: `{URL}/#/goblins?viewListingsForLand=1`
2. After game load (and if needed, after auth flow), bypass the splash screen and load directly into goblin town.
3. Auto-display the trader modal, with `Land ID 1`'s current trades.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

https://user-images.githubusercontent.com/103600068/187569166-ee2029f5-48e0-4a16-aaed-03b94931f244.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
