### PR TITLE
[FIX] Observatory not closeable

### DIFF
--- a/src/features/island/collectibles/components/Observatory.tsx
+++ b/src/features/island/collectibles/components/Observatory.tsx
@@ -13,38 +13,39 @@ import { Loading } from "features/auth/components";
 export const Observatory: React.FC = () => {
   // Using rand value helps force-replay gifs.
   // Also, putting this in state ensures the gif doesn't replay during random compontent rerenders.
-  const [playRand, setPlayRand] = useState<number | null>(null);
+  const [playRand, setPlayRand] = useState<number | undefined>(undefined);
   const [modalTimer, setModalTimer] = useState<number>();
   const [loading, setLoading] = useState(false);
 
   const handleOpenTelescope = () => {
     setLoading(true);
-    setPlayRand(Math.random());
+    setPlayRand(Math.random() + 1); // PlayRand cannot be 0 when set
   };
 
   const handleCloseTelescope = () => {
     observatoryAnimationAudio.stop();
 
-    setPlayRand(null);
+    setPlayRand(undefined);
     setModalTimer(clearTimeout(modalTimer) as undefined);
   };
 
   return (
-    <div
-      className="absolute w-full h-full hover:img-highlight cursor-pointer"
-      onClick={handleOpenTelescope}
-    >
-      <img
-        style={{
-          width: `${PIXEL_SCALE * 31}px`,
-          bottom: `${PIXEL_SCALE * 0}px`,
-        }}
-        id={Section.Observatory}
-        className="absolute pointer-events-none"
-        src={observatory}
+    <>
+      <div
+        className="absolute w-full h-full hover:img-highlight cursor-pointer"
         onClick={handleOpenTelescope}
-        alt="Observatory"
-      />
+      >
+        <img
+          style={{
+            width: `${PIXEL_SCALE * 31}px`,
+            bottom: `${PIXEL_SCALE * 0}px`,
+          }}
+          id={Section.Observatory}
+          className="absolute pointer-events-none"
+          src={observatory}
+          alt="Observatory"
+        />
+      </div>
       <Modal centered show={!!playRand} onHide={handleCloseTelescope}>
         <CloseButtonPanel onClose={handleCloseTelescope}>
           {loading && <Loading />}
@@ -58,13 +59,13 @@ export const Observatory: React.FC = () => {
                 setLoading(false);
                 if (!observatoryAnimationAudio.playing() && playRand) {
                   observatoryAnimationAudio.play();
+                  setModalTimer(window.setTimeout(handleCloseTelescope, 26000));
                 }
-                setModalTimer(window.setTimeout(handleCloseTelescope, 26000));
               }}
             />
           </div>
         </CloseButtonPanel>
       </Modal>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
# Description

- move modal outside of observatory so it won't create an inflinite click loop when trying to close the modal

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click observatory and close it

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
