### PR TITLE
[FIX] Plot not showing popup on mobile in land expansion

### DIFF
--- a/src/features/farming/crops/components/CropZoneFour.tsx
+++ b/src/features/farming/crops/components/CropZoneFour.tsx
@@ -42,7 +42,7 @@ export const CropZoneFour: React.FC = () => {
         <>
           <img
             src={goblinDig}
-            className="absolute z-20 hover:img-highlight cursor-pointer -scale-x-100"
+            className="absolute z-10 hover:img-highlight cursor-pointer -scale-x-100"
             onClick={() => setShowModal(true)}
             style={{
               width: `${GRID_WIDTH_PX * 5}px`,
@@ -64,7 +64,7 @@ export const CropZoneFour: React.FC = () => {
           />
           <img
             src={cauliflowerRice}
-            className="absolute "
+            className="absolute z-10"
             style={{
               width: `${GRID_WIDTH_PX * 0.8}px`,
               left: `${GRID_WIDTH_PX * 5.3}px`,
@@ -84,12 +84,12 @@ export const CropZoneFour: React.FC = () => {
           top: `${GRID_WIDTH_PX * 3}px`,
         }}
       >
-        <div className="flex justify-between items-center z-20">
+        <div className="flex justify-between items-center">
           <Field selectedItem={selectedItem} fieldIndex={16} />
           <Field selectedItem={selectedItem} fieldIndex={17} />
           <Field selectedItem={selectedItem} fieldIndex={18} />
         </div>
-        <div className="flex justify-between items-center z-30">
+        <div className="flex justify-between items-center">
           <Field selectedItem={selectedItem} fieldIndex={19} />
           <Field selectedItem={selectedItem} fieldIndex={20} />
           <Field selectedItem={selectedItem} fieldIndex={21} />

--- a/src/features/farming/crops/components/CropZoneOne.tsx
+++ b/src/features/farming/crops/components/CropZoneOne.tsx
@@ -24,11 +24,11 @@ export const CropZoneOne: React.FC = () => {
         <Field selectedItem={selectedItem} fieldIndex={1} />
       </div>
       {/* Middle row */}
-      <div className="flex justify-center z-10">
+      <div className="flex justify-center">
         <Field selectedItem={selectedItem} fieldIndex={2} />
       </div>
       {/* Bottom row */}
-      <div className="flex justify-between z-20">
+      <div className="flex justify-between">
         <Field selectedItem={selectedItem} fieldIndex={3} />
         <Field selectedItem={selectedItem} fieldIndex={4} />
       </div>

--- a/src/features/farming/crops/components/CropZoneThree.tsx
+++ b/src/features/farming/crops/components/CropZoneThree.tsx
@@ -42,7 +42,7 @@ export const CropZoneThree: React.FC = () => {
         <>
           <img
             src={goblinWatering}
-            className="absolute z-20 hover:img-highlight cursor-pointer"
+            className="absolute z-10 hover:img-highlight cursor-pointer"
             onClick={() => setShowModal(true)}
             style={{
               width: `${GRID_WIDTH_PX * 5}px`,
@@ -64,7 +64,7 @@ export const CropZoneThree: React.FC = () => {
           />
           <img
             src={cabbageSoup}
-            className="absolute "
+            className="absolute z-10"
             style={{
               width: `${GRID_WIDTH_PX * 0.3}px`,
               left: `${GRID_WIDTH_PX * 5}px`,
@@ -91,7 +91,7 @@ export const CropZoneThree: React.FC = () => {
           <Field selectedItem={selectedItem} fieldIndex={12} />
         </div>
         {/* Bottom row */}
-        <div className="flex justify-between items-center z-10">
+        <div className="flex justify-between items-center">
           <Field selectedItem={selectedItem} fieldIndex={13} />
           <Field selectedItem={selectedItem} fieldIndex={14} />
           <Field selectedItem={selectedItem} fieldIndex={15} />

--- a/src/features/farming/crops/components/CropZoneTwo.tsx
+++ b/src/features/farming/crops/components/CropZoneTwo.tsx
@@ -109,11 +109,11 @@ export const CropZoneTwo: React.FC = () => {
           <Field selectedItem={selectedItem} fieldIndex={6} />
         </div>
         {/* Middle row */}
-        <div className="flex justify-center z-10">
+        <div className="flex justify-center">
           <Field selectedItem={selectedItem} fieldIndex={7} />
         </div>
         {/* Bottom row */}
-        <div className="flex justify-between z-20">
+        <div className="flex justify-between">
           <Field selectedItem={selectedItem} fieldIndex={8} />
           <Field selectedItem={selectedItem} fieldIndex={9} />
         </div>

--- a/src/features/farming/crops/components/Field.tsx
+++ b/src/features/farming/crops/components/Field.tsx
@@ -270,7 +270,7 @@ export const Field: React.FC<Props> = ({
 
       <div
         className={classNames(
-          "transition-opacity absolute -bottom-2 w-full z-20 pointer-events-none flex justify-center",
+          "transition-opacity absolute -bottom-6 w-full z-20 pointer-events-none flex justify-center",
           {
             "opacity-100": showPopover,
             "opacity-0": !showPopover,

--- a/src/features/island/Plots/Plot.tsx
+++ b/src/features/island/Plots/Plot.tsx
@@ -296,7 +296,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
     );
   }
 
-  // onMouseUp is needed for PC to prevent lingering issues when clicking the crop results in receiving a reward
+  // onMouseUp is needed for PC to prevent lingering issues if clicking the crop results in showing the crop reward modal
   const onMouseUpProps = isMobile
     ? {}
     : { onMouseUp: () => handleMouseLeave() };

--- a/src/features/island/Plots/Plot.tsx
+++ b/src/features/island/Plots/Plot.tsx
@@ -296,11 +296,16 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
     );
   }
 
+  // onMouseUp is needed for PC to prevent lingering issues when clicking the crop results in receiving a reward
+  const onMouseUpProps = isMobile
+    ? {}
+    : { onMouseUp: () => handleMouseLeave() };
+
   return (
     <div
       onMouseEnter={handleMouseHover}
       onMouseLeave={handleMouseLeave}
-      onMouseUp={handleMouseLeave}
+      {...onMouseUpProps}
       className="w-full h-full relative"
     >
       {/* Crop base image */}


### PR DESCRIPTION
# Description

- fix popup not showing on growing crops on mobile when tapping on them
- fix overlapping popover when planting crops in old farm
- fix plant info popup z index in old farm

**popup in land expansion on mobile**
Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/200623552-00cbc153-d8d8-4e4f-bd61-609031aca58f.png)  |  ![image](https://user-images.githubusercontent.com/107602352/200623590-f5146108-b764-496c-86f2-b5ea5054529f.png)

**popup in old farm**
Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/200622902-30098a9e-6ae9-463b-b2b6-0c679f0b7949.png)  |  ![image](https://user-images.githubusercontent.com/107602352/200622952-ab19104d-05cb-4ea1-a346-bf407abca923.png)

**z-index in old farm**
Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/200622735-4c1ef37e-3b1d-4d06-a6b6-f728bac47fbc.png)  |  ![image](https://user-images.githubusercontent.com/107602352/200622788-abdfcc00-298b-4503-9065-27a24d831397.png)


This is a follow up of https://github.com/sunflower-land/sunflower-land/pull/1629

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- harvest crops and plant crops in old farm
- hover on growing crops in both old farm and land expansion for both PC and moible

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x ] New and existing unit tests pass locally with my changes
