### PR TITLE
[FIX] Prevent clicking same goblin 3 times to solve the puzzle. Add 500ms delay.

### DIFF
--- a/src/features/farming/crops/components/CropReward.tsx
+++ b/src/features/farming/crops/components/CropReward.tsx
@@ -26,6 +26,7 @@ export const CropReward: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
   const [opened, setOpened] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const challenge = useRef<Challenge>(
     Math.random() > 0.5 ? "chest" : "goblins"
@@ -36,6 +37,8 @@ export const CropReward: React.FC<Props> = ({
   useEffect(() => {
     if (reward) {
       addNoise(id.current);
+      setLoading(true);
+      setTimeout(() => setLoading(false), 500);
     }
   }, [reward]);
 
@@ -63,7 +66,9 @@ export const CropReward: React.FC<Props> = ({
     <Modal centered show={true}>
       <Panel>
         <div className="flex flex-col items-center justify-between">
-          {opened ? (
+          {loading ? (
+            "Loading..."
+          ) : opened ? (
             <>
               <span className="text-center mb-2">
                 Woohoo! Here is your reward

--- a/src/features/farming/crops/components/StopTheGoblins.tsx
+++ b/src/features/farming/crops/components/StopTheGoblins.tsx
@@ -79,24 +79,24 @@ interface Props {
 }
 
 export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
-  const [wrongAttempts, setWrongAttempts] = useState<number[]>([]);
-  const [correctAttempts, setCorrectAttempts] = useState<number[]>([]);
+  const [wrongAttempts, setWrongAttempts] = useState(new Set<number>());
+  const [correctAttempts, setCorrectAttempts] = useState(new Set<number>());
   const [items] = useState(generateImages());
 
-  const attemptsLeft = MAX_ATTEMPTS - wrongAttempts.length;
+  const attemptsLeft = MAX_ATTEMPTS - wrongAttempts.size;
 
   const check = (index: number) => {
     if (items[index].isGoblin) {
-      setCorrectAttempts((prev) => [...prev, index]);
+      setCorrectAttempts((prev) => new Set([...prev, index]));
 
-      if (correctAttempts.length === GOBLIN_COUNT - 1) {
+      if (correctAttempts.size === GOBLIN_COUNT - 1) {
         onOpen();
       }
 
       return;
     }
 
-    setWrongAttempts((prev) => [...new Set([...prev, index])]);
+    setWrongAttempts((prev) => new Set([...prev, index]));
 
     if (attemptsLeft <= 1) {
       onFail();
@@ -108,8 +108,8 @@ export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
       <span className="text-center mb-2">Stop the Goblins!</span>
       <div className="flex flex-wrap justify-center items-center">
         {items.map((item, index) => {
-          const failed = wrongAttempts.includes(index);
-          const confirmed = correctAttempts.includes(index);
+          const failed = wrongAttempts.has(index);
+          const confirmed = correctAttempts.has(index);
 
           return (
             <div


### PR DESCRIPTION
# Description

1. Prevent clicking same goblin 3 times to solve puzzle.

2. Add 500ms delay before displaying puzzle/captcha to prevent spam clicks triggering fail action.

PS: I can separate those fixes if delay is not a proper way of handling that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [n/a] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
