### PR TITLE
[FEAT] Bumpkin equipped items boost

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -630,9 +630,28 @@ describe("plant", () => {
 
 describe("getCropTime", () => {
   it("applies a 5% speed boost with Cultivator skill", () => {
-    const time = getCropTime("Carrot", {}, {}, { Cultivator: 1 });
+    const time = getCropTime(
+      "Carrot",
+      {},
+      {},
+      { ...INITIAL_BUMPKIN, skills: { Cultivator: 1 } }
+    );
 
     expect(time).toEqual(57 * 60);
+  });
+
+  it("reduces in 20% carrot time when Bumpkin is wearing Carrot Amulet", () => {
+    const time = getCropTime(
+      "Carrot",
+      {},
+      {},
+      {
+        ...INITIAL_BUMPKIN,
+        equipped: { ...INITIAL_BUMPKIN.equipped, necklace: "Carrot Amulet" },
+      }
+    );
+
+    expect(time).toEqual(60 * 60 * 0.8);
   });
 });
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -12,7 +12,6 @@ import { isSeed } from "../plant";
 import { PLANT_STAMINA_COST } from "features/game/lib/constants";
 import { replenishStamina } from "./replenishStamina";
 import { getKeys } from "features/game/types/craftables";
-import { BumpkinSkillName } from "features/game/types/bumpkinSkills";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
 export type LandExpansionPlantAction = {
@@ -67,8 +66,11 @@ export const getCropTime = (
   crop: CropName,
   inventory: Inventory,
   collectibles: Collectibles,
-  skills: Partial<Record<BumpkinSkillName, number>>
+  bumpkin: Bumpkin
 ) => {
+  const { skills, equipped } = bumpkin;
+  const { necklace } = equipped;
+
   let seconds = CROPS()[crop].harvestSeconds;
 
   if (inventory["Seed Specialist"]?.gte(1)) {
@@ -82,7 +84,7 @@ export const getCropTime = (
     seconds = seconds * 0.5;
   }
 
-  if (crop === "Carrot" && inventory["Carrot Amulet"]?.gte(1)) {
+  if (crop === "Carrot" && necklace === "Carrot Amulet") {
     seconds = seconds * 0.8;
   }
 
@@ -106,7 +108,7 @@ type GetPlantedAtArgs = {
   crop: CropName;
   inventory: Inventory;
   collectibles: Collectibles;
-  skills: Partial<Record<BumpkinSkillName, number>>;
+  bumpkin: Bumpkin;
   createdAt: number;
 };
 
@@ -117,11 +119,11 @@ export function getPlantedAt({
   crop,
   inventory,
   collectibles,
-  skills,
+  bumpkin,
   createdAt,
 }: GetPlantedAtArgs): number {
   const cropTime = CROPS()[crop].harvestSeconds;
-  const boostedTime = getCropTime(crop, inventory, collectibles, skills);
+  const boostedTime = getCropTime(crop, inventory, collectibles, bumpkin);
 
   const offset = cropTime - boostedTime;
 
@@ -250,7 +252,7 @@ export function plant({
         crop: cropName,
         inventory,
         collectibles,
-        skills: bumpkin.skills,
+        bumpkin,
         createdAt,
       }),
       name: cropName,


### PR DESCRIPTION
# Description

This PR implements the new mechanic of applying the boosts for bumpkin items only when they're equipped.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
