### PR TITLE
[FIX] Loading Text on Helios Travel

### DIFF
--- a/src/features/helios/Helios.tsx
+++ b/src/features/helios/Helios.tsx
@@ -59,6 +59,7 @@ export const Helios: React.FC = () => {
           x={5}
           y={-17}
           onTravelDialogOpened={() => gameService.send("SAVE")}
+          isTravelAllowed={!gameState.matches("autosaving")}
         />
       </div>
     </>


### PR DESCRIPTION
# Description

When clicking the boat on Helios, an autosave gets triggered (which is working as intended). However, the problem is that there is no "Loading..." text blocking the view until autosave completes (like it does on player's island). Without this blocking UI, the player can technically travel faster than the autosave completes, resulting in lost gameState progress from helios.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I purchased white tulips on helios then immediately clicked the boat. I confirmed I received a "Loading..." text, similar to how it works on player's island.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
