### PR TITLE
[FIX] Force autosave before being allowed to travel.

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -406,6 +406,8 @@ export const Land: React.FC = () => {
           key="island-travel"
           bumpkin={bumpkin}
           isVisiting={gameState.matches("visiting")}
+          isTravelAllowed={!gameState.matches("autosaving")}
+          onTravelDialogOpened={() => gameService.send("SAVE")}
           x={boatCoordinates.x}
           y={boatCoordinates.y}
         />

--- a/src/features/game/expansion/components/IslandTravel.tsx
+++ b/src/features/game/expansion/components/IslandTravel.tsx
@@ -13,11 +13,20 @@ import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
 interface Props {
   bumpkin: Bumpkin | undefined;
   isVisiting?: boolean;
+  isTravelAllowed?: boolean;
+  onTravelDialogOpened?: () => void;
   x: number;
   y: number;
 }
 
-export const IslandTravel = ({ bumpkin, x, y, isVisiting = false }: Props) => {
+export const IslandTravel = ({
+  bumpkin,
+  x,
+  y,
+  isVisiting = false,
+  isTravelAllowed = true,
+  onTravelDialogOpened,
+}: Props) => {
   const [openIslandList, setOpenIslandList] = useState(false);
 
   return (
@@ -43,6 +52,7 @@ export const IslandTravel = ({ bumpkin, x, y, isVisiting = false }: Props) => {
         centered
         show={openIslandList}
         onHide={() => setOpenIslandList(false)}
+        onShow={onTravelDialogOpened}
       >
         <div className="absolute w-48 -left-4 -top-32 -z-10">
           <DynamicNFT
@@ -71,7 +81,10 @@ export const IslandTravel = ({ bumpkin, x, y, isVisiting = false }: Props) => {
               onClick={() => setOpenIslandList(false)}
             />
           </div>
-          <IslandList bumpkin={bumpkin} showVisitList={isVisiting} />
+          {isTravelAllowed && (
+            <IslandList bumpkin={bumpkin} showVisitList={isVisiting} />
+          )}
+          {!isTravelAllowed && <span className="loading">Loading</span>}
         </Panel>
       </Modal>
     </>


### PR DESCRIPTION
# Description

Remake of https://github.com/sunflower-land/sunflower-land/pull/1596 - much simpler now :+1: 

BugBash Spreadsheet Ticket # 9

- Will now fire an autosave event the moment you open the IslandTravel modal.
- Will now show "Loading..." text if player is autosaving + has travel modal opened.
- Waits for autosave event to complete before presenting player any navigation options.

https://user-images.githubusercontent.com/103600068/199262517-f4bf24ec-e8b9-41e1-a75e-05a46a3b6e2c.mp4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

visual, see video above

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes