### PR TITLE
[FIX] Bumpkin feed modal too large on mobile

### DIFF
--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -23,6 +23,7 @@ import { MachineInterpreter } from "./wishingWellMachine";
 import { WishingWellTokens } from "./actions/loadWishingWell";
 import { Context } from "features/game/GoblinProvider";
 import { setPrecision } from "lib/utils/formatNumber";
+import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 
 type GrantedArgs = Pick<WishingWellTokens, "lockedTime"> & {
   onClose: () => void;
@@ -245,6 +246,8 @@ export const WishingWellModal: React.FC = () => {
   const [machine, send] = useActor(child);
 
   const { state: wishingWell, errorCode } = machine.context;
+
+  useUiRefresher({ active: machine.matches("granted") });
 
   const handleClose = () => {
     send("CLOSING");

--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -13,6 +13,7 @@ import { getFoodExpBoost } from "features/game/expansion/lib/boosts";
 import heart from "assets/icons/level_up.png";
 import firePit from "src/assets/buildings/fire_pit.png";
 import { Bumpkin } from "features/game/types/game";
+import { TAB_CONTENT_HEIGHT } from "features/island/hud/components/inventory/Basket";
 
 interface Props {
   food: Consumable[];
@@ -48,8 +49,11 @@ export const Feed: React.FC<Props> = ({ food, onClose, onFeed }) => {
   };
 
   return (
-    <div className="flex">
-      <div className="w-1/2 flex flex-wrap h-fit">
+    <div className="flex flex-col-reverse sm:flex-row">
+      <div
+        className="w-full sm:w-3/5 overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
+        style={{ maxHeight: TAB_CONTENT_HEIGHT }}
+      >
         {selected !== undefined &&
           food.map((item) => (
             <Box
@@ -64,26 +68,24 @@ export const Feed: React.FC<Props> = ({ food, onClose, onFeed }) => {
           <span className="p-1">No food in inventory</span>
         )}
       </div>
-      <OuterPanel className="flex-1 w-1/2">
+      <OuterPanel className="w-full flex-1">
         <div className="flex flex-col justify-center items-center p-2 relative">
           {selected !== undefined && (
             <>
-              <span className="text-shadow text-basetext-center mb-1">
-                {selected.name}
-              </span>
+              <span className="text-center mb-1">{selected.name}</span>
               <img
                 src={ITEM_DETAILS[selected.name].image}
-                className="h-16 img-highlight mt-1"
+                className="h-16 img-highlight mt-2"
                 alt={selected.name}
               />
-              <span className="text-shadow text-center mt-2 sm:text-sm">
+              <span className="text-center mt-2 text-sm">
                 {ITEM_DETAILS[selected.name].description}
               </span>
 
               <div className="border-t border-white w-full mt-2 pt-1">
                 <div className="flex justify-center flex-wrap items-center">
                   <img src={heart} className="me-2 w-6" />
-                  <span className="text-xs text-shadow text-center">
+                  <span className="text-xs text-center">
                     {`${getFoodExpBoost(
                       selected.experience,
                       state.bumpkin as Bumpkin
@@ -102,13 +104,13 @@ export const Feed: React.FC<Props> = ({ food, onClose, onFeed }) => {
           )}
           {selected === undefined && (
             <>
-              <span className="text-shadow text-center">Hungry?</span>
+              <span className="text-center">Hungry?</span>
               <img
                 src={firePit}
-                className="h-16 img-highlight my-3"
+                className="h-16 img-highlight mt-3"
                 alt={"Fire Pit"}
               />
-              <span className="text-shadow text-center mt-2 sm:text-sm">
+              <span className="text-center mt-2 text-sm">
                 You will need to cook food in order to feed your bumpkin
               </span>
             </>

--- a/src/features/island/bumpkin/components/FeedModal.tsx
+++ b/src/features/island/bumpkin/components/FeedModal.tsx
@@ -1,13 +1,17 @@
 import React, { useContext } from "react";
 
 import { Panel } from "components/ui/Panel";
-import { Modal } from "react-bootstrap";
 import { getEntries } from "features/game/types/craftables";
 
 import { ConsumableName, CONSUMABLES } from "features/game/types/consumables";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { Feed } from "./Feed";
+import { Modal } from "react-bootstrap";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import foodIcon from "src/assets/food/chicken_drumstick.png";
+import close from "assets/icons/close.png";
+import { Tab } from "components/ui/Tab";
 
 interface Props {
   isOpen: boolean;
@@ -28,7 +32,34 @@ export const FeedModal: React.FC<Props> = ({ isOpen, onFeed, onClose }) => {
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel bumpkinParts={state.bumpkin?.equipped}>
+      <Panel
+        className="relative"
+        bumpkinParts={state.bumpkin?.equipped}
+        hasTabs
+      >
+        <div
+          className="absolute flex"
+          style={{
+            top: `${PIXEL_SCALE * 1}px`,
+            left: `${PIXEL_SCALE * 1}px`,
+            right: `${PIXEL_SCALE * 1}px`,
+          }}
+        >
+          <img
+            src={close}
+            className="absolute cursor-pointer z-20"
+            onClick={onClose}
+            style={{
+              top: `${PIXEL_SCALE * 1}px`,
+              right: `${PIXEL_SCALE * 1}px`,
+              width: `${PIXEL_SCALE * 11}px`,
+            }}
+          />
+          <Tab isActive>
+            <img src={foodIcon} className="h-5 mr-2" />
+            <span className="text-sm">Feed Bumpkin</span>
+          </Tab>
+        </div>
         <Feed food={availableFood} onFeed={onFeed} onClose={onClose} />
       </Panel>
     </Modal>

--- a/src/features/island/collectibles/components/Bean.tsx
+++ b/src/features/island/collectibles/components/Bean.tsx
@@ -13,6 +13,7 @@ import { Context } from "features/game/GameProvider";
 import { Modal } from "react-bootstrap";
 import { Panel } from "components/ui/Panel";
 import { secondsToString } from "lib/utils/time";
+import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 
 export const Bean: React.FC<CollectibleProps> = ({
   createdAt,
@@ -21,6 +22,8 @@ export const Bean: React.FC<CollectibleProps> = ({
 }) => {
   const { gameService } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
+
+  useUiRefresher();
 
   const plantSeconds = BEANS()[name as BeanName].plantSeconds;
 

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -73,7 +73,7 @@ export const Inventory: React.FC<Props> = ({
         />
       </div>
 
-      <Modal centered scrollable show={isOpen} onHide={() => setIsOpen(false)}>
+      <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
         <InventoryItems state={state} onClose={() => setIsOpen(false)} />
       </Modal>
 


### PR DESCRIPTION
# Description

- improved bumpkin feed modal UI/UX:
  - added tab and close button
  - changed left screen to w-3/5 from w-1/2 for screens larger than sm
  - moved right screen to top for smaller screens (eg. phones)
  - add scrolling and limit left/bottom screen content height
- added ui refresher for exotic seeds and wishing well modal

**PC**
Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/203718826-873c4d81-42e9-4497-a7d1-95aa002adaf0.png)  |  ![image](https://user-images.githubusercontent.com/107602352/203718854-e623d3bf-34ef-411c-88de-5036657f6436.png)

**Mobile**
Before  |  After
---  |  ---
![image](https://user-images.githubusercontent.com/107602352/203718915-bf17a312-c14b-4d49-b55e-3f903dfa84ad.png)  |  ![image](https://user-images.githubusercontent.com/107602352/203718940-a1875282-c057-48f7-86b7-a27779b4593c.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click mini bumpkin while having lots of food types in inventory

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes