### PR TITLE
[CHORE] Enable precision for all item counts

### DIFF
--- a/src/components/InventoryTabContent.tsx
+++ b/src/components/InventoryTabContent.tsx
@@ -17,6 +17,8 @@ import { getKeys } from "features/game/types/craftables";
 import { useMakeDefaultInventoryItem } from "components/hooks/useGetDefaultInventoryItem";
 import { useHasBoostForItem } from "./hooks/useHasBoostForItem";
 import { KNOWN_IDS } from "features/game/types";
+import { setPrecision } from "lib/utils/formatNumber";
+import Decimal from "decimal.js-light";
 
 const ITEM_CARD_MIN_HEIGHT = "148px";
 
@@ -49,19 +51,23 @@ export const InventoryTabContent = ({
 
   const divRef = useRef<HTMLDivElement>(null);
 
-  const inventoryMap = inventoryItems.reduce((acc, curr) => {
-    const category = inventoryCategories.find(
-      (category) => curr in tabItems[category].items
-    );
+  const inventoryMap = inventoryItems
+    .filter((item) =>
+      setPrecision(new Decimal(inventory[item] || 0)).greaterThan(0)
+    )
+    .reduce((acc, curr) => {
+      const category = inventoryCategories.find(
+        (category) => curr in tabItems[category].items
+      );
 
-    if (category) {
-      const currentItems = acc[category] || [];
+      if (category) {
+        const currentItems = acc[category] || [];
 
-      acc[category] = [...currentItems, curr];
-    }
+        acc[category] = [...currentItems, curr];
+      }
 
-    return acc;
-  }, {} as Record<string, InventoryItemName[]>);
+      return acc;
+    }, {} as Record<string, InventoryItemName[]>);
 
   useMakeDefaultInventoryItem({
     setDefaultSelectedItem,

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -10,7 +10,7 @@ import selectBoxTR from "assets/ui/select/selectbox_tr.png";
 import timer from "assets/icons/timer.png";
 import cancel from "assets/icons/cancel.png";
 import { useLongPress } from "lib/utils/hooks/useLongPress";
-import { shortenCount } from "lib/utils/formatNumber";
+import { setPrecision, shortenCount } from "lib/utils/formatNumber";
 import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -70,15 +70,20 @@ export const Box: React.FC<BoxProps> = ({
   const labelRef = useRef<HTMLDivElement>(null);
   const labelCheckerRef = useRef<HTMLDivElement>(null);
 
+  const precisionCount = setPrecision(new Decimal(count || 0));
+
   // re-execute function on count change
-  useEffect(() => setShortCount(shortenCount(count)), [count]);
+  useEffect(
+    () => setShortCount(shortenCount(precisionCount)),
+    [precisionCount]
+  );
 
   const canClick = !locked && !disabled;
 
   const longPressEvents = useLongPress(
     (e) => (canClick ? onClick?.() : undefined),
     undefined,
-    count,
+    precisionCount,
     {
       delay: 500,
       interval: 20,
@@ -89,8 +94,7 @@ export const Box: React.FC<BoxProps> = ({
     ? longPressEvents
     : { onClick: canClick ? onClick : undefined };
 
-  const showCountLabel =
-    !locked && !hideCount && !!count && count.greaterThan(0);
+  const showCountLabel = !locked && !hideCount && precisionCount.greaterThan(0);
 
   // shift count label position to right if out of parent div or viewport bounds on hover
   // restore count label position when not on hover
@@ -258,7 +262,9 @@ export const Box: React.FC<BoxProps> = ({
             }}
           >
             <Label type="default" className="px-0.5 text-xxs">
-              {isHover && !showHiddenCountLabel ? count.toString() : shortCount}
+              {isHover && !showHiddenCountLabel
+                ? precisionCount.toString()
+                : shortCount}
             </Label>
           </div>
         )}
@@ -275,7 +281,7 @@ export const Box: React.FC<BoxProps> = ({
             }}
           >
             <Label type="default" className="px-0.5 text-xxs">
-              {count.toString()}
+              {precisionCount.toString()}
             </Label>
           </div>
         )}

--- a/src/features/community/scientist/components/Incubator.tsx
+++ b/src/features/community/scientist/components/Incubator.tsx
@@ -27,6 +27,7 @@ import empty_incubator from "features/community/assets/incubator/empty-small.gif
 import active_incubator from "features/community/assets/incubator/algae-small.gif";
 import token from "features/community/assets/icons/token.png";
 import { TAB_CONTENT_HEIGHT } from "features/island/hud/components/inventory/Basket";
+import { setPrecision } from "lib/utils/formatNumber";
 
 export const Incubator: React.FC = () => {
   const [machine, send] = useMachine(incubateMachine);
@@ -296,9 +297,9 @@ export const Incubator: React.FC = () => {
                       setSelected("active");
                       setSelectedActiveIncubator(incubator.id);
                       setSelectedIncubatorEarnings(
-                        incubator.earnings
-                          ?.toDecimalPlaces(4, Decimal.ROUND_DOWN)
-                          .toString()
+                        setPrecision(
+                          new Decimal(incubator.earnings || 0)
+                        ).toString()
                       );
                     }}
                     key={index}

--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -235,7 +235,12 @@ export const WishingWellModal: React.FC = () => {
 
   const { state: wishingWell, errorCode } = machine.context;
 
-  useUiRefresher({ active: machine.matches("granted") });
+  useUiRefresher({
+    active:
+      machine.matches("granted") ||
+      machine.matches("waiting") ||
+      machine.matches("wished"),
+  });
 
   const handleClose = () => {
     send("CLOSING");

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -48,7 +48,7 @@ export const Crops: React.FC = () => {
     });
   };
 
-  const cropAmount = new Decimal(inventory[selected.name] || 0);
+  const cropAmount = setPrecision(new Decimal(inventory[selected.name] || 0));
   const noCrop = cropAmount.lessThanOrEqualTo(0);
   const displaySellPrice = (crop: Crop) =>
     getSellPrice(crop, inventory, state.bumpkin as Bumpkin);
@@ -99,7 +99,7 @@ export const Crops: React.FC = () => {
               key={item.name}
               onClick={() => setSelected(item)}
               image={ITEM_DETAILS[item.name].image}
-              count={setPrecision(inventory[item.name] ?? new Decimal(0))}
+              count={inventory[item.name]}
               parentDivRef={divRef}
             />
           ))}

--- a/src/features/island/farmerQuest/components/FarmerQuestProgress.tsx
+++ b/src/features/island/farmerQuest/components/FarmerQuestProgress.tsx
@@ -10,6 +10,7 @@ import Decimal from "decimal.js-light";
 import { Button } from "components/ui/Button";
 import { ITEM_IDS } from "features/game/types/bumpkin";
 import { getImageUrl } from "features/goblins/tailor/TabContent";
+import { setPrecision } from "lib/utils/formatNumber";
 
 const PROGRESS_BAR_DIMENSIONS = {
   width: 80,
@@ -124,7 +125,7 @@ export const FarmerQuestProgress: React.FC = () => {
                 PIXEL_SCALE * PROGRESS_BAR_DIMENSIONS.width + 8
               }px`,
             }}
-          >{`${new Decimal(progress).toDecimalPlaces(4, Decimal.ROUND_DOWN)}/${
+          >{`${setPrecision(new Decimal(progress))}/${
             quest.requirement
           }`}</span>
         </div>

--- a/src/features/island/hud/components/inventory/utils/inventory.test.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
-import { getBasketItems } from "./utils/inventory";
+import { getBasketItems } from "./inventory";
 
-describe("basket", () => {
+describe("getBasketItems", () => {
   it("creates an empty basket", () => {
     const basket = getBasketItems({});
 
@@ -116,6 +116,11 @@ describe("basket", () => {
   });
   it("excludes rare items from the basket", () => {
     const basket = getBasketItems({ Scarecrow: new Decimal(3) });
+
+    expect(basket).toEqual({});
+  });
+  it("excludes item dusts from the basket", () => {
+    const basket = getBasketItems({ Wheat: new Decimal(0.00009) });
 
     expect(basket).toEqual({});
   });

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -7,6 +7,7 @@ import {
 } from "features/game/types/craftables";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
+import { setPrecision } from "lib/utils/formatNumber";
 
 const PLACEABLE_DIMENSIONS = {
   ...BUILDINGS_DIMENSIONS,
@@ -14,16 +15,20 @@ const PLACEABLE_DIMENSIONS = {
 };
 
 export const getBasketItems = (inventory: Inventory) => {
-  return getKeys(inventory).reduce((acc, itemName) => {
-    if (itemName in PLACEABLE_DIMENSIONS) {
-      return acc;
-    }
+  return getKeys(inventory)
+    .filter((itemName) =>
+      setPrecision(new Decimal(inventory[itemName] || 0)).greaterThan(0)
+    )
+    .reduce((acc, itemName) => {
+      if (itemName in PLACEABLE_DIMENSIONS) {
+        return acc;
+      }
 
-    return {
-      ...acc,
-      [itemName]: inventory[itemName],
-    };
-  }, {} as Inventory);
+      return {
+        ...acc,
+        [itemName]: inventory[itemName],
+      };
+    }, {} as Inventory);
 };
 
 export const getChestItems = (state: GameState) => {

--- a/src/lib/utils/formatNumber.ts
+++ b/src/lib/utils/formatNumber.ts
@@ -82,4 +82,4 @@ export const shortenCount = (count: Decimal | undefined): string => {
 };
 
 export const setPrecision = (number: Decimal) =>
-  number.todp(4, Decimal.ROUND_DOWN);
+  number.toDecimalPlaces(4, Decimal.ROUND_DOWN);


### PR DESCRIPTION
# Description

- fix all item counts for the <Box/> component to 4 decimal places
  - hide count if less than 0.0001 of an item is available
- hide item from inventory if less than 0.0001 of an item is available
  - for land expansion, hide SFTs from chest if owned - placed amount is less than 0.0001
- disable sell button for crops if less than 0.0001 of a crop is available

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/205433604-baaa316a-c898-4513-bdfc-230e2bd08aff.png)|![image](https://user-images.githubusercontent.com/107602352/205433636-d6a7ace4-2edc-492f-8075-3bd3b5f13d35.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- initialize inventory with different amount for each item (either with a lot of decimal places or less than 0.0001)
- check inventory for old farm and land expansion
- sell crops in old farm and land expansion

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
