### PR TITLE
[FIX] Remove invisible items after fruit animation

### DIFF
--- a/src/components/animation/FruitDropAnimator.tsx
+++ b/src/components/animation/FruitDropAnimator.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const FruitDropAnimator = ({
-  wrapperClassName,
+  wrapperClassName = "",
   mainImageProps,
   dropImageProps,
   dropCount,
@@ -36,10 +36,9 @@ export const FruitDropAnimator = ({
           "tree-shake-animation": playShakeAnimation,
         })}
       />
-      {playDropAnimation && (
+      {playDropAnimation && !hideFruits && (
         <div
           className={classNames("absolute fruit-wrapper", {
-            "opacity-0": hideFruits,
             "drop-animation-left": current === 1,
             "drop-animation-right": current === 2,
           })}

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -88,6 +88,10 @@ export const FruitPatch: React.FC<Props> = ({
         setPlayAnimation(true);
 
         setToast({
+          icon: ITEM_DETAILS.Axe.image,
+          content: `-1`,
+        });
+        setToast({
           icon: ITEM_DETAILS.Wood.image,
           content: `+1`,
         });


### PR DESCRIPTION
# Description

Prevent invisible items from fruit animation to interfere with adjacent map objects
Display '-1 axe' toast on tree chopping

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
