### PR TITLE
[FIX] Disable button for double mints

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctionDetails.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionDetails.tsx
@@ -160,6 +160,27 @@ export const AuctionDetails: React.FC<Props> = ({
     );
   };
 
+  const MintButton = () => {
+    if (isUpcomingItem || isSoldOut) {
+      return null;
+    }
+
+    if (game.inventory[name]) {
+      return <span className="text-sm">Already minted</span>;
+    }
+
+    return (
+      <Button
+        disabled={
+          !isMintStarted || isMintComplete || isMinting || !hasIngredients
+        }
+        onClick={onMint}
+      >
+        Mint
+      </Button>
+    );
+  };
+
   console.log({ isUpcomingItem });
 
   const releasesList = isUpcomingItem ? releases : releases.slice(1);
@@ -206,16 +227,7 @@ export const AuctionDetails: React.FC<Props> = ({
         {makeIngredients(currentRelease?.ingredients)}
       </div>
 
-      {!isUpcomingItem && !isSoldOut && (
-        <Button
-          disabled={
-            !isMintStarted || isMintComplete || isMinting || !hasIngredients
-          }
-          onClick={onMint}
-        >
-          Mint
-        </Button>
-      )}
+      {MintButton()}
 
       {releasesList.length > 0 && (
         <div


### PR DESCRIPTION
# Description

Double mints have now been prevented on the API side.

This PR removes the button once a user has already minted an auctioneer item.