### PR TITLE
[FIX] updated quickswap link for Add liquidity

### DIFF
--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -257,7 +257,7 @@ export const WishingWellModal: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const goToQuickSwap = () => {
     window.open(
-      "https://quickswap.exchange/#/analytics/pair/0x6f9e92dd4734c168a734b873dc3db77e39552eb6",
+      "https://quickswap.exchange/#/add/0xd1f9c58e33933a993a3891f8acfe05a68e1afc05/ETH",
       "_blank"
     );
   };


### PR DESCRIPTION
# Description

Currently on click on Add liquidity button it redirects to a [blank page](https://quickswap.exchange/#/analytics/pair/0x6f9e92dd4734c168a734b873dc3db77e39552eb6)
From the [docs](https://docs.sunflower-land.com/economy/wishing-well#what-is-in-the-wishing-well) it looks like the following quickswap link should be used to liquidate SFLs:
https://quickswap.exchange/#/add/0xd1f9c58e33933a993a3891f8acfe05a68e1afc05/ETH
(Apologies in advance if this URL is incorrect)

<img width="515" alt="image" src="https://user-images.githubusercontent.com/3134785/201468206-11a3563a-738d-4f7c-a361-3ad6645cae26.png">


Fixes #1662 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by going directly to that quickswap link
And all existing test cases passed locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
