### PR TITLE
[FIX] Typos and OpenSea link

### DIFF
--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -35,7 +35,7 @@ export const WORKBENCH_TOOLS: () => Record<
   },
   Pickaxe: {
     name: "Pickaxe",
-    description: "Used to collect wood",
+    description: "Used to collect stone",
     ingredients: {
       Wood: new Decimal(5),
     },
@@ -49,7 +49,7 @@ export const WORKBENCH_TOOLS: () => Record<
   },
   "Stone Pickaxe": {
     name: "Stone Pickaxe",
-    description: "Used to collect wood",
+    description: "Used to collect iron",
     ingredients: {
       Wood: new Decimal(5),
       Stone: new Decimal(5),
@@ -58,7 +58,7 @@ export const WORKBENCH_TOOLS: () => Record<
   },
   "Iron Pickaxe": {
     name: "Iron Axe",
-    description: "Used to collect wood",
+    description: "Used to collect gold",
     ingredients: {
       Wood: new Decimal(10),
       Iron: new Decimal(5),

--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -89,7 +89,7 @@ const SFLItemsInstructions = () => (
         Only send items from the
         <a
           className="underline ml-2"
-          href="https://docs.sunflower-land.com/fundamentals/withdrawing"
+          href="https://opensea.io/collection/sunflower-land-collectibles"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
# Description

* Fixes tools text that got reverted.

* Fixes bank's Deposit link from Withdraw man page to OpenSea official collection

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
