### PR TITLE
[FEAT] Add lock icon to locked seeds

### DIFF
--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -29,10 +29,15 @@ import { INITIAL_STOCK } from "features/game/lib/constants";
 import { makeBulkSeedBuyAmount } from "./lib/makeBulkSeedBuyAmount";
 import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { SeedName, SEEDS } from "features/game/types/seeds";
+import { Seed, SeedName, SEEDS } from "features/game/types/seeds";
+import { Bumpkin } from "features/game/types/game";
 
 interface Props {
   onClose: () => void;
+}
+
+function isSeedLocked(bumpkin: Bumpkin | undefined, seed: Seed) {
+  return getBumpkinLevel(bumpkin?.experience ?? 0) < seed.bumpkinLevel;
 }
 
 export const Seeds: React.FC<Props> = ({ onClose }) => {
@@ -116,10 +121,9 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       />
     );
   }
+
   const Action = () => {
-    const userBumpkinLevel = getBumpkinLevel(state.bumpkin?.experience ?? 0);
-    const requiredLevel = selected.bumpkinLevel ?? 0;
-    if (userBumpkinLevel < requiredLevel) {
+    if (isSeedLocked(state.bumpkin, selected)) {
       return (
         <div className="flex items-center mt-2">
           <img src={heart} className="h-4 ml-0.5 mr-1" />
@@ -127,7 +131,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
             className="bg-error border text-xs p-1 rounded-md"
             style={{ lineHeight: "10px" }}
           >
-            Lvl {requiredLevel}
+            Lvl {selected.bumpkinLevel ?? 0}
           </span>
           <img src={lock} className="h-4 ml-0.5 mr-2" />
         </div>
@@ -194,6 +198,9 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
             key={name}
             onClick={() => setSelectedName(name)}
             image={ITEM_DETAILS[name].image}
+            secondaryImage={
+              isSeedLocked(state.bumpkin, SEEDS()[name]) ? lock : undefined
+            }
             count={inventory[name]}
           />
         ))}


### PR DESCRIPTION
# Description

When I was playing LE on testnet, I found that I didn't notice I unlocked seeds when I leveled up my bumpkin. This PR adds a small lock icon on the seed box UI if that seed is currently locked to my level. IMO this small change goes a long way, as I see another thing I get to grind for and make playing even more exciting.

Also a small refactor for helper function to determine if seed is locked for me.

BugBash Ticket # 56

Before
![before](https://user-images.githubusercontent.com/103600068/201258119-832fc266-0433-473e-ba05-4f3748389a2d.png)

After:
![after](https://user-images.githubusercontent.com/103600068/201258144-d47d7e63-4cf8-4724-9e23-ae5e9cfbcdf1.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visually

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
