### PR TITLE
[FIX] Plaza chat improvements

### DIFF
--- a/src/features/game/components/CloseablePanel.tsx
+++ b/src/features/game/components/CloseablePanel.tsx
@@ -6,6 +6,7 @@ import { Equipped } from "features/game/types/bumpkin";
 import { Tab } from "components/ui/Tab";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { SUNNYSIDE } from "assets/sunnyside";
+import classNames from "classnames";
 
 export interface PanelTabs {
   icon: string;
@@ -22,6 +23,7 @@ interface Props {
   showBackButton?: boolean;
   onBack?: () => void;
   bumpkinParts?: Partial<Equipped>;
+  className?: string;
 }
 
 /**
@@ -35,6 +37,7 @@ interface Props {
  * @showCloseButton Whether to show the back button for the panel or not. Default is true.
  * @onClose The back button method.
  * @bumpkinParts The list of bumpkin parts for the modal.
+ * @className Additional class name for the parent panel.
  * @children The panel children content.
  */
 export const CloseButtonPanel: React.FC<Props> = ({
@@ -48,13 +51,18 @@ export const CloseButtonPanel: React.FC<Props> = ({
   onBack,
   bumpkinParts,
   children,
+  className,
 }) => {
   const handleTabClick = (index: number) => {
     setCurrentTab && setCurrentTab(index);
   };
 
   return (
-    <Panel className="relative" bumpkinParts={bumpkinParts} hasTabs={!!tabs}>
+    <Panel
+      className={classNames("relative", className)}
+      bumpkinParts={bumpkinParts}
+      hasTabs={!!tabs}
+    >
       {/* Tabs */}
       {tabs && (
         <div

--- a/src/features/pumpkinPlaza/components/Bumpkins.tsx
+++ b/src/features/pumpkinPlaza/components/Bumpkins.tsx
@@ -15,6 +15,7 @@ import { BumpkinDiscovery, ChatMessage, Player } from "../lib/types";
 import { BumpkinFriend } from "./BumpkinFriend";
 import { SelectBox } from "./SelectBox";
 import { getDistance } from "../lib/coordinates";
+import { SquareIcon } from "components/ui/SquareIcon";
 
 interface Props {
   messages: ChatMessage[];
@@ -31,7 +32,7 @@ const Message: React.FC<ChatMessage> = ({ text, reaction }) => {
   if (text) {
     return (
       <span
-        className="absolute  text-white text-xs"
+        className="absolute text-xs"
         style={{
           bottom: "29px",
           left: "-58px",
@@ -46,16 +47,18 @@ const Message: React.FC<ChatMessage> = ({ text, reaction }) => {
 
   if (reaction) {
     return (
-      <img
-        src={REACTIONS.find((r) => r.name === reaction)?.icon}
-        className="absolute"
+      <div
+        className="flex justify-center absolute w-full pointer-events-none"
         style={{
-          bottom: "29px",
-          left: "12px",
-          width: `${PIXEL_SCALE * 8}px`,
-          textAlign: "center",
+          top: `${PIXEL_SCALE * -4}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
-      />
+      >
+        <SquareIcon
+          icon={REACTIONS.find((r) => r.name === reaction)?.icon ?? ""}
+          width={8}
+        />
+      </div>
     );
   }
 
@@ -66,15 +69,15 @@ const Discovery: React.FC<BumpkinDiscovery> = ({ items, sfl }) => {
   if (sfl) {
     return (
       <div
-        className="absolute flex  items-center"
+        className="absolute flex items-center"
         style={{
           bottom: "29px",
           left: "8px",
           textAlign: "center",
         }}
       >
-        <img src={token} className="h-8  img-highlight-heavy mr-2" />
-        <span className=" text-white">{sfl}</span>
+        <img src={token} className="h-8 img-highlight-heavy mr-2" />
+        <span>{sfl}</span>
       </div>
     );
   }
@@ -93,7 +96,7 @@ const Discovery: React.FC<BumpkinDiscovery> = ({ items, sfl }) => {
         textAlign: "center",
       }}
     >
-      <span className=" text-white mr-2">+</span>
+      <span className="mr-2">+</span>
       <img
         src={ITEM_DETAILS[names[0]].image}
         className="h-8 img-highlight-heavy"
@@ -139,13 +142,13 @@ export const Bumpkins: React.FC<Props> = ({
       {bumpkin && (
         <div
           key={bumpkin.id}
-          className="absolute z-30 transition-transform ease-linear"
+          className="absolute z-30 transition-transform ease-linear pointer-events-none"
           style={{
             transform: `translate(${position?.x}px,${position?.y}px)`,
             height: `${GRID_WIDTH_PX}px`,
             width: `${GRID_WIDTH_PX}px`,
-            left: "-27px",
-            top: "-47px",
+            left: `${PIXEL_SCALE * -8}px`,
+            top: `${PIXEL_SCALE * -18}px`,
             // speed = distance ÷ time
             transitionDuration: `${
               Math.floor(getDistance(lastPosition, position)) * WALKING_SPEED
@@ -153,13 +156,12 @@ export const Bumpkins: React.FC<Props> = ({
           }}
         >
           {myMessage && <Message {...myMessage} />}
-
           {myDiscovery && <Discovery {...myDiscovery} />}
 
           <NPC {...bumpkin.equipped} />
 
           <div
-            className="absolute text-center "
+            className="absolute text-center"
             style={{
               bottom: "-36px",
               width: "60px",
@@ -167,10 +169,7 @@ export const Bumpkins: React.FC<Props> = ({
               fontSize: "4px",
             }}
           >
-            <span
-              className=" text-white"
-              style={{ fontSize: "10px" }}
-            >{`#${bumpkin.id}`}</span>
+            <span style={{ fontSize: "10px" }}>{`#${bumpkin.id}`}</span>
           </div>
         </div>
       )}
@@ -215,7 +214,7 @@ export const Bumpkins: React.FC<Props> = ({
                 onClick={() => setSelectedBumpkin(otherBumpkin)}
               />
               <div
-                className="absolute text-center "
+                className="absolute text-center"
                 style={{
                   bottom: "-36px",
                   width: "60px",
@@ -224,7 +223,6 @@ export const Bumpkins: React.FC<Props> = ({
                 }}
               >
                 <span
-                  className=" text-white"
                   style={{ fontSize: "10px" }}
                 >{`#${otherBumpkin.bumpkin.id}`}</span>
               </div>

--- a/src/features/pumpkinPlaza/components/ChatText.tsx
+++ b/src/features/pumpkinPlaza/components/ChatText.tsx
@@ -90,7 +90,8 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
           style={{
             border: "1px solid #ead4aa",
             fontFamily: "monospace",
-            maxHeight: "180px",
+            minHeight: "40px",
+            maxHeight: "160px",
           }}
           placeholder="Type here..."
           className="text-sm placeholder-white w-full rounded-md bg-brown-200 pr-10 pl-2 py-2"

--- a/src/features/pumpkinPlaza/components/ChatText.tsx
+++ b/src/features/pumpkinPlaza/components/ChatText.tsx
@@ -42,6 +42,12 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
   };
 
   useEffect(() => {
+    const handleClickOutside = (event: any) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        ref.current.blur();
+      }
+    };
+
     const keyDownListener = (event: KeyboardEvent) => {
       if (event.key === "Enter") {
         event.preventDefault();
@@ -49,9 +55,13 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
       }
     };
 
+    document.addEventListener("click", handleClickOutside, true);
     window.addEventListener("keydown", keyDownListener);
 
-    return () => window.removeEventListener("keydown", keyDownListener);
+    return () => {
+      document.removeEventListener("click", handleClickOutside, true);
+      window.removeEventListener("keydown", keyDownListener);
+    };
   });
 
   return (
@@ -61,6 +71,8 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
         onClick={() => console.log("text div clicked")}
       >
         <textarea
+          maxLength={MAX_CHARACTERS * 2}
+          data-prevent-drag-scroll
           name="message"
           value={text}
           disabled={false}
@@ -73,25 +85,26 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
           style={{
             border: "1px solid #ead4aa",
             fontFamily: "monospace",
+            maxHeight: "180px",
           }}
           placeholder="Type here..."
-          className="text-sm placeholder-white w-full  mono rounded-md  bg-brown-200 pr-10 pl-2 py-2"
+          className="text-sm placeholder-white w-full rounded-md bg-brown-200 pr-10 pl-2 py-2"
         />
 
         {text.length > MAX_CHARACTERS && (
-          <Label className="mt-2 mb-1 float-right" type="danger">
+          <Label className="mt-3 mb-1 float-right" type="danger">
             {`Max ${MAX_CHARACTERS} characters`}
           </Label>
         )}
 
         {isUrl && (
-          <Label className="mt-2 mb-1 float-right" type="danger">
+          <Label className="mt-3 mb-1 float-right" type="danger">
             {`No URLs allowed`}
           </Label>
         )}
 
         {!isValidText && (
-          <Label className="mt-2 mb-1 float-right" type="danger">
+          <Label className="mt-3 mb-1 float-right" type="danger">
             {`Alphanumeric characters only`}
           </Label>
         )}

--- a/src/features/pumpkinPlaza/components/ChatText.tsx
+++ b/src/features/pumpkinPlaza/components/ChatText.tsx
@@ -27,7 +27,12 @@ export const ChatText: React.FC<Props> = ({ onMessage }) => {
   const send = (event?: React.SyntheticEvent) => {
     event?.preventDefault();
 
-    if (text === "" || text.length > MAX_CHARACTERS) {
+    if (text?.trim() === "") {
+      setText("");
+      return;
+    }
+
+    if (text.length > MAX_CHARACTERS) {
       return;
     }
 

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -20,25 +20,24 @@ export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
       style={{ zIndex: 999 }}
       onClick={() => console.log("parent clicked")}
     >
-      <div className="w-full sm:w-[30rem]">
-        <CloseButtonPanel
-          showCloseButton={false}
-          tabs={[
-            { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
-            { icon: SUNNYSIDE.icons.heart, name: "Reactions" },
-          ]}
-          currentTab={tab}
-          setCurrentTab={setTab}
-        >
-          {tab === 0 && <ChatText onMessage={(text) => onMessage({ text })} />}
-          {tab === 1 && (
-            <ChatReactions
-              onReact={(reaction) => onMessage({ reaction })}
-              game={game}
-            />
-          )}
-        </CloseButtonPanel>
-      </div>
+      <CloseButtonPanel
+        className="w-full sm:w-[30rem]"
+        showCloseButton={false}
+        tabs={[
+          { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
+          { icon: SUNNYSIDE.icons.heart, name: "Reactions" },
+        ]}
+        currentTab={tab}
+        setCurrentTab={setTab}
+      >
+        {tab === 0 && <ChatText onMessage={(text) => onMessage({ text })} />}
+        {tab === 1 && (
+          <ChatReactions
+            onReact={(reaction) => onMessage({ reaction })}
+            game={game}
+          />
+        )}
+      </CloseButtonPanel>
     </div>
   );
 };

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -1,4 +1,3 @@
-import { Panel } from "components/ui/Panel";
 import React, { useState } from "react";
 
 import { ChatText } from "./ChatText";
@@ -6,13 +5,14 @@ import { ChatReactions } from "./ChatReactions";
 import { GameState } from "features/game/types/game";
 import { ReactionName } from "../lib/reactions";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   game: GameState;
   onMessage: (content: { text?: string; reaction?: ReactionName }) => void;
 }
 export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
-  const [tab, setTab] = useState<"text" | "reactions">("text");
+  const [tab, setTab] = useState(0);
 
   return (
     <div
@@ -20,54 +20,23 @@ export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
       style={{ zIndex: 999 }}
       onClick={() => console.log("parent clicked")}
     >
-      <Panel className="md:w-1/2 w-full h-full">
-        <div className="flex justify-between">
-          {tab === "text" && (
-            <>
-              <div className="flex items-center">
-                <img
-                  src={SUNNYSIDE.icons.expression_chat}
-                  className="h-6 mr-2"
-                />
-                <span className="text-sm">Chat</span>
-              </div>
-              <div
-                className="flex items-center cursor-pointer"
-                onClick={() => setTab("reactions")}
-              >
-                <span className="text-xs underline">Reactions</span>
-                <img src={SUNNYSIDE.icons.heart} className="h-4 ml-2" />
-              </div>
-            </>
-          )}
-
-          {tab === "reactions" && (
-            <>
-              <div className="flex items-center">
-                <img src={SUNNYSIDE.icons.heart} className="h-6 mr-2" />
-                <span className="text-sm">Reactions</span>
-              </div>
-              <div
-                className="flex items-center cursor-pointer"
-                onClick={() => setTab("text")}
-              >
-                <img src={SUNNYSIDE.icons.arrow_left} className="h-4 mr-2" />
-                <span className="text-xs underline">Back</span>
-              </div>
-            </>
-          )}
-        </div>
-
-        {tab === "text" && (
-          <ChatText onMessage={(text) => onMessage({ text })} />
-        )}
-        {tab === "reactions" && (
+      <CloseButtonPanel
+        showCloseButton={false}
+        tabs={[
+          { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
+          { icon: SUNNYSIDE.icons.heart, name: "Reactions" },
+        ]}
+        currentTab={tab}
+        setCurrentTab={setTab}
+      >
+        {tab === 0 && <ChatText onMessage={(text) => onMessage({ text })} />}
+        {tab === 1 && (
           <ChatReactions
             onReact={(reaction) => onMessage({ reaction })}
             game={game}
           />
         )}
-      </Panel>
+      </CloseButtonPanel>
     </div>
   );
 };

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -16,27 +16,29 @@ export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
 
   return (
     <div
-      className="w-full flex justify-center fixed bottom-4 pl-2 md:pr-2 pr-20"
+      className="w-full flex justify-center fixed bottom-4 pl-2 pr-[73.5px] md:pr-2"
       style={{ zIndex: 999 }}
       onClick={() => console.log("parent clicked")}
     >
-      <CloseButtonPanel
-        showCloseButton={false}
-        tabs={[
-          { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
-          { icon: SUNNYSIDE.icons.heart, name: "Reactions" },
-        ]}
-        currentTab={tab}
-        setCurrentTab={setTab}
-      >
-        {tab === 0 && <ChatText onMessage={(text) => onMessage({ text })} />}
-        {tab === 1 && (
-          <ChatReactions
-            onReact={(reaction) => onMessage({ reaction })}
-            game={game}
-          />
-        )}
-      </CloseButtonPanel>
+      <div className="w-full sm:w-[30rem]">
+        <CloseButtonPanel
+          showCloseButton={false}
+          tabs={[
+            { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
+            { icon: SUNNYSIDE.icons.heart, name: "Reactions" },
+          ]}
+          currentTab={tab}
+          setCurrentTab={setTab}
+        >
+          {tab === 0 && <ChatText onMessage={(text) => onMessage({ text })} />}
+          {tab === 1 && (
+            <ChatReactions
+              onReact={(reaction) => onMessage({ reaction })}
+              game={game}
+            />
+          )}
+        </CloseButtonPanel>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Description

- use tabs for chatbox
- allow players to scroll and select text in chatbox instead of scrolling the map
- add max height and text content for chatbox
- fix keyboard not hiding (mobile) after sending text
- fix error when sending spaces only for text
- consistent sizing for different reaction icons
- minor styling improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/215048558-7ee273ce-a15f-4cee-822c-d0a99978a4f6.png)|![image](https://user-images.githubusercontent.com/107602352/215048585-a9329734-2dc4-43fa-9a10-76997aa5780d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- go to pumpkin plaza
- chat
  - enter normal text
  - enter censored text
  - enter space
  - enter empty string
  - type invalid text
  - drag bottom left corner of text input area up and down
  - type a lot of text, then try scrolling and navigating around the text and do text highlighting
- reactions
  - try different reactions and observe the size of the icons
- try different screensizes and observe chatbox size

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
