### PR TITLE
[FIX] Collectible placement issue

### DIFF
--- a/src/features/game/events/buyDecoration.test.ts
+++ b/src/features/game/events/buyDecoration.test.ts
@@ -14,7 +14,6 @@ describe("buyDecoration", () => {
         action: {
           type: "decoration.bought",
           item: "Goblin Key" as DecorationName,
-          amount: 1,
         },
       })
     ).toThrow("This item is not a decoration");
@@ -30,7 +29,6 @@ describe("buyDecoration", () => {
         action: {
           type: "decoration.bought",
           item: "Potted Sunflower",
-          amount: 1,
         },
       })
     ).toThrow("Insufficient tokens");
@@ -47,7 +45,6 @@ describe("buyDecoration", () => {
         action: {
           type: "decoration.bought",
           item: "Potted Sunflower",
-          amount: 1,
         },
       })
     ).toThrow("Insufficient ingredient: Sunflower");
@@ -66,7 +63,6 @@ describe("buyDecoration", () => {
       action: {
         type: "decoration.bought",
         item: "Potted Sunflower",
-        amount: 1,
       },
     });
 
@@ -78,7 +74,6 @@ describe("buyDecoration", () => {
   it("mints the newly bought decoration", () => {
     const balance = new Decimal(150);
     const item = "Potted Sunflower";
-    const amount = 1;
     const state = buyDecoration({
       state: {
         ...GAME_STATE,
@@ -89,14 +84,13 @@ describe("buyDecoration", () => {
       },
       action: {
         item,
-        amount,
         type: "decoration.bought",
       },
     });
 
     const oldAmount = GAME_STATE.inventory[item] ?? new Decimal(0);
 
-    expect(state.inventory[item]).toEqual(oldAmount.add(amount));
+    expect(state.inventory[item]).toEqual(oldAmount.add(1));
   });
 
   it("throws an error if the player doesnt have a bumpkin", async () => {
@@ -109,7 +103,6 @@ describe("buyDecoration", () => {
         action: {
           type: "decoration.bought",
           item: "Potted Sunflower",
-          amount: 1,
         },
       })
     ).toThrow("Bumpkin not found");
@@ -127,7 +120,6 @@ describe("buyDecoration", () => {
       action: {
         type: "decoration.bought",
         item: "Potted Sunflower",
-        amount: 1,
       },
     });
     expect(state.bumpkin?.activity?.["SFL Spent"]).toEqual(
@@ -136,7 +128,6 @@ describe("buyDecoration", () => {
   });
 
   it("increments the decoration bought activity ", () => {
-    const amount = 1;
     const state = buyDecoration({
       state: {
         ...GAME_STATE,
@@ -148,11 +139,8 @@ describe("buyDecoration", () => {
       action: {
         type: "decoration.bought",
         item: "Potted Sunflower",
-        amount,
       },
     });
-    expect(state.bumpkin?.activity?.["Potted Sunflower Bought"]).toEqual(
-      amount
-    );
+    expect(state.bumpkin?.activity?.["Potted Sunflower Bought"]).toEqual(1);
   });
 });

--- a/src/features/game/events/buyDecoration.ts
+++ b/src/features/game/events/buyDecoration.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
-import { getBumpkinLevel } from "../lib/level";
 import { trackActivity } from "../types/bumpkinActivity";
 import { getKeys } from "../types/craftables";
 import { DecorationName, DECORATIONS } from "../types/decorations";

--- a/src/features/game/events/buyDecoration.ts
+++ b/src/features/game/events/buyDecoration.ts
@@ -9,7 +9,6 @@ import { GameState } from "../types/game";
 export type buyDecorationAction = {
   type: "decoration.bought";
   item: DecorationName;
-  amount: number;
 };
 
 type Options = {
@@ -24,7 +23,7 @@ const VALID_DECORATIONS: DecorationName[] = [
 
 export function buyDecoration({ state, action }: Options) {
   const stateCopy = cloneDeep(state);
-  const { item, amount } = action;
+  const { item } = action;
   const desiredItem = DECORATIONS()[item];
 
   if (!desiredItem) {
@@ -36,9 +35,6 @@ export function buyDecoration({ state, action }: Options) {
   if (!bumpkin) {
     throw new Error("Bumpkin not found");
   }
-
-  const userBumpkinLevel = getBumpkinLevel(stateCopy.bumpkin?.experience ?? 0);
-  //   const seed = SEEDS()[item];
 
   const totalExpenses = desiredItem.sfl;
 
@@ -74,7 +70,7 @@ export function buyDecoration({ state, action }: Options) {
   bumpkin.activity = trackActivity(
     `${item} Bought`,
     bumpkin?.activity,
-    new Decimal(amount)
+    new Decimal(1)
   );
 
   return {

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -5,6 +5,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import {
+  CollectibleName,
   getKeys,
   LimitedItemName,
   LIMITED_ITEMS,
@@ -30,6 +31,7 @@ export const Chest: React.FC<Props> = ({ state, closeModal }: Props) => {
   const [scrollIntoView] = useScrollIntoView();
 
   const chestMap = getChestItems(state);
+  const { inventory, collectibles: placedItems } = state;
 
   const collectibles = getKeys(chestMap).reduce((acc, item) => {
     if (item in LIMITED_ITEMS || item in DECORATIONS()) {
@@ -111,7 +113,9 @@ export const Chest: React.FC<Props> = ({ state, closeModal }: Props) => {
             <div className="flex mb-2 flex-wrap -ml-1.5 pt-1">
               {getKeys(collectibles).map((item) => (
                 <Box
-                  count={state.inventory[item]}
+                  count={inventory[item]?.sub(
+                    placedItems[item as CollectibleName]?.length ?? 0
+                  )}
                   isSelected={selected === item}
                   key={item}
                   onClick={() => handleItemClick(item)}

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -1,6 +1,10 @@
 import { Inventory } from "components/InventoryItems";
+import Decimal from "decimal.js-light";
 import { BUILDINGS_DIMENSIONS } from "features/game/types/buildings";
-import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
+import {
+  CollectibleName,
+  COLLECTIBLES_DIMENSIONS,
+} from "features/game/types/craftables";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 
@@ -23,10 +27,16 @@ export const getBasketItems = (inventory: Inventory) => {
 };
 
 export const getChestItems = (state: GameState) => {
+  const { collectibles } = state;
   return getKeys(state.inventory).reduce((acc, itemName) => {
+    const isCollectible = itemName in collectibles;
+    const collectiblesPlaced = new Decimal(
+      collectibles[itemName as CollectibleName]?.length ?? 0
+    );
+    const collectibleInventory = state.inventory[itemName] ?? new Decimal(0);
     if (
       itemName in COLLECTIBLES_DIMENSIONS &&
-      !(itemName in state.collectibles)
+      !(isCollectible && collectiblesPlaced.eq(collectibleInventory))
     ) {
       return {
         ...acc,


### PR DESCRIPTION
# Description

There was an issue for placing the same collectible multiple times. With decorations, users can buy the same decorations multiple times. But in our current framework, once a collectible has been placed it is removed from the chest ui modal. i have fixed it.

<img width="696" alt="image" src="https://user-images.githubusercontent.com/35486909/199509129-853417fa-6e89-4a29-b41a-98e7b33ff7ac.png">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
