### PR TITLE
[FIX] Visit Friend on Retreat Return Blank

### DIFF
--- a/src/features/game/expansion/components/IslandList.tsx
+++ b/src/features/game/expansion/components/IslandList.tsx
@@ -240,7 +240,9 @@ export const IslandList = ({
             currentPath={location.pathname}
           />
         ))}
-        <VisitFriendListItem onClick={() => setView("visitForm")} />
+        {!location.pathname.includes("retreat") && (
+          <VisitFriendListItem onClick={() => setView("visitForm")} />
+        )}
       </>
     );
   };


### PR DESCRIPTION
# Description

The visit a friend component is trying to access the game state which dose not intialize on the goblin retreat which is why the user gets a blank page. I have removed the option from the travel list when the user is on the goblin retreat page.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
