### PR TITLE
[FIX] Disable scroll into view before placing placeables

### DIFF
--- a/src/features/island/buildings/components/building/henHouse/components/HenHouseModal.tsx
+++ b/src/features/island/buildings/components/building/henHouse/components/HenHouseModal.tsx
@@ -16,7 +16,6 @@ import { Context } from "features/game/GameProvider";
 import { getBuyPrice } from "features/game/events/craft";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
-import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getSupportedChickens } from "features/game/events/landExpansion/utils";
 import { Label } from "components/ui/Label";
@@ -34,7 +33,6 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
       context: { state },
     },
   ] = useActor(gameService);
-  const [scrollIntoView] = useScrollIntoView();
 
   const inventory = state.inventory;
 
@@ -73,7 +71,6 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
       placeable: "Chicken",
       action: "chicken.bought",
     });
-    scrollIntoView(Section.GenesisBlock);
     onClose();
   };
 
@@ -82,7 +79,6 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
       placeable: "Chicken",
       action: "chicken.placed",
     });
-    scrollIntoView(Section.GenesisBlock);
     onClose();
   };
 

--- a/src/features/island/buildings/components/ui/ModalContent.tsx
+++ b/src/features/island/buildings/components/ui/ModalContent.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { BuildingName } from "features/game/types/buildings";
-import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { ListView } from "./ListView";
 import { DetailView } from "./DetailView";
 import Decimal from "decimal.js-light";
@@ -14,7 +13,6 @@ export const ModalContent: React.FC<{ closeModal: () => void }> = ({
   const { gameService } = useContext(Context);
   const [game] = useActor(gameService);
   const { state } = game.context;
-  const [scrollIntoView] = useScrollIntoView();
 
   const [selected, setSelected] = useState<BuildingName | null>(null);
 
@@ -33,7 +31,6 @@ export const ModalContent: React.FC<{ closeModal: () => void }> = ({
       action: hasUnplacedBuildings ? "building.placed" : "building.constructed",
     });
     closeModal();
-    scrollIntoView(Section.GenesisBlock);
   };
 
   if (!selected) {

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -17,7 +17,6 @@ import lightning from "assets/icons/lightning.png";
 import basket from "assets/icons/basket.png";
 
 import { secondsToString } from "lib/utils/time";
-import { useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { getCropTime } from "features/game/events/plant";
 import { getCropTime as getCropTimeLandExpansion } from "features/game/events/landExpansion/plant";
 import { getKeys, SHOVELS, TOOLS } from "features/game/types/craftables";
@@ -40,8 +39,6 @@ interface Prop {
 }
 
 export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
-  const [scrollIntoView] = useScrollIntoView();
-
   const divRef = useRef<HTMLDivElement>(null);
 
   const { inventory, bumpkin, collectibles } = gameState;
@@ -73,10 +70,6 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
 
   const handleItemClick = (item: InventoryItemName) => {
     onSelect(item);
-
-    if (item && ITEM_DETAILS[item].section) {
-      scrollIntoView(ITEM_DETAILS[item].section);
-    }
   };
 
   const basketIsEmpty = Object.values(basketMap).length === 0;

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -3,7 +3,6 @@ import { Box } from "components/ui/Box";
 import { OuterPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { GameState, InventoryItemName } from "features/game/types/game";
-import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import {
   CollectibleName,
   getKeys,
@@ -35,8 +34,6 @@ export const Chest: React.FC<Props> = ({
   closeModal,
   onPlace,
 }: Props) => {
-  const [scrollIntoView] = useScrollIntoView();
-
   const divRef = useRef<HTMLDivElement>(null);
 
   const chestMap = getChestItems(state);
@@ -72,15 +69,10 @@ export const Chest: React.FC<Props> = ({
     onPlace && onPlace(selected);
 
     closeModal();
-    scrollIntoView(Section.GenesisBlock);
   };
 
   const handleItemClick = (item: InventoryItemName) => {
     setSelected(item);
-
-    if (item && ITEM_DETAILS[item].section) {
-      scrollIntoView(ITEM_DETAILS[item].section);
-    }
   };
 
   const basketIsEmpty = getKeys(collectibles).length === 0;


### PR DESCRIPTION
# Description

- since https://github.com/sunflower-land/sunflower-land/pull/1859 sets the initial placeable coordinates to the middle of the screen rather than (0, 0) of the island, scrolling to (0, 0) after pulling out the placeable will be an annoyance to the user.  Therefore the scroll into view effect is removed for these cases.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- attempt to place the following
  - items in the chest
  - buildings
  - chickens

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
