### PR TITLE
[FIX] Add option to make a new wish if LP withdrawn

### DIFF
--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from "react-bootstrap";
 import ReCAPTCHA from "react-google-recaptcha";
 
 import wisingWell from "assets/buildings/wishing_well.png";
+import goblinHead from "assets/icons/goblin_head.png";
 import player from "assets/icons/player.png";
 import timer from "assets/icons/timer.png";
 import alert from "assets/icons/expression_alerted.png";
@@ -27,7 +28,7 @@ type GrantedArgs = Pick<WishingWellTokens, "lockedTime"> & {
   reward: string;
 };
 
-type GrantWishArgs = Pick<WishingWellTokens, "totalTokensInWell"> & {
+type ZeroTokensArgs = {
   onClose: () => void;
   onClick?: () => void;
 };
@@ -89,6 +90,30 @@ const GrantWish = ({ totalTokensInWell, onClick, onClose }: GrantWishArgs) => (
       </Button>
       <Button className="ml-1" onClick={onClick}>
         Grant Wish
+      </Button>
+    </div>
+  </>
+);
+
+const ZeroTokens = ({ onClick, onClose }: ZeroTokensArgs) => (
+  <>
+    <div className="p-2">
+      <div className="flex flex-col items-center mb-3">
+        <h1 className="text-xl mb-4 text-center">{`Uh oh!`}</h1>
+        <img src={goblinHead} alt="skeleton death" className="w-16 mb-2" />
+      </div>
+      <p className="mb-4 text-sm">
+        You have no reward available! Liquidity needs to be held for 3 days to
+        get a reward!
+      </p>
+      <p className="mb-2 text-sm">{`Grant a new wish and see how lucky you are!`}</p>
+    </div>
+    <div className="flex">
+      <Button className="mr-1 whitespace-nowrap" onClick={onClose}>
+        Close
+      </Button>
+      <Button className="ml-1 whitespace-nowrap" onClick={onClick}>
+        Grant New Wish
       </Button>
     </div>
   </>
@@ -238,7 +263,7 @@ export const WishingWellModal: React.FC<Props> = ({ isOpen, onClose }) => {
         {machine.matches("loading") && (
           <span className="loading mt-1">Loading</span>
         )}
-        {machine.matches("granting") && (
+        {(machine.matches("granting") || machine.matches("signing")) && (
           <span className="loading mt-1">Granting your wish</span>
         )}
         {machine.matches("wishing") && (
@@ -260,6 +285,9 @@ export const WishingWellModal: React.FC<Props> = ({ isOpen, onClose }) => {
             onClick={goToQuickSwap}
             onClose={handleClose}
           />
+        )}
+        {machine.matches("zeroTokens") && (
+          <ZeroTokens onClick={() => send("WISH")} onClose={handleClose} />
         )}
         {machine.matches("canWish") && (
           <NoWish

--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -28,6 +28,11 @@ type GrantedArgs = Pick<WishingWellTokens, "lockedTime"> & {
   reward: string;
 };
 
+type GrantWishArgs = Pick<WishingWellTokens, "totalTokensInWell"> & {
+  onClose: () => void;
+  onClick?: () => void;
+};
+
 type ZeroTokensArgs = {
   onClose: () => void;
   onClick?: () => void;

--- a/src/features/goblins/wishingWell/actions/collectFromWell.ts
+++ b/src/features/goblins/wishingWell/actions/collectFromWell.ts
@@ -12,13 +12,20 @@ type Request = {
 
 const API_URL = CONFIG.API_URL;
 
-export async function collectFromWell({
+export interface SignedTransaction {
+  signature: string;
+  tokens: string;
+  deadline: number;
+  farmId: number;
+}
+
+export async function signCollectFromWell({
   farmId,
   sessionId,
   token,
   amount,
   captcha,
-}: Request) {
+}: Request): Promise<SignedTransaction | void> {
   if (!API_URL) return;
 
   const response = await window.fetch(`${API_URL}/wishing-well`, {
@@ -41,6 +48,10 @@ export async function collectFromWell({
 
   const transaction = await response.json();
 
+  return transaction as SignedTransaction;
+}
+
+export async function collectFromWell(transaction: SignedTransaction) {
   const receipt = await metamask.getWishingWell().collectFromWell(transaction);
 
   return receipt;

--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -10,7 +10,11 @@ import { metamask } from "lib/blockchain/metamask";
 import { ERRORS } from "lib/errors";
 
 import { WishingWellTokens, loadWishingWell } from "./actions/loadWishingWell";
-import { collectFromWell } from "./actions/collectFromWell";
+import {
+  collectFromWell,
+  signCollectFromWell,
+  SignedTransaction,
+} from "./actions/collectFromWell";
 import Decimal from "decimal.js-light";
 import { reset } from "features/farming/hud/actions/reset";
 import { fromWei } from "web3-utils";
@@ -26,6 +30,7 @@ export interface Context {
   token?: string;
   balance?: Decimal;
   totalRewards?: Decimal;
+  transaction?: SignedTransaction;
 }
 
 type CaptchaEvent = {
@@ -58,6 +63,8 @@ export type BlockchainState = {
     | "wishing"
     | "wished"
     | "captcha"
+    | "signing"
+    | "zeroTokens"
     | "granting"
     | "searched"
     | "granted"
@@ -171,7 +178,43 @@ export const wishingWellMachine = createMachine<
       captcha: {
         on: {
           VERIFIED: {
-            target: "granting",
+            target: "signing",
+          },
+        },
+      },
+      signing: {
+        invoke: {
+          src: async (context, event) => {
+            const transaction = await signCollectFromWell({
+              farmId: context.farmId as number,
+              sessionId: context.sessionId as string,
+              amount: context.state.myTokensInWell.toString(),
+              token: context.token as string,
+              captcha: (event as CaptchaEvent).captcha,
+            });
+            return { transaction };
+          },
+          onDone: [
+            {
+              target: "zeroTokens",
+              cond: (_, event) => Number(event.data.transaction.tokens) === 0,
+              actions: assign({
+                transaction: (_, event) => event.data.transaction,
+              }),
+            },
+            {
+              target: "granting",
+              actions: assign({
+                transaction: (_, event) => event.data.transaction,
+              }),
+            },
+          ],
+        },
+      },
+      zeroTokens: {
+        on: {
+          WISH: {
+            target: "wishing",
           },
         },
       },
@@ -179,13 +222,10 @@ export const wishingWellMachine = createMachine<
         invoke: {
           src: async (context, event) => {
             // Collect from well and await receipt
-            const receipt: any = await collectFromWell({
-              farmId: context.farmId as number,
-              sessionId: context.sessionId as string,
-              amount: context.state.myTokensInWell.toString(),
-              token: context.token as string,
-              captcha: (event as CaptchaEvent).captcha,
-            });
+            const receipt: any = await collectFromWell(
+              context.transaction as SignedTransaction
+            );
+
             // Get reward amount from Rewarded event
             const reward = new Decimal(
               fromWei(receipt.events.Rewarded.returnValues[1])


### PR DESCRIPTION
# Description

When a withdraws LP, they are no longer eligible for rewards from the wishing well. LP must be held for 3 days.

If LP is added after withdrawing, the wishing well will fail at a contract level detecting the player hasn't held LP for three days. This PR intercepts this error, and gives the player a chance to make a new wish to restart the three days.

![Screen Shot 2022-09-07 at 8 36 39 am](https://user-images.githubusercontent.com/41215134/188753498-d9a9df04-9d09-4044-b958-9e7129ff730c.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
