### PR TITLE
[FIX] Potted Pumpkin collectible and smalls fixes

### DIFF
--- a/src/features/game/types/beans.ts
+++ b/src/features/game/types/beans.ts
@@ -49,4 +49,4 @@ export type MutantCropName =
   | "Stellar Sunflower"
   | "Peaceful Potato"
   | "Perky Pumpkin"
-  | "Collosal Crop";
+  | "Colossal Crop";

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -226,7 +226,7 @@ export const BUMPKIN_SKILL_TREE: Record<BumpkinSkillName, BumpkinSkill> = {
       points: 2,
       skill: "Michelin Stars",
     },
-    boosts: "Consuming fermented goods adds extra 15% exp",
+    boosts: "Consuming deli goods adds extra 15% exp",
     image: question,
   },
   "Stable Hand": {

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1231,7 +1231,7 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Stellar Sunflower": { height: 1, width: 1 },
   "Peaceful Potato": { height: 1, width: 1 },
   "Perky Pumpkin": { height: 1, width: 1 },
-  "Collosal Crop": { height: 1, width: 1 },
+  "Colossal Crop": { height: 1, width: 1 },
 };
 
 export const ANIMAL_DIMENSIONS: Record<"Chicken", Dimensions> = {

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1501,7 +1501,7 @@ export const ITEM_DETAILS: Items = {
     description: GOBLIN_RETREAT_ITEMS["Prized Potato"].description,
   },
 
-  "Collosal Crop": {
+  "Colossal Crop": {
     image: questionMark,
     description: "???",
   },

--- a/src/features/game/types/index.ts
+++ b/src/features/game/types/index.ts
@@ -96,7 +96,7 @@ export const KNOWN_IDS: Record<InventoryItemName, number> = {
   "Stellar Sunflower": 437,
   "Peaceful Potato": 438,
   "Perky Pumpkin": 439,
-  "Collosal Crop": 440,
+  "Colossal Crop": 440,
 
   "Pumpkin Soup": 501,
   "Roasted Cauliflower": 502,

--- a/src/features/island/collectibles/Collectible.tsx
+++ b/src/features/island/collectibles/Collectible.tsx
@@ -69,6 +69,7 @@ import { getShortcuts } from "features/farming/hud/lib/shortcuts";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Bean } from "./components/Bean";
+import { PottedPumpkin } from "features/island/collectibles/components/PottedPumpkin";
 
 export interface CollectibleProps {
   name: CollectibleName;
@@ -165,7 +166,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
 
   // TODO
   "Potted Potato": () => null,
-  "Potted Pumpkin": () => null,
+  "Potted Pumpkin": PottedPumpkin,
   "Collosal Crop": () => null,
   "Peaceful Potato": () => null,
   "Perky Pumpkin": () => null,

--- a/src/features/island/collectibles/Collectible.tsx
+++ b/src/features/island/collectibles/Collectible.tsx
@@ -167,7 +167,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
   // TODO
   "Potted Potato": () => null,
   "Potted Pumpkin": PottedPumpkin,
-  "Collosal Crop": () => null,
+  "Colossal Crop": () => null,
   "Peaceful Potato": () => null,
   "Perky Pumpkin": () => null,
   "Stellar Sunflower": () => null,

--- a/src/features/island/collectibles/components/PottedPumpkin.tsx
+++ b/src/features/island/collectibles/components/PottedPumpkin.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import pottedPumpkin from "assets/decorations/potted_pumpkin.webp";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+export const PottedPumpkin: React.FC = () => {
+  return (
+    <>
+      <img
+        src={pottedPumpkin}
+        style={{
+          width: `${PIXEL_SCALE * 13}px`,
+          bottom: `${PIXEL_SCALE * 2}px`,
+          left: `${PIXEL_SCALE * 2}px`,
+        }}
+        className="absolute"
+        alt="Potted Sunflower"
+      />
+    </>
+  );
+};

--- a/src/features/island/collectibles/components/PottedPumpkin.tsx
+++ b/src/features/island/collectibles/components/PottedPumpkin.tsx
@@ -14,7 +14,7 @@ export const PottedPumpkin: React.FC = () => {
           left: `${PIXEL_SCALE * 2}px`,
         }}
         className="absolute"
-        alt="Potted Sunflower"
+        alt="Potted Pumpkin"
       />
     </>
   );


### PR DESCRIPTION
# Description

Potted Pumpkin placement was glitched, when placing it, no image would appear, that was because there was no Potted Pumpkin collectible component.

Also fixed some small typos in this PR

BEFORE: 
![image](https://user-images.githubusercontent.com/94913189/204413957-496dee20-2cee-4da6-9374-ca8829cb2612.png)
AFTER:
![image](https://user-images.githubusercontent.com/94913189/204413988-65c99004-bfa8-486e-9601-e46c54249758.png)



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go ingame and place a potted pumpkin

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
