### PR TITLE
[FIX] Crops disappear after removing water well

### DIFF
--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -48,7 +48,7 @@ function getUnSupportedPlotCount(gameState: GameState): number {
     return count;
   }, 0);
 
-  return plotCount - supportedPlots;
+  return Math.max(plotCount - supportedPlots, 0);
 }
 
 /**


### PR DESCRIPTION
# Description

there is a bug under which the crops disappear when the water well is removed. Upon investigation i found that there is an edge case scenario, when the supported crops are more than plot count. In this case the function returns a negative number and it creates the issue. 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
