### PR TITLE
[FIX] Frogs Visit Farm Bugs

### DIFF
--- a/src/features/visiting/water/FrogNft.tsx
+++ b/src/features/visiting/water/FrogNft.tsx
@@ -23,10 +23,12 @@ export const FrogNft: React.FC = () => {
   useEffect(() => {
     const fetchFrogs = async () => {
       const data = await loadFrogs(gameState.context.owner);
-      setFrogData(data);
+      setFrogData(data as Frog[]);
     };
 
-    fetchFrogs();
+    if (gameState.context.owner) {
+      fetchFrogs();
+    }
   }, [gameState.context.owner]);
 
   return (


### PR DESCRIPTION
# Description

This PR fixes the ff:
1. When visiting a farm which has frog/s, there is a short animation which displays your OWN frogs then updates to their roster

https://user-images.githubusercontent.com/89294757/194734298-4b0adc27-d03b-49b1-9317-8b16678b597d.mp4

2. When visiting a farm which has no frog/s, it displays your OWN frogs instead (Farm 6 has no frogs)

![sfl-own-frog-on-empty-visit](https://user-images.githubusercontent.com/89294757/194734314-7fdd0364-1874-42dd-90a0-2a3b94fd2fb3.PNG)

### Cause

`gameState.context.owner`  updates twice, first is `undefined` then second is the actual visited farm address. when undefined is passed the contract call uses `this.account` instead.

### Fix

1. call `fetchFrogs()` only when owner is defined
2. ~~typecast `Frog[]` to update render~~ unnecessary but dont want to submit another commit 

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test - testnet

1. Visit Farm 1 which has frogs

https://user-images.githubusercontent.com/89294757/194734422-c382bea1-1eb8-4b68-b233-3b212f561c9f.mp4

2. Visit Farm 6 which has no frogs

https://user-images.githubusercontent.com/89294757/194734434-6286f80a-663a-47a7-8e11-7afdfd3ef2f6.mp4

3. Visit own Farm (regression test)

https://user-images.githubusercontent.com/89294757/194734445-af50a2eb-3200-4013-b0d2-971f9ff59c66.mp4

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
