### PR TITLE
[CHANGE] Don't Display Never Withdrawable Items at Goblin Bank

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -134,3 +134,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
 };
+
+// Explicit false check is important, as we also want to check if it's a bool.
+export const isNeverWithdrawable = (itemName: InventoryItemName) =>
+  WITHDRAWABLES[itemName] === false;

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -149,25 +149,27 @@ export const WithdrawItems: React.FC<Props> = ({
       <div className="mt-3">
         <div className="flex items-center border-2 rounded-md border-black p-2 bg-green-background mb-3">
           <span className="text-xs">
-            Items that are{" "}
+            {
+              "Some items cannot be withdrawn. Other items may be restricted when "
+            }
             <a
               href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
               target="_blank"
               rel="noreferrer"
               className="underline"
             >
-              in use
-            </a>{" "}
-            or{" "}
+              {"in use"}
+            </a>
+            {" or are "}
             <a
               href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
               target="_blank"
               rel="noreferrer"
               className="underline"
             >
-              still being built
-            </a>{" "}
-            by the goblins are not available to be withdrawn.
+              {"still being built"}
+            </a>
+            {"."}
           </span>
         </div>
         <h2 className="mb-3">Select items to withdraw</h2>

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -24,6 +24,7 @@ import {
   isLimitedItem,
   LimitedItemName,
 } from "features/game/types/craftables";
+import { isNeverWithdrawable } from "features/game/types/withdrawables";
 import { mintCooldown } from "features/goblins/blacksmith/lib/mintUtils";
 import { getBankItems } from "features/goblins/storageHouse/lib/storageItems";
 
@@ -108,8 +109,8 @@ export const WithdrawItems: React.FC<Props> = ({
       : details;
   };
 
-  const inventoryItems = getKeys(inventory)
-    .filter((item) => inventory[item]?.gt(0))
+  const withdrawableItems = getKeys(inventory)
+    .filter((item) => !isNeverWithdrawable(item) && inventory[item]?.gt(0))
     .sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b]);
 
   const selectedItems = getKeys(selected)
@@ -171,7 +172,7 @@ export const WithdrawItems: React.FC<Props> = ({
         </div>
         <h2 className="mb-3">Select items to withdraw</h2>
         <div className="flex flex-wrap h-fit -ml-1.5">
-          {inventoryItems.map((itemName) => {
+          {withdrawableItems.map((itemName) => {
             const details = makeItemDetails(itemName);
             const gameState = goblinState.context.state;
 
@@ -206,8 +207,8 @@ export const WithdrawItems: React.FC<Props> = ({
             );
           })}
           {/* Pad with empty boxes */}
-          {inventoryItems.length < 4 &&
-            new Array(4 - inventoryItems.length)
+          {withdrawableItems.length < 4 &&
+            new Array(4 - withdrawableItems.length)
               .fill(null)
               .map((_, index) => <Box disabled key={index} />)}
         </div>


### PR DESCRIPTION
# Description

Items which are never possible to withdraw shouldn't be shown at the goblin bank. Displaying these items adds a lot of spam to the UI.

Summary of changes:

- Items which are never withdrawable (i.e. seeds, buildings, etc.) are now hidden from the bankWithdraw UI completely.
- Items that are withdrawable BUT not withdrawable at that moment are shown with the "X" icon (i.e. Woody while wood is recovering, Kuebiko while seeds are in inventory).
- Everything else that is withdrawable remains normally withdrawable in UI.

Before:

![before](https://user-images.githubusercontent.com/103600068/206918378-cf5efc13-74e1-45ff-8926-c24d3013bba1.png)

After:

(Woody hard-coded in inventory for example purposes)

![after](https://user-images.githubusercontent.com/103600068/206918387-950e4bc9-8828-479d-a0b3-476ee44983dd.png)

## Type of change

Change

# How Has This Been Tested?

Visually, see screenshots.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
