### PR TITLE
[FEAT] Show Circulating SFL Supply

### DIFF
--- a/src/features/farming/mail/lib/mail.ts
+++ b/src/features/farming/mail/lib/mail.ts
@@ -25,7 +25,14 @@ async function getSFLSupply() {
       ])
     : [toBN(0), toBN(0)];
 
-  return new Decimal(fromWei(total)).minus(new Decimal(fromWei(burned)));
+  const totalSupply = new Decimal(fromWei(total));
+
+  // total and circulating
+  return [totalSupply, totalSupply.minus(new Decimal(fromWei(burned)))];
+}
+
+function formatAmount(num: Decimal) {
+  return num.toDecimalPlaces(3, Decimal.ROUND_DOWN).toNumber().toLocaleString();
 }
 
 /**
@@ -57,25 +64,30 @@ function getNextHalvening(currentSupply: Decimal) {
 }
 
 export async function getInbox() {
-  const sflBalance = await getSFLSupply();
-  const nextHalvening = getNextHalvening(sflBalance);
+  const [totalSfl, circSfl] = await getSFLSupply();
+  const nextHalvening = getNextHalvening(totalSfl);
 
   return [
     // double space for line break
     {
-      id: "sfl-supply",
-      title: "SFL Supply",
+      id: "halvening",
+      title: "Halvening",
       body: API_URL
-        ? `Circulating SFL: ${sflBalance
-            .toDecimalPlaces(3, Decimal.ROUND_DOWN)
-            .toNumber()
-            .toLocaleString()}  
+        ? `Total SFL: ${formatAmount(totalSfl)}  
         &nbsp;  
         Next halvening is at ${nextHalvening.toNumber().toLocaleString()}  
         &nbsp;   
-        Notes:  
-        * This value is read from the Blockchain. Other farmers may not have synced yet.  
-        * Excludes burned SFL
+        Notes: This value is read from the Blockchain. Other farmers may not have synced yet. 
+      `
+        : "You're running Sunflower Land locally!",
+    },
+    {
+      id: "sfl-supply",
+      title: "SFL Supply",
+      body: API_URL
+        ? `Circulating SFL: ${formatAmount(circSfl)}  
+        &nbsp;     
+        Notes: The amount of SFL in farms, wallets, and pools. This excludes burned SFL. 
       `
         : "You're running Sunflower Land locally!",
     },


### PR DESCRIPTION
# Description

This PR shows circulating SFL supply i.e. SFL that are not burned / in null address when clicking bald man. Feel free to suggest wording.

Fixes #issue

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual test - testnet

![circulating-sfl](https://user-images.githubusercontent.com/89294757/191063441-b88a445a-d615-4a13-a170-72694f03a69c.PNG)

verifed on testnet explorer
![image](https://user-images.githubusercontent.com/89294757/191063686-b02d5f09-43b2-4e12-8900-7faa5715f122.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
