### PR TITLE
[FIX] Place and remove within one autosave cycle

### DIFF
--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -24,6 +24,7 @@ describe("Construct building", () => {
       constructBuilding({
         state: { ...GAME_STATE, bumpkin: undefined },
         action: {
+          id: "123",
           type: "building.constructed",
           name: "Water Well",
           coordinates: {
@@ -45,6 +46,7 @@ describe("Construct building", () => {
           },
         },
         action: {
+          id: "123",
           type: "building.constructed",
           name: "Water Well",
           coordinates: {
@@ -97,6 +99,7 @@ describe("Construct building", () => {
           },
         },
         action: {
+          id: "123",
           type: "building.constructed",
           name: "Water Well",
           coordinates: {
@@ -123,6 +126,7 @@ describe("Construct building", () => {
           balance: new Decimal(0),
         },
         action: {
+          id: "123",
           type: "building.constructed",
           name: "Water Well",
           coordinates: {
@@ -149,6 +153,7 @@ describe("Construct building", () => {
           balance: new Decimal(100),
         },
         action: {
+          id: "123",
           type: "building.constructed",
           name: "Water Well",
           coordinates: {
@@ -179,6 +184,7 @@ describe("Construct building", () => {
         balance: initialSFL,
       },
       action: {
+        id: "123",
         type: "building.constructed",
         name: "Water Well",
         coordinates: {
@@ -214,6 +220,7 @@ describe("Construct building", () => {
         },
       },
       action: {
+        id: "123",
         type: "building.constructed",
         name: "Fire Pit",
         coordinates: {
@@ -235,6 +242,7 @@ describe("Construct building", () => {
         inventory: { Wood: new Decimal(20), Stone: new Decimal(100) },
       },
       action: {
+        id: "123",
         type: "building.constructed",
         name: "Fire Pit",
         coordinates: {
@@ -247,6 +255,7 @@ describe("Construct building", () => {
 
     expect(state.buildings["Fire Pit"]).toHaveLength(1);
     expect(state.buildings["Fire Pit"]?.[0]).toEqual({
+      id: expect.any(String),
       coordinates: { x: 1, y: 2 },
       readyAt: dateNow + 30 * 1000,
       createdAt: dateNow,
@@ -278,6 +287,7 @@ describe("Construct building", () => {
         },
       },
       action: {
+        id: "123",
         type: "building.constructed",
         name: "Water Well",
         coordinates: {
@@ -289,6 +299,7 @@ describe("Construct building", () => {
     });
     expect(state.buildings["Water Well"]).toHaveLength(2);
   });
+
   it("does not affect existing Buildings when constructing new Water Well", () => {
     const buildings = {
       "Water Well": [
@@ -326,6 +337,7 @@ describe("Construct building", () => {
         },
       },
       action: {
+        id: "123",
         type: "building.constructed",
         name: "Water Well",
         coordinates: {
@@ -344,6 +356,7 @@ describe("Construct building", () => {
           id: "1",
         },
         {
+          id: "123",
           coordinates: {
             x: 1,
             y: 2,

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -15,6 +15,7 @@ export enum CONSTRUCT_BUILDING_ERRORS {
 export type ConstructBuildingAction = {
   type: "building.constructed";
   name: BuildingName;
+  id: string;
   coordinates: {
     x: number;
     y: number;
@@ -82,7 +83,8 @@ export function constructBuilding({
   const buildingInventory = stateCopy.inventory[action.name] || new Decimal(0);
   const placed = stateCopy.buildings[action.name] || [];
 
-  const newBuilding: Omit<PlacedItem, "id"> = {
+  const newBuilding: PlacedItem = {
+    id: action.id,
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + building.constructionSeconds * 1000,

--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -21,6 +21,7 @@ describe("Place building", () => {
       placeBuilding({
         state: { ...GAME_STATE, bumpkin: undefined },
         action: {
+          id: "123",
           type: "building.placed",
           name: "Water Well",
           coordinates: {
@@ -42,6 +43,7 @@ describe("Place building", () => {
           },
         },
         action: {
+          id: "123",
           type: "building.placed",
           name: "Water Well",
           coordinates: {
@@ -94,6 +96,7 @@ describe("Place building", () => {
           },
         },
         action: {
+          id: "123",
           type: "building.placed",
           name: "Water Well",
           coordinates: {
@@ -120,6 +123,7 @@ describe("Place building", () => {
       },
 
       action: {
+        id: "123",
         type: "building.placed",
         name: "Water Well",
         coordinates: {
@@ -156,6 +160,7 @@ describe("Place building", () => {
       },
       createdAt: dateNow,
       action: {
+        id: "456",
         type: "building.placed",
         name: "Water Well",
         coordinates: {
@@ -173,6 +178,7 @@ describe("Place building", () => {
       createdAt: dateNow,
     });
     expect(state.buildings["Water Well"]?.[1]).toEqual({
+      id: expect.any(String),
       coordinates: { x: 0, y: 0 },
       readyAt: dateNow + waterWell.constructionSeconds * 1000,
       createdAt: dateNow,

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+// import { randomUUID } from "crypto";
 import { getBumpkinLevel } from "features/game/lib/level";
 import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
@@ -13,6 +14,7 @@ export enum PLACE_BUILDING_ERRORS {
 export type PlaceBuildingAction = {
   type: "building.placed";
   name: BuildingName;
+  id: string;
   coordinates: {
     x: number;
     y: number;
@@ -58,7 +60,8 @@ export function placeBuilding({
     throw new Error(PLACE_BUILDING_ERRORS.NO_UNPLACED_BUILDINGS);
   }
 
-  const newBuilding: Omit<PlacedItem, "id"> = {
+  const newBuilding: PlacedItem = {
+    id: action.id,
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + building.constructionSeconds * 1000,

--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -29,8 +29,8 @@ describe("Place Collectible", () => {
             ],
           },
         },
-
         action: {
+          id: "123",
           type: "collectible.placed",
           name: "Scarecrow",
           coordinates: {
@@ -50,8 +50,8 @@ describe("Place Collectible", () => {
           inventory: {},
           collectibles: {},
         },
-
         action: {
+          id: "123",
           type: "collectible.placed",
           name: "Scarecrow",
           coordinates: {
@@ -72,8 +72,8 @@ describe("Place Collectible", () => {
         },
         collectibles: {},
       },
-
       action: {
+        id: "123",
         type: "collectible.placed",
         name: "Brazilian Flag",
         coordinates: {
@@ -106,6 +106,7 @@ describe("Place Collectible", () => {
       },
       createdAt: date,
       action: {
+        id: "1234",
         type: "collectible.placed",
         name: "Scarecrow",
         coordinates: {
@@ -123,6 +124,7 @@ describe("Place Collectible", () => {
       createdAt: date,
     });
     expect(state.collectibles["Scarecrow"]?.[1]).toEqual({
+      id: expect.any(String),
       coordinates: { x: 0, y: 0 },
       readyAt: date + 5 * 60 * 1000,
       createdAt: date,
@@ -141,8 +143,8 @@ describe("Place Collectible", () => {
           },
           collectibles: {},
         },
-
         action: {
+          id: "123",
           type: "collectible.placed",
           name: "Fire Pit" as CollectibleName,
           coordinates: {

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -18,6 +18,7 @@ export const COLLECTIBLE_PLACE_SECONDS: Partial<
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
   name: CollectibleName;
+  id: string;
   coordinates: {
     x: number;
     y: number;
@@ -62,7 +63,8 @@ export function placeCollectible({
 
   const placed = stateCopy.collectibles[action.name] || [];
   const seconds = COLLECTIBLE_PLACE_SECONDS[action.name] ?? 0;
-  const newCollectiblePlacement: Omit<PlacedItem, "id"> = {
+  const newCollectiblePlacement: PlacedItem = {
+    id: action.id,
     createdAt: createdAt,
     coordinates: action.coordinates,
     readyAt: createdAt + seconds * 1000,

--- a/src/features/game/expansion/placeable/editingMachine.ts
+++ b/src/features/game/expansion/placeable/editingMachine.ts
@@ -78,6 +78,7 @@ export const editingMachine = createMachine<
                 type: action,
                 name: placeable,
                 coordinates: { x, y },
+                id: crypto.randomUUID(),
               } as PlacementEvent)
           ),
         },


### PR DESCRIPTION
# Description

We were generating the placeable item's id on the BE but we require it when removing a placeable so if a user placed/constructed and then removed within an autosave period it failed because the remove action didn't know the id because it wasn't assigned yet. 

I have moved the id generation to the FE.

Fixes [this](https://discord.com/channels/880987707214544966/1043094139979444246/1043094139979444246)

**NEEDS BE MERGE**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests and manual testing

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
