### PR TITLE
[FIX] Restore Deep-Linking to Goblin Trader

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,6 +1,13 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useActor } from "@xstate/react";
-import { Routes, Route, HashRouter, Navigate } from "react-router-dom";
+import {
+  Routes,
+  Route,
+  HashRouter,
+  Navigate,
+  useSearchParams,
+  createSearchParams,
+} from "react-router-dom";
 
 import * as AuthProvider from "features/auth/lib/Provider";
 
@@ -15,6 +22,21 @@ import { CONFIG } from "lib/config";
 import { Community } from "features/community/Community";
 import { Retreat } from "features/retreat/Retreat";
 import { Builder } from "features/builder/Builder";
+
+/**
+ * FarmID must always be passed to the /retreat/:id route.
+ * The problem is that when deep-linking to goblin trader, the FarmID will not be present.
+ * This reacter-router helper component will compute correct route and navigate to retreat.
+ */
+const TraderDeeplinkHandler: React.FC<{ farmId?: number }> = ({ farmId }) => {
+  const [params] = useSearchParams();
+
+  if (!farmId) return null;
+
+  return (
+    <Navigate to={`/retreat/${farmId}?${createSearchParams(params)}`} replace />
+  );
+};
 
 /**
  * Entry point for game which reflects the user session state
@@ -95,7 +117,15 @@ export const Navigation: React.FC = () => {
             {/* {CONFIG.NETWORK !== "mainnet" && (
               <Route path="/helios/:id" element={<Helios key="helios" />} />
             )} */}
-            <Route path="/retreat/:id" element={<Retreat key="helios" />} />
+            <Route path="/retreat">
+              <Route
+                index
+                element={
+                  <TraderDeeplinkHandler farmId={authState.context.farmId} />
+                }
+              />
+              <Route path=":id" element={<Retreat key="helios" />} />
+            </Route>
             {CONFIG.NETWORK === "mumbai" && (
               <Route path="/builder" element={<Builder key="builder" />} />
             )}

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -438,9 +438,7 @@ export const authMachine = createMachine<
           readyToStart: {
             invoke: {
               src: async () => ({
-                skipSplash:
-                  window.location.hash.includes("goblins") ||
-                  window.location.hash.includes("retreat"),
+                skipSplash: window.location.hash.includes("retreat"),
               }),
               onDone: {
                 cond: (_, event) => event.data.skipSplash,
@@ -474,7 +472,7 @@ export const authMachine = createMachine<
             entry: [
               "clearTransactionId",
               (context, event) => {
-                if (window.location.hash.includes("goblins")) return;
+                if (window.location.hash.includes("retreat")) return;
 
                 // When no 'screen' parameter is given to the event
                 const defaultScreen = window.location.hash.includes("land")

--- a/src/features/retreat/Game.tsx
+++ b/src/features/retreat/Game.tsx
@@ -18,7 +18,8 @@ import { Context } from "features/game/GoblinProvider";
 import { useActor } from "@xstate/react";
 import { Modal } from "react-bootstrap";
 import { Panel } from "components/ui/Panel";
-import { Loading } from "features/auth/components";
+import { Loading, Splash } from "features/auth/components";
+import { Forbidden } from "features/auth/components/Forbidden";
 import { ErrorMessage } from "features/auth/ErrorMessage";
 import { ErrorCode } from "lib/errors";
 import {
@@ -115,7 +116,7 @@ export const Game = () => {
                 imageRendering: "pixelated",
               }}
             />
-            {hasRequiredLevel && (
+            {hasRequiredLevel && !goblinState.matches("loading") && (
               <div
                 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
                 style={{
@@ -140,6 +141,11 @@ export const Game = () => {
                 <IslandTravelWrapper />
                 <LostSeal left={sealSpawn[0]} top={sealSpawn[1]} />
               </div>
+            )}
+            {!hasRequiredLevel && !goblinState.matches("loading") && (
+              <Splash>
+                <Forbidden />
+              </Splash>
             )}
           </div>
         </ScrollContainer>


### PR DESCRIPTION
# Description

- Restores deep-link functionality to the GoblinTrader at Retreat.
- Adds "Forbidden" modal when you try to deep-link to Retreat, but do not have required level for access.

### Important Note:

TLDR; Players can still deep-link to goblinTrader, they will just need to selected their login method at splashScreen first.

In the old version of the game, I was able to bypass the splash-screen completely while deep-linking to the game. However, I lost this functionality when "Wallet Connect" and "Sequence" login strategies were introduced, as the authMachine needs to know which login method to use before the game can proceed.

There may be an automated way to figure this out while deep-linking, but is outside the scope of this patch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visually tested deep-linking functionality by running sfl.tools locally and clicking the "purchase" button. Game successfully navigates to goblinTrader in Retreat and auto-opens Trader modal (after signing-in first).
- Visually tested "Forbidden" modal by hard-coding my bumpkin level to 1, then deep-linking to the goblinTrader.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
