### PR TITLE
[FEAT] Reduce pear requirements

### DIFF
--- a/src/features/game/events/landExpansion/craftCollectible.test.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.test.ts
@@ -40,7 +40,12 @@ describe("craftCollectible", () => {
       state: {
         ...GAME_STATE,
         balance: new Decimal(1),
-        inventory: { Gold: new Decimal(100) },
+        inventory: {
+          Gold: new Decimal(10),
+          Apple: new Decimal(15),
+          Orange: new Decimal(12),
+          Blueberry: new Decimal(10),
+        },
       },
       action: {
         type: "collectible.crafted",
@@ -49,7 +54,10 @@ describe("craftCollectible", () => {
     });
 
     expect(state.inventory["Immortal Pear"]).toEqual(new Decimal(1));
-    expect(state.inventory["Gold"]).toEqual(new Decimal(75));
+    expect(state.inventory["Gold"]).toEqual(new Decimal(5));
+    expect(state.inventory["Apple"]).toEqual(new Decimal(5));
+    expect(state.inventory["Orange"]).toEqual(new Decimal(2));
+    expect(state.inventory["Blueberry"]).toEqual(new Decimal(0));
   });
 
   it("does not craft an item that is not in stock", () => {
@@ -76,7 +84,10 @@ describe("craftCollectible", () => {
         ...GAME_STATE,
         balance: new Decimal(1),
         inventory: {
-          Gold: new Decimal(100),
+          Gold: new Decimal(10),
+          Apple: new Decimal(15),
+          Orange: new Decimal(12),
+          Blueberry: new Decimal(10),
         },
       },
       action: {

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -22,7 +22,10 @@ export const HELIOS_BLACKSMITH_ITEMS: Record<
   "Immortal Pear": {
     description: "A long-lived pear that makes fruit trees last longer.",
     ingredients: {
-      Gold: new Decimal(25),
+      Gold: new Decimal(5),
+      Apple: new Decimal(10),
+      Blueberry: new Decimal(10),
+      Orange: new Decimal(10),
     },
     boost: "+1 harvest",
   },


### PR DESCRIPTION
# Description

Based on player feedback, the pear requirements were too difficult to attain.

The new requirements require 1/5th gold and rely on fruits.

Those who crafted it prior, will be reimbursed gold