### PR TITLE
[FIX] LandExpansion Foreman Beaver Fix

### DIFF
--- a/src/features/game/events/landExpansion/chop.test.ts
+++ b/src/features/game/events/landExpansion/chop.test.ts
@@ -5,7 +5,12 @@ import {
   TREE_RECOVERY_TIME,
 } from "features/game/lib/constants";
 import { GameState, LandExpansionTree } from "features/game/types/game";
-import { chop, getChoppedAt, LandExpansionChopAction } from "./chop";
+import {
+  chop,
+  getChoppedAt,
+  LandExpansionChopAction,
+  CHOP_ERRORS,
+} from "./chop";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -79,7 +84,7 @@ describe("chop", () => {
           index: 0,
         },
       })
-    ).toThrow("No axe");
+    ).toThrow(CHOP_ERRORS.MISSING_AXE);
   });
 
   it("throws an error if no axes are left", () => {
@@ -93,7 +98,7 @@ describe("chop", () => {
           index: 0,
         },
       })
-    ).toThrow("No axes left");
+    ).toThrow(CHOP_ERRORS.NO_AXES);
   });
 
   it("throws an error if tree is not ready", () => {
@@ -120,7 +125,7 @@ describe("chop", () => {
         state: game,
         action: payload.action,
       })
-    ).toThrow("Tree is still growing");
+    ).toThrow(CHOP_ERRORS.STILL_GROWING);
   });
 
   it("chops a tree", () => {

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -11,6 +11,13 @@ import {
 } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
 
+export enum CHOP_ERRORS {
+  MISSING_AXE = "No axe",
+  NO_AXES = "No axes left",
+  NO_TREE = "No tree",
+  STILL_GROWING = "Tree is still growing",
+}
+
 type GetChoppedAtArgs = {
   skills: Partial<Record<BumpkinSkillName, number>>;
   collectibles: Collectibles;
@@ -93,22 +100,22 @@ export function chop({
   const requiredAxes = getRequiredAxeAmount(collectibles);
 
   if (action.item !== "Axe" && requiredAxes.gt(0)) {
-    throw new Error("No axe");
+    throw new Error(CHOP_ERRORS.MISSING_AXE);
   }
 
   const axeAmount = inventory.Axe || new Decimal(0);
   if (axeAmount.lessThan(requiredAxes)) {
-    throw new Error("No axes left");
+    throw new Error(CHOP_ERRORS.NO_AXES);
   }
 
   const tree = trees[action.index];
 
   if (!tree) {
-    throw new Error("No tree");
+    throw new Error(CHOP_ERRORS.NO_TREE);
   }
 
   if (!canChop(tree, createdAt)) {
-    throw new Error("Tree is still growing");
+    throw new Error(CHOP_ERRORS.STILL_GROWING);
   }
 
   const woodHarvested = tree.wood.amount;

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -30,6 +30,7 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import { LandExpansionTree } from "features/game/types/game";
 import {
   canChop,
+  CHOP_ERRORS,
   getRequiredAxeAmount,
 } from "features/game/events/landExpansion/chop";
 import { Overlay } from "react-bootstrap";
@@ -165,8 +166,7 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
       await new Promise((res) => setTimeout(res, 2000));
       setCollecting(false);
     } catch (e: any) {
-      // TODO - Don't compare hard-coded value
-      if (e.message === "No axes left") {
+      if (e.message === CHOP_ERRORS.NO_AXES) {
         displayPopover(
           <div className="flex">
             <img src={axe} className="w-4 h-4 mr-2" />

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -21,7 +21,6 @@ import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
 import { useActor } from "@xstate/react";
-import { CHOP_ERRORS, getRequiredAxeAmount } from "features/game/events/chop";
 
 import { getTimeLeft } from "lib/utils/time";
 import { Label } from "components/ui/Label";
@@ -29,7 +28,10 @@ import { chopAudio, treeFallAudio } from "lib/utils/sfx";
 import { HealthBar } from "components/ui/HealthBar";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import { LandExpansionTree } from "features/game/types/game";
-import { canChop } from "features/game/events/landExpansion/chop";
+import {
+  canChop,
+  getRequiredAxeAmount,
+} from "features/game/events/landExpansion/chop";
 import { Overlay } from "react-bootstrap";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 
@@ -105,7 +107,7 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
     setShowStumpTimeLeft(false);
   };
 
-  const axesNeeded = getRequiredAxeAmount(game.context.state.inventory);
+  const axesNeeded = getRequiredAxeAmount(game.context.state.collectibles);
   const axeAmount = game.context.state.inventory.Axe || new Decimal(0);
 
   // Has enough axes to chop the tree
@@ -163,7 +165,8 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
       await new Promise((res) => setTimeout(res, 2000));
       setCollecting(false);
     } catch (e: any) {
-      if (e.message === CHOP_ERRORS.NO_AXES) {
+      // TODO - Don't compare hard-coded value
+      if (e.message === "No axes left") {
         displayPopover(
           <div className="flex">
             <img src={axe} className="w-4 h-4 mr-2" />


### PR DESCRIPTION
# Description

The `<Tree />`  landExpansion component was using the `getRequiredAxeAmount()` from the old game instead of the new LE version. This was resulting in the foreman beaver effect only to work if it was in your inventory, but not placed on the map.

This PR also has a small refactor, where the chop.ts error constants were transferred-over to the LE side.

Fixes bugBash spreadshett ticket # 42

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The core logic seemed correct, this was just a UI bug. I modified my gameState manually in gameMachine.ts and visually inspected.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
