### PR TITLE
[FIX] Frog Limit for Rarity

### DIFF
--- a/src/features/community/merchant/actions/loadFrogs.ts
+++ b/src/features/community/merchant/actions/loadFrogs.ts
@@ -83,34 +83,37 @@ function filterFrogs(frogs: Frog[]) {
   const highestRarity = frogs[0].attributes[5].value;
 
   console.log("highest rarity", highestRarity);
+  console.log("length before", frogs.length);
 
   /** Limit frogs based on highest rarity of frog in farm
-   * Legendary = 6 frogs
-   * Epic = 5 frogs
-   * Rare = 4 frogs
-   * Uncommon = 3 frogs
-   * Common = 2 frogs
+   * Legendary = 7 frogs
+   * Epic = 6 frogs
+   * Rare = 5 frogs
+   * Uncommon = 4 frogs
+   * Common = 3 frogs
    */
+
   switch (highestRarity) {
     case "Legendary":
-      frogs.splice(6, frogs.length);
+      frogs.splice(7, frogs.length);
       break;
     case "Epic":
-      frogs.slice(5, frogs.length);
+      frogs.splice(6, frogs.length);
       break;
     case "Rare":
-      frogs.slice(4, frogs.length);
+      frogs.splice(5, frogs.length);
       break;
     case "Uncommon":
-      frogs.slice(3, frogs.length);
+      frogs.splice(4, frogs.length);
       break;
     case "Common":
-      frogs.splice(2, frogs.length);
+      frogs.splice(3, frogs.length);
       break;
     default:
-      frogs.slice(0, 2);
+      frogs.splice(0, 2);
   }
 
+  console.log("length after", frogs.length);
   return frogs;
 }
 


### PR DESCRIPTION
# Description

Fixes rarity limit for frogs. 

   * Legendary = 7 frogs
   * Epic = 6 frogs
   * Rare = 5 frogs
   * Uncommon = 4 frogs
   * Common = 3 frogs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
on localhost / testnet

I have 8 frogs on my farm and only 7 show (Legendary - highest rarity)
<img width="608" alt="Screen Shot 2022-09-24 at 2 21 29 AM" src="https://user-images.githubusercontent.com/18549210/192032365-32c6e704-a91d-4ab5-9427-6c88d3e18ee9.png">

`yarn test`
<img width="290" alt="Screen Shot 2022-09-24 at 2 23 53 AM" src="https://user-images.githubusercontent.com/18549210/192032749-d01a4c5b-47ad-4112-9e54-82391e78e0da.png">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
