### PR TITLE
FIX/Modify Amulet Inventory Descriptions

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -581,31 +581,31 @@ export const SALESMAN_ITEMS: Record<TravelingSalesmanItem, LimitedItem> = {
 export const WAR_TENT_ITEMS: Record<WarTentItem, LimitedItem> = {
   "Sunflower Amulet": {
     name: "Sunflower Amulet",
-    description: "10% increased Sunflower yield.",
+    description: "10% increased Sunflower yield",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
   "Carrot Amulet": {
     name: "Carrot Amulet",
-    description: "Carrots grow 20% faster.",
+    description: "Carrots grow 20% faster",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
   "Beetroot Amulet": {
     name: "Beetroot Amulet",
-    description: "20% increased Beetroot yield.",
+    description: "20% increased Beetroot yield",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
   "Green Amulet": {
     name: "Green Amulet",
-    description: "Chance for 10x crop yield.",
+    description: "Chance for 10x crop yield",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
   "Warrior Shirt": {
     name: "Warrior Shirt",
-    description: "A mark of a true warrior.",
+    description: "A mark of a true warrior",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
@@ -623,13 +623,13 @@ export const WAR_TENT_ITEMS: Record<WarTentItem, LimitedItem> = {
   },
   "Reward 8": {
     name: "Reward 8",
-    description: "A rare item.",
+    description: "A rare item",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },
   "Reward 9": {
     name: "Reward 9",
-    description: "A rare item.",
+    description: "A rare item",
     type: LimitedItemType.WarTentItem,
     disabled: true,
   },

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -955,39 +955,39 @@ export const ITEM_DETAILS: Items = {
 
   "Sunflower Amulet": {
     image: sunflowerAmulet,
-    description: "A reward for your war efforts.",
+    description: "10% increased Sunflower yield",
   },
   "Carrot Amulet": {
     image: carrotAmulet,
-    description: "A reward for your war efforts.",
+    description: "Carrots grow 20% faster",
   },
   "Beetroot Amulet": {
     image: beetrootAmulet,
-    description: "A reward for your war efforts.",
+    description: "20% increased Beetroot yield",
   },
   "Green Amulet": {
     image: greenAmulet,
-    description: "A reward for your war efforts.",
+    description: "Chance for 10x crop yield",
   },
   "Warrior Shirt": {
     image: warriorShirt,
-    description: "A reward for your war efforts.",
+    description: "A mark of a true warrior",
   },
   "Warrior Pants": {
     image: warriorPants,
-    description: "A reward for your war efforts.",
+    description: "Protect your thighs!",
   },
   "Warrior Helmet": {
     image: warriorHelmet,
-    description: "A reward for your war efforts.",
+    description: "Immune to arrows",
   },
   "Reward 8": {
     image: questionMark,
-    description: "A reward for your war efforts.",
+    description: "A reward for your war efforts",
   },
   "Reward 9": {
     image: questionMark,
-    description: "A reward for your war efforts.",
+    description: "A reward for your war efforts",
   },
 
   "Boiled Egg": {


### PR DESCRIPTION
# Description

Changes the in-game inventory description for amulets when in your collectables.

Before: 
<img width="264" alt="Screen Shot 2022-09-19 at 10 10 55 PM" src="https://user-images.githubusercontent.com/79071868/191159208-84566fe7-317a-4f87-a823-37bd4a10b661.png">

After:
<img width="320" alt="Screen Shot 2022-09-19 at 10 13 51 PM" src="https://user-images.githubusercontent.com/79071868/191159293-d0c5b68d-8821-4e56-9632-af5b97e6d360.png">


This also takes a stand on the punctuation standards across the game, removing periods from these descriptions, will review the rest of the game to determine if we should add more periods or remove more 🤔 
Fixes #issue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Visually

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
