### PR TITLE
[FIX] Update expansions with server data after autosave

### DIFF
--- a/src/features/game/events/landExpansion/chop.test.ts
+++ b/src/features/game/events/landExpansion/chop.test.ts
@@ -152,7 +152,7 @@ describe("chop", () => {
 
     expect(game.inventory.Axe).toEqual(new Decimal(0));
     expect(game.inventory.Wood).toEqual(new Decimal(3));
-    expect(tree.wood.amount).toBeGreaterThan(2);
+    expect(tree.wood.amount).toBeGreaterThan(0);
   });
 
   it("chops multiple tree", () => {
@@ -188,8 +188,8 @@ describe("chop", () => {
 
     expect(game.inventory.Axe).toEqual(new Decimal(1));
     expect(game.inventory.Wood).toEqual(new Decimal(7));
-    expect(tree1.wood.amount).toBeGreaterThan(2);
-    expect(tree2.wood.amount).toBeGreaterThan(2);
+    expect(tree1.wood.amount).toBeGreaterThan(0);
+    expect(tree2.wood.amount).toBeGreaterThan(0);
   });
 
   it("chops trees with the logger Skill", () => {
@@ -217,7 +217,7 @@ describe("chop", () => {
     const tree = (trees as Record<number, LandExpansionTree>)[0];
 
     expect(game.inventory.Wood).toEqual(new Decimal(3));
-    expect(tree.wood.amount).toBeGreaterThan(2);
+    expect(tree.wood.amount).toBeGreaterThan(0);
     expect(game.inventory.Axe).toEqual(new Decimal(0.5));
   });
   it("tree replenishes normally", () => {
@@ -351,7 +351,7 @@ describe("chop", () => {
     const tree = (trees as Record<number, LandExpansionTree>)[0];
 
     expect(game.inventory.Wood).toEqual(new Decimal(3));
-    expect(tree.wood.amount).toBeGreaterThan(2);
+    expect(tree.wood.amount).toBeGreaterThan(0);
   });
 
   it("throws an error if the player doesnt have a bumpkin", async () => {

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -136,8 +136,8 @@ export function chop({
       skills: bumpkin.skills,
       collectibles,
     }),
-    // Amount for next drop
-    amount: 3,
+    // Placeholder amount for next drop. This will get overridden on the next autosave.
+    amount: 1,
   };
   inventory.Axe = axeAmount.sub(requiredAxes);
   inventory.Wood = woodAmount.add(woodHarvested);

--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
+import { GameState, LandExpansion } from "../types/game";
 import { TEST_FARM } from "./constants";
-import { getLowestGameState } from "./transforms";
+import { getLowestGameState, updateExpansions } from "./transforms";
 
 describe("transform", () => {
   it("gets the lowest balance from the first object", () => {
@@ -56,6 +57,114 @@ describe("transform", () => {
     expect(lowest.inventory).toEqual({
       Sunflower: new Decimal(5),
       Axe: new Decimal(90),
+    });
+  });
+
+  describe.only("updateExpansions", () => {
+    const oldExpansions: LandExpansion[] = [
+      {
+        createdAt: 0,
+        readyAt: 0,
+        plots: {
+          0: {
+            x: -2,
+            y: -1,
+            height: 1,
+            width: 1,
+            crop: {
+              plantedAt: 10,
+              amount: 1,
+              name: "Sunflower",
+            },
+          },
+          1: {
+            x: -1,
+            y: -1,
+            height: 1,
+            width: 1,
+          },
+          2: {
+            x: -2,
+            y: -2,
+            height: 1,
+            width: 1,
+          },
+        } as GameState["plots"],
+        trees: {
+          0: {
+            wood: {
+              amount: 3,
+              choppedAt: 0,
+            },
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+          },
+        },
+      },
+    ];
+
+    it("adds a reward to a crop", () => {
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 4,
+          readyAt: 0,
+          plots: {
+            0: {
+              x: -2,
+              y: -1,
+              height: 1,
+              width: 1,
+              crop: {
+                plantedAt: 10,
+                amount: 1,
+                name: "Sunflower",
+                reward: {
+                  items: [
+                    {
+                      name: "Sunflower Seed",
+                      amount: 3,
+                    },
+                  ],
+                },
+              },
+            },
+            1: {
+              x: -1,
+              y: -1,
+              height: 1,
+              width: 1,
+            },
+            2: {
+              x: -2,
+              y: -2,
+              height: 1,
+              width: 1,
+            },
+          } as GameState["plots"],
+
+          trees: {
+            0: {
+              wood: {
+                amount: 3,
+                choppedAt: 0,
+              },
+              x: 1,
+              y: 1,
+              height: 2,
+              width: 2,
+            },
+          },
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.plots?.["0"]?.crop?.reward).toBeDefined();
+      expect(expansions[0]?.plots?.["0"]?.crop?.reward?.items?.[0].amount).toBe(
+        3
+      );
     });
   });
 });

--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -60,7 +60,7 @@ describe("transform", () => {
     });
   });
 
-  describe.only("updateExpansions", () => {
+  describe("updateExpansions", () => {
     it("returns old crop values if nothing has changed", () => {
       const oldExpansions: LandExpansion[] = [
         {

--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -61,51 +61,69 @@ describe("transform", () => {
   });
 
   describe.only("updateExpansions", () => {
-    const oldExpansions: LandExpansion[] = [
-      {
-        createdAt: 0,
-        readyAt: 0,
-        plots: {
-          0: {
-            x: -2,
-            y: -1,
-            height: 1,
-            width: 1,
-            crop: {
-              plantedAt: 10,
-              amount: 1,
-              name: "Sunflower",
+    it("returns old crop values if nothing has changed", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          plots: {
+            0: {
+              x: -2,
+              y: -1,
+              height: 1,
+              width: 1,
+              crop: {
+                plantedAt: 10,
+                amount: 1,
+                name: "Sunflower",
+              },
             },
-          },
-          1: {
-            x: -1,
-            y: -1,
-            height: 1,
-            width: 1,
-          },
-          2: {
-            x: -2,
-            y: -2,
-            height: 1,
-            width: 1,
-          },
-        } as GameState["plots"],
-        trees: {
-          0: {
-            wood: {
-              amount: 3,
-              choppedAt: 0,
+            1: {
+              x: -1,
+              y: -1,
+              height: 1,
+              width: 1,
             },
-            x: 1,
-            y: 1,
-            height: 2,
-            width: 2,
-          },
+          } as GameState["plots"],
         },
-      },
-    ];
+      ];
+
+      const newExpansions = [...oldExpansions];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.plots?.["0"]?.crop).toEqual(
+        oldExpansions[0]?.plots?.["0"]?.crop
+      );
+    });
 
     it("adds a reward to a crop", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          plots: {
+            0: {
+              x: -2,
+              y: -1,
+              height: 1,
+              width: 1,
+              crop: {
+                plantedAt: 10,
+                amount: 1,
+                name: "Sunflower",
+              },
+            },
+            1: {
+              x: -1,
+              y: -1,
+              height: 1,
+              width: 1,
+            },
+          } as GameState["plots"],
+        },
+      ];
+
       const newExpansions: LandExpansion[] = [
         {
           createdAt: 4,
@@ -143,19 +161,6 @@ describe("transform", () => {
               width: 1,
             },
           } as GameState["plots"],
-
-          trees: {
-            0: {
-              wood: {
-                amount: 3,
-                choppedAt: 0,
-              },
-              x: 1,
-              y: 1,
-              height: 2,
-              width: 2,
-            },
-          },
         },
       ];
 
@@ -165,6 +170,275 @@ describe("transform", () => {
       expect(expansions[0]?.plots?.["0"]?.crop?.reward?.items?.[0].amount).toBe(
         3
       );
+      expect(expansions[0]?.plots?.["1"]?.crop?.reward).not.toBeDefined();
+    });
+
+    it("updates the next drop amount for an updated tree", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          trees: {
+            0: {
+              wood: {
+                amount: 1,
+                choppedAt: 0,
+              },
+              x: -3,
+              y: 3,
+              height: 2,
+              width: 2,
+            },
+            1: {
+              wood: {
+                amount: 1,
+                choppedAt: 0,
+              },
+              x: -3,
+              y: 3,
+              height: 2,
+              width: 2,
+            },
+          },
+        },
+      ];
+
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          trees: {
+            0: {
+              wood: {
+                amount: 10,
+                choppedAt: 0,
+              },
+              x: -3,
+              y: 3,
+              height: 2,
+              width: 2,
+            },
+            1: {
+              wood: {
+                amount: 1,
+                choppedAt: 0,
+              },
+              x: -3,
+              y: 3,
+              height: 2,
+              width: 2,
+            },
+          },
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.trees?.["0"]?.wood?.amount).toBeDefined();
+      expect(expansions[0]?.trees?.["0"]?.wood?.amount).toBe(10);
+      expect(expansions[0]?.trees?.["1"]).toEqual(
+        oldExpansions[0]?.trees?.["1"]
+      );
+    });
+
+    it("updates the next drop amount for an updated stone", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          stones: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          stones: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 10,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.stones?.["1"]?.stone?.amount).toBeDefined();
+      expect(expansions[0]?.stones?.["1"]?.stone?.amount).toBe(10);
+      expect(expansions[0]?.stones?.["0"]).toEqual(
+        oldExpansions[0]?.stones?.["0"]
+      );
+    });
+
+    it("updates the next drop amount for an updated gold", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          gold: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          gold: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 10,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.gold?.["1"]?.stone?.amount).toBeDefined();
+      expect(expansions[0]?.gold?.["1"]?.stone?.amount).toBe(10);
+      expect(expansions[0]?.gold?.["0"]).toEqual(oldExpansions[0]?.gold?.["0"]);
+    });
+
+    it("updates the next drop amount for an updated iron", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          iron: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          iron: {
+            0: {
+              x: 0,
+              y: 3,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 1,
+                minedAt: 0,
+              },
+            },
+            1: {
+              x: 0,
+              y: 4,
+              width: 1,
+              height: 1,
+              stone: {
+                amount: 10,
+                minedAt: 0,
+              },
+            },
+          },
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.iron?.["1"]?.stone?.amount).toBeDefined();
+      expect(expansions[0]?.iron?.["1"]?.stone?.amount).toBe(10);
+      expect(expansions[0]?.iron?.["0"]).toEqual(oldExpansions[0]?.iron?.["0"]);
     });
   });
 });

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -166,7 +166,7 @@ function updatePlots(
   }, {} as Record<number, LandExpansionPlot>);
 }
 
-function updateExpansionCrops(
+export function updateExpansions(
   oldExpansions: LandExpansion[],
   newExpansions: LandExpansion[]
 ): LandExpansion[] {
@@ -180,6 +180,21 @@ function updateExpansionCrops(
     };
   });
 }
+
+// function updateExpansionCrops(
+//   oldPlots: Record<number, LandExpansionPlot>,
+//   newPlots: Record<number, LandExpansionPlot>
+// ): LandExpansion[] {
+//   return oldExpansions.map((expansion, index) => {
+//     const { plots } = expansion;
+
+//     return {
+//       ...expansion,
+//       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+//       ...(plots && { plots: updatePlots(plots, newExpansions[index].plots!) }),
+//     };
+//   });
+// }
 
 /**
  * Merge RNG from server
@@ -227,10 +242,10 @@ export function updateGame(
       gold: updateRocks(oldGameState.gold, newGameState.gold),
       skills: newGameState.skills,
       chickens: newGameState.chickens,
-      expansions: updateExpansionCrops(
-        oldGameState.expansions,
-        newGameState.expansions
-      ),
+      // expansions: updateExpansionCrops(
+      //   oldGameState.expansions,
+      //   newGameState.expansions
+      // ),
     };
   } catch (e) {
     console.log({ e });


### PR DESCRIPTION
# Description
An issue was raised were sometimes people were seeing tree drops of 3. This was happening when a person didn't refresh during the time it took for the tree to replenish and then chopping again. On the client side event we set a hardcoded placeholder value for the next drop from that tree. We set that value to 3. This "should" have been overridden by the real server value on the next autosave however we weren't updating these values 😱 

This PR fixes that issue by updating land expansion resource data in the `updateGame` function.

Fixes #[issue](https://discord.com/channels/880987707214544966/1043856744918564904/1043856744918564904)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
