### PR TITLE
[FEAT] Revert crop disable Sell 1 and 10

### DIFF
--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -53,13 +53,12 @@ export const Crops: React.FC = () => {
   const displaySellPrice = (crop: Crop) =>
     getSellPrice(crop, inventory, state.bumpkin as Bumpkin);
 
-  const handleSellOneOrLess = () => {
-    const sellAmount = cropAmount.gte(1) ? new Decimal(1) : cropAmount;
-    sell(sellAmount);
+  const handleSellOne = () => {
+    sell(new Decimal(1));
   };
-  const handleSellTenOrLess = () => {
-    const sellAmount = cropAmount.gte(10) ? new Decimal(10) : cropAmount;
-    sell(sellAmount);
+
+  const handleSellTen = () => {
+    sell(new Decimal(10));
   };
 
   const handleSellAll = () => {
@@ -70,7 +69,7 @@ export const Crops: React.FC = () => {
   // ask confirmation if crop supply is greater than 1
   const openConfirmationModal = () => {
     if (cropAmount.equals(1)) {
-      handleSellOneOrLess();
+      handleSellOne();
     } else {
       showSellAllModal(true);
     }
@@ -116,29 +115,29 @@ export const Crops: React.FC = () => {
             {selected.description}
           </span>
 
-          <div className="border-t border-white w-full mt-2 pt-1">
-            <div className="flex justify-center items-end">
+          <div className="border-t border-white w-full my-2 pt-1">
+            <div className="flex justify-center items-center">
               <img src={token} className="h-5 mr-1" />
               {isPriceBoosted && <img src={lightning} className="h-6 me-2" />}
-              <span className="text-xs text-shadow text-center mt-2 ">
+              <span className="text-xs text-shadow text-center">
                 {`${displaySellPrice(selected)}`}
               </span>
             </div>
           </div>
           <div className="flex sm:flex-col w-full">
             <Button
-              disabled={noCrop}
+              disabled={cropAmount.lessThan(1)}
               className="text-xs mt-1 mr-1 sm:mr-0 flex-1"
-              onClick={handleSellOneOrLess}
+              onClick={handleSellOne}
             >
-              {`Sell ${cropAmount.gte(1) ? "1" : "<1"}`}
+              Sell 1
             </Button>
             <Button
-              disabled={noCrop}
+              disabled={cropAmount.lessThan(10)}
               className="text-xs mt-1 flex-1"
-              onClick={handleSellTenOrLess}
+              onClick={handleSellTen}
             >
-              {`Sell ${cropAmount.gte(10) ? "10" : "<10"}`}
+              Sell 10
             </Button>
           </div>
           <Button

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -53,8 +53,9 @@ export const Crops: React.FC = () => {
   const displaySellPrice = (crop: Crop) =>
     getSellPrice(crop, inventory, state.bumpkin as Bumpkin);
 
-  const handleSellOne = () => {
-    sell(new Decimal(1));
+  const handleSellOneOrLess = () => {
+    const sellAmount = cropAmount.gte(1) ? new Decimal(1) : cropAmount;
+    sell(sellAmount);
   };
 
   const handleSellTen = () => {
@@ -69,7 +70,7 @@ export const Crops: React.FC = () => {
   // ask confirmation if crop supply is greater than 1
   const openConfirmationModal = () => {
     if (cropAmount.equals(1)) {
-      handleSellOne();
+      handleSellOneOrLess();
     } else {
       showSellAllModal(true);
     }
@@ -79,6 +80,13 @@ export const Crops: React.FC = () => {
     showSellAllModal(false);
   };
 
+  const sellOneButtonText = () => {
+    // In the case of 0 the button will be disabled
+    if (cropAmount.greaterThan(1) || cropAmount.eq(0)) return "Sell 1";
+
+    return `Sell ${cropAmount}`;
+  };
+
   useEffect(() => {
     setIsPriceBoosted(hasSellBoost(inventory, state.bumpkin as Bumpkin));
   }, [inventory, state.inventory]);
@@ -86,7 +94,7 @@ export const Crops: React.FC = () => {
   return (
     <div className="flex flex-col-reverse sm:flex-row">
       <div
-        className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
+        className="w-full sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
         style={{ maxHeight: TAB_CONTENT_HEIGHT }}
         ref={divRef}
       >
@@ -126,11 +134,11 @@ export const Crops: React.FC = () => {
           </div>
           <div className="flex sm:flex-col w-full">
             <Button
-              disabled={cropAmount.lessThan(1)}
+              disabled={cropAmount.eq(0)}
               className="text-xs mt-1 mr-1 sm:mr-0 flex-1"
-              onClick={handleSellOne}
+              onClick={handleSellOneOrLess}
             >
-              Sell 1
+              {sellOneButtonText()}
             </Button>
             <Button
               disabled={cropAmount.lessThan(10)}

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -258,11 +258,11 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
             className="w-8 sm:w-12 img-highlight mt-1"
             alt={selectedName}
           />
-          <div className="border-t border-white w-full mt-2 pt-1">
-            <div className="flex justify-center items-center scale-75 sm:scale-100">
+          <div className="border-t border-white w-full my-2 pt-1">
+            <div className="flex justify-center items-center">
               <img src={timer} className="h-5 me-2" />
               {isTimeBoosted && <img src={lightning} className="h-6 me-2" />}
-              <span className="text-xs text-center mt-2">
+              <span className="text-xs text-center">
                 {secondsToString(
                   getCropTime(
                     crop?.name,
@@ -277,14 +277,14 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
                 )}
               </span>
             </div>
-            <div className="flex justify-center items-end">
+            <div className="flex justify-center items-center mt-1">
               <img src={token} className="h-5 mr-1" />
               <span
-                className={classNames("text-xs text-center mt-2", {
+                className={classNames("text-xs text-center", {
                   "text-red-500": lessFunds(),
                 })}
               >
-                {`${price}`}
+                {price.equals(0) ? `Free` : `${price}`}
               </span>
             </div>
           </div>


### PR DESCRIPTION
# Description

Following to discord bugs [Link](https://discord.com/channels/880987707214544966/1049249747824807977)
- Disable sell 1 when crops < 1
- Disable sell 10 when crops < 10
- Margin and alignment adjustment on seed price and timer (font was too small)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## UIX inspection

https://user-images.githubusercontent.com/12151051/205631316-919a8a73-adb4-4b58-9499-4ddbb46fe953.mp4

## Yarn Test
![image](https://user-images.githubusercontent.com/12151051/205631426-b10f457c-2d8f-42b3-ab3d-a5a4d2e381cc.png)

Note: the warning already exist before this change was made.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE], or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
