### PR TITLE
[FEAT] Jigger detection on withdraw/trade

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -656,7 +656,7 @@ export const authMachine = createMachine<
           farmId: parseInt(farmAccount.tokenId),
           address: farmAccount.account,
           createdAt,
-          blacklistStatus: botStatus ?? isBanned ? "BANNED" : "OK",
+          blacklistStatus: isBanned ? "BANNED" : "OK",
           verificationUrl,
         };
       },

--- a/src/features/game/actions/bans.ts
+++ b/src/features/game/actions/bans.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
+import { JiggerStatus } from "../components/Jigger";
 
 const API_URL = CONFIG.API_URL;
 
@@ -10,7 +11,7 @@ export async function loadBanDetails(
 ): Promise<{
   isBanned: boolean;
   verificationUrl: string;
-  botStatus?: "VERIFY" | "PENDING" | "REJECTED";
+  botStatus?: JiggerStatus;
 }> {
   // Go and fetch the metadata file for this farm
   const url = `${API_URL}/bans/${id}`;

--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -20,7 +20,6 @@ type Response = {
   isBlacklisted?: boolean;
   whitelistedAt?: string;
   itemsMintedAt?: MintedAt;
-  blacklistStatus?: "investigating" | "permanent";
   deviceTrackerId: string;
   status?: "COOL_DOWN";
 };
@@ -70,7 +69,6 @@ export async function loadSession(
     isBlacklisted,
     whitelistedAt,
     itemsMintedAt,
-    blacklistStatus,
     deviceTrackerId,
     status,
   } = await sanitizeHTTPResponse<{
@@ -79,7 +77,6 @@ export async function loadSession(
     isBlacklisted: boolean;
     whitelistedAt: string;
     itemsMintedAt: MintedAt;
-    blacklistStatus: Response["blacklistStatus"];
     deviceTrackerId: string;
     status?: "COOL_DOWN";
   }>(response);
@@ -100,7 +97,6 @@ export async function loadSession(
     isBlacklisted,
     whitelistedAt,
     itemsMintedAt,
-    blacklistStatus,
     deviceTrackerId,
     status,
   };

--- a/src/features/game/components/Jigger.tsx
+++ b/src/features/game/components/Jigger.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+
+import alert from "assets/icons/expression_alerted.png";
+import suspiciousGoblin from "assets/npcs/suspicious_goblin.gif";
+import { Button } from "components/ui/Button";
+
+export type JiggerStatus = "VERIFY" | "PENDING" | "REJECTED";
+interface Props {
+  verificationUrl: string;
+  status: JiggerStatus;
+  onClose: () => void;
+}
+
+export const Jigger: React.FC<Props> = ({
+  verificationUrl,
+  status,
+  onClose,
+}) => {
+  const [showWarning, setShowWarning] = useState(false);
+
+  if (showWarning) {
+    return (
+      <div className="flex flex-col items-center p-2">
+        <span className="text-center">Proof of Humanity</span>
+        <img src={alert} className="w-6 mt-2" />
+        <span className="text-sm mt-2 mb-2">
+          You will be redirected to a 3rd party service to take a quick selfie.
+          Never share any personal information or crypto data.
+        </span>
+
+        <div className="flex w-full">
+          <Button
+            onClick={() => {
+              window.location.href = verificationUrl as string;
+            }}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "REJECTED") {
+    return (
+      <div className="flex flex-col items-center p-2">
+        <span className="text-center">Uh oh!</span>
+        <img src={suspiciousGoblin} alt="Warning" className="w-16 m-2" />
+        <span className="text-sm mt-2 mb-2">
+          You failed the Jigger Proof of Humanity.
+        </span>
+        <span className="text-sm mt-2 mb-2">
+          You can continue playing, but some actions will be restricted while
+          you are being verified.
+        </span>
+        <span className="text-sm mt-2 mb-2">
+          Please reach out to support@usejigger.com if you beleive this was a
+          mistake.
+        </span>
+        <div className="flex w-full">
+          <Button className="mr-2" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "PENDING") {
+    return (
+      <div className="flex flex-col items-center p-2">
+        <span className="text-center">Uh oh!</span>
+        <img src={suspiciousGoblin} alt="Warning" className="w-16 m-2" />
+        <span className="text-sm mt-2 mb-2">
+          Your proof of humanity is still being processed by Jigger. This can
+          take up to 2 hours.
+        </span>
+        <span className="text-sm mt-2 mb-2">
+          You can continue playing, but some actions will be restricted while
+          you are being verified.
+        </span>
+        <span className="text-sm mt-2 mb-2">Thank you for your patience.</span>
+        <div className="flex w-full">
+          <Button className="mr-2" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center p-2">
+      <span className="text-center">Uh oh!</span>
+      <img src={suspiciousGoblin} alt="Warning" className="w-16 m-2" />
+      <span className="text-sm mt-2 mb-2">
+        The multi-account detection system has picked up strange behaviour.
+      </span>
+      <span className="text-sm mt-2 mb-2">
+        You can continue playing, but some actions will be restricted while you
+        are being verified.
+      </span>
+      <div className="flex w-full">
+        <Button className="mr-2" onClick={onClose}>
+          Close
+        </Button>
+        <Button onClick={() => setShowWarning(true)}>Verify</Button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/goblins/bank/components/Withdraw.tsx
+++ b/src/features/goblins/bank/components/Withdraw.tsx
@@ -17,27 +17,31 @@ interface Props {
   onClose: () => void;
 }
 export const Withdraw: React.FC<Props> = ({ onClose }) => {
-  const [isLoading, setIsLoading] = useState(false);
   const { authService } = useContext(AuthProvider.Context);
   const { goblinService } = useContext(Context);
   const [authState] = useActor(authService);
+  const [page, setPage] = useState<"tokens" | "items">();
+
   const [jiggerState, setJiggerState] =
     useState<{ url: string; status: JiggerStatus }>();
-
-  const [page, setPage] = useState<"tokens" | "items">();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const load = async () => {
+      setIsLoading(true);
       const check = await loadBanDetails(
         authState.context.farmId?.toString() as string,
         authState.context.rawToken as string,
         authState.context.transactionId as string
       );
 
-      setJiggerState({
-        url: check.verificationUrl,
-        status: check.botStatus as JiggerStatus,
-      });
+      if (check.verificationUrl) {
+        setJiggerState({
+          url: check.verificationUrl,
+          status: check.botStatus as JiggerStatus,
+        });
+      }
+      setIsLoading(false);
     };
 
     load();
@@ -78,6 +82,10 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
     });
     onClose();
   };
+
+  if (isLoading) {
+    return <span className="loading">Loading</span>;
+  }
 
   if (jiggerState) {
     return (

--- a/src/features/goblins/trader/selling/Selling.tsx
+++ b/src/features/goblins/trader/selling/Selling.tsx
@@ -1,12 +1,16 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useActor } from "@xstate/react";
 
 import alert from "assets/icons/expression_alerted.png";
+
+import * as AuthProvider from "features/auth/lib/Provider";
 
 import { Context } from "features/game/GoblinProvider";
 import { KNOWN_ITEMS } from "features/game/types";
 import { Button } from "components/ui/Button";
 
+import { Jigger, JiggerStatus } from "features/game/components/Jigger";
+import { loadBanDetails } from "features/game/actions/bans";
 import { MachineInterpreter as TradingPostMachineInterpreter } from "../tradingPost/lib/tradingPostMachine";
 import { MachineInterpreter as SellingMachineInterpreter } from "./lib/sellingMachine";
 import { Idle } from "./components/Idle";
@@ -27,6 +31,48 @@ export const Selling: React.FC = () => {
   const sellingService = tradingPostState.children
     .selling as SellingMachineInterpreter;
   const [machine, send] = useActor(sellingService);
+
+  const { authService } = useContext(AuthProvider.Context);
+  const [authState] = useActor(authService);
+
+  const [jiggerState, setJiggerState] =
+    useState<{ url: string; status: JiggerStatus }>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      const check = await loadBanDetails(
+        authState.context.farmId?.toString() as string,
+        authState.context.rawToken as string,
+        authState.context.transactionId as string
+      );
+
+      if (check.verificationUrl) {
+        setJiggerState({
+          url: check.verificationUrl,
+          status: check.botStatus as JiggerStatus,
+        });
+      }
+      setIsLoading(false);
+    };
+
+    load();
+  }, []);
+
+  if (isLoading) {
+    return <span className="loading">Loading</span>;
+  }
+
+  if (jiggerState) {
+    return (
+      <Jigger
+        onClose={() => send("BACK")}
+        status={jiggerState.status}
+        verificationUrl={jiggerState.url}
+      />
+    );
+  }
 
   if (machine.matches("idle")) {
     return (

--- a/src/features/goblins/trader/selling/Selling.tsx
+++ b/src/features/goblins/trader/selling/Selling.tsx
@@ -1,16 +1,12 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 import { useActor } from "@xstate/react";
 
 import alert from "assets/icons/expression_alerted.png";
-
-import * as AuthProvider from "features/auth/lib/Provider";
 
 import { Context } from "features/game/GoblinProvider";
 import { KNOWN_ITEMS } from "features/game/types";
 import { Button } from "components/ui/Button";
 
-import { Jigger, JiggerStatus } from "features/game/components/Jigger";
-import { loadBanDetails } from "features/game/actions/bans";
 import { MachineInterpreter as TradingPostMachineInterpreter } from "../tradingPost/lib/tradingPostMachine";
 import { MachineInterpreter as SellingMachineInterpreter } from "./lib/sellingMachine";
 import { Idle } from "./components/Idle";
@@ -31,48 +27,6 @@ export const Selling: React.FC = () => {
   const sellingService = tradingPostState.children
     .selling as SellingMachineInterpreter;
   const [machine, send] = useActor(sellingService);
-
-  const { authService } = useContext(AuthProvider.Context);
-  const [authState] = useActor(authService);
-
-  const [jiggerState, setJiggerState] =
-    useState<{ url: string; status: JiggerStatus }>();
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const load = async () => {
-      setIsLoading(true);
-      const check = await loadBanDetails(
-        authState.context.farmId?.toString() as string,
-        authState.context.rawToken as string,
-        authState.context.transactionId as string
-      );
-
-      if (check.verificationUrl) {
-        setJiggerState({
-          url: check.verificationUrl,
-          status: check.botStatus as JiggerStatus,
-        });
-      }
-      setIsLoading(false);
-    };
-
-    load();
-  }, []);
-
-  if (isLoading) {
-    return <span className="loading">Loading</span>;
-  }
-
-  if (jiggerState) {
-    return (
-      <Jigger
-        onClose={() => send("BACK")}
-        status={jiggerState.status}
-        verificationUrl={jiggerState.url}
-      />
-    );
-  }
 
   if (machine.matches("idle")) {
     return (

--- a/src/features/goblins/trader/tradingPost/TraderModal.tsx
+++ b/src/features/goblins/trader/tradingPost/TraderModal.tsx
@@ -79,7 +79,7 @@ export const TraderModal: React.FC<TraderModalProps> = ({
       return <span className="loading">Loading</span>;
     }
 
-    if (jiggerState) {
+    if (isTrading && isSelling && jiggerState) {
       return (
         <Jigger
           onClose={onClose}

--- a/src/features/goblins/trader/tradingPost/TraderModal.tsx
+++ b/src/features/goblins/trader/tradingPost/TraderModal.tsx
@@ -128,6 +128,7 @@ export const TraderModal: React.FC<TraderModalProps> = ({
           setIsSelling={setIsSelling}
           onClose={handleClose}
         />
+        <Content />
       </Panel>
     </Modal>
   );


### PR DESCRIPTION
# Description

Jigger has made some significant improvements to their detection system and we are re-enabling them.

The prompt to verify now pops up when withdrawing/trading, instead of being obtrusive in the log in process.

This check happens on:

- Bank
- Hot Air Balloon Listing
- Storage House Delivery

<img width="526" alt="Screen Shot 2022-12-30 at 10 11 54 am" src="https://user-images.githubusercontent.com/11745561/210019985-2c04193d-638f-48eb-a1af-e4285013646a.png">
<img width="523" alt="Screen Shot 2022-12-30 at 10 12 02 am" src="https://user-images.githubusercontent.com/11745561/210019993-a360b02f-0807-4ca0-9c01-3246f3e6427f.png">
