### PR TITLE
[FIX] Allow withdraw of item when another of type is placed

### DIFF
--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -150,7 +150,7 @@ const makeLimitedItemsById = (items: LimitedItemRecipeWithMintedAt[]) => {
   }, {} as Record<number, LimitedItemRecipeWithMintedAt>);
 };
 
-const LEVEL_REQUIREMENT = 5;
+export const RETREAT_LEVEL_REQUIREMENT = 5;
 
 export function startGoblinVillage(authContext: AuthContext) {
   return createMachine<Context, BlockchainEvent, GoblinMachineState>(
@@ -236,7 +236,7 @@ export function startGoblinVillage(authContext: AuthContext) {
 
                   const bumpkinLevel = getBumpkinLevel(bumpkin.experience);
 
-                  return bumpkinLevel < LEVEL_REQUIREMENT;
+                  return bumpkinLevel < RETREAT_LEVEL_REQUIREMENT;
                 },
               },
               {

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -19,6 +19,7 @@ import { wallet } from "lib/blockchain/wallet";
 import { canWithdraw } from "../lib/bankUtils";
 
 import {
+  CollectibleName,
   getKeys,
   isLimitedItem,
   LimitedItemName,
@@ -124,6 +125,19 @@ export const WithdrawItems: React.FC<Props> = ({
       const totalHungryChicks = inventory["Chicken"].sub(totalChicksLayingEggs);
 
       return new Decimal(totalHungryChicks);
+    }
+
+    const { collectibles } = state;
+
+    if (
+      itemName in collectibles &&
+      collectibles[itemName as CollectibleName]?.length
+    ) {
+      const numberInInventory = inventory[itemName as CollectibleName];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const numberPlaced = collectibles[itemName as CollectibleName]!.length;
+
+      return numberInInventory?.minus(numberPlaced) || new Decimal(0);
     }
 
     return inventory[itemName] || new Decimal(0);

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -559,4 +559,58 @@ describe("canWithdraw", () => {
 
     expect(enabled).toBeTruthy();
   });
+
+  it("withdraws a collectible when a player has two and one is placed", () => {
+    const enabled = canWithdraw({
+      item: "Apprentice Beaver",
+      game: {
+        ...TEST_FARM,
+        inventory: {
+          "Apprentice Beaver": new Decimal(2),
+        },
+        collectibles: {
+          "Apprentice Beaver": [
+            {
+              id: "123",
+              createdAt: 0,
+              coordinates: { x: 1, y: 1 },
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(enabled).toBeTruthy();
+  });
+
+  it("does not withdraw a collectible when a player has two and both are placed", () => {
+    const enabled = canWithdraw({
+      item: "Apprentice Beaver",
+      game: {
+        ...TEST_FARM,
+        inventory: {
+          "Apprentice Beaver": new Decimal(2),
+        },
+        collectibles: {
+          "Apprentice Beaver": [
+            {
+              id: "123",
+              createdAt: 0,
+              coordinates: { x: 1, y: 1 },
+              readyAt: 0,
+            },
+            {
+              id: "345",
+              createdAt: 0,
+              coordinates: { x: 1, y: 1 },
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(enabled).toBeFalsy();
+  });
 });

--- a/src/features/goblins/bank/lib/bankUtils.ts
+++ b/src/features/goblins/bank/lib/bankUtils.ts
@@ -67,6 +67,12 @@ export function canWithdraw({ item, game }: CanWithdrawArgs) {
     item in game.collectibles &&
     game.collectibles[item as CollectibleName]?.length
   ) {
+    const numberInInventory = game.inventory[item];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const numberPlaced = game.collectibles[item as CollectibleName]!.length;
+
+    if (numberInInventory?.gt(numberPlaced)) return true;
+
     return false;
   }
 


### PR DESCRIPTION
# Description

**NOTE: Has a backend fix to go along with this. Make sure to merge both**

Currently if you have two of the same collectible and one of them is placed, withdraw is blocked even for the one that isn't placed. This PR fixes that issue.

Eg. I have two Apprentice Beavers. I have one placed. I can now withdraw the other one.

While working on this ticket I noticed that we didn't have any goblin machine state modals in the Retreat so you could never move out of the `withdrawing` state. I am brought the modals in and have tidied up the logic for level gating the retreat map. I haven't changed the level gate logic just fixed the visual conditions.

<img width="365" alt="Screen Shot 2022-12-03 at 2 19 48 pm" src="https://user-images.githubusercontent.com/17863697/205420518-25c7e56b-e83a-48b0-9d77-0cc13b28c80d.png">


Fixes [NFTs can't be withdrawn if you own multiple and only 1 is placed](https://discord.com/channels/880987707214544966/1046903860008062986/1046903860008062986)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests. Manual testing with multiple of a single collectible and checking the withdraw functionality.

- Have multiple of a collectible
- Place one or more but not all
- Go to Bank
- Confirm the correct number of non placed of that collectible shows
- Withdraw successfully

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
