### PR TITLE
[FIX] Increase seed limits

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -5,7 +5,7 @@ import { GameState, Inventory, InventoryItemName } from "../types/game";
 import { SKILL_TREE } from "../types/skills";
 
 const maxItems: Inventory = {
-  // Seed limits + buffer of 10
+  // Seed limits + buffer of 20
   Sunflower: new Decimal("3000"),
   Potato: new Decimal("2000"),
   Pumpkin: new Decimal("1000"),
@@ -23,16 +23,16 @@ const maxItems: Inventory = {
   "Rich Chicken": new Decimal("5"),
   "Fat Chicken": new Decimal("5"),
 
-  "Sunflower Seed": new Decimal(410),
-  "Potato Seed": new Decimal(210),
-  "Pumpkin Seed": new Decimal(110),
-  "Carrot Seed": new Decimal(110),
-  "Cabbage Seed": new Decimal(100),
-  "Beetroot Seed": new Decimal(90),
-  "Cauliflower Seed": new Decimal(90),
-  "Parsnip Seed": new Decimal(70),
-  "Radish Seed": new Decimal(50),
-  "Wheat Seed": new Decimal(50),
+  "Sunflower Seed": new Decimal(420),
+  "Potato Seed": new Decimal(220),
+  "Pumpkin Seed": new Decimal(120),
+  "Carrot Seed": new Decimal(120),
+  "Cabbage Seed": new Decimal(110),
+  "Beetroot Seed": new Decimal(100),
+  "Cauliflower Seed": new Decimal(100),
+  "Parsnip Seed": new Decimal(80),
+  "Radish Seed": new Decimal(60),
+  "Wheat Seed": new Decimal(60),
 
   Gold: new Decimal("90"),
   Iron: new Decimal("400"),


### PR DESCRIPTION
# Description

If you have 109 pumpkin seeds in your inventory and you're about to harvest your pumpkins to plant potatoes, if you get a +3 pumpkin seeds bonus you get an error message asking you to sync.
Since many people seem to buy all their seeds while the crops are growing, increasing the buff from 10 to 20 would correct this problem.

![image](https://user-images.githubusercontent.com/102468955/201374342-d11fb572-2d08-457c-aaba-b544ccec25c0.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Harvesting pumpkins and getting free pumpkin seeds while having 109 pumpkin seeds in the inventory.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
