### PR TITLE
[FIX] Maneki Safari Issue

### DIFF
--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -76,11 +76,9 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
   }
 
   if (isShaking) {
-    const shakenManekiNeko = manekiNekos
-      .filter((maneki) => {
-        return maneki.shakenAt && 0 < maneki.shakenAt;
-      })
-      .at(0);
+    const shakenManekiNeko = manekiNekos.filter((maneki) => {
+      return maneki.shakenAt && 0 < maneki.shakenAt;
+    })[0];
 
     let time = COLLECTIBLE_PLACE_SECONDS["Maneki Neko"] ?? 0;
     if (shakenManekiNeko && shakenManekiNeko.shakenAt) {


### PR DESCRIPTION
# Description

ES6 `.at` is not supported on latest versions of safari.