### PR TITLE
[FIX] Adust rock golem height

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1187,7 +1187,7 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Homeless Tent": { width: 2, height: 2 },
   "Farmer Bath": { width: 2, height: 3 },
   "Mysterious Head": { width: 2, height: 2 },
-  "Rock Golem": { width: 2, height: 3 },
+  "Rock Golem": { width: 2, height: 2 },
   "Tunnel Mole": { width: 1, height: 1 },
   "Rocky the Mole": { width: 1, height: 1 },
   Nugget: { width: 1, height: 1 },

--- a/src/features/island/collectibles/components/RockGolem.tsx
+++ b/src/features/island/collectibles/components/RockGolem.tsx
@@ -36,8 +36,8 @@ export const RockGolem: React.FC = () => {
           className="absolute group-hover:img-highlight pointer-events-none transform z-10"
           style={{
             width: `${PIXEL_SCALE * 34}px`,
-            bottom: `${PIXEL_SCALE * 5}px`,
-            right: `${PIXEL_SCALE * 2.5} px`,
+            bottom: `${PIXEL_SCALE * 0}px`,
+            right: `${PIXEL_SCALE * 2}px`,
             imageRendering: "pixelated",
           }}
           getInstance={(spritesheet) => {
@@ -59,8 +59,8 @@ export const RockGolem: React.FC = () => {
           className="absolute group-hover:img-highlight pointer-events-none transform z-10"
           style={{
             width: `${PIXEL_SCALE * 34}px`,
-            bottom: `${PIXEL_SCALE * 5}px`,
-            right: `${PIXEL_SCALE * 2.5}px`,
+            bottom: `${PIXEL_SCALE * 0}px`,
+            right: `${PIXEL_SCALE * 2}px`,
             imageRendering: "pixelated",
           }}
           getInstance={(spritesheet) => {


### PR DESCRIPTION
# Description

- reduce rock golem height from 2x3 grid to 2x2 grid
- align rock golem image pixels with the rest of the pixels

![image](https://user-images.githubusercontent.com/107602352/203242127-86964411-0205-49e0-9d21-f5e37c1ebb9e.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- place rock golem in farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
