### PR TITLE
[FIX] Airdrop 0 SFL Display

### DIFF
--- a/src/features/game/components/Airdrop.tsx
+++ b/src/features/game/components/Airdrop.tsx
@@ -61,7 +61,7 @@ export const Airdrop: React.FC = () => {
           </p>
 
           <div className="flex flex-col pt-4">
-            {airdrop.sfl && (
+            {!!airdrop.sfl && (
               <div className="flex items-center justify-center mb-2">
                 <img src={token} className="w-6 mr-2" />
                 <span>{airdrop.sfl} SFL</span>


### PR DESCRIPTION
# Description

This PR fixes the minor bug where it displays 0 when sfl in airdrop is zero

![image](https://user-images.githubusercontent.com/89294757/189653479-84983d1f-6cfe-4291-a601-370fe013c36c.png)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test - local, edited sfl in `constants.js`

![image](https://user-images.githubusercontent.com/89294757/189653630-870a1b35-7532-4669-ba8e-2f656da182d3.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
