### PR TITLE
[FEAT] Placed Collectibles Boost

### DIFF
--- a/src/features/game/events/landExpansion/chop.test.ts
+++ b/src/features/game/events/landExpansion/chop.test.ts
@@ -42,6 +42,7 @@ const GAME_STATE: GameState = {
 };
 
 describe("chop", () => {
+  const dateNow = Date.now();
   it("throws an error if expansion does not exist", () => {
     expect(() =>
       chop({
@@ -189,6 +190,140 @@ describe("chop", () => {
     expect(tree2.wood.amount).toBeGreaterThan(2);
   });
 
+  it("tree replenishes normally", () => {
+    const dateNow = Date.now();
+    const game = chop({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          Axe: new Decimal(3),
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "timber.chopped",
+        item: "Axe",
+        expansionIndex: 0,
+        index: 0,
+      } as LandExpansionChopAction,
+    });
+
+    const { expansions } = game;
+    const trees = expansions[0].trees;
+    const tree = (trees as Record<number, LandExpansionTree>)[0];
+
+    // Should be set to now - add 5 ms to account for any CPU clock speed
+    expect(tree.wood.choppedAt).toBeGreaterThan(dateNow - 5);
+  });
+
+  it("tree replenishes on normal rate when Apprentice Beaver is placed but not ready", () => {
+    const game = chop({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          Axe: new Decimal(3),
+        },
+        collectibles: {
+          "Apprentice Beaver": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              readyAt: dateNow + 5 * 60 * 1000,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "timber.chopped",
+        item: "Axe",
+        expansionIndex: 0,
+        index: 0,
+      } as LandExpansionChopAction,
+    });
+
+    const { expansions } = game;
+    const trees = expansions[0].trees;
+    const tree = (trees as Record<number, LandExpansionTree>)[0];
+
+    expect(tree.wood.choppedAt).toBe(dateNow);
+  });
+
+  it("tree replenishes faster when Apprentice Beaver is placed", () => {
+    const game = chop({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          Axe: new Decimal(3),
+        },
+        collectibles: {
+          "Apprentice Beaver": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "timber.chopped",
+        item: "Axe",
+        expansionIndex: 0,
+        index: 0,
+      } as LandExpansionChopAction,
+    });
+
+    const { expansions } = game;
+    const trees = expansions[0].trees;
+    const tree = (trees as Record<number, LandExpansionTree>)[0];
+
+    // Should be set to now - add 5 ms to account for any CPU clock speed
+    const ONE_HOUR = 60 * 60 * 1000;
+    expect(tree.wood.choppedAt).toBeLessThan(Date.now() - ONE_HOUR + 5);
+  });
+
+  it("chops trees without axes when Foreman Beaver is placed and ready", () => {
+    const game = chop({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        collectibles: {
+          "Foreman Beaver": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // Ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "timber.chopped",
+        item: "Axe",
+        index: 0,
+        expansionIndex: 0,
+      } as LandExpansionChopAction,
+    });
+
+    const { expansions } = game;
+    const trees = expansions[0].trees;
+    const tree = (trees as Record<number, LandExpansionTree>)[0];
+
+    expect(game.inventory.Wood).toEqual(new Decimal(3));
+    expect(tree.wood.amount).toBeGreaterThan(2);
+  });
+
   it("throws an error if the player doesnt have a bumpkin", async () => {
     expect(() =>
       chop({
@@ -285,6 +420,71 @@ describe("chop", () => {
       MAX_STAMINA[getBumpkinLevel(INITIAL_BUMPKIN.experience)] -
         CHOP_STAMINA_COST
     );
+  });
+
+  describe("BumpkinActivity", () => {
+    it("increments Trees Chopped activity by 1 when 1 tree is chopped", () => {
+      const createdAt = Date.now();
+      const bumpkin = {
+        ...INITIAL_BUMPKIN,
+        stamina: { value: 0, replenishedAt: 0 },
+      };
+      const game = chop({
+        state: {
+          ...GAME_STATE,
+          bumpkin,
+          inventory: {
+            Axe: new Decimal(1),
+          },
+        },
+        createdAt,
+        action: {
+          type: "timber.chopped",
+          item: "Axe",
+          expansionIndex: 0,
+          index: 0,
+        } as LandExpansionChopAction,
+      });
+
+      expect(game.bumpkin?.activity?.["Tree Chopped"]).toBe(1);
+    });
+    it("increments Trees Chopped activity by 2 when 2 trees are chopped", () => {
+      const createdAt = Date.now();
+      const bumpkin = {
+        ...INITIAL_BUMPKIN,
+        stamina: { value: 0, replenishedAt: 0 },
+      };
+      const state1 = chop({
+        state: {
+          ...GAME_STATE,
+          bumpkin,
+          inventory: {
+            Axe: new Decimal(2),
+          },
+        },
+        createdAt,
+        action: {
+          type: "timber.chopped",
+          item: "Axe",
+          expansionIndex: 0,
+          index: 0,
+        } as LandExpansionChopAction,
+      });
+      const game = chop({
+        state: {
+          ...state1,
+        },
+        createdAt,
+        action: {
+          type: "timber.chopped",
+          item: "Axe",
+          expansionIndex: 0,
+          index: 1,
+        } as LandExpansionChopAction,
+      });
+
+      expect(game.bumpkin?.activity?.["Tree Chopped"]).toBe(2);
+    });
   });
 });
 

--- a/src/features/game/events/landExpansion/chop.test.ts
+++ b/src/features/game/events/landExpansion/chop.test.ts
@@ -493,7 +493,7 @@ describe("getChoppedAt", () => {
     const now = Date.now();
 
     const time = getChoppedAt({
-      inventory: {},
+      collectibles: {},
       skills: { "Tree Hugger": 1 },
       createdAt: now,
     });

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -6,7 +6,6 @@ import { BumpkinSkillName } from "features/game/types/bumpkinSkills";
 import {
   Collectibles,
   GameState,
-  Inventory,
   InventoryItemName,
   LandExpansionTree,
 } from "features/game/types/game";
@@ -14,7 +13,6 @@ import cloneDeep from "lodash.clonedeep";
 import { replenishStamina } from "./replenishStamina";
 
 type GetChoppedAtArgs = {
-  inventory: Inventory;
   skills: Partial<Record<BumpkinSkillName, number>>;
   collectibles: Collectibles;
   createdAt: number;
@@ -42,8 +40,7 @@ export function canChop(tree: LandExpansionTree, now: number = Date.now()) {
 /**
  * Set a chopped in the past to make it replenish faster
  */
-function getChoppedAt({
-  inventory,
+export function getChoppedAt({
   collectibles,
   skills,
   createdAt,
@@ -133,7 +130,6 @@ export function chop({
   tree.wood = {
     choppedAt: getChoppedAt({
       createdAt,
-      inventory,
       skills: bumpkin.skills,
       collectibles,
     }),

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -19,6 +19,7 @@ const GAME_STATE: GameState = {
 };
 
 describe("plant", () => {
+  const dateNow = Date.now();
   it("does not plant on a non existent expansion", () => {
     const { inventory } = GAME_STATE;
     expect(() =>
@@ -165,7 +166,7 @@ describe("plant", () => {
                   ...plot,
                   crop: {
                     name: "Sunflower",
-                    plantedAt: Date.now(),
+                    plantedAt: dateNow,
                   },
                 },
               },
@@ -296,6 +297,17 @@ describe("plant", () => {
           "Golden Cauliflower": new Decimal(1),
           "Water Well": new Decimal(1),
         },
+        collectibles: {
+          "Golden Cauliflower": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
+        },
       },
       action: {
         type: "seed.planted",
@@ -352,8 +364,19 @@ describe("plant", () => {
         ...GAME_STATE,
         inventory: {
           "Parsnip Seed": new Decimal(1),
-          "Mysterious Parsnip": new Decimal(1),
+          // "Mysterious Parsnip": new Decimal(1),
           "Water Well": new Decimal(1),
+        },
+        collectibles: {
+          "Mysterious Parsnip": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
         },
       },
       action: {
@@ -362,6 +385,7 @@ describe("plant", () => {
         expansionIndex: 0,
         item: "Parsnip Seed",
       },
+      createdAt: dateNow,
     });
 
     // Should be twice as fast! (Planted in the past)
@@ -372,12 +396,12 @@ describe("plant", () => {
     expect(plots).toBeDefined();
     const plantedAt =
       (plots as Record<number, LandExpansionPlot>)[0].crop?.plantedAt || 0;
+    console.log(plantedAt);
 
-    // Offset 5 ms for CPU time
-    expect(plantedAt - 5).toBeLessThan(Date.now() - parnsipTime * 0.5);
+    expect(plantedAt).toBe(dateNow - parnsipTime * 0.5);
   });
 
-  it("grows faster with a Nancy", () => {
+  it("grows faster with a Nancy placed and ready", () => {
     const state = plant({
       state: {
         ...GAME_STATE,
@@ -386,6 +410,17 @@ describe("plant", () => {
           Nancy: new Decimal(1),
           "Water Well": new Decimal(1),
         },
+        collectibles: {
+          Nancy: [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
+        },
       },
       action: {
         type: "seed.planted",
@@ -393,6 +428,7 @@ describe("plant", () => {
         expansionIndex: 0,
         item: "Carrot Seed",
       },
+      createdAt: dateNow,
     });
 
     // Should be twice as fast! (Planted in the psat)
@@ -403,8 +439,7 @@ describe("plant", () => {
     expect(plots).toBeDefined();
     const plantedAt = (plots as LandExpansionPlot[])[0].crop?.plantedAt || 0;
 
-    // Offset 5 ms for CPU time
-    expect(plantedAt - 5).toBeLessThan(Date.now() - carrotTime * 0.15);
+    expect(plantedAt).toBe(dateNow - carrotTime * 0.15);
   });
 
   it("yields more crop with a scarecrow", () => {
@@ -416,6 +451,17 @@ describe("plant", () => {
           Scarecrow: new Decimal(1),
           "Water Well": new Decimal(1),
         },
+        collectibles: {
+          Scarecrow: [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              // ready at < now
+              readyAt: dateNow - 5 * 60 * 1000,
+            },
+          ],
+        },
       },
       action: {
         type: "seed.planted",
@@ -429,7 +475,6 @@ describe("plant", () => {
 
     expect(plots).toBeDefined();
 
-    // Offset 5 ms for CPU time
     expect(
       (plots as Record<number, LandExpansionPlot>)[0].crop?.amount
     ).toEqual(1.2);
@@ -465,7 +510,7 @@ describe("plant", () => {
             ...INITIAL_BUMPKIN,
             stamina: {
               value: 0,
-              replenishedAt: Date.now(),
+              replenishedAt: dateNow,
             },
           },
           inventory: {
@@ -484,7 +529,7 @@ describe("plant", () => {
   });
 
   it("replenishes stamina before planting", () => {
-    const createdAt = Date.now();
+    const createdAt = dateNow;
 
     const state = plant({
       state: {
@@ -514,7 +559,7 @@ describe("plant", () => {
   });
 
   it("deducts stamina from bumpkin", () => {
-    const createdAt = Date.now();
+    const createdAt = dateNow;
 
     const state = plant({
       state: {
@@ -566,7 +611,7 @@ describe("plant", () => {
 
     const game = plant({
       state,
-      createdAt: Date.now(),
+      createdAt: dateNow,
       action: {
         type: "seed.planted",
         index: 0,
@@ -585,7 +630,7 @@ describe("plant", () => {
 
 describe("getCropTime", () => {
   it("applies a 5% speed boost with Cultivator skill", () => {
-    const time = getCropTime("Carrot", {}, { Cultivator: 1 });
+    const time = getCropTime("Carrot", {}, {}, { Cultivator: 1 });
 
     expect(time).toEqual(57 * 60);
   });

--- a/src/features/game/lib/collectibleBuilt.ts
+++ b/src/features/game/lib/collectibleBuilt.ts
@@ -1,0 +1,12 @@
+import { CollectibleName } from "../types/craftables";
+import { Collectibles } from "../types/game";
+
+export function isCollectibleBuilt(
+  name: CollectibleName,
+  collectible: Collectibles
+) {
+  return (
+    collectible[name] &&
+    collectible[name]?.some((placed) => placed.readyAt < Date.now())
+  );
+}

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -164,6 +164,7 @@ export type CollectibleName =
   | MarketItem
   | Flag
   | TravelingSalesmanItem
+  | MutantChicken
   | "War Skull"
   | "War Tombstone";
 
@@ -1127,6 +1128,11 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Egg Basket": { height: 1, width: 1 },
   "War Skull": { height: 1, width: 1 },
   "War Tombstone": { height: 1, width: 1 },
+
+  // Mutant Chickens
+  "Fat Chicken": { height: 1, width: 1 },
+  "Rich Chicken": { height: 1, width: 1 },
+  "Speed Chicken": { height: 1, width: 1 },
 };
 
 export const ANIMAL_DIMENSIONS: Record<"Chicken", Dimensions> = {


### PR DESCRIPTION
# Description

This PR implements the new mechanic in which items boost are only applied when the item is placed and ready.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
