### PR TITLE
[FIX] added parseFloat to remove extra zeros

### DIFF
--- a/src/features/farming/shop/Plants.tsx
+++ b/src/features/farming/shop/Plants.tsx
@@ -128,12 +128,13 @@ export const Plants: React.FC = () => {
           <div className="m-auto flex flex-col">
             <span className="text-sm text-center text-shadow">
               Are you sure you want to <br className="hidden md:block" />
-              sell {cropAmount.toFixed(4, Decimal.ROUND_DOWN).toString()}{" "}
+              sell {parseFloat(cropAmount.toFixed(4, Decimal.ROUND_DOWN))}{" "}
               {selected.name} for <br className="hidden md:block" />
-              {displaySellPrice(selected)
-                .mul(cropAmount)
-                .toFixed(4, Decimal.ROUND_DOWN)
-                .toString()}{" "}
+              {parseFloat(
+                displaySellPrice(selected)
+                  .mul(cropAmount)
+                  .toFixed(4, Decimal.ROUND_DOWN)
+              )}{" "}
               SFL?
             </span>
           </div>

--- a/src/features/island/buildings/components/building/market/Plants.tsx
+++ b/src/features/island/buildings/components/building/market/Plants.tsx
@@ -128,12 +128,13 @@ export const Plants: React.FC = () => {
           <div className="m-auto flex flex-col">
             <span className="text-sm text-center text-shadow">
               Are you sure you want to <br className="hidden md:block" />
-              sell {cropAmount.toFixed(4, Decimal.ROUND_DOWN).toString()}{" "}
+              sell {parseFloat(cropAmount.toFixed(4, Decimal.ROUND_DOWN))}{" "}
               {selected.name} for <br className="hidden md:block" />
-              {displaySellPrice(selected)
-                .mul(cropAmount.toNumber())
-                .toFixed(4, Decimal.ROUND_DOWN)
-                .toString()}{" "}
+              {parseFloat(
+                displaySellPrice(selected)
+                  .mul(cropAmount.toNumber())
+                  .toFixed(4, Decimal.ROUND_DOWN)
+              )}{" "}
               SFL?
             </span>
           </div>


### PR DESCRIPTION
# Description

added parseFloat to remove the extra four zeros that some items have.

BEFORE
![image](https://user-images.githubusercontent.com/94913189/196607349-009c6895-69c0-4920-9c52-9b008ab376ab.png)


AFTER
![image](https://user-images.githubusercontent.com/94913189/196607290-28eee9ff-b001-461d-8088-543936569a76.png)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

go to the Shop and try to sell any item.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
