### PR TITLE
[FIX] Trader input overlay

### DIFF
--- a/src/features/goblins/trader/selling/components/Drafting.tsx
+++ b/src/features/goblins/trader/selling/components/Drafting.tsx
@@ -15,6 +15,7 @@ import { Draft } from "../lib/sellingMachine";
 
 const MAX_SFL = new Decimal(10000);
 const VALID_NUMBER = new RegExp(/^\d*\.?\d*$/);
+const INPUT_MAX_CHAR = 10;
 
 interface DraftingProps {
   slotId: number;
@@ -73,13 +74,13 @@ export const Drafting: React.FC<DraftingProps> = ({
 
   const handleSflChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (VALID_NUMBER.test(e.target.value)) {
-      setSflAmount(Number(e.target.value));
+      setSflAmount(Number(e.target.value.slice(0, INPUT_MAX_CHAR)));
     }
   };
 
   const handleResourceChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (VALID_NUMBER.test(e.target.value)) {
-      setResourceAmount(Number(e.target.value));
+      setResourceAmount(Number(e.target.value.slice(0, INPUT_MAX_CHAR)));
     }
   };
 


### PR DESCRIPTION
# Description

too many characters in the input fields in **the trading functionality** overlap with other elements (most noticeable on the mobile):
-  the label max:500 max:10000 
- when the trade is listed it overlaps with the other text 

I set a limit of 10 chars for both fields based on the max SFL of 10K and after examining the current trades on [https://sfl.land/](https://sfl.land/)
The highest trades are 11000.0000 SFL which is exactly 10 characters long
![image](https://user-images.githubusercontent.com/9072434/202250874-f657ac14-a200-43e3-b7c9-24f0dd6a713e.png)



| Before listing | After listing (on production) |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/9072434/202248402-e2ca3daa-b1e5-42fd-a367-7ee0075864cc.png)  | ![image](https://user-images.githubusercontent.com/9072434/202248702-4138cdf7-c733-43ca-92f4-97748bbbdb1a.png)  |

**After the fix** 

| Desktop  | Mobile |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/9072434/202249679-6545d712-8d7f-4ee8-8b2b-4749ebe3e783.png)  | ![image](https://user-images.githubusercontent.com/9072434/202249502-920b5c3f-0026-4683-9cea-74c0e1dee680.png)  |


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the result locally

`yarn test`
![image](https://user-images.githubusercontent.com/9072434/202252561-26c7c0b2-5871-4745-ae28-c1a936a307a5.png)

for some reason not all test pass, I run the test on the master and they didn't pass as well.
![image](https://user-images.githubusercontent.com/9072434/202253018-7310cd85-bdfa-4a84-9418-b430d73e1654.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
