### PR TITLE
[CHORE] increase flag size by 50%

### DIFF
--- a/src/features/island/collectibles/components/Flags.tsx
+++ b/src/features/island/collectibles/components/Flags.tsx
@@ -15,22 +15,16 @@ interface Props {
 
 const FlagsImages: React.FC<Props> = ({ flagName }) => {
   return (
-    <div
-      className="absolute"
+    <img
+      className="absolute max-w-none hover:img-highlight"
       style={{
-        width: `${PIXEL_SCALE * 11}px`,
-        right: `${PIXEL_SCALE * 2.5}px`,
+        width: `${PIXEL_SCALE * 1.5 * 11}px`,
+        left: `${PIXEL_SCALE * 5}px`,
+        bottom: `${PIXEL_SCALE * 6}px`,
       }}
-    >
-      <img
-        className="hover:img-highlight"
-        style={{
-          width: `${PIXEL_SCALE * 11}px`,
-        }}
-        src={ITEM_DETAILS[flagName].image}
-        alt={flagName}
-      />
-    </div>
+      src={ITEM_DETAILS[flagName].image}
+      alt={flagName}
+    />
   );
 };
 


### PR DESCRIPTION
# Description

Currently flags look a bit off, too small.

My change alters pixel size of flags, but I think it still looks better than with small flags. Best approach is to redraw flags on a bigger scale, but I doubt someone will do that.

I made intentionally so flag still takes 1 grid cell, but is displayed in 2 cells, that way it can wave above the island if placed on top row. Players can decide where to put the flag and if it interfere with other items on map they can reposition it. But it seems that all interactions work even with odd flag placements.(see the video).

Before:
![image](https://user-images.githubusercontent.com/9656961/202896248-6a07b164-87ea-4cb0-8216-2b6d1b4bfd10.png)

After:
https://user-images.githubusercontent.com/9656961/202896575-1d7adf2e-726a-4cf6-a3f0-09de825c7a7a.mp4




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
