### PR TITLE
[FIX] Disable Basic Bears and Chickens withdrawals

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -99,7 +99,7 @@ const globalDefaults = Object.keys(KNOWN_IDS).reduce(
 
 // Group withdraw conditions for common items
 const cropDefaults = buildDefaults(Object.keys(CROPS()), true);
-//Fruits will be disabled untill all the fruit SFT's are sold out
+// Fruits will be disabled untill all the fruit SFT's are sold out
 const fruitDefaults = buildDefaults(Object.keys(FRUIT()), false);
 const resourceDefaults = buildDefaults(Object.keys(RESOURCES), true);
 const mutantChickenDefaults = buildDefaults(
@@ -119,7 +119,8 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   ...easterEggDefaults,
 
   // Explicit Rules
-  Chicken: true,
+  Chicken: false,
+  "Basic Bear": false,
   "Farm Cat": true,
   "Farm Dog": true,
   "Gold Egg": true,
@@ -176,7 +177,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
-  "Basic Bear": (game) => hasCompletedAchievment(game, "Sun Seeker"),
 };
 
 // Explicit false check is important, as we also want to check if it's a bool.

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -2,6 +2,8 @@ import "lib/__mocks__/configMock.ts";
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { canWithdraw } from "./bankUtils";
+import { FRUIT } from "features/game/types/fruits";
+import { getKeys } from "features/game/types/craftables";
 
 describe("canWithdraw", () => {
   describe("prevents", () => {
@@ -90,6 +92,20 @@ describe("canWithdraw", () => {
         item: "Fire Pit",
         game: {
           ...TEST_FARM,
+        },
+      });
+
+      expect(enabled).toBeFalsy();
+    });
+
+    it("prevents a user from withdrawing chickens", () => {
+      const enabled = canWithdraw({
+        item: "Chicken",
+        game: {
+          ...TEST_FARM,
+          inventory: {
+            Chicken: new Decimal(1),
+          },
         },
       });
 
@@ -1324,6 +1340,50 @@ describe("canWithdraw", () => {
             },
           },
         ],
+      },
+    });
+
+    expect(enabled).toBeTruthy();
+  });
+
+  it("prevents users from withdrawing fruits", () => {
+    getKeys(FRUIT()).map((item) => {
+      const enabled = canWithdraw({
+        item: item,
+        game: {
+          ...TEST_FARM,
+          inventory: {
+            [item]: new Decimal(1),
+          },
+        },
+      });
+
+      expect(enabled).toBeFalsy();
+    });
+  });
+
+  it("prevents users from withdrawing basic bear", () => {
+    const enabled = canWithdraw({
+      item: "Basic Bear",
+      game: {
+        ...TEST_FARM,
+        inventory: {
+          "Basic Bear": new Decimal(1),
+        },
+      },
+    });
+
+    expect(enabled).toBeFalsy();
+  });
+
+  it("allows users from withdrawing bears other than basic bear", () => {
+    const enabled = canWithdraw({
+      item: "Chef Bear",
+      game: {
+        ...TEST_FARM,
+        inventory: {
+          "Chef Bear": new Decimal(1),
+        },
       },
     });
 


### PR DESCRIPTION
# Description

- Disable withdrawals of chickens and basic bears
  -  Core developers please merge the ticket if it seems fit, or close the ticket otherwise

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- unit tests
- try withdrawing fruits, basic bear or chickens

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
