### PR TITLE
[FIX] Treasure island shovel goblin alignments

### DIFF
--- a/src/features/treasureIsland/components/GoblinDigging.tsx
+++ b/src/features/treasureIsland/components/GoblinDigging.tsx
@@ -4,12 +4,12 @@ import shadow from "assets/npcs/shadow.png";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Modal } from "react-bootstrap";
-import { Panel } from "components/ui/Panel";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Context } from "features/game/GameProvider";
 import classNames from "classnames";
 import { useActor } from "@xstate/react";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 export const GoblinDigging: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -18,41 +18,46 @@ export const GoblinDigging: React.FC = () => {
 
   return (
     <MapPlacement x={3} y={2} height={1} width={2}>
-      <img
-        src={SUNNYSIDE.soil.sand_dug}
-        className="absolute"
-        style={{
-          width: `${PIXEL_SCALE * 16}px`,
-          right: `${PIXEL_SCALE * 2}px`,
-          bottom: `${PIXEL_SCALE * -4}px`,
-        }}
-      />
-      <img
-        src={shadow}
-        className="absolute"
-        style={{
-          width: `${PIXEL_SCALE * 15}px`,
-          left: `0px`,
-          bottom: `0px`,
-        }}
-      />
-      <div className="w-max h-full relative">
+      <div
+        className={classNames(
+          "w-max h-full relative cursor-pointer hover:img-highlight",
+          {
+            "pointer-events-none": !gameState.matches("playing"),
+          }
+        )}
+        onClick={() => setShowModal(true)}
+      >
+        <img
+          src={SUNNYSIDE.soil.sand_dug}
+          className="absolute pointer-events-none"
+          style={{
+            width: `${PIXEL_SCALE * 16}px`,
+            left: `${PIXEL_SCALE * 16}px`,
+            bottom: `${PIXEL_SCALE * 2}px`,
+          }}
+        />
+        <img
+          src={shadow}
+          className="absolute pointer-events-none"
+          style={{
+            width: `${PIXEL_SCALE * 15}px`,
+            left: `${PIXEL_SCALE * 2}px`,
+            bottom: `${PIXEL_SCALE * 6}px`,
+          }}
+        />
         <img
           src={SUNNYSIDE.npcs.goblin_treasure}
-          className={classNames("relative cursor-pointer hover:img-highlight", {
-            "pointer-events-none": !gameState.matches("playing"),
-          })}
+          className="relative pointer-events-none"
           style={{
             width: `${PIXEL_SCALE * 33}px`,
-            left: `${PIXEL_SCALE * -7}px`,
-            bottom: `${PIXEL_SCALE * 13}px`,
+            left: `${PIXEL_SCALE * -5}px`,
+            bottom: `${PIXEL_SCALE * 19}px`,
           }}
-          onClick={() => setShowModal(true)}
         />
       </div>
 
       <Modal centered show={showModal} onHide={() => setShowModal(false)}>
-        <Panel
+        <CloseButtonPanel
           bumpkinParts={{
             body: "Goblin Potion",
             hair: "Sun Spots",
@@ -61,24 +66,15 @@ export const GoblinDigging: React.FC = () => {
             background: "Farm Background",
             shoes: "Black Farmer Boots",
           }}
+          onClose={() => setShowModal(false)}
         >
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={() => setShowModal(false)}
-            style={{
-              top: `${PIXEL_SCALE * 6}px`,
-              right: `${PIXEL_SCALE * 6}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
           <div className="p-2">
-            <p className="mb-4">
+            <p className="mb-3 mr-7">
               My uncle found a diamond ring digging at this beach.
             </p>
             <p>All I keep finding is boring SFL coins.</p>
           </div>
-        </Panel>
+        </CloseButtonPanel>
       </Modal>
     </MapPlacement>
   );


### PR DESCRIPTION
# Description

- fix treasure island shovel goblin alignments
  - limit clickable area to 1x2 grid
- use new close button panel for dialog

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/215648926-43b5e691-eb4d-41c2-b79c-8cdbfd6c65f8.png)|![image](https://user-images.githubusercontent.com/107602352/215648947-13ccb7be-03dc-4fa2-96a3-f5c03a742c5a.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click digging goblin with shovel

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
