### PR TITLE
[FIX] Withdraw of Crop Boost Collectibles

### DIFF
--- a/src/features/game/components/Withdrawn.tsx
+++ b/src/features/game/components/Withdrawn.tsx
@@ -40,7 +40,7 @@ export const Withdrawn: React.FC = () => {
         <span className="mb-7">
           You can view your tokens by importing the SFL Token to your wallet.
         </span>
-        <Button className="mb-7 sm:w-3/4" onClick={handleAddToken}>
+        <Button className="mb-7 sm:w-3/4 text-xs" onClick={handleAddToken}>
           Import SFL Token to MetaMask
         </Button>
         <span className="mb-4">

--- a/src/features/game/expansion/components/resources/components/ChestReward.tsx
+++ b/src/features/game/expansion/components/resources/components/ChestReward.tsx
@@ -82,22 +82,22 @@ export const ChestReward: React.FC<Props> = ({
                   }`;
 
                   return (
-                    <div key={item.name} className="flex items-center">
+                    <div key={item.name} className="flex items-center my-2">
                       <img
-                        className="w-8 img-highlight mr-2"
+                        className="w-5 img-highlight mr-2"
                         src={ITEM_DETAILS[item.name].image}
                       />
-                      <span className="text-center mb-2">{name}</span>
+                      <span className="text-center">{name}</span>
                     </div>
                   );
                 })}
               {sfl && (
                 <div key="sfl" className="flex items-center my-2">
-                  <img className="w-8 img-highlight mr-2" src={token} />
-                  <span className="text-center mb-2">{`${sfl} SFL`}</span>
+                  <img className="w-5 img-highlight mr-2" src={token} />
+                  <span className="text-center">{`${sfl} SFL`}</span>
                 </div>
               )}
-              <Button onClick={() => close(true)} className="w-full mt-3">
+              <Button onClick={() => close(true)} className="w-full mt-1">
                 Close
               </Button>
             </>

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -146,7 +146,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
-  "Peeled Potato": (game) => !cropIsPlanted({ item: "Potato", game }),
 };
 
 // Explicit false check is important, as we also want to check if it's a bool.

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -31,7 +31,11 @@ type CanWithdrawArgs = {
 };
 
 function cropIsPlanted({ item, game }: CanWithdrawArgs): boolean {
-  return Object.values(game.fields).some((field) => field.name === item);
+  return Object.values(game?.expansions).some((expansion) =>
+    Object.values(expansion.plots ?? {}).some(
+      (plot) => plot.crop && plot.crop.name === item
+    )
+  );
 }
 
 function hasSeeds(inventory: Inventory) {
@@ -39,7 +43,9 @@ function hasSeeds(inventory: Inventory) {
 }
 
 function areAnyCropsPlanted(game: GoblinState): boolean {
-  return Object.values(game.fields).length > 0;
+  return Object.values(game?.expansions).some((expansion) =>
+    Object.values(expansion.plots ?? {}).some((plot) => !!plot.crop)
+  );
 }
 
 function areAnyTreesChopped(game: GoblinState): boolean {

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -146,6 +146,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
+  "Peeled Potato": (game) => !cropIsPlanted({ item: "Potato", game }),
 };
 
 // Explicit false check is important, as we also want to check if it's a bool.

--- a/src/features/goblins/bank/components/WithdrawItems.tsx
+++ b/src/features/goblins/bank/components/WithdrawItems.tsx
@@ -263,7 +263,7 @@ export const WithdrawItems: React.FC<Props> = ({
       </div>
 
       <Button
-        className="my-3"
+        className="mt-3"
         onClick={withdraw}
         disabled={selectedItems.length <= 0}
       >

--- a/src/features/goblins/bank/components/WithdrawTokens.tsx
+++ b/src/features/goblins/bank/components/WithdrawTokens.tsx
@@ -103,7 +103,7 @@ export const WithdrawTokens: React.FC<Props> = ({ onWithdraw }) => {
   return (
     <>
       <div className="flex flex-wrap mt-3">
-        <span className="mb-3 text-base">Choose amount to withdraw</span>
+        <span className="mb-3 text-sm">Choose amount to withdraw</span>
       </div>
       <span className="text-sm">
         {balance.toFixed(2)}SFL is available on-chain

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -2,7 +2,6 @@ import "lib/__mocks__/configMock.ts";
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { canWithdraw } from "./bankUtils";
-import { LandExpansion } from "features/game/types/game";
 
 describe("canWithdraw", () => {
   describe("prevents", () => {
@@ -179,12 +178,21 @@ describe("canWithdraw", () => {
           inventory: {
             "Carrot Sword": new Decimal(1),
           },
-          fields: {
-            0: {
-              name: "Sunflower",
-              plantedAt: Date.now(),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Beetroot", amount: 1, plantedAt: Date.now() },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -196,12 +204,21 @@ describe("canWithdraw", () => {
         item: "Easter Bunny",
         game: {
           ...TEST_FARM,
-          fields: {
-            0: {
-              name: "Carrot",
-              plantedAt: Date.now(),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Carrot", plantedAt: Date.now(), amount: 1 },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -213,12 +230,21 @@ describe("canWithdraw", () => {
         item: "Victoria Sisters",
         game: {
           ...TEST_FARM,
-          fields: {
-            0: {
-              name: "Pumpkin",
-              plantedAt: Date.now(),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Pumpkin", plantedAt: Date.now(), amount: 1 },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -230,12 +256,25 @@ describe("canWithdraw", () => {
         item: "Golden Cauliflower",
         game: {
           ...TEST_FARM,
-          fields: {
-            0: {
-              name: "Cauliflower",
-              plantedAt: Date.now(),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: {
+                    name: "Cauliflower",
+                    plantedAt: Date.now(),
+                    amount: 1,
+                  },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -247,12 +286,21 @@ describe("canWithdraw", () => {
         item: "Mysterious Parsnip",
         game: {
           ...TEST_FARM,
-          fields: {
-            0: {
-              name: "Parsnip",
-              plantedAt: Date.now(),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Parsnip", plantedAt: Date.now(), amount: 1 },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -262,7 +310,24 @@ describe("canWithdraw", () => {
     it("prevents a user from withdrawing a T1 scarecrow while they have crops", () => {
       const enabled = canWithdraw({
         item: "Nancy",
-        game: TEST_FARM,
+        game: {
+          ...TEST_FARM,
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
+        },
       });
 
       expect(enabled).toBeFalsy();
@@ -271,7 +336,24 @@ describe("canWithdraw", () => {
     it("prevents a user from withdrawing a T2 scarecrow while they have crops", () => {
       const enabled = canWithdraw({
         item: "Scarecrow",
-        game: TEST_FARM,
+        game: {
+          ...TEST_FARM,
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
+        },
       });
 
       expect(enabled).toBeFalsy();
@@ -280,7 +362,24 @@ describe("canWithdraw", () => {
     it("prevents a user from withdrawing a T3 scarecrow while they have crops", () => {
       const enabled = canWithdraw({
         item: "Kuebiko",
-        game: TEST_FARM,
+        game: {
+          ...TEST_FARM,
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
+        },
       });
 
       expect(enabled).toBeFalsy();
@@ -293,19 +392,21 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               trees: {
                 0: {
-                  height: 1,
-                  width: 1,
-                  x: 1,
-                  y: 1,
                   wood: {
                     amount: 1,
                     choppedAt: Date.now(),
                   },
+                  x: -3,
+                  y: 3,
+                  height: 2,
+                  width: 2,
                 },
               },
-            } as any as LandExpansion,
+            },
           ],
         },
       });
@@ -320,19 +421,21 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               trees: {
                 0: {
-                  height: 1,
-                  width: 1,
-                  x: 1,
-                  y: 1,
                   wood: {
                     amount: 1,
                     choppedAt: Date.now(),
                   },
+                  x: -3,
+                  y: 3,
+                  height: 2,
+                  width: 2,
                 },
               },
-            } as any as LandExpansion,
+            },
           ],
         },
       });
@@ -347,31 +450,22 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               trees: {
                 0: {
-                  height: 1,
-                  width: 1,
-                  x: 1,
-                  y: 1,
                   wood: {
                     amount: 1,
                     choppedAt: Date.now(),
                   },
+                  x: -3,
+                  y: 3,
+                  height: 2,
+                  width: 2,
                 },
               },
-            } as any as LandExpansion,
-          ],
-          trees: {
-            0: {
-              // Just been chopped
-              choppedAt: Date.now(),
-              wood: new Decimal(3),
-              x: 0,
-              y: 0,
-              width: 2,
-              height: 2,
             },
-          },
+          ],
         },
       });
 
@@ -383,7 +477,20 @@ describe("canWithdraw", () => {
         item: "Kuebiko",
         game: {
           ...TEST_FARM,
-          fields: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
           inventory: {
             "Sunflower Seed": new Decimal(1),
           },
@@ -400,20 +507,21 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               stones: {
                 0: {
-                  height: 1,
+                  x: 0,
+                  y: 3,
                   width: 1,
-                  x: 1,
-                  y: 1,
-                  // Just been mined
+                  height: 1,
                   stone: {
+                    amount: 1,
                     minedAt: Date.now(),
-                    amount: 3,
                   },
                 },
               },
-            } as any as LandExpansion,
+            },
           ],
         },
       });
@@ -428,20 +536,21 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               stones: {
                 0: {
-                  height: 1,
+                  x: 0,
+                  y: 3,
                   width: 1,
-                  x: 1,
-                  y: 1,
-                  // Just been mined
+                  height: 1,
                   stone: {
+                    amount: 1,
                     minedAt: Date.now(),
-                    amount: 3,
                   },
                 },
               },
-            } as any as LandExpansion,
+            },
           ],
         },
       });
@@ -456,28 +565,22 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               iron: {
                 0: {
-                  height: 1,
+                  x: 0,
+                  y: 3,
                   width: 1,
-                  x: 1,
-                  y: 1,
-                  // Just been mined
+                  height: 1,
                   stone: {
+                    amount: 1,
                     minedAt: Date.now(),
-                    amount: 3,
                   },
                 },
               },
-            } as any as LandExpansion,
-          ],
-          iron: {
-            0: {
-              // Just been mined
-              minedAt: Date.now(),
-              amount: new Decimal(2),
             },
-          },
+          ],
         },
       });
 
@@ -491,20 +594,21 @@ describe("canWithdraw", () => {
           ...TEST_FARM,
           expansions: [
             {
+              createdAt: 0,
+              readyAt: 0,
               gold: {
                 0: {
-                  height: 1,
+                  x: 0,
+                  y: 3,
                   width: 1,
-                  x: 1,
-                  y: 1,
-                  // Just been mined
+                  height: 1,
                   stone: {
+                    amount: 1,
                     minedAt: Date.now(),
-                    amount: 3,
                   },
                 },
               },
-            } as any as LandExpansion,
+            },
           ],
         },
       });
@@ -640,7 +744,20 @@ describe("canWithdraw", () => {
         item: "Easter Bunny",
         game: {
           ...TEST_FARM,
-          fields: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -652,7 +769,20 @@ describe("canWithdraw", () => {
         item: "Victoria Sisters",
         game: {
           ...TEST_FARM,
-          fields: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -664,7 +794,21 @@ describe("canWithdraw", () => {
         item: "Golden Cauliflower",
         game: {
           ...TEST_FARM,
-          fields: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -676,7 +820,21 @@ describe("canWithdraw", () => {
         item: "Mysterious Parsnip",
         game: {
           ...TEST_FARM,
-          fields: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -688,7 +846,23 @@ describe("canWithdraw", () => {
         item: "Nancy",
         game: {
           ...TEST_FARM,
-          fields: {},
+          inventory: {
+            Nancy: new Decimal(1),
+          },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -700,7 +874,23 @@ describe("canWithdraw", () => {
         item: "Scarecrow",
         game: {
           ...TEST_FARM,
-          fields: {},
+          inventory: {
+            Scarecrow: new Decimal(1),
+          },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -712,7 +902,21 @@ describe("canWithdraw", () => {
         item: "Kuebiko",
         game: {
           ...TEST_FARM,
-          fields: {},
+          inventory: { Kuebiko: new Decimal(1) },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -724,17 +928,27 @@ describe("canWithdraw", () => {
         item: "Woody the Beaver",
         game: {
           ...TEST_FARM,
-          trees: {
-            0: {
-              // ready to be chopped
-              choppedAt: 0,
-              wood: new Decimal(3),
-              x: 0,
-              y: 0,
-              width: 2,
-              height: 2,
-            },
+          inventory: {
+            "Woody the Beaver": new Decimal(1),
           },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              trees: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  wood: {
+                    amount: 1,
+                    choppedAt: 0,
+                  },
+                },
+              },
+            },
+          ],
         },
       });
 
@@ -746,17 +960,25 @@ describe("canWithdraw", () => {
         item: "Apprentice Beaver",
         game: {
           ...TEST_FARM,
-          trees: {
-            0: {
-              // ready to be chopped
-              choppedAt: 0,
-              wood: new Decimal(3),
-              x: 0,
-              y: 0,
-              width: 2,
-              height: 2,
+          inventory: { "Apprentice Beaver": new Decimal(1) },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              trees: {
+                0: {
+                  wood: {
+                    amount: 1,
+                    choppedAt: 0,
+                  },
+                  x: -3,
+                  y: 3,
+                  height: 2,
+                  width: 2,
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -768,90 +990,171 @@ describe("canWithdraw", () => {
         item: "Foreman Beaver",
         game: {
           ...TEST_FARM,
-          trees: {
-            0: {
-              // ready to be chopped
-              choppedAt: 0,
-              wood: new Decimal(3),
-              x: 0,
-              y: 0,
-              width: 2,
-              height: 2,
-            },
+          inventory: {
+            "Foreman Beaver": new Decimal(1),
           },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              trees: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  wood: {
+                    amount: 1,
+                    choppedAt: 0,
+                  },
+                },
+              },
+            },
+          ],
         },
       });
 
       expect(enabled).toBeTruthy();
     });
 
-    it("enable a user to withdraw kuebiko while they dont have seeds or crops", () => {
+    it("enable a user to withdraw kuebiko while they don't have seeds or crops", () => {
       const enabled = canWithdraw({
         item: "Kuebiko",
         game: {
           ...TEST_FARM,
-          fields: {},
-          inventory: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
+          inventory: {
+            Kuebiko: new Decimal(1),
+          },
         },
       });
 
       expect(enabled).toBeTruthy();
     });
 
-    it("enable a user to withdraw Rock Golem while they dont have stones replenishing", () => {
+    it("enable a user to withdraw Rock Golem while they don't have stones replenishing", () => {
       const enabled = canWithdraw({
         item: "Rock Golem",
         game: {
           ...TEST_FARM,
-          stones: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              iron: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  stone: {
+                    amount: 1,
+                    minedAt: 0,
+                  },
+                },
+              },
+            },
+          ],
         },
       });
 
       expect(enabled).toBeTruthy();
     });
 
-    it("enable a user to withdraw Tunnel Mole while they dont have stones replenishing", () => {
+    it("enable a user to withdraw Tunnel Mole while they don't have stones replenishing", () => {
       const enabled = canWithdraw({
         item: "Tunnel Mole",
         game: {
           ...TEST_FARM,
-          stones: {},
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              stones: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  stone: {
+                    amount: 1,
+                    minedAt: 0,
+                  },
+                },
+              },
+            },
+          ],
         },
       });
 
       expect(enabled).toBeTruthy();
     });
 
-    it("enable a user to withdraw Rocky the Mole while they dont have irons replenishing", () => {
+    it("enable a user to withdraw Rocky the Mole while they don't have irons replenishing", () => {
       const iron = canWithdraw({
         item: "Rocky the Mole",
         game: {
           ...TEST_FARM,
-          iron: {
-            0: {
-              // Available to mine
-              minedAt: 0,
-              amount: new Decimal(2),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              iron: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  stone: {
+                    amount: 1,
+                    minedAt: 0,
+                  },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
       expect(iron).toBeTruthy();
     });
 
-    it("enable a user to withdraw Nugget while they dont have stones replenishing", () => {
+    it("enable a user to withdraw Nugget while they don't have stones replenishing", () => {
       const gold = canWithdraw({
         item: "Nugget",
         game: {
           ...TEST_FARM,
-          gold: {
-            0: {
-              // Available to mine
-              minedAt: 0,
-              amount: new Decimal(2),
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              gold: {
+                0: {
+                  x: 0,
+                  y: 3,
+                  width: 1,
+                  height: 1,
+                  stone: {
+                    amount: 1,
+                    minedAt: 0,
+                  },
+                },
+              },
             },
-          },
+          ],
         },
       });
 
@@ -908,10 +1211,23 @@ describe("canWithdraw", () => {
         item: "Carrot Sword",
         game: {
           ...TEST_FARM,
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                },
+              },
+            },
+          ],
           inventory: {
             "Carrot Sword": new Decimal(1),
           },
-          fields: {},
         },
       });
 
@@ -924,6 +1240,21 @@ describe("canWithdraw", () => {
         game: {
           ...TEST_FARM,
           collectibles: {},
+        },
+      });
+
+      expect(enabled).toBeTruthy();
+    });
+
+    // Hang over from previous bug where we were leaving an empty array against a collectible key if all were removed.
+    it("enables a user to withdraw a collectible that is not placed but has a key in the db with empty array", () => {
+      const enabled = canWithdraw({
+        item: "Apprentice Beaver",
+        game: {
+          ...TEST_FARM,
+          collectibles: {
+            "Apprentice Beaver": [],
+          },
         },
       });
 

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -666,6 +666,35 @@ describe("canWithdraw", () => {
 
       expect(enabled).toBeFalsy();
     });
+
+    it("prevents a user from withdrawing a peeled potato when potato's are planted", () => {
+      const enabled = canWithdraw({
+        item: "Peeled Potato",
+        game: {
+          ...TEST_FARM,
+          inventory: {
+            "Peeled Potato": new Decimal(2),
+          },
+          expansions: [
+            {
+              createdAt: 0,
+              readyAt: 0,
+              plots: {
+                0: {
+                  x: -2,
+                  y: -1,
+                  height: 1,
+                  width: 1,
+                  crop: { name: "Potato", plantedAt: Date.now(), amount: 1 },
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(enabled).toBeFalsy();
+    });
   });
 
   describe("enables", () => {
@@ -1284,5 +1313,34 @@ describe("canWithdraw", () => {
 
       expect(enabled).toBeTruthy();
     });
+  });
+
+  it("enables a user to withdraw a peeled potato when not in use", () => {
+    const enabled = canWithdraw({
+      item: "Peeled Potato",
+      game: {
+        ...TEST_FARM,
+        inventory: {
+          "Peeled Potato": new Decimal(2),
+        },
+        expansions: [
+          {
+            createdAt: 0,
+            readyAt: 0,
+            plots: {
+              0: {
+                x: -2,
+                y: -1,
+                height: 1,
+                width: 1,
+                crop: { name: "Sunflower", plantedAt: Date.now(), amount: 1 },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(enabled).toBeTruthy();
   });
 });

--- a/src/features/island/buildings/components/building/henHouse/components/HenHouseModal.tsx
+++ b/src/features/island/buildings/components/building/henHouse/components/HenHouseModal.tsx
@@ -26,6 +26,7 @@ interface Props {
 
 export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
   const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
 
   const [
     {
@@ -81,6 +82,8 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
     onClose();
   };
 
+  const isSaving = gameState.matches("autosaving");
+
   const Details = () => {
     if (selectedChicken === "buy") {
       return (
@@ -108,11 +111,11 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
               </div>
             </div>
             <Button
-              disabled={!canBuyChicken}
+              disabled={!canBuyChicken || isSaving}
               className="text-xs mt-3 whitespace-nowrap"
               onClick={handleBuy}
             >
-              Buy
+              {isSaving ? "Saving..." : "Buy"}
             </Button>
           </>
         </div>
@@ -137,9 +140,9 @@ export const HenHouseModal: React.FC<Props> = ({ onClose }) => {
           <Button
             className="text-xs mt-3 whitespace-nowrap"
             onClick={handlePlace}
-            disabled={!canPlaceLazyChicken}
+            disabled={!canPlaceLazyChicken || isSaving}
           >
-            Place
+            {isSaving ? "Saving..." : "Place"}
           </Button>
         </div>
       );

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -41,6 +41,7 @@ export const Hud: React.FC = () => {
                 action: "collectible.placed",
               });
             }}
+            isSaving={gameState.matches("autosaving")}
             isFarming
           />
           {landId && <LandId landId={landId} />}

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -25,6 +25,7 @@ interface Props {
   state: GameState;
   closeModal: () => void;
   onPlace?: (name: InventoryItemName) => void;
+  isSaving?: boolean;
 }
 
 const TAB_CONTENT_HEIGHT = 400;
@@ -32,6 +33,7 @@ const TAB_CONTENT_HEIGHT = 400;
 export const Chest: React.FC<Props> = ({
   state,
   closeModal,
+  isSaving,
   onPlace,
 }: Props) => {
   const divRef = useRef<HTMLDivElement>(null);
@@ -122,8 +124,12 @@ export const Chest: React.FC<Props> = ({
             </div>
 
             {onPlace && (
-              <Button className="text-xs w-full mb-1" onClick={handlePlace}>
-                Place on map
+              <Button
+                className="text-xs w-full mb-1"
+                onClick={handlePlace}
+                disabled={isSaving}
+              >
+                {isSaving ? "Saving..." : "Place on map"}
               </Button>
             )}
           </>

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -48,7 +48,7 @@ export const Inventory: React.FC<Props> = ({
       className="flex flex-col items-center fixed z-50"
       style={{
         right: `${PIXEL_SCALE * 3}px`,
-        top: `${PIXEL_SCALE * 50}px`,
+        top: isFarming ? `${PIXEL_SCALE * 50}px` : `${PIXEL_SCALE * 25}px`,
       }}
     >
       <div

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -20,6 +20,7 @@ interface Props {
   shortcutItem?: (item: InventoryItemName) => void;
   onPlace?: (item: InventoryItemName) => void;
   isFarming?: boolean;
+  isSaving?: boolean;
 }
 
 export const Inventory: React.FC<Props> = ({
@@ -27,6 +28,7 @@ export const Inventory: React.FC<Props> = ({
   selectedItem,
   shortcutItem,
   isFarming,
+  isSaving,
   onPlace,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -85,6 +87,7 @@ export const Inventory: React.FC<Props> = ({
           onSelect={handleItemClick}
           selected={selectedItem}
           onPlace={onPlace}
+          isSaving={isSaving}
         />
       </Modal>
 

--- a/src/features/island/hud/components/inventory/InventoryItems.tsx
+++ b/src/features/island/hud/components/inventory/InventoryItems.tsx
@@ -21,6 +21,7 @@ interface Props {
   selected: InventoryItemName;
   onSelect: (name: InventoryItemName) => void;
   onPlace?: (name: InventoryItemName) => void;
+  isSaving?: boolean;
 }
 
 export type TabItems = Record<string, { items: object }>;
@@ -33,6 +34,7 @@ export const InventoryItems: React.FC<Props> = ({
   selected,
   onSelect,
   onPlace,
+  isSaving,
 }) => {
   const [currentTab, setCurrentTab] = useState<Tab>("basket");
 
@@ -82,7 +84,12 @@ export const InventoryItems: React.FC<Props> = ({
         <Basket gameState={state} onSelect={onSelect} selected={selected} />
       )}
       {currentTab === "chest" && (
-        <Chest state={state} closeModal={onClose} onPlace={onPlace} />
+        <Chest
+          state={state}
+          closeModal={onClose}
+          onPlace={onPlace}
+          isSaving={isSaving}
+        />
       )}
     </Panel>
   );


### PR DESCRIPTION
# Description

Crop boost collectibles were unable to be withdrawn if there were still crops planted in the old game (fields key). I have changed the logic to look at crops in expansions only.

I have also disabled the `Place Item` and `Buy/Place` chicken button when an autosave is in progress. The button wouldn't initiate the placing overlay during an autosave.

<img width="372" alt="Screen Shot 2022-12-21 at 10 03 12 pm" src="https://user-images.githubusercontent.com/17863697/208892786-89757fa5-0384-4f86-b900-67641f8585bd.png">

I have also fixed the placement of the inventory button when visiting a farm.

<img width="223" alt="Screen Shot 2022-12-21 at 9 53 25 pm" src="https://user-images.githubusercontent.com/17863697/208892833-cb67f13b-9a3c-436a-ba60-49ed433b3614.png">

Fixes (#[issue](https://discord.com/channels/880987707214544966/1054916027382779904))

**NOTE: API PR NEEDS MERGING WITH THIS**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
