### PR TITLE
[FIX] ADD RED ENVELOPE LIMIT/HOARDER

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -50,6 +50,7 @@ const maxItems: Inventory = {
   "Goblin War Banner": new Decimal(1),
   "Chef Hat": new Decimal(1),
   "Rapid Growth": new Decimal(100),
+  "Red Envelope": new Decimal(100),
 
   // Max of 1000 food item
   ...(Object.keys(FOODS()) as InventoryItemName[]).reduce(


### PR DESCRIPTION
# Description

This PR add the hoarder modal for red envelope, some players are getting the Auto Save error because they tried to collect red envelope number 101(more than the limit).


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
