### PR TITLE
[FIX] Buy Tools in Bulk

### DIFF
--- a/src/features/treasureIsland/components/TreasureShopBuy.tsx
+++ b/src/features/treasureIsland/components/TreasureShopBuy.tsx
@@ -115,7 +115,7 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
   if (showCaptcha) {
     return (
       <CloudFlareCaptcha
-        action="carfting-sync"
+        action="crafting-sync"
         onDone={onCaptchaSolved}
         onExpire={() => setShowCaptcha(false)}
         onError={() => setShowCaptcha(false)}


### PR DESCRIPTION
# Description
 
Allow users to buy tools in bulk. 
With the increase of axes per sync to 125 it's a struggle to buy them 1 by 1. 
This will apply to all the tools in workbench, bulk buy will be the same (10) as the seeds.

Corrected 2 typos (action="carfting-sync").

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran the tests manually

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
