### PR TITLE
[FIX] Hide SFL Requirement if not Needed for Crafting

### DIFF
--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -145,7 +145,8 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
             );
           })}
 
-          {selected.tokenAmount && (
+          {/* SFL requirement */}
+          {selected.tokenAmount?.gt(0) && (
             <div className="flex justify-center items-end">
               <img src={token} className="h-5 mr-1" />
               <span

--- a/src/features/farming/blacksmith/components/CraftingItems.tsx
+++ b/src/features/farming/blacksmith/components/CraftingItems.tsx
@@ -18,7 +18,6 @@ import { InventoryItemName } from "features/game/types/game";
 import { Stock } from "components/ui/Stock";
 import { getBuyPrice } from "features/game/events/craft";
 import { getMaxChickens } from "features/game/events/feedChicken";
-import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 
 interface Props {
   items: Partial<Record<InventoryItemName, CraftableItem>>;
@@ -82,24 +81,6 @@ export const CraftingItems: React.FC<Props> = ({
     shortcutItem(selected.name);
   };
 
-  const onCaptchaSolved = async (captcha: string | null) => {
-    await new Promise((res) => setTimeout(res, 1000));
-
-    gameService.send("SYNC", { captcha });
-
-    onClose();
-  };
-
-  const sync = () => {
-    gameService.send("SYNC", { captcha: "" });
-
-    onClose();
-  };
-
-  const restock = () => {
-    // setShowCaptcha(true);
-    sync();
-  };
   // ask confirmation if crafting more than 10
   const openConfirmationModal = () => {
     showCraftTenModal(true);
@@ -112,16 +93,6 @@ export const CraftingItems: React.FC<Props> = ({
     craft(10);
     closeConfirmationModal();
   };
-  if (showCaptcha) {
-    return (
-      <CloudFlareCaptcha
-        action="carfting-sync"
-        onDone={onCaptchaSolved}
-        onExpire={() => setShowCaptcha(false)}
-        onError={() => setShowCaptcha(false)}
-      />
-    );
-  }
 
   const Action = () => {
     if (selected.disabled) {
@@ -148,9 +119,6 @@ export const CraftingItems: React.FC<Props> = ({
           <p className="text-xxs text-center">
             Sync your farm to the Blockchain to restock
           </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
         </div>
       );
     }
@@ -276,16 +244,22 @@ export const CraftingItems: React.FC<Props> = ({
               );
             })}
 
-            <div className="flex justify-center items-end">
-              <img src={token} className="h-5 mr-1" />
-              <span
-                className={classNames("text-xs text-shadow text-center mt-2 ", {
-                  "text-red-500": lessFunds(),
-                })}
-              >
-                {`$${price?.toNumber()}`}
-              </span>
-            </div>
+            {/* SFL requirement */}
+            {price?.gt(0) && (
+              <div className="flex justify-center items-end">
+                <img src={token} className="h-5 mr-1" />
+                <span
+                  className={classNames(
+                    "text-xs text-shadow text-center mt-2 ",
+                    {
+                      "text-red-500": lessFunds(),
+                    }
+                  )}
+                >
+                  {`$${price?.toNumber()}`}
+                </span>
+              </div>
+            )}
           </div>
           {Action()}
         </div>

--- a/src/features/farming/shop/Seeds.tsx
+++ b/src/features/farming/shop/Seeds.tsx
@@ -25,7 +25,6 @@ import { getBuyPrice } from "features/game/events/craft";
 import { getCropTime } from "features/game/events/plant";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { makeBulkSeedBuyAmount } from "./lib/makeBulkSeedBuyAmount";
-import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 
 interface Props {
   onClose: () => void;
@@ -43,7 +42,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     },
   ] = useActor(gameService);
   const [isTimeBoosted, setIsTimeBoosted] = useState(false);
-  const [showCaptcha, setShowCaptcha] = useState(false);
 
   const inventory = state.inventory;
 
@@ -61,21 +59,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     });
 
     shortcutItem(selected.name);
-  };
-
-  const restock = () => {
-    // setShowCaptcha(true);
-    gameService.send("SYNC", { captcha: "" });
-
-    onClose();
-  };
-
-  const onCaptchaSolved = async (captcha: string | null) => {
-    await new Promise((res) => setTimeout(res, 1000));
-
-    gameService.send("SYNC", { captcha });
-
-    onClose();
   };
 
   const lessFunds = (amount = 1) => {
@@ -101,16 +84,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     [inventory, selected.name, state.inventory]
   );
 
-  if (showCaptcha) {
-    return (
-      <CloudFlareCaptcha
-        action="seeds-sync"
-        onDone={onCaptchaSolved}
-        onExpire={() => setShowCaptcha(false)}
-        onError={() => setShowCaptcha(false)}
-      />
-    );
-  }
   const Action = () => {
     const isLocked = selected.requires && !inventory[selected.requires];
     if (isLocked || selected.disabled) {
@@ -126,9 +99,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
           <p className="text-xxs text-center">
             Sync your farm to the Blockchain to restock
           </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
         </div>
       );
     }

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -338,8 +338,8 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
                 );
               })}
 
-              {/* Don't render SFL for war rewards */}
-              {selected.type !== LimitedItemType.WarTentItem &&
+              {/* SFL requirement */}
+              {selected.tokenAmount?.gt(0) &&
                 (selected.isPlaceholder ? (
                   <span className="text-xs">?</span>
                 ) : (
@@ -353,7 +353,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
                         }
                       )}
                     >
-                      {`${selected.tokenAmount?.toNumber()} SFL`}
+                      {`$${selected.tokenAmount?.toNumber()}`}
                     </span>
                   </div>
                 ))}

--- a/src/features/island/buildings/components/building/chickenHouse/components/ChickenHouseModal.tsx
+++ b/src/features/island/buildings/components/building/chickenHouse/components/ChickenHouseModal.tsx
@@ -118,6 +118,7 @@ export const ChickenHouseModal: React.FC<Props> = ({ onClose }) => {
             Feed wheat and collect eggs
           </span>
           <>
+            {/* SFL requirement */}
             <div className="border-t border-white w-full mt-2 pt-1">
               <div className="flex justify-center items-end">
                 <img src={token} className="h-5 mr-1" />
@@ -133,6 +134,7 @@ export const ChickenHouseModal: React.FC<Props> = ({ onClose }) => {
                 </span>
               </div>
             </div>
+
             <Button
               disabled={lessFunds()}
               className="text-xxs sm:text-xs mt-1 whitespace-nowrap"

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -25,7 +25,6 @@ import { getBuyPrice } from "features/game/events/craft";
 import { getCropTime } from "features/game/events/plant";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { makeBulkSeedBuyAmount } from "./lib/makeBulkSeedBuyAmount";
-import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 import { getBumpkinLevel } from "features/game/lib/level";
 
 interface Props {
@@ -44,7 +43,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     },
   ] = useActor(gameService);
   const [isTimeBoosted, setIsTimeBoosted] = useState(false);
-  const [showCaptcha, setShowCaptcha] = useState(false);
 
   const inventory = state.inventory;
 
@@ -62,24 +60,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     });
 
     shortcutItem(selected.name);
-  };
-
-  const restock = () => {
-    sync();
-  };
-
-  const sync = () => {
-    gameService.send("SYNC", { captcha: "" });
-
-    onClose();
-  };
-
-  const onCaptchaSolved = async (captcha: string | null) => {
-    await new Promise((res) => setTimeout(res, 1000));
-
-    gameService.send("SYNC", { captcha });
-
-    onClose();
   };
 
   const lessFunds = (amount = 1) => {
@@ -105,16 +85,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     [inventory, selected.name, state.inventory]
   );
 
-  if (showCaptcha) {
-    return (
-      <CloudFlareCaptcha
-        action="seeds-sync"
-        onDone={onCaptchaSolved}
-        onExpire={() => setShowCaptcha(false)}
-        onError={() => setShowCaptcha(false)}
-      />
-    );
-  }
   const Action = () => {
     const userBumpkinLevel = getBumpkinLevel(state.bumpkin?.experience ?? 0);
     const requiredLevel = selected.bumpkinLevel ?? 0;
@@ -136,9 +106,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
           <p className="text-xxs text-center">
             Sync your farm to the Blockchain to restock
           </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
         </div>
       );
     }
@@ -205,6 +172,8 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
                 {secondsToMidString(getCropTime(crop.name, inventory))}
               </span>
             </div>
+
+            {/* SFL requirement */}
             <div className="flex justify-center items-end">
               <img src={token} className="h-5 mr-1" />
               <span


### PR DESCRIPTION
# Description

- hide "$0" (hide SFL) row if no SFL is needed to craft an item
- remove sync option after running out of stock
  - unify behaviour across all crafting screens (currently cakes does not have the sync button)
  - players would often accidently click the sync button after buying seeds and running out of stock

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/195717435-b65d73aa-1bbc-4edf-a1ff-239d6e0324a9.png)  |  ![image](https://user-images.githubusercontent.com/107602352/195717382-17d63008-947b-4d06-a6a7-2cfa81e66ea5.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit Human Village
  - Visit Shop, Craft and Kitchen buildings
- Visit Goblin Village
  - Visit Craft, Taylor, Farmer and War Tent buildings

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
