### PR TITLE
[FIX] Improve session expired flow

### DIFF
--- a/src/features/auth/components/SessionExpired.tsx
+++ b/src/features/auth/components/SessionExpired.tsx
@@ -1,8 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
+import * as Auth from "features/auth/lib/Provider";
 
 import humanDeath from "assets/npcs/human_death.gif";
+import { Button } from "components/ui/Button";
 
 export const SessionExpired: React.FC = () => {
+  const { authService } = useContext(Auth.Context);
+
   return (
     <div className="flex flex-col text-center text-shadow items-center p-1">
       <div className="flex mb-3 items-center ml-8">
@@ -13,6 +17,7 @@ export const SessionExpired: React.FC = () => {
       <p className="text-center mb-4 text-xs">
         {`It looks like your session has expired. Please refresh the page to continue playing.`}
       </p>
+      <Button onClick={() => authService.send("REFRESH")}>Refresh</Button>
     </div>
   );
 };

--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -1,5 +1,3 @@
-import { removeSession } from "features/auth/actions/login";
-import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { sanitizeHTTPResponse } from "lib/network";
@@ -125,7 +123,7 @@ export async function autosave(request: Request) {
   }
 
   if (response.status === 401) {
-    removeSession(wallet.myAccount as string);
+    throw new Error(ERRORS.SESSION_EXPIRED);
   }
 
   if (response.status === 429) {

--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -1,4 +1,3 @@
-import { removeSession } from "features/auth/actions/login";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -58,7 +57,7 @@ export async function loadSession(
   }
 
   if (response.status === 401) {
-    removeSession(wallet.myAccount as string);
+    throw new Error(ERRORS.SESSION_EXPIRED);
   }
 
   if (response.status >= 400) {

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -907,7 +907,7 @@ export function startGame(authContext: Options) {
         expanding: {
           entry: "setTransactionId",
           invoke: {
-            src: async (context, event) => {
+            src: async (context) => {
               // Autosave just in case
               if (context.actions.length > 0) {
                 await autosave({


### PR DESCRIPTION
# Description

Currently, when a session has expired and we receive a 401 response we were showing the user the Something Went Wrong modal with a `Refresh` button. This button was not doing anything because it was calling the `REFRESH` event inside of the `gameMachine` rather than the `authMachine`.

We have changed this so we now see the session expired modal and the refresh button will actually refresh the `authMachine`.

![Screen Shot 2022-12-19 at 3 54 08 pm](https://user-images.githubusercontent.com/17863697/208350638-ec38768d-877f-4595-86a6-97d2dd8c4a69.png)

Fixes #issue

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
