### PR TITLE
[FEAT] Maneki Neko Timer Left

### DIFF
--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -332,6 +332,7 @@ export const OFFLINE_FARM: GameState = {
         createdAt: Date.now() - 12 * 60 * 60 * 1000,
         id: "0",
         readyAt: 0,
+        shakenAt: Date.now() - 12 * 60 * 60 * 1000,
       },
     ],
   },

--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -12,6 +12,7 @@ import { Revealing } from "features/game/components/Revealing";
 import { Revealed } from "features/game/components/Revealed";
 import { Panel } from "components/ui/Panel";
 import Modal from "react-bootstrap/esm/Modal";
+import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 
 interface Props {
   id: string;
@@ -20,7 +21,7 @@ interface Props {
 export const ManekiNeko: React.FC<Props> = ({ id }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
-
+  const [showTooltip, setShowTooltip] = useState(false);
   const manekiNekos = gameState.context.state.collectibles["Maneki Neko"] ?? [];
   const hasShakenRecently = manekiNekos.some(
     (maneki) =>
@@ -75,8 +76,22 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
   }
 
   if (isShaking) {
+    const shakenManekiNeko = manekiNekos
+      .filter((maneki) => {
+        return maneki.shakenAt && 0 < maneki.shakenAt;
+      })
+      .at(0);
+
+    let time = COLLECTIBLE_PLACE_SECONDS["Maneki Neko"] ?? 0;
+    if (shakenManekiNeko && shakenManekiNeko.shakenAt) {
+      time = time - (Date.now() - shakenManekiNeko.shakenAt) / 1000;
+    }
+
     return (
-      <>
+      <div
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
         <img
           src={manekiNekoShaking}
           style={{
@@ -95,7 +110,20 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
           }}
           className="absolute"
         />
-      </>
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -20}px`,
+            right: `${PIXEL_SCALE * -20}px`,
+          }}
+        >
+          <TimeLeftPanel
+            text="Ready in:"
+            timeLeft={time}
+            showTimeLeft={showTooltip}
+          />
+        </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
# Description

Add LeftTimer for Maneki Neko after shaken.

![image](https://user-images.githubusercontent.com/54077079/214501198-a69205a0-eb69-40aa-b8f8-6e6baf35931b.png)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

After shaken Maneki Neko you should see tooltip with time to next shaken after move mouse on Maneki Neko.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
