### PR TITLE
[FIX] Prevent placing placeables on constructing lands

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -71,6 +71,17 @@ describe("detectCollisions", () => {
     expect(hasCollision).toBe(false);
   });
 
+  it("returns true if checking collision on a building land", () => {
+    const state: GameState = cloneDeep(TEST_FARM);
+    state.expansions = [{ createdAt: 0, readyAt: Date.now() + 86400000 }];
+
+    const position: Position = { x: 0, y: 0, height: 1, width: 1 };
+
+    const hasCollision = detectCollision(state, position);
+
+    expect(hasCollision).toBe(true);
+  });
+
   it("returns true if a collision is detected with an expansion resource", () => {
     const state: GameState = cloneDeep(TEST_FARM);
 


### PR DESCRIPTION
# Description

- prevent placing placeables on constructing lands

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/204979479-1fed21dc-dfe6-4224-921f-3d632e7f8f91.png)|![image](https://user-images.githubusercontent.com/107602352/204979494-a2791574-e70f-42c1-ac92-07a4fd108994.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- expand the land and try placing placeables on constructing lands

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes