### PR TITLE
[FEAT] Bring back grub shop timer

### DIFF
--- a/src/features/helios/components/grubShop/components/GrubShopModal.tsx
+++ b/src/features/helios/components/grubShop/components/GrubShopModal.tsx
@@ -63,6 +63,8 @@ export const GrubShopModal: React.FC<Props> = ({ onClose }) => {
     state.grubOrdersFulfilled?.find((fulfilled) => fulfilled.id === order.id)
   );
 
+  const isAllFullFilled = fulFilledOrders.length === grubShop.orders.length;
+
   const hiddenPositionStart = 3 + fulFilledOrders.length;
 
   const bumpkinParts: Partial<Equipped> = {
@@ -107,66 +109,78 @@ export const GrubShopModal: React.FC<Props> = ({ onClose }) => {
         >
           <div className="flex flex-col-reverse sm:flex-row">
             <div
-              className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
+              className="w-full sm:w-3/5 overflow-y-auto 
+              scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1
+              flex justify-between sm:flex-col flex-wrap"
               style={{ maxHeight: TAB_CONTENT_HEIGHT }}
             >
-              {Object.values(grubShop.orders).map((item, index) => {
-                const isFulfilled = !!state.grubOrdersFulfilled?.find(
-                  (order) => order.id === item.id
-                );
-                return (
-                  <Box
-                    isSelected={selectedId === item.id}
-                    key={`${item.name}-${index}`}
-                    onClick={() => setSelectedId(item.id)}
-                    image={
-                      index <= hiddenPositionStart
-                        ? ITEM_DETAILS[item.name].image
-                        : questionMark
-                    }
-                    showOverlay={isFulfilled}
-                    overlayIcon={
-                      <img
-                        src={confirm}
-                        id="confirm"
-                        alt="confirm"
-                        className="relative object-contain"
-                        style={{
-                          width: `${PIXEL_SCALE * 12}px`,
-                        }}
-                      />
-                    }
-                    disabled={index > hiddenPositionStart}
-                    count={
-                      index <= hiddenPositionStart
-                        ? state.inventory[item.name]
-                        : undefined
-                    }
-                  />
-                );
-              })}
+              <div className="flex flex-wrap">
+                {Object.values(grubShop.orders).map((item, index) => {
+                  const isFulfilled = !!state.grubOrdersFulfilled?.find(
+                    (order) => order.id === item.id
+                  );
+                  return (
+                    <Box
+                      isSelected={selectedId === item.id}
+                      key={`${item.name}-${index}`}
+                      onClick={() => setSelectedId(item.id)}
+                      image={
+                        index <= hiddenPositionStart
+                          ? ITEM_DETAILS[item.name].image
+                          : questionMark
+                      }
+                      showOverlay={isFulfilled}
+                      overlayIcon={
+                        <img
+                          src={confirm}
+                          id="confirm"
+                          alt="confirm"
+                          className="relative object-contain"
+                          style={{
+                            width: `${PIXEL_SCALE * 12}px`,
+                          }}
+                        />
+                      }
+                      disabled={index > hiddenPositionStart}
+                      count={
+                        index <= hiddenPositionStart
+                          ? state.inventory[item.name]
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </div>
+              {isAllFullFilled && (
+                <div className="flex items-start sm:flex-col ml-2 mt-2">
+                  <p className="text-xs my-1 mr-2">More order in</p>
+                  <Label type="info" className="flex flex-row items-center">
+                    <img src={stopwatch} className="w-3 left-0 mr-1" />
+                    {`${secondsToString(secondsLeft as number, {
+                      length: "medium",
+                    })} left`}
+                  </Label>
+                </div>
+              )}
             </div>
             {selected && (
               <OuterPanel className="w-full flex-1">
-                <Label
-                  type={selectedFulFilled ? "success" : "info"}
-                  className="flex justify-center items-center"
-                >
-                  {selectedFulFilled ? (
-                    <span className="text-center text-xxs">
-                      Order fulfilled
-                    </span>
-                  ) : (
-                    <>
-                      <img src={stopwatch} className="w-3 left-0 mr-1" />
-                      <span className="mt-0.5">{`${secondsToString(
-                        secondsLeft as number,
-                        { length: "medium" }
-                      )} left`}</span>
-                    </>
-                  )}
-                </Label>
-                <div className="flex flex-col justify-center items-center p-2 ">
+                <div className="flex flex-col justify-center items-center p-2 relative">
+                  <Label
+                    type={selectedFulFilled ? "success" : "info"}
+                    className="flex justify-center items-center mb-1"
+                  >
+                    {selectedFulFilled ? (
+                      `Order fulfilled`
+                    ) : (
+                      <>
+                        <img src={stopwatch} className="w-3 left-0 mr-1" />
+                        {`${secondsToString(secondsLeft as number, {
+                          length: "medium",
+                        })} left`}
+                      </>
+                    )}
+                  </Label>
                   <span className="text-center">{selected.name}</span>
                   <img
                     src={ITEM_DETAILS[selected.name].image}

--- a/src/features/helios/components/grubShop/components/GrubShopModal.tsx
+++ b/src/features/helios/components/grubShop/components/GrubShopModal.tsx
@@ -153,7 +153,7 @@ export const GrubShopModal: React.FC<Props> = ({ onClose }) => {
               </div>
               {isAllFullFilled && (
                 <div className="flex items-start sm:flex-col ml-2 mt-2">
-                  <p className="text-xs my-1 mr-2">More order in</p>
+                  <p className="text-xs my-1 mr-2">More orders in</p>
                   <Label type="info" className="flex flex-row items-center">
                     <img src={stopwatch} className="w-3 left-0 mr-1" />
                     {`${secondsToString(secondsLeft as number, {

--- a/src/features/helios/components/grubShop/components/GrubShopModal.tsx
+++ b/src/features/helios/components/grubShop/components/GrubShopModal.tsx
@@ -158,7 +158,7 @@ export const GrubShopModal: React.FC<Props> = ({ onClose }) => {
                     <img src={stopwatch} className="w-3 left-0 mr-1" />
                     {`${secondsToString(secondsLeft as number, {
                       length: "medium",
-                    })} left`}
+                    })}`}
                   </Label>
                 </div>
               )}


### PR DESCRIPTION
# Description

Resolving discord bugs [Link](https://discord.com/channels/880987707214544966/1048968177016647752)
- Fixing grub shop label stretching
- Bring back the grub shop timer if only all of the orders get fulfilled

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## UIX Inspection

https://user-images.githubusercontent.com/12151051/205682983-b2ee1d88-b2e9-4f9c-99fb-9b4971ed0346.mp4


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
