### PR TITLE
[FIX] Users able to go to old farm after migrated

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -100,7 +100,7 @@ export const Navigation: React.FC = () => {
             <Route
               path="/farm/:id"
               element={
-                authState.context.migrated ? (
+                authState.context.migrated === true ? (
                   <Navigate to={`/land/${authState.context.farmId}`} />
                 ) : (
                   <Humans key="farm" />


### PR DESCRIPTION
# Description

Players are able to return to old farm and perform actions successfully after players are migrated.  At certain circumstances, the game cannot obtain the state of `authState.context.migrated` (it would be undefined) and migrated players can successfully navigate to the old farm to chop wood / craft food etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- not really sure how to test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
