### PR TITLE
[FIX] Toast overlapping with bumpkin hud

### DIFF
--- a/src/features/game/Game.tsx
+++ b/src/features/game/Game.tsx
@@ -116,7 +116,7 @@ export const Game: React.FC = () => {
 
   return (
     <>
-      <ToastManager />
+      <ToastManager island={false} />
 
       <Modal show={SHOW_MODAL[gameState.value as StateValues]} centered>
         <Panel className="text-shadow">

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -216,7 +216,7 @@ export const Game: React.FC = () => {
 
   return (
     <>
-      <ToastManager />
+      <ToastManager island={true} />
 
       <Modal show={SHOW_MODAL[gameState.value as StateValues]} centered>
         <Panel>

--- a/src/features/game/toast/ToastManager.tsx
+++ b/src/features/game/toast/ToastManager.tsx
@@ -1,15 +1,14 @@
 import React, { useContext, useState, useEffect } from "react";
 import { Panel } from "components/ui/Panel";
 import { ToastContext } from "./ToastQueueProvider";
-import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 import { Context } from "../GameProvider";
 import { useActor } from "@xstate/react";
+import { PIXEL_SCALE } from "../lib/constants";
 
-export const ToastManager: React.FC = () => {
+export const ToastManager: React.FC<{ island: boolean }> = ({ island }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const { toastList } = useContext(ToastContext);
-  const [isMobile] = useIsMobile();
   const [listed, setListed] = useState<boolean>(false);
 
   useEffect(() => {
@@ -24,17 +23,23 @@ export const ToastManager: React.FC = () => {
     <div>
       {listed && (
         <div
-          className={`p-0.5 flex flex-col items-end mr-2 sm:block fixed left-2 z-[99999] ${
-            isMobile ? "top-24" : "top-32"
-          }`}
+          className={
+            "flex flex-col items-end sm:block fixed z-[99999] pointer-events-none"
+          }
+          style={{
+            top: `${PIXEL_SCALE * (island ? 23 : 30)}px`,
+            ...(island
+              ? { right: `${PIXEL_SCALE * 3}px` }
+              : { left: `${PIXEL_SCALE * 3}px` }),
+          }}
         >
           <Panel>
             {toastList.map(({ content, id, icon }) => (
               <div className="flex items-center relative" key={id}>
                 {icon && (
-                  <img className="h-6 mr-3" src={icon} alt="toast-icon" />
+                  <img className="h-6 mr-1" src={icon} alt="toast-icon" />
                 )}
-                <span>{content}</span>
+                <span className="text-sm mx-1">{content}</span>
               </div>
             ))}
           </Panel>


### PR DESCRIPTION
# Description

- move toast to the right of the screen for land expansion
  - toast is still on the left hand side of the screen for old farm
- added pointer-events-none to toast class

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/204321931-08ed9323-4428-4fe2-aa3a-444920093f94.png)|![image](https://user-images.githubusercontent.com/107602352/204321879-d9934c8e-f146-4e04-9b32-3d5545034763.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- trigger toast events in old farm and land expansion

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
