### PR TITLE
[FIX] Improve inventory layout for large screens

### DIFF
--- a/src/features/game/components/SplitScreenView.tsx
+++ b/src/features/game/components/SplitScreenView.tsx
@@ -5,6 +5,7 @@ import classNames from "classnames";
 interface Props {
   divRef?: React.RefObject<HTMLDivElement>;
   tallMobileContent?: boolean;
+  wideModal?: boolean;
   showHeader?: boolean;
   header: JSX.Element;
   content: JSX.Element;
@@ -13,6 +14,7 @@ interface Props {
 export const SplitScreenView: React.FC<Props> = ({
   divRef,
   tallMobileContent = false,
+  wideModal = false,
   showHeader = true,
   header,
   content,
@@ -21,16 +23,25 @@ export const SplitScreenView: React.FC<Props> = ({
     <div className="flex flex-col-reverse sm:flex-row">
       <div
         className={classNames(
-          "w-full sm:w-3/5 h-fit sm:max-h-96 overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap",
-          { "max-h-80": tallMobileContent },
-          { "max-h-48": !tallMobileContent }
+          "w-full sm:w-3/5 lg:w-3/4 h-fit sm:max-h-96 overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap",
+          {
+            "max-h-80": tallMobileContent,
+            "max-h-48": !tallMobileContent,
+            "lg:w-3/4": wideModal,
+          }
         )}
         ref={divRef}
       >
         {content}
       </div>
       {showHeader && (
-        <OuterPanel className="w-full sm:w-2/5">{header}</OuterPanel>
+        <OuterPanel
+          className={classNames("w-full sm:w-2/5", {
+            "lg:w-1/4": wideModal,
+          })}
+        >
+          {header}
+        </OuterPanel>
       )}
     </div>
   );

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -114,6 +114,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     <SplitScreenView
       divRef={divRef}
       tallMobileContent={true}
+      wideModal={true}
       showHeader={!basketIsEmpty && !!selected}
       header={
         selected && (

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -97,6 +97,7 @@ export const Chest: React.FC<Props> = ({
     <SplitScreenView
       divRef={divRef}
       tallMobileContent={true}
+      wideModal={true}
       showHeader={!chestIsEmpty && !!selected}
       header={
         selected && (

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -80,7 +80,7 @@ export const Inventory: React.FC<Props> = ({
         />
       </div>
 
-      <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
+      <Modal size="lg" centered show={isOpen} onHide={() => setIsOpen(false)}>
         <InventoryItems
           state={state}
           onClose={() => setIsOpen(false)}


### PR DESCRIPTION
# Description

- increase inventory modal width for large screens

**Medium size screens (what it originally looked like)**
Basket|Chest
---|---
![image](https://user-images.githubusercontent.com/107602352/211693388-5038f694-1007-4c69-acb0-e09ea710e471.png)|![image](https://user-images.githubusercontent.com/107602352/211693418-6ff78336-71c9-465a-add2-1792fe78056a.png)

**Large size screens (new layout)**
Basket|Chest
---|---
![image](https://user-images.githubusercontent.com/107602352/211693436-578f8ad5-34af-4fe7-b3a3-f1b828bc1536.png)|![image](https://user-images.githubusercontent.com/107602352/211693471-5d49f9a2-723f-4218-b30e-a2d0196e08f4.png)

**Mobile screens (what it originally looked like)**
Basket|Chest
---|---
![image](https://user-images.githubusercontent.com/107602352/211693331-1716af77-5c97-4dbe-8e1d-d38df74524d5.png)|![image](https://user-images.githubusercontent.com/107602352/211693349-2ac3387f-e800-4de0-9998-a71ebf2795be.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open inventory with different screen sizes

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
