### PR TITLE
[FIX] Hide SFL Requirement if not Needed for Crafting

### DIFF
--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -145,7 +145,8 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
             );
           })}
 
-          {selected.tokenAmount && (
+          {/* SFL requirement */}
+          {selected.tokenAmount?.gt(0) && (
             <div className="flex justify-center items-end">
               <img src={token} className="h-5 mr-1" />
               <span

--- a/src/features/farming/blacksmith/components/CraftingItems.tsx
+++ b/src/features/farming/blacksmith/components/CraftingItems.tsx
@@ -276,16 +276,22 @@ export const CraftingItems: React.FC<Props> = ({
               );
             })}
 
-            <div className="flex justify-center items-end">
-              <img src={token} className="h-5 mr-1" />
-              <span
-                className={classNames("text-xs text-shadow text-center mt-2 ", {
-                  "text-red-500": lessFunds(),
-                })}
-              >
-                {`$${price?.toNumber()}`}
-              </span>
-            </div>
+            {/* SFL requirement */}
+            {price?.gt(0) && (
+              <div className="flex justify-center items-end">
+                <img src={token} className="h-5 mr-1" />
+                <span
+                  className={classNames(
+                    "text-xs text-shadow text-center mt-2 ",
+                    {
+                      "text-red-500": lessFunds(),
+                    }
+                  )}
+                >
+                  {`$${price?.toNumber()}`}
+                </span>
+              </div>
+            )}
           </div>
           {Action()}
         </div>

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -339,8 +339,8 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
                 );
               })}
 
-              {/* Don't render SFL for war rewards */}
-              {selected.type !== LimitedItemType.WarTentItem &&
+              {/* SFL requirement */}
+              {selected.tokenAmount?.gt(0) &&
                 (selected.isPlaceholder ? (
                   <span className="text-xs">?</span>
                 ) : (
@@ -354,7 +354,7 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
                         }
                       )}
                     >
-                      {`${selected.tokenAmount?.toNumber()} SFL`}
+                      {`$${selected.tokenAmount?.toNumber()}`}
                     </span>
                   </div>
                 ))}


### PR DESCRIPTION
# Description

- hide "$0" (hide SFL) row if no SFL is needed to craft an item

based on feedback in #1519

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/195772657-be96581c-631b-4c2f-8734-bbb2d17d6e50.png)  |  ![image](https://user-images.githubusercontent.com/107602352/195772578-df01bf96-f5b6-40c9-9a95-57a8dbc05d6d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit Human Village
  - Visit Shop, Craft and Kitchen buildings
- Visit Goblin Village
  - Visit Craft, Taylor, Farmer and War Tent buildings

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
