### PR TITLE
[FIX] Hide placed items in Goblin Retreat

### DIFF
--- a/src/features/game/components/Revealing.tsx
+++ b/src/features/game/components/Revealing.tsx
@@ -1,4 +1,3 @@
-import { SUNNYSIDE } from "assets/sunnyside";
 import React from "react";
 
 import maneki from "assets/sfts/maneki_neko.gif";

--- a/src/features/game/lib/goblinMachine.ts
+++ b/src/features/game/lib/goblinMachine.ts
@@ -16,7 +16,7 @@ import { wishingWellMachine } from "features/goblins/wishingWell/wishingWellMach
 import { tradingPostMachine } from "features/goblins/trader/tradingPost/lib/tradingPostMachine";
 import Decimal from "decimal.js-light";
 import { CONFIG } from "lib/config";
-import { getLowestGameState } from "./transforms";
+import { getAvailableGameState } from "./transforms";
 import { Item } from "features/retreat/components/auctioneer/actions/auctioneerItems";
 import { fetchAuctioneerDrops } from "../actions/auctioneer";
 import { auctioneerMachine } from "features/retreat/auctioneer/auctioneerMachine";
@@ -191,9 +191,9 @@ export function startGoblinVillage(authContext: AuthContext) {
               const game = response?.game as GameState;
 
               // Show whatever is lower, on chain or offchain
-              const availableState = getLowestGameState({
-                first: onChainState.game,
-                second: game,
+              const availableState = getAvailableGameState({
+                onChain: onChainState.game,
+                offChain: game,
               });
 
               game.id = farmId;

--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -1,16 +1,16 @@
 import Decimal from "decimal.js-light";
 import { LandExpansion } from "../types/game";
 import { TEST_FARM } from "./constants";
-import { getLowestGameState, updateExpansions } from "./transforms";
+import { getAvailableGameState, updateExpansions } from "./transforms";
 
 describe("transform", () => {
   it("gets the lowest balance from the first object", () => {
-    const lowest = getLowestGameState({
-      first: {
+    const lowest = getAvailableGameState({
+      onChain: {
         ...TEST_FARM,
         balance: new Decimal(0.5),
       },
-      second: {
+      offChain: {
         ...TEST_FARM,
         balance: new Decimal(5),
       },
@@ -20,12 +20,12 @@ describe("transform", () => {
   });
 
   it("gets the lowest balance from the second object", () => {
-    const lowest = getLowestGameState({
-      first: {
+    const lowest = getAvailableGameState({
+      onChain: {
         ...TEST_FARM,
         balance: new Decimal(2),
       },
-      second: {
+      offChain: {
         ...TEST_FARM,
         balance: new Decimal(105),
       },
@@ -35,8 +35,8 @@ describe("transform", () => {
   });
 
   it("gets the lowest inventory", () => {
-    const lowest = getLowestGameState({
-      first: {
+    const lowest = getAvailableGameState({
+      onChain: {
         ...TEST_FARM,
         inventory: {
           Sunflower: new Decimal(5),
@@ -44,7 +44,7 @@ describe("transform", () => {
           Stone: new Decimal(20),
         },
       },
-      second: {
+      offChain: {
         ...TEST_FARM,
         inventory: {
           Sunflower: new Decimal(10),
@@ -57,6 +57,39 @@ describe("transform", () => {
     expect(lowest.inventory).toEqual({
       Sunflower: new Decimal(5),
       Axe: new Decimal(90),
+    });
+  });
+
+  it("filters out placed items", () => {
+    const lowest = getAvailableGameState({
+      onChain: {
+        ...TEST_FARM,
+        inventory: {
+          "Peeled Potato": new Decimal(1),
+          "Sunflower Rock": new Decimal(1),
+        },
+      },
+      offChain: {
+        ...TEST_FARM,
+        inventory: {
+          "Peeled Potato": new Decimal(1),
+          "Sunflower Rock": new Decimal(1),
+        },
+        collectibles: {
+          "Peeled Potato": [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(lowest.inventory).toEqual({
+      "Sunflower Rock": new Decimal(1),
     });
   });
 

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -1,4 +1,8 @@
 import Decimal from "decimal.js-light";
+import {
+  getBasketItems,
+  getChestItems,
+} from "features/island/hud/components/inventory/utils/inventory";
 import { getKeys } from "../types/craftables";
 import {
   GameState,
@@ -247,27 +251,32 @@ export function updateGame(
 /**
  * Returns the lowest values out of 2 game states
  */
-export function getLowestGameState({
-  first,
-  second,
+export function getAvailableGameState({
+  onChain,
+  offChain,
 }: {
-  first: GameState;
-  second: GameState;
+  onChain: GameState;
+  offChain: GameState;
 }) {
-  const balance = first.balance.lt(second.balance)
-    ? first.balance
-    : second.balance;
+  // Grab items that are available in inventory(not placed)
+  const chestItems = getChestItems(offChain);
+  const basketItems = getBasketItems(offChain.inventory);
+  const availableItems = { ...chestItems, ...basketItems };
+
+  const balance = onChain.balance.lt(offChain.balance)
+    ? onChain.balance
+    : offChain.balance;
 
   const items = [
     ...new Set([
-      ...(Object.keys(first.inventory) as InventoryItemName[]),
-      ...(Object.keys(second.inventory) as InventoryItemName[]),
+      ...(Object.keys(onChain.inventory) as InventoryItemName[]),
+      ...(Object.keys(availableItems) as InventoryItemName[]),
     ]),
   ];
 
   const inventory: Inventory = items.reduce((inv, name) => {
-    const firstAmount = first.inventory[name] || new Decimal(0);
-    const secondAmount = second.inventory[name] || new Decimal(0);
+    const firstAmount = onChain.inventory[name] || new Decimal(0);
+    const secondAmount = availableItems[name] || new Decimal(0);
 
     const amount = firstAmount.lt(secondAmount) ? firstAmount : secondAmount;
 

--- a/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
+++ b/src/features/goblins/trader/tradingPost/lib/actions/loadUpdatedSession.ts
@@ -1,6 +1,6 @@
 import { loadSession } from "features/game/actions/loadSession";
 import { getOnChainState } from "features/game/actions/onchain";
-import { getLowestGameState } from "features/game/lib/transforms";
+import { getAvailableGameState } from "features/game/lib/transforms";
 import { GameState } from "features/game/types/game";
 import { getSessionId } from "lib/blockchain/Sessions";
 import { wallet } from "lib/blockchain/wallet";
@@ -31,9 +31,9 @@ export const loadUpdatedSession = async (
   const deviceTrackerId = response?.deviceTrackerId as string;
 
   // Whatever is lower, on chain or offchain
-  const { inventory, balance } = getLowestGameState({
-    first: onChainState.game,
-    second: game,
+  const { inventory, balance } = getAvailableGameState({
+    onChain: onChainState.game,
+    offChain: game,
   });
 
   return { inventory, balance, sessionId, deviceTrackerId };


### PR DESCRIPTION
# Description

Similar to the Island HUD, filter out any items that are placed.

I've done this on the root level, so these items won't be available anywhere inside of the Retreat - this then automatically applies to the Auctioneer and Blacksmith.

**Backend validation coming in separate PR**

### How to test?

1. Sync your island (so items will exist in Goblin Retreat)
2. Place a collectible (e.g. Brilliant Bear)
3. Visit Goblin Retreat - item should now be hidden at Auctioneer.