### PR TITLE
[FEAT] Web3 Classes -> Functional

### DIFF
--- a/src/features/auth/actions/createAccount.ts
+++ b/src/features/auth/actions/createAccount.ts
@@ -1,3 +1,5 @@
+import { createNewAccount } from "lib/blockchain/AccountMinter";
+import { getNewFarm } from "lib/blockchain/Farm";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -73,9 +75,13 @@ export async function createAccount({
     transactionId,
   });
 
-  await wallet.getAccountMinter().createAccount(transaction);
+  await createNewAccount({
+    ...transaction,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 
-  const farm = await wallet.getFarm().getNewFarm();
+  const farm = await getNewFarm(wallet.web3Provider, wallet.myAccount);
 
   return farm;
 }

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -633,7 +633,6 @@ export const authMachine = createMachine<
           wallet.myAccount
         );
 
-        console.log({ farmAccounts });
         if (farmAccounts?.length === 0) {
           return;
         }
@@ -644,7 +643,6 @@ export const authMachine = createMachine<
           wallet.myAccount as string
         );
 
-        console.log({ createdAt });
         // V1 just support 1 farm per account - in future let them choose between the NFTs they hold
         const farmAccount = farmAccounts[0];
 

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -171,7 +171,7 @@ export const authMachine = createMachine<
 >(
   {
     id: "authMachine",
-    initial: API_URL ? "connectingToMetamask" : "connected",
+    initial: API_URL ? "idle" : "connected",
     states: {
       idle: {
         id: "idle",
@@ -633,6 +633,7 @@ export const authMachine = createMachine<
           wallet.myAccount
         );
 
+        console.log({ farmAccounts });
         if (farmAccounts?.length === 0) {
           return;
         }
@@ -643,6 +644,7 @@ export const authMachine = createMachine<
           wallet.myAccount as string
         );
 
+        console.log({ createdAt });
         // V1 just support 1 farm per account - in future let them choose between the NFTs they hold
         const farmAccount = farmAccounts[0];
 

--- a/src/features/bumpkins/components/DynamicNFT.tsx
+++ b/src/features/bumpkins/components/DynamicNFT.tsx
@@ -39,7 +39,6 @@ export const DynamicNFT: React.FC<Props> = ({
     return null;
   }
 
-  console.log({ showBackground });
   if (!showBackground) {
     delete parts.background;
   }

--- a/src/features/community/lib/communityMachine.ts
+++ b/src/features/community/lib/communityMachine.ts
@@ -8,6 +8,8 @@ import { getOnChainState } from "features/game/actions/onchain";
 import { loadSession } from "features/game/actions/loadSession";
 import { Bumpkin } from "features/game/types/game";
 import { randomID } from "lib/utils/random";
+import { getSessionId } from "lib/blockchain/Sessions";
+import { sflBalanceOf } from "lib/blockchain/Token";
 
 export interface Context {
   balance: Decimal;
@@ -45,9 +47,11 @@ export function startCommunityMachine(authContext: AuthContext) {
           entry: "setTransactionId",
           invoke: {
             src: async (context) => {
-              const balance = await wallet
-                .getToken()
-                .balanceOf(wallet.myAccount as string);
+              const balance = await sflBalanceOf(
+                wallet.web3Provider,
+                wallet.myAccount,
+                wallet.myAccount as string
+              );
 
               const farmId = authContext.farmId as number;
 
@@ -55,9 +59,11 @@ export function startCommunityMachine(authContext: AuthContext) {
                 farmAddress: authContext.address as string,
                 id: Number(authContext.farmId),
               });
-              const sessionIdFn = wallet
-                .getSessionManager()
-                .getSessionId(farmId);
+              const sessionIdFn = getSessionId(
+                wallet.web3Provider,
+                wallet.myAccount,
+                farmId
+              );
               const [onChainState, sessionId] = await Promise.all([
                 onChainStateFn,
                 sessionIdFn,

--- a/src/features/community/merchant/actions/mintFrog.ts
+++ b/src/features/community/merchant/actions/mintFrog.ts
@@ -1,5 +1,6 @@
 import { wallet } from "lib/blockchain/wallet";
 import { communityContracts } from "features/community/lib/communityContracts";
+import { approveSFL } from "lib/blockchain/Token";
 
 type Request = {
   farmId: number;
@@ -18,6 +19,11 @@ export async function mintFrog(request: Request) {
 }
 
 export async function approve(address: string) {
-  const approveToken = await wallet.getToken().approve(address, 100);
+  const approveToken = await approveSFL(
+    wallet.web3Provider,
+    wallet.myAccount,
+    address,
+    100
+  );
   return approveToken;
 }

--- a/src/features/community/merchant/lib/frogMachine.ts
+++ b/src/features/community/merchant/lib/frogMachine.ts
@@ -6,6 +6,8 @@ import { communityContracts } from "features/community/lib/communityContracts";
 import { mintFrog, approve } from "../actions/mintFrog";
 import { ErrorCode } from "lib/errors";
 import { CONFIG } from "lib/config";
+import { getFarms } from "lib/blockchain/Farm";
+import { isTokenApprovedForContract } from "lib/blockchain/Token";
 
 const frogAddress = CONFIG.FROG_CONTRACT;
 
@@ -140,9 +142,11 @@ export const frogMachine = createMachine<Context, FrogEvent, FrogState>(
       check_token: {
         invoke: {
           src: async () => {
-            const isTokenApproved = await wallet
-              .getToken()
-              .isTokenApprovedForContract(frogAddress);
+            const isTokenApproved = await isTokenApprovedForContract(
+              wallet.web3Provider,
+              wallet.myAccount,
+              frogAddress
+            );
 
             return { isTokenApproved };
           },
@@ -194,7 +198,7 @@ export const frogMachine = createMachine<Context, FrogEvent, FrogState>(
       minting: {
         invoke: {
           src: async () => {
-            const farm = await wallet.getFarm()?.getFarms();
+            const farm = await getFarms(wallet.web3Provider, wallet.myAccount);
             const mint = await mintFrog({ farmId: Number(farm[0].tokenId) });
 
             return { mint };

--- a/src/features/farming/hud/actions/transfer.ts
+++ b/src/features/farming/hud/actions/transfer.ts
@@ -1,3 +1,4 @@
+import { transfer } from "lib/blockchain/Farm";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 
@@ -26,9 +27,12 @@ export async function transferAccount(request: Request) {
 
   const data: { success: boolean } = await response.json();
 
-  await wallet
-    .getFarm()
-    .transfer({ to: request.receiver, tokenId: request.farmId });
+  await transfer({
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+    to: request.receiver,
+    tokenId: request.farmId,
+  });
 
   return data;
 }

--- a/src/features/farming/mail/lib/mail.ts
+++ b/src/features/farming/mail/lib/mail.ts
@@ -4,6 +4,7 @@ import Decimal from "decimal.js-light";
 import { fromWei, toBN } from "web3-utils";
 import { Message } from "../types/message";
 import { CONFIG } from "lib/config";
+import { sflBalanceOf, totalSFLSupply } from "lib/blockchain/Token";
 
 const MESSAGES_KEY = "readMessages";
 
@@ -18,10 +19,12 @@ const API_URL = CONFIG.API_URL;
 async function getSFLSupply() {
   const [total, burned] = API_URL
     ? await Promise.all([
-        wallet.getToken().totalSupply(),
-        wallet
-          .getToken()
-          .balanceOf("0x000000000000000000000000000000000000dead"),
+        totalSFLSupply(wallet.web3Provider, wallet.myAccount),
+        sflBalanceOf(
+          wallet.web3Provider,
+          wallet.myAccount,
+          "0x000000000000000000000000000000000000dead"
+        ),
       ])
     : [toBN(0), toBN(0)];
 

--- a/src/features/game/actions/auctioneer.ts
+++ b/src/features/game/actions/auctioneer.ts
@@ -1,4 +1,5 @@
 import { Item } from "features/retreat/components/auctioneer/actions/auctioneerItems";
+import { getInventorySupply } from "lib/blockchain/Inventory";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -77,5 +78,5 @@ export const fetchAuctioneerDrops = async (
 };
 
 export const fetchAuctioneerSupply = (ids: number[]) => {
-  return wallet.getInventory().getSupply(ids);
+  return getInventorySupply(wallet.web3Provider, wallet.myAccount, ids);
 };

--- a/src/features/game/actions/mint.ts
+++ b/src/features/game/actions/mint.ts
@@ -1,3 +1,4 @@
+import { mintCollectible } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -15,10 +16,6 @@ type Request = {
 const API_URL = CONFIG.API_URL;
 
 export async function mint(request: Request) {
-  return mintCollectible(request);
-}
-
-async function mintCollectible(request: Request) {
   const response = await window.fetch(
     `${API_URL}/mint-collectible/${request.farmId}`,
     {
@@ -46,9 +43,11 @@ async function mintCollectible(request: Request) {
 
   const transaction = await response.json();
 
-  const sessionId = await wallet
-    .getSessionManager()
-    .mintCollectible(transaction);
+  const sessionId = await mintCollectible({
+    ...transaction,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 
   return { sessionId, verified: true };
 }

--- a/src/features/game/actions/onChainEvents.ts
+++ b/src/features/game/actions/onChainEvents.ts
@@ -2,7 +2,7 @@ import { wallet } from "lib/blockchain/wallet";
 
 import { ITEM_DETAILS } from "../types/images";
 import { KNOWN_ITEMS } from "../types";
-import { ListingStatus } from "lib/blockchain/Trader";
+import { getFarmSlots, ListingStatus } from "lib/blockchain/Trader";
 import { CONFIG } from "lib/config";
 
 export type OnChainEvent = {
@@ -36,7 +36,7 @@ async function loadPastEvents({
     // metamask.getInventory().getTransfers(farmAddress, block.blockNumber),
     // metamask.getInventory().getBatchTransfers(farmAddress, block.blockNumber),
     // metamask.getToken().getPastDeposits(farmAddress, block.blockNumber),
-    wallet.getTrader().getFarmSlots(farmId),
+    getFarmSlots(wallet.web3Provider, wallet.myAccount, farmId),
   ]);
 
   const recentPurchases = farmTrades.filter(

--- a/src/features/game/actions/onChainEvents.ts
+++ b/src/features/game/actions/onChainEvents.ts
@@ -146,9 +146,7 @@ export async function unseenEvents({
   }
 
   const lastBlock = getLastBlock();
-  console.log({ lastBlock });
   const block = await getCurrentBlock();
-  console.log({ block });
 
   // First time playing the game, so no new events!
   if (!lastBlock) {
@@ -161,7 +159,6 @@ export async function unseenEvents({
     farmId,
     block: lastBlock,
   });
-  console.log({ pastEvents });
 
   const unseen = pastEvents.filter(
     (event) => event.timestamp > lastBlock.timestamp / 1000

--- a/src/features/game/actions/onchain.ts
+++ b/src/features/game/actions/onchain.ts
@@ -9,8 +9,11 @@ import { LIMITED_ITEM_NAMES } from "../types/craftables";
 import { EMPTY } from "../lib/constants";
 import { CONFIG } from "lib/config";
 import { KNOWN_IDS } from "../types";
-import { Recipe } from "lib/blockchain/Sessions";
-import { OnChainBumpkin } from "lib/blockchain/BumpkinDetails";
+import { getMintedAtBatch, getRecipes, Recipe } from "lib/blockchain/Sessions";
+import { loadBumpkins, OnChainBumpkin } from "lib/blockchain/BumpkinDetails";
+import { sflBalanceOf } from "lib/blockchain/Token";
+import { getInventoryBalances } from "lib/blockchain/Inventory";
+import { getFarm } from "lib/blockchain/Farm";
 
 const API_URL = CONFIG.API_URL;
 
@@ -56,11 +59,19 @@ export async function getGameOnChainState({
     return { game: EMPTY };
   }
 
-  const balance = await wallet.getToken().balanceOf(farmAddress);
+  const balance = await sflBalanceOf(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmAddress
+  );
   console.log({ balance, farmAddress });
-  const balances = await wallet.getInventory().getBalances(farmAddress);
+  const balances = await getInventoryBalances(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmAddress
+  );
   console.log({ balances });
-  const bumpkins = await wallet.getBumpkinDetails().loadBumpkins();
+  const bumpkins = await loadBumpkins(wallet.web3Provider, wallet.myAccount);
   console.log({ bumpkins });
 
   const inventory = balancesToInventory(balances);
@@ -91,17 +102,32 @@ export async function getOnChainState({
     return { game: EMPTY, owner: "", limitedItems: [] };
   }
 
-  const balanceFn = wallet.getToken().balanceOf(farmAddress);
-  const balancesFn = wallet.getInventory().getBalances(farmAddress);
-  const farmFn = wallet.getFarm().getFarm(id);
-  const bumpkinFn = wallet.getBumpkinDetails().loadBumpkins();
+  const balanceFn = sflBalanceOf(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmAddress
+  );
+  const balancesFn = getInventoryBalances(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmAddress
+  );
+  const farmFn = getFarm(wallet.web3Provider, wallet.myAccount, id);
+  const bumpkinFn = loadBumpkins(wallet.web3Provider, wallet.myAccount);
 
   // Short term workaround to get data from session contract
-  const recipesFn = wallet.getSessionManager().getRecipes(RECIPES_IDS);
+  const recipesFn = getRecipes(
+    wallet.web3Provider,
+    wallet.myAccount,
+    RECIPES_IDS
+  );
 
-  const mintedAtsFn = wallet
-    .getSessionManager()
-    .getMintedAtBatch(id, RECIPES_IDS);
+  const mintedAtsFn = getMintedAtBatch(
+    wallet.web3Provider,
+    wallet.myAccount,
+    id,
+    RECIPES_IDS
+  );
 
   // Promise all
   const [balance, balances, farm, recipes, mintedAts, bumpkins] =
@@ -138,9 +164,11 @@ export async function getOnChainState({
 export async function getTreasuryItems() {
   if (!API_URL) return {} as Inventory;
 
-  const treasuryItems = await wallet
-    .getInventory()
-    .getBalances(CONFIG.TREASURY_ADDRESS);
+  const treasuryItems = await getInventoryBalances(
+    wallet.web3Provider,
+    wallet.myAccount,
+    CONFIG.TREASURY_ADDRESS
+  );
 
   return balancesToInventory(treasuryItems);
 }

--- a/src/features/game/actions/onchain.ts
+++ b/src/features/game/actions/onchain.ts
@@ -64,15 +64,12 @@ export async function getGameOnChainState({
     wallet.myAccount,
     farmAddress
   );
-  console.log({ balance, farmAddress });
   const balances = await getInventoryBalances(
     wallet.web3Provider,
     wallet.myAccount,
     farmAddress
   );
-  console.log({ balances });
   const bumpkins = await loadBumpkins(wallet.web3Provider, wallet.myAccount);
-  console.log({ bumpkins });
 
   const inventory = balancesToInventory(balances);
   const fields = populateFields(inventory);

--- a/src/features/game/actions/sync.ts
+++ b/src/features/game/actions/sync.ts
@@ -1,3 +1,4 @@
+import { syncProgress } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -12,7 +13,7 @@ type Options = {
   transactionId: string;
 };
 
-export async function syncProgress({
+export async function sync({
   farmId,
   sessionId,
   token,
@@ -43,9 +44,11 @@ export async function syncProgress({
   const transaction = await response.json();
 
   // TODO
-  const newSessionId = await wallet
-    .getSessionManager()
-    .syncProgress(transaction);
+  const newSessionId = await syncProgress({
+    ...transaction,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 
   return { verified: true, sessionId: newSessionId };
 }

--- a/src/features/game/actions/withdraw.ts
+++ b/src/features/game/actions/withdraw.ts
@@ -1,3 +1,4 @@
+import { withdrawItems } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -50,7 +51,11 @@ export async function withdraw({
 
   const transaction = await response.json();
 
-  const newSessionId = await wallet.getSessionManager().withdraw(transaction);
+  const newSessionId = await withdrawItems({
+    ...transaction,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 
   return { sessionId: newSessionId, verified: true };
 }

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -214,7 +214,6 @@ export const Game: React.FC = () => {
     );
   };
 
-  console.log({ state: gameState.value });
   return (
     <>
       <ToastManager />

--- a/src/features/game/expansion/actions/expand.ts
+++ b/src/features/game/expansion/actions/expand.ts
@@ -1,3 +1,4 @@
+import { syncProgress } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -43,5 +44,9 @@ export async function expandRequest(request: Request) {
 export async function expand(request: Request) {
   const response = await expandRequest(request);
 
-  return await wallet.getSessionManager().syncProgress(response);
+  return await syncProgress({
+    ...response,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 }

--- a/src/features/game/expansion/lib/quest/actions/loadQuests.ts
+++ b/src/features/game/expansion/lib/quest/actions/loadQuests.ts
@@ -1,10 +1,16 @@
 import { BUMPKIN_QUEST_IDS, QuestName } from "features/game/types/quests";
+import { hasCompletedQuest } from "lib/blockchain/Quests";
 import { wallet } from "lib/blockchain/wallet";
 
 export async function loadQuests(quests: QuestName[], bumpkinId: number) {
   const IDS = quests.map((name) => BUMPKIN_QUEST_IDS[name]);
 
-  const statuses = await wallet.getQuests().hasCompletedQuest(IDS, bumpkinId);
+  const statuses = await hasCompletedQuest(
+    wallet.web3Provider,
+    wallet.myAccount,
+    IDS,
+    bumpkinId
+  );
   console.log({ statuses });
   return quests.map((name, index) => ({
     name,

--- a/src/features/game/expansion/lib/quest/actions/loadQuests.ts
+++ b/src/features/game/expansion/lib/quest/actions/loadQuests.ts
@@ -11,7 +11,6 @@ export async function loadQuests(quests: QuestName[], bumpkinId: number) {
     IDS,
     bumpkinId
   );
-  console.log({ statuses });
   return quests.map((name, index) => ({
     name,
     isComplete: statuses[index],

--- a/src/features/game/expansion/lib/quest/actions/mintQuestItem.ts
+++ b/src/features/game/expansion/lib/quest/actions/mintQuestItem.ts
@@ -2,11 +2,15 @@ import { wallet } from "lib/blockchain/wallet";
 import { QuestName } from "features/game/types/quests";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
+import { hasCompletedQuest, mintQuestItemOnChain } from "lib/blockchain/Quests";
 
 async function waitForQuest(questId: number, bumpkinId: number): Promise<void> {
-  const statuses = await wallet
-    .getQuests()
-    .hasCompletedQuest([questId], bumpkinId);
+  const statuses = await hasCompletedQuest(
+    wallet.web3Provider,
+    wallet.myAccount,
+    [questId],
+    bumpkinId
+  );
 
   console.log({ statuses: statuses, questId });
   if (statuses[0] === false) {
@@ -79,7 +83,9 @@ export async function mintQuestItem({
       farmId,
     });
 
-  await wallet.getQuests().mintQuestItem({
+  await mintQuestItemOnChain({
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
     bumpkinId,
     deadline,
     questId,

--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -31,6 +31,7 @@ import { auctioneerMachine } from "features/retreat/auctioneer/auctioneerMachine
 import { getBumpkinLevel } from "./level";
 import { randomID } from "lib/utils/random";
 import { OFFLINE_FARM } from "./landData";
+import { getSessionId } from "lib/blockchain/Sessions";
 
 const API_URL = CONFIG.API_URL;
 
@@ -186,9 +187,11 @@ export function startGoblinVillage(authContext: AuthContext) {
               );
 
               // Get session id
-              const sessionIdFn = wallet
-                .getSessionManager()
-                .getSessionId(farmId);
+              const sessionIdFn = getSessionId(
+                wallet.web3Provider,
+                wallet.myAccount,
+                farmId
+              );
 
               const [onChainState, { id, items }, sessionId] =
                 await Promise.all([

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -17,7 +17,6 @@ import {
  * Converts API response into a game state
  */
 export function makeGame(farm: any): GameState {
-  console.log({ farm });
   return {
     inventory: Object.keys(farm.inventory).reduce(
       (items, item) => ({

--- a/src/features/game/lib/visitingMachine.ts
+++ b/src/features/game/lib/visitingMachine.ts
@@ -1,3 +1,4 @@
+import { getFarm } from "lib/blockchain/Farm";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -91,7 +92,11 @@ export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
     {
       services: {
         loadFarmToVisit: async (): Promise<Context | undefined> => {
-          const farmAccount = await wallet.getFarm()?.getFarm(farmToVisitID);
+          const farmAccount = await getFarm(
+            wallet.web3Provider,
+            wallet.myAccount,
+            farmToVisitID
+          );
 
           const { game: onChain, owner } = await getOnChainState({
             farmAddress: farmAccount.account,

--- a/src/features/goblins/tailor/actions/items.ts
+++ b/src/features/goblins/tailor/actions/items.ts
@@ -4,6 +4,7 @@ import { BumpkinItem, BumpkinPart } from "features/game/types/bumpkin";
 import { Release } from "../TabContent";
 import { MOCK_SHOP } from "./mockShopItems";
 import { wallet } from "lib/blockchain/wallet";
+import { loadSupplyBatch } from "lib/blockchain/BumpkinItems";
 
 const API_URL = CONFIG.API_URL;
 
@@ -124,7 +125,7 @@ async function loadItems(): Promise<BumpkinShopItem[]> {
   let supply: string[] = [];
 
   try {
-    supply = await wallet.getBumpkinItems().loadSupplyBatch(ids);
+    supply = await loadSupplyBatch(wallet.web3Provider, wallet.myAccount, ids);
   } catch (e) {
     console.log("Loading supply failed: ", e);
   }

--- a/src/features/goblins/trader/buying/lib/actions/loadFarm.ts
+++ b/src/features/goblins/trader/buying/lib/actions/loadFarm.ts
@@ -1,7 +1,12 @@
+import { getFarmSlots } from "lib/blockchain/Trader";
 import { wallet } from "lib/blockchain/wallet";
 
 export const loadFarmSlots = async (farmId: number) => {
-  const farmSlots = await wallet.getTrader().getFarmSlots(farmId);
+  const farmSlots = await getFarmSlots(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmId
+  );
 
   return { farmSlots };
 };

--- a/src/features/goblins/trader/tradingPost/lib/actions/cancel.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/cancel.ts
@@ -1,3 +1,4 @@
+import { cancelTrade } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -61,7 +62,10 @@ export async function cancelRequest(request: Request): Promise<Response> {
 export async function cancel(request: Request) {
   const response = await cancelRequest(request);
 
-  await wallet
-    .getSessionManager()
-    .cancelTrade({ ...response.payload, signature: response.signature });
+  await cancelTrade({
+    ...response.payload,
+    signature: response.signature,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 }

--- a/src/features/goblins/trader/tradingPost/lib/actions/list.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/list.ts
@@ -6,6 +6,7 @@ import { ERRORS } from "lib/errors";
 
 import { Draft } from "../../../selling/lib/sellingMachine";
 import { getItemUnit } from "features/game/lib/conversion";
+import { listTrade } from "lib/blockchain/Sessions";
 
 const API_URL = CONFIG.API_URL;
 
@@ -77,7 +78,10 @@ export async function listRequest(request: Request): Promise<Response> {
 export async function list(request: Request) {
   const response = await listRequest(request);
 
-  await wallet
-    .getSessionManager()
-    .listTrade({ ...response.payload, signature: response.signature });
+  await listTrade({
+    ...response.payload,
+    signature: response.signature,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 }

--- a/src/features/goblins/trader/tradingPost/lib/actions/loadTradingPost.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/loadTradingPost.ts
@@ -1,12 +1,23 @@
+import { getInventoryBalance } from "lib/blockchain/Inventory";
+import {
+  getFarmSlots,
+  getLimits,
+  getRemainingListings,
+} from "lib/blockchain/Trader";
 import { wallet } from "lib/blockchain/wallet";
 
 export async function loadTradingPost(farmId: number, farmAddress: string) {
   const [remainingListings, farmSlots, freeListings, itemLimits] =
     await Promise.all([
-      wallet.getTrader().getRemainingListings(farmId),
-      wallet.getTrader().getFarmSlots(farmId),
-      wallet.getInventory().getBalance(farmAddress, 713),
-      wallet.getTrader().getLimits(),
+      getRemainingListings(wallet.web3Provider, wallet.myAccount, farmId),
+      getFarmSlots(wallet.web3Provider, wallet.myAccount, farmId),
+      getInventoryBalance(
+        wallet.web3Provider,
+        wallet.myAccount,
+        farmAddress,
+        713
+      ),
+      getLimits(wallet.web3Provider, wallet.myAccount),
     ]);
 
   return { farmSlots, remainingListings, freeListings, itemLimits };

--- a/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
@@ -2,6 +2,7 @@ import { loadSession } from "features/game/actions/loadSession";
 import { getOnChainState } from "features/game/actions/onchain";
 import { getLowestGameState } from "features/game/lib/transforms";
 import { GameState } from "features/game/types/game";
+import { getSessionId } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 
 export const loadUpdatedSession = async (
@@ -12,7 +13,11 @@ export const loadUpdatedSession = async (
 ) => {
   const onChainState = await getOnChainState({ farmAddress, id: farmId });
 
-  const sessionId = await wallet.getSessionManager().getSessionId(farmId);
+  const sessionId = await getSessionId(
+    wallet.web3Provider,
+    wallet.myAccount,
+    farmId
+  );
 
   const response = await loadSession({
     farmId,

--- a/src/features/goblins/trader/tradingPost/lib/actions/purchase.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/purchase.ts
@@ -1,3 +1,4 @@
+import { purchaseTrade } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
@@ -70,7 +71,10 @@ export async function purchaseRequest(request: Request): Promise<Response> {
 export async function purchase(request: Request) {
   const response = await purchaseRequest(request);
 
-  await wallet
-    .getSessionManager()
-    .purchaseTrade({ ...response.payload, signature: response.signature });
+  await purchaseTrade({
+    ...response.payload,
+    signature: response.signature,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 }

--- a/src/features/goblins/wishingWell/WishingWellModal.tsx
+++ b/src/features/goblins/wishingWell/WishingWellModal.tsx
@@ -26,6 +26,7 @@ import { Context } from "features/game/GoblinProvider";
 import { setPrecision } from "lib/utils/formatNumber";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { PIXEL_SCALE } from "features/game/lib/constants";
+import { mintTestnetTokens } from "lib/blockchain/Pair";
 
 type GrantedArgs = Pick<WishingWellTokens, "lockedTime"> & {
   onClose: () => void;
@@ -216,7 +217,9 @@ const NoWish = ({
       <div>
         <Button
           className="text-xs mt-2"
-          onClick={() => wallet.getPair().mintTestnetTokens()}
+          onClick={() =>
+            mintTestnetTokens(wallet.web3Provider, wallet.myAccount)
+          }
         >
           Mint testnet LP tokens
         </Button>

--- a/src/features/goblins/wishingWell/actions/collectFromWell.ts
+++ b/src/features/goblins/wishingWell/actions/collectFromWell.ts
@@ -1,4 +1,5 @@
 import { wallet } from "lib/blockchain/wallet";
+import { collectFromWellOnChain } from "lib/blockchain/WishingWell";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 
@@ -59,7 +60,11 @@ export async function signCollectFromWell({
 }
 
 export async function collectFromWell(transaction: SignedTransaction) {
-  const receipt = await wallet.getWishingWell().collectFromWell(transaction);
+  const receipt = await collectFromWellOnChain({
+    ...transaction,
+    web3: wallet.web3Provider,
+    account: wallet.myAccount,
+  });
 
   return receipt;
 }

--- a/src/features/goblins/wishingWell/actions/loadWishingWell.ts
+++ b/src/features/goblins/wishingWell/actions/loadWishingWell.ts
@@ -1,4 +1,12 @@
+import { getPairBalance } from "lib/blockchain/Pair";
+import { sflBalanceOf } from "lib/blockchain/Token";
 import { wallet } from "lib/blockchain/wallet";
+import {
+  canCollectFromWell,
+  getLockedPeriod,
+  getWellBalance,
+  lastCollectedFromWell,
+} from "lib/blockchain/WishingWell";
 import { CONFIG } from "lib/config";
 import { secondsToString } from "lib/utils/time";
 
@@ -17,14 +25,28 @@ export type WishingWellTokens = {
  * Load Blockchain data for the wishing well
  */
 export async function loadWishingWell(): Promise<WishingWellTokens> {
-  const tokensInWellPromise = wallet.getWishingWell().getBalance();
-  const canCollectPromise = wallet.getWishingWell().canCollect();
-  const lastCollectedPromise = wallet.getWishingWell().lastCollected();
-  const lockedPeriodPromise = wallet.getWishingWell().getLockedPeriod();
-  const lpTokensPromise = wallet.getPair().getBalance();
-  const totalTokensInWellPromise = wallet
-    .getToken()
-    .balanceOf(wishingWellAddress as string);
+  const tokensInWellPromise = getWellBalance(
+    wallet.web3Provider,
+    wallet.myAccount
+  );
+  const canCollectPromise = canCollectFromWell(
+    wallet.web3Provider,
+    wallet.myAccount
+  );
+  const lastCollectedPromise = lastCollectedFromWell(
+    wallet.web3Provider,
+    wallet.myAccount
+  );
+  const lockedPeriodPromise = getLockedPeriod(
+    wallet.web3Provider,
+    wallet.myAccount
+  );
+  const lpTokensPromise = getPairBalance(wallet.web3Provider, wallet.myAccount);
+  const totalTokensInWellPromise = sflBalanceOf(
+    wallet.web3Provider,
+    wallet.myAccount,
+    wishingWellAddress as string
+  );
 
   const [
     myTokensInWell,

--- a/src/features/goblins/wishingWell/wishingWellMachine.ts
+++ b/src/features/goblins/wishingWell/wishingWellMachine.ts
@@ -20,6 +20,7 @@ import { reset } from "features/farming/hud/actions/reset";
 import { fromWei } from "web3-utils";
 import { loadSession } from "features/game/actions/loadSession";
 import { randomID } from "lib/utils/random";
+import { wish } from "lib/blockchain/WishingWell";
 
 export interface Context {
   state: WishingWellTokens;
@@ -159,7 +160,7 @@ export const wishingWellMachine = createMachine<
       wishing: {
         invoke: {
           src: async () => {
-            await wallet.getWishingWell().wish();
+            await wish(wallet.web3Provider, wallet.myAccount);
           },
           onDone: {
             target: "wished",

--- a/src/features/retreat/auctioneer/auctioneerMachine.ts
+++ b/src/features/retreat/auctioneer/auctioneerMachine.ts
@@ -1,7 +1,6 @@
 import { fetchAuctioneerSupply } from "features/game/actions/auctioneer";
 import { mint } from "features/game/actions/mint";
 import { GoblinRetreatItemName } from "features/game/types/craftables";
-import { Inventory } from "lib/blockchain/Inventory";
 import { CONFIG } from "lib/config";
 import Web3 from "web3";
 import { createMachine, Interpreter, assign } from "xstate";
@@ -9,6 +8,7 @@ import { Item } from "../components/auctioneer/actions/auctioneerItems";
 import { escalate } from "xstate/lib/actions";
 import { wallet } from "lib/blockchain/wallet";
 import { randomID } from "lib/utils/random";
+import { getInventorySupply } from "lib/blockchain/Inventory";
 
 export interface Context {
   farmId: number;
@@ -114,7 +114,6 @@ export const auctioneerMachine = createMachine<
                 "base64"
               ).toString("ascii")}`
             );
-            const inventory = new Inventory(web3, wallet.myAccount as string);
 
             const id = setInterval(async () => {
               if (context.auctioneerItems === undefined) {
@@ -122,7 +121,11 @@ export const auctioneerMachine = createMachine<
               }
 
               const ids = context.auctioneerItems.map((item) => item.id);
-              const supply = await inventory.getSupply(ids);
+              const supply = await getInventorySupply(
+                web3,
+                wallet.myAccount as string,
+                ids
+              );
 
               const auctioneerItems = context.auctioneerItems.map(
                 (item, index) => ({

--- a/src/lib/blockchain/AccountMinter.ts
+++ b/src/lib/blockchain/AccountMinter.ts
@@ -5,8 +5,6 @@ import MinterABI from "./abis/AccountMinter.json";
 import { AccountMinter as IAccountMinter } from "./types/AccountMinter";
 import { estimateGasPrice, parseMetamaskError } from "./utils";
 
-const address = CONFIG.ACCOUNT_MINTER_CONTRACT;
-
 export async function getCreatedAt(
   web3: Web3,
   account: string,
@@ -15,11 +13,12 @@ export async function getCreatedAt(
 ): Promise<number> {
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
+  console.log({ web3, account, address, attempts });
   try {
     const createdAt = await (
       new web3.eth.Contract(
         MinterABI as AbiItem[],
-        address as string
+        CONFIG.ACCOUNT_MINTER_CONTRACT as string
       ) as unknown as IAccountMinter
     ).methods
       .farmCreatedAt(address)
@@ -69,7 +68,7 @@ export async function createNewAccount({
     (
       new web3.eth.Contract(
         MinterABI as AbiItem[],
-        address as string
+        CONFIG.ACCOUNT_MINTER_CONTRACT as string
       ) as unknown as IAccountMinter
     ).methods
       .mintAccount(
@@ -119,7 +118,7 @@ export async function getMaxSupply(
   const maxSupply = await (
     new web3.eth.Contract(
       MinterABI as AbiItem[],
-      address as string
+      CONFIG.ACCOUNT_MINTER_CONTRACT as string
     ) as unknown as IAccountMinter
   ).methods
     .maxSupply()

--- a/src/lib/blockchain/AccountMinter.ts
+++ b/src/lib/blockchain/AccountMinter.ts
@@ -13,7 +13,6 @@ export async function getCreatedAt(
 ): Promise<number> {
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  console.log({ web3, account, address, attempts });
   try {
     const createdAt = await (
       new web3.eth.Contract(
@@ -56,14 +55,6 @@ export async function createNewAccount({
 }): Promise<string> {
   const gasPrice = await estimateGasPrice(web3);
 
-  console.log({
-    signature,
-    charity,
-    deadline,
-    fee,
-    bumpkinWearableIds,
-    bumpkinTokenUri,
-  });
   return new Promise((resolve, reject) => {
     (
       new web3.eth.Contract(

--- a/src/lib/blockchain/AccountMinter.ts
+++ b/src/lib/blockchain/AccountMinter.ts
@@ -7,114 +7,123 @@ import { estimateGasPrice, parseMetamaskError } from "./utils";
 
 const address = CONFIG.ACCOUNT_MINTER_CONTRACT;
 
-/**
- * Account minter contract
- */
-export class AccountMinter {
-  private web3: Web3;
-  private account: string;
+export async function getCreatedAt(
+  web3: Web3,
+  account: string,
+  address: string,
+  attempts = 1
+): Promise<number> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  private contract: IAccountMinter;
+  try {
+    const createdAt = await (
+      new web3.eth.Contract(
+        MinterABI as AbiItem[],
+        address as string
+      ) as unknown as IAccountMinter
+    ).methods
+      .farmCreatedAt(address)
+      .call({ from: account });
 
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
-      MinterABI as AbiItem[],
-      address as string
-    ) as unknown as IAccountMinter;
-  }
-
-  public async getCreatedAt(address: string, attempts = 1): Promise<number> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
-
-    try {
-      const createdAt = await this.contract.methods
-        .farmCreatedAt(address)
-        .call({ from: this.account });
-
-      return Number(createdAt);
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.getCreatedAt(address, attempts + 1);
-      }
-
-      throw error;
+    return Number(createdAt);
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return getCreatedAt(web3, account, address, attempts + 1);
     }
-  }
 
-  public async createAccount({
+    throw error;
+  }
+}
+
+export async function createNewAccount({
+  web3,
+  account,
+  signature,
+  charity,
+  deadline,
+  fee,
+  bumpkinWearableIds,
+  bumpkinTokenUri,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  charity: string;
+  deadline: number;
+  fee: string;
+  bumpkinWearableIds: number[];
+  bumpkinTokenUri: string;
+}): Promise<string> {
+  const gasPrice = await estimateGasPrice(web3);
+
+  console.log({
     signature,
     charity,
     deadline,
     fee,
     bumpkinWearableIds,
     bumpkinTokenUri,
-  }: {
-    signature: string;
-    charity: string;
-    deadline: number;
-    fee: string;
-    bumpkinWearableIds: number[];
-    bumpkinTokenUri: string;
-  }): Promise<string> {
-    const gasPrice = await estimateGasPrice(this.web3);
+  });
+  return new Promise((resolve, reject) => {
+    (
+      new web3.eth.Contract(
+        MinterABI as AbiItem[],
+        address as string
+      ) as unknown as IAccountMinter
+    ).methods
+      .mintAccount(
+        signature,
+        charity,
+        deadline,
+        fee,
+        bumpkinWearableIds,
+        bumpkinTokenUri
+      )
+      .send({ from: account, value: fee, gasPrice })
+      .on("error", function (error: any) {
+        console.log({ error });
+        const parsed = parseMetamaskError(error);
 
-    console.log({
-      signature,
-      charity,
-      deadline,
-      fee,
-      bumpkinWearableIds,
-      bumpkinTokenUri,
-    });
-    return new Promise((resolve, reject) => {
-      this.contract.methods
-        .mintAccount(
-          signature,
-          charity,
-          deadline,
-          fee,
-          bumpkinWearableIds,
-          bumpkinTokenUri
-        )
-        .send({ from: this.account, value: fee, gasPrice })
-        .on("error", function (error: any) {
-          console.log({ error });
-          const parsed = parseMetamaskError(error);
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
+}
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
-  }
+export async function getMaxSupply(
+  web3: Web3,
+  account: string,
+  attempts = 0
+): Promise<number> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  public async getMaxSupply(attempts = 0): Promise<number> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
+  const maxSupply = await (
+    new web3.eth.Contract(
+      MinterABI as AbiItem[],
+      address as string
+    ) as unknown as IAccountMinter
+  ).methods
+    .maxSupply()
+    .call({ from: account });
 
-    const maxSupply = await this.contract.methods
-      .maxSupply()
-      .call({ from: this.account });
-
-    return Number(maxSupply);
-  }
+  return Number(maxSupply);
 }

--- a/src/lib/blockchain/BumpkinDetails.ts
+++ b/src/lib/blockchain/BumpkinDetails.ts
@@ -18,28 +18,16 @@ export type OnChainBumpkin = {
   wardrobe: string;
 };
 
-/*
- * Bumpkin details contract
- */
-export class BumpkinDetails {
-  private web3: Web3;
-  private account: string;
-
-  private contract: IBumpkinDetails;
-
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-
-    this.contract = new this.web3.eth.Contract(
+export async function loadBumpkins(
+  web3: Web3,
+  account: string
+): Promise<OnChainBumpkin[]> {
+  return (
+    new web3.eth.Contract(
       BumpkinDetailsABI as AbiItem[],
       address as string
-    ) as unknown as IBumpkinDetails;
-  }
-
-  public async loadBumpkins(): Promise<OnChainBumpkin[]> {
-    return this.contract.methods
-      .loadBumpkins(wallet.myAccount as string)
-      .call({ from: this.account });
-  }
+    ) as unknown as IBumpkinDetails
+  ).methods
+    .loadBumpkins(wallet.myAccount as string)
+    .call({ from: account });
 }

--- a/src/lib/blockchain/BumpkinItems.ts
+++ b/src/lib/blockchain/BumpkinItems.ts
@@ -44,7 +44,6 @@ export async function balanceOf(
 ): Promise<number> {
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  console.log({ account: account, id });
   try {
     const balance: string = await (
       new web3.eth.Contract(

--- a/src/lib/blockchain/Farm.ts
+++ b/src/lib/blockchain/Farm.ts
@@ -20,6 +20,7 @@ export async function getFarms(
 ): Promise<FarmAccount[]> {
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
+  console.log({ web3, account, attempts });
   try {
     const accounts = await new web3.eth.Contract(
       FarmABI as AbiItem[],

--- a/src/lib/blockchain/Farm.ts
+++ b/src/lib/blockchain/Farm.ts
@@ -20,7 +20,6 @@ export async function getFarms(
 ): Promise<FarmAccount[]> {
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  console.log({ web3, account, attempts });
   try {
     const accounts = await new web3.eth.Contract(
       FarmABI as AbiItem[],

--- a/src/lib/blockchain/Inventory.ts
+++ b/src/lib/blockchain/Inventory.ts
@@ -13,134 +13,167 @@ const address = CONFIG.INVENTORY_CONTRACT;
 
 export type ItemSupply = Record<InventoryItemName, Decimal>;
 
-/**
- * Inventory contract
- */
-export class Inventory {
-  private web3: Web3;
-  private account: string;
+async function loadSupplyBatch(
+  web3: Web3,
+  account: string,
+  ids: number[],
+  attempts = 0
+): Promise<string[]> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  private contract: SunflowerLandInventory;
+  try {
+    const supplies: string[] = await (
+      new web3.eth.Contract(
+        InventoryJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandInventory
+    ).methods
+      .totalSupplyBatch(ids)
+      .call({ from: account });
 
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
+    return supplies;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return loadSupplyBatch(web3, account, ids, attempts + 1);
+    }
+
+    throw error;
+  }
+}
+
+export async function totalSupply(web3: Web3, account: string) {
+  const ids = Object.values(KNOWN_IDS);
+  const names = Object.keys(KNOWN_IDS) as InventoryItemName[];
+
+  const supplies: string[] = await loadSupplyBatch(web3, account, ids);
+
+  return supplies.reduce(
+    (items, supply, index) => ({
+      ...items,
+      [names[index]]: new Decimal(supply),
+    }),
+    {} as ItemSupply
+  );
+}
+
+export async function getInventorySupply(
+  web3: Web3,
+  account: string,
+  ids: number[]
+) {
+  const supply = await loadSupplyBatch(web3, account, ids);
+  return supply.map(Number);
+}
+
+export async function getInventoryBalances(
+  web3: Web3,
+  account: string,
+  farmAddress: string
+) {
+  const batchAccounts = Array(IDS.length).fill(farmAddress);
+  const balances = await (
+    new web3.eth.Contract(
       InventoryJSON as AbiItem[],
       address as string
-    ) as unknown as SunflowerLandInventory;
-  }
+    ) as unknown as SunflowerLandInventory
+  ).methods
+    .balanceOfBatch(batchAccounts, IDS)
+    .call({ from: account });
 
-  private async loadSupplyBatch(
-    ids: number[],
-    attempts = 0
-  ): Promise<string[]> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
+  return balances;
+}
 
-    try {
-      const supplies: string[] = await this.contract.methods
-        .totalSupplyBatch(ids)
-        .call({ from: this.account });
+export async function getInventoryBalance(
+  web3: Web3,
+  account: string,
+  farmAddress: string,
+  id: number
+): Promise<string> {
+  return await (
+    new web3.eth.Contract(
+      InventoryJSON as AbiItem[],
+      address as string
+    ) as unknown as SunflowerLandInventory
+  ).methods
+    .balanceOf(farmAddress, id)
+    .call();
+}
 
-      return supplies;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.loadSupplyBatch(ids, attempts + 1);
+export async function getInventoryTransfers(
+  web3: Web3,
+  account: string,
+  farmAddress: string,
+  fromBlock: number
+) {
+  const events: TransferSingle[] = await new Promise((res, rej) => {
+    (
+      new web3.eth.Contract(
+        InventoryJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandInventory
+    ).getPastEvents(
+      "TransferSingle",
+      {
+        filter: {
+          to: farmAddress,
+        },
+        fromBlock,
+        toBlock: "latest",
+      },
+      function (error, events) {
+        if (error) {
+          rej(error);
+        }
+
+        res(events as unknown as TransferSingle[]);
       }
-
-      throw error;
-    }
-  }
-
-  public async totalSupply() {
-    const ids = Object.values(KNOWN_IDS);
-    const names = Object.keys(KNOWN_IDS) as InventoryItemName[];
-
-    const supplies: string[] = await this.loadSupplyBatch(ids);
-
-    return supplies.reduce(
-      (items, supply, index) => ({
-        ...items,
-        [names[index]]: new Decimal(supply),
-      }),
-      {} as ItemSupply
     );
-  }
+  });
 
-  public async getSupply(ids: number[]) {
-    const supply = await this.loadSupplyBatch(ids);
-    return supply.map(Number);
-  }
+  const externalEvents = events.filter(
+    (event) =>
+      event.returnValues.from !== "0x0000000000000000000000000000000000000000"
+  );
 
-  public async getBalances(farmAddress: string) {
-    const batchAccounts = Array(IDS.length).fill(farmAddress);
-    const balances = await this.contract.methods
-      .balanceOfBatch(batchAccounts, IDS)
-      .call();
+  return externalEvents;
+}
 
-    return balances;
-  }
-
-  public async getBalance(farmAddress: string, id: number): Promise<string> {
-    return await this.contract.methods.balanceOf(farmAddress, id).call();
-  }
-
-  public async getTransfers(farmAddress: string, fromBlock: number) {
-    const events: TransferSingle[] = await new Promise((res, rej) => {
-      this.contract.getPastEvents(
-        "TransferSingle",
-        {
-          filter: {
-            to: farmAddress,
-          },
-          fromBlock,
-          toBlock: "latest",
+export async function getInventoryBatchTransfers(
+  web3: Web3,
+  account: string,
+  farmAddress: string,
+  fromBlock: number
+) {
+  const events: TransferBatch[] = await new Promise((res, rej) => {
+    (
+      new web3.eth.Contract(
+        InventoryJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandInventory
+    ).getPastEvents(
+      "TransferBatch",
+      {
+        filter: {
+          to: farmAddress,
         },
-        function (error, events) {
-          if (error) {
-            rej(error);
-          }
-
-          res(events as unknown as TransferSingle[]);
+        fromBlock,
+        toBlock: "latest",
+      },
+      function (error, events) {
+        if (error) {
+          rej(error);
         }
-      );
-    });
 
-    const externalEvents = events.filter(
-      (event) =>
-        event.returnValues.from !== "0x0000000000000000000000000000000000000000"
+        res(events as unknown as TransferBatch[]);
+      }
     );
+  });
 
-    return externalEvents;
-  }
+  const externalEvents = events.filter(
+    (event) =>
+      event.returnValues.from !== "0x0000000000000000000000000000000000000000"
+  );
 
-  public async getBatchTransfers(farmAddress: string, fromBlock: number) {
-    const events: TransferBatch[] = await new Promise((res, rej) => {
-      this.contract.getPastEvents(
-        "TransferBatch",
-        {
-          filter: {
-            to: farmAddress,
-          },
-          fromBlock,
-          toBlock: "latest",
-        },
-        function (error, events) {
-          if (error) {
-            rej(error);
-          }
-
-          res(events as unknown as TransferBatch[]);
-        }
-      );
-    });
-
-    const externalEvents = events.filter(
-      (event) =>
-        event.returnValues.from !== "0x0000000000000000000000000000000000000000"
-    );
-
-    return externalEvents;
-  }
+  return externalEvents;
 }

--- a/src/lib/blockchain/Pair.ts
+++ b/src/lib/blockchain/Pair.ts
@@ -4,64 +4,47 @@ import { AbiItem, toWei } from "web3-utils";
 import PairJSON from "./abis/Pair.json";
 
 const address = CONFIG.PAIR_CONTRACT;
-const wishingWellAddress = CONFIG.WISHING_WELL_CONTRACT;
 
-/**
- * Pair contract
- */
-export class Pair {
-  private web3: Web3;
-  private account: string;
+export async function getPairBalance(web3: Web3, account: string) {
+  const balance: string = await new web3.eth.Contract(
+    PairJSON as AbiItem[],
+    address as string
+  ).methods
+    .balanceOf(account)
+    .call({ from: account });
 
-  private contract: any;
+  return balance;
+}
 
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
-      PairJSON as AbiItem[],
-      address as string
-    );
-  }
+export async function mintTestnetTokens(web3: Web3, account: string) {
+  const amount = toWei("100");
+  return new Promise((resolve, reject) => {
+    new web3.eth.Contract(PairJSON as AbiItem[], address as string).methods
+      .mint(account, amount)
+      .send({ from: account })
+      .on("error", function (error: any) {
+        console.log({ error });
 
-  public async getBalance() {
-    const balance: string = await this.contract.methods
-      .balanceOf(this.account)
-      .call({ from: this.account });
+        reject(error);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    return balance;
-  }
-
-  public async mintTestnetTokens() {
-    const amount = toWei("100");
-    return new Promise((resolve, reject) => {
-      this.contract.methods
-        .mint(this.account, amount)
-        .send({ from: this.account })
-        .on("error", function (error: any) {
-          console.log({ error });
-
-          reject(error);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
-
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 }

--- a/src/lib/blockchain/Quests.ts
+++ b/src/lib/blockchain/Quests.ts
@@ -7,87 +7,90 @@ import { BumpkinQuest } from "./types/BumpkinQuest";
 
 const address = CONFIG.QUEST_CONTRACT;
 
-/**
- * Inventory contract
- */
-export class QuestContract {
-  private web3: Web3;
-  private account: string;
+export async function hasCompletedQuest(
+  web3: Web3,
+  account: string,
+  questIds: number[],
+  bumpkinId: number,
+  attempts = 0
+): Promise<boolean[]> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  private contract: BumpkinQuest;
+  try {
+    const statues: boolean[] = await (
+      new web3.eth.Contract(
+        ABI as AbiItem[],
+        address as string
+      ) as unknown as BumpkinQuest
+    ).methods
+      .questStatuses(questIds, bumpkinId)
+      .call({ from: account });
 
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
-      ABI as AbiItem[],
-      address as string
-    ) as unknown as BumpkinQuest;
-  }
-
-  public async hasCompletedQuest(
-    questIds: number[],
-    bumpkinId: number,
-    attempts = 0
-  ): Promise<boolean[]> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
-
-    try {
-      const statues: boolean[] = await this.contract.methods
-        .questStatuses(questIds, bumpkinId)
-        .call({ from: this.account });
-
-      return statues;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.hasCompletedQuest(questIds, bumpkinId, attempts + 1);
-      }
-
-      throw error;
+    return statues;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return hasCompletedQuest(
+        web3,
+        account,
+        questIds,
+        bumpkinId,
+        attempts + 1
+      );
     }
+
+    throw error;
   }
+}
 
-  public async mintQuestItem({
-    questId,
-    bumpkinId,
-    deadline,
-    signature,
-  }: {
-    questId: number;
-    bumpkinId: number;
-    deadline: number;
-    signature: string;
-  }): Promise<void> {
-    const gasPrice = await estimateGasPrice(this.web3);
+export async function mintQuestItemOnChain({
+  web3,
+  account,
+  questId,
+  bumpkinId,
+  deadline,
+  signature,
+}: {
+  web3: Web3;
+  account: string;
+  questId: number;
+  bumpkinId: number;
+  deadline: number;
+  signature: string;
+}): Promise<void> {
+  const gasPrice = await estimateGasPrice(web3);
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .mint(signature, questId, bumpkinId, deadline)
-        .send({ from: this.account, gasPrice })
-        .on("error", function (error: any) {
-          console.log({ error });
-          const parsed = parseMetamaskError(error);
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+  await new Promise((resolve, reject) => {
+    (
+      new web3.eth.Contract(
+        ABI as AbiItem[],
+        address as string
+      ) as unknown as BumpkinQuest
+    ).methods
+      .mint(signature, questId, bumpkinId, deadline)
+      .send({ from: account, gasPrice })
+      .on("error", function (error: any) {
+        console.log({ error });
+        const parsed = parseMetamaskError(error);
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          resolve(receipt);
-        });
-    });
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        resolve(receipt);
+      });
+  });
 }

--- a/src/lib/blockchain/Sessions.ts
+++ b/src/lib/blockchain/Sessions.ts
@@ -84,7 +84,6 @@ export async function getSessionId(
   await new Promise((res) => setTimeout(res, 3000 * attempts));
 
   try {
-    console.log({ farmId, attempts, account });
     const sessionId = await contract.methods
       .getSessionId(farmId)
       .call({ from: account });

--- a/src/lib/blockchain/Sessions.ts
+++ b/src/lib/blockchain/Sessions.ts
@@ -27,6 +27,8 @@ export type LandExpansionData = {
 };
 
 export type SyncProgressArgs = {
+  web3: Web3;
+  account: string;
   signature: string;
   sender: string;
   farmId: number;
@@ -40,6 +42,8 @@ export type SyncProgressArgs = {
 };
 
 export type MintCollectibleArgs = {
+  web3: Web3;
+  account: string;
   signature: string;
   sessionId: string;
   nextSessionId: string;
@@ -66,647 +70,713 @@ export type Recipe = {
   releaseDate?: number;
 };
 
-/**
- * Sessions contract
- */
-export class SessionManager {
-  private web3: Web3;
-  private account: string;
+export async function getSessionId(
+  web3: Web3,
+  account: string,
+  farmId: number,
+  attempts = 0
+): Promise<string> {
+  const contract = new web3.eth.Contract(
+    SessionABI as AbiItem[],
+    address as string
+  );
 
-  private contract: any;
-  private sessionABI = SessionABI;
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
-      this.sessionABI as AbiItem[],
-      address as string
-    );
-  }
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-  public async getSessionId(farmId: number, attempts = 0): Promise<string> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
-
-    try {
-      console.log({ farmId, attempts, account: this.account });
-      const sessionId = await this.contract.methods
-        .getSessionId(farmId)
-        .call({ from: this.account });
-
-      return sessionId;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.getSessionId(farmId, attempts + 1);
-      }
-
-      throw error;
-    }
-  }
-
-  /**
-   * Poll until data is ready
-   */
-  public async getNextSessionId(
-    farmId: number,
-    oldSessionId: string
-  ): Promise<string> {
-    await new Promise((res) => setTimeout(res, 3000));
-
-    const sessionId = await this.getSessionId(farmId);
-
-    // Try again
-    if (sessionId === oldSessionId) {
-      return this.getNextSessionId(farmId, oldSessionId);
-    }
+  try {
+    console.log({ farmId, attempts, account });
+    const sessionId = await contract.methods
+      .getSessionId(farmId)
+      .call({ from: account });
 
     return sessionId;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return getSessionId(web3, account, farmId, attempts + 1);
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Poll until data is ready
+ */
+export async function getNextSessionId(
+  web3: Web3,
+  account: string,
+  farmId: number,
+  oldSessionId: string
+): Promise<string> {
+  await new Promise((res) => setTimeout(res, 3000));
+
+  const sessionId = await getSessionId(web3, account, farmId);
+
+  // Try again
+  if (sessionId === oldSessionId) {
+    return getNextSessionId(web3, account, farmId, oldSessionId);
   }
 
-  public async getRecipes(ids: number[], attempts = 0): Promise<Recipe[]> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
+  return sessionId;
+}
 
-    try {
-      const recipes: Recipe[] = await this.contract.methods
-        .getRecipeBatch(ids)
-        .call({ from: this.account });
+export async function getRecipes(
+  web3: Web3,
+  account: string,
+  ids: number[],
+  attempts = 0
+): Promise<Recipe[]> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
 
-      // Undefined recipes come back with ID 0. Map the provided ID into the recipe.
-      const recipesWithIds = recipes.map((recipe, i) => ({
-        ...recipe,
-        mintId: ids[i],
-      }));
+  try {
+    const contract = new web3.eth.Contract(
+      SessionABI as AbiItem[],
+      address as string
+    );
+    const recipes: Recipe[] = await new web3.eth.Contract(
+      SessionABI as AbiItem[],
+      address as string
+    ).methods
+      .getRecipeBatch(ids)
+      .call({ from: account });
 
-      // For UI purposes, do not show the wei values
-      const ethBasedRecipes = recipesWithIds.map((recipe) => {
-        if (CONFIG.NETWORK === "mumbai") {
-          return {
-            ...recipe,
-            cooldownSeconds: Number(recipe.cooldownSeconds),
-          };
-        }
+    // Undefined recipes come back with ID 0. Map the provided ID into the recipe.
+    const recipesWithIds = recipes.map((recipe, i) => ({
+      ...recipe,
+      mintId: ids[i],
+    }));
 
-        const {
-          tokenAmount,
-          ingredientAmounts = [],
-          ingredientIds = [],
-        } = recipe;
-
+    // For UI purposes, do not show the wei values
+    const ethBasedRecipes = recipesWithIds.map((recipe) => {
+      if (CONFIG.NETWORK === "mumbai") {
         return {
           ...recipe,
-          tokenAmount: tokenAmount
-            ? Number(fromWei(tokenAmount.toString()))
-            : 0,
-          ingredientAmounts: ingredientAmounts.map((amount, index) =>
-            Number(
-              fromWei(
-                amount.toString(),
-                getItemUnit(KNOWN_ITEMS[ingredientIds[index]])
-              )
-            )
-          ),
           cooldownSeconds: Number(recipe.cooldownSeconds),
         };
+      }
+
+      const {
+        tokenAmount,
+        ingredientAmounts = [],
+        ingredientIds = [],
+      } = recipe;
+
+      return {
+        ...recipe,
+        tokenAmount: tokenAmount ? Number(fromWei(tokenAmount.toString())) : 0,
+        ingredientAmounts: ingredientAmounts.map((amount, index) =>
+          Number(
+            fromWei(
+              amount.toString(),
+              getItemUnit(KNOWN_ITEMS[ingredientIds[index]])
+            )
+          )
+        ),
+        cooldownSeconds: Number(recipe.cooldownSeconds),
+      };
+    });
+
+    return ethBasedRecipes;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return getRecipes(web3, account, ids, attempts + 1);
+    }
+
+    throw error;
+  }
+}
+
+export async function getMintedAtBatch(
+  web3: Web3,
+  account: string,
+  farmId: number,
+  ids: number[],
+  attempts = 0
+): Promise<number[]> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
+
+  try {
+    const mintedAts: number[] = await new web3.eth.Contract(
+      SessionABI as AbiItem[],
+      address as string
+    ).methods
+      .getMintedAtBatch(farmId, ids)
+      .call({ from: account });
+
+    return mintedAts;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+
+    if (attempts < 3) {
+      return getMintedAtBatch(web3, account, farmId, ids, attempts + 1);
+    }
+
+    throw error;
+  }
+}
+
+export async function syncProgress({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  bumpkinId,
+  progress,
+  fee,
+  expansion,
+}: SyncProgressArgs): Promise<string> {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
+
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .syncProgress({
+        signature,
+        farmId,
+        bumpkinId,
+        deadline,
+        sessionId,
+        nextSessionId,
+        progress,
+        expansion,
+        fee,
+      })
+      .send({ from: account, value: fee, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt = await web3.eth.getTransactionReceipt(transactionHash);
+
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        resolve(receipt);
       });
+  });
 
-      return ethBasedRecipes;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.getRecipes(ids, attempts + 1);
-      }
-
-      throw error;
-    }
-  }
-
-  public async getMintedAtBatch(
-    farmId: number,
-    ids: number[],
-    attempts = 0
-  ): Promise<number[]> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
-
-    try {
-      const mintedAts: number[] = await this.contract.methods
-        .getMintedAtBatch(farmId, ids)
-        .call({ from: this.account });
-
-      return mintedAts;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-
-      if (attempts < 3) {
-        return this.getMintedAtBatch(farmId, ids, attempts + 1);
-      }
-
-      throw error;
-    }
-  }
-
-  public async syncProgress({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    bumpkinId,
-    progress,
-    fee,
-    expansion,
-  }: SyncProgressArgs): Promise<string> {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .syncProgress({
-          signature,
-          farmId,
-          bumpkinId,
-          deadline,
-          sessionId,
-          nextSessionId,
-          progress,
-          expansion,
-          fee,
-        })
-        .send({ from: this.account, value: fee, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function mint({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  mintId,
+  fee,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  deadline: number;
+  // Data
+  farmId: number;
+  mintId: number;
+  fee: string;
+}): Promise<string> {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .mint(signature, sessionId, nextSessionId, deadline, farmId, mintId, fee)
+      .send({ from: account, value: fee, gasPrice })
+      .on("error", function (error: any) {
+        console.log({ error });
+        const parsed = parseMetamaskError(error);
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        resolve(receipt);
+      });
+  });
 
-  public async mint({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    mintId,
-    fee,
-  }: {
-    signature: string;
-    sessionId: string;
-    nextSessionId: string;
-    deadline: number;
-    // Data
-    farmId: number;
-    mintId: number;
-    fee: string;
-  }): Promise<string> {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .mint(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          mintId,
-          fee
-        )
-        .send({ from: this.account, value: fee, gasPrice })
-        .on("error", function (error: any) {
-          console.log({ error });
-          const parsed = parseMetamaskError(error);
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function mintCollectible({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  fee,
+  mintData,
+}: MintCollectibleArgs): Promise<string> {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .mintCollectible(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        farmId,
+        fee,
+        mintData
+      )
+      .send({ from: account, value: fee, gasPrice })
+      .on("error", function (error: any) {
+        console.log({ error });
+        const parsed = parseMetamaskError(error);
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        resolve(receipt);
+      });
+  });
 
-  public async mintCollectible({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    fee,
-    mintData,
-  }: MintCollectibleArgs): Promise<string> {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .mintCollectible(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          fee,
-          mintData
-        )
-        .send({ from: this.account, value: fee, gasPrice })
-        .on("error", function (error: any) {
-          console.log({ error });
-          const parsed = parseMetamaskError(error);
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function withdrawItems({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  ids,
+  amounts,
+  tax,
+  sfl,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  deadline: number;
+  // Data
+  farmId: number;
+  ids: number[];
+  amounts: number[];
+  sfl: number;
+  tax: number;
+}): Promise<string> {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .withdraw(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        farmId,
+        ids,
+        amounts,
+        sfl,
+        tax
+      )
+      .send({ from: account, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        console.log({ parsedIt: parsed });
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 
-  public async withdraw({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    ids,
-    amounts,
-    tax,
-    sfl,
-  }: {
-    signature: string;
-    sessionId: string;
-    nextSessionId: string;
-    deadline: number;
-    // Data
-    farmId: number;
-    ids: number[];
-    amounts: number[];
-    sfl: number;
-    tax: number;
-  }): Promise<string> {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .withdraw(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          ids,
-          amounts,
-          sfl,
-          tax
-        )
-        .send({ from: this.account, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          console.log({ parsedIt: parsed });
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function listTrade({
+  web3,
+  account,
+  signature,
+  farmId,
+  fee,
+  resourceAmount,
+  resourceId,
+  sessionId,
+  sfl,
+  slotId,
+  tax,
+  deadline,
+  nextSessionId,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  farmId: number;
+  fee: string;
+  resourceAmount: string;
+  resourceId: number;
+  sender: string;
+  sessionId: string;
+  sfl: string;
+  slotId: number;
+  tax: number;
+  deadline: number;
+  nextSessionId: string;
+}) {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .listTrade(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        slotId,
+        farmId,
+        resourceId,
+        resourceAmount,
+        sfl,
+        tax,
+        fee
+      )
+      .send({ from: account, value: fee, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        console.log({ parsedIt: parsed });
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 
-  public async listTrade({
-    signature,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    fee,
-    resourceAmount,
-    resourceId,
-    sessionId,
-    sfl,
-    slotId,
-    tax,
-    deadline,
-    nextSessionId,
-  }: {
-    signature: string;
-    farmId: number;
-    fee: string;
-    resourceAmount: string;
-    resourceId: number;
-    sender: string;
-    sessionId: string;
-    sfl: string;
-    slotId: number;
-    tax: number;
-    deadline: number;
-    nextSessionId: string;
-  }) {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .listTrade(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          slotId,
-          farmId,
-          resourceId,
-          resourceAmount,
-          sfl,
-          tax,
-          fee
-        )
-        .send({ from: this.account, value: fee, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          console.log({ parsedIt: parsed });
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function cancelTrade({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  listingId,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  deadline: number;
+  farmId: number;
+  listingId: number;
+}) {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .cancelTrade(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        farmId,
+        listingId
+      )
+      .send({ from: account, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        console.log({ parsedIt: parsed });
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 
-  public async cancelTrade({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    listingId,
-  }: {
-    signature: string;
-    sessionId: string;
-    nextSessionId: string;
-    deadline: number;
-    farmId: number;
-    listingId: number;
-  }) {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .cancelTrade(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          listingId
-        )
-        .send({ from: this.account, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          console.log({ parsedIt: parsed });
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function purchaseTrade({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  listingId,
+  sfl,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  deadline: number;
+  farmId: number;
+  listingId: number;
+  sfl: number;
+}) {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .purchaseTrade(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        farmId,
+        listingId,
+        sfl
+      )
+      .send({ from: account, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        console.log({ parsedIt: parsed });
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 
-  public async purchaseTrade({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    listingId,
-    sfl,
-  }: {
-    signature: string;
-    sessionId: string;
-    nextSessionId: string;
-    deadline: number;
-    farmId: number;
-    listingId: number;
-    sfl: number;
-  }) {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
+    oldSessionId
+  );
+  return newSessionId;
+}
 
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .purchaseTrade(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          listingId,
-          sfl
-        )
-        .send({ from: this.account, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          console.log({ parsedIt: parsed });
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
+export async function expandLand({
+  web3,
+  account,
+  signature,
+  sessionId,
+  nextSessionId,
+  deadline,
+  farmId,
+  sfl,
+  nonce,
+  metadata,
+  resourceIds,
+  resourceAmounts,
+}: {
+  web3: Web3;
+  account: string;
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  deadline: number;
+  farmId: number;
+  sfl: string;
+  nonce: string;
+  metadata: string;
+  resourceIds: number[];
+  resourceAmounts: string[];
+}) {
+  const oldSessionId = await getSessionId(web3, account, farmId);
+  const gasPrice = await estimateGasPrice(web3);
 
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
+  await new Promise((resolve, reject) => {
+    new web3.eth.Contract(SessionABI as AbiItem[], address as string).methods
+      .expandLand(
+        signature,
+        sessionId,
+        nextSessionId,
+        deadline,
+        farmId,
+        nonce,
+        metadata,
+        sfl,
+        resourceIds,
+        resourceAmounts
+      )
+      .send({ from: account, gasPrice })
+      .on("error", function (error: any) {
+        const parsed = parseMetamaskError(error);
+        console.log({ parsedIt: parsed });
+        reject(parsed);
+      })
+      .on("transactionHash", async (transactionHash: any) => {
+        console.log({ transactionHash });
+        try {
+          // Sequence wallet doesn't resolve the receipt. Therefore
+          // We try to fetch it after we have a tx hash returned
+          // From Sequence.
+          const receipt: any = await web3.eth.getTransactionReceipt(
+            transactionHash
+          );
 
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+          if (receipt) resolve(receipt);
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .on("receipt", function (receipt: any) {
+        console.log({ receipt });
+        resolve(receipt);
+      });
+  });
 
-  public async expandLand({
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
+  const newSessionId = await getNextSessionId(
+    web3,
+    account,
     farmId,
-    sfl,
-    nonce,
-    metadata,
-    resourceIds,
-    resourceAmounts,
-  }: {
-    signature: string;
-    sessionId: string;
-    nextSessionId: string;
-    deadline: number;
-    farmId: number;
-    sfl: string;
-    nonce: string;
-    metadata: string;
-    resourceIds: number[];
-    resourceAmounts: string[];
-  }) {
-    const oldSessionId = await this.getSessionId(farmId);
-    const gasPrice = await estimateGasPrice(this.web3);
-
-    await new Promise((resolve, reject) => {
-      this.contract.methods
-        .expandLand(
-          signature,
-          sessionId,
-          nextSessionId,
-          deadline,
-          farmId,
-          nonce,
-          metadata,
-          sfl,
-          resourceIds,
-          resourceAmounts
-        )
-        .send({ from: this.account, gasPrice })
-        .on("error", function (error: any) {
-          const parsed = parseMetamaskError(error);
-          console.log({ parsedIt: parsed });
-          reject(parsed);
-        })
-        .on("transactionHash", async (transactionHash: any) => {
-          console.log({ transactionHash });
-          try {
-            // Sequence wallet doesn't resolve the receipt. Therefore
-            // We try to fetch it after we have a tx hash returned
-            // From Sequence.
-            const receipt: any = await this.web3.eth.getTransactionReceipt(
-              transactionHash
-            );
-
-            if (receipt) resolve(receipt);
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .on("receipt", function (receipt: any) {
-          console.log({ receipt });
-          resolve(receipt);
-        });
-    });
-
-    const newSessionId = await this.getNextSessionId(farmId, oldSessionId);
-    return newSessionId;
-  }
+    oldSessionId
+  );
+  return newSessionId;
 }

--- a/src/lib/blockchain/Token.ts
+++ b/src/lib/blockchain/Token.ts
@@ -9,108 +9,130 @@ import Decimal from "decimal.js-light";
 const address = CONFIG.TOKEN_CONTRACT;
 
 /**
- * Token contract
+ * Keep full wei amount as used for approving/sending
  */
-export class Token {
-  private web3: Web3;
-  private account: string;
-
-  private contract: SunflowerLandToken;
-
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
+export async function sflBalanceOf(
+  web3: Web3,
+  account: string,
+  address: string
+) {
+  console.log({ address, from: account });
+  const balance = await (
+    new web3.eth.Contract(
       TokenJSON as AbiItem[],
       address as string
-    ) as unknown as SunflowerLandToken;
-  }
+    ) as unknown as SunflowerLandToken
+  ).methods
+    .balanceOf(address)
+    .call({ from: account });
 
-  /**
-   * Keep full wei amount as used for approving/sending
-   */
-  public async balanceOf(address: string) {
-    console.log({ address, from: this.account });
-    const balance = await this.contract.methods
-      .balanceOf(address)
-      .call({ from: this.account });
+  return balance;
+}
 
-    return balance;
-  }
+/**
+ * Onchain SFL balance
+ */
+export async function totalSFLSupply(web3: Web3, account: string) {
+  const supply = await (
+    new web3.eth.Contract(
+      TokenJSON as AbiItem[],
+      address as string
+    ) as unknown as SunflowerLandToken
+  ).methods
+    .totalSupply()
+    .call({ from: account });
 
-  /**
-   * Onchain SFL balance
-   */
-  public async totalSupply() {
-    const supply = await this.contract.methods
-      .totalSupply()
-      .call({ from: this.account });
+  return supply;
+}
 
-    return supply;
-  }
-
-  public async getPastDeposits(farmAddress: string, fromBlock: number) {
-    const events: Transfer[] = await new Promise((res, rej) => {
-      this.contract.getPastEvents(
-        "Transfer",
-        {
-          filter: {
-            to: farmAddress,
-          },
-          fromBlock,
-          toBlock: "latest",
+export async function getPastDeposits(
+  web3: Web3,
+  account: string,
+  farmAddress: string,
+  fromBlock: number
+) {
+  const events: Transfer[] = await new Promise((res, rej) => {
+    (
+      new web3.eth.Contract(
+        TokenJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandToken
+    ).getPastEvents(
+      "Transfer",
+      {
+        filter: {
+          to: farmAddress,
         },
-        function (error, events) {
-          if (error) {
-            rej(error);
-          }
-
-          res(events as unknown as Transfer[]);
+        fromBlock,
+        toBlock: "latest",
+      },
+      function (error, events) {
+        if (error) {
+          rej(error);
         }
-      );
-    });
 
-    // Exclude game mints/burns
-    const externalEvents = events.filter(
-      (event) =>
-        event.returnValues.from !==
-          "0x0000000000000000000000000000000000000000" &&
-        Number(event.returnValues.value) > 0
-    );
-
-    return externalEvents;
-  }
-
-  public async approve(address: string, value: number) {
-    const gasPrice = await estimateGasPrice(this.web3);
-    const getWei = toWei(value.toString());
-    const approve = await this.contract.methods
-      .approve(address, getWei)
-      .send({ from: this.account, gasPrice });
-
-    return approve;
-  }
-
-  public async isTokenApprovedForContract(
-    address: string,
-    attempts = 0
-  ): Promise<boolean> {
-    await new Promise((res) => setTimeout(res, 3000 * attempts));
-    try {
-      const allowance = await this.contract.methods
-        .allowance(this.account, address)
-        .call({ from: this.account });
-      const allowanceNumber = new Decimal(fromWei(allowance));
-      const isApproved = allowanceNumber.gte(100);
-
-      return isApproved;
-    } catch (e) {
-      const error = parseMetamaskError(e);
-      if (attempts < 3) {
-        return this.isTokenApprovedForContract(address, attempts + 1);
+        res(events as unknown as Transfer[]);
       }
+    );
+  });
 
-      throw error;
+  // Exclude game mints/burns
+  const externalEvents = events.filter(
+    (event) =>
+      event.returnValues.from !==
+        "0x0000000000000000000000000000000000000000" &&
+      Number(event.returnValues.value) > 0
+  );
+
+  return externalEvents;
+}
+
+export async function approveSFL(
+  web3: Web3,
+  account: string,
+  address: string,
+  value: number
+) {
+  const gasPrice = await estimateGasPrice(web3);
+  const getWei = toWei(value.toString());
+  const approve = await (
+    new web3.eth.Contract(
+      TokenJSON as AbiItem[],
+      address as string
+    ) as unknown as SunflowerLandToken
+  ).methods
+    .approve(address, getWei)
+    .send({ from: account, gasPrice });
+
+  return approve;
+}
+
+export async function isTokenApprovedForContract(
+  web3: Web3,
+  account: string,
+  address: string,
+  attempts = 0
+): Promise<boolean> {
+  await new Promise((res) => setTimeout(res, 3000 * attempts));
+  try {
+    const allowance = await (
+      new web3.eth.Contract(
+        TokenJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandToken
+    ).methods
+      .allowance(account, address)
+      .call({ from: account });
+    const allowanceNumber = new Decimal(fromWei(allowance));
+    const isApproved = allowanceNumber.gte(100);
+
+    return isApproved;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return isTokenApprovedForContract(web3, account, address, attempts + 1);
     }
+
+    throw error;
   }
 }

--- a/src/lib/blockchain/Token.ts
+++ b/src/lib/blockchain/Token.ts
@@ -14,7 +14,6 @@ export async function sflBalanceOf(
   account: string,
   address: string
 ) {
-  console.log({ address, from: account });
   const balance = await (
     new web3.eth.Contract(
       TokenJSON as AbiItem[],

--- a/src/lib/blockchain/Token.ts
+++ b/src/lib/blockchain/Token.ts
@@ -6,8 +6,6 @@ import { SunflowerLandToken, Transfer } from "./types/SunflowerLandToken";
 import { estimateGasPrice, parseMetamaskError } from "./utils";
 import Decimal from "decimal.js-light";
 
-const address = CONFIG.TOKEN_CONTRACT;
-
 /**
  * Keep full wei amount as used for approving/sending
  */
@@ -20,7 +18,7 @@ export async function sflBalanceOf(
   const balance = await (
     new web3.eth.Contract(
       TokenJSON as AbiItem[],
-      address as string
+      CONFIG.TOKEN_CONTRACT as string
     ) as unknown as SunflowerLandToken
   ).methods
     .balanceOf(address)
@@ -36,7 +34,7 @@ export async function totalSFLSupply(web3: Web3, account: string) {
   const supply = await (
     new web3.eth.Contract(
       TokenJSON as AbiItem[],
-      address as string
+      CONFIG.TOKEN_CONTRACT as string
     ) as unknown as SunflowerLandToken
   ).methods
     .totalSupply()
@@ -55,7 +53,7 @@ export async function getPastDeposits(
     (
       new web3.eth.Contract(
         TokenJSON as AbiItem[],
-        address as string
+        CONFIG.TOKEN_CONTRACT as string
       ) as unknown as SunflowerLandToken
     ).getPastEvents(
       "Transfer",
@@ -98,7 +96,7 @@ export async function approveSFL(
   const approve = await (
     new web3.eth.Contract(
       TokenJSON as AbiItem[],
-      address as string
+      CONFIG.TOKEN_CONTRACT as string
     ) as unknown as SunflowerLandToken
   ).methods
     .approve(address, getWei)
@@ -118,7 +116,7 @@ export async function isTokenApprovedForContract(
     const allowance = await (
       new web3.eth.Contract(
         TokenJSON as AbiItem[],
-        address as string
+        CONFIG.TOKEN_CONTRACT as string
       ) as unknown as SunflowerLandToken
     ).methods
       .allowance(account, address)

--- a/src/lib/blockchain/Trader.ts
+++ b/src/lib/blockchain/Trader.ts
@@ -37,100 +37,120 @@ export type FarmSlot = {
   slotId: number;
   listing?: Listing;
 };
-/**
- * Trader contract
- */
-export class Trader {
-  private web3: Web3;
-  private account: string;
 
-  private contract: SunflowerLandTrader;
-
-  constructor(web3: Web3, account: string) {
-    this.web3 = web3;
-    this.account = account;
-    this.contract = new this.web3.eth.Contract(
+export async function getFarmSlots(
+  web3: Web3,
+  account: string,
+  farmId: number
+): Promise<FarmSlot[]> {
+  const farmSlots = await (
+    new web3.eth.Contract(
       TraderJSON as AbiItem[],
       address as string
-    ) as unknown as SunflowerLandTrader;
-  }
+    ) as unknown as SunflowerLandTrader
+  ).methods
+    .getFarmSlots(farmId, 3)
+    .call();
 
-  public async getFarmSlots(farmId: number): Promise<FarmSlot[]> {
-    const farmSlots = await this.contract.methods
-      .getFarmSlots(farmId, 3)
-      .call();
-
-    return farmSlots.map((slot, index) => {
-      if (slot.status == "0") {
-        return { slotId: index };
-      }
-      return {
-        slotId: index,
-        listing: {
-          id: Number(slot.listingId),
-          status: Number(slot.status),
-          resourceId: Number(slot.resourceId),
-          resourceAmount: Number(
-            fromWei(
-              slot.resourceAmount,
-              getItemUnit(KNOWN_ITEMS[slot.resourceId])
-            )
-          ),
-          sfl: Number(fromWei(slot.sfl)),
-          tax: Number(slot.tax) / 1000,
-          purchasedAt: Number(slot.purchasedAt),
-          purchasedById: Number(slot.purchasedById),
-        },
-      };
-    });
-  }
-
-  public async getRemainingListings(farmId: number): Promise<number> {
-    return Number(
-      await this.contract.methods.getRemainingListings(farmId).call()
-    );
-  }
-
-  public async getLimits(): Promise<ItemLimits> {
-    const ids = Object.values(KNOWN_IDS);
-    const names = Object.keys(KNOWN_IDS) as InventoryItemName[];
-
-    const limits: string[] = await this.contract.methods
-      .getLimitBatch(ids)
-      .call();
-
-    return limits.reduce(
-      (items, limit, index) => ({
-        ...items,
-        [names[index]]: new Decimal(
-          fromWei(String(limit), getItemUnit(names[index]))
+  return farmSlots.map((slot, index) => {
+    if (slot.status == "0") {
+      return { slotId: index };
+    }
+    return {
+      slotId: index,
+      listing: {
+        id: Number(slot.listingId),
+        status: Number(slot.status),
+        resourceId: Number(slot.resourceId),
+        resourceAmount: Number(
+          fromWei(
+            slot.resourceAmount,
+            getItemUnit(KNOWN_ITEMS[slot.resourceId])
+          )
         ),
-      }),
-      {} as ItemLimits
-    );
-  }
+        sfl: Number(fromWei(slot.sfl)),
+        tax: Number(slot.tax) / 1000,
+        purchasedAt: Number(slot.purchasedAt),
+        purchasedById: Number(slot.purchasedById),
+      },
+    };
+  });
+}
 
-  public async getPastTrades(farmId: number, fromBlock: number) {
-    const events: Purchased[] = await new Promise((res, rej) => {
-      this.contract.getPastEvents(
-        "Purchased",
-        {
-          filter: {
-            sellerFarmId: farmId,
-          },
-          fromBlock,
-          toBlock: "latest",
+export async function getRemainingListings(
+  web3: Web3,
+  account: string,
+  farmId: number
+): Promise<number> {
+  return Number(
+    await (
+      new web3.eth.Contract(
+        TraderJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandTrader
+    ).methods
+      .getRemainingListings(farmId)
+      .call()
+  );
+}
+
+export async function getLimits(
+  web3: Web3,
+  account: string
+): Promise<ItemLimits> {
+  const ids = Object.values(KNOWN_IDS);
+  const names = Object.keys(KNOWN_IDS) as InventoryItemName[];
+
+  const limits: string[] = await (
+    new web3.eth.Contract(
+      TraderJSON as AbiItem[],
+      address as string
+    ) as unknown as SunflowerLandTrader
+  ).methods
+    .getLimitBatch(ids)
+    .call();
+
+  return limits.reduce(
+    (items, limit, index) => ({
+      ...items,
+      [names[index]]: new Decimal(
+        fromWei(String(limit), getItemUnit(names[index]))
+      ),
+    }),
+    {} as ItemLimits
+  );
+}
+
+export async function getPastTrades(
+  web3: Web3,
+  account: string,
+  farmId: number,
+  fromBlock: number
+) {
+  const events: Purchased[] = await new Promise((res, rej) => {
+    (
+      new web3.eth.Contract(
+        TraderJSON as AbiItem[],
+        address as string
+      ) as unknown as SunflowerLandTrader
+    ).getPastEvents(
+      "Purchased",
+      {
+        filter: {
+          sellerFarmId: farmId,
         },
-        function (error, events) {
-          if (error) {
-            rej(error);
-          }
-
-          res(events as unknown as Purchased[]);
+        fromBlock,
+        toBlock: "latest",
+      },
+      function (error, events) {
+        if (error) {
+          rej(error);
         }
-      );
-    });
 
-    return events;
-  }
+        res(events as unknown as Purchased[]);
+      }
+    );
+  });
+
+  return events;
 }

--- a/src/lib/blockchain/wallet.ts
+++ b/src/lib/blockchain/wallet.ts
@@ -1,20 +1,11 @@
 import { pingHealthCheck } from "web3-health-check";
 import { ERRORS } from "lib/errors";
 import Web3 from "web3";
-import { SessionManager } from "./Sessions";
-import { Farm } from "./Farm";
-import { AccountMinter } from "./AccountMinter";
-import { Inventory } from "./Inventory";
-import { Pair } from "./Pair";
-import { WishingWell } from "./WishingWell";
-import { Token } from "./Token";
+
 import { toHex, toWei } from "web3-utils";
 import { CONFIG } from "lib/config";
 import { estimateGasPrice, parseMetamaskError } from "./utils";
-import { Trader } from "./Trader";
-import { BumpkinDetails } from "./BumpkinDetails";
-import { BumpkinItems } from "./BumpkinItems";
-import { QuestContract } from "./Quests";
+
 import { createAlchemyWeb3 } from "@alch/alchemy-web3";
 
 export type WalletType = "METAMASK" | "WALLET_CONNECT" | "SEQUENCE";
@@ -24,18 +15,6 @@ export type WalletType = "METAMASK" | "WALLET_CONNECT" | "SEQUENCE";
 export class Wallet {
   private web3: Web3 | null = null;
 
-  private farm: Farm | null = null;
-  private session: SessionManager | null = null;
-  private accountMinter: AccountMinter | null = null;
-  private bumpkinDetails: BumpkinDetails | null = null;
-  private bumpkinItems: BumpkinItems | null = null;
-  private inventory: Inventory | null = null;
-  private pair: Pair | null = null;
-  private wishingWell: WishingWell | null = null;
-  private token: Token | null = null;
-  private trader: Trader | null = null;
-  private quests: QuestContract | null = null;
-
   private account: string | null = null;
 
   private type: WalletType | null = null;
@@ -43,36 +22,7 @@ export class Wallet {
 
   private async initialiseContracts() {
     try {
-      this.farm = new Farm(this.web3 as Web3, this.account as string);
-
-      this.session = new SessionManager(
-        this.web3 as Web3,
-        this.account as string
-      );
-      this.accountMinter = new AccountMinter(
-        this.web3 as Web3,
-        this.account as string
-      );
-      this.bumpkinDetails = new BumpkinDetails(
-        this.web3 as Web3,
-        this.account as string
-      );
-      this.bumpkinItems = new BumpkinItems(
-        this.web3 as Web3,
-        this.account as string
-      );
-      this.inventory = new Inventory(this.web3 as Web3, this.account as string);
-      this.pair = new Pair(this.web3 as Web3, this.account as string);
-      this.token = new Token(this.web3 as Web3, this.account as string);
-      this.wishingWell = new WishingWell(
-        this.web3 as Web3,
-        this.account as string
-      );
-      this.trader = new Trader(this.web3 as Web3, this.account as string);
-      this.quests = new QuestContract(
-        this.web3 as Web3,
-        this.account as string
-      );
+      // TODO - initialise a test contract???
 
       const isHealthy = await this.healthCheck();
 
@@ -168,7 +118,7 @@ export class Wallet {
   }
 
   public isAlchemy = false;
-  public overrideProvider() {
+  public async overrideProvider() {
     this.isAlchemy = true;
 
     if (CONFIG.ALCHEMY_RPC) {
@@ -185,6 +135,8 @@ export class Wallet {
       }
 
       this.web3 = new Web3(web3 as any);
+
+      await this.initialiseContracts();
     }
   }
 
@@ -318,52 +270,8 @@ export class Wallet {
     }
   }
 
-  public getFarm() {
-    return this.farm as Farm;
-  }
-
-  public getInventory() {
-    return this.inventory as Inventory;
-  }
-
-  public getAccountMinter() {
-    return this.accountMinter as AccountMinter;
-  }
-
-  public getBumpkinDetails() {
-    return this.bumpkinDetails as BumpkinDetails;
-  }
-
-  public getBumpkinItems() {
-    return this.bumpkinItems as BumpkinItems;
-  }
-
-  public getSessionManager() {
-    return this.session as SessionManager;
-  }
-
-  public getPair() {
-    return this.pair as Pair;
-  }
-
-  public getWishingWell() {
-    return this.wishingWell as WishingWell;
-  }
-
-  public getToken() {
-    return this.token as Token;
-  }
-
-  public getTrader() {
-    return this.trader as Trader;
-  }
-
-  public getQuests() {
-    return this.quests as QuestContract;
-  }
-
   public get myAccount() {
-    return this.account;
+    return this.account as string;
   }
 
   public async getBlockNumber() {
@@ -408,7 +316,7 @@ export class Wallet {
   }
 
   public get web3Provider() {
-    return this.web3;
+    return this.web3 as Web3;
   }
 }
 


### PR DESCRIPTION
# Description 

This PR removes the old class style of Contracts with a functional approach that takes in the `web3` provider.

The old class approach was caching the old Web3 Providers used to initialise the `Contract` which made changing providers difficult. I also suspected that when we initialised these Web3 contracts, they were doing some sort of caching of error responses.

