### PR TITLE
[FIX] Withdraw Unplaced/Dug Collectibles

### DIFF
--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -6,6 +6,7 @@ import { canMine as canMineGold } from "features/game/events/goldMine";
 import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import {
+  CollectibleName,
   FOODS,
   getKeys,
   QUEST_ITEMS,
@@ -62,7 +63,10 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
   }
 
   // Placed items
-  if (item in game.collectibles) {
+  if (
+    item in game.collectibles &&
+    (game.collectibles[item as CollectibleName] || []).length > 0
+  ) {
     return false;
   }
 


### PR DESCRIPTION
# Description

This PR fixes the bug where you cannot withdraw a previously placed (and dug) item. This is because backend still save the name as key but is empty array. added length check in FE

![image](https://user-images.githubusercontent.com/89294757/204142487-7252c52a-c0e2-4695-b90a-97a4f2d75d34.png)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests only. No NFT in testnet

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
