### PR TITLE
[FIX] checkFarm blacklisted condition

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -461,7 +461,7 @@ export const authMachine = createMachine<
           onDone: [
             {
               target: "blacklisted",
-              cond: (context) => context.blacklistStatus !== "OK",
+              cond: (_, event) => event.data.blacklistStatus !== "OK",
               actions: "assignFarm",
             },
             {


### PR DESCRIPTION
# Description

This PR fixes the condition for blacklisted when visiting a farm via url (new tab, refresh). Caused by incorrect access for `blacklistStatus` i.e. should be `event.data` instead of `context`. `undefined !== "OK"` returns `true`.

![visit url banned](https://user-images.githubusercontent.com/89294757/194604788-68f16096-afe5-45ab-9b95-45c8f5af0d70.PNG)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test - testnet

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
