### PR TITLE
[FEAT] Display food prepare time

### DIFF
--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -3,6 +3,7 @@ import { useActor } from "@xstate/react";
 import Decimal from "decimal.js-light";
 
 import heart from "assets/icons/heart.png";
+import watch from "assets/icons/stopwatch.png";
 
 import { Box } from "components/ui/Box";
 import { OuterPanel } from "components/ui/Panel";
@@ -12,6 +13,7 @@ import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getKeys } from "features/game/types/craftables";
 import { Consumable, ConsumableName } from "features/game/types/consumables";
+import { secondsToMidString } from "lib/utils/time";
 
 interface Props {
   recipes: Consumable[];
@@ -159,6 +161,12 @@ export const Recipes: React.FC<Props> = ({ recipes, onClose, onCook }) => {
           <div className="flex mt-2 items-center">
             <img src={heart} className="h-5 mr-2" />
             <span className="text-xs">{selected.experience} exp</span>
+          </div>
+          <div className="flex mt-2 items-center">
+            <img src={watch} className="h-5 mr-2" />
+            <span className="text-xs">
+              {secondsToMidString(selected.cookingSeconds)}
+            </span>
           </div>
           {Action()}
         </div>


### PR DESCRIPTION
# Description
Displaying the time it will take to a food be ready
![image](https://user-images.githubusercontent.com/94913189/201002860-c2d2f703-bd81-4c65-8dc0-1b9b17c6e2be.png)
![image](https://user-images.githubusercontent.com/94913189/201003061-d275f84e-f909-4a2b-a29d-a9ba21b619f5.png)


## Type of change

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Go in-game and open the firepit or the kitchen.

yarn test
![image](https://user-images.githubusercontent.com/94913189/201002917-b8fdf497-6c53-4044-b9fd-7f1f851dff6b.png)


# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
