### PR TITLE
[FIX] Fix Something Shiny rewards

### DIFF
--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -336,7 +336,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
     requirement: 500,
     sfl: marketRate(0),
     rewards: {
-      Pickaxe: new Decimal(20),
+      "Stone Pickaxe": new Decimal(20),
     },
   },
 


### PR DESCRIPTION
# Description

- change Something Shiny rewards to 20 Stone pickaxes instead of 20 Pickaxes
  - backend fixes needed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- claim Something Shiny rewards

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
