### PR TITLE
[FEAT] Maneki Neko Shakenable after cooldown finish

### DIFF
--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -330,7 +330,7 @@ export const OFFLINE_FARM: GameState = {
         createdAt: Date.now() - 12 * 60 * 60 * 1000,
         id: "0",
         readyAt: 0,
-        shakenAt: Date.now() - 12 * 60 * 60 * 1000,
+        shakenAt: Date.now() - 24 * 60 * 60 * 1000 + 60 * 1000,
       },
     ],
   },

--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -84,12 +84,18 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
 
     let time = COLLECTIBLE_PLACE_SECONDS["Maneki Neko"] ?? 0;
     if (shakenManekiNeko && shakenManekiNeko.shakenAt) {
-      time = time - (Date.now() - shakenManekiNeko.shakenAt) / 1000;
+      const timeFromShaken = Date.now() - shakenManekiNeko.shakenAt;
+      time = time - timeFromShaken / 1000;
     }
 
     return (
       <div
-        onMouseEnter={() => setShowTooltip(true)}
+        onMouseEnter={() => {
+          if (time <= 0) {
+            setIsShaking(false);
+          }
+          return setShowTooltip(true);
+        }}
         onMouseLeave={() => setShowTooltip(false)}
       >
         <img
@@ -120,7 +126,7 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
           <TimeLeftPanel
             text="Ready in:"
             timeLeft={time}
-            showTimeLeft={showTooltip}
+            showTimeLeft={showTooltip && time > 0}
           />
         </div>
       </div>


### PR DESCRIPTION
# Description

This PR reload Maneki Neko after cooldown finish and hide modal when time is negative.

https://user-images.githubusercontent.com/54077079/214837461-57c53b12-0056-4d04-94c2-6d59a57570a9.mp4

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

With landData config after run project you have to wait 60 secods to cooldown finish.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
