### PR TITLE
[FIX] Close modal when food is ready

### DIFF
--- a/src/features/island/buildings/components/building/InProgressInfo.tsx
+++ b/src/features/island/buildings/components/building/InProgressInfo.tsx
@@ -10,9 +10,13 @@ import { MachineInterpreter } from "../../lib/craftingMachine";
 
 interface Props {
   craftingService: MachineInterpreter;
+  onClose: () => void;
 }
 
-export const InProgressInfo: React.FC<Props> = ({ craftingService }) => {
+export const InProgressInfo: React.FC<Props> = ({
+  craftingService,
+  onClose,
+}) => {
   const [
     {
       context: { secondsTillReady, name },
@@ -20,6 +24,10 @@ export const InProgressInfo: React.FC<Props> = ({ craftingService }) => {
   ] = useActor(craftingService);
 
   if (!name || !secondsTillReady) return null;
+
+  if (secondsTillReady <= 0) {
+    onClose();
+  }
 
   const { cookingSeconds } = CONSUMABLES[name];
 

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -89,7 +89,7 @@ export const Recipes: React.FC<Props> = ({
     <div className="flex">
       <div className="w-1/2 flex flex-col p-1">
         {craftingService && (
-          <InProgressInfo craftingService={craftingService} />
+          <InProgressInfo craftingService={craftingService} onClose={onClose} />
         )}
         <p className="mb-1">Recipes</p>
         <div className="flex flex-wrap h-fit">

--- a/src/features/island/buildings/lib/craftingMachine.ts
+++ b/src/features/island/buildings/lib/craftingMachine.ts
@@ -178,7 +178,7 @@ export const craftingMachine = createMachine<
 
           const now = Date.now();
 
-          return Math.floor((readyAt - now) / 1000);
+          return (readyAt - now) / 1000;
         },
       }),
     },


### PR DESCRIPTION
# Description

This PR will close the cooking modal when an in progress item is cooked so that the player can collect the food before cooking another item.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
