### PR TITLE
[FIX] Show Sync Button After Crafting Cakes

### DIFF
--- a/src/features/farming/bakery/components/Crafting.tsx
+++ b/src/features/farming/bakery/components/Crafting.tsx
@@ -37,7 +37,7 @@ export const Crafting: React.FC<Props> = ({ onClose }) => {
           minHeight: "200px",
         }}
       >
-        {tab === "cook" && <CraftingItems items={FOODS()} />}
+        {tab === "cook" && <CraftingItems items={FOODS()} onClose={onClose} />}
       </div>
     </Panel>
   );

--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -113,10 +113,6 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
   }
 
   const ItemContent = () => {
-    if (hasSelectedFood) {
-      return <span className="text-xs text-center mt-4">Already crafted</span>;
-    }
-
     if (!state.stock[selected.name] || state.stock[selected.name]?.eq(0)) {
       return (
         <div>
@@ -131,6 +127,10 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
           </Button>
         </div>
       );
+    }
+
+    if (hasSelectedFood) {
+      return <span className="text-xs text-center mt-4">Already crafted</span>;
     }
 
     return (

--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -17,17 +17,21 @@ import { CraftableItem } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { secondsToMidString } from "lib/utils/time";
 import { isExpired } from "features/game/lib/stock";
+import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 
 interface Props {
   items: Partial<Record<InventoryItemName, CraftableItem>>;
+  onClose: () => void;
 }
 
-export const CraftingItems: React.FC<Props> = ({ items }) => {
+export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
   const [selected, setSelected] = useState<CraftableItem>(
     Object.values(items)[0]
   );
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
+  const [showCaptcha, setShowCaptcha] = useState(false);
+
   const [
     {
       context: { state },
@@ -72,13 +76,47 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
     shortcutItem(selected.name);
   };
 
+  const onCaptchaSolved = async (captcha: string | null) => {
+    await new Promise((res) => setTimeout(res, 1000));
+
+    gameService.send("SYNC", { captcha });
+
+    onClose();
+  };
+
+  const sync = () => {
+    gameService.send("SYNC", { captcha: "" });
+
+    onClose();
+  };
+
+  const restock = () => {
+    // setShowCaptcha(true);
+    sync();
+  };
+
   const validItems = Object.values(items).filter(
     (item) => !isExpired({ name: item.name, stockExpiry: state.stockExpiry })
   );
 
   const expiryTime = state.stockExpiry[selected.name];
 
+  if (showCaptcha) {
+    return (
+      <CloudFlareCaptcha
+        action="bakery-sync"
+        onDone={onCaptchaSolved}
+        onExpire={() => setShowCaptcha(false)}
+        onError={() => setShowCaptcha(false)}
+      />
+    );
+  }
+
   const ItemContent = () => {
+    if (hasSelectedFood) {
+      return <span className="text-xs text-center mt-4">Already crafted</span>;
+    }
+
     if (!state.stock[selected.name] || state.stock[selected.name]?.eq(0)) {
       return (
         <div>
@@ -88,12 +126,11 @@ export const CraftingItems: React.FC<Props> = ({ items }) => {
           <p className="text-xxs text-center">
             Sync your farm to the Blockchain to restock
           </p>
+          <Button className="text-xs mt-1" onClick={restock}>
+            Sync
+          </Button>
         </div>
       );
-    }
-
-    if (hasSelectedFood) {
-      return <span className="text-xs text-center mt-4">Already crafted</span>;
     }
 
     return (


### PR DESCRIPTION
# Description

- add sync option after running out of stock when crafting cakes
  - unify behaviour across all crafting screens (currently all other crafting menus have the sync button)

based on feedback in #1519

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/195775417-5fb558e4-c87a-4c4f-8994-dca990df9ad6.png)  |  ![image](https://user-images.githubusercontent.com/107602352/195775338-5bd3ef65-893d-4d40-82c8-2a0f8f194ff9.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit Human Village, visit Craft building and craft a cake

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
