### PR TITLE
[FIX] add close button to airdrop chest

### DIFF
--- a/src/features/game/expansion/components/Airdrop.tsx
+++ b/src/features/game/expansion/components/Airdrop.tsx
@@ -7,6 +7,7 @@ import { Modal } from "react-bootstrap";
 import chest from "src/assets/decorations/treasure_chest.png";
 import token from "src/assets/icons/token_2.png";
 import alerted from "assets/icons/expression_alerted.png";
+import close from "assets/icons/close.png";
 import { Context } from "features/game/GameProvider";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { getKeys } from "features/game/types/craftables";
@@ -55,6 +56,16 @@ export const Airdrop: React.FC = () => {
     <>
       <Modal centered show={showModal} onHide={() => setShowModal(false)}>
         <Panel>
+          <img
+            src={close}
+            className="absolute cursor-pointer z-20"
+            onClick={() => setShowModal(false)}
+            style={{
+              top: `${PIXEL_SCALE * 6}px`,
+              right: `${PIXEL_SCALE * 6}px`,
+              width: `${PIXEL_SCALE * 11}px`,
+            }}
+          />
           <p className="text-center">
             {airdrop.message ?? "Congratulations, you found a reward!"}
           </p>


### PR DESCRIPTION
# Description

The close button was missing on the airdrop model

**After the fix**
![image](https://user-images.githubusercontent.com/9072434/207705495-a7bd5937-3ae2-4609-bce7-33bcd25cf04b.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
