### PR TITLE
[FIX] Box label z-index

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -202,7 +202,8 @@ export const Box: React.FC<BoxProps> = ({
         {showCountLabel && (
           <div
             ref={labelRef}
-            className={classNames("absolute z-10", {
+            className={classNames("absolute", {
+              "z-10": !isHover,
               "z-20": isHover,
             })}
             style={{


### PR DESCRIPTION
# Description

- fix box label z-index while hovering

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/201788787-e34fe32f-c491-4ce4-9f6a-09e905f156c2.png)  |  ![image](https://user-images.githubusercontent.com/107602352/201788763-996571be-c256-45ec-90c1-0757048ad05f.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- hover on boxes if the actual number display is very long

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
