### PR TITLE
[CHORE] Trigger actions on whole balance panel. Minor style fixes.

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -15,36 +15,31 @@ interface Props {
 }
 
 export const Balance: React.FC<Props> = ({ balance }) => {
-  const [isShown, setIsShown] = useState(false);
+  const [showFullBalance, setShowFullBalance] = useState(false);
   const [showDepositModal, setShowDepositModal] = useState(false);
 
   return (
     <>
       <InnerPanel
-        className="fixed z-50 flex items-center cursor-pointer"
+        className="fixed z-50 flex items-center cursor-pointer gap-2 p-1"
         style={{
           top: `${PIXEL_SCALE * 3}px`,
           right: `${PIXEL_SCALE * 3}px`,
         }}
+        onMouseEnter={() => setShowFullBalance(true)}
+        onMouseLeave={() => setShowFullBalance(false)}
+        onClick={() => setShowDepositModal(true)}
       >
         <img
           src={token}
           style={{
             width: `${PIXEL_SCALE * 10}px`,
-            margin: `${PIXEL_SCALE * 1}px`,
           }}
         />
-        <span
-          className="text-white text-base h-7 mx-1"
-          onMouseEnter={() => setIsShown(true)}
-          onMouseLeave={() => setIsShown(false)}
-          onClick={() => setShowDepositModal(true)}
-        >
-          {isShown === false ? (
-            <small>{setPrecision(balance).toString()}</small>
-          ) : (
-            <small>{balance.toString()}</small>
-          )}
+        <span className="text-white text-sm">
+          {showFullBalance
+            ? balance.toString()
+            : setPrecision(balance).toString()}
         </span>
       </InnerPanel>
       <Modal

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -9,22 +9,22 @@ import {
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Equipped } from "features/game/types/bumpkin";
 
-interface Props {
-  className?: string;
+interface OuterPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   hasTabs?: boolean;
+}
+
+interface PanelProps extends OuterPanelProps {
   bumpkinParts?: Partial<Equipped>;
-  style?: React.CSSProperties;
 }
 
 /**
  * Default panel has the double layered pixel effect
  */
-export const Panel: React.FC<Props> = ({
+export const Panel: React.FC<PanelProps> = ({
   children,
-  className,
   hasTabs,
   bumpkinParts,
-  style,
+  ...divProps
 }) => {
   return (
     <>
@@ -41,8 +41,8 @@ export const Panel: React.FC<Props> = ({
           <DynamicNFT bumpkinParts={bumpkinParts} />
         </div>
       )}
-      <OuterPanel className={className} style={style} hasTabs={hasTabs}>
-        <InnerPanel hasTabs={hasTabs}>{children}</InnerPanel>
+      <OuterPanel hasTabs={hasTabs} {...divProps}>
+        <InnerPanel>{children}</InnerPanel>
       </OuterPanel>
     </>
   );
@@ -51,7 +51,11 @@ export const Panel: React.FC<Props> = ({
 /**
  * Light panel with border effect
  */
-export const InnerPanel: React.FC<Props> = ({ children, className, style }) => {
+export const InnerPanel: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+  children,
+  ...divProps
+}) => {
+  const { className, style, ...otherDivProps } = divProps;
   return (
     <div
       className={classNames("bg-brown-300", className)}
@@ -60,6 +64,7 @@ export const InnerPanel: React.FC<Props> = ({ children, className, style }) => {
         padding: `${PIXEL_SCALE * 1}px`,
         ...style,
       }}
+      {...otherDivProps}
     >
       {children}
     </div>
@@ -69,12 +74,12 @@ export const InnerPanel: React.FC<Props> = ({ children, className, style }) => {
 /**
  * A panel with a single layered pixel effect
  */
-export const OuterPanel: React.FC<Props> = ({
+export const OuterPanel: React.FC<OuterPanelProps> = ({
   children,
-  className,
   hasTabs,
-  style,
+  ...divProps
 }) => {
+  const { className, style, ...otherDivProps } = divProps;
   return (
     <div
       className={classNames("bg-brown-600 text-white", className)}
@@ -84,6 +89,7 @@ export const OuterPanel: React.FC<Props> = ({
         ...(hasTabs ? { paddingTop: `${PIXEL_SCALE * 15}px` } : {}),
         ...style,
       }}
+      {...otherDivProps}
     >
       {children}
     </div>


### PR DESCRIPTION
# Description

Previously you had to click on numbers in balance panel to open deposit modal, now whole panel is interactable.
Also made few style fixes, visually nothing changed.

![image](https://user-images.githubusercontent.com/9656961/209206655-49e29c17-6775-44e3-8be4-942679f334fd.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
