### PR TITLE
[FIX] Remember selected recipes after switching pages

### DIFF
--- a/src/features/island/buildings/components/building/bakery/Bakery.tsx
+++ b/src/features/island/buildings/components/building/bakery/Bakery.tsx
@@ -169,6 +169,7 @@ export const Bakery: React.FC<Props> = ({
         onClose={() => setShowModal(false)}
         onCook={handleCook}
         crafting={!!crafting}
+        itemInProgress={name}
         craftingService={craftingService}
       />
     </>

--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -21,6 +21,7 @@ interface Props {
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
   crafting: boolean;
+  itemInProgress?: ConsumableName;
   craftingService?: MachineInterpreter;
 }
 export const BakeryModal: React.FC<Props> = ({
@@ -28,6 +29,7 @@ export const BakeryModal: React.FC<Props> = ({
   onCook,
   onClose,
   crafting,
+  itemInProgress,
   craftingService,
 }) => {
   const cakeRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
@@ -37,7 +39,10 @@ export const BakeryModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
-  const [selected, setSelected] = useState<Consumable>(cakeRecipes[0]);
+  const [selected, setSelected] = useState<Consumable>(
+    cakeRecipes.find((recipe) => recipe.name === itemInProgress) ||
+      cakeRecipes[0]
+  );
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>

--- a/src/features/island/buildings/components/building/deli/Deli.tsx
+++ b/src/features/island/buildings/components/building/deli/Deli.tsx
@@ -156,6 +156,7 @@ export const Deli: React.FC<Props> = ({
         onClose={() => setShowModal(false)}
         onCook={handleCook}
         crafting={!!crafting}
+        itemInProgress={name}
         craftingService={craftingService}
       />
     </>

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -21,6 +21,7 @@ interface Props {
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
   crafting: boolean;
+  itemInProgress?: ConsumableName;
   craftingService?: MachineInterpreter;
 }
 export const DeliModal: React.FC<Props> = ({
@@ -28,6 +29,7 @@ export const DeliModal: React.FC<Props> = ({
   onCook,
   onClose,
   crafting,
+  itemInProgress,
   craftingService,
 }) => {
   const deliRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
@@ -37,7 +39,10 @@ export const DeliModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
-  const [selected, setSelected] = useState<Consumable>(deliRecipes[0]);
+  const [selected, setSelected] = useState<Consumable>(
+    deliRecipes.find((recipe) => recipe.name === itemInProgress) ||
+      deliRecipes[0]
+  );
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -154,6 +154,7 @@ export const FirePit: React.FC<Props> = ({
         onClose={() => setShowModal(false)}
         onCook={handleCook}
         crafting={!!crafting}
+        itemInProgress={name}
         craftingService={craftingService}
       />
     </>

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -24,6 +24,7 @@ interface Props {
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
   crafting: boolean;
+  itemInProgress?: ConsumableName;
   craftingService?: MachineInterpreter;
 }
 export const FirePitModal: React.FC<Props> = ({
@@ -31,6 +32,7 @@ export const FirePitModal: React.FC<Props> = ({
   onCook,
   onClose,
   crafting,
+  itemInProgress,
   craftingService,
 }) => {
   const [showTutorial, setShowTutorial] = useState<boolean>(
@@ -43,7 +45,10 @@ export const FirePitModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
-  const [selected, setSelected] = useState<Consumable>(firePitRecipes[0]);
+  const [selected, setSelected] = useState<Consumable>(
+    firePitRecipes.find((recipe) => recipe.name === itemInProgress) ||
+      firePitRecipes[0]
+  );
 
   const bumpkinParts: Partial<Equipped> = {
     body: "Beige Farmer Potion",

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -154,6 +154,7 @@ export const Kitchen: React.FC<Props> = ({
         onClose={() => setShowModal(false)}
         onCook={handleCook}
         crafting={!!crafting}
+        itemInProgress={name}
         craftingService={craftingService}
       />
     </>

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -21,6 +21,7 @@ interface Props {
   onClose: () => void;
   onCook: (name: ConsumableName) => void;
   crafting: boolean;
+  itemInProgress?: ConsumableName;
   craftingService?: MachineInterpreter;
 }
 export const KitchenModal: React.FC<Props> = ({
@@ -28,6 +29,7 @@ export const KitchenModal: React.FC<Props> = ({
   onCook,
   onClose,
   crafting,
+  itemInProgress,
   craftingService,
 }) => {
   const kitchenRecipes = getKeys(CONSUMABLES).reduce((acc, name) => {
@@ -37,7 +39,10 @@ export const KitchenModal: React.FC<Props> = ({
 
     return [...acc, CONSUMABLES[name]];
   }, [] as Consumable[]);
-  const [selected, setSelected] = useState<Consumable>(kitchenRecipes[0]);
+  const [selected, setSelected] = useState<Consumable>(
+    kitchenRecipes.find((recipe) => recipe.name === itemInProgress) ||
+      kitchenRecipes[0]
+  );
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 /**
- * The recipes of a food producing building
+ * The recipes of a food producing building.
  * @selected The selected food in the interface.  This prop is set in the parent so closing the modal will not reset the selected state.
  * @setSelected Sets the selected food in the interface.  This prop is set in the parent so closing the modal will not reset the selected state.
  * @recipes The list of available recipes.


### PR DESCRIPTION
# Description

- upon reloading the home island page, the selected recipe will be default to the one that is aready crafting in progress.  If there are no items in progress, the first item will be selected as usual.

![image](https://user-images.githubusercontent.com/107602352/205699433-3b1d020e-a4c1-47d0-8ac1-b5c050f1d0e1.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- start crafting a recipe in a food producing building (kitchen/bakery/deli/fire pit), go to Helios / any other islands, then come back (or refresh page) and click the buildings again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
