### PR TITLE
[FIX] Unable to sell cakes

### DIFF
--- a/src/features/farming/cakeStall/components/Cakes.tsx
+++ b/src/features/farming/cakeStall/components/Cakes.tsx
@@ -37,7 +37,7 @@ export const Cakes: React.FC = () => {
   const sell = () => {
     gameService.send("item.sell", {
       item: selected,
-      amount: 1,
+      amount: new Decimal(1),
     });
 
     setToast({
@@ -102,7 +102,7 @@ export const Cakes: React.FC = () => {
               className="text-xs mt-1"
               onClick={openConfirmationModal}
             >
-              Sell
+              Sell 1
             </Button>
           )}
         </div>


### PR DESCRIPTION
# Description

- fix unable to sell cakes
- change "Sell" to "Sell 1" when selling cakes.  This makes it clearer for people who have multiple cakes in their inventory

This is a follow up for #1529 (related ot #1537)

Before:
![image](https://user-images.githubusercontent.com/107602352/196598340-499f6765-3942-4110-9f3b-3cc891a48929.png)

After:
![image](https://user-images.githubusercontent.com/107602352/196598357-50421079-5c01-4675-8790-2264a8d1ccd8.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- go to sunflower island and sell cakes

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
