### PR TITLE
[FIX] Crafting Modal UI

### DIFF
--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -10,7 +10,7 @@ type progressType = "progress" | "health" | "error";
 interface Props {
   percentage: number;
   type: progressType;
-  seconds: number;
+  seconds?: number;
 }
 
 const DIMENSIONS = {
@@ -120,7 +120,11 @@ export const Bar: React.FC<{ percentage: number; type: progressType }> = ({
   );
 };
 
-export const ProgressBar: React.FC<Props> = ({ percentage, type, seconds }) => {
+export const ProgressBar: React.FC<Props> = ({
+  percentage,
+  type,
+  seconds = 0,
+}) => {
   return (
     <div className="absolute">
       {seconds > 0 && (

--- a/src/features/auth/components/Connect.tsx
+++ b/src/features/auth/components/Connect.tsx
@@ -64,8 +64,8 @@ export const Connect: React.FC = () => {
       </Button>
 
       <div className="bg-white b-1 w-full h-[1px] my-4" />
-      <div className="flex justify-center relative">
-        <span className="text-xs text-center bg-[#c28669] px-2 absolute top-[-34px] italic">
+      <div className="flex justify-center relative pb-1">
+        <span className="text-xs text-center bg-[#c28669] px-2 absolute top-[-34px] italic ">
           Connect with an email or social login
         </span>
       </div>

--- a/src/features/bumpkins/components/AchievementDetails.tsx
+++ b/src/features/bumpkins/components/AchievementDetails.tsx
@@ -228,19 +228,25 @@ export const AchievementDetails: React.FC<Props> = ({
                       <span className="text-xs">{`${achievement.sfl} SFL`}</span>
                     </div>
                   )}
-                  {getKeys(achievement.rewards || {}).map((name) => (
-                    <div key={name} className="flex items-center mt-1">
-                      <img
-                        src={ITEM_DETAILS[name].image}
-                        style={{
-                          opacity: 0,
-                          marginRight: `${PIXEL_SCALE * 4}px`,
-                        }}
-                        onLoad={(e) => setImageWidth(e.currentTarget)}
-                      />
-                      <span className="text-xs">{name}</span>
-                    </div>
-                  ))}
+                  {getKeys(achievement.rewards || {}).map((name) => {
+                    const amount =
+                      achievement.rewards?.[name] || new Decimal(0);
+                    const rewardAmount = amount.gt(1) ? `(${amount})` : "";
+
+                    return (
+                      <div key={name} className="flex items-center mt-1">
+                        <img
+                          src={ITEM_DETAILS[name].image}
+                          style={{
+                            opacity: 0,
+                            marginRight: `${PIXEL_SCALE * 4}px`,
+                          }}
+                          onLoad={(e) => setImageWidth(e.currentTarget)}
+                        />
+                        <span className="text-xs">{`${name} ${rewardAmount}`}</span>
+                      </div>
+                    );
+                  })}
                 </div>
                 {!isVisiting && (
                   <Button

--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -119,7 +119,7 @@ export const Game: React.FC = () => {
       <ToastManager />
 
       <Modal show={SHOW_MODAL[gameState.value as StateValues]} centered>
-        <Panel className="text-shadow">
+        <Panel>
           {gameState.matches("loading") && <Loading />}
 
           {gameState.matches("offerMigration") && <Migrate />}

--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -97,7 +97,6 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
       "Pumpkin Seed": new Decimal(50),
     },
   },
-
   Timbeerrr: {
     description: "Chop 150 trees",
     progress: (gameState: GameState) =>
@@ -113,7 +112,6 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
     progress: (gameState: GameState) =>
       gameState.expansions.length - INITIAL_EXPANSIONS.length,
     requirement: 5,
-
     sfl: marketRate(50),
   },
   "Cool Flower": {

--- a/src/features/game/types/consumables.ts
+++ b/src/features/game/types/consumables.ts
@@ -41,7 +41,7 @@ export type Consumable = {
 export const CONSUMABLES: Record<ConsumableName, Consumable> = {
   "Mashed Potato": {
     name: "Mashed Potato",
-    description: "Boiled Eggss are always a good breakfast choice",
+    description: "My life is potato.",
     experience: 3,
     building: "Fire Pit",
     cookingSeconds: 60,
@@ -50,7 +50,6 @@ export const CONSUMABLES: Record<ConsumableName, Consumable> = {
     },
     marketRate: 10,
   },
-
   "Pumpkin Soup": {
     name: "Pumpkin Soup",
     description: "Boiled Eggss are always a good breakfast choice",

--- a/src/features/island/buildings/components/building/InProgressInfo.tsx
+++ b/src/features/island/buildings/components/building/InProgressInfo.tsx
@@ -1,0 +1,52 @@
+import { useActor } from "@xstate/react";
+import { Box } from "components/ui/Box";
+import { Bar } from "components/ui/ProgressBar";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { CONSUMABLES } from "features/game/types/consumables";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { secondsToString } from "lib/utils/time";
+import React from "react";
+import { MachineInterpreter } from "../../lib/craftingMachine";
+
+interface Props {
+  craftingService: MachineInterpreter;
+}
+
+export const InProgressInfo: React.FC<Props> = ({ craftingService }) => {
+  const [
+    {
+      context: { secondsTillReady, name },
+    },
+  ] = useActor(craftingService);
+
+  if (!name || !secondsTillReady) return null;
+
+  const { cookingSeconds } = CONSUMABLES[name];
+
+  return (
+    <div className="flex flex-col mb-2">
+      <p className="text-sm">In Progress</p>
+      <div className="flex">
+        <Box image={ITEM_DETAILS[name].image} />
+        <div
+          className="relative flex flex-col w-full"
+          style={{
+            marginTop: `${PIXEL_SCALE * 3}px`,
+            marginBottom: `${PIXEL_SCALE * 2}px`,
+          }}
+          id="progress-bar"
+        >
+          <span className="text-xs mb-1">
+            {secondsToString(secondsTillReady, { length: "medium" })}
+          </span>
+          <div className="relative w-full h">
+            <Bar
+              percentage={(1 - secondsTillReady / cookingSeconds) * 100}
+              type="progress"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/island/buildings/components/building/WithCraftingMachine.tsx
+++ b/src/features/island/buildings/components/building/WithCraftingMachine.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { useInterpret, useSelector } from "@xstate/react";
 import isEmpty from "lodash.isempty";
 import { Context } from "features/game/GameProvider";
@@ -8,7 +8,6 @@ import {
   MachineInterpreter,
   MachineState,
 } from "../../lib/craftingMachine";
-import { CraftingTimerModal } from "../ui/CraftingTimerModal";
 import { BuildingProps } from "./Building";
 import { ConsumableName } from "features/game/types/consumables";
 
@@ -37,7 +36,6 @@ export const WithCraftingMachine = ({
 }: BuildingProps & {
   children: React.ReactElement<CraftingMachineChildProps>;
 }) => {
-  const [showTimer, setShowTimer] = useState(false);
   const { gameService } = useContext(Context);
   const craftingInProgress = craftingState && !isEmpty(craftingState);
   const craftingMachineContext: CraftingContext = {
@@ -58,10 +56,6 @@ export const WithCraftingMachine = ({
   const ready = useSelector(craftingService, isReady);
   const name = useSelector(craftingService, itemName);
 
-  const handleShowCraftingTimer = () => {
-    setShowTimer(true);
-  };
-
   // The building component is cloned and crafting state machine props are injected into it
   const clonedChildren = React.cloneElement(children, {
     idle,
@@ -69,17 +63,7 @@ export const WithCraftingMachine = ({
     ready,
     name,
     craftingService,
-    handleShowCraftingTimer,
   });
 
-  return (
-    <>
-      {clonedChildren}
-      <CraftingTimerModal
-        show={showTimer}
-        service={craftingService}
-        onClose={() => setShowTimer(false)}
-      />
-    </>
-  );
+  return <>{clonedChildren}</>;
 };

--- a/src/features/island/buildings/components/building/bakery/Bakery.tsx
+++ b/src/features/island/buildings/components/building/bakery/Bakery.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import bakery from "assets/buildings/bakery.png";
 import smoke from "assets/buildings/smoke.gif";
 import goblinChef from "assets/npcs/goblin_chef.gif";
-import goblinChefdoing from "assets/npcs/goblin_chef_doing.gif";
+import goblinChefDoing from "assets/npcs/goblin_chef_doing.gif";
 import shadow from "assets/npcs/shadow.png";
 
 import { ConsumableName } from "features/game/types/consumables";
@@ -27,14 +27,12 @@ export const Bakery: React.FC<Props> = ({
   name,
   craftingService,
   isBuilt,
-  handleShowCraftingTimer,
   onRemove,
 }) => {
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService || !handleShowCraftingTimer)
-    return <img src={bakery} className="w-full" />;
+  if (!craftingService) return <img src={bakery} className="w-full" />;
 
   const handleCook = (item: ConsumableName) => {
     craftingService.send({
@@ -70,13 +68,8 @@ export const Bakery: React.FC<Props> = ({
 
     if (isBuilt) {
       // Add future on click actions here
-      if (idle) {
+      if (idle || crafting) {
         setShowModal(true);
-        return;
-      }
-
-      if (crafting) {
-        handleShowCraftingTimer();
         return;
       }
 
@@ -116,7 +109,7 @@ export const Bakery: React.FC<Props> = ({
         />
         {crafting ? (
           <img
-            src={goblinChefdoing}
+            src={goblinChefDoing}
             className="absolute pointer-events-none"
             style={{
               width: `${PIXEL_SCALE * 22}px`,
@@ -169,6 +162,8 @@ export const Bakery: React.FC<Props> = ({
         isOpen={showModal}
         onClose={() => setShowModal(false)}
         onCook={handleCook}
+        crafting={!!crafting}
+        craftingService={craftingService}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -10,13 +10,22 @@ import {
   ConsumableName,
   CONSUMABLES,
 } from "features/game/types/consumables";
+import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
+  crafting: boolean;
+  craftingService?: MachineInterpreter;
 }
-export const BakeryModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
+export const BakeryModal: React.FC<Props> = ({
+  isOpen,
+  onCook,
+  onClose,
+  crafting,
+  craftingService,
+}) => {
   const cakeRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
     if (CONSUMABLES[name].building !== "Bakery") {
       return acc;
@@ -39,7 +48,13 @@ export const BakeryModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
           shoes: "Black Farmer Boots",
         }}
       >
-        <Recipes recipes={cakeRecipes} onCook={onCook} onClose={onClose} />
+        <Recipes
+          recipes={cakeRecipes}
+          onCook={onCook}
+          onClose={onClose}
+          crafting={crafting}
+          craftingService={craftingService}
+        />
       </Panel>
     </Modal>
   );

--- a/src/features/island/buildings/components/building/deli/Deli.tsx
+++ b/src/features/island/buildings/components/building/deli/Deli.tsx
@@ -26,14 +26,12 @@ export const Deli: React.FC<Props> = ({
   name,
   craftingService,
   isBuilt,
-  handleShowCraftingTimer,
   onRemove,
 }) => {
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService || !handleShowCraftingTimer)
-    return <img src={deli} className="w-full" />;
+  if (!craftingService) return <img src={deli} className="w-full" />;
 
   const handleCook = (item: ConsumableName) => {
     craftingService.send({
@@ -68,14 +66,8 @@ export const Deli: React.FC<Props> = ({
     }
 
     if (isBuilt) {
-      // Add future on click actions here
-      if (idle) {
+      if (idle || crafting) {
         setShowModal(true);
-        return;
-      }
-
-      if (crafting) {
-        handleShowCraftingTimer();
         return;
       }
 
@@ -158,6 +150,8 @@ export const Deli: React.FC<Props> = ({
         isOpen={showModal}
         onClose={() => setShowModal(false)}
         onCook={handleCook}
+        crafting={!!crafting}
+        craftingService={craftingService}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -10,13 +10,22 @@ import {
   ConsumableName,
   CONSUMABLES,
 } from "features/game/types/consumables";
+import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
+  crafting: boolean;
+  craftingService?: MachineInterpreter;
 }
-export const DeliModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
+export const DeliModal: React.FC<Props> = ({
+  isOpen,
+  onCook,
+  onClose,
+  crafting,
+  craftingService,
+}) => {
   const deliRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
     if (CONSUMABLES[name].building !== "Deli") {
       return acc;
@@ -38,7 +47,13 @@ export const DeliModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
           shoes: "Black Farmer Boots",
         }}
       >
-        <Recipes recipes={deliRecipes} onCook={onCook} onClose={onClose} />
+        <Recipes
+          recipes={deliRecipes}
+          onCook={onCook}
+          onClose={onClose}
+          crafting={crafting}
+          craftingService={craftingService}
+        />
       </Panel>
     </Modal>
   );

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -26,13 +26,12 @@ export const FirePit: React.FC<Props> = ({
   name,
   craftingService,
   isBuilt,
-  handleShowCraftingTimer,
   onRemove,
 }) => {
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService || !handleShowCraftingTimer) {
+  if (!craftingService) {
     return null;
   }
 
@@ -70,13 +69,8 @@ export const FirePit: React.FC<Props> = ({
 
     if (isBuilt) {
       // Add future on click actions here
-      if (idle) {
+      if (idle || crafting) {
         setShowModal(true);
-        return;
-      }
-
-      if (crafting) {
-        handleShowCraftingTimer();
         return;
       }
 
@@ -152,6 +146,8 @@ export const FirePit: React.FC<Props> = ({
         isOpen={showModal}
         onClose={() => setShowModal(false)}
         onCook={handleCook}
+        crafting={!!crafting}
+        craftingService={craftingService}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -10,13 +10,22 @@ import {
   ConsumableName,
   CONSUMABLES,
 } from "features/game/types/consumables";
+import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
+  crafting: boolean;
+  craftingService?: MachineInterpreter;
 }
-export const FirePitModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
+export const FirePitModal: React.FC<Props> = ({
+  isOpen,
+  onCook,
+  onClose,
+  crafting,
+  craftingService,
+}) => {
   const firePitRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
     if (CONSUMABLES[name].building !== "Fire Pit") {
       return acc;
@@ -39,7 +48,13 @@ export const FirePitModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
           shoes: "Black Farmer Boots",
         }}
       >
-        <Recipes recipes={firePitRecipes} onCook={onCook} onClose={onClose} />
+        <Recipes
+          recipes={firePitRecipes}
+          onCook={onCook}
+          onClose={onClose}
+          crafting={!!crafting}
+          craftingService={craftingService}
+        />
       </Panel>
     </Modal>
   );

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -26,7 +26,6 @@ export const Kitchen: React.FC<Props> = ({
   name,
   craftingService,
   isBuilt,
-  handleShowCraftingTimer,
   onRemove,
 }) => {
   const [showModal, setShowModal] = useState(false);
@@ -66,13 +65,8 @@ export const Kitchen: React.FC<Props> = ({
 
     if (isBuilt) {
       // Add future on click actions here
-      if (idle) {
+      if (idle || crafting) {
         setShowModal(true);
-        return;
-      }
-
-      if (crafting) {
-        handleShowCraftingTimer && handleShowCraftingTimer();
         return;
       }
 
@@ -148,6 +142,8 @@ export const Kitchen: React.FC<Props> = ({
         isOpen={showModal}
         onClose={() => setShowModal(false)}
         onCook={handleCook}
+        crafting={!!crafting}
+        craftingService={craftingService}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -10,13 +10,22 @@ import {
   ConsumableName,
   CONSUMABLES,
 } from "features/game/types/consumables";
+import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
+  crafting: boolean;
+  craftingService?: MachineInterpreter;
 }
-export const KitchenModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
+export const KitchenModal: React.FC<Props> = ({
+  isOpen,
+  onCook,
+  onClose,
+  crafting,
+  craftingService,
+}) => {
   const kitchenRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
     if (CONSUMABLES[name].building !== "Kitchen") {
       return acc;
@@ -38,7 +47,13 @@ export const KitchenModal: React.FC<Props> = ({ isOpen, onCook, onClose }) => {
           shoes: "Black Farmer Boots",
         }}
       >
-        <Recipes recipes={kitchenRecipes} onCook={onCook} onClose={onClose} />
+        <Recipes
+          craftingService={craftingService}
+          recipes={kitchenRecipes}
+          onCook={onCook}
+          onClose={onClose}
+          crafting={crafting}
+        />
       </Panel>
     </Modal>
   );

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -48,11 +48,11 @@ export const KitchenModal: React.FC<Props> = ({
         }}
       >
         <Recipes
-          craftingService={craftingService}
           recipes={kitchenRecipes}
           onCook={onCook}
           onClose={onClose}
           crafting={crafting}
+          craftingService={craftingService}
         />
       </Panel>
     </Modal>

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -20,14 +20,24 @@ import {
   getFoodExpBoost,
 } from "features/game/expansion/lib/boosts";
 import { Bumpkin } from "features/game/types/game";
+import { InProgressInfo } from "../building/InProgressInfo";
+import { MachineInterpreter } from "../../lib/craftingMachine";
 
 interface Props {
   recipes: Consumable[];
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
+  craftingService?: MachineInterpreter;
+  crafting: boolean;
 }
 
-export const Recipes: React.FC<Props> = ({ recipes, onClose, onCook }) => {
+export const Recipes: React.FC<Props> = ({
+  recipes,
+  onClose,
+  onCook,
+  crafting,
+  craftingService,
+}) => {
   const [selected, setSelected] = useState<Consumable>(recipes[0]);
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
@@ -61,47 +71,38 @@ export const Recipes: React.FC<Props> = ({ recipes, onClose, onCook }) => {
   };
 
   const Action = () => {
-    // if (stock?.equals(0)) {
-    //   return (
-    //     <div>
-    //       <p className="text-xxs no-wrap text-center my-1 underline">
-    //         Sold out
-    //       </p>
-    //       <p className="text-xxs text-center">
-    //         Sync your farm to the Blockchain to restock
-    //       </p>
-    //     </div>
-    //   );
-    // }
-
     return (
       <>
         <Button
-          disabled={lessIngredients()}
-          // disabled={lessIngredients() || stock?.lessThan(1)}
+          disabled={lessIngredients() || crafting}
           className="text-sm mt-1 whitespace-nowrap"
           onClick={() => cook()}
         >
           Cook
         </Button>
+        {crafting && <p className="text-xs my-1">Chef is busy</p>}
       </>
     );
   };
 
-  const stock = state.stock[selected.name] || new Decimal(0);
-
   return (
     <div className="flex">
-      <div className="w-1/2 flex flex-wrap h-fit">
-        {recipes.map((item) => (
-          <Box
-            isSelected={selected.name === item.name}
-            key={item.name}
-            onClick={() => setSelected(item)}
-            image={ITEM_DETAILS[item.name].image}
-            count={inventory[item.name]}
-          />
-        ))}
+      <div className="w-1/2 flex flex-col p-1">
+        {craftingService && (
+          <InProgressInfo craftingService={craftingService} />
+        )}
+        <p className="mb-1">Recipes</p>
+        <div className="flex flex-wrap h-fit">
+          {recipes.map((item) => (
+            <Box
+              isSelected={selected.name === item.name}
+              key={item.name}
+              onClick={() => setSelected(item)}
+              image={ITEM_DETAILS[item.name].image}
+              count={inventory[item.name]}
+            />
+          ))}
+        </div>
       </div>
       <OuterPanel className="flex-1 w-1/2">
         <div className="flex flex-col justify-center items-center p-2 relative">
@@ -129,8 +130,8 @@ export const Recipes: React.FC<Props> = ({ recipes, onClose, onCook }) => {
                 requiredAmount
               );
 
-              // rendering item remenants
-              const renderRemenants = () => {
+              // rendering item remnants
+              const renderRemnants = () => {
                 if (lessIngredient) {
                   // if inventory items is less than required items
                   return (
@@ -154,7 +155,7 @@ export const Recipes: React.FC<Props> = ({ recipes, onClose, onCook }) => {
                   key={index}
                 >
                   <img src={item.image} className="h-5 me-2" />
-                  {renderRemenants()}
+                  {renderRemnants()}
                 </div>
               );
             })}

--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useActor } from "@xstate/react";
 
 import { Box } from "components/ui/Box";
@@ -32,6 +32,14 @@ export const Feed: React.FC<Props> = ({ food, onClose, onFeed }) => {
     },
   ] = useActor(gameService);
   const inventory = state.inventory;
+
+  useEffect(() => {
+    if (food.length) {
+      setSelected(food[0]);
+    } else {
+      setSelected(undefined);
+    }
+  }, [food.length]);
 
   const feed = (food: Consumable) => {
     onFeed(food.name);


### PR DESCRIPTION
# Description

This PR removes the `Is it ready?` modal from the food buildings and moves the "in progress" UI into the modal so that a player can still peruse the recipes while they're cooking something. 

I have added two other small fixes:

- Show the reward amounts for items when claiming achievements.
- Select the next food in `Feed` modal after eating all of one type.
<img width="512" alt="Screen Shot 2022-11-28 at 8 21 21 pm" src="https://user-images.githubusercontent.com/17863697/204252469-5536ae19-df05-4839-8c17-627da95b9be3.png">
<img width="502" alt="Screen Shot 2022-11-28 at 8 28 25 pm" src="https://user-images.githubusercontent.com/17863697/204252488-043a0425-09db-4a66-b784-1f850633d300.png">
<img width="454" alt="Screen Shot 2022-11-28 at 9 12 20 pm" src="https://user-images.githubusercontent.com/17863697/204252507-8e257b34-ca31-4d65-b404-22a8e79a4b27.png">

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Cook something then open the modal.
- Eat food and see the next item selected.
- View achievements rewards

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
