### PR TITLE
[FEAT] No need to refresh to mint new items

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -65,6 +65,12 @@ export interface CraftableItem {
   isPlaceholder?: boolean;
   bumpkinLevel?: number;
   canMintMultiple?: boolean;
+  /**
+   * Date the item will be craftable in milliseconds
+   * Date.UTC(YEAR, MONTH, DAY, HOUR?, MINUTE?, SECONDS?, MS?)
+   * REMEMBER MONTHS START IN 0, 0 = JAN, 1 = FEB...
+   */
+  mintReleaseDate?: number;
 }
 
 export type MutantChicken = "Speed Chicken" | "Rich Chicken" | "Fat Chicken";
@@ -616,30 +622,35 @@ export const WAR_TENT_ITEMS: Record<WarTentItem, LimitedItem> = {
     description: "A mark of a true warrior",
     type: LimitedItemType.WarTentItem,
     disabled: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "Warrior Pants": {
     name: "Warrior Pants",
     description: "Protect your thighs",
     type: LimitedItemType.WarTentItem,
     disabled: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "Warrior Helmet": {
     name: "Warrior Helmet",
     description: "Immune to arrows",
     type: LimitedItemType.WarTentItem,
     disabled: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "Sunflower Shield": {
     name: "Sunflower Shield",
     description: "A hero of Sunflower Land. Free Sunflower Seeds!",
     type: LimitedItemType.WarTentItem,
     disabled: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "Skull Hat": {
     name: "Skull Hat",
     description: "A rare hat for your Bumpkin.",
     type: LimitedItemType.WarTentItem,
     disabled: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "War Skull": {
     name: "War Skull",
@@ -647,18 +658,21 @@ export const WAR_TENT_ITEMS: Record<WarTentItem, LimitedItem> = {
     type: LimitedItemType.WarTentItem,
     disabled: true,
     canMintMultiple: true,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "War Tombstone": {
     name: "War Tombstone",
     description: "R.I.P",
     type: LimitedItemType.WarTentItem,
     disabled: false,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
   "Undead Rooster": {
     name: "Undead Rooster",
     description: "An unfortunate casualty of the war. 10% increased egg yield.",
     type: LimitedItemType.WarTentItem,
     disabled: false,
+    mintReleaseDate: Date.UTC(2022, 9, 13, 6, 0, 0, 0),
   },
 };
 
@@ -1036,6 +1050,7 @@ export const makeLimitedItemsByName = (
         disabled: !enabled,
         isPlaceholder: items[name].isPlaceholder || isNewItem,
         canMintMultiple: items[name].canMintMultiple,
+        mintReleaseDate: items[name].mintReleaseDate || 0,
       };
     }
 

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -229,7 +229,11 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
       );
     }
 
-    if (selected.disabled) {
+    if (!selected.mintReleaseDate) return;
+
+    const currentDate = Date.now();
+    const mintReleaseDate = selected.mintReleaseDate;
+    if (mintReleaseDate < currentDate && selected.disabled) {
       return <span className="text-xs mt-2">Coming soon</span>;
     }
 

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -233,7 +233,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
 
     const currentDate = Date.now();
     const mintReleaseDate = selected.mintReleaseDate;
-    if (mintReleaseDate < currentDate && selected.disabled) {
+    if (mintReleaseDate > currentDate && selected.disabled) {
       return <span className="text-xs mt-2">Coming soon</span>;
     }
 


### PR DESCRIPTION
# Description

As the title says, this pull request solves the problem of players needing to refresh the page to mint a new item.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


https://user-images.githubusercontent.com/94913189/195290860-7ab628bc-7293-43d7-932e-790bcc48b9c1.mp4



# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
