### PR TITLE
[FIX] Update crop drop amount after autosave

### DIFF
--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -173,6 +173,78 @@ describe("transform", () => {
       expect(expansions[0]?.plots?.["1"]?.crop?.reward).not.toBeDefined();
     });
 
+    it("updated the drop amount for the crop", () => {
+      const oldExpansions: LandExpansion[] = [
+        {
+          createdAt: 0,
+          readyAt: 0,
+          plots: {
+            0: {
+              x: -2,
+              y: -1,
+              height: 1,
+              width: 1,
+              crop: {
+                plantedAt: 10,
+                amount: 1,
+                name: "Sunflower",
+              },
+            },
+            1: {
+              x: -1,
+              y: -1,
+              height: 1,
+              width: 1,
+            },
+          } as GameState["plots"],
+        },
+      ];
+
+      const newExpansions: LandExpansion[] = [
+        {
+          createdAt: 4,
+          readyAt: 0,
+          plots: {
+            0: {
+              x: -2,
+              y: -1,
+              height: 1,
+              width: 1,
+              crop: {
+                plantedAt: 10,
+                amount: 1.25,
+                name: "Sunflower",
+                reward: {
+                  items: [
+                    {
+                      name: "Sunflower Seed",
+                      amount: 3,
+                    },
+                  ],
+                },
+              },
+            },
+            1: {
+              x: -1,
+              y: -1,
+              height: 1,
+              width: 1,
+            },
+            2: {
+              x: -2,
+              y: -2,
+              height: 1,
+              width: 1,
+            },
+          } as GameState["plots"],
+        },
+      ];
+
+      const expansions = updateExpansions(oldExpansions, newExpansions);
+
+      expect(expansions[0]?.plots?.["0"]?.crop?.amount).toBe(1.25);
+    });
+
     it("updates the next drop amount for an updated tree", () => {
       const oldExpansions: LandExpansion[] = [
         {

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -150,17 +150,20 @@ function updatePlots(
   newPlots: Record<number, LandExpansionPlot>
 ) {
   return getKeys(oldPlots).reduce((plots, plotId) => {
-    const { crop } = oldPlots[plotId];
-    const reward = newPlots[plotId].crop?.reward;
+    const { crop: oldCrop } = oldPlots[plotId];
+    const { crop: newCrop } = newPlots[plotId];
+
+    const hasCrop = oldCrop && newCrop;
 
     return {
       ...plots,
       [plotId]: {
         ...oldPlots[plotId],
-        ...(crop && {
+        ...(hasCrop && {
           crop: {
-            ...crop,
-            ...(reward && { reward }),
+            ...oldCrop,
+            amount: newCrop.amount,
+            ...(newCrop.reward && { reward: newCrop.reward }),
           },
         }),
       },


### PR DESCRIPTION
# Description

Drop amounts for crops weren't getting updated after autosave.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests + manual

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
