### PR TITLE
[FIX] Disable "List trade" button if qty is more than max sell amount

### DIFF
--- a/src/features/goblins/trader/selling/components/Drafting.tsx
+++ b/src/features/goblins/trader/selling/components/Drafting.tsx
@@ -85,12 +85,14 @@ export const Drafting: React.FC<DraftingProps> = ({
 
   const currentInventoryAmount = inventory[selected] || new Decimal(0);
   const maxSellAmount = itemLimits[selected] ?? 0;
+  const decimalResourceAmount = new Decimal(resourceAmount);
 
   const disableListTradeButton =
     !sflAmount ||
     !resourceAmount ||
     new Decimal(sflAmount).gt(MAX_SFL) ||
-    new Decimal(resourceAmount).gt(currentInventoryAmount);
+    decimalResourceAmount.gt(currentInventoryAmount) ||
+    decimalResourceAmount.gt(maxSellAmount);
 
   const hasItemsToList = inventoryItems.length > 0;
 
@@ -131,9 +133,9 @@ export const Drafting: React.FC<DraftingProps> = ({
                 className={classNames(
                   "text-shadow shadow-inner shadow-black bg-brown-200 w-full p-2",
                   {
-                    "text-error": new Decimal(resourceAmount).gt(
-                      currentInventoryAmount || maxSellAmount
-                    ),
+                    "text-error":
+                      decimalResourceAmount.gt(currentInventoryAmount) ||
+                      decimalResourceAmount.gt(maxSellAmount),
                   }
                 )}
               />


### PR DESCRIPTION
# Description

This fix will disable the "List Trade" button if the resource amount is greater than the max allowed amount
Currently, it allows user to enter the value more than max allowed but since there is a check in backend, the API call fails

<img width="492" alt="image" src="https://user-images.githubusercontent.com/3134785/201919475-056308f2-da92-42ab-80a0-170a966a1e58.png">

Added a condition to the existing check `disableListTradeButton` and fixed the `className` check

Fixes #1601 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Sorry I couldn't test this by running locally on my machine because list trade feature requires `VITE_API_URL` which I don't have.
Ran all the tests locally and all passed

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
