### PR TITLE
[FIX] Decorations shop clickable area

### DIFF
--- a/src/features/helios/components/decorations/Decorations.tsx
+++ b/src/features/helios/components/decorations/Decorations.tsx
@@ -22,7 +22,7 @@ export const Decorations: React.FC = () => {
         // TODO some sort of coordinate system
         style={{
           width: `${GRID_WIDTH_PX * 6}px`,
-          right: `${GRID_WIDTH_PX * 17.6}px`,
+          right: `${GRID_WIDTH_PX * 17.5}px`,
           top: `${GRID_WIDTH_PX * 25.2}px`,
         }}
         onClick={handleClick}
@@ -47,6 +47,7 @@ export const Decorations: React.FC = () => {
         />
         <img
           src={building}
+          className="absolute"
           style={{
             width: `${PIXEL_SCALE * 50}px`,
           }}


### PR DESCRIPTION
# Description

- fix decorations shop clickable area.  Previously the clickable area was shifted to the right

![image](https://user-images.githubusercontent.com/107602352/202839930-3bbb51d3-f293-4504-8dc5-63f187ccdd8f.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click the area to the right of the decoration shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
