### PR TITLE
[FIX] Prevent clicking same goblin multiple times to solve puzzle

### DIFF
--- a/src/features/farming/crops/components/StopTheGoblins.tsx
+++ b/src/features/farming/crops/components/StopTheGoblins.tsx
@@ -87,7 +87,7 @@ export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
 
   const check = (index: number) => {
     if (items[index].isGoblin) {
-      let _correctAttempts = new Set([...correctAttempts, index]);
+      const _correctAttempts = new Set([...correctAttempts, index]);
       setCorrectAttempts(_correctAttempts);
 
       if (_correctAttempts.size === GOBLIN_COUNT) {

--- a/src/features/farming/crops/components/StopTheGoblins.tsx
+++ b/src/features/farming/crops/components/StopTheGoblins.tsx
@@ -87,9 +87,10 @@ export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
 
   const check = (index: number) => {
     if (items[index].isGoblin) {
-      setCorrectAttempts((prev) => new Set([...prev, index]));
+      let _correctAttempts = new Set([...prev, index])
+      setCorrectAttempts((prev) => _correctAttempts);
 
-      if (correctAttempts.size === GOBLIN_COUNT - 1) {
+      if (_correctAttempts.size === GOBLIN_COUNT) {
         onOpen();
       }
 

--- a/src/features/farming/crops/components/StopTheGoblins.tsx
+++ b/src/features/farming/crops/components/StopTheGoblins.tsx
@@ -87,8 +87,8 @@ export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
 
   const check = (index: number) => {
     if (items[index].isGoblin) {
-      let _correctAttempts = new Set([...prev, index])
-      setCorrectAttempts((prev) => _correctAttempts);
+      let _correctAttempts = new Set([...correctAttempts, index]);
+      setCorrectAttempts(_correctAttempts);
 
       if (_correctAttempts.size === GOBLIN_COUNT) {
         onOpen();


### PR DESCRIPTION
# Description

Prevents clicking of same goblin multiple times
The current implementation checks that 2 goblins are clicked, and the goblin clicks are checked before the React state may update. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
[N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
[N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
