### PR TITLE
[FIX] Withdraw hasFedChickens condition

### DIFF
--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -38,7 +38,7 @@ function hasFedChickens(game: GoblinState): boolean {
 
   const hasFedChickens = Object.values(game.chickens).some(
     (chicken) =>
-      !chicken.fedAt || Date.now() - chicken.fedAt < CHICKEN_TIME_TO_EGG
+      chicken.fedAt && Date.now() - chicken.fedAt < CHICKEN_TIME_TO_EGG
   );
 
   return hasFedChickens;


### PR DESCRIPTION
# Description

This PR fixes the bug where mutant chickens cannot be withdrawn when chickens are **not** fed. Reported by Bill in [discord](https://discord.com/channels/880987707214544966/881648372249939980/1029037276430344232)

![image](https://user-images.githubusercontent.com/89294757/194899371-b160866c-443e-4b31-b63b-aaffebaa1aba.png)

### Cause
`!chicken.fedAt` returns `true` which disables the withdraw for mutant chickens.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Untested - no testnet data / have not reproduced in local.

I removed left side expression i.e. reverted and it showed a `Object is possibly 'undefined'` error so I assume it is added to fix that. 

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
