### PR TITLE
[FIX] Allow minting of war items again

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -663,17 +663,38 @@ export const WAR_TENT_ITEMS: Record<WarTentItem, LimitedItem> = {
     description: "Decorate the land with the bones of your enemies.",
     type: LimitedItemType.WarTentItem,
     canMintMultiple: true,
+    ingredients: [
+      {
+        id: 917,
+        item: "War Bond",
+        amount: new Decimal(300),
+      },
+    ],
   },
   "War Tombstone": {
     name: "War Tombstone",
     description: "R.I.P",
     type: LimitedItemType.WarTentItem,
     canMintMultiple: true,
+    ingredients: [
+      {
+        id: 917,
+        item: "War Bond",
+        amount: new Decimal(500),
+      },
+    ],
   },
   "Undead Rooster": {
     name: "Undead Rooster",
     description: "An unfortunate casualty of the war. 10% increased egg yield.",
     type: LimitedItemType.WarTentItem,
+    ingredients: [
+      {
+        id: 917,
+        item: "War Bond",
+        amount: new Decimal(1000),
+      },
+    ],
   },
 };
 
@@ -1054,7 +1075,7 @@ export const makeLimitedItemsByName = (
         tokenAmount,
         maxSupply,
         cooldownSeconds,
-        ingredients,
+        ingredients: items[name].ingredients || undefined,
         mintedAt,
         type: items[name].type,
         disabled: !enabled,

--- a/src/features/goblins/Rare.tsx
+++ b/src/features/goblins/Rare.tsx
@@ -247,7 +247,11 @@ export const Rare: React.FC<Props> = ({ onClose, type, canCraft = true }) => {
     return (
       <>
         <Button
-          disabled={lessFunds() || lessIngredients()}
+          disabled={
+            lessFunds() ||
+            lessIngredients() ||
+            selected.ingredients === undefined
+          }
           className="text-xs mt-1"
           onClick={() => craft()}
         >


### PR DESCRIPTION
# Description

New mint collectible disabled the onchain ingredients, so users can't mint war items.

This is only a quick fix, i plan to come back to this and get the ingredients via onchain later.

BEFORE: 
![image](https://user-images.githubusercontent.com/94913189/201042669-e909fe24-f9c0-4686-9ac1-d0fd7a11da3a.png)
AFTER:
![image](https://user-images.githubusercontent.com/94913189/201042695-bc49724a-4058-49be-8ae6-943300126530.png)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go to the war tent and try to mint any item with supply

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
