### PR TITLE
[FIX] updated the wishing well link to point to v2 on quickswap

### DIFF
--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -243,7 +243,7 @@ export const WishingWellModal: React.FC = () => {
 
   const goToQuickSwap = () => {
     window.open(
-      "https://quickswap.exchange/#/add/0xd1f9c58e33933a993a3891f8acfe05a68e1afc05/ETH",
+      "https://quickswap.exchange/#/add/0xd1f9c58e33933a993a3891f8acfe05a68e1afc05/ETH/v2",
       "_blank"
     );
   };


### PR DESCRIPTION
quickswap defaults to v3 which is not recognised by wishing well

# Description

The current link for "Add liquidity" button points to https://quickswap.exchange/#/add/0xd1f9c58e33933a993a3891f8acfe05a68e1afc05/ETH which defaults to V3 pool.
Since Wishing well uses V2 pool, updated the link to point to that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran tests locally - all passed

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
