### PR TITLE
[FIX] Disable build button on insufficient balance.

### DIFF
--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -44,7 +44,7 @@ export const DetailView: React.FC<Props> = ({
 
     const missingBalance = BUILDINGS()[building].sfl > state.balance;
 
-    return missingIngredients && missingBalance;
+    return missingIngredients || missingBalance;
   };
 
   const bumpkinLevel = getBumpkinLevel(bumpkin?.experience ?? 0);


### PR DESCRIPTION
# Description

Fixes bug where build button wasn't being properly disabled in LE build mode.

Before:
![broken](https://user-images.githubusercontent.com/103600068/199157036-193e5f55-3ade-4c46-a85b-0ed974d02118.png)

After:
![fixed](https://user-images.githubusercontent.com/103600068/199157052-8bbe1495-6c57-460c-8d92-d32dd83e0211.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

visual

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
