### PR TITLE
[FEAT] Adding React error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { initialise } from "lib/utils/init";
 import { Navigation } from "./Navigation";
 
 import "./styles.css";
+import ErrorBoundary from "features/auth/components/ErrorBoundary";
 
 // Initialise Global Settings
 initialise();
@@ -15,7 +16,9 @@ initialise();
 export const App: React.FC = () => {
   return (
     <Auth.Provider>
-      <Navigation />
+      <ErrorBoundary>
+        <Navigation />
+      </ErrorBoundary>
     </Auth.Provider>
   );
 };

--- a/src/features/auth/components/ErrorBoundary.tsx
+++ b/src/features/auth/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import React, { Component, ReactNode } from "react";
+import ocean from "assets/decorations/ocean.webp";
+import { SomethingWentWrong } from "./SomethingWentWrong";
+import { Modal } from "react-bootstrap";
+import { Panel } from "components/ui/Panel";
+
+interface Props {
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <>
+          <div
+            className="absolute inset-0 bg-repeat w-full h-full"
+            style={{
+              backgroundImage: `url(${ocean})`,
+              backgroundSize: `${64 * PIXEL_SCALE}px`,
+              imageRendering: "pixelated",
+            }}
+          />
+          <Modal show={true} centered>
+            <Panel>
+              <SomethingWentWrong />
+            </Panel>
+          </Modal>
+        </>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
# Description

In this PR, I have placed an error boundary for react over the project so that the UI degrades gracefully if any JS error happens on FE. https://reactjs.org/docs/error-boundaries.html

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/35486909/208004669-519b5bba-b850-4ec5-bba7-f7056a109f3e.png">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
