### PR TITLE
[fix] Resource node no tool warning popover overflow

### DIFF
--- a/src/features/farming/animals/components/Chicken.tsx
+++ b/src/features/farming/animals/components/Chicken.tsx
@@ -61,7 +61,7 @@ const TimeToEgg = ({ showTimeToEgg, service }: TimeToEggProps) => {
   return (
     <InnerPanel
       className={classNames(
-        "transition-opacity scale-90 absolute whitespace-nowrap sm:opacity-0 bottom-5 w-fit left-10 z-20 pointer-events-none",
+        "transition-opacity scale-90 absolute whitespace-nowrap sm:opacity-0 bottom-5 w-fit left-10 z-40 pointer-events-none",
         {
           "opacity-100": showTimeToEgg,
           "opacity-0": !showTimeToEgg,

--- a/src/features/farming/forest/components/Tree.tsx
+++ b/src/features/farming/forest/components/Tree.tsx
@@ -25,10 +25,10 @@ import {
 
 import { getTimeLeft } from "lib/utils/time";
 import { Bar, ProgressBar } from "components/ui/ProgressBar";
-import { Label } from "components/ui/Label";
 import { chopAudio, treeFallAudio } from "lib/utils/sfx";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -220,13 +220,19 @@ export const Tree: React.FC<Props> = ({ treeIndex }) => {
               spritesheet.pause();
             }}
           />
-          <div
-            className={`absolute bottom-8 -right-[1rem] transition pointer-events-none w-28 z-20 ${
-              showLabel ? "opacity-100" : "opacity-0"
-            }`}
+          <InnerPanel
+            className={classNames(
+              "ml-10 transition-opacity absolute top-6 w-fit left-5 z-40 pointer-events-none",
+              {
+                "opacity-100": showLabel,
+                "opacity-0": !showLabel,
+              }
+            )}
           >
-            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-          </div>
+            <div className="text-xxs text-white mx-1">
+              <span>Equip {tool.toLowerCase()}</span>
+            </div>
+          </InnerPanel>
         </div>
       )}
 

--- a/src/features/farming/quarry/components/Gold.tsx
+++ b/src/features/farming/quarry/components/Gold.tsx
@@ -19,11 +19,11 @@ import { useActor } from "@xstate/react";
 
 import { getTimeLeft } from "lib/utils/time";
 import { Bar, ProgressBar } from "components/ui/ProgressBar";
-import { Label } from "components/ui/Label";
 import { canMine } from "features/game/events/goldMine";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -222,13 +222,19 @@ export const Gold: React.FC<Props> = ({ rockIndex }) => {
               spritesheet.pause();
             }}
           />
-          <div
-            className={`absolute top-8 transition pointer-events-none w-28 z-20 ${
-              showLabel ? "opacity-100" : "opacity-0"
-            }`}
+          <InnerPanel
+            className={classNames(
+              "ml-10 transition-opacity absolute top-6 w-fit left-5 z-40 pointer-events-none",
+              {
+                "opacity-100": showLabel,
+                "opacity-0": !showLabel,
+              }
+            )}
           >
-            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-          </div>
+            <div className="text-xxs text-white mx-1">
+              <span>Equip {tool.toLowerCase()}</span>
+            </div>
+          </InnerPanel>
         </div>
       )}
 

--- a/src/features/farming/quarry/components/Iron.tsx
+++ b/src/features/farming/quarry/components/Iron.tsx
@@ -19,11 +19,11 @@ import { useActor } from "@xstate/react";
 
 import { getTimeLeft } from "lib/utils/time";
 import { Bar, ProgressBar } from "components/ui/ProgressBar";
-import { Label } from "components/ui/Label";
 import { canMine } from "features/game/events/ironMine";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -227,13 +227,19 @@ export const Iron: React.FC<Props> = ({ rockIndex }) => {
               spritesheet.pause();
             }}
           />
-          <div
-            className={`absolute top-5 transition pointer-events-none w-28 z-20 ${
-              showLabel ? "opacity-100" : "opacity-0"
-            }`}
+          <InnerPanel
+            className={classNames(
+              "ml-10 transition-opacity absolute top-6 w-fit left-5 z-40 pointer-events-none",
+              {
+                "opacity-100": showLabel,
+                "opacity-0": !showLabel,
+              }
+            )}
           >
-            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-          </div>
+            <div className="text-xxs text-white mx-1">
+              <span>Equip {tool.toLowerCase()}</span>
+            </div>
+          </InnerPanel>
         </div>
       )}
 

--- a/src/features/farming/quarry/components/Stone.tsx
+++ b/src/features/farming/quarry/components/Stone.tsx
@@ -22,11 +22,11 @@ import { useActor } from "@xstate/react";
 
 import { getTimeLeft } from "lib/utils/time";
 import { Bar, ProgressBar } from "components/ui/ProgressBar";
-import { Label } from "components/ui/Label";
 import { canMine } from "features/game/events/stoneMine";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -228,13 +228,19 @@ export const Stone: React.FC<Props> = ({ rockIndex }) => {
               spritesheet.pause();
             }}
           />
-          <div
-            className={`absolute top-10 transition pointer-events-none w-28 z-20 ${
-              showLabel ? "opacity-100" : "opacity-0"
-            }`}
+          <InnerPanel
+            className={classNames(
+              "ml-10 transition-opacity absolute top-6 w-fit left-5 z-40 pointer-events-none",
+              {
+                "opacity-100": showLabel,
+                "opacity-0": !showLabel,
+              }
+            )}
           >
-            <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-          </div>
+            <div className="text-xxs text-white mx-1">
+              <span>Equip {tool.toLowerCase()}</span>
+            </div>
+          </InnerPanel>
         </div>
       )}
 

--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -20,12 +20,11 @@ import { getTimeLeft } from "lib/utils/time";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { LandExpansionRock } from "features/game/types/game";
 import { EVENT_ERRORS } from "features/game/events/landExpansion/mineGold";
-import { Overlay } from "react-bootstrap";
-import { Label } from "components/ui/Label";
 import { canMine } from "../../lib/utils";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -216,22 +215,19 @@ export const Gold: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
                 spritesheet.pause();
               }}
             />
-            <Overlay
-              target={containerRef.current}
-              show={errorLabel !== undefined}
-              placement="right"
-            >
-              {({ show, arrowProps, ...props }) => (
-                <div
-                  {...props}
-                  className="absolute -left-1/2 z-10 w-28 pointer-events-none"
-                >
-                  {errorLabel === "noPickaxe" && (
-                    <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-                  )}
-                </div>
+            <InnerPanel
+              className={classNames(
+                "transition-opacity absolute top-2 w-fit left-12 z-40 pointer-events-none",
+                {
+                  "opacity-100": errorLabel === "noPickaxe",
+                  "opacity-0": errorLabel !== "noPickaxe",
+                }
               )}
-            </Overlay>
+            >
+              <div className="text-xxs text-white mx-1">
+                <span>Equip {tool.toLowerCase()}</span>
+              </div>
+            </InnerPanel>
           </>
         </div>
       )}

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -20,12 +20,11 @@ import { getTimeLeft } from "lib/utils/time";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { LandExpansionRock } from "features/game/types/game";
 import { MINE_ERRORS } from "features/game/events/landExpansion/ironMine";
-import { Overlay } from "react-bootstrap";
-import { Label } from "components/ui/Label";
 import { canMine } from "../../lib/utils";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -215,19 +214,19 @@ export const Iron: React.FC<Props> = ({ ironIndex, expansionIndex }) => {
                 spritesheet.pause();
               }}
             />
-            <Overlay
-              target={containerRef.current}
-              show={errorLabel !== undefined}
-              placement="right"
-            >
-              {({ show, arrowProps, ...props }) => (
-                <div {...props} className="absolute -left-1/2 z-10 w-28">
-                  {errorLabel === "noPickaxe" && (
-                    <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-                  )}
-                </div>
+            <InnerPanel
+              className={classNames(
+                "transition-opacity absolute top-2 w-fit left-12 z-40 pointer-events-none",
+                {
+                  "opacity-100": errorLabel === "noPickaxe",
+                  "opacity-0": errorLabel !== "noPickaxe",
+                }
               )}
-            </Overlay>
+            >
+              <div className="text-xxs text-white mx-1">
+                <span>Equip {tool.toLowerCase()}</span>
+              </div>
+            </InnerPanel>
           </>
         </div>
       )}

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -23,12 +23,11 @@ import { getTimeLeft } from "lib/utils/time";
 import { miningAudio, miningFallAudio } from "lib/utils/sfx";
 import { LandExpansionRock } from "features/game/types/game";
 import { MINE_ERRORS } from "features/game/events/stoneMine";
-import { Overlay } from "react-bootstrap";
-import { Label } from "components/ui/Label";
 import { canMine } from "../../lib/utils";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -220,22 +219,19 @@ export const Stone: React.FC<Props> = ({ rockIndex, expansionIndex }) => {
                 spritesheet.pause();
               }}
             />
-            <Overlay
-              target={containerRef.current}
-              show={errorLabel !== undefined}
-              placement="right"
-            >
-              {({ show, arrowProps, ...props }) => (
-                <div
-                  {...props}
-                  className="absolute -left-1/2 z-10 w-28 pointer-events-none"
-                >
-                  {errorLabel === "noPickaxe" && (
-                    <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-                  )}
-                </div>
+            <InnerPanel
+              className={classNames(
+                "transition-opacity absolute top-2 w-fit left-12 z-40 pointer-events-none",
+                {
+                  "opacity-100": errorLabel === "noPickaxe",
+                  "opacity-0": errorLabel !== "noPickaxe",
+                }
               )}
-            </Overlay>
+            >
+              <div className="text-xxs text-white mx-1">
+                <span>Equip {tool.toLowerCase()}</span>
+              </div>
+            </InnerPanel>
           </>
         </div>
       )}

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -23,7 +23,6 @@ import classNames from "classnames";
 import { useActor } from "@xstate/react";
 
 import { getTimeLeft } from "lib/utils/time";
-import { Label } from "components/ui/Label";
 import { chopAudio, treeFallAudio } from "lib/utils/sfx";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import { LandExpansionTree } from "features/game/types/game";
@@ -32,9 +31,9 @@ import {
   CHOP_ERRORS,
   getRequiredAxeAmount,
 } from "features/game/events/landExpansion/chop";
-import { Overlay } from "react-bootstrap";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
+import { InnerPanel } from "components/ui/Panel";
 
 const POPOVER_TIME_MS = 1000;
 const HITS = 3;
@@ -236,22 +235,19 @@ export const Tree: React.FC<Props> = ({ treeIndex, expansionIndex }) => {
               }}
             />
           </div>
-          <Overlay
-            target={treeRef.current}
-            show={errorLabel !== undefined}
-            placement="right"
-          >
-            {({ arrowProps, show, ...props }) => (
-              <div
-                {...props}
-                className="absolute -left-1/2 z-10 w-28 pointer-events-none"
-              >
-                {errorLabel === "noAxe" && (
-                  <Label className="p-2">Equip {tool.toLowerCase()}</Label>
-                )}
-              </div>
+          <InnerPanel
+            className={classNames(
+              "transition-opacity absolute top-2 w-fit left-20 ml-2 z-40 pointer-events-none",
+              {
+                "opacity-100": errorLabel === "noAxe",
+                "opacity-0": errorLabel !== "noAxe",
+              }
             )}
-          </Overlay>
+          >
+            <div className="text-xxs text-white mx-1">
+              <span>Equip {tool.toLowerCase()}</span>
+            </div>
+          </InnerPanel>
         </>
       )}
 


### PR DESCRIPTION
# Description

- standardize no tool warning popover style with the rest of the popovers
- fix popover overflow for no tool warning
- fix jaggering movement of no tool warning popover on mobile while moving the screen

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/202841232-f96e12d5-035b-44ae-9cb7-1b3fc0949e8d.png)  |  ![image](https://user-images.githubusercontent.com/107602352/202841228-c03bc177-389d-4eae-8d83-97ffd3743141.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- hover on resource nodes without the correct tool

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
