### PR TITLE
[FIX] Give 2 rusty shovels upon migration

### DIFF
--- a/src/features/game/events/landExpansion/migrate.test.ts
+++ b/src/features/game/events/landExpansion/migrate.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";
-import { canMigrate } from "./migrate";
+import { canMigrate, migrate } from "./migrate";
 
 const GAME_STATE: GameState = { ...TEST_FARM, inventory: {} };
 
@@ -79,5 +79,21 @@ describe("Migrate", () => {
     });
 
     expect(result).toBe(true);
+  });
+
+  it("gives a player 2 Rusty Shovels as part of migration", () => {
+    const result = migrate({
+      state: {
+        ...GAME_STATE,
+        inventory: { Coder: new Decimal(1) },
+      },
+      action: {
+        type: "game.migrated",
+      },
+    });
+
+    expect(result.inventory["Rusty Shovel"]?.toNumber()).toBeGreaterThanOrEqual(
+      2
+    );
   });
 });

--- a/src/features/game/events/landExpansion/migrate.ts
+++ b/src/features/game/events/landExpansion/migrate.ts
@@ -34,5 +34,10 @@ export function migrate({
 
   stateCopy.migrated = true;
 
+  const rustyShovelCount =
+    stateCopy.inventory["Rusty Shovel"] || new Decimal(0);
+
+  stateCopy.inventory["Rusty Shovel"] = rustyShovelCount.add(new Decimal(2));
+
   return stateCopy;
 }


### PR DESCRIPTION
# Description

Give players 2 rusty shovels when migrating to get them out of hairy situations.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
