### PR TITLE
[FIX] Remove z-index for land expansion elements

### DIFF
--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -179,7 +179,7 @@ export const Gold: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
   return (
     <div
       ref={overlayRef}
-      className="relative z-10"
+      className="relative"
       style={{ height: "40px" }}
       onMouseEnter={handleHover}
       onMouseLeave={handleMouseLeave}
@@ -268,7 +268,7 @@ export const Gold: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
         <>
           <img
             src={hitbox}
-            className="pointer-events-none -z-10 absolute opacity-50"
+            className="pointer-events-none absolute opacity-50"
             style={{
               width: `${GRID_WIDTH_PX}px`,
             }}

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -178,7 +178,7 @@ export const Iron: React.FC<Props> = ({ ironIndex, expansionIndex }) => {
   return (
     <div
       ref={overlayRef}
-      className="relative z-10"
+      className="relative"
       style={{ height: "40px" }}
       onMouseEnter={handleHover}
       onMouseLeave={handleMouseLeave}
@@ -264,7 +264,7 @@ export const Iron: React.FC<Props> = ({ ironIndex, expansionIndex }) => {
         <>
           <img
             src={hitbox}
-            className="pointer-events-none -z-10 absolute opacity-50"
+            className="pointer-events-none absolute opacity-50"
             style={{
               width: `${GRID_WIDTH_PX}px`,
             }}

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -183,7 +183,7 @@ export const Stone: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
   return (
     <div
       ref={overlayRef}
-      className="relative z-10"
+      className="relative"
       style={{ height: "40px" }}
       onMouseEnter={handleHover}
       onMouseLeave={handleMouseLeave}
@@ -272,7 +272,7 @@ export const Stone: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
         <>
           <img
             src={hitbox}
-            className="pointer-events-none -z-10 absolute opacity-50"
+            className="pointer-events-none absolute opacity-50"
             style={{
               width: `${GRID_WIDTH_PX}px`,
             }}

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -194,7 +194,7 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
   const timeLeft = getTimeLeft(tree.wood.choppedAt, TREE_RECOVERY_TIME);
 
   return (
-    <div className="relative z-10 w-full h-full mt-3">
+    <div className="relative w-full h-full mt-3">
       {!chopped && (
         <>
           <div

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -202,7 +202,7 @@ export const Chicken: React.FC<Props> = ({ index }) => {
         top: -20,
       }}
     >
-      <div className="relative w-16 h-16" style={{ zIndex: index }}>
+      <div className="relative w-16 h-16">
         {hungry && (
           <>
             <img
@@ -258,7 +258,6 @@ export const Chicken: React.FC<Props> = ({ index }) => {
               className="absolute w-16 h-16"
               style={{
                 imageRendering: "pixelated",
-                zIndex: 10 * index,
               }}
               image={walkingChickenSheet}
               widthFrame={32}


### PR DESCRIPTION
# Description

-remove z-index for land expansion elements so some weird element overlapping effects won't occur

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/199364092-47a0f41c-c178-438d-8c72-668a4c3a81e1.png)  |  ![image](https://user-images.githubusercontent.com/107602352/199364052-fe33887a-1ec1-4afa-8aad-a9b02d7b1002.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
# How Has This Been Tested?

- visit land expansion with current test island layout, then plant sunflowers in all plots and wait till they are fully grown

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
