### PR TITLE
[FEAT] Bulk Sand Shovel

### DIFF
--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -74,7 +74,11 @@ export function craftTool({ state, action }: Options) {
 
   const oldAmount = stateCopy.inventory[action.tool] || new Decimal(0);
 
-  bumpkin.activity = trackActivity(`${action.tool} Crafted`, bumpkin.activity);
+  bumpkin.activity = trackActivity(
+    `${action.tool} Crafted`,
+    bumpkin.activity,
+    new Decimal(amount)
+  );
   bumpkin.activity = trackActivity("SFL Spent", bumpkin.activity, price);
 
   return {

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -79,9 +79,9 @@ export const TREASURE_TOOLS: Record<TreasureToolName, Tool> = {
     name: "Sand Shovel",
     description: "Used for digging treasure",
     ingredients: {
-      Wood: new Decimal(20),
-      Stone: new Decimal(5),
+      Wood: new Decimal(2),
+      Stone: new Decimal(1),
     },
-    sfl: marketRate(25),
+    sfl: marketRate(5),
   },
 };


### PR DESCRIPTION
# Description

This PR updates the UI to support bulk purchases of Sand Shovels.

A user can only buy a minimum of 5 Sand Shovel - Since roughly 2/3 holes are empty, we want to make sure they have enough shovels to find an item

<img width="464" alt="Screen Shot 2023-01-30 at 10 44 54 am" src="https://user-images.githubusercontent.com/11745561/215363131-3e99ab84-1b7e-4b9a-ae24-3a8a5b48a865.png">
