### PR TITLE
[FIX] Bumpkin XP Progress Bar Not Syncing

### DIFF
--- a/src/features/island/hud/components/BumpkinHUD.tsx
+++ b/src/features/island/hud/components/BumpkinHUD.tsx
@@ -13,7 +13,11 @@ import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { Equipped as BumpkinParts } from "features/game/types/bumpkin";
-import { getBumpkinLevel, LEVEL_BRACKETS } from "features/game/lib/level";
+import {
+  BumpkinLevel,
+  getBumpkinLevel,
+  LEVEL_BRACKETS,
+} from "features/game/lib/level";
 import {
   acknowledgeSkillPoints,
   hasUnacknowledgedSkillPoints,
@@ -44,6 +48,11 @@ export const BumpkinHUD: React.FC = () => {
   const experience = state.bumpkin?.experience ?? 0;
   const level = getBumpkinLevel(experience);
   const nextLevelExperience = LEVEL_BRACKETS[level];
+  const previousLevelExperience =
+    LEVEL_BRACKETS[(level - 1) as BumpkinLevel] || 0;
+
+  const currentExperienceProgress = experience - previousLevelExperience;
+  const experienceToNextLevel = nextLevelExperience - previousLevelExperience;
 
   const showSkillPointAlert = hasUnacknowledgedSkillPoints(state.bumpkin);
 
@@ -151,7 +160,9 @@ export const BumpkinHUD: React.FC = () => {
               className="h-full bg-[#63c74d] absolute -z-10"
               style={{
                 borderRadius: "10px 0 0 10px",
-                width: `${(experience / nextLevelExperience) * 100}%`,
+                width: `${
+                  (currentExperienceProgress / experienceToNextLevel) * 100
+                }%`,
                 maxWidth: "100%",
               }}
             />


### PR DESCRIPTION
# Description

Bumpkin XP progress is not the same on the HUD with the Bumpkin profile modals.
| Before | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/12151051/200755543-e80bf51e-e249-44ed-a9e2-a64e04784352.png" width=640 />  | <img src="https://user-images.githubusercontent.com/12151051/200755591-bf8940cc-7d10-4506-a65c-537d8af9df0a.png" width=640 />  |

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A further inspection of HTML elements

- Bumpkin profile modal
![image](https://user-images.githubusercontent.com/12151051/200756291-5a598c22-8bf9-443d-82c4-60ecb99f558e.png)

- Bumpkin HUD
![image](https://user-images.githubusercontent.com/12151051/200756495-237d998b-96bb-4988-b17a-5fe4675be615.png)

- Test suites
![image](https://user-images.githubusercontent.com/12151051/200756713-d11560ee-82d4-4f38-a4d8-921e06db54a5.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
