### PR TITLE
[FEAT] Add boosts.ts to land expansion :)

### DIFF
--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -2,10 +2,10 @@ import Decimal from "decimal.js-light";
 import { CropName, CROPS } from "../../types/crops";
 import { GameState } from "../../types/game";
 import cloneDeep from "lodash.clonedeep";
-import { getSellPrice } from "features/game/lib/boosts";
-import { SellableItem } from "../sell";
+import { getSellPrice } from "features/game/expansion/lib/boosts";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { setPrecision } from "lib/utils/formatNumber";
+import { Cake } from "features/game/types/craftables";
 
 export type SellCropAction = {
   type: "crop.sold";
@@ -13,7 +13,14 @@ export type SellCropAction = {
   amount: number;
 };
 
-const SELLABLE = { ...CROPS() };
+export type SellableName = CropName | Cake;
+
+export type SellableItem = {
+  name: SellableName;
+  sellPrice?: Decimal;
+};
+
+export const SELLABLE = { ...CROPS() };
 
 type Options = {
   state: GameState;
@@ -45,7 +52,11 @@ export function sellCrop({ state, action }: Options): GameState {
     throw new Error("Insufficient quantity to sell");
   }
 
-  const price = getSellPrice(sellables as SellableItem, game.inventory);
+  const price = getSellPrice(
+    sellables as SellableItem,
+    game.inventory,
+    bumpkin
+  );
 
   const sflEarned = price.mul(action.amount);
   bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sflEarned);

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -1,0 +1,34 @@
+import Decimal from "decimal.js-light";
+import { CAKES } from "../../types/craftables";
+import { getSellPrice } from "./boosts";
+import { INITIAL_BUMPKIN } from "features/game/lib/constants";
+import { marketRate } from "features/game/lib/halvening";
+import { SellableItem } from "features/game/events/landExpansion/sellCrop";
+import { Bumpkin } from "features/game/types/game";
+
+describe("boosts", () => {
+  describe("getSellPrice", () => {
+    it("applies chef apron boost to cakes if equipped on the bumpkin", () => {
+      const bumpkin: Bumpkin = {
+        ...INITIAL_BUMPKIN,
+        equipped: { ...INITIAL_BUMPKIN.equipped, coat: "Chef Apron" },
+      };
+      const amount = getSellPrice(
+        CAKES()["Beetroot Cake"] as SellableItem,
+        {},
+        bumpkin
+      );
+      expect(amount).toEqual(new Decimal(marketRate(672)));
+    });
+
+    it("does not apply chef apron boost if not equipped on the bumpkin", () => {
+      const bumpkin = INITIAL_BUMPKIN;
+      const amount = getSellPrice(
+        CAKES()["Beetroot Cake"] as SellableItem,
+        {},
+        bumpkin
+      );
+      expect(amount).toEqual(new Decimal(marketRate(560)));
+    });
+  });
+});

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -76,13 +76,6 @@ export const hasBoost = ({ item, inventory }: HasBoostArgs) => {
   }
 
   if (
-    item === "Carrot Seed" &&
-    inventory["Carrot Sword"]?.greaterThanOrEqualTo(1)
-  ) {
-    return true;
-  }
-
-  if (
     item === "Parsnip Seed" &&
     inventory["Mysterious Parsnip"]?.greaterThanOrEqualTo(1)
   ) {

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -1,9 +1,15 @@
-import { Bumpkin, Inventory, InventoryItemName } from "../../types/game";
+import {
+  Bumpkin,
+  Collectibles,
+  Inventory,
+  InventoryItemName,
+} from "../../types/game";
 import { SellableItem } from "features/game/events/landExpansion/sellCrop";
 import { isSeed } from "features/game/events/plant";
 import { CROPS } from "../../types/crops";
 import { CAKES } from "../../types/craftables";
 import Decimal from "decimal.js-light";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
 const crops = CROPS();
 const cakes = CAKES();
@@ -59,32 +65,39 @@ export const hasSellBoost = (inventory: Inventory, bumpkin: Bumpkin) => {
 
 type HasBoostArgs = {
   item: InventoryItemName;
-  inventory: Inventory;
+  collectibles: Collectibles;
 };
 /**
  * To be used as boolean flag
  * Update if more upcoming boosts
  */
-export const hasBoost = ({ item, inventory }: HasBoostArgs) => {
+export const hasBoost = ({ item, collectibles }: HasBoostArgs) => {
   if (
     isSeed(item) &&
-    (inventory.Nancy?.greaterThanOrEqualTo(1) ||
-      inventory.Scarecrow?.greaterThanOrEqualTo(1) ||
-      inventory.Kuebiko?.greaterThanOrEqualTo(1))
+    (isCollectibleBuilt("Nancy", collectibles) ||
+      isCollectibleBuilt("Scarecrow", collectibles) ||
+      isCollectibleBuilt("Kuebiko", collectibles))
+  ) {
+    return true;
+  }
+
+  if (
+    item === "Carrot Seed" &&
+    isCollectibleBuilt("Easter Bunny", collectibles)
   ) {
     return true;
   }
 
   if (
     item === "Parsnip Seed" &&
-    inventory["Mysterious Parsnip"]?.greaterThanOrEqualTo(1)
+    isCollectibleBuilt("Mysterious Parsnip", collectibles)
   ) {
     return true;
   }
 
   if (
     item === "Cauliflower Seed" &&
-    inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)
+    isCollectibleBuilt("Golden Cauliflower", collectibles)
   ) {
     return true;
   }

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -35,7 +35,11 @@ export const getSellPrice = (
   }
 
   // apply Chef Apron 20% boost when selling cakes
-  if (item.name in cakes && bumpkin.equipped.coat === "Chef Apron") {
+  if (
+    item.name in cakes &&
+    bumpkin.equipped.coat &&
+    bumpkin.equipped.coat === "Chef Apron"
+  ) {
     price = price.mul(1.2);
   }
 

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -1,0 +1,100 @@
+import { Bumpkin, Inventory, InventoryItemName } from "../../types/game";
+import { SellableItem } from "features/game/events/landExpansion/sellCrop";
+import { isSeed } from "features/game/events/plant";
+import { CROPS } from "../../types/crops";
+import { CAKES } from "../../types/craftables";
+import Decimal from "decimal.js-light";
+
+const crops = CROPS();
+const cakes = CAKES();
+
+/**
+ * How much SFL an item is worth
+ */
+export const getSellPrice = (
+  item: SellableItem,
+  inventory: Inventory,
+  bumpkin: Bumpkin
+) => {
+  let price = item.sellPrice;
+  const { skills } = bumpkin;
+
+  if (!price) {
+    return new Decimal(0);
+  }
+
+  // apply Green Thumb boost to crop LEGACY SKILL!
+  if (item.name in crops && inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
+    price = price.mul(1.05);
+  }
+
+  // apply Chef Apron 20% boost when selling cakes
+  if (item.name in cakes && bumpkin.equipped.coat === "Chef Apron") {
+    price = price.mul(1.2);
+  }
+
+  // apply Green Thumb boost to crop BUMPKIN NEW SKILL!
+  if (item.name in crops && skills["Green Thumb"]) {
+    price = price.mul(1.05);
+  }
+
+  return price;
+};
+
+/**
+ * To be used as boolean flag
+ * Update if more upcoming boosts
+ */
+export const hasSellBoost = (inventory: Inventory, bumpkin: Bumpkin) => {
+  const { skills } = bumpkin;
+  if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
+    return true;
+  }
+  if (skills["Green Thumb"]) {
+    return true;
+  }
+
+  return false;
+};
+
+type HasBoostArgs = {
+  item: InventoryItemName;
+  inventory: Inventory;
+};
+/**
+ * To be used as boolean flag
+ * Update if more upcoming boosts
+ */
+export const hasBoost = ({ item, inventory }: HasBoostArgs) => {
+  if (
+    isSeed(item) &&
+    (inventory.Nancy?.greaterThanOrEqualTo(1) ||
+      inventory.Scarecrow?.greaterThanOrEqualTo(1) ||
+      inventory.Kuebiko?.greaterThanOrEqualTo(1))
+  ) {
+    return true;
+  }
+
+  if (
+    item === "Carrot Seed" &&
+    inventory["Carrot Sword"]?.greaterThanOrEqualTo(1)
+  ) {
+    return true;
+  }
+
+  if (
+    item === "Parsnip Seed" &&
+    inventory["Mysterious Parsnip"]?.greaterThanOrEqualTo(1)
+  ) {
+    return true;
+  }
+
+  if (
+    item === "Cauliflower Seed" &&
+    inventory["Golden Cauliflower"]?.greaterThanOrEqualTo(1)
+  ) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -16,8 +16,9 @@ import { useActor } from "@xstate/react";
 import { Modal } from "react-bootstrap";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
-import { getSellPrice, hasSellBoost } from "features/game/lib/boosts";
+import { getSellPrice, hasSellBoost } from "features/game/expansion/lib/boosts";
 import { setPrecision } from "lib/utils/formatNumber";
+import { Bumpkin } from "features/game/types/game";
 
 export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<Crop>(CROPS().Sunflower);
@@ -46,7 +47,8 @@ export const Crops: React.FC = () => {
 
   const cropAmount = new Decimal(inventory[selected.name] || 0);
   const noCrop = cropAmount.equals(0);
-  const displaySellPrice = (crop: Crop) => getSellPrice(crop, inventory);
+  const displaySellPrice = (crop: Crop) =>
+    getSellPrice(crop, inventory, state.bumpkin as Bumpkin);
 
   const handleSellOne = () => {
     sell(new Decimal(1));
@@ -71,7 +73,7 @@ export const Crops: React.FC = () => {
   };
 
   useEffect(() => {
-    setIsPriceBoosted(hasSellBoost(inventory));
+    setIsPriceBoosted(hasSellBoost(inventory, state.bumpkin as Bumpkin));
   }, [inventory, state.inventory]);
 
   return (

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -100,7 +100,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       setIsTimeBoosted(
         hasBoost({
           item: selectedName,
-          inventory,
+          collectibles,
         })
       ),
     [inventory, selectedName, state.inventory]

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -22,7 +22,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Decimal } from "decimal.js-light";
 import { Stock } from "components/ui/Stock";
-import { hasBoost } from "features/game/lib/boosts";
+import { hasBoost } from "features/game/expansion/lib/boosts";
 import { getBuyPrice } from "features/game/events/landExpansion/seedBought";
 import { getCropTime } from "features/game/events/plant";
 import { INITIAL_STOCK } from "features/game/lib/constants";


### PR DESCRIPTION
# Description


Add boosts.ts to land expansion

Market prices now reflects bumpkin skills and equipped outfits (e.g new Green thumb skill or chef apron when selling cakes)
![image](https://user-images.githubusercontent.com/94913189/201268947-8034870e-4dfb-4024-ac25-195871304dff.png)

Apply hasBoost function only when the collectible is built

Also this needs a backend update, because Green Thumb bumpkin skill gives 5% crop yield, but it actually should give 5% more SFL when selling crops.

#Fixes bug bash 8

I will move the cake boost to the grubshop in another pr.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

sell any crop with the skill on your bumpkin.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
