### PR TITLE
[FIX] Enable system wide text-white and text-shadow

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -18,7 +18,7 @@ export const Button: React.FC<Props> = ({
   return (
     <button
       className={classnames(
-        "bg-brown-200 w-full p-1 text-white text-shadow text-xs object-contain justify-center items-center hover:bg-brown-300 cursor-pointer flex disabled:opacity-50 ",
+        "bg-brown-200 w-full p-1 text-xs object-contain justify-center items-center hover:bg-brown-300 cursor-pointer flex disabled:opacity-50 ",
         className
       )}
       type={type}

--- a/src/features/game/components/Revealing.tsx
+++ b/src/features/game/components/Revealing.tsx
@@ -1,4 +1,3 @@
-import { SUNNYSIDE } from "assets/sunnyside";
 import React from "react";
 
 import maneki from "assets/sfts/maneki_neko.gif";

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,11 +32,17 @@
 body {
   font-family: "Paytone One", sans-serif;
   overflow: hidden;
-  text-shadow: 1px 1px #1f1f1f;
+  color: white;
   font-size: 22px;
   letter-spacing: -0.4px;
   word-spacing: 3px;
   line-height: 20px;
+}
+
+body,
+button,
+input {
+  text-shadow: 1px 1px #1f1f1f;
 }
 
 button:disabled {


### PR DESCRIPTION
# Description

- enable system wide text-white and text-shadow
  - text-white and text-shadow no longer needed when defining components.  They can be removed in future PRs when those files are touched

Changes based on #2027

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check text color and shadow for buttons

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
