### PR TITLE
[FIX] Remember selected item for food producing buildings

### DIFF
--- a/src/features/island/buildings/components/building/bakery/Bakery.tsx
+++ b/src/features/island/buildings/components/building/bakery/Bakery.tsx
@@ -33,12 +33,8 @@ export const Bakery: React.FC<Props> = ({
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService) {
-    return null;
-  }
-
   const handleCook = (item: ConsumableName) => {
-    craftingService.send({
+    craftingService?.send({
       type: "CRAFT",
       event: "recipe.cooked",
       item,
@@ -49,7 +45,7 @@ export const Bakery: React.FC<Props> = ({
   const handleCollect = () => {
     if (!name) return;
 
-    craftingService.send({
+    craftingService?.send({
       type: "COLLECT",
       item: name,
       event: "recipe.collected",

--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
@@ -33,6 +33,7 @@ export const BakeryModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
+  const [selected, setSelected] = useState<Consumable>(cakeRecipes[0]);
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
@@ -49,6 +50,8 @@ export const BakeryModal: React.FC<Props> = ({
         }}
       >
         <Recipes
+          selected={selected}
+          setSelected={setSelected}
           recipes={cakeRecipes}
           onCook={onCook}
           onClose={onClose}

--- a/src/features/island/buildings/components/building/deli/Deli.tsx
+++ b/src/features/island/buildings/components/building/deli/Deli.tsx
@@ -32,12 +32,8 @@ export const Deli: React.FC<Props> = ({
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService) {
-    return null;
-  }
-
   const handleCook = (item: ConsumableName) => {
-    craftingService.send({
+    craftingService?.send({
       type: "CRAFT",
       event: "recipe.cooked",
       item,
@@ -48,7 +44,7 @@ export const Deli: React.FC<Props> = ({
   const handleCollect = () => {
     if (!name) return;
 
-    craftingService.send({
+    craftingService?.send({
       type: "COLLECT",
       item: name,
       event: "recipe.collected",

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
@@ -33,6 +33,7 @@ export const DeliModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
+  const [selected, setSelected] = useState<Consumable>(deliRecipes[0]);
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
@@ -48,6 +49,8 @@ export const DeliModal: React.FC<Props> = ({
         }}
       >
         <Recipes
+          selected={selected}
+          setSelected={setSelected}
           recipes={deliRecipes}
           onCook={onCook}
           onClose={onClose}

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -32,12 +32,8 @@ export const FirePit: React.FC<Props> = ({
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService) {
-    return null;
-  }
-
   const handleCook = (item: ConsumableName) => {
-    craftingService.send({
+    craftingService?.send({
       type: "CRAFT",
       event: "recipe.cooked",
       item,
@@ -48,7 +44,7 @@ export const FirePit: React.FC<Props> = ({
   const handleCollect = () => {
     if (!name) return;
 
-    craftingService.send({
+    craftingService?.send({
       type: "COLLECT",
       item: name,
       event: "recipe.collected",

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
@@ -33,6 +33,7 @@ export const FirePitModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
+  const [selected, setSelected] = useState<Consumable>(firePitRecipes[0]);
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
@@ -49,6 +50,8 @@ export const FirePitModal: React.FC<Props> = ({
         }}
       >
         <Recipes
+          selected={selected}
+          setSelected={setSelected}
           recipes={firePitRecipes}
           onCook={onCook}
           onClose={onClose}

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -32,10 +32,6 @@ export const Kitchen: React.FC<Props> = ({
   const [showModal, setShowModal] = useState(false);
   const { setToast } = useContext(ToastContext);
 
-  if (!craftingService) {
-    return null;
-  }
-
   const handleCook = (item: ConsumableName) => {
     craftingService?.send({
       type: "CRAFT",

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
@@ -33,6 +33,7 @@ export const KitchenModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
+  const [selected, setSelected] = useState<Consumable>(kitchenRecipes[0]);
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
@@ -48,6 +49,8 @@ export const KitchenModal: React.FC<Props> = ({
         }}
       >
         <Recipes
+          selected={selected}
+          setSelected={setSelected}
           recipes={kitchenRecipes}
           onCook={onCook}
           onClose={onClose}

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { Dispatch, SetStateAction, useContext } from "react";
 import { useActor } from "@xstate/react";
 import Decimal from "decimal.js-light";
 
@@ -24,6 +24,8 @@ import { InProgressInfo } from "../building/InProgressInfo";
 import { MachineInterpreter } from "../../lib/craftingMachine";
 
 interface Props {
+  selected: Consumable;
+  setSelected: Dispatch<SetStateAction<Consumable>>;
   recipes: Consumable[];
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
@@ -31,16 +33,27 @@ interface Props {
   crafting: boolean;
 }
 
+/**
+ * The recipes of a food producing building
+ * @selected The selected food in the interface.  This prop is set in the parent so closing the modal will not reset the selected state.
+ * @setSelected Sets the selected food in the interface.  This prop is set in the parent so closing the modal will not reset the selected state.
+ * @recipes The list of available recipes.
+ * @onClose The close action.
+ * @onCook The cook action.
+ * @crafting Whether the building is in the process of crafting a food item.
+ * @craftingService The crafting service.
+ */
 export const Recipes: React.FC<Props> = ({
+  selected,
+  setSelected,
   recipes,
   onClose,
   onCook,
   crafting,
   craftingService,
 }) => {
-  const [selected, setSelected] = useState<Consumable>(recipes[0]);
   const { setToast } = useContext(ToastContext);
-  const { gameService, shortcutItem } = useContext(Context);
+  const { gameService } = useContext(Context);
 
   const [
     {


### PR DESCRIPTION
# Description

- remember what users selected for food producing buildings

https://user-images.githubusercontent.com/107602352/204593524-db7c1470-fd80-4dd9-a44f-ad0fb2992737.mp4

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- select items for kitchen, deli, bakery and fire pit, exit modal and open them again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
