### PR TITLE
[FIX] Fixing issues in drop animation

### DIFF
--- a/src/components/animation/FruitDropAnimator.tsx
+++ b/src/components/animation/FruitDropAnimator.tsx
@@ -7,6 +7,8 @@ interface Props {
   mainImageProps: React.ImgHTMLAttributes<HTMLImageElement>;
   dropImageProps: React.ImgHTMLAttributes<HTMLImageElement>;
   dropCount?: number;
+  playDropAnimation?: boolean;
+  playShakeAnimation?: boolean;
 }
 
 export const FruitDropAnimator = ({
@@ -14,6 +16,8 @@ export const FruitDropAnimator = ({
   mainImageProps,
   dropImageProps,
   dropCount,
+  playDropAnimation = true,
+  playShakeAnimation = true,
 }: Props) => {
   const [hideFruits, setHideFruits] = useState(false);
   const { current } = useRef(randomInt(1, 3));
@@ -28,28 +32,32 @@ export const FruitDropAnimator = ({
     <div className={`${wrapperClassName} relative`}>
       <img
         {...mainImageProps}
-        className={`${mainImageProps?.className} tree-shake-animation`}
-      />
-      <div
-        className={classNames("absolute fruit-wrapper", {
-          "opacity-0": hideFruits,
-          "drop-animation-left": current === 1,
-          "drop-animation-right": current === 2,
+        className={classNames(`${mainImageProps?.className}`, {
+          "tree-shake-animation": playShakeAnimation,
         })}
-      >
-        {dropCount && (
-          <span className="text-sm text-white absolute -top-6">{`+${dropCount}`}</span>
-        )}
-        <img {...dropImageProps} className={`w-5 relative img-highlight`} />
-        <img
-          {...dropImageProps}
-          className={`w-5 absolute top-2 left-2 img-highlight`}
-        />
-        <img
-          {...dropImageProps}
-          className={`w-5 absolute top-3 -left-2 img-highlight`}
-        />
-      </div>
+      />
+      {playDropAnimation && (
+        <div
+          className={classNames("absolute fruit-wrapper", {
+            "opacity-0": hideFruits,
+            "drop-animation-left": current === 1,
+            "drop-animation-right": current === 2,
+          })}
+        >
+          {dropCount && (
+            <span className="text-sm text-white absolute -top-6">{`+${dropCount}`}</span>
+          )}
+          <img {...dropImageProps} className={`w-5 relative img-highlight`} />
+          <img
+            {...dropImageProps}
+            className={`w-5 absolute top-2 left-2 img-highlight`}
+          />
+          <img
+            {...dropImageProps}
+            className={`w-5 absolute top-3 -left-2 img-highlight`}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -36,6 +36,7 @@ export const FruitPatch: React.FC<Props> = ({
   const [game] = useActor(gameService);
   const { setToast } = useContext(ToastContext);
   const [showError, setShowError] = useState(false);
+  const [playAnimation, setPlayAnimation] = useState(false);
   const expansion = game.context.state.expansions[expansionIndex];
   const patch = expansion.fruitPatches?.[fruitPatchIndex];
 
@@ -51,7 +52,6 @@ export const FruitPatch: React.FC<Props> = ({
 
   const harvestFruit = () => {
     if (!fruit) return;
-
     try {
       const newState = gameService.send("fruit.harvested", {
         index: fruitPatchIndex,
@@ -60,7 +60,7 @@ export const FruitPatch: React.FC<Props> = ({
 
       if (!newState.matches("hoarding")) {
         harvestAudio.play();
-
+        setPlayAnimation(true);
         setToast({
           icon: ITEM_DETAILS[fruit.name].image,
           content: `+${fruit.amount || 1}`,
@@ -125,6 +125,7 @@ export const FruitPatch: React.FC<Props> = ({
             removeTree={removeTree}
             onError={displayError}
             playing={playing}
+            playAnimation={playAnimation}
           />
         ) : (
           <img

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -1,15 +1,31 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { getTimeLeft } from "lib/utils/time";
 import { setImageWidth } from "lib/images";
 import { PlantedFruit } from "features/game/types/game";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
-import { FRUIT } from "features/game/types/fruits";
+import { FRUIT, FruitName } from "features/game/types/fruits";
 import { FRUIT_LIFECYCLE } from "./fruits";
 import { Soil } from "./Soil";
 
 import { Seedling } from "./Seedling";
 import { ReplenishingTree } from "./ReplenishingTree";
+
+import apple from "/src/assets/resources/apple.png";
+import orange from "/src/assets/resources/orange.png";
+import blueberry from "/src/assets/resources/blueberry.png";
+import { FruitDropAnimator } from "components/animation/FruitDropAnimator";
+
+export const getFruitImage = (fruitName: FruitName): string => {
+  switch (fruitName) {
+    case "Apple":
+      return apple;
+    case "Orange":
+      return orange;
+    case "Blueberry":
+      return blueberry;
+  }
+};
 
 interface Props {
   plantedFruit?: PlantedFruit;
@@ -18,6 +34,7 @@ interface Props {
   harvestFruit: () => void;
   removeTree: () => void;
   onError: () => void;
+  playAnimation: boolean;
 }
 
 export const FruitTree: React.FC<Props> = ({
@@ -27,46 +44,68 @@ export const FruitTree: React.FC<Props> = ({
   removeTree,
   onError,
   playing,
+  playAnimation,
 }) => {
   useUiRefresher({ active: !!plantedFruit });
+  //UI Refresher reloads this component after a regular time intervals.
+  //which results to pre loading of the image again and again.
+  const [alreadyPreloaded, setAlreadyPreloaded] = useState(false);
+
+  const preloadImage = (url: string) => {
+    const img = new Image();
+    img.src = url;
+    setAlreadyPreloaded(true);
+  };
 
   if (!plantedFruit) {
     return <Soil playing={playing} onClick={plantTree} />;
   }
 
-  const { harvestSeconds, isBush } = FRUIT()[plantedFruit.name];
-  const lifecycle = FRUIT_LIFECYCLE[plantedFruit.name];
+  const { name, amount, harvestsLeft, harvestedAt, plantedAt } = plantedFruit;
+  const { harvestSeconds, isBush } = FRUIT()[name];
+  const lifecycle = FRUIT_LIFECYCLE[name];
 
   // Dead tree
-  if (!plantedFruit.harvestsLeft) {
+  if (!harvestsLeft) {
     return (
-      <img
-        className="relative cursor-pointer hover:img-highlight"
-        style={{
-          bottom: "-10px",
-          zIndex: "1",
+      <FruitDropAnimator
+        mainImageProps={{
+          src: lifecycle.dead,
+          className: "relative cursor-pointer hover:img-highlight",
+          style: {
+            bottom: "-9px",
+            zIndex: "1",
+          },
+          onLoad: (e) => setImageWidth(e.currentTarget),
+          onClick: removeTree,
         }}
-        src={lifecycle.dead}
-        onLoad={(e) => setImageWidth(e.currentTarget)}
-        onClick={removeTree}
+        dropImageProps={{
+          src: getFruitImage(name),
+        }}
+        dropCount={amount}
+        playDropAnimation={playAnimation}
+        playShakeAnimation={false}
       />
     );
   }
 
   // Replenishing tree
-  if (plantedFruit.harvestedAt) {
-    const replenishingTimeLeft = getTimeLeft(
-      plantedFruit.harvestedAt,
-      harvestSeconds
-    );
+  if (harvestedAt) {
+    const replenishingTimeLeft = getTimeLeft(harvestedAt, harvestSeconds);
 
     if (replenishingTimeLeft > 0) {
-      return <ReplenishingTree onClick={onError} plantedFruit={plantedFruit} />;
+      return (
+        <ReplenishingTree
+          onClick={onError}
+          plantedFruit={plantedFruit}
+          playAnimation={playAnimation}
+        />
+      );
     }
   }
 
   // Seedling
-  const growingTimeLeft = getTimeLeft(plantedFruit.plantedAt, harvestSeconds);
+  const growingTimeLeft = getTimeLeft(plantedAt, harvestSeconds);
 
   if (growingTimeLeft > 0) {
     return (
@@ -76,6 +115,13 @@ export const FruitTree: React.FC<Props> = ({
         plantedFruit={plantedFruit}
       />
     );
+  }
+
+  //Pre loading the harvested tree image so that we get a smooth transition
+  // when the user clicks on the ready tree and it transitions to the harvest state.
+  if (!alreadyPreloaded) {
+    preloadImage(lifecycle.harvested);
+    preloadImage(getFruitImage(name));
   }
 
   // Ready tree

--- a/src/features/island/fruit/ReplenishingTree.tsx
+++ b/src/features/island/fruit/ReplenishingTree.tsx
@@ -6,34 +6,23 @@ import { getTimeLeft } from "lib/utils/time";
 import { PlantedFruit } from "features/game/types/game";
 import { ProgressBar } from "components/ui/ProgressBar";
 import { Popover } from "./Popover";
-import { FRUIT, FruitName } from "features/game/types/fruits";
+import { FRUIT } from "features/game/types/fruits";
 import { FRUIT_LIFECYCLE } from "./fruits";
 import { setImageWidth } from "lib/images";
 import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 import { FruitDropAnimator } from "components/animation/FruitDropAnimator";
-import apple from "/src/assets/resources/apple.png";
-import orange from "/src/assets/resources/orange.png";
-import blueberry from "/src/assets/resources/blueberry.png";
+import { getFruitImage } from "./FruitTree";
 
 interface Props {
   plantedFruit: PlantedFruit;
   onClick: () => void;
+  playAnimation: boolean;
 }
-
-export const getFruitImage = (fruitName: FruitName): string => {
-  switch (fruitName) {
-    case "Apple":
-      return apple;
-    case "Orange":
-      return orange;
-    case "Blueberry":
-      return blueberry;
-  }
-};
 
 export const ReplenishingTree: React.FC<Props> = ({
   plantedFruit,
   onClick,
+  playAnimation,
 }) => {
   const { showTimers } = useContext(Context);
   const [isMobile] = useIsMobile();
@@ -56,7 +45,7 @@ export const ReplenishingTree: React.FC<Props> = ({
       <FruitDropAnimator
         mainImageProps={{
           src: lifecycle.harvested,
-          className: "relative",
+          className: "relative hover:img-highlight",
           style: {
             bottom: `${isBush ? "-11px" : "25px"}`,
             zIndex: "1",
@@ -68,6 +57,8 @@ export const ReplenishingTree: React.FC<Props> = ({
           src: getFruitImage(name),
         }}
         dropCount={amount}
+        playDropAnimation={playAnimation}
+        playShakeAnimation={playAnimation}
       />
       {showTimers && (
         <div


### PR DESCRIPTION
# Description

In this PR, I have the following issues with the fruit drop animation:
1. Pre-loading harvest tree image so that we have a smooth transition when the user clicks on the ready tree and the animation starts.
2. Added drop when 1 harvest is left.
3. Run the animation only when the harvest action is performed and not every time on page load.
4. Added configurations in fruitdropanimation component so that anyone can choose which animation to play and what not to play.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
