### PR TITLE
[FEAT] Eat ten meals at one click

### DIFF
--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -230,7 +230,7 @@ const INITIAL_EXPANSIONS: LandExpansion[] = [
 
 const INITIAL_BUMPKIN: Bumpkin = {
   id: 1,
-  experience: 220501,
+  experience: 0,
   tokenUri: "bla",
   equipped: {
     body: "Light Brown Farmer Potion",
@@ -280,6 +280,8 @@ export const OFFLINE_FARM: GameState = {
     Warrior: new Decimal(0),
     Gold: new Decimal(50),
     "Immortal Pear": new Decimal(1),
+    "Pumpkin Soup": new Decimal(9),
+    "Bumpkin Broth": new Decimal(10),
   },
   migrated: true,
   stock: INITIAL_STOCK,

--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -43,20 +43,21 @@ export const Feed: React.FC<Props> = ({ food, onFeed }) => {
     }
   }, [food.length]);
 
-  const feed = (food: Consumable) => {
-    onFeed(food.name);
+  const feed = (food: Consumable, count: number) => {
+    for (let i = 0; i < count; i++) {
+      onFeed(food.name);
+    }
 
     setToast({
       icon: heart,
-      content: `+${getFoodExpBoost(
-        food,
-        state.bumpkin as Bumpkin,
-        state.collectibles
-      )}`,
+      content: `+${
+        getFoodExpBoost(food, state.bumpkin as Bumpkin, state.collectibles) *
+        count
+      }`,
     });
     setToast({
       icon: ITEM_DETAILS[food.name].image,
-      content: `-1`,
+      content: `-${count}`,
     });
 
     shortcutItem(food.name);
@@ -125,13 +126,22 @@ export const Feed: React.FC<Props> = ({ food, onFeed }) => {
           )}
         </div>
         {selected !== undefined && (
-          <Button
-            disabled={!inventory[selected.name]?.gt(0)}
-            className="text-sm mt-1 whitespace-nowrap"
-            onClick={() => feed(selected)}
-          >
-            {isJuice(selected.name) ? "Drink 1" : "Eat 1"}
-          </Button>
+          <>
+            <Button
+              disabled={!inventory[selected.name]?.gt(0)}
+              className="text-sm mt-1 whitespace-nowrap"
+              onClick={() => feed(selected, 1)}
+            >
+              {isJuice(selected.name) ? "Drink 1" : "Eat 1"}
+            </Button>
+            <Button
+              disabled={!inventory[selected.name]?.gt(9)}
+              className="text-sm mt-1 whitespace-nowrap"
+              onClick={() => feed(selected, 10)}
+            >
+              {isJuice(selected.name) ? "Drink 10" : "Eat 10"}
+            </Button>
+          </>
         )}
       </OuterPanel>
     </div>


### PR DESCRIPTION
# Description

High level players often have a lot of meals like Pumpkin Soup or Mashed Potato. They must click so many time how there have meals. This PR add button to eat 10 meal at one time.

[eat_x10_meals.webm](https://user-images.githubusercontent.com/54077079/214954353-8398096e-8229-4f74-bb2a-5ca4809826b1.webm)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

In Feed Bumpkin Modal you shoud check behavior of button. If you don't have enough meals than button should be disabled. If you have more or equal than 10 meals than button is active. After click you should see toast with how many meals you eaten and how many expirance you got. You also should check your bumpkin level increments.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
