### PR TITLE
[FIX] Reduce click area for expansion

### DIFF
--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -59,14 +59,12 @@ export const UpcomingExpansion: React.FC<Props> = ({ gameState }) => {
         height={LAND_SIZE}
         width={LAND_SIZE}
       >
-        <div
-          className="w-full h-full flex items-center justify-center cursor-pointer opacity-90 hover:opacity-100"
-          onClick={() => setShowBumpkinModal(true)}
-        >
+        <div className="w-full h-full flex items-center justify-center opacity-90 hover:opacity-100">
           <img
             src={expandIcon}
             width={18 * PIXEL_SCALE}
-            className="relative top-4"
+            className="relative top-4 cursor-pointer hover:img-highlight"
+            onClick={() => setShowBumpkinModal(true)}
           />
         </div>
       </MapPlacement>


### PR DESCRIPTION
# Description

Reducing the click area for land expansion. Now you will click on the icon only.

<img width="238" alt="Screen Shot 2022-11-10 at 2 28 07 pm" src="https://user-images.githubusercontent.com/17863697/200993773-6b35f4c1-92e0-4bf0-b2ce-7df243bab01c.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
