### PR TITLE
[FIX] Fix LE placement logic for Kuebiko's boost to take effect.

### DIFF
--- a/src/features/game/events/seedBought.ts
+++ b/src/features/game/events/seedBought.ts
@@ -1,10 +1,11 @@
 import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
+import { isCollectibleBuilt } from "../lib/collectibleBuilt";
 import { getBumpkinLevel } from "../lib/level";
 import { trackActivity } from "../types/bumpkinActivity";
 import { CraftableItem } from "../types/craftables";
 import { SEEDS, SeedName } from "../types/crops";
-import { GameState, Inventory } from "../types/game";
+import { Collectibles, GameState, Inventory } from "../types/game";
 import { isSeed } from "./plant";
 
 export type SeedBoughtAction = {
@@ -13,8 +14,12 @@ export type SeedBoughtAction = {
   amount: number;
 };
 
-export function getBuyPrice(item: CraftableItem, inventory: Inventory) {
-  if (inventory.Kuebiko?.gte(1)) {
+export function getBuyPrice(
+  item: CraftableItem,
+  inventory: Inventory,
+  collectibles: Collectibles
+) {
+  if (isCollectibleBuilt("Kuebiko", collectibles)) {
     return new Decimal(0);
   }
 
@@ -66,7 +71,7 @@ export function seedBought({ state, action }: Options) {
     throw new Error("Not enough stock");
   }
 
-  const price = getBuyPrice(seed, stateCopy.inventory);
+  const price = getBuyPrice(seed, stateCopy.inventory, stateCopy.collectibles);
   const totalExpenses = price?.mul(amount);
 
   if (totalExpenses && stateCopy.balance.lessThan(totalExpenses)) {


### PR DESCRIPTION
# Description

This PR fixes a bug in LE where Kuebiko's effect was taking place by simply having the item in inventory. This is not correct. Rather, Kuebiko's effect should only take place when it becomes a Placement on the land, and is a "ready" Placement.

BugBash Spreadsheet # 41

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please see newly added test cases :+1: .

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes