### PR TITLE
[FIX] Skill points indications

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -127,15 +127,13 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
         <div className="flex-1">
           <div className="mb-3">
             <div className="flex items-center ml-1 my-2">
-              {hasAvaliableSP && (
-                <img
-                  src={levelIcon}
-                  style={{
-                    width: `${PIXEL_SCALE * 10}px`,
-                    marginRight: `${PIXEL_SCALE * 4}px`,
-                  }}
-                />
-              )}
+              <img
+                src={levelIcon}
+                style={{
+                  width: `${PIXEL_SCALE * 10}px`,
+                  marginRight: `${PIXEL_SCALE * 4}px`,
+                }}
+              />
               <div>
                 <p className="text-base">
                   Level {level}

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -23,6 +23,7 @@ import { hasUnacknowledgedSkillPoints } from "features/island/bumpkin/lib/skillP
 import { CONFIG } from "lib/config";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SkillBadges } from "./SkillBadges";
+import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
 
 type ViewState = "home" | "achievements" | "skills";
 
@@ -83,6 +84,7 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
     getExperienceToNextLevel(experience);
 
   const hasSkillPoint = hasUnacknowledgedSkillPoints(state.bumpkin);
+  const hasAvaliableSP = getAvailableBumpkinSkillPoints(state.bumpkin) > 0;
 
   const progressWidth = Math.min(
     Math.floor(
@@ -127,13 +129,15 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
         <div className="flex-1">
           <div className="mb-3">
             <div className="flex items-center ml-1 my-2">
-              <img
-                src={levelIcon}
-                style={{
-                  width: `${PIXEL_SCALE * 10}px`,
-                  marginRight: `${PIXEL_SCALE * 4}px`,
-                }}
-              />
+              {hasAvaliableSP && (
+                <img
+                  src={levelIcon}
+                  style={{
+                    width: `${PIXEL_SCALE * 10}px`,
+                    marginRight: `${PIXEL_SCALE * 4}px`,
+                  }}
+                />
+              )}
               <div>
                 <p className="text-base">
                   Level {level}

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -19,7 +19,6 @@ import {
 import { Achievements } from "./Achievements";
 import { AchievementBadges } from "./AchievementBadges";
 import { Skills } from "features/bumpkins/components/Skills";
-import { hasUnacknowledgedSkillPoints } from "features/island/bumpkin/lib/skillPointStorage";
 import { CONFIG } from "lib/config";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SkillBadges } from "./SkillBadges";
@@ -83,7 +82,6 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
   const { currentExperienceProgress, experienceToNextLevel } =
     getExperienceToNextLevel(experience);
 
-  const hasSkillPoint = hasUnacknowledgedSkillPoints(state.bumpkin);
   const hasAvaliableSP = getAvailableBumpkinSkillPoints(state.bumpkin) > 0;
 
   const progressWidth = Math.min(
@@ -216,7 +214,7 @@ export const BumpkinModal: React.FC<Props> = ({ initialView, onClose }) => {
               <div className="flex items-center mb-1 justify-between">
                 <div className="flex items-center">
                   <span className="text-xs">Skills</span>
-                  {hasSkillPoint && !gameState.matches("visiting") && (
+                  {hasAvaliableSP && !gameState.matches("visiting") && (
                     <img src={alert} className="h-4 ml-2" />
                   )}
                 </div>


### PR DESCRIPTION
# Description

In the bumpkin model, the green arrow was showing up all the time.
1. now the green level-up arrow shows up only if you have unspent skill points.
2. the alert icon near the skills panel wasn't showing up if you had unspent.

I found out about the second point after I fixed the first one.
now when I think about it there are 2 indications for the same thing.
maybe I should remove one of them?

**update**: only the alert indication is showing if there are unspent skill points

| State | Screen Shot | 
| ------------- | ------------- |
| Before | ![image](https://user-images.githubusercontent.com/9072434/204387988-26b85813-110f-42bf-bc08-e349921fc3fc.png) | 
| After fix (before using spending the points )| ![image](https://user-images.githubusercontent.com/9072434/204388059-7fa545a7-95fd-46b5-bd89-0054c1c7aa78.png) | 
|  After fix (after spending the points) | ![image](https://user-images.githubusercontent.com/9072434/204391563-ec1cd30f-b3ac-4e84-92db-1bf650a7c3ef.png) |


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. spending all the points - remove all the indication
2. spending some of the points - the indication still shows up

`yarn test`
![image](https://user-images.githubusercontent.com/9072434/204389586-15a28eca-86fa-4102-acd2-2c516faa81f2.png)

the main branch had the same result


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
