### PR TITLE
[FIX] canMine on canWithdraw

### DIFF
--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -1,6 +1,8 @@
 import { canChop } from "features/game/events/chop";
 import { isSeed } from "features/game/events/plant";
-import { canMine } from "features/game/events/stoneMine";
+import { canMine as canMineStone } from "features/game/events/stoneMine";
+import { canMine as canMineIron } from "features/game/events/ironMine";
+import { canMine as canMineGold } from "features/game/events/goldMine";
 import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import {
@@ -112,20 +114,24 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
   // Make sure stones are not replenishing
   if (item === "Tunnel Mole") {
     const stoneReady = Object.values(game?.stones).every((stone) =>
-      canMine(stone)
+      canMineStone(stone)
     );
     return stoneReady;
   }
 
   // Make sure irons are not replenishing
   if (item === "Rocky the Mole") {
-    const ironReady = Object.values(game?.iron).every((iron) => canMine(iron));
+    const ironReady = Object.values(game?.iron).every((iron) =>
+      canMineIron(iron)
+    );
     return ironReady;
   }
 
   // Make sure gold is not replenishing
   if (item === "Nugget") {
-    const goldReady = Object.values(game?.gold).every((gold) => canMine(gold));
+    const goldReady = Object.values(game?.gold).every((gold) =>
+      canMineGold(gold)
+    );
     return goldReady;
   }
 


### PR DESCRIPTION
# Description

This PR fixes the issue of Rocky the Mole being withdrawable on frontend even if iron nodes are on timer.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`yarn tsc | format | test`

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
