### PR TITLE
[FEAT] Adding bear to withdraw logic

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -99,7 +99,8 @@ const globalDefaults = Object.keys(KNOWN_IDS).reduce(
 
 // Group withdraw conditions for common items
 const cropDefaults = buildDefaults(Object.keys(CROPS()), true);
-const fruitDefaults = buildDefaults(Object.keys(FRUIT()), true);
+//Fruits will be disabled untill all the fruit SFT's are sold out
+const fruitDefaults = buildDefaults(Object.keys(FRUIT()), false);
 const resourceDefaults = buildDefaults(Object.keys(RESOURCES), true);
 const mutantChickenDefaults = buildDefaults(
   Object.keys(MUTANT_CHICKENS),

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -136,7 +136,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Mysterious Head": true,
   "Golden Bonsai": true,
   "Wicker Man": true,
-  "Engine Core": true,
+  "Engine Core": false,
   Observatory: true,
   "Christmas Snow Globe": true,
   "Cabbage Boy": true,

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -7,6 +7,7 @@ import { FLAGS, getKeys, MUTANT_CHICKENS } from "./craftables";
 import { RESOURCES } from "./resources";
 import { canChop } from "../events/landExpansion/chop";
 import { canMine } from "../events/landExpansion/stoneMine";
+import { AchievementName } from "./achievements";
 
 type WithdrawCondition = boolean | ((gameState: GoblinState) => boolean);
 
@@ -79,6 +80,13 @@ function areAnyChickensFed(game: GoblinState): boolean {
   );
 }
 
+function hasCompletedAchievment(
+  game: GoblinState,
+  achievement: AchievementName
+): boolean {
+  return Object.keys(game.bumpkin?.achievements ?? []).includes(achievement);
+}
+
 // Everything is non-withdrawable by default
 const globalDefaults = Object.keys(KNOWN_IDS).reduce(
   (prev, cur) => ({
@@ -126,6 +134,18 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Golden Bonsai": true,
   "Wicker Man": true,
   Observatory: true,
+  "Chef Bear": true,
+  "Construction Bear": true,
+  "Angel Bear": true,
+  "Badass Bear": true,
+  "Bear Trap": true,
+  "Brilliant Bear": true,
+  "Classy Bear": true,
+  "Farmer Bear": true,
+  "Sunflower Bear": true,
+  "Rich Bear": true,
+  "Rainbow Artist Bear": true,
+  "Devil Bear": true,
 
   // Conditional Rules
   "Chicken Coop": (game) => !areAnyChickensFed(game),
@@ -146,6 +166,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
+  "Basic Bear": (game) => hasCompletedAchievment(game, "Sun Seeker"),
 };
 
 // Explicit false check is important, as we also want to check if it's a bool.

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -2,6 +2,7 @@ import { KNOWN_IDS } from ".";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
 import { CROPS, CROP_SEEDS } from "./crops";
+import { FRUIT } from "./fruits";
 import { EASTER_EGGS, Inventory, InventoryItemName } from "./game";
 import { FLAGS, getKeys, MUTANT_CHICKENS } from "./craftables";
 import { RESOURCES } from "./resources";
@@ -98,6 +99,7 @@ const globalDefaults = Object.keys(KNOWN_IDS).reduce(
 
 // Group withdraw conditions for common items
 const cropDefaults = buildDefaults(Object.keys(CROPS()), true);
+const fruitDefaults = buildDefaults(Object.keys(FRUIT()), true);
 const resourceDefaults = buildDefaults(Object.keys(RESOURCES), true);
 const mutantChickenDefaults = buildDefaults(
   Object.keys(MUTANT_CHICKENS),
@@ -109,13 +111,14 @@ const easterEggDefaults = buildDefaults([...EASTER_EGGS, "Egg Basket"], true);
 export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   ...globalDefaults,
   ...cropDefaults,
+  ...fruitDefaults,
   ...resourceDefaults,
   ...mutantChickenDefaults,
   ...flagDefaults,
   ...easterEggDefaults,
 
   // Explicit Rules
-  Chicken: false, // Temporarily disabled until land expansion
+  Chicken: true,
   "Farm Cat": true,
   "Farm Dog": true,
   "Gold Egg": true,
@@ -133,7 +136,12 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Mysterious Head": true,
   "Golden Bonsai": true,
   "Wicker Man": true,
+  "Engine Core": true,
   Observatory: true,
+  "Christmas Snow Globe": true,
+  "Cabbage Boy": true,
+  "Cabbage Girl": true,
+  "Wood Nymph Wendy": true,
   "Chef Bear": true,
   "Construction Bear": true,
   "Angel Bear": true,
@@ -146,6 +154,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Rich Bear": true,
   "Rainbow Artist Bear": true,
   "Devil Bear": true,
+  "Christmas Bear": true,
 
   // Conditional Rules
   "Chicken Coop": (game) => !areAnyChickensFed(game),

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -96,20 +96,6 @@ describe("canWithdraw", () => {
       expect(enabled).toBeFalsy();
     });
 
-    it("[TEMP] prevents a user from withdrawing chickens", () => {
-      const enabled = canWithdraw({
-        item: "Chicken",
-        game: {
-          ...TEST_FARM,
-          inventory: {
-            Chicken: new Decimal(1),
-          },
-        },
-      });
-
-      expect(enabled).toBeFalsy();
-    });
-
     it("prevents a user from withdrawing mutant chickens if some chicken is fed", () => {
       const enabled = canWithdraw({
         item: "Rich Chicken",


### PR DESCRIPTION
# Description

In this PR, I have added all those items which were missing from the withdrawable list. 

Basic bear is not withdrawable if the "Sun Seeker" achievement has not been completed. 

Basic bear not withdrawable:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/35486909/211699629-59e418ae-d753-4140-92cf-74e5ea926539.png">

Basic Bear withdrawable:
<img width="581" alt="image" src="https://user-images.githubusercontent.com/35486909/211699860-dc12f0c0-3f30-444b-b760-e1112272e1a5.png">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
