### PR TITLE
[FEAT] Bumpkin URI detection

### DIFF
--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -8,7 +8,7 @@ import { GameState, InventoryItemName } from "../types/game";
 
 type Request = {
   sessionId: string;
-  bumpkinId?: number;
+  bumpkinTokenUri?: string;
   farmId: number;
   token: string;
 };
@@ -40,7 +40,7 @@ export async function loadSession(
     },
     body: JSON.stringify({
       sessionId: request.sessionId,
-      bumpkinId: request.bumpkinId,
+      bumpkinTokenUri: request.bumpkinTokenUri,
       clientVersion: CONFIG.CLIENT_VERSION as string,
     }),
   });

--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -40,6 +40,7 @@ describe("Construct building", () => {
               pants: "Farmer Pants",
               shoes: "Black Farmer Boots",
             },
+            tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
           },
         },
         action: {
@@ -87,6 +88,7 @@ describe("Construct building", () => {
               pants: "Farmer Pants",
               shoes: "Black Farmer Boots",
             },
+            tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
           },
         },
         action: {
@@ -144,6 +146,7 @@ describe("Construct building", () => {
               pants: "Farmer Pants",
               shoes: "Black Farmer Boots",
             },
+            tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
           },
           balance: new Decimal(0),
         },
@@ -180,6 +183,7 @@ describe("Construct building", () => {
               pants: "Farmer Pants",
               shoes: "Black Farmer Boots",
             },
+            tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
           },
           balance: new Decimal(100),
         },
@@ -213,6 +217,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
       },
       action: {
@@ -249,6 +254,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
       },
       action: {
@@ -283,6 +289,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
       },
       action: {
@@ -322,6 +329,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
       },
       action: {
@@ -357,6 +365,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
       },
       action: {
@@ -393,6 +402,7 @@ describe("Construct building", () => {
             pants: "Farmer Pants",
             shoes: "Black Farmer Boots",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
         buildings: {
           "Fire Pit": [
@@ -459,6 +469,7 @@ describe("Construct building", () => {
             shoes: "Black Farmer Boots",
             tool: "Farmer Pitchfork",
           },
+          tokenUri: "https://api-dev.sunflower-land.com/bumpkin/1_v1_1_2_3",
         },
         buildings: {
           ...buildings,

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -276,9 +276,7 @@ export function startGame(authContext: Options) {
 
                 const response = await loadSession({
                   farmId,
-                  bumpkinId: bumpkin?.tokenId
-                    ? Number(bumpkin.tokenId)
-                    : undefined,
+                  bumpkinTokenUri: bumpkin?.tokenURI,
                   sessionId,
                   token: authContext.rawToken as string,
                 });

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -390,7 +390,16 @@ export function startGame(authContext: Options) {
                 if (sessionID !== context.sessionId) {
                   cb("EXPIRED");
                 }
-              }, 1000 * 20);
+
+                const bumpkins = await metamask
+                  .getBumpkinDetails()
+                  .loadBumpkins();
+                const tokenURI = bumpkins[0]?.tokenURI;
+
+                if (tokenURI !== context.state.bumpkin?.tokenUri) {
+                  cb("EXPIRED");
+                }
+              }, 1000 * 30);
 
               return () => {
                 clearInterval(interval);

--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -169,7 +169,7 @@ export function startGoblinVillage(authContext: AuthContext) {
                 farmId,
                 sessionId,
                 token: authContext.rawToken as string,
-                bumpkinId: Number(onChainState.bumpkin?.tokenId),
+                bumpkinTokenUri: onChainState.bumpkin?.tokenURI,
               });
 
               const game = response?.game as GameState;
@@ -233,7 +233,8 @@ export function startGoblinVillage(authContext: AuthContext) {
             src: wishingWellMachine,
             data: {
               farmId: () => authContext.farmId,
-              bumpkinId: (context: Context) => context.state.bumpkin?.id,
+              bumpkinTokenUri: (context: Context) =>
+                context.state.bumpkin?.tokenUri,
               farmAddress: () => authContext.address,
               sessionId: (context: Context) => context.sessionId,
               token: () => authContext.rawToken,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -92,6 +92,7 @@ export type Bumpkin = {
   id: number;
   level: number;
   equipped: BumpkinParts;
+  tokenUri: string;
 };
 
 export type SpecialEvent = "Chef Apron" | "Chef Hat";

--- a/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
@@ -17,7 +17,7 @@ export const loadUpdatedSession = async (
     farmId,
     sessionId,
     token,
-    bumpkinId: Number(onChainState.bumpkin?.tokenId),
+    bumpkinTokenUri: onChainState.bumpkin?.tokenURI,
   });
 
   const game = response?.game as GameState;

--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -20,7 +20,7 @@ export interface Context {
   state: WishingWellTokens;
   errorCode?: keyof typeof ERRORS;
   farmId?: number;
-  bumpkinId?: number;
+  bumpkinTokenUri?: string;
   sessionId?: string;
   farmAddress?: string;
   token?: string;
@@ -203,7 +203,7 @@ export const wishingWellMachine = createMachine<
               farmId: context.farmId as number,
               sessionId: context.sessionId as string,
               token: context.token as string,
-              bumpkinId: context.bumpkinId,
+              bumpkinTokenUri: context.bumpkinTokenUri as string,
             });
 
             const well = await loadWishingWell();


### PR DESCRIPTION
# Description

Use the Bumpkin Token URI for change detection. This is because users can equip/unequip at Bumpkin.io and need to stay in sync.


## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Run against local API