### PR TITLE
[FIX] Minor treasure island improvements

### DIFF
--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -239,12 +239,8 @@ export const SandPlot: React.FC<{
             }}
           />
         </div>
-        <Modal
-          centered
-          show={treasureFound}
-          onHide={handleAcknowledgeTreasureFound}
-        >
-          <CloseButtonPanel onClose={handleAcknowledgeTreasureFound}>
+        <Modal centered show={treasureFound}>
+          <CloseButtonPanel showCloseButton={false}>
             <Revealed onAcknowledged={handleAcknowledgeTreasureFound} />
           </CloseButtonPanel>
         </Modal>

--- a/src/features/treasureIsland/components/TreasureShopSell.tsx
+++ b/src/features/treasureIsland/components/TreasureShopSell.tsx
@@ -31,7 +31,7 @@ export const TreasureShopSell: React.FC = () => {
 
   const selected = BEACH_BOUNTY_TREASURE[selectedName];
   const { setToast } = useContext(ToastContext);
-  const { gameService, shortcutItem } = useContext(Context);
+  const { gameService } = useContext(Context);
   const [
     {
       context: { state },
@@ -51,10 +51,8 @@ export const TreasureShopSell: React.FC = () => {
 
     setToast({
       icon: token,
-      content: `-${price?.mul(amount).toString()}`,
+      content: `+${price?.mul(amount).toString()}`,
     });
-
-    shortcutItem(selectedName);
   };
 
   const Action = () => {


### PR DESCRIPTION
# Description

- selling treasure island decorations now show +xxx SFL instead of -xxx SFL
- item not selected in shortcut when selling treasure island decorations
- players need to click okay to claim treasure reward.  Previously they could close out the modal or click outside to close it, however players won't be able to dig anything afterwards

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- selling treasure island decorations in treasure island shop
- dug treasure and claim reward

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
