### PR TITLE
[FIX] Add delay time to sync button when buying seeds and tools

### DIFF
--- a/src/features/helios/components/exoticShop/component/ExoticSeeds.tsx
+++ b/src/features/helios/components/exoticShop/component/ExoticSeeds.tsx
@@ -22,6 +22,7 @@ import { CONFIG } from "lib/config";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { CloudFlareCaptcha } from "components/ui/CloudFlareCaptcha";
 import { secondsToString } from "lib/utils/time";
+import { Delayed } from "features/island/buildings/components/building/market/Delayed";
 
 interface Props {
   onClose: () => void;
@@ -128,16 +129,7 @@ export const ExoticSeeds: React.FC<Props> = ({ onClose }) => {
 
   const Action = () => {
     if (stock?.equals(0)) {
-      return (
-        <div>
-          <p className="text-xxs sm:text-xs mb-1 sm:text-center">
-            Sync your farm on chain to restock
-          </p>
-          <Button className="text-xxs sm:text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
-        </div>
-      );
+      return <Delayed restock={restock}></Delayed>;
     }
 
     if (inventoryFull) {

--- a/src/features/helios/components/rustyShovelSeller/RustyShovelSeller.tsx
+++ b/src/features/helios/components/rustyShovelSeller/RustyShovelSeller.tsx
@@ -18,6 +18,7 @@ import { Stock } from "components/ui/Stock";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
+import { Delayed } from "features/island/buildings/components/building/market/Delayed";
 
 export const RustyShovelSeller: React.FC = () => {
   const { gameService, shortcutItem } = useContext(Context);
@@ -59,16 +60,7 @@ export const RustyShovelSeller: React.FC = () => {
 
   const Action = () => {
     if (stock.equals(0)) {
-      return (
-        <div className="my-1">
-          <p className="text-xxs text-center mb-2">
-            Sync your farm on chain to restock.
-          </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
-        </div>
-      );
+      return <Delayed restock={restock}></Delayed>;
     }
 
     return <Button onClick={() => craft(1)}>Buy 1</Button>;

--- a/src/features/island/buildings/components/building/market/Delayed.tsx
+++ b/src/features/island/buildings/components/building/market/Delayed.tsx
@@ -1,0 +1,28 @@
+import React, { SyntheticEvent, useEffect, useState } from "react";
+import { Button } from "components/ui/Button";
+
+interface Props {
+  restock: (event: SyntheticEvent) => void;
+}
+
+export const Delayed: React.FC<Props> = ({ restock }) => {
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsDisabled(false);
+    }, 500);
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    <div className="my-1">
+      <p className="text-xxs text-center">
+        Sync your farm to the Blockchain to restock
+      </p>
+      <Button disabled={isDisabled} className="text-xs mt-1" onClick={restock}>
+        Sync
+      </Button>
+    </div>
+  );
+};

--- a/src/features/island/buildings/components/building/market/Delayed.tsx
+++ b/src/features/island/buildings/components/building/market/Delayed.tsx
@@ -13,7 +13,7 @@ export const Delayed: React.FC<Props> = ({ restock }) => {
       setIsDisabled(false);
     }, 500);
     return () => clearTimeout(timer);
-  });
+  }, []);
 
   return (
     <div className="my-1">

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -31,6 +31,7 @@ import { SeedName, SEEDS } from "features/game/types/seeds";
 import { Bumpkin } from "features/game/types/game";
 import { FRUIT_SEEDS } from "features/game/types/fruits";
 import { Label } from "components/ui/Label";
+import { Delayed } from "features/island/buildings/components/building/market/Delayed";
 
 interface Props {
   onClose: () => void;
@@ -155,16 +156,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
     }
 
     if (stock?.equals(0)) {
-      return (
-        <div className="my-1">
-          <p className="text-xxs text-center">
-            Sync your farm on chain to restock
-          </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
-        </div>
-      );
+      return <Delayed restock={restock}></Delayed>;
     }
 
     const max = INITIAL_STOCK[selectedName];

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -25,6 +25,7 @@ import { acknowledgeTutorial, hasShownTutorial } from "lib/tutorial";
 import { Tutorial } from "./Tutorial";
 import { Equipped } from "features/game/types/bumpkin";
 import classNames from "classnames";
+import { Delayed } from "features/island/buildings/components/building/market/Delayed";
 
 interface Props {
   isOpen: boolean;
@@ -166,16 +167,7 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
 
   const Action = () => {
     if (stock?.equals(0)) {
-      return (
-        <div className="my-1">
-          <p className="text-xs sm:text-xs sm:text-center px-2">
-            Sync your farm on chain to restock
-          </p>
-          <Button className="text-xxs sm:text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
-        </div>
-      );
+      return <Delayed restock={restock}></Delayed>;
     }
 
     return (

--- a/src/features/treasureIsland/components/ShovelShopItems.tsx
+++ b/src/features/treasureIsland/components/ShovelShopItems.tsx
@@ -20,6 +20,7 @@ import { getKeys } from "features/game/types/craftables";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Label } from "components/ui/Label";
 import { TAB_CONTENT_HEIGHT } from "features/island/hud/components/inventory/Basket";
+import { Delayed } from "features/island/buildings/components/building/market/Delayed";
 
 interface Props {
   onClose: (e?: SyntheticEvent) => void;
@@ -124,19 +125,7 @@ export const ShovelShopItems: React.FC<Props> = ({ onClose }) => {
 
   const Action = () => {
     if (stock?.equals(0)) {
-      return (
-        <div className="w-full">
-          <p className="text-xxs no-wrap text-center my-1 underline">
-            Sold out
-          </p>
-          <p className="text-xxs text-center">
-            Sync your farm on chain to restock
-          </p>
-          <Button className="text-xs mt-1" onClick={restock}>
-            Sync
-          </Button>
-        </div>
-      );
+      return <Delayed restock={restock}></Delayed>;
     }
 
     return (


### PR DESCRIPTION
# Description

Added a little delay to the sync button which appeared too fast making lots of users to hit it and get metamask popup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
