### PR TITLE
[FEAT] Add crop sold events

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -82,6 +82,7 @@ import {
 import { craftTool, CraftToolAction } from "./landExpansion/craftTool";
 import { LandExpansionMigrateAction, migrate } from "./landExpansion/migrate";
 import { buyDecoration, buyDecorationAction } from "./buyDecoration";
+import { sellCrop, SellCropAction } from "./landExpansion/sellCrop";
 
 export type PlayingEvent =
   | CraftAction
@@ -120,7 +121,8 @@ export type PlayingEvent =
   | LandExpansionFeedChickenAction
   | CraftToolAction
   | LandExpansionMigrateAction
-  | buyDecorationAction;
+  | buyDecorationAction
+  | SellCropAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -181,6 +183,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "tool.crafted": craftTool,
   "game.migrated": migrate,
   "decoration.bought": buyDecoration,
+  "crop.sold": sellCrop,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -1,0 +1,159 @@
+import Decimal from "decimal.js-light";
+import { GameState } from "../../types/game";
+import { CropName, CROPS } from "../../types/crops";
+import { sellCrop } from "./sellCrop";
+import { INITIAL_BUMPKIN, INITIAL_FARM } from "../../lib/constants";
+
+const GAME_STATE: GameState = {
+  ...INITIAL_FARM,
+  bumpkin: INITIAL_BUMPKIN,
+  fields: {},
+  balance: new Decimal(0),
+
+  inventory: {},
+  trees: {},
+};
+
+describe("sell", () => {
+  it("does not sell a non sellable item", () => {
+    expect(() =>
+      sellCrop({
+        state: GAME_STATE,
+        action: {
+          type: "crop.sold",
+          crop: "Axe" as CropName,
+          amount: 1,
+        },
+      })
+    ).toThrow("Not for sale");
+  });
+
+  it("does not sell  an unusual amount", () => {
+    expect(() =>
+      sellCrop({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Sunflower: new Decimal(5),
+          },
+        },
+        action: {
+          type: "crop.sold",
+          crop: "Sunflower",
+          amount: 0,
+        },
+      })
+    ).toThrow("Invalid amount");
+  });
+
+  it("does not sell a missing item", () => {
+    expect(() =>
+      sellCrop({
+        state: GAME_STATE,
+        action: {
+          type: "crop.sold",
+          crop: "Sunflower",
+          amount: 1,
+        },
+      })
+    ).toThrow("Insufficient quantity to sell");
+  });
+
+  it("sells an item", () => {
+    const state = sellCrop({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Sunflower: new Decimal(5),
+        },
+      },
+      action: {
+        type: "crop.sold",
+        crop: "Sunflower",
+        amount: 1,
+      },
+    });
+
+    expect(state.inventory.Sunflower).toEqual(new Decimal(4));
+    expect(state.balance).toEqual(
+      GAME_STATE.balance.add(CROPS().Sunflower.sellPrice)
+    );
+  });
+
+  it("sell an item in bulk given sufficient quantity", () => {
+    const state = sellCrop({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Sunflower: new Decimal(11),
+        },
+      },
+      action: {
+        type: "crop.sold",
+        crop: "Sunflower",
+        amount: 10,
+      },
+    });
+
+    expect(state.inventory.Sunflower).toEqual(new Decimal(1));
+    expect(state.balance).toEqual(
+      GAME_STATE.balance.add(CROPS().Sunflower.sellPrice.mul(10))
+    );
+  });
+
+  it("does not sell an item in bulk given insufficient quantity", () => {
+    expect(() =>
+      sellCrop({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Sunflower: new Decimal(2),
+          },
+        },
+        action: {
+          type: "crop.sold",
+          crop: "Sunflower",
+          amount: 10,
+        },
+      })
+    ).toThrow("Insufficient quantity to sell");
+  });
+
+  it("sells a cauliflower for a normal price", () => {
+    const state = sellCrop({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Cauliflower: new Decimal(1),
+        },
+      },
+      action: {
+        type: "crop.sold",
+        crop: "Cauliflower",
+        amount: 1,
+      },
+    });
+
+    expect(state.balance).toEqual(new Decimal(CROPS().Cauliflower.sellPrice));
+  });
+
+  it("increments SFL earned when cauliflower is sold", () => {
+    const state = sellCrop({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Cauliflower: new Decimal(1),
+        },
+      },
+      action: {
+        type: "crop.sold",
+        crop: "Cauliflower",
+        amount: 1,
+      },
+    });
+
+    expect(state.bumpkin?.activity?.["SFL Earned"]).toEqual(
+      new Decimal(CROPS().Cauliflower.sellPrice).toNumber()
+    );
+  });
+});

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,0 +1,61 @@
+import Decimal from "decimal.js-light";
+import { CropName, CROPS } from "../../types/crops";
+import { GameState } from "../../types/game";
+import cloneDeep from "lodash.clonedeep";
+import { getSellPrice } from "features/game/lib/boosts";
+import { SellableItem } from "../sell";
+import { trackActivity } from "features/game/types/bumpkinActivity";
+
+export type SellCropAction = {
+  type: "crop.sold";
+  crop: CropName;
+  amount: number;
+};
+
+const SELLABLE = { ...CROPS() };
+
+type Options = {
+  state: GameState;
+  action: SellCropAction;
+};
+export function sellCrop({ state, action }: Options): GameState {
+  const game = cloneDeep(state);
+
+  const { bumpkin } = game;
+
+  if (bumpkin === undefined) {
+    throw new Error("You do not have a Bumpkin");
+  }
+
+  if (!(action.crop in SELLABLE)) {
+    throw new Error("Not for sale");
+  }
+
+  const amount = new Decimal(action.amount);
+  if (amount.lessThanOrEqualTo(0)) {
+    throw new Error("Invalid amount");
+  }
+
+  const sellables = SELLABLE[action.crop];
+
+  const count = game.inventory[action.crop] || new Decimal(0);
+
+  if (count.lessThan(action.amount)) {
+    throw new Error("Insufficient quantity to sell");
+  }
+
+  const price = getSellPrice(sellables as SellableItem, game.inventory);
+
+  const sflEarned = price.mul(action.amount);
+  bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sflEarned);
+
+  return {
+    ...game,
+    bumpkin,
+    balance: game.balance.add(sflEarned),
+    inventory: {
+      ...game.inventory,
+      [sellables.name]: count.sub(amount),
+    },
+  };
+}

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -18,7 +18,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { getSellPrice, hasSellBoost } from "features/game/lib/boosts";
 
-export const Plants: React.FC = () => {
+export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<Crop>(CROPS().Sunflower);
   const { setToast } = useContext(ToastContext);
   const [isSellAllModalOpen, showSellAllModal] = React.useState(false);
@@ -33,8 +33,8 @@ export const Plants: React.FC = () => {
   const inventory = state.inventory;
 
   const sell = (amount: Decimal) => {
-    gameService.send("item.sell", {
-      item: selected.name,
+    gameService.send("crop.sold", {
+      crop: selected.name,
       amount,
     });
     setToast({

--- a/src/features/island/buildings/components/building/market/ShopItems.tsx
+++ b/src/features/island/buildings/components/building/market/ShopItems.tsx
@@ -8,7 +8,7 @@ import { Panel } from "components/ui/Panel";
 import { Tab } from "components/ui/Tab";
 
 import { Seeds } from "./Seeds";
-import { Plants } from "./Plants";
+import { Crops } from "./Crops";
 import { acknowledgeTutorial, hasIntroducedBuilding } from "lib/tutorial";
 import { Button } from "components/ui/Button";
 
@@ -58,7 +58,7 @@ export const ShopItems: React.FC<Props> = ({ onClose }) => {
       </div>
 
       {tab === "buy" && <Seeds onClose={onClose} />}
-      {tab === "sell" && <Plants />}
+      {tab === "sell" && <Crops />}
     </Panel>
   );
 };


### PR DESCRIPTION
# Description

Create the corresponding event for Land Expansion selling of Crops.

Required by #1597 as we are altering the initial event.