### PR TITLE
[FIX] Display all cakes.

### DIFF
--- a/src/features/farming/cakeStall/CakeStall.tsx
+++ b/src/features/farming/cakeStall/CakeStall.tsx
@@ -32,9 +32,7 @@ export const CakeStall: React.FC = () => {
   };
 
   const specialCake = Object.values(CAKES()).find(
-    (item) =>
-      !isExpired({ name: item.name, stockExpiry: state.stockExpiry }) &&
-      state.inventory[item.name]
+    (item) => !isExpired({ name: item.name, stockExpiry: state.stockExpiry })
   );
 
   return (

--- a/src/features/farming/cakeStall/components/Cakes.tsx
+++ b/src/features/farming/cakeStall/components/Cakes.tsx
@@ -4,7 +4,6 @@ import { useActor } from "@xstate/react";
 
 import token from "assets/icons/token.gif";
 import tokenStatic from "assets/icons/token.png";
-import questionMark from "assets/icons/expression_confused.png";
 
 import { Box } from "components/ui/Box";
 import { OuterPanel, Panel } from "components/ui/Panel";
@@ -72,11 +71,7 @@ export const Cakes: React.FC = () => {
             isSelected={selected === item.name}
             key={item.name}
             onClick={() => setSelected(item.name as Cake)}
-            image={
-              inventory[item.name]?.gte(1)
-                ? ITEM_DETAILS[item.name].image
-                : questionMark
-            }
+            image={ITEM_DETAILS[item.name].image}
             count={inventory[item.name]}
           />
         ))}
@@ -85,7 +80,7 @@ export const Cakes: React.FC = () => {
         <div className="flex flex-col justify-center items-center p-2 ">
           <span className="text-shadow text-center">{selected}</span>
           <img
-            src={amount.gte(1) ? ITEM_DETAILS[selected].image : questionMark}
+            src={ITEM_DETAILS[selected].image}
             className="h-16 img-highlight mt-1"
             alt={selected}
           />


### PR DESCRIPTION
# Description

Since cake event is finished, we might want to display all cakes in cakes collection.

Current view:
![image](https://user-images.githubusercontent.com/9656961/188542659-5fd652d4-504a-43c6-accc-9c057484f172.png)

After the fix:
![image](https://user-images.githubusercontent.com/9656961/188542706-bb1cfefa-36d5-48f2-980f-ab72558543e1.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual tests.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
