### PR TITLE
[FIX] Add rusty shovel back to workbench

### DIFF
--- a/src/features/game/events/landExpansion/craftTool.test.ts
+++ b/src/features/game/events/landExpansion/craftTool.test.ts
@@ -64,7 +64,7 @@ describe("craftTool", () => {
     });
 
     expect(state.balance).toEqual(
-      new Decimal(1).minus(WORKBENCH_TOOLS()["Axe"].sfl)
+      new Decimal(1).minus(WORKBENCH_TOOLS["Axe"].sfl)
     );
     expect(state.inventory["Axe"]).toEqual(new Decimal(1));
   });

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -3,7 +3,7 @@ import { getKeys } from "features/game/types/craftables";
 import {
   TreasureToolName,
   TREASURE_TOOLS,
-  WorkbenchTool,
+  Tool,
   WorkbenchToolName,
   WORKBENCH_TOOLS,
 } from "features/game/types/tools";
@@ -11,28 +11,18 @@ import { trackActivity } from "features/game/types/bumpkinActivity";
 import cloneDeep from "lodash.clonedeep";
 
 import { GameState } from "../../types/game";
-import { marketRate } from "features/game/lib/halvening";
 
-type CraftableToolName = WorkbenchToolName | TreasureToolName | "Rusty Shovel";
+type CraftableToolName = WorkbenchToolName | TreasureToolName;
 
 export type CraftToolAction = {
   type: "tool.crafted";
   tool: CraftableToolName;
 };
 
-export const CRAFTABLE_TOOLS: () => Record<
-  CraftableToolName,
-  WorkbenchTool
-> = () => ({
-  ...WORKBENCH_TOOLS(),
-  ...TREASURE_TOOLS(),
-  "Rusty Shovel": {
-    name: "Rusty Shovel",
-    description: "Used to move buildings and collectibles",
-    ingredients: {},
-    sfl: marketRate(5),
-  },
-});
+export const CRAFTABLE_TOOLS: Record<CraftableToolName, Tool> = {
+  ...WORKBENCH_TOOLS,
+  ...TREASURE_TOOLS,
+};
 
 type Options = {
   state: Readonly<GameState>;
@@ -43,7 +33,7 @@ export function craftTool({ state, action }: Options) {
   const stateCopy = cloneDeep(state);
   const bumpkin = stateCopy.bumpkin;
 
-  const tool = CRAFTABLE_TOOLS()[action.tool];
+  const tool = CRAFTABLE_TOOLS[action.tool];
 
   if (!tool) {
     throw new Error("Tool does not exist");

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -11,12 +11,10 @@ import { CROPS } from "../../types/crops";
 import { CAKES } from "../../types/craftables";
 import Decimal from "decimal.js-light";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
-import { CRAFTABLE_TOOLS } from "features/game/events/landExpansion/craftTool";
 import { Consumable } from "features/game/types/consumables";
 
 const crops = CROPS();
 const cakes = CAKES();
-const tools = CRAFTABLE_TOOLS();
 
 /**
  * How much SFL an item is worth
@@ -27,7 +25,6 @@ export const getSellPrice = (
   bumpkin: Bumpkin
 ) => {
   let price = item.sellPrice;
-  const { skills } = bumpkin;
 
   if (!price) {
     return new Decimal(0);
@@ -54,8 +51,7 @@ export const getSellPrice = (
  * To be used as boolean flag
  * Update if more upcoming boosts
  */
-export const hasSellBoost = (inventory: Inventory, bumpkin: Bumpkin) => {
-  const { skills } = bumpkin;
+export const hasSellBoost = (inventory: Inventory) => {
   if (inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
     return true;
   }

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -20,8 +20,7 @@ export type BuyEvent = `${BuyableName} Bought`;
 export type CraftedEvent = `${
   | ToolName
   | WorkbenchToolName
-  | TreasureToolName
-  | "Rusty Shovel"} Crafted`;
+  | TreasureToolName} Crafted`;
 export type ConsumableEvent = `${ConsumableName} Collected`;
 export type SellEvent = `${SellableName} Sold`;
 

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -11,21 +11,20 @@ export type WorkbenchToolName =
   | "Pickaxe"
   | "Stone Pickaxe"
   | "Iron Pickaxe"
+  | "Rusty Shovel"
   | "Power Shovel";
 
 export type TreasureToolName = "Sand Shovel";
 
-export type WorkbenchTool = {
-  sfl: Decimal;
-  ingredients: Inventory;
+export interface Tool {
+  name: string;
   description: string;
+  ingredients: Inventory;
+  sfl: Decimal;
   disabled?: boolean;
-};
+}
 
-export const WORKBENCH_TOOLS: () => Record<
-  WorkbenchToolName,
-  WorkbenchTool
-> = () => ({
+export const WORKBENCH_TOOLS: Record<WorkbenchToolName, Tool> = {
   Axe: {
     name: "Axe",
     description: "Used to collect wood",
@@ -58,6 +57,12 @@ export const WORKBENCH_TOOLS: () => Record<
     },
     sfl: marketRate(5),
   },
+  "Rusty Shovel": {
+    name: "Rusty Shovel",
+    description: "Used to move buildings and collectibles",
+    ingredients: {},
+    sfl: marketRate(5),
+  },
   "Power Shovel": {
     name: "Power Shovel",
     description: "Used for landscaping",
@@ -67,21 +72,9 @@ export const WORKBENCH_TOOLS: () => Record<
     },
     sfl: marketRate(5),
   },
-  "Sand Shovel": {
-    name: "Sand Shovel",
-    description: "Used for digging treasure",
-    ingredients: {
-      Wood: new Decimal(20),
-      Stone: new Decimal(5),
-    },
-    sfl: marketRate(25),
-  },
-});
+};
 
-export const TREASURE_TOOLS: () => Record<
-  TreasureToolName,
-  WorkbenchTool
-> = () => ({
+export const TREASURE_TOOLS: Record<TreasureToolName, Tool> = {
   "Sand Shovel": {
     name: "Sand Shovel",
     description: "Used for digging treasure",
@@ -91,4 +84,4 @@ export const TREASURE_TOOLS: () => Record<
     },
     sfl: marketRate(25),
   },
-});
+};

--- a/src/features/helios/components/rustyShovelSeller/RustyShovelSeller.tsx
+++ b/src/features/helios/components/rustyShovelSeller/RustyShovelSeller.tsx
@@ -21,21 +21,15 @@ import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 
 export const RustyShovelSeller: React.FC = () => {
   const { gameService, shortcutItem } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const [{ context }] = useActor(gameService);
   const { setToast } = useContext(ToastContext);
   const [showModal, setShowModal] = useState(false);
-  const stock = state.stock["Rusty Shovel"] || new Decimal(0);
 
-  const { sfl: price } = CRAFTABLE_TOOLS()["Rusty Shovel"];
+  const stock = context.state.stock["Rusty Shovel"] || new Decimal(0);
+  const { sfl: price, name: tool } = CRAFTABLE_TOOLS["Rusty Shovel"];
 
   const craft = (amount: number) => {
-    gameService.send("tool.crafted", {
-      tool: "Rusty Shovel",
-    });
+    gameService.send("tool.crafted", { tool });
 
     setToast({
       icon: token,

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -87,7 +87,7 @@ export const Crops: React.FC = () => {
   };
 
   useEffect(() => {
-    setIsPriceBoosted(hasSellBoost(inventory, state.bumpkin as Bumpkin));
+    setIsPriceBoosted(hasSellBoost(inventory));
   }, [inventory, state.inventory]);
 
   return (

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -17,12 +17,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Stock } from "components/ui/Stock";
 import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 import { Tab } from "components/ui/Tab";
-import {
-  TreasureToolName,
-  TREASURE_TOOLS,
-  WorkbenchToolName,
-  WORKBENCH_TOOLS,
-} from "features/game/types/tools";
+import { WorkbenchToolName, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { getKeys } from "features/game/types/craftables";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Label } from "components/ui/Label";
@@ -52,11 +47,7 @@ const CloseButton = ({ onClose }: { onClose: (e: SyntheticEvent) => void }) => {
 };
 
 export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
-  const craftableItems = { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS };
-
-  const [selectedName, setSelectedName] = useState<
-    WorkbenchToolName | TreasureToolName
-  >("Axe");
+  const [selectedName, setSelectedName] = useState<WorkbenchToolName>("Axe");
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
   const [showCaptcha, setShowCaptcha] = useState(false);
@@ -93,7 +84,7 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
     );
   }
 
-  const selected = craftableItems[selectedName];
+  const selected = WORKBENCH_TOOLS[selectedName];
   const inventory = state.inventory;
 
   const price = selected.sfl;
@@ -228,7 +219,7 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
         >
           <div className="flex flex-col-reverse sm:flex-row">
             <div className="w-full max-h-48 sm:max-h-96 sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
-              {getKeys(craftableItems).map((toolName) => (
+              {getKeys(WORKBENCH_TOOLS).map((toolName) => (
                 <Box
                   isSelected={selectedName === toolName}
                   key={toolName}

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -17,7 +17,12 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Stock } from "components/ui/Stock";
 import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 import { Tab } from "components/ui/Tab";
-import { WorkbenchToolName, WORKBENCH_TOOLS } from "features/game/types/tools";
+import {
+  TreasureToolName,
+  TREASURE_TOOLS,
+  WorkbenchToolName,
+  WORKBENCH_TOOLS,
+} from "features/game/types/tools";
 import { getKeys } from "features/game/types/craftables";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Label } from "components/ui/Label";
@@ -47,9 +52,11 @@ const CloseButton = ({ onClose }: { onClose: (e: SyntheticEvent) => void }) => {
 };
 
 export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
-  const craftableItems = WORKBENCH_TOOLS();
+  const craftableItems = { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS };
 
-  const [selectedName, setSelectedName] = useState<WorkbenchToolName>("Axe");
+  const [selectedName, setSelectedName] = useState<
+    WorkbenchToolName | TreasureToolName
+  >("Axe");
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
   const [showCaptcha, setShowCaptcha] = useState(false);

--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -15,7 +15,8 @@ import { BuildingName, BUILDINGS } from "features/game/types/buildings";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { CONSUMABLES } from "features/game/types/consumables";
-import { getKeys, TOOLS } from "features/game/types/craftables";
+import { getKeys } from "features/game/types/craftables";
+import { WORKBENCH_TOOLS, TREASURE_TOOLS } from "features/game/types/tools";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SEEDS } from "features/game/types/seeds";
 import { Label } from "components/ui/Label";
@@ -33,7 +34,7 @@ export const UNLOCKABLES: Record<BuildingName, InventoryItemName[]> = {
   Deli: getKeys(CONSUMABLES).filter(
     (name) => CONSUMABLES[name].building === "Deli"
   ),
-  Workbench: getKeys(TOOLS),
+  Workbench: getKeys({ ...WORKBENCH_TOOLS, ...TREASURE_TOOLS }),
   "Hen House": ["Chicken", "Egg"],
   "Water Well": [],
   Market: getKeys(SEEDS()),

--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -16,7 +16,7 @@ import { GameState, InventoryItemName } from "features/game/types/game";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { CONSUMABLES } from "features/game/types/consumables";
 import { getKeys } from "features/game/types/craftables";
-import { WORKBENCH_TOOLS, TREASURE_TOOLS } from "features/game/types/tools";
+import { WORKBENCH_TOOLS } from "features/game/types/tools";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SEEDS } from "features/game/types/seeds";
 import { Label } from "components/ui/Label";
@@ -34,7 +34,7 @@ export const UNLOCKABLES: Record<BuildingName, InventoryItemName[]> = {
   Deli: getKeys(CONSUMABLES).filter(
     (name) => CONSUMABLES[name].building === "Deli"
   ),
-  Workbench: getKeys({ ...WORKBENCH_TOOLS, ...TREASURE_TOOLS }),
+  Workbench: getKeys(WORKBENCH_TOOLS),
   "Hen House": ["Chicken", "Egg"],
   "Water Well": [],
   Market: getKeys(SEEDS()),

--- a/src/features/treasureIsland/components/ShovelShopItems.tsx
+++ b/src/features/treasureIsland/components/ShovelShopItems.tsx
@@ -162,7 +162,7 @@ export const ShovelShopItems: React.FC<Props> = ({ onClose }) => {
     >
       <div className="flex flex-col-reverse sm:flex-row">
         <div
-          className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
+          className="w-full sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
           style={{ maxHeight: TAB_CONTENT_HEIGHT }}
         >
           {getKeys(TREASURE_TOOLS).map((toolName) => (

--- a/src/features/treasureIsland/components/ShovelShopItems.tsx
+++ b/src/features/treasureIsland/components/ShovelShopItems.tsx
@@ -41,8 +41,6 @@ const CloseButton = ({ onClose }: { onClose: (e: SyntheticEvent) => void }) => {
 };
 
 export const ShovelShopItems: React.FC<Props> = ({ onClose }) => {
-  const craftableItems = TREASURE_TOOLS();
-
   const [selectedName, setSelectedName] =
     useState<TreasureToolName>("Sand Shovel");
   const { setToast } = useContext(ToastContext);
@@ -55,7 +53,7 @@ export const ShovelShopItems: React.FC<Props> = ({ onClose }) => {
     },
   ] = useActor(gameService);
 
-  const selected = craftableItems[selectedName];
+  const selected = TREASURE_TOOLS[selectedName];
   const inventory = state.inventory;
 
   const price = selected.sfl;
@@ -167,7 +165,7 @@ export const ShovelShopItems: React.FC<Props> = ({ onClose }) => {
           className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
           style={{ maxHeight: TAB_CONTENT_HEIGHT }}
         >
-          {getKeys(craftableItems).map((toolName) => (
+          {getKeys(TREASURE_TOOLS).map((toolName) => (
             <Box
               isSelected={selectedName === toolName}
               key={toolName}


### PR DESCRIPTION
# Description

Added rusty shovel back to workbench, so players who built it dont have to go to Helios.
![image](https://user-images.githubusercontent.com/9656961/206455168-983dc89a-b681-4644-87de-d899b93c002f.png)
![image](https://user-images.githubusercontent.com/9656961/206455406-e4a82d40-fa84-40b4-ab09-7873c0efe8f3.png)


CRAFTABLE_TOOLS, WORKBENCH_TOOLS and TREASURE_TOOLS converted to objects to enable correct type checks. Previously we had name field that was not available in Tool interface and we had Sand Shovel in workbench items while it was not in WorkbenchToolName type. Now typescript highlights all the errors in those objects.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test, yarn test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
