### PR TITLE
[FIX] Show revealing and revealed prompt in pumpkin plaza

### DIFF
--- a/src/features/game/components/Revealing.tsx
+++ b/src/features/game/components/Revealing.tsx
@@ -1,20 +1,20 @@
 import React from "react";
 
-import maneki from "assets/sfts/maneki_neko.gif";
+import { setImageWidth } from "lib/images";
 
-import { PIXEL_SCALE } from "../lib/constants";
+interface Props {
+  icon: string;
+}
 
-export const Revealing: React.FC = () => {
+export const Revealing: React.FC<Props> = ({ icon }) => {
   return (
     <div className="flex flex-col items-center p-2">
-      <span className="text-center">What could it be?</span>
+      <span className="text-center mb-2">What could it be?</span>
       <img
-        src={maneki}
+        src={icon}
         alt="digging"
         className="my-2"
-        style={{
-          width: `${PIXEL_SCALE * 33}px`,
-        }}
+        onLoad={(e) => setImageWidth(e.currentTarget)}
       />
       <span
         className="text-center text-xs loading mb-2"

--- a/src/features/island/collectibles/components/Bean.tsx
+++ b/src/features/island/collectibles/components/Bean.tsx
@@ -55,7 +55,7 @@ export const Bean: React.FC<CollectibleProps> = ({
   };
 
   if (gameState.matches("revealing")) {
-    return <Revealing />;
+    return <Revealing icon={ready} />;
   }
 
   if (gameState.matches("revealed")) {

--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -59,7 +59,7 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
     return (
       <Modal show centered>
         <Panel>
-          <Revealing />
+          <Revealing icon={manekiNeko} />
         </Panel>
       </Modal>
     );

--- a/src/features/pumpkinPlaza/components/DailyReward.tsx
+++ b/src/features/pumpkinPlaza/components/DailyReward.tsx
@@ -9,6 +9,8 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { secondsToString } from "lib/utils/time";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { Revealing } from "features/game/components/Revealing";
+import { Revealed } from "features/game/components/Revealed";
 
 export const DailyReward: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -23,68 +25,69 @@ export const DailyReward: React.FC = () => {
   const collectedAt =
     gameState.context.state.pumpkinPlaza?.rewardCollectedAt ?? 0;
   const readyInSeconds = (collectedAt + cooldown - Date.now()) / 1000;
+  const isReady = readyInSeconds <= 0;
 
-  if (readyInSeconds > 0) {
-    return (
-      <>
-        <img
-          id="daily-reward"
-          src={SUNNYSIDE.decorations.treasure_chest_opened}
-          className="cursor-pointer absolute z-20 hover:img-highlight"
-          style={{
-            width: `${PIXEL_SCALE * 16}px`,
-            left: `${GRID_WIDTH_PX * 52}px`,
-            top: `${GRID_WIDTH_PX * 30}px`,
-          }}
-          onClick={() => setShowCollectedModal(true)}
-        />
-        <Modal
-          show={showCollectedModal}
-          onHide={() => setShowCollectedModal(false)}
-          centered
-        >
-          <CloseButtonPanel onClose={() => setShowCollectedModal(false)}>
-            <div className="flex flex-col items-center p-2">
-              <img
-                src={SUNNYSIDE.decorations.treasure_chest_opened}
-                className="mb-2"
-                style={{
-                  width: `${PIXEL_SCALE * 16}px`,
-                }}
-              />
-              <span className="text-center">
-                Come back in{" "}
-                {secondsToString(readyInSeconds, { length: "full" })} for more
-                rewards!
-              </span>
-            </div>
-          </CloseButtonPanel>
-        </Modal>
-      </>
-    );
-  }
+  const reveal = () => {
+    gameService.send("REVEAL", {
+      event: {
+        type: "dailyReward.collected",
+        createdAt: new Date(),
+      },
+    });
+  };
 
-  // Load data
   return (
     <>
       <img
         id="daily-reward"
-        src={SUNNYSIDE.decorations.treasure_chest}
+        src={
+          isReady
+            ? SUNNYSIDE.decorations.treasure_chest
+            : SUNNYSIDE.decorations.treasure_chest_opened
+        }
         className="cursor-pointer absolute z-20 hover:img-highlight"
         style={{
           width: `${PIXEL_SCALE * 16}px`,
           left: `${GRID_WIDTH_PX * 52}px`,
           top: `${GRID_WIDTH_PX * 30}px`,
         }}
-        onClick={() => {
-          gameService.send("REVEAL", {
-            event: {
-              type: "dailyReward.collected",
-              createdAt: new Date(),
-            },
-          });
-        }}
+        onClick={isReady ? reveal : () => setShowCollectedModal(true)}
       />
+      <Modal
+        show={showCollectedModal}
+        onHide={() => setShowCollectedModal(false)}
+        centered
+      >
+        <CloseButtonPanel onClose={() => setShowCollectedModal(false)}>
+          <div className="flex flex-col items-center p-2">
+            <img
+              src={SUNNYSIDE.decorations.treasure_chest_opened}
+              className="mb-2"
+              style={{
+                width: `${PIXEL_SCALE * 16}px`,
+              }}
+            />
+            <span className="text-center">
+              Come back in {secondsToString(readyInSeconds, { length: "full" })}{" "}
+              for more rewards!
+            </span>
+          </div>
+        </CloseButtonPanel>
+      </Modal>
+      {gameState.matches("revealing") && (
+        <Modal show centered>
+          <CloseButtonPanel showCloseButton={false}>
+            <Revealing icon={SUNNYSIDE.decorations.treasure_chest} />
+          </CloseButtonPanel>
+        </Modal>
+      )}
+      {gameState.matches("revealed") && (
+        <Modal show centered>
+          <CloseButtonPanel showCloseButton={false}>
+            <Revealed />
+          </CloseButtonPanel>
+        </Modal>
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Description

- make `Revealing` component universal by taking in a custom icon
- show revealing and revealed modal in pumpkin plaza so the modal won't show up when players have maneki nekos in main island

![image](https://user-images.githubusercontent.com/107602352/215922419-2b86c2bb-893b-4ec8-b736-25c235f94db6.png)

# Type of fix

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open chest in pumpkin plaza when reward is ready
- open chest in pumpkin plaza when reward is not ready

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
