### PR TITLE
[FIX] Chicken hover modal z-index

### DIFF
--- a/src/features/farming/forest/components/Tree.tsx
+++ b/src/features/farming/forest/components/Tree.tsx
@@ -12,7 +12,11 @@ import stump from "assets/resources/tree/stump.png";
 import wood from "assets/resources/wood.png";
 import axe from "assets/tools/axe.png";
 
-import { GRID_WIDTH_PX, TREE_RECOVERY_TIME } from "features/game/lib/constants";
+import {
+  GRID_WIDTH_PX,
+  POPOVER_TIME_MS,
+  TREE_RECOVERY_TIME,
+} from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
@@ -30,7 +34,6 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 const tool = "Axe";
 

--- a/src/features/farming/quarry/components/Gold.tsx
+++ b/src/features/farming/quarry/components/Gold.tsx
@@ -11,7 +11,11 @@ import dropSheet from "assets/resources/gold/gold_drop.png";
 import empty from "assets/resources/gold/gold_empty.png";
 import gold from "assets/resources/gold_ore.png";
 
-import { GOLD_RECOVERY_TIME, GRID_WIDTH_PX } from "features/game/lib/constants";
+import {
+  GOLD_RECOVERY_TIME,
+  GRID_WIDTH_PX,
+  POPOVER_TIME_MS,
+} from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
@@ -25,7 +29,6 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/farming/quarry/components/Iron.tsx
+++ b/src/features/farming/quarry/components/Iron.tsx
@@ -11,7 +11,11 @@ import dropSheet from "assets/resources/iron/iron_dropped.png";
 import empty from "assets/resources/iron/iron_empty.png";
 import ironOre from "assets/resources/iron_ore.png";
 
-import { GRID_WIDTH_PX, IRON_RECOVERY_TIME } from "features/game/lib/constants";
+import {
+  GRID_WIDTH_PX,
+  IRON_RECOVERY_TIME,
+  POPOVER_TIME_MS,
+} from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
@@ -25,7 +29,6 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/farming/quarry/components/Stone.tsx
+++ b/src/features/farming/quarry/components/Stone.tsx
@@ -13,6 +13,7 @@ import stone from "assets/resources/stone.png";
 
 import {
   GRID_WIDTH_PX,
+  POPOVER_TIME_MS,
   STONE_RECOVERY_TIME,
 } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
@@ -28,7 +29,6 @@ import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -10,7 +10,11 @@ import hitbox from "assets/resources/gold/gold.png";
 import gold from "assets/resources/gold_ore.png";
 import pickaxe from "assets/tools/iron_pickaxe.png";
 
-import { GRID_WIDTH_PX, GOLD_RECOVERY_TIME } from "features/game/lib/constants";
+import {
+  GRID_WIDTH_PX,
+  GOLD_RECOVERY_TIME,
+  POPOVER_TIME_MS,
+} from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
@@ -26,7 +30,6 @@ import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -10,7 +10,11 @@ import hitbox from "assets/resources/iron_small.png";
 import iron from "assets/resources/iron_rock_ore.png";
 import pickaxe from "assets/tools/stone_pickaxe.png";
 
-import { GRID_WIDTH_PX, IRON_RECOVERY_TIME } from "features/game/lib/constants";
+import {
+  GRID_WIDTH_PX,
+  IRON_RECOVERY_TIME,
+  POPOVER_TIME_MS,
+} from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import classNames from "classnames";
@@ -26,7 +30,6 @@ import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -12,6 +12,7 @@ import pickaxe from "assets/tools/wood_pickaxe.png";
 
 import {
   GRID_WIDTH_PX,
+  POPOVER_TIME_MS,
   STONE_RECOVERY_TIME,
 } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
@@ -29,7 +30,6 @@ import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 
 interface Props {

--- a/src/features/game/expansion/components/resources/Tree.tsx
+++ b/src/features/game/expansion/components/resources/Tree.tsx
@@ -15,6 +15,7 @@ import axe from "assets/tools/axe.png";
 import {
   GRID_WIDTH_PX,
   PIXEL_SCALE,
+  POPOVER_TIME_MS,
   TREE_RECOVERY_TIME,
 } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
@@ -35,7 +36,6 @@ import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { Bar } from "components/ui/ProgressBar";
 import { InnerPanel } from "components/ui/Panel";
 
-const POPOVER_TIME_MS = 1000;
 const HITS = 3;
 const tool = "Axe";
 

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -60,7 +60,7 @@ const TimeToEgg = ({ showTimeToEgg, service }: TimeToEggProps) => {
   return (
     <InnerPanel
       className={classNames(
-        "ml-10 transition-opacity absolute whitespace-nowrap sm:opacity-0 bottom-5 w-fit left-1 z-20 pointer-events-none",
+        "ml-10 transition-opacity absolute whitespace-nowrap sm:opacity-0 bottom-5 w-fit left-1 z-40 pointer-events-none",
         {
           "opacity-100": showTimeToEgg,
           "opacity-0": !showTimeToEgg,


### PR DESCRIPTION
# Description

- fix chicken hover modal z-index

Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/203446600-61aca33d-1e88-489d-b28f-bab19de50181.png)  |  ![image](https://user-images.githubusercontent.com/107602352/203446529-ba2de068-b4b0-4198-aec5-861a5a84c471.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- feed chickens and hover on chicken so that modal is right on top of another progress bar

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
