### PR TITLE
[FIX] Floating bumpkin on top of modal on mobile again

### DIFF
--- a/src/features/game/expansion/components/IslandTravel.tsx
+++ b/src/features/game/expansion/components/IslandTravel.tsx
@@ -43,7 +43,7 @@ export const IslandTravel = ({ bumpkin, x, y }: Props) => {
         show={openIslandList}
         onHide={() => setOpenIslandList(false)}
       >
-        <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+        <div className="absolute w-48 -left-4 -top-32 -z-10">
           <DynamicNFT
             bumpkinParts={{
               body: "Goblin Potion",

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -28,7 +28,7 @@ export const FirePitModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+      <div className="absolute w-48 -left-4 -top-32 -z-10">
         <DynamicNFT
           bumpkinParts={{
             body: "Beige Farmer Potion",

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -28,7 +28,7 @@ export const KitchenModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+      <div className="absolute w-48 -left-4 -top-32 -z-10">
         <DynamicNFT
           bumpkinParts={{
             body: "Beige Farmer Potion",

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -51,7 +51,7 @@ export const Market: React.FC = () => {
         }}
       />
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
-        <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+        <div className="absolute w-48 -left-4 -top-32 -z-10">
           <DynamicNFT
             bumpkinParts={{
               body: "Beige Farmer Potion",

--- a/src/features/island/buildings/components/building/workBench/WorkBench.tsx
+++ b/src/features/island/buildings/components/building/workBench/WorkBench.tsx
@@ -52,7 +52,7 @@ export const WorkBench: React.FC = () => {
         }}
       />
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
-        <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+        <div className="absolute w-48 -left-4 -top-32 -z-10">
           <DynamicNFT
             bumpkinParts={{
               body: "Light Brown Farmer Potion",

--- a/src/features/island/buildings/components/ui/CraftingTimerModal.tsx
+++ b/src/features/island/buildings/components/ui/CraftingTimerModal.tsx
@@ -39,7 +39,7 @@ export const CraftingTimerModal: React.FC<Props> = ({
 
   return (
     <Modal show={show} centered onHide={onClose}>
-      <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+      <div className="absolute w-48 -left-4 -top-32 -z-10">
         <DynamicNFT
           bumpkinParts={{
             body: "Beige Farmer Potion",

--- a/src/features/island/bumpkin/components/FeedModal.tsx
+++ b/src/features/island/bumpkin/components/FeedModal.tsx
@@ -29,15 +29,10 @@ export const FeedModal: React.FC<Props> = ({ isOpen, onFeed, onClose }) => {
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <div className="absolute w-1/2 -left-2 top-[-150px] -z-10">
+      <div className="absolute w-48 -left-4 -top-32 -z-10">
         {state.bumpkin && <DynamicNFT bumpkinParts={state.bumpkin.equipped} />}
       </div>
       <Panel>
-        <div className="absolute w-48 -left-4 -top-32 -z-10">
-          {state.bumpkin && (
-            <DynamicNFT bumpkinParts={state.bumpkin.equipped} />
-          )}
-        </div>
         <Feed food={availableFood} onFeed={onFeed} onClose={onClose} />
       </Panel>
     </Modal>


### PR DESCRIPTION
# Description

- use standard size and position for bumpkins on top of modals again

A followup to https://github.com/sunflower-land/sunflower-land/pull/1605 https://github.com/sunflower-land/sunflower-land/pull/1605/commits/f16471feff917cbd1a9e77af5cd216ae05010c52: Fixes incorrect merge caused by https://github.com/sunflower-land/sunflower-land/pull/1605/commits/339da2298efa212cab9ce543f6ef2a384964e193

Sidenotes:
The following video shows 2 bumpkins.  The one with variable size uses `absolute w-1/2 -left-2 top-[-150px] -z-10` for the parent `div` `classname`, while the one with the fixed size uses `absolute w-48 -left-4 -top-32 -z-10`.

https://user-images.githubusercontent.com/107602352/199454111-8f501676-50b9-4933-acc1-b1ec87b8998c.mp4


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click any placed buildings in land expansion

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
