### PR TITLE
[FEAT] Background Color on Placeables

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect } from "react";
+import React, { useContext, useEffect, useLayoutEffect, useState } from "react";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { Coordinates, MapPlacement } from "./components/MapPlacement";
 import { useActor } from "@xstate/react";
@@ -50,7 +50,8 @@ type ExpansionProps = Pick<
 
 const getExpansions = (
   expansionProps: ExpansionProps,
-  expansionIndex: number
+  expansionIndex: number,
+  isEditing?: boolean
 ) => {
   const { x: xOffset, y: yOffset } = EXPANSION_ORIGINS[expansionIndex];
 
@@ -68,6 +69,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Gold rockIndex={Number(index)} expansionIndex={expansionIndex} />
           </MapPlacement>
@@ -88,6 +90,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Plot plotIndex={Number(index)} expansionIndex={expansionIndex} />
           </MapPlacement>
@@ -108,6 +111,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Tree treeIndex={Number(index)} expansionIndex={expansionIndex} />
           </MapPlacement>
@@ -128,6 +132,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Stone rockIndex={Number(index)} expansionIndex={expansionIndex} />
           </MapPlacement>
@@ -148,6 +153,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Iron ironIndex={Number(index)} expansionIndex={expansionIndex} />
           </MapPlacement>
@@ -169,6 +175,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <FruitPatch fruit={fruit?.name} />
           </MapPlacement>
@@ -189,6 +196,7 @@ const getExpansions = (
             y={y + yOffset}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <Boulder />
           </MapPlacement>
@@ -208,6 +216,7 @@ const getIslandElements = ({
   chickens,
   bumpkin,
   bumpkinParts,
+  isEditing,
 }: {
   islandLevel: number;
   expansions: LandExpansion[];
@@ -216,6 +225,7 @@ const getIslandElements = ({
   chickens: Partial<Record<number, Chicken>>;
   bumpkin: Bumpkin | undefined;
   bumpkinParts: BumpkinParts | undefined;
+  isEditing?: boolean;
 }) => {
   const pirateCoordinates = {
     x: islandLevel > 7 ? -8.4 : -1.4,
@@ -252,7 +262,8 @@ const getIslandElements = ({
               fruitPatches: fruitPatches,
               boulders: boulders,
             },
-            index
+            index,
+            isEditing
           )
       )
   );
@@ -265,6 +276,7 @@ const getIslandElements = ({
         y={BUMPKIN_POSITION.y}
         width={2}
         height={2}
+        isEditing={isEditing}
       >
         <Character
           body={bumpkinParts.body}
@@ -292,6 +304,7 @@ const getIslandElements = ({
               y={y}
               height={height}
               width={width}
+              isEditing={isEditing}
             >
               <Building building={building} name={name as BuildingName} />
             </MapPlacement>
@@ -317,6 +330,7 @@ const getIslandElements = ({
               y={y}
               height={height}
               width={width}
+              isEditing={isEditing}
             >
               <Collectible
                 name={name}
@@ -346,6 +360,7 @@ const getIslandElements = ({
             y={y}
             height={height}
             width={width}
+            isEditing={isEditing}
           >
             <ChickenElement index={index} />
           </MapPlacement>
@@ -363,12 +378,17 @@ export const Land: React.FC = () => {
 
   const { expansions, buildings, collectibles, chickens, bumpkin } = state;
   const level = expansions.length + 1;
+  const [isEditing, setIsEditing] = useState(false);
 
   const [scrollIntoView] = useScrollIntoView();
 
   useLayoutEffect(() => {
     scrollIntoView(Section.GenesisBlock, "auto");
   }, []);
+
+  useEffect(() => {
+    setIsEditing(gameState.matches("editing"));
+  }, [gameState.value]);
 
   const boatCoordinates = {
     x: level > 7 ? -9 : -2,
@@ -404,6 +424,7 @@ export const Land: React.FC = () => {
             chickens,
             bumpkin,
             bumpkinParts: gameState.context.state.bumpkin?.equipped,
+            isEditing,
           }).sort((a, b) => b.props.y - a.props.y)}
         </div>
         <IslandTravel

--- a/src/features/game/expansion/components/MapPlacement.tsx
+++ b/src/features/game/expansion/components/MapPlacement.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 import { GRID_WIDTH_PX } from "../../lib/constants";
 
 export type Coordinates = {
@@ -11,21 +12,28 @@ export type Position = {
   width?: number;
 } & Coordinates;
 
+type Props = {
+  isEditing?: boolean;
+} & Position;
+
 /**
  * This component is used to place items on the map. It uses the cartesian place coordinates
  * as the basis for its positioning. If the coordinates are 1,1 then the item will be placed one
  * grid size up and one grid right. The item will be placed at 0,0 of this coordinate.
  */
-export const MapPlacement: React.FC<Position> = ({
+export const MapPlacement: React.FC<Props> = ({
   x,
   y,
   height,
   width,
+  isEditing = false,
   children,
 }) => {
   return (
     <div
-      className="absolute"
+      className={classNames("absolute", {
+        "bg-red-background/80": isEditing,
+      })}
       style={{
         top: `calc(50% - ${GRID_WIDTH_PX * y}px)`,
         left: `calc(50% + ${GRID_WIDTH_PX * x}px)`,

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -139,8 +139,8 @@ export const Placeable: React.FC = () => {
               className={classNames(
                 " w-full h-full relative img-highlight pointer-events-none",
                 {
-                  "bg-green-background": !collideRef.current,
-                  "bg-red-background": collideRef.current,
+                  "bg-green-background/80": !collideRef.current,
+                  "bg-red-background/80": collideRef.current,
                 }
               )}
               style={{

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -42,6 +42,7 @@ export const Placeable: React.FC = () => {
   const { gameService } = useContext(Context);
 
   const [showHint, setShowHint] = useState(true);
+  const collideRef = useRef(false);
 
   useEffect(() => {
     detect({ x: DEFAULT_POSITION_X, y: -DEFAULT_POSITION_Y });
@@ -64,6 +65,8 @@ export const Placeable: React.FC = () => {
       width,
       height,
     });
+
+    collideRef.current = collisionDetected;
 
     send({ type: "UPDATE", coordinates: { x, y }, collisionDetected });
   };
@@ -133,7 +136,13 @@ export const Placeable: React.FC = () => {
             )}
             <div
               draggable={false}
-              className=" w-full h-full relative img-highlight pointer-events-none"
+              className={classNames(
+                " w-full h-full relative img-highlight pointer-events-none",
+                {
+                  "bg-green-background": !collideRef.current,
+                  "bg-red-background": collideRef.current,
+                }
+              )}
               style={{
                 width: `${width * GRID_WIDTH_PX}px`,
                 height: `${height * GRID_WIDTH_PX}px`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -81,6 +81,9 @@ module.exports = {
         green: {
           background: "#63c74d",
         },
+        red: {
+          background: "#e43b44",
+        },
         blue: {
           300: "#0099da",
           600: "#0d87ff",


### PR DESCRIPTION
# Description

This PR puts background color when placing a collectible/building in the map. This will serve as added visual cue to help players organize their placeables.

Fixes #issue

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing - local

![image](https://user-images.githubusercontent.com/89294757/204077704-bd95a408-1c59-4d39-aaad-b9206e34d507.png)

![image](https://user-images.githubusercontent.com/89294757/204077709-4eea1001-0802-407a-9878-13ac1e609809.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
