### PR TITLE
[FEAT] Remove the auto modal when cooking

### DIFF
--- a/src/features/island/buildings/components/building/WithCraftingMachine.tsx
+++ b/src/features/island/buildings/components/building/WithCraftingMachine.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { useInterpret, useSelector } from "@xstate/react";
 import isEmpty from "lodash.isempty";
 import { Context } from "features/game/GameProvider";
@@ -61,12 +61,6 @@ export const WithCraftingMachine = ({
   const handleShowCraftingTimer = () => {
     setShowTimer(true);
   };
-
-  useEffect(() => {
-    if (crafting && craftingService.state.event.type === "CRAFT") {
-      handleShowCraftingTimer();
-    }
-  }, [crafting, craftingService]);
 
   // The building component is cloned and crafting state machine props are injected into it
   const clonedChildren = React.cloneElement(children, {

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -56,7 +56,6 @@ export const Kitchen: React.FC<Props> = ({
   };
 
   const handleClick = () => {
-    console.log({ idle });
     if (idle) {
       setShowModal(true);
       return;

--- a/src/features/island/buildings/components/ui/CraftingTimerModal.tsx
+++ b/src/features/island/buildings/components/ui/CraftingTimerModal.tsx
@@ -23,7 +23,7 @@ export const CraftingTimerModal: React.FC<Props> = ({
 }) => {
   const [
     {
-      context: { secondsTillReady, name, gameService },
+      context: { secondsTillReady, name },
     },
   ] = useActor(service);
 


### PR DESCRIPTION
# Description

The "Is it ready?" modal pops up automatically when cooking an item. This is overkill as you can see its being made and you can click on there to see the modal. I have removed this for now.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
