### PR TITLE
[FIX] Quickswap LP for Wishing Well

### DIFF
--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -257,7 +257,7 @@ export const WishingWellModal: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const goToQuickSwap = () => {
     window.open(
-      "https://quickswap.exchange/#/add/ETH/0xD1f9c58e33933a993A3891F8acFe05a68E1afC05",
+      "https://quickswap.exchange/#/analytics/pair/0x6f9e92dd4734c168a734b873dc3db77e39552eb6",
       "_blank"
     );
   };


### PR DESCRIPTION
# Description

This PR updates the quickswap link from Wishing Well modal since the old link is not working anymore. I opted to open the pair contract `/analytics/pair/aaa` instead of adding WMATIC and SFL to the pool's page i.e. `/pools?currency0=xxx&currency1=yyy`. Feel free to disagree tho :)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
