### PR TITLE
[FIX] Allow crafting 1 item per player only for helios blacksmith

### DIFF
--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -51,6 +51,10 @@ export const HeliosBlacksmithItems: React.FC<Props> = ({ onClose }) => {
         content: `-${item.ingredients[name]}`,
       });
     });
+    setToast({
+      icon: ITEM_DETAILS[selected].image,
+      content: "+1",
+    });
 
     shortcutItem(selected);
   };

--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -37,10 +37,19 @@ export const HeliosBlacksmithItems: React.FC<Props> = ({ onClose }) => {
   const inventory = state.inventory;
 
   const item = HELIOS_BLACKSMITH_ITEMS[selected];
+  const isAlreadyCrafted = state.inventory[selected]?.greaterThanOrEqualTo(1);
 
   const craft = () => {
     gameService.send("collectible.crafted", {
       name: selected,
+    });
+
+    getKeys(item.ingredients).map((name) => {
+      const ingredient = ITEM_DETAILS[name];
+      setToast({
+        icon: ingredient.image,
+        content: `-${item.ingredients[name]}`,
+      });
     });
 
     shortcutItem(selected);
@@ -163,13 +172,19 @@ export const HeliosBlacksmithItems: React.FC<Props> = ({ onClose }) => {
             </div>
           </div>
         </div>
-        <Button
-          disabled={stock?.lessThan(1) || lessIngredients()}
-          className="text-xxs sm:text-xs mt-1"
-          onClick={() => craft()}
-        >
-          Craft
-        </Button>
+        {isAlreadyCrafted ? (
+          <p className="text-xxs sm:text-xs text-center my-1">
+            Already crafted!
+          </p>
+        ) : (
+          <Button
+            disabled={stock?.lessThan(1) || lessIngredients()}
+            className="text-xxs sm:text-xs mt-1"
+            onClick={() => craft()}
+          >
+            Craft
+          </Button>
+        )}
       </OuterPanel>
     </div>
   );


### PR DESCRIPTION
# Description

- Allow crafting 1 item only for helios blacksmith
- show toast when crafting items

![image](https://user-images.githubusercontent.com/107602352/211436894-bb881d72-3b67-4ce5-b2a4-6f2ff190dca7.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- buy items in helios blacksmith if players have the item already

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
