### PR TITLE
[FIX] Land expansion modal unfocus

### DIFF
--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -70,7 +70,11 @@ export const UpcomingExpansion: React.FC<Props> = ({ gameState }) => {
           />
         </div>
       </MapPlacement>
-      <Modal show={showBumpkinModal} centered>
+      <Modal
+        show={showBumpkinModal}
+        onHide={() => setShowBumpkinModal(false)}
+        centered
+      >
         <Panel>
           <UpcomingExpansionModal
             gameState={gameState}


### PR DESCRIPTION
# Description

- unfocus land expansion movel when clicking outside

![image](https://user-images.githubusercontent.com/107602352/199403444-0fcd5822-3bce-4c2d-8687-7c5b13507342.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- try to expand land then click outside of the modal

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes