### PR TITLE
[FIX] Show countdown for pumpkin plaza rewards

### DIFF
--- a/src/features/pumpkinPlaza/components/DailyReward.tsx
+++ b/src/features/pumpkinPlaza/components/DailyReward.tsx
@@ -7,6 +7,8 @@ import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { Modal } from "react-bootstrap";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { secondsToString } from "lib/utils/time";
+import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 
 export const DailyReward: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -14,16 +16,21 @@ export const DailyReward: React.FC = () => {
 
   const [showCollectedModal, setShowCollectedModal] = useState(false);
 
+  useUiRefresher();
+
+  const cooldown = 24 * 60 * 60 * 1000; // 1 day
+
   const collectedAt =
     gameState.context.state.pumpkinPlaza?.rewardCollectedAt ?? 0;
+  const readyInSeconds = (collectedAt + cooldown - Date.now()) / 1000;
 
-  if (Date.now() - collectedAt < 24 * 60 * 60 * 1000) {
+  if (readyInSeconds > 0) {
     return (
       <>
         <img
           id="daily-reward"
           src={SUNNYSIDE.decorations.treasure_chest_opened}
-          className="cursor-pointer absolute z-20  hover:img-highlight"
+          className="cursor-pointer absolute z-20 hover:img-highlight"
           style={{
             width: `${PIXEL_SCALE * 16}px`,
             left: `${GRID_WIDTH_PX * 52}px`,
@@ -37,13 +44,18 @@ export const DailyReward: React.FC = () => {
           centered
         >
           <CloseButtonPanel onClose={() => setShowCollectedModal(false)}>
-            <div className="flex flex-col items-center">
+            <div className="flex flex-col items-center p-2">
               <img
                 src={SUNNYSIDE.decorations.treasure_chest_opened}
-                className="w-1/4 mb-2"
+                className="mb-2"
+                style={{
+                  width: `${PIXEL_SCALE * 16}px`,
+                }}
               />
               <span className="text-center">
-                Come back tomorrow for more rewards!
+                Come back in{" "}
+                {secondsToString(readyInSeconds, { length: "full" })} for more
+                rewards!
               </span>
             </div>
           </CloseButtonPanel>


### PR DESCRIPTION
# Description

- standardize pixel scale
- show countdown for pumpkin plaza rewards.  "Tomorrow" is a bit vague

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/215253533-da1b8876-585b-4548-9b93-3e14d0a33247.png)|![image](https://user-images.githubusercontent.com/107602352/215253536-baec09a0-6641-424a-a170-44bf6e1e6b76.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open chest rewards in pumpkin plaza
- open rewards modal and wait for the countdown to reach 0.  The modal should hide itself and the chest should be closed

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
