### PR TITLE
[FEAT] removes the collectible key if there are none of the type placed

### DIFF
--- a/src/features/game/events/landExpansion/removeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.test.ts
@@ -259,4 +259,33 @@ describe("removeCollectible", () => {
 
     expect(getKeys(gameState.chickens).length).toEqual(20);
   });
+
+  it("removes the collectible key if there are none of the type placed", () => {
+    const gameState = removeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Rusty Shovel": new Decimal(2),
+        },
+        chickens: makeChickens(30),
+        collectibles: {
+          "Rock Golem": [
+            {
+              id: "123",
+              createdAt: 0,
+              coordinates: { x: 1, y: 1 },
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "collectible.removed",
+        collectible: "Rock Golem",
+        id: "123",
+      },
+    });
+
+    expect(gameState.collectibles["Rock Golem"]).toBeUndefined();
+  });
 });

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -23,12 +23,14 @@ type Options = {
   createdAt?: number;
 };
 
-function removeItem<T>(arr: Array<T>, value: T): Array<T> {
+function removeItem<T>(arr: Array<T>, value: T): Array<T> | undefined {
   const index = arr.indexOf(value);
+
   if (index > -1) {
     arr.splice(index, 1);
   }
-  return arr;
+
+  return arr.length ? arr : undefined;
 }
 
 export function removeCollectible({
@@ -67,6 +69,11 @@ export function removeCollectible({
     collectibleGroup,
     collectibleGroup[collectibleIndex]
   );
+
+  // Remove collectible key if there are none placed
+  if (!stateCopy.collectibles[action.collectible]) {
+    delete stateCopy.collectibles[action.collectible];
+  }
 
   if (action.collectible === "Chicken Coop") {
     stateCopy.chickens = removeUnsupportedChickens(stateCopy);

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -6,6 +6,7 @@ import { canMine as canMineGold } from "features/game/events/goldMine";
 import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import {
+  CollectibleName,
   FOODS,
   getKeys,
   QUEST_ITEMS,
@@ -62,7 +63,10 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
   }
 
   // Placed items
-  if (item in game.collectibles) {
+  if (
+    item in game.collectibles &&
+    game.collectibles[item as CollectibleName]?.length
+  ) {
     return false;
   }
 


### PR DESCRIPTION
# Description

This PR removes the collectible key in the collectibles object if there are none of that type placed. 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
