### PR TITLE
[FIX] Sort chest items in land expansion

### DIFF
--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -17,6 +17,7 @@ import { Button } from "components/ui/Button";
 import chest from "assets/npcs/synced.gif";
 import { Context } from "features/game/GameProvider";
 import { DECORATIONS } from "features/game/types/decorations";
+import { KNOWN_IDS } from "features/game/types";
 
 const ITEM_CARD_MIN_HEIGHT = "148px";
 
@@ -117,18 +118,20 @@ export const Chest: React.FC<Props> = ({ state, closeModal }: Props) => {
         {Object.values(collectibles) && (
           <div className="flex flex-col pl-2" key={"Collectibles"}>
             <div className="flex mb-2 flex-wrap -ml-1.5 pt-1">
-              {getKeys(collectibles).map((item) => (
-                <Box
-                  count={inventory[item]?.sub(
-                    placedItems[item as CollectibleName]?.length ?? 0
-                  )}
-                  isSelected={selected === item}
-                  key={item}
-                  onClick={() => handleItemClick(item)}
-                  image={ITEM_DETAILS[item].image}
-                  parentDivRef={divRef}
-                />
-              ))}
+              {getKeys(collectibles)
+                .sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b])
+                .map((item) => (
+                  <Box
+                    count={inventory[item]?.sub(
+                      placedItems[item as CollectibleName]?.length ?? 0
+                    )}
+                    isSelected={selected === item}
+                    key={item}
+                    onClick={() => handleItemClick(item)}
+                    image={ITEM_DETAILS[item].image}
+                    parentDivRef={divRef}
+                  />
+                ))}
             </div>
           </div>
         )}


### PR DESCRIPTION
# Description

- sort chest items in land expansion

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/202573580-30dd586e-208f-4878-b7c0-04190c52429d.png)  |  ![image](https://user-images.githubusercontent.com/107602352/202573629-2e2fd735-a0f8-48f1-90f7-10bcce04d6ef.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open inventory chest in land expansion

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes