### PR TITLE
[FIX] added the new seed names to the valid seeds array

### DIFF
--- a/src/features/game/events/plant.ts
+++ b/src/features/game/events/plant.ts
@@ -26,7 +26,7 @@ const VALID_SEEDS: InventoryItemName[] = [
   "Kale Seed",
   "Apple Seed",
   "Orange Seed",
-  "Blueberry Seed"
+  "Blueberry Seed",
 ];
 
 export function isSeed(item: InventoryItemName): item is CropSeedName {

--- a/src/features/game/events/plant.ts
+++ b/src/features/game/events/plant.ts
@@ -23,6 +23,10 @@ const VALID_SEEDS: InventoryItemName[] = [
   "Parsnip Seed",
   "Radish Seed",
   "Wheat Seed",
+  "Kale Seed",
+  "Apple Seed",
+  "Orange Seed",
+  "Blueberry Seed"
 ];
 
 export function isSeed(item: InventoryItemName): item is CropSeedName {


### PR DESCRIPTION
# Description

The new seed names weren't in the VALID_SEED array.
which is replaced on the bank's withdrawal UI

![image](https://user-images.githubusercontent.com/9072434/204162211-7d940b47-2c94-4517-ab20-87a58aacff56.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

wasn't able to test as I'm low-level on the testnet.

`yarn test` on the main branch
![image](https://user-images.githubusercontent.com/9072434/204162378-19219578-b18e-4762-928a-e2e18645682d.png)


`yarn test` on the current branch
![image](https://user-images.githubusercontent.com/9072434/204162274-9d7f4f4b-6682-4461-aae9-fcc345027ed6.png)


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
