### PR TITLE
[FIX] Safety check on basket open when visiting other farm

### DIFF
--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -77,7 +77,7 @@ export const getCropTime = (
   crop: CropName,
   inventory: Inventory,
   collectibles: Collectibles,
-  bumpkin: Bumpkin
+  bumpkin: Bumpkin | undefined
 ) => {
   let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -79,8 +79,6 @@ export const getCropTime = (
   collectibles: Collectibles,
   bumpkin: Bumpkin
 ) => {
-  const { skills, equipped } = bumpkin;
-  const { necklace } = equipped;
   let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
 
   if (inventory["Seed Specialist"]?.gte(1)) {
@@ -93,10 +91,6 @@ export const getCropTime = (
   ) {
     seconds = seconds * 0.5;
   }
-  //Bumpkin Wearable Boost
-  if (crop === "Carrot" && necklace === "Carrot Amulet") {
-    seconds = seconds * 0.8;
-  }
 
   // Scarecrow: 15% reduction
   if (
@@ -107,8 +101,15 @@ export const getCropTime = (
     seconds = seconds * 0.85;
   }
 
-  if (skills["Cultivator"]) {
-    seconds = seconds * 0.95;
+  if (bumpkin) {
+    //Bumpkin Wearable Boost
+    if (crop === "Carrot" && bumpkin.equipped.necklace === "Carrot Amulet") {
+      seconds = seconds * 0.8;
+    }
+
+    if (bumpkin.skills["Cultivator"]) {
+      seconds = seconds * 0.95;
+    }
   }
 
   return seconds;

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -209,12 +209,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
 
     if (yields in CROPS())
       return secondsToString(
-        getCropTime(
-          yields as CropName,
-          inventory,
-          collectibles,
-          state.bumpkin as Bumpkin
-        ),
+        getCropTime(yields as CropName, inventory, collectibles, state.bumpkin),
         {
           length: "medium",
           removeTrailingZeros: true,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -6,7 +6,6 @@ import {
   InventoryItemName,
   FERTILISERS,
   COUPONS,
-  Bumpkin,
   GameState,
 } from "features/game/types/game";
 
@@ -46,7 +45,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     const crop = seedName.split(" ")[0] as CropName;
 
     return secondsToString(
-      getCropTime(crop, inventory, collectibles, bumpkin as Bumpkin),
+      getCropTime(crop, inventory, collectibles, bumpkin),
       {
         length: "medium",
       }

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -16,10 +16,7 @@ import timer from "assets/icons/timer.png";
 import basket from "assets/icons/basket.png";
 
 import { secondsToString } from "lib/utils/time";
-import {
-  getCropTime,
-  getCropTime as getCropTimeLandExpansion,
-} from "features/game/events/landExpansion/plant";
+import { getCropTime } from "features/game/events/landExpansion/plant";
 import { getKeys, SHOVELS, TOOLS } from "features/game/types/craftables";
 import { getBasketItems } from "./utils/inventory";
 import { RESOURCES } from "features/game/types/resources";
@@ -48,27 +45,8 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const getCropHarvestTime = (seedName = "") => {
     const crop = seedName.split(" ")[0] as CropName;
 
-    if (bumpkin) {
-      return secondsToString(
-        getCropTimeLandExpansion(
-          crop,
-          inventory,
-          collectibles,
-          bumpkin as Bumpkin
-        ),
-        {
-          length: "medium",
-        }
-      );
-    }
-
     return secondsToString(
-      getCropTime(
-        crop,
-        gameState.inventory,
-        gameState.collectibles,
-        gameState.bumpkin as Bumpkin
-      ),
+      getCropTime(crop, inventory, collectibles, bumpkin as Bumpkin),
       {
         length: "medium",
       }


### PR DESCRIPTION
# Description

There is an issue when opening inventory on a farm that has no bumpkin.
For example visit farm 77 and click on inventory.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
