### PR TITLE
[FIX] Set Leaderboard Modal to Close Default & Other fixes

### DIFF
--- a/src/features/game/components/Decorations.tsx
+++ b/src/features/game/components/Decorations.tsx
@@ -340,10 +340,9 @@ export const Trivia: React.FC = () => {
               style={{
                 width: `${GRID_WIDTH_PX * 3}px`,
               }}
-              className="hover:img-highlight cursor-pointer mb-2 m-auto"
+              className="mb-2 m-auto"
               src={trivia}
               alt="Goblin Trivia"
-              onClick={() => setShowModal(true)}
             />
             <p className="text-left mb-2">Congratulations Team Goblin.</p>
             <p className="text-left mb-2">

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -137,6 +137,15 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
 
   if (item === "Human War Banner" || item === "Goblin War Banner") return false;
 
+  // War Bond
+  if (item === "War Bond") return false;
+
+  //Rapid Growth
+  if (item === "Rapid Growth") return false;
+
+  //Chef Hat
+  if (item === "Chef Hat") return false;
+
   // War items
   if (
     item === "Human War Point" ||

--- a/src/features/war/components/Leaderboard.tsx
+++ b/src/features/war/components/Leaderboard.tsx
@@ -21,7 +21,7 @@ export const Leaderboard: React.FC = () => {
     humanTeam: { total: 0, percentage: 0 },
   });
   const [loading, setLoading] = useState<boolean>(false);
-  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const getValues = async () => {
     // End of Week 1 points


### PR DESCRIPTION
# Description
This PR fixes the issue of Leaderboard Modal having display default to ON which is slightly annoying specially to mobile users. This PR will also fix the hover highlight bug of Goblin Trivia Winner image when Modal is hovered.
Fixes issue in Discord:  https://discord.com/channels/880987707214544966/897594873274830919/1017822983521320970

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
## Leaderboard Modal fix
### Before:
![image](https://user-images.githubusercontent.com/104184348/191258594-3cfc4fe9-2e5b-4a13-9a2a-e215216ee17c.png)
### After:
No records were available but it is tested on local.
![image](https://user-images.githubusercontent.com/104184348/191261813-0ef9845a-bd6e-4410-9fae-246d20fe9f1b.png)

## Trivia Game Hover fix
### Before:
![image](https://user-images.githubusercontent.com/104184348/191266890-5a5c6162-add2-40d8-b556-c52e75dc1057.png)
### After:
This was also tested on local. Mouse cannot be seen on screenshot but codewise the mouse is hovered to make sure the bug is fixed.
![image](https://user-images.githubusercontent.com/104184348/191266939-d7d68194-ccfb-4769-a46b-a63385d04165.png)

## Make War Bonds, Chef Hat, Rapid Growth show non-withdrawable in Goblin Bank
### Before:
This 3 items(War Bonds, Chef Hat, Rapid Growth) shows that they are withdrawable but will then give an error when done so.
![image](https://user-images.githubusercontent.com/104184348/191303713-15af6c49-5ae5-41e1-9490-e474aa94a00d.png)

### After:
This was tested locally by adding test codes in constants.ts and removing this test codes before commit.
![image](https://user-images.githubusercontent.com/104184348/191303294-1e38cdbf-af1f-452c-94a7-ddad858b3f46.png)

# Checklist:
- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
