### PR TITLE
[FIX] Bumpkin experience bar

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -1,25 +1,22 @@
 import { useActor } from "@xstate/react";
 import React, { useContext, useState } from "react";
 
-import heart from "assets/icons/level_up.png";
+import levelIcon from "assets/icons/level_up.png";
 import close from "assets/icons/close.png";
 import alert from "assets/icons/expression_alerted.png";
 
 import progressBarSmall from "assets/ui/progress/transparent_bar_small.png";
 
 import { Context } from "features/game/GameProvider";
-import {
-  BumpkinItem,
-  Equipped as BumpkinParts,
-} from "features/game/types/bumpkin";
+import { Equipped as BumpkinParts } from "features/game/types/bumpkin";
 import { DynamicNFT } from "./DynamicNFT";
 import { InnerPanel, Panel } from "components/ui/Panel";
 import { Badges } from "features/farming/house/House";
 import {
   getBumpkinLevel,
   getExperienceToNextLevel,
+  isMaxLevel,
 } from "features/game/lib/level";
-import { formatNumber } from "lib/utils/formatNumber";
 import { Achievements } from "./Achievements";
 import { AchievementBadges } from "./AchievementBadges";
 import { Skills } from "features/bumpkins/components/Skills";
@@ -28,6 +25,15 @@ import { CONFIG } from "lib/config";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 type ViewState = "home" | "achievements" | "skills";
+
+const PROGRESS_BAR_DIMENSIONS = {
+  width: 40,
+  height: 7,
+  innerWidth: 36,
+  innerHeight: 2,
+  marginTop: 2,
+  marginLeft: 2,
+};
 
 interface Props {
   initialView: ViewState;
@@ -70,14 +76,18 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
   const { body, hair, background, ...wearables } = state.bumpkin
     ?.equipped as BumpkinParts;
 
-  const equippedItems = Object.values(wearables) as BumpkinItem[];
-
   const experience = state.bumpkin?.experience ?? 0;
   const level = getBumpkinLevel(experience);
+  const maxLevel = isMaxLevel(experience);
   const { currentExperienceProgress, experienceToNextLevel } =
     getExperienceToNextLevel(experience);
 
   const hasSkillPoint = hasUnacknowledgedSkillPoints(state.bumpkin);
+
+  const progressWidth = Math.floor(
+    (PROGRESS_BAR_DIMENSIONS.innerWidth * currentExperienceProgress) /
+      experienceToNextLevel
+  );
 
   return (
     <Panel>
@@ -114,32 +124,55 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
         <div className="flex-1">
           <div className="mb-2">
             <div className="flex items-center mt-2 md:mt-0">
-              <p className="text-sm">Level {level}</p>
-              <img src={heart} className="w-4 ml-1" />
+              <p className="text-sm">
+                Level {level}
+                {maxLevel ? " (Max)" : ""}
+              </p>
+              <img src={levelIcon} className="w-4 ml-1" />
             </div>
+
+            {/* Progress bar */}
             <div className="flex items-center">
-              <div className="flex mr-2 items-center relative w-20 z-10">
+              <div
+                className="flex mr-2 items-center relative z-10"
+                style={{
+                  width: `${PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.width}px`,
+                }}
+              >
                 <img src={progressBarSmall} className="w-full" />
                 <div
-                  className="w-full h-full bg-[#193c3e] absolute -z-20"
+                  className="absolute bg-[#193c3e]"
                   style={{
-                    borderRadius: "10px",
+                    top: `${PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.marginTop}px`,
+                    left: `${
+                      PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.marginLeft
+                    }px`,
+                    width: `${
+                      PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.innerWidth
+                    }px`,
+                    height: `${
+                      PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.innerHeight
+                    }px`,
                   }}
                 />
                 <div
-                  className="h-full bg-[#63c74d] absolute -z-10 "
+                  className="absolute bg-[#63c74d]"
                   style={{
-                    borderRadius: "10px 0 0 10px",
-                    width: `${
-                      (currentExperienceProgress / experienceToNextLevel) * 100
-                    }%`,
-                    maxWidth: "100%",
+                    top: `${PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.marginTop}px`,
+                    left: `${
+                      PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.marginLeft
+                    }px`,
+                    width: `${PIXEL_SCALE * progressWidth}px`,
+                    height: `${
+                      PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.innerHeight
+                    }px`,
                   }}
                 />
               </div>
-              <p className="text-xxs">{`${formatNumber(
+
+              <p className="text-xxs">{`${Math.floor(
                 currentExperienceProgress
-              )}/${formatNumber(experienceToNextLevel)} XP`}</p>
+              )}/${Math.floor(experienceToNextLevel)} XP`}</p>
             </div>
           </div>
 

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -84,9 +84,12 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
 
   const hasSkillPoint = hasUnacknowledgedSkillPoints(state.bumpkin);
 
-  const progressWidth = Math.floor(
-    (PROGRESS_BAR_DIMENSIONS.innerWidth * currentExperienceProgress) /
-      experienceToNextLevel
+  const progressWidth = Math.min(
+    Math.floor(
+      (PROGRESS_BAR_DIMENSIONS.innerWidth * currentExperienceProgress) /
+        experienceToNextLevel
+    ),
+    PROGRESS_BAR_DIMENSIONS.innerWidth
   );
 
   return (

--- a/src/features/game/events/landExpansion/pickSkill.test.ts
+++ b/src/features/game/events/landExpansion/pickSkill.test.ts
@@ -38,7 +38,7 @@ describe("PickSkill", () => {
           ...TEST_FARM,
           bumpkin: {
             ...INITIAL_BUMPKIN,
-            experience: LEVEL_BRACKETS[2],
+            experience: LEVEL_BRACKETS[1],
             skills: { "Green Thumb": 1 },
           },
         },

--- a/src/features/game/lib/level.test.ts
+++ b/src/features/game/lib/level.test.ts
@@ -1,16 +1,58 @@
-import { findLevelRequiredForNextSkillPoint } from "./level";
+import {
+  findLevelRequiredForNextSkillPoint,
+  getBumpkinLevel,
+  isMaxLevel,
+} from "./level";
 
 describe("findLevelRequiredForNextSkillPoint", () => {
   it("returns level 3 if the player has 1 skill points", () => {
-    const bumpkinExp = 70;
+    const bumpkinExp = 5; // level 2
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(3);
   });
+  it("returns level 5 if the player has 2 skill points", () => {
+    const bumpkinExp = 70; // level 3
+    expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(5);
+  });
   it("returns level 6 if the player has 3 skill points", () => {
-    const bumpkinExp = 1242;
+    const bumpkinExp = 1242; // level 5
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(6);
   });
   it("returns level 15 if the player has 10 skill points", () => {
-    const bumpkinExp = 36500;
+    const bumpkinExp = 36500; // level 14
     expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(15);
+  });
+  it("returns level 19 if the player has 10 skill points", () => {
+    const bumpkinExp = 60500; // level 17
+    expect(findLevelRequiredForNextSkillPoint(bumpkinExp)).toEqual(19);
+  });
+});
+
+describe("getBumpkinLevel", () => {
+  it("returns level 6 if the player is 1 exp away from level 7", () => {
+    const bumpkinExp = 4581;
+    expect(Number(getBumpkinLevel(bumpkinExp))).toEqual(6);
+  });
+  it("returns level 7 if the player is 0 exp away from level 7", () => {
+    const bumpkinExp = 4582;
+    expect(Number(getBumpkinLevel(bumpkinExp))).toEqual(7);
+  });
+  it("returns level 7 if the player is 1 exp above level 7", () => {
+    const bumpkinExp = 4583;
+    expect(Number(getBumpkinLevel(bumpkinExp))).toEqual(7);
+  });
+});
+
+describe("isMaxLevel", () => {
+  it("returns false if 1 exp away from max level", () => {
+    const bumpkinExp = 89999;
+    expect(isMaxLevel(bumpkinExp)).toBeFalsy();
+  });
+  it("returns false if 0 exp away from max level", () => {
+    const bumpkinExp = 90000;
+    expect(isMaxLevel(bumpkinExp)).toBeTruthy();
+  });
+  it("returns false if 1 exp above max level", () => {
+    const bumpkinExp = 90001;
+    expect(isMaxLevel(bumpkinExp)).toBeTruthy();
   });
 });

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -46,16 +46,22 @@ export const LEVEL_BRACKETS: Record<BumpkinLevel, number> = {
   20: 100500,
 };
 
-const MAX_BUMPKIN_LEVEL =
+const MAX_BUMPKIN_LEVEL_BRACKET =
   getKeys(LEVEL_BRACKETS)[getKeys(LEVEL_BRACKETS).length - 1];
+const MAX_BUMPKIN_LEVEL_BRACKET_MINUS_ONE =
+  getKeys(LEVEL_BRACKETS)[getKeys(LEVEL_BRACKETS).length - 2];
+
+export const isMaxLevel = (experience: number): boolean => {
+  return experience >= LEVEL_BRACKETS[MAX_BUMPKIN_LEVEL_BRACKET_MINUS_ONE];
+};
 
 export const getBumpkinLevel = (experience: number): BumpkinLevel => {
   const levels = getKeys(LEVEL_BRACKETS);
   const bumpkinLevel = levels.find(
-    (level) => experience <= LEVEL_BRACKETS[level]
+    (level) => experience < LEVEL_BRACKETS[level]
   );
 
-  return bumpkinLevel ?? MAX_BUMPKIN_LEVEL;
+  return bumpkinLevel ?? MAX_BUMPKIN_LEVEL_BRACKET;
 };
 
 export const getExperienceToNextLevel = (experience: number) => {


### PR DESCRIPTION
# Description

- show full xp rounded down to nearest integer
- bumpkin should reach next level if level bracket is reached
- fix green pixels overflowing xp bar when full
- standardize xp bar and progress pixel size
- show indicator when player reaches max level

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/202402114-80c115d7-f17a-4ad4-8d05-1898c1457981.png)  |  ![image](https://user-images.githubusercontent.com/107602352/202402095-ad9e5e6d-d98a-48aa-bb44-979d1802d25d.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open bumpkin hud

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
