### PR TITLE
[Fix] Sort Inventory Items, Fix Inventory Shortcut UI on Mobile

### DIFF
--- a/src/components/InventoryTabContent.tsx
+++ b/src/components/InventoryTabContent.tsx
@@ -16,6 +16,7 @@ import { getCropTime } from "features/game/events/plant";
 import { getKeys } from "features/game/types/craftables";
 import { useMakeDefaultInventoryItem } from "components/hooks/useGetDefaultInventoryItem";
 import { useHasBoostForItem } from "./hooks/useHasBoostForItem";
+import { KNOWN_IDS } from "features/game/types";
 
 const ITEM_CARD_MIN_HEIGHT = "148px";
 
@@ -134,15 +135,17 @@ export const InventoryTabContent = ({
             {<p className="mb-2 underline">{category}</p>}
             {findIfItemsExistForCategory(category) ? (
               <div className="flex mb-2 flex-wrap -ml-1.5">
-                {inventoryMap[category].map((item) => (
-                  <Box
-                    count={inventory[item]}
-                    isSelected={selectedItem === item}
-                    key={item}
-                    onClick={() => handleItemClick(item)}
-                    image={ITEM_DETAILS[item].image}
-                  />
-                ))}
+                {inventoryMap[category]
+                  .sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b])
+                  .map((item) => (
+                    <Box
+                      count={inventory[item]}
+                      isSelected={selectedItem === item}
+                      key={item}
+                      onClick={() => handleItemClick(item)}
+                      image={ITEM_DETAILS[item].image}
+                    />
+                  ))}
               </div>
             ) : (
               <p className="text-white text-xs text-shadow mb-2 pl-2.5">

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -9,6 +9,7 @@ import timer from "assets/icons/timer.png";
 import cancel from "assets/icons/cancel.png";
 import { useLongPress } from "lib/utils/hooks/useLongPress";
 import { shortenCount } from "lib/utils/formatNumber";
+import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 
 export interface BoxProps {
   hideCount?: boolean;
@@ -47,6 +48,7 @@ export const Box: React.FC<BoxProps> = ({
 }) => {
   const [isHover, setIsHover] = useState(false);
   const [shortCount, setShortCount] = useState("");
+  const [isMobile] = useIsMobile();
 
   // re execute function on count change
   useEffect(() => setShortCount(shortenCount(count)), [count]);
@@ -69,7 +71,7 @@ export const Box: React.FC<BoxProps> = ({
   return (
     <div
       className={`relative ${className}`}
-      onMouseEnter={() => setIsHover(true)}
+      onMouseEnter={() => setIsHover(!isMobile)}
       onMouseLeave={() => setIsHover(false)}
     >
       <div

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -107,13 +107,13 @@ export const WithdrawItems: React.FC<Props> = ({
       : details;
   };
 
-  const inventoryItems = getKeys(inventory).filter((item) =>
-    inventory[item]?.gt(0)
-  );
+  const inventoryItems = getKeys(inventory)
+    .filter((item) => inventory[item]?.gt(0))
+    .sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b]);
 
-  const selectedItems = getKeys(selected).filter((item) =>
-    selected[item]?.gt(0)
-  );
+  const selectedItems = getKeys(selected)
+    .filter((item) => selected[item]?.gt(0))
+    .sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b]);
 
   const getTotalNumberOfItemType = (itemName: InventoryItemName) => {
     const state = goblinState.context.state;


### PR DESCRIPTION
# Description

- Sort inventory items 
- Sort withdrawable items
- Fix double selected items on mobile when selecting shortcut items

![image](https://user-images.githubusercontent.com/107602352/194244713-452ae0b5-b964-448b-9a95-3681c5025641.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open inventory
- Open withdraw menu in Goblin Village
- Click the 2nd/3rd items in the inventory shortcut

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
