### PR TITLE
[FIX] Inventory shows nothing when there are no seeds

### DIFF
--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -96,7 +96,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const allTools = [...tools, ...shovels];
 
   const itemsSection = (title: string, items: InventoryItemName[]) => {
-    if (!allSeeds.length) {
+    if (!items.length) {
       return <></>;
     }
 


### PR DESCRIPTION
# Description

- fix inventory category filter

Before|Aftre
---|---
![image](https://user-images.githubusercontent.com/107602352/215036299-0270948d-1700-4b6e-a195-2504e1955a67.png)|![image](https://user-images.githubusercontent.com/107602352/215036325-47d5550c-e7b5-47f4-8ee7-ce72068d28be.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- have no seeds in inventory

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
