### PR TITLE
[FIX] Correcting kale seed level issue

### DIFF
--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -76,7 +76,7 @@ export const SEEDS: () => Record<SeedName, Seed> = () => ({
   "Kale Seed": {
     sfl: marketRate(5),
     description: "A Bumpkin Power Food!",
-    bumpkinLevel: 6,
+    bumpkinLevel: 7,
     plantSeconds: 24 * 60 * 60,
   },
   ...FRUIT_SEEDS(),


### PR DESCRIPTION
# Description

the bumpkin experience level required for Kale seed is 7 but in the front end, it was 6. This is why a user who tries to buy kale seed at level 6, his autosave call will fail.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
