### PR TITLE
[FIX] Add in progress UI after collectible placed

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -299,7 +299,8 @@ const getIslandElements = ({
       .flatMap((name, nameIndex) => {
         const items = collectibles[name]!;
         return items.map((collectible, itemIndex) => {
-          const { x, y } = collectible.coordinates;
+          const { readyAt, createdAt, coordinates, id } = collectible;
+          const { x, y } = coordinates;
           const { width, height } = COLLECTIBLES_DIMENSIONS[name];
 
           return (
@@ -310,7 +311,12 @@ const getIslandElements = ({
               height={height}
               width={width}
             >
-              <Collectible name={name} id={collectible.id} />
+              <Collectible
+                name={name}
+                id={id}
+                readyAt={readyAt}
+                createdAt={createdAt}
+              />
             </MapPlacement>
           );
         });

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -458,11 +458,18 @@ export function startGame(authContext: Options) {
             },
             {
               target: "offerMigration",
-              cond: (context) =>
-                (CONFIG.NETWORK === "mumbai" ||
-                  !!authContext.token?.userAccess.admin) &&
-                !authContext.migrated &&
-                canMigrate(context.state),
+              cond: (context) => {
+                const landRoute = window.location.hash.includes("/land");
+
+                if (landRoute) return false;
+
+                return (
+                  (CONFIG.NETWORK === "mumbai" ||
+                    !!authContext.token?.userAccess.admin) &&
+                  !authContext.migrated &&
+                  canMigrate(context.state)
+                );
+              },
             },
             {
               target: "playing",

--- a/src/features/island/collectibles/Collectible.tsx
+++ b/src/features/island/collectibles/Collectible.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { CollectibleName } from "features/game/types/craftables";
 import { MysteriousHead } from "./components/MysteriousHead";
@@ -161,8 +161,20 @@ export const Collectible: React.FC<Prop> = ({
 
   const overlayRef = useRef<HTMLDivElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(
+    Math.floor((readyAt - Date.now()) / 1000)
+  );
   const totalSeconds = (readyAt - createdAt) / 1000;
-  const secondsLeft = Math.floor((readyAt - Date.now()) / 1000);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const secondsLeft = Math.floor((readyAt - Date.now()) / 1000);
+
+      setSecondsLeft(secondsLeft);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  });
 
   const inProgress = readyAt > Date.now();
 


### PR DESCRIPTION
# Description

This PR adds the "inProgress" UI to indicate that a collectible is "building" after its placed. 

Fixes #issue
<img width="83" alt="Screen Shot 2022-11-10 at 11 40 24 am" src="https://user-images.githubusercontent.com/17863697/200972369-f7388245-c9a5-442f-83ef-0e77fb79657e.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
