### PR TITLE
[FIX] Play harvest sound and display amount harvested after reward 

### DIFF
--- a/src/features/farming/crops/components/Field.tsx
+++ b/src/features/farming/crops/components/Field.tsx
@@ -69,10 +69,7 @@ export const Field: React.FC<Props> = ({
   const onCollectReward = () => {
     setReward(null);
     setTouchCount(0);
-
-    gameService.send("item.harvested", {
-      index: fieldIndex,
-    });
+    harvestCrop();
   };
 
   const removeCrop = () => {
@@ -85,6 +82,21 @@ export const Field: React.FC<Props> = ({
       fieldIndex,
     });
     setIsRemoving(false);
+  };
+
+  const harvestCrop = () => {
+    gameService.send("item.harvested", {
+      index: fieldIndex,
+    });
+
+    harvestAudio.play();
+
+    displayPopover(
+      <div className="flex items-center justify-center text-xs text-white text-shadow overflow-visible">
+        <img src={ITEM_DETAILS[field.name].image} className="w-4 mr-1" />
+        <span>{`+${field.multiplier || 1}`}</span>
+      </div>
+    );
   };
 
   const handleMouseHover = () => {
@@ -189,18 +201,7 @@ export const Field: React.FC<Props> = ({
     }
 
     try {
-      gameService.send("item.harvested", {
-        index: fieldIndex,
-      });
-
-      harvestAudio.play();
-
-      displayPopover(
-        <div className="flex items-center justify-center text-xs text-white text-shadow overflow-visible">
-          <img src={ITEM_DETAILS[field.name].image} className="w-4 mr-1" />
-          <span>{`+${field.multiplier || 1}`}</span>
-        </div>
-      );
+      harvestCrop();
     } catch (e: any) {
       // TODO - catch more elaborate errors
       displayPopover(<img className="w-5" src={cancel} />);

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -85,7 +85,7 @@ export const INITIAL_FIELDS: GameState["fields"] = {
       items: [
         {
           amount: 2,
-          name: "Sunflower",
+          name: "Sunflower Seed",
         },
       ],
     },


### PR DESCRIPTION
# Description

Before:
If field has reward it doesnt play harvest sound and doesnt display amount harvested.

After:
Reuse same logic for both harvest events.

With green amulet its nice to see amount received on all harvests.

https://user-images.githubusercontent.com/9656961/194352611-1ae486cc-55df-4128-a7c2-f646b74f3edb.mp4

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
