### PR TITLE
[FIX] Block skill alert on visit. Limit personal skill info when visiting

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -147,7 +147,9 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
               <div className="flex items-center  mb-1 justify-between">
                 <div className="flex items-center">
                   <span className="text-xs">Skills</span>
-                  {hasSkillPoint && <img src={alert} className="h-4 ml-2" />}
+                  {hasSkillPoint && !gameState.matches("visiting") && (
+                    <img src={alert} className="h-4 ml-2" />
+                  )}
                 </div>
                 <span
                   className="text-xxs underline cursor-pointer"

--- a/src/features/bumpkins/components/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/SkillPathDetails.tsx
@@ -16,8 +16,6 @@ import { acknowledgeSkillPoints } from "../../island/bumpkin/lib/skillPointStora
 import { SkillPath } from "./SkillPath";
 import { Button } from "components/ui/Button";
 
-import arrowLeft from "assets/icons/arrow_left.png";
-
 interface Props {
   selectedSkillPath: BumpkinSkillTree;
   skillsInPath: BumpkinSkill[];
@@ -30,11 +28,10 @@ export const SkillPathDetails: React.FC<Props> = ({
   skillsInPath,
 }) => {
   const { gameService } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const [gameState] = useActor(gameService);
+  const {
+    context: { state },
+  } = gameState;
 
   const [showConfirmButton, setShowConfirmButton] = useState(false);
   const [selectedSkill, setSelectedSkill] =
@@ -79,12 +76,12 @@ export const SkillPathDetails: React.FC<Props> = ({
     <div className="flex flex-col">
       <OuterPanel className="relative flex-1 min-w-[42%] flex flex-col justify-between items-center shadow-none">
         <div className="flex flex-col justify-center items-center p-2 relative w-full">
-          <img
+          {/* <img
             src={arrowLeft}
             className="absolute top-1 left-1 self-start w-5 cursor-pointer right-96"
             alt="back"
             onClick={onBack}
-          />
+          /> */}
           {showConfirmButton && (
             <div className="flex flex-col">
               <p className="mx-4 text-center">{`Are you sure you want to claim the ${selectedSkill} skill?`}</p>

--- a/src/features/bumpkins/components/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/SkillPathDetails.tsx
@@ -16,14 +16,58 @@ import { acknowledgeSkillPoints } from "../../island/bumpkin/lib/skillPointStora
 import { SkillPath } from "./SkillPath";
 import { Button } from "components/ui/Button";
 
+const RequiredSkillPoints = ({
+  missingPointRequirement,
+  availableSkillPoints,
+  pointsRequired,
+}: {
+  missingPointRequirement: boolean;
+  availableSkillPoints: number;
+  pointsRequired: number;
+}) => {
+  return (
+    <div
+      className={classNames("flex justify-center flex-wrap items-end mt-2", {
+        "text-error": missingPointRequirement,
+      })}
+    >
+      <span className="text-shadow text-center text-xxs sm:text-xs">
+        Required Skill Points:
+      </span>
+      <span className="text-xxs sm:text-xs text-shadow text-center">
+        {`${availableSkillPoints}/${pointsRequired}`}
+      </span>
+    </div>
+  );
+};
+
+const RequiredSkill = ({
+  missingSkillRequirement,
+  requiredSkillImage,
+}: {
+  missingSkillRequirement: boolean;
+  requiredSkillImage?: string;
+}) => {
+  return (
+    <div
+      className={classNames("flex justify-center flex-wrap items-center mt-2", {
+        "text-error": missingSkillRequirement,
+      })}
+    >
+      <span className="text-shadow text-center text-xxs sm:text-xs">
+        Required Skills:
+      </span>
+      <img src={requiredSkillImage} />
+    </div>
+  );
+};
+
 interface Props {
   selectedSkillPath: BumpkinSkillTree;
   skillsInPath: BumpkinSkill[];
-  onBack: () => void;
 }
 
 export const SkillPathDetails: React.FC<Props> = ({
-  onBack,
   selectedSkillPath,
   skillsInPath,
 }) => {
@@ -76,12 +120,6 @@ export const SkillPathDetails: React.FC<Props> = ({
     <div className="flex flex-col">
       <OuterPanel className="relative flex-1 min-w-[42%] flex flex-col justify-between items-center shadow-none">
         <div className="flex flex-col justify-center items-center p-2 relative w-full">
-          {/* <img
-            src={arrowLeft}
-            className="absolute top-1 left-1 self-start w-5 cursor-pointer right-96"
-            alt="back"
-            onClick={onBack}
-          /> */}
           {showConfirmButton && (
             <div className="flex flex-col">
               <p className="mx-4 text-center">{`Are you sure you want to claim the ${selectedSkill} skill?`}</p>
@@ -114,38 +152,19 @@ export const SkillPathDetails: React.FC<Props> = ({
                 {BUMPKIN_SKILL_TREE[selectedSkill].boosts}
               </span>
 
-              {!hasSelectedSkill && (
+              {!hasSelectedSkill && !gameState.matches("visiting") && (
                 <>
                   <div className="border-t border-white w-full pt-1 text-center">
-                    <div
-                      className={classNames(
-                        "flex justify-center flex-wrap items-end mt-2",
-                        {
-                          "text-error": missingPointRequirement,
-                        }
-                      )}
-                    >
-                      <span className="text-shadow text-center text-xxs sm:text-xs">
-                        Required Skill Points:
-                      </span>
-                      <span className="text-xxs sm:text-xs text-shadow text-center">
-                        {`${availableSkillPoints}/${pointsRequired}`}
-                      </span>
-                    </div>
+                    <RequiredSkillPoints
+                      missingPointRequirement={missingPointRequirement}
+                      availableSkillPoints={availableSkillPoints}
+                      pointsRequired={pointsRequired}
+                    />
                     {skillRequired && (
-                      <div
-                        className={classNames(
-                          "flex justify-center flex-wrap items-center mt-2",
-                          {
-                            "text-error": missingSkillRequirement,
-                          }
-                        )}
-                      >
-                        <span className="text-shadow text-center text-xxs sm:text-xs">
-                          Required Skills:
-                        </span>
-                        <img src={requiredSkillImage} />
-                      </div>
+                      <RequiredSkill
+                        requiredSkillImage={requiredSkillImage}
+                        missingSkillRequirement={missingSkillRequirement}
+                      />
                     )}
                   </div>
                   <Button

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -18,6 +18,7 @@ import seedSpecialist from "assets/skills/seed_specialist.png";
 import { SkillPathDetails } from "./SkillPathDetails";
 import arrowLeft from "assets/icons/arrow_left.png";
 import { Label } from "components/ui/Label";
+import { findLevelRequiredForNextSkillPoint } from "features/game/lib/level";
 
 interface Props {
   onBack: () => void;
@@ -58,6 +59,7 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
   };
 
   const { bumpkin } = state;
+  const { experience } = bumpkin;
 
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
 
@@ -89,11 +91,14 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
             alt="back"
             onClick={handleBack}
           />
-          {availableSkillPoints > 0 ? (
+          {availableSkillPoints > 0 && (
             <SkillPointsLabel points={availableSkillPoints} />
-          ) : (
+          )}
+          {!availableSkillPoints && (
             <Label>
-              <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${2}`}</p>
+              <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${findLevelRequiredForNextSkillPoint(
+                experience
+              )}`}</p>
             </Label>
           )}
         </div>
@@ -106,7 +111,6 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
           <SkillPathDetails
             selectedSkillPath={selectedSkillPath}
             skillsInPath={skillsInPath}
-            onBack={handleBackToSkillList}
           />
         )}
       </div>

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -27,11 +27,10 @@ interface Props {
 
 export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
   const { gameService } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const [gameState] = useActor(gameService);
+  const {
+    context: { state },
+  } = gameState;
 
   const [selectedSkillPath, setSelectedSkillPath] =
     useState<BumpkinSkillTree | null>(null);
@@ -59,9 +58,24 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
   };
 
   const { bumpkin } = state;
-  const { experience } = bumpkin;
+  const experience = bumpkin?.experience || 0;
 
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+
+  const skillPointsInfo = () => (
+    <>
+      {availableSkillPoints > 0 && (
+        <SkillPointsLabel points={availableSkillPoints} />
+      )}
+      {!availableSkillPoints && (
+        <Label>
+          <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${findLevelRequiredForNextSkillPoint(
+            experience
+          )}`}</p>
+        </Label>
+      )}
+    </>
+  );
 
   return (
     <Panel className="pt-5 relative">
@@ -78,7 +92,6 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
           onClick={onClose}
         />
       </div>
-
       <div
         style={{
           minHeight: "200px",
@@ -91,16 +104,7 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
             alt="back"
             onClick={handleBack}
           />
-          {availableSkillPoints > 0 && (
-            <SkillPointsLabel points={availableSkillPoints} />
-          )}
-          {!availableSkillPoints && (
-            <Label>
-              <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${findLevelRequiredForNextSkillPoint(
-                experience
-              )}`}</p>
-            </Label>
-          )}
+          {!gameState.matches("visiting") && skillPointsInfo()}
         </div>
         {!selectedSkillPath && (
           <SkillCategoryList

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -48,6 +48,15 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
     setSelectedSkillPath(null);
   };
 
+  const handleBack = () => {
+    if (selectedSkillPath) {
+      handleBackToSkillList();
+      return;
+    }
+
+    onBack();
+  };
+
   const { bumpkin } = state;
 
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
@@ -73,12 +82,12 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
           minHeight: "200px",
         }}
       >
-        <div className="flex flex-row mb-2">
+        <div className="flex flex-row mb-2 items-center">
           <img
             src={arrowLeft}
-            className="self-start w-5 cursor-pointer mx-2 mb-2"
+            className="self-start w-5 cursor-pointer mx-2"
             alt="back"
-            onClick={onBack}
+            onClick={handleBack}
           />
           {availableSkillPoints > 0 ? (
             <SkillPointsLabel points={availableSkillPoints} />

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -62,20 +62,24 @@ export const Skills: React.FC<Props> = ({ onBack, onClose }) => {
 
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
 
-  const skillPointsInfo = () => (
-    <>
-      {availableSkillPoints > 0 && (
-        <SkillPointsLabel points={availableSkillPoints} />
-      )}
-      {!availableSkillPoints && (
-        <Label>
-          <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${findLevelRequiredForNextSkillPoint(
-            experience
-          )}`}</p>
-        </Label>
-      )}
-    </>
-  );
+  const skillPointsInfo = () => {
+    const levelRequired = findLevelRequiredForNextSkillPoint(experience);
+
+    return (
+      <>
+        {availableSkillPoints > 0 && (
+          <SkillPointsLabel points={availableSkillPoints} />
+        )}
+        {!availableSkillPoints && levelRequired && (
+          <Label>
+            <p className="text-[10px] ml-2 pr-2">{`Unlock skill point: level ${findLevelRequiredForNextSkillPoint(
+              experience
+            )}`}</p>
+          </Label>
+        )}
+      </>
+    );
+  };
 
   return (
     <Panel className="pt-5 relative">

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -59,14 +59,12 @@ export const UpcomingExpansion: React.FC<Props> = ({ gameState }) => {
         height={LAND_SIZE}
         width={LAND_SIZE}
       >
-        <div
-          className="w-full h-full flex items-center justify-center cursor-pointer opacity-90 hover:opacity-100"
-          onClick={() => setShowBumpkinModal(true)}
-        >
+        <div className="w-full h-full flex items-center justify-center opacity-90 hover:opacity-100">
           <img
             src={expandIcon}
             width={18 * PIXEL_SCALE}
-            className="relative top-4"
+            className="relative top-4 cursor-pointer hover:img-highlight"
+            onClick={() => setShowBumpkinModal(true)}
           />
         </div>
       </MapPlacement>

--- a/src/features/game/lib/level.test.ts
+++ b/src/features/game/lib/level.test.ts
@@ -3,19 +3,14 @@ import { findLevelRequiredForNextSkillPoint } from "./level";
 describe("findLevelRequiredForNextSkillPoint", () => {
   it("returns level 3 if the player has 1 skill points", () => {
     const bumpkinExp = 70;
-
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(3);
   });
-
   it("returns level 6 if the player has 3 skill points", () => {
     const bumpkinExp = 1242;
-
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(6);
   });
-
   it("returns level 15 if the player has 10 skill points", () => {
     const bumpkinExp = 36500;
-
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(15);
   });
 });

--- a/src/features/game/lib/level.test.ts
+++ b/src/features/game/lib/level.test.ts
@@ -1,0 +1,21 @@
+import { findLevelRequiredForNextSkillPoint } from "./level";
+
+describe("findLevelRequiredForNextSkillPoint", () => {
+  it("returns level 3 if the player has 1 skill points", () => {
+    const bumpkinExp = 70;
+
+    expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(3);
+  });
+
+  it("returns level 6 if the player has 3 skill points", () => {
+    const bumpkinExp = 1242;
+
+    expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(6);
+  });
+
+  it("returns level 15 if the player has 10 skill points", () => {
+    const bumpkinExp = 36500;
+
+    expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(15);
+  });
+});

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -1,3 +1,4 @@
+import { flipObject } from "lib/utils/flipObject";
 import { getKeys } from "../types/craftables";
 
 export type BumpkinLevel =
@@ -79,4 +80,14 @@ export const SKILL_POINTS: Record<BumpkinLevel, number> = {
   18: 13,
   19: 14,
   20: 15,
+};
+
+export const findLevelRequiredForNextSkillPoint = (
+  experience: number
+): BumpkinLevel => {
+  const level = getBumpkinLevel(experience);
+  const currentSkillPoints = SKILL_POINTS[level];
+  const skillPointToLevels = flipObject(SKILL_POINTS);
+
+  return Number(skillPointToLevels[currentSkillPoints + 1]) as BumpkinLevel;
 };

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -82,10 +82,19 @@ export const SKILL_POINTS: Record<BumpkinLevel, number> = {
   20: 15,
 };
 
+export const getMaxLevel = () => {
+  const levels = getKeys(SKILL_POINTS);
+
+  return levels[levels.length - 1];
+};
+
 export const findLevelRequiredForNextSkillPoint = (
   experience: number
-): BumpkinLevel => {
+): BumpkinLevel | undefined => {
   const level = getBumpkinLevel(experience);
+
+  if (level >= getMaxLevel()) return undefined;
+
   const currentSkillPoints = SKILL_POINTS[level];
   const skillPointToLevels = flipObject(SKILL_POINTS);
 

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -93,7 +93,7 @@ export const findLevelRequiredForNextSkillPoint = (
 ): BumpkinLevel | undefined => {
   const level = getBumpkinLevel(experience);
 
-  if (level >= getMaxLevel()) return undefined;
+  if (Number(level) >= getMaxLevel()) return undefined;
 
   const currentSkillPoints = SKILL_POINTS[level];
   const skillPointToLevels = flipObject(SKILL_POINTS);

--- a/src/features/island/hud/components/BumpkinHUD.tsx
+++ b/src/features/island/hud/components/BumpkinHUD.tsx
@@ -28,11 +28,10 @@ export const BumpkinHUD: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
 
   const { gameService } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const [gameState] = useActor(gameService);
+  const {
+    context: { state },
+  } = gameState;
 
   const handleShowHomeModal = () => {
     setViewSkillsPage(false);
@@ -128,7 +127,7 @@ export const BumpkinHUD: React.FC = () => {
         </div>
 
         {/* Skill point alert */}
-        {showSkillPointAlert && (
+        {showSkillPointAlert && !gameState.matches("visiting") && (
           <div
             id="alert"
             className="absolute top-[150px] px-4 py-3 ready cursor-pointer hover:img-highlight"

--- a/src/lib/utils/flipObject.ts
+++ b/src/lib/utils/flipObject.ts
@@ -1,0 +1,13 @@
+export type AnyKey = keyof any;
+
+export function flipObject<K extends AnyKey, V extends AnyKey>(
+  object: Record<K, V>
+) {
+  const flipped: Partial<Record<V, K>> = {};
+
+  for (const key in object) {
+    flipped[object[key]] = key;
+  }
+
+  return flipped as Record<V, K>;
+}

--- a/src/lib/utils/flipObject.ts
+++ b/src/lib/utils/flipObject.ts
@@ -1,5 +1,10 @@
 export type AnyKey = keyof any;
 
+/**
+ *  Flips your object so that values are keys and keys are values
+ * @param object
+ * @returns object flipped { v: k }
+ */
 export function flipObject<K extends AnyKey, V extends AnyKey>(
   object: Record<K, V>
 ) {


### PR DESCRIPTION
# Description

This PR limits the skill information available when visiting another players farm. Previously you were able to see skill points available when visiting another player. You were also able to see the skill point alert.

There was also a placeholder for showing level required for next skill point. I have added real data here.

<img width="499" alt="Screen Shot 2022-11-10 at 4 19 45 pm" src="https://user-images.githubusercontent.com/17863697/201008648-74236d26-ed4e-482b-b34f-1ca368400ab1.png">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by giving exp to another farm and then visiting it. 

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
