### PR TITLE
[FEAT] Tree and Stone drop Animations

### DIFF
--- a/src/ResourceDropAnimations.css
+++ b/src/ResourceDropAnimations.css
@@ -28,7 +28,7 @@
   }
 }
 
-.fruit-wrapper {
+.item-wrapper {
   top: 30%;
   z-index: 2;
   transition: opacity 0.1s ease-out;

--- a/src/components/animation/ResourceDropAnimator.tsx
+++ b/src/components/animation/ResourceDropAnimator.tsx
@@ -11,7 +11,7 @@ interface Props {
   playShakeAnimation?: boolean;
 }
 
-export const FruitDropAnimator = ({
+export const ResourceDropAnimator = ({
   wrapperClassName,
   mainImageProps,
   dropImageProps,
@@ -19,12 +19,12 @@ export const FruitDropAnimator = ({
   playDropAnimation = true,
   playShakeAnimation = true,
 }: Props) => {
-  const [hideFruits, setHideFruits] = useState(false);
+  const [hideItem, setHideItems] = useState(false);
   const { current } = useRef(randomInt(1, 3));
 
   useEffect(() => {
     setTimeout(() => {
-      setHideFruits(true);
+      setHideItems(true);
     }, 1500);
   }, []);
 
@@ -38,8 +38,8 @@ export const FruitDropAnimator = ({
       />
       {playDropAnimation && (
         <div
-          className={classNames("absolute fruit-wrapper", {
-            "opacity-0": hideFruits,
+          className={classNames("absolute item-wrapper", {
+            "opacity-0": hideItem,
             "drop-animation-left": current === 1,
             "drop-animation-right": current === 2,
           })}
@@ -47,14 +47,17 @@ export const FruitDropAnimator = ({
           {dropCount && (
             <span className="text-sm text-white absolute -top-6">{`+${dropCount}`}</span>
           )}
-          <img {...dropImageProps} className={`w-5 relative img-highlight`} />
           <img
             {...dropImageProps}
-            className={`w-5 absolute top-2 left-2 img-highlight`}
+            className={`w-5 relative img-highlight ${dropImageProps.className}`}
           />
           <img
             {...dropImageProps}
-            className={`w-5 absolute top-3 -left-2 img-highlight`}
+            className={`w-5 absolute top-2 left-2 img-highlight ${dropImageProps.className}`}
+          />
+          <img
+            {...dropImageProps}
+            className={`w-5 absolute top-3 -left-2 img-highlight ${dropImageProps.className}`}
           />
         </div>
       )}

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -14,7 +14,7 @@ import { ReplenishingTree } from "./ReplenishingTree";
 import apple from "/src/assets/resources/apple.png";
 import orange from "/src/assets/resources/orange.png";
 import blueberry from "/src/assets/resources/blueberry.png";
-import { FruitDropAnimator } from "components/animation/FruitDropAnimator";
+import { ResourceDropAnimator } from "components/animation/ResourceDropAnimator";
 
 export const getFruitImage = (fruitName: FruitName): string => {
   switch (fruitName) {
@@ -68,7 +68,7 @@ export const FruitTree: React.FC<Props> = ({
   // Dead tree
   if (!harvestsLeft) {
     return (
-      <FruitDropAnimator
+      <ResourceDropAnimator
         mainImageProps={{
           src: lifecycle.dead,
           className: "relative cursor-pointer hover:img-highlight",

--- a/src/features/island/fruit/ReplenishingTree.tsx
+++ b/src/features/island/fruit/ReplenishingTree.tsx
@@ -10,7 +10,7 @@ import { FRUIT } from "features/game/types/fruits";
 import { FRUIT_LIFECYCLE } from "./fruits";
 import { setImageWidth } from "lib/images";
 import { useIsMobile } from "lib/utils/hooks/useIsMobile";
-import { FruitDropAnimator } from "components/animation/FruitDropAnimator";
+import { ResourceDropAnimator } from "components/animation/ResourceDropAnimator";
 import { getFruitImage } from "./FruitTree";
 
 interface Props {
@@ -42,7 +42,7 @@ export const ReplenishingTree: React.FC<Props> = ({
       onMouseLeave={() => setFruitDetails(false)}
       className="flex justify-center"
     >
-      <FruitDropAnimator
+      <ResourceDropAnimator
         mainImageProps={{
           src: lifecycle.harvested,
           className: "relative hover:img-highlight",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
-@import "./fruitAnimations.css";
+@import "./ResourceDropAnimations.css";
 @layer utilities {
   .text-shadow {
     text-shadow: 1px 1px #1f1f1f;


### PR DESCRIPTION
# Description

I have removed the sprite sheet being used for showing the drop animations on the trees and stones. Now they would be handled using our reusable drop animator component. In the next PR, I would apply this to iron and gold.


https://user-images.githubusercontent.com/35486909/210805758-f493d98d-71d3-4bbd-9893-da9a51132ea5.mov


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
