### PR TITLE
[FIX] Enable Sell 1 Button when Selling Fractional Crop

### DIFF
--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -48,8 +48,9 @@ export const Crops: React.FC = () => {
   const noCrop = cropAmount.equals(0);
   const displaySellPrice = (crop: Crop) => getSellPrice(crop, inventory);
 
-  const handleSellOne = () => {
-    sell(new Decimal(1));
+  const handleSellOneOrLess = () => {
+    const sellAmount = cropAmount.gte(1) ? new Decimal(1) : cropAmount;
+    sell(sellAmount);
   };
 
   const handleSellAll = () => {
@@ -60,7 +61,7 @@ export const Crops: React.FC = () => {
   // ask confirmation if crop supply is greater than 1
   const openConfirmationModal = () => {
     if (cropAmount.equals(1)) {
-      handleSellOne();
+      handleSellOneOrLess();
     } else {
       showSellAllModal(true);
     }
@@ -111,11 +112,11 @@ export const Crops: React.FC = () => {
             </div>
           </div>
           <Button
-            disabled={cropAmount.lessThan(1)}
+            disabled={cropAmount.lte(0)}
             className="text-xs mt-1"
-            onClick={handleSellOne}
+            onClick={handleSellOneOrLess}
           >
-            Sell 1
+            {`Sell ${cropAmount.gte(1) ? "1" : "<1"}`}
           </Button>
           <Button
             disabled={noCrop}


### PR DESCRIPTION
# Description

When selling a crop less that 1, the "Sell 1" button was disabled. This felt a bit awkward to me, so in this PR I added the ability to click this button which sells the remaining amount of crops less than one. It also renders the text "<1" on the button in the scenario you have less than one to sell.

Finally, the reason I didn't make this text the actual fractional crop amount:  Theoretically it can get to be a really large decimal number (i.e. like `0.123456781234567812`).I thought a simple "less-than" char summarized it just fine, without hte risk of the text overflowing.

BugBash Ticket # 48

Before:
![bug](https://user-images.githubusercontent.com/103600068/201249621-5093a1cf-868c-42b4-9b86-e47fcd1c9ebe.png)

After:
![fix](https://user-images.githubusercontent.com/103600068/201249633-5d18eb12-7e5e-42e9-9c57-16613e8f28a0.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visually

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
