### PR TITLE
[FIX] Block goblin village for LE migrants. Block goblin retreat if level not met.

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -62,8 +62,8 @@ export const Navigation: React.FC = () => {
         <HashRouter>
           <Routes>
             <Route path="/" element={<Humans />} />
-            {/* Forbid entry to Goblin Village when in Visiting State, show Forbidden screen */}
-            {!authState.matches("visiting") ? (
+            {/* Forbid entry to Goblin Village when in Visiting State or when a player has migrated to LE, show Forbidden screen */}
+            {!authState.matches("visiting") && !authState.context.migrated ? (
               <Route path="/goblins" element={<Goblins />} />
             ) : (
               <Route

--- a/src/features/auth/Auth.tsx
+++ b/src/features/auth/Auth.tsx
@@ -48,7 +48,7 @@ export const Auth: React.FC = () => {
           }}
         />
       </div>
-      <Panel>
+      <Panel className="pb-1">
         {(authState.matches({ connected: "loadingFarm" }) ||
           authState.matches("checkFarm") ||
           authState.matches("initialising") ||

--- a/src/features/auth/components/ConnectingError.tsx
+++ b/src/features/auth/components/ConnectingError.tsx
@@ -1,13 +1,23 @@
 import React, { useContext } from "react";
 import lightningAnimation from "assets/npcs/human_death.gif";
+
+import * as Auth from "features/auth/lib/Provider";
+
 import { CONFIG } from "lib/config";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 
 export const ConnectingError: React.FC = () => {
+  const { authService } = useContext(Auth.Context);
   const { gameService } = useContext(Context);
+
   const onAcknowledge = () => {
-    gameService.send("REFRESH");
+    // If we get a connecting error before the game has loaded then try to connect again via the authService
+    if (gameService) {
+      gameService.send("REFRESH");
+    } else {
+      authService.send("REFRESH");
+    }
   };
   return (
     <div className="flex flex-col text-center items-center p-2">

--- a/src/features/auth/components/Forbidden.tsx
+++ b/src/features/auth/components/Forbidden.tsx
@@ -8,7 +8,7 @@ import suspiciousGoblin from "assets/npcs/suspicious_goblin.gif";
 export const Forbidden: React.FC = () => {
   const { authService } = useContext(Auth.Context);
 
-  const goBack = () => {
+  const goHome = () => {
     authService.send("RETURN");
   };
 
@@ -17,12 +17,9 @@ export const Forbidden: React.FC = () => {
       <span>Forbidden !</span>
       <img src={suspiciousGoblin} alt="Warning" className="w-16 m-2" />
       <span className="text-xs mt-2 mb-2">
-        You are not allowed to visit the Goblin Village while, visiting someone
-        else&apos; farm !<br />
-        <br />
-        Click on the &quot;Back&quot; button to go back To Login Screen.
+        You are not allowed to visit Goblin Village!
       </span>
-      <Button className="mt-2" onClick={goBack}>
+      <Button className="mt-2" onClick={goHome}>
         Back
       </Button>
     </div>

--- a/src/features/auth/components/Splash.tsx
+++ b/src/features/auth/components/Splash.tsx
@@ -126,7 +126,6 @@ export const Splash: React.FC = ({ children }) => {
           <Panel>{children}</Panel>
         </Modal>
       )}
-
       {/* z-index must be 1056 or higher to break out of bootstrap modal */}
       <div
         className="absolute bottom-0 right-0 m-1 pointer-events-auto"

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -466,6 +466,10 @@ export const authMachine = createMachine<
             target: "connecting",
             actions: "refreshFarm",
           },
+          REFRESH: {
+            target: "connecting",
+            actions: "refreshFarm",
+          },
         },
       },
       exploring: {

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -426,6 +426,10 @@ export const authMachine = createMachine<
               }
             },
             on: {
+              RETURN: {
+                target: "#connecting",
+                actions: ["refreshFarm", "deleteFarmIdUrl"],
+              },
               REFRESH: {
                 target: "#connecting",
               },

--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -25,13 +25,10 @@ import { tradingPostMachine } from "features/goblins/trader/tradingPost/lib/trad
 import Decimal from "decimal.js-light";
 import { CONFIG } from "lib/config";
 import { getLowestGameState } from "./transforms";
-<<<<<<< HEAD
 import { Item } from "features/retreat/components/auctioneer/actions/auctioneerItems";
 import { fetchAuctioneerDrops } from "../actions/auctioneer";
 import { auctioneerMachine } from "features/retreat/auctioneer/auctioneerMachine";
-=======
 import { getBumpkinLevel } from "./level";
->>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
 
 const API_URL = CONFIG.API_URL;
 
@@ -126,11 +123,8 @@ export type GoblinMachineState = {
     | "withdrawn"
     | "playing"
     | "trading"
-<<<<<<< HEAD
     | "auctioneer"
-=======
     | "levelRequirementNotReached"
->>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
     | "error";
   context: Context;
 };
@@ -230,23 +224,6 @@ export function startGoblinVillage(authContext: AuthContext) {
                 auctioneerId: id,
               };
             },
-<<<<<<< HEAD
-            onDone: {
-              target: "playing",
-              actions: assign({
-                state: (_, event) => event.data.state,
-                limitedItems: (_, event) =>
-                  makeLimitedItemsByName(
-                    LIMITED_ITEMS,
-                    event.data.limitedItems
-                  ),
-                sessionId: (_, event) => event.data.sessionId,
-                deviceTrackerId: (_, event) => event.data.deviceTrackerId,
-                auctioneerItems: (_, event) => event.data.auctioneerItems,
-                auctioneerId: (_, event) => event.data.auctioneerId,
-              }),
-            },
-=======
             onDone: [
               {
                 target: "levelRequirementNotReached",
@@ -273,14 +250,16 @@ export function startGoblinVillage(authContext: AuthContext) {
                     ),
                   sessionId: (_, event) => event.data.sessionId,
                   deviceTrackerId: (_, event) => event.data.deviceTrackerId,
+                  auctioneerItems: (_, event) => event.data.auctioneerItems,
+                  auctioneerId: (_, event) => event.data.auctioneerId,
                 }),
               },
             ],
->>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
             onError: {},
           },
         },
         levelRequirementNotReached: {
+          // Go back... you have no business being here :)
           entry: () => history.go(-1),
         },
         playing: {

--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -25,9 +25,13 @@ import { tradingPostMachine } from "features/goblins/trader/tradingPost/lib/trad
 import Decimal from "decimal.js-light";
 import { CONFIG } from "lib/config";
 import { getLowestGameState } from "./transforms";
+<<<<<<< HEAD
 import { Item } from "features/retreat/components/auctioneer/actions/auctioneerItems";
 import { fetchAuctioneerDrops } from "../actions/auctioneer";
 import { auctioneerMachine } from "features/retreat/auctioneer/auctioneerMachine";
+=======
+import { getBumpkinLevel } from "./level";
+>>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
 
 const API_URL = CONFIG.API_URL;
 
@@ -122,7 +126,11 @@ export type GoblinMachineState = {
     | "withdrawn"
     | "playing"
     | "trading"
+<<<<<<< HEAD
     | "auctioneer"
+=======
+    | "levelRequirementNotReached"
+>>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
     | "error";
   context: Context;
 };
@@ -147,6 +155,8 @@ const makeLimitedItemsById = (items: LimitedItemRecipeWithMintedAt[]) => {
     return obj;
   }, {} as Record<number, LimitedItemRecipeWithMintedAt>);
 };
+
+const LEVEL_REQUIREMENT = 5;
 
 export function startGoblinVillage(authContext: AuthContext) {
   return createMachine<Context, BlockchainEvent, GoblinMachineState>(
@@ -220,6 +230,7 @@ export function startGoblinVillage(authContext: AuthContext) {
                 auctioneerId: id,
               };
             },
+<<<<<<< HEAD
             onDone: {
               target: "playing",
               actions: assign({
@@ -235,8 +246,42 @@ export function startGoblinVillage(authContext: AuthContext) {
                 auctioneerId: (_, event) => event.data.auctioneerId,
               }),
             },
+=======
+            onDone: [
+              {
+                target: "levelRequirementNotReached",
+                cond: (_, event) => {
+                  if (!authContext.migrated) return false;
+
+                  const { bumpkin } = event.data.state;
+
+                  if (!bumpkin) return true;
+
+                  const bumpkinLevel = getBumpkinLevel(bumpkin.experience);
+
+                  return bumpkinLevel < LEVEL_REQUIREMENT;
+                },
+              },
+              {
+                target: "playing",
+                actions: assign({
+                  state: (_, event) => event.data.state,
+                  limitedItems: (_, event) =>
+                    makeLimitedItemsByName(
+                      LIMITED_ITEMS,
+                      event.data.limitedItems
+                    ),
+                  sessionId: (_, event) => event.data.sessionId,
+                  deviceTrackerId: (_, event) => event.data.deviceTrackerId,
+                }),
+              },
+            ],
+>>>>>>> 2ebb8746 ([FIX] Block retreat from url change when level not met)
             onError: {},
           },
+        },
+        levelRequirementNotReached: {
+          entry: () => history.go(-1),
         },
         playing: {
           on: {

--- a/src/features/retreat/Retreat.tsx
+++ b/src/features/retreat/Retreat.tsx
@@ -1,107 +1,20 @@
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
-import React, { useContext, useEffect, useRef, useState } from "react";
-import ScrollContainer from "react-indiana-drag-scroll";
+import React, { useEffect } from "react";
+import { GoblinProvider } from "features/game/GoblinProvider";
+import { Game } from "./Game";
 
-import ocean from "assets/decorations/ocean.png";
-import background from "assets/land/retreat.png";
-import { ToastProvider } from "features/game/toast/ToastQueueProvider";
-import { Context, GoblinProvider } from "features/game/GoblinProvider";
-import { RetreatBank } from "./components/bank/RetreatBank";
-import { RetreatStorageHouse } from "./components/storageHouse/RetreatStorageHouse";
-import { RetreatHotAirBalloon } from "./components/hotAirBalloon/RetreatHotAirBalloon";
-import { RetreatTailor } from "./components/tailor/RetreatTailor";
-import { RetreatBlacksmith } from "./components/blacksmith/RetreatBlacksmith";
-import { Auctioneer } from "./components/auctioneer/Auctioneer";
-import { Resale } from "./components/resale/Resale";
-import { RetreatWishingWell } from "./components/wishingWell/RetreatWishingWell";
-import { IslandTravelWrapper } from "./components/islandTravel/IslandTravelWrapper";
-import { useActor } from "@xstate/react";
-import { INITIAL_SESSION } from "features/game/lib/gameMachine";
-import { Modal } from "react-bootstrap";
-import { Panel } from "components/ui/Panel";
-import { Loading } from "features/auth/components";
-import { GRID_WIDTH_PX } from "features/game/lib/constants";
-
-const RetreatContent: React.FC = () => {
-  const { goblinService } = useContext(Context);
-  const [goblinState] = useActor(goblinService);
-  // Records the first UI load
-  const [loaded, setLoaded] = useState(false);
-
-  const { sessionId } = goblinState.context;
-
+export const Retreat: React.FC = () => {
   const [scrollIntoView] = useScrollIntoView();
 
   useEffect(() => {
-    if (sessionId === INITIAL_SESSION || loaded) return;
     // Start with island centered
     scrollIntoView(Section.RetreatBackground, "auto");
-    setLoaded(true);
-  }, [scrollIntoView, sessionId, loaded]);
-
-  // Only load the map once the session has loaded. This allows us to block the retreat for bumpkins without the level requirement.
-  if (sessionId === INITIAL_SESSION)
-    return (
-      <Modal show={sessionId === INITIAL_SESSION} backdrop={false} centered>
-        <Panel>
-          <Loading />
-        </Panel>
-      </Modal>
-    );
-
-  return (
-    <>
-      <div
-        id="retreat"
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-        style={{
-          width: `${40 * GRID_WIDTH_PX}px`,
-          height: `${40 * GRID_WIDTH_PX}px`,
-        }}
-      >
-        <img
-          src={background}
-          className="absolute inset-0 w-full h-full"
-          id={Section.RetreatBackground}
-        />
-        <RetreatBank />
-        <RetreatStorageHouse />
-        <RetreatHotAirBalloon />
-        <RetreatTailor />
-        <RetreatBlacksmith />
-        <Auctioneer />
-        <Resale />
-        <RetreatWishingWell />
-        <IslandTravelWrapper />
-      </div>
-    </>
-  );
-};
-
-export const Retreat: React.FC = () => {
-  const container = useRef(null);
+  }, [scrollIntoView]);
 
   // Load data
   return (
     <GoblinProvider>
-      <ToastProvider>
-        <ScrollContainer
-          className="bg-blue-300 overflow-scroll relative w-full h-full"
-          innerRef={container}
-        >
-          <div className="relative h-retreatGameboard w-retreatGameboard">
-            <div
-              className="absolute inset-0 bg-repeat w-full h-full"
-              style={{
-                backgroundImage: `url(${ocean})`,
-                backgroundSize: "200px",
-                imageRendering: "pixelated",
-              }}
-            />
-            <RetreatContent />
-          </div>
-        </ScrollContainer>
-      </ToastProvider>
+      <Game />
     </GoblinProvider>
   );
 };

--- a/src/features/retreat/Retreat.tsx
+++ b/src/features/retreat/Retreat.tsx
@@ -1,20 +1,107 @@
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
-import React, { useEffect } from "react";
-import { GoblinProvider } from "features/game/GoblinProvider";
-import { Game } from "./Game";
+import React, { useContext, useEffect, useRef, useState } from "react";
+import ScrollContainer from "react-indiana-drag-scroll";
 
-export const Retreat: React.FC = () => {
+import ocean from "assets/decorations/ocean.png";
+import background from "assets/land/retreat.png";
+import { ToastProvider } from "features/game/toast/ToastQueueProvider";
+import { Context, GoblinProvider } from "features/game/GoblinProvider";
+import { RetreatBank } from "./components/bank/RetreatBank";
+import { RetreatStorageHouse } from "./components/storageHouse/RetreatStorageHouse";
+import { RetreatHotAirBalloon } from "./components/hotAirBalloon/RetreatHotAirBalloon";
+import { RetreatTailor } from "./components/tailor/RetreatTailor";
+import { RetreatBlacksmith } from "./components/blacksmith/RetreatBlacksmith";
+import { Auctioneer } from "./components/auctioneer/Auctioneer";
+import { Resale } from "./components/resale/Resale";
+import { RetreatWishingWell } from "./components/wishingWell/RetreatWishingWell";
+import { IslandTravelWrapper } from "./components/islandTravel/IslandTravelWrapper";
+import { useActor } from "@xstate/react";
+import { INITIAL_SESSION } from "features/game/lib/gameMachine";
+import { Modal } from "react-bootstrap";
+import { Panel } from "components/ui/Panel";
+import { Loading } from "features/auth/components";
+import { GRID_WIDTH_PX } from "features/game/lib/constants";
+
+const RetreatContent: React.FC = () => {
+  const { goblinService } = useContext(Context);
+  const [goblinState] = useActor(goblinService);
+  // Records the first UI load
+  const [loaded, setLoaded] = useState(false);
+
+  const { sessionId } = goblinState.context;
+
   const [scrollIntoView] = useScrollIntoView();
 
   useEffect(() => {
+    if (sessionId === INITIAL_SESSION || loaded) return;
     // Start with island centered
     scrollIntoView(Section.RetreatBackground, "auto");
-  }, [scrollIntoView]);
+    setLoaded(true);
+  }, [scrollIntoView, sessionId, loaded]);
+
+  // Only load the map once the session has loaded. This allows us to block the retreat for bumpkins without the level requirement.
+  if (sessionId === INITIAL_SESSION)
+    return (
+      <Modal show={sessionId === INITIAL_SESSION} backdrop={false} centered>
+        <Panel>
+          <Loading />
+        </Panel>
+      </Modal>
+    );
+
+  return (
+    <>
+      <div
+        id="retreat"
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        style={{
+          width: `${40 * GRID_WIDTH_PX}px`,
+          height: `${40 * GRID_WIDTH_PX}px`,
+        }}
+      >
+        <img
+          src={background}
+          className="absolute inset-0 w-full h-full"
+          id={Section.RetreatBackground}
+        />
+        <RetreatBank />
+        <RetreatStorageHouse />
+        <RetreatHotAirBalloon />
+        <RetreatTailor />
+        <RetreatBlacksmith />
+        <Auctioneer />
+        <Resale />
+        <RetreatWishingWell />
+        <IslandTravelWrapper />
+      </div>
+    </>
+  );
+};
+
+export const Retreat: React.FC = () => {
+  const container = useRef(null);
 
   // Load data
   return (
     <GoblinProvider>
-      <Game />
+      <ToastProvider>
+        <ScrollContainer
+          className="bg-blue-300 overflow-scroll relative w-full h-full"
+          innerRef={container}
+        >
+          <div className="relative h-retreatGameboard w-retreatGameboard">
+            <div
+              className="absolute inset-0 bg-repeat w-full h-full"
+              style={{
+                backgroundImage: `url(${ocean})`,
+                backgroundSize: "200px",
+                imageRendering: "pixelated",
+              }}
+            />
+            <RetreatContent />
+          </div>
+        </ScrollContainer>
+      </ToastProvider>
     </GoblinProvider>
   );
 };


### PR DESCRIPTION
# Description

This PR blocks the old Goblin Village from being accessed by players who have migrated to Land Expansion. This was happening when people were deep linking from other sites/loading url etc. 

<img width="508" alt="Screen Shot 2022-11-23 at 2 28 14 pm" src="https://user-images.githubusercontent.com/17863697/203466708-0b19db63-f24e-4a98-ab81-6611810b09cc.png">

I have also blocked access to Goblin Retreat for players who don't meet the level requirements. Players who were already loaded into LE were able to just swap out the url path and access even if they weren't at Level 5. 

I have also fixed a small bug when getting a connecting error on the home screen. The button was not doing anything because it was always pointing to the gameMachine which wasn't loaded in that instance. I have set it to conditionally use that machine.

Fixes #[issue](https://discord.com/channels/880987707214544966/1043179321159852155/1043179321159852155)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Test with an account that doesn't have Level 5. Load LE and then swap `/land/:id` with `/retreat/:id`. You should be sent back to where you came from.
- Confirm that Level 5 account can still access the retreat.
- With a migrated account, try to load `..../#/goblins` directly from the url bar and you should not be allowed to access the village.
- Check to make sure an unmigrated account can access old goblin village.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
