### PR TITLE
[FIX] Align withdrawable rules

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -211,7 +211,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Christmas Snow Globe": true,
   "Cabbage Boy": true,
   "Cabbage Girl": true,
-  "Wood Nymph Wendy": false,
   "Chef Bear": true,
   "Construction Bear": true,
   "Angel Bear": true,
@@ -232,6 +231,9 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Squirrel Monkey": false,
   "Lady Bug": false,
   "Cyborg Bear": true,
+  "Collectible Bear": false,
+  // TODO add rule when beans are introduced
+  "Carrot Sword": true,
 
   // Conditional Rules
   "Chicken Coop": (game) => !areAnyChickensFed(game),
@@ -243,19 +245,17 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Easter Bunny": (game) => !cropIsPlanted({ item: "Carrot", game }),
   "Golden Cauliflower": (game) => !cropIsPlanted({ item: "Cauliflower", game }),
   "Mysterious Parsnip": (game) => !cropIsPlanted({ item: "Parsnip", game }),
-  "Carrot Sword": (game) => !areAnyCropsPlanted(game),
   Nancy: (game) => !areAnyCropsPlanted(game),
   Scarecrow: (game) => !areAnyCropsPlanted(game),
   Kuebiko: (game) => !areAnyCropsPlanted(game) && !hasSeeds(game.inventory),
   "Woody the Beaver": (game) => !areAnyTreesChopped(game),
   "Apprentice Beaver": (game) => !areAnyTreesChopped(game),
   "Foreman Beaver": (game) => !areAnyTreesChopped(game),
+  "Wood Nymph Wendy": (game) => !areAnyTreesChopped(game),
   "Rock Golem": (game) => !areAnyStonesMined(game),
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
-  "Collectible Bear": () =>
-    Date.now() < new Date("2023-02-01T08:30:00.000Z").getTime(),
 
   "Pirate Bounty": false,
   Pearl: false,

--- a/src/features/goblins/bank/lib/bankUtil.test.ts
+++ b/src/features/goblins/bank/lib/bankUtil.test.ts
@@ -172,35 +172,6 @@ describe("canWithdraw", () => {
       expect(enabled).toBeFalsy();
     });
 
-    it("prevents a user from withdrawing carrot sword if some crop is planted", () => {
-      const enabled = canWithdraw({
-        item: "Carrot Sword",
-        game: {
-          ...TEST_FARM,
-          inventory: {
-            "Carrot Sword": new Decimal(1),
-          },
-          expansions: [
-            {
-              createdAt: 0,
-              readyAt: 0,
-              plots: {
-                0: {
-                  x: -2,
-                  y: -1,
-                  height: 1,
-                  width: 1,
-                  crop: { name: "Beetroot", amount: 1, plantedAt: Date.now() },
-                },
-              },
-            },
-          ],
-        },
-      });
-
-      expect(enabled).toBeFalsy();
-    });
-
     it("prevents a user from withdrawing an easter bunny when in use", () => {
       const enabled = canWithdraw({
         item: "Easter Bunny",


### PR DESCRIPTION
# Description

Few fixes in rules.

- Wendy should not be withdrawable if any trees grow
- Collectible bear is delayed its better to keep it as non withdrawable before new date is announced
- Carrot sword is not dependent on crops, new rule for beans should be added later


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
