### PR TITLE
[FIX] Allow crafting multiple cakes!🎂

### DIFF
--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -13,7 +13,7 @@ import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { CraftableItem } from "features/game/types/craftables";
+import { CAKES, CraftableItem } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { secondsToMidString } from "lib/utils/time";
 import { isExpired } from "features/game/lib/stock";
@@ -49,6 +49,7 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
   const hasSelectedFood =
     Object.keys(inventory).includes(selected.name) &&
     inventory[selected.name]?.gt(0);
+  const isCake = selected.name in CAKES();
 
   const canCraft = !(lessFunds() || lessIngredients());
 
@@ -129,7 +130,7 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
       );
     }
 
-    if (hasSelectedFood) {
+    if (hasSelectedFood && !isCake) {
       return <span className="text-xs text-center mt-4">Already crafted</span>;
     }
 
@@ -201,7 +202,7 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
           className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
           onClick={craft}
         >
-          {hasSelectedFood ? "Already crafted" : "Craft"}
+          {hasSelectedFood && !isCake ? "Already crafted" : "Craft"}
         </Button>
       </>
     );

--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -199,7 +199,9 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
         </div>
         <Button
           disabled={(hasSelectedFood && !isCake) || !canCraft}
-          className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
+          className={`${
+            hasSelectedFood && !isCake ? "pe-none" : ""
+          } text-xs mt-1`}
           onClick={craft}
         >
           {hasSelectedFood && !isCake ? "Already crafted" : "Craft"}

--- a/src/features/farming/bakery/components/CraftingItems.tsx
+++ b/src/features/farming/bakery/components/CraftingItems.tsx
@@ -198,7 +198,7 @@ export const CraftingItems: React.FC<Props> = ({ items, onClose }) => {
           )}
         </div>
         <Button
-          disabled={hasSelectedFood || !canCraft}
+          disabled={(hasSelectedFood && !isCake) || !canCraft}
           className={`${hasSelectedFood ? "pe-none" : ""} text-xs mt-1`}
           onClick={craft}
         >

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -63,18 +63,18 @@ export const INITIAL_STOCK: Inventory = {
   Sauerkraut: new Decimal(1),
   "Roasted Cauliflower": new Decimal(1),
 
-  "Sunflower Cake": new Decimal(1),
-  "Potato Cake": new Decimal(1),
-  "Pumpkin Cake": new Decimal(1),
-  "Carrot Cake": new Decimal(1),
-  "Cabbage Cake": new Decimal(1),
-  "Beetroot Cake": new Decimal(1),
-  "Cauliflower Cake": new Decimal(1),
-  "Parsnip Cake": new Decimal(1),
-  "Radish Cake": new Decimal(1),
-  "Wheat Cake": new Decimal(1),
+  "Sunflower Cake": new Decimal(2),
+  "Potato Cake": new Decimal(2),
+  "Pumpkin Cake": new Decimal(2),
+  "Carrot Cake": new Decimal(2),
+  "Cabbage Cake": new Decimal(2),
+  "Beetroot Cake": new Decimal(2),
+  "Cauliflower Cake": new Decimal(2),
+  "Parsnip Cake": new Decimal(2),
+  "Radish Cake": new Decimal(2),
+  "Wheat Cake": new Decimal(2),
 
-  "Boiled Egg": new Decimal(1),
+  "Boiled Egg": new Decimal(2),
 };
 
 export const INITIAL_FIELDS: GameState["fields"] = {
@@ -496,7 +496,7 @@ export const INITIAL_FARM: GameState = {
     "Carrot Cake": new Decimal(1),
     Radish: new Decimal(100),
     Wheat: new Decimal(100),
-    Egg: new Decimal(15),
+    Egg: new Decimal(30),
     "Rusty Shovel": new Decimal(1),
     Axe: new Decimal(3),
     Observatory: new Decimal(1),

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -63,18 +63,18 @@ export const INITIAL_STOCK: Inventory = {
   Sauerkraut: new Decimal(1),
   "Roasted Cauliflower": new Decimal(1),
 
-  "Sunflower Cake": new Decimal(2),
-  "Potato Cake": new Decimal(2),
-  "Pumpkin Cake": new Decimal(2),
-  "Carrot Cake": new Decimal(2),
-  "Cabbage Cake": new Decimal(2),
-  "Beetroot Cake": new Decimal(2),
-  "Cauliflower Cake": new Decimal(2),
-  "Parsnip Cake": new Decimal(2),
-  "Radish Cake": new Decimal(2),
-  "Wheat Cake": new Decimal(2),
+  "Sunflower Cake": new Decimal(1),
+  "Potato Cake": new Decimal(1),
+  "Pumpkin Cake": new Decimal(1),
+  "Carrot Cake": new Decimal(1),
+  "Cabbage Cake": new Decimal(1),
+  "Beetroot Cake": new Decimal(1),
+  "Cauliflower Cake": new Decimal(1),
+  "Parsnip Cake": new Decimal(1),
+  "Radish Cake": new Decimal(1),
+  "Wheat Cake": new Decimal(1),
 
-  "Boiled Egg": new Decimal(2),
+  "Boiled Egg": new Decimal(1),
 };
 
 export const INITIAL_FIELDS: GameState["fields"] = {


### PR DESCRIPTION
# Description

Allow users to craft multiple cakes! (They still need to sync to re-stock)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Go to the Kitchen and craft more than one cake :)

https://user-images.githubusercontent.com/94913189/196885270-3741d7bc-a8b0-42fa-9a3c-60ad62d4f53e.mp4


# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
