### PR TITLE
[FEAT] Drill Treasure

### DIFF
--- a/metadata/metadata.ts
+++ b/metadata/metadata.ts
@@ -3138,4 +3138,11 @@ export const OPEN_SEA_ITEMS: Record<InventoryItemName, Metadata> = {
     image_url: "../public/erc1155/images/question_mark.png",
     attributes: [],
   },
+  "Sand Drill": {
+    description: "?",
+    decimals: 0,
+    external_url: "https://docs.sunflower-land.com/getting-started/about",
+    image_url: "../public/erc1155/images/question_mark.png",
+    attributes: [],
+  },
 };

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -23,6 +23,8 @@ const INITIAL_STOCK: Inventory = {
   "Stone Pickaxe": new Decimal(10),
   "Iron Pickaxe": new Decimal(5),
   "Rusty Shovel": new Decimal(10),
+  "Sand Shovel": new Decimal(30),
+  "Sand Drill": new Decimal(5),
 
   // One off items
   "Pumpkin Soup": new Decimal(1),

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -197,7 +197,7 @@ export type ToolName =
   | "Hammer"
   | "Rod";
 
-export type Shovel = "Rusty Shovel" | "Shovel" | "Power Shovel" | "Sand Shovel";
+export type Shovel = "Rusty Shovel" | "Shovel" | "Power Shovel";
 
 export type Food =
   | "Pumpkin Soup"
@@ -584,22 +584,6 @@ export const SHOVELS: Record<Shovel, CraftableItem> = {
       },
       {
         item: "Gold",
-        amount: new Decimal(5),
-      },
-    ],
-    disabled: true,
-  },
-  "Sand Shovel": {
-    name: "Sand Shovel",
-    description: "Used for digging treasure",
-    tokenAmount: new Decimal(25),
-    ingredients: [
-      {
-        item: "Wood",
-        amount: new Decimal(20),
-      },
-      {
-        item: "Stone",
         amount: new Decimal(5),
       },
     ],

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -18,6 +18,7 @@ import { FruitName, FruitSeedName } from "./fruits";
 import { TreasureName } from "./treasure";
 import { GoblinBlacksmithItemName, HeliosBlacksmithItem } from "./collectibles";
 import { AuctioneerItemName } from "./auctioneer";
+import { TreasureToolName } from "./tools";
 
 export type Reward = {
   sfl?: Decimal;
@@ -178,7 +179,8 @@ export type InventoryItemName =
   | TreasureName
   | HeliosBlacksmithItem
   | GoblinBlacksmithItemName
-  | TreasureName;
+  | TreasureName
+  | TreasureToolName;
 
 export type Inventory = Partial<Record<InventoryItemName, Decimal>>;
 

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -638,8 +638,12 @@ export const ITEM_DETAILS: Items = {
     image: SUNNYSIDE.tools.power_shovel,
   },
   "Sand Shovel": {
-    ...SHOVELS["Sand Shovel"],
+    description: "Used for digging treasure",
     image: SUNNYSIDE.tools.sand_shovel,
+  },
+  "Sand Drill": {
+    description: "Drill deep for rare treasure",
+    image: SUNNYSIDE.icons.expression_confused,
   },
 
   // SFTs

--- a/src/features/game/types/index.ts
+++ b/src/features/game/types/index.ts
@@ -56,6 +56,7 @@ export const KNOWN_IDS: Record<InventoryItemName, number> = {
   Shovel: 308,
   "Power Shovel": 309,
   "Sand Shovel": 310,
+  "Sand Drill": 311,
 
   "Sunflower Statue": 401,
   "Potato Statue": 402,

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -14,7 +14,7 @@ export type WorkbenchToolName =
   | "Rusty Shovel"
   | "Power Shovel";
 
-export type TreasureToolName = "Sand Shovel";
+export type TreasureToolName = "Sand Shovel" | "Sand Drill";
 
 export interface Tool {
   name: string;
@@ -83,5 +83,13 @@ export const TREASURE_TOOLS: Record<TreasureToolName, Tool> = {
       Stone: new Decimal(1),
     },
     sfl: marketRate(5),
+  },
+  "Sand Drill": {
+    name: "Sand Drill",
+    description: "Drill deep for rare treasure",
+    ingredients: {
+      Gold: new Decimal(1),
+    },
+    sfl: marketRate(10),
   },
 };

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -31,6 +31,7 @@ import { SKILL_TREE } from "./skills";
 import { BUILDINGS } from "./buildings";
 import { CONSUMABLES } from "./consumables";
 import { DECORATIONS } from "./decorations";
+import { TREASURE_TOOLS } from "./tools";
 
 type WithdrawCondition = boolean | ((gameState: GoblinState) => boolean);
 
@@ -118,7 +119,10 @@ const seedDefaults = buildDefaults(getKeys(SEEDS()), false);
 const beanDefaults = buildDefaults(getKeys(BEANS()), false);
 const questItemDefaults = buildDefaults(getKeys(QUEST_ITEMS), false);
 const warTentItemsDefaults = buildDefaults(getKeys(WAR_TENT_ITEMS), false);
-const toolDefaults = buildDefaults(getKeys(TOOLS), false);
+const toolDefaults = buildDefaults(
+  getKeys({ ...TOOLS, ...TREASURE_TOOLS }),
+  false
+);
 const foodDefaults = buildDefaults(getKeys(FOODS()), false);
 const shovelDefaults = buildDefaults(getKeys(SHOVELS), false);
 const warBannerDefaults = buildDefaults(getKeys(WAR_BANNERS), false);

--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -352,7 +352,7 @@ export const SandPlot: React.FC<{
 
   if (drilling) {
     return (
-      <Modal centered show onHide={handleAcknowledgeTreasureFound}>
+      <Modal centered show>
         <Panel>
           <p className="loading">Drilling</p>
         </Panel>

--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from "components/ui/Button";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { getKeys } from "features/game/types/craftables";
+import { Panel } from "components/ui/Panel";
 
 type TreasureReward = {
   discovered: InventoryItemName | null;
@@ -120,6 +121,7 @@ const isTreasureFound = (state: MachineState) => state.matches("treasureFound");
 const isIdle = (state: MachineState) => state.matches("idle");
 const isNoShovel = (state: MachineState) => state.matches("noShovel");
 const isFinishing = (state: MachineState) => state.matches("finishing");
+const isDrilling = (state: MachineState) => state.matches("drilling");
 const discovered = (state: MachineState) => state.context.discovered;
 
 const MAX_HOLES_PER_DAY = 30;
@@ -149,6 +151,7 @@ export const SandPlot: React.FC<{
   const dug = useSelector(sandPlotService, isDug);
   const noShovel = useSelector(sandPlotService, isNoShovel);
   const finishing = useSelector(sandPlotService, isFinishing);
+  const drilling = useSelector(sandPlotService, isDrilling);
   const discoveredItem = useSelector(sandPlotService, discovered);
 
   const [showHoverState, setShowHoverState] = useState(false);
@@ -161,6 +164,10 @@ export const SandPlot: React.FC<{
   const hasSandShovel =
     selectedItem === "Sand Shovel" &&
     gameState.context.state.inventory["Sand Shovel"]?.gte(1);
+
+  const hasSandDrill =
+    selectedItem === "Sand Drill" &&
+    gameState.context.state.inventory["Sand Drill"]?.gte(1);
 
   useEffect(() => {
     // If no treasure is found, move gameMachine back into playing state and
@@ -184,11 +191,6 @@ export const SandPlot: React.FC<{
   };
 
   const handleDig = () => {
-    if (!hasSandShovel) {
-      handleNoShovel();
-      return;
-    }
-
     const holes = gameState.context.state.treasureIsland?.holes ?? {};
     const holesDug = getKeys(holes).filter(
       (holeId) => !canDig(holes[holeId]?.dugAt)
@@ -199,15 +201,32 @@ export const SandPlot: React.FC<{
       return;
     }
 
-    gameService.send("REVEAL", {
-      event: {
-        type: "treasure.dug",
-        id,
-        createdAt: new Date(),
-      },
-    });
+    if (hasSandShovel) {
+      gameService.send("REVEAL", {
+        event: {
+          type: "treasure.dug",
+          id,
+          createdAt: new Date(),
+        },
+      });
 
-    sandPlotService.send("DIG");
+      sandPlotService.send("DIG");
+      return;
+    }
+
+    if (hasSandDrill) {
+      gameService.send("REVEAL", {
+        event: {
+          type: "treasure.drilled",
+          id,
+          createdAt: new Date(),
+        },
+      });
+      sandPlotService.send("DRILL");
+      return;
+    }
+
+    handleNoShovel();
   };
 
   const handleAcknowledgeTreasureFound = () => {
@@ -226,10 +245,13 @@ export const SandPlot: React.FC<{
     onMissingShovelAcknowledge();
   };
 
+  // Each time the sprite sheet gets to the 10th frame (shovel up)
+  // If reward has returned then stop sprite here.
   const handleTreasureCheck = () => {
-    // Each time the sprite sheet gets to the 10th frame (shovel up)
-    // If reward has returned then stop sprite here.
-    if (reward !== undefined) {
+    // Avoid checking for previous day rewards
+    const hasRecentReward = reward && reward?.dugAt > Date.now() - 60 * 1000;
+
+    if (hasRecentReward) {
       goblinDiggingRef.current?.pause();
       setShowGoblinEmotion(true);
 
@@ -241,6 +263,16 @@ export const SandPlot: React.FC<{
       }, 1000);
     }
   };
+
+  useEffect(() => {
+    console.log({ reward, drilling });
+    if (reward && drilling) {
+      sandPlotService.send("FINISH_DIGGING", {
+        discovered: reward.discovered,
+        dugAt: reward?.dugAt,
+      });
+    }
+  }, [drilling, reward]);
 
   if (dug || treasureFound) {
     return (
@@ -318,9 +350,23 @@ export const SandPlot: React.FC<{
     );
   }
 
+  if (drilling) {
+    return (
+      <Modal centered show onHide={handleAcknowledgeTreasureFound}>
+        <Panel>
+          <p className="loading">Drilling</p>
+        </Panel>
+      </Modal>
+    );
+  }
+
   const gameMachinePlaying = gameState.matches("playing");
   const showShovelGoblin = !idle && !dug && !noShovel;
-  const showSelectBox = showHoverState && idle && gameMachinePlaying;
+  const showSelectBox =
+    showHoverState &&
+    !showShovelGoblin &&
+    gameMachinePlaying &&
+    (hasSandShovel || hasSandDrill);
 
   return (
     <div

--- a/src/features/treasureIsland/lib/sandPlotMachine.ts
+++ b/src/features/treasureIsland/lib/sandPlotMachine.ts
@@ -72,6 +72,7 @@ export const sandPlotMachine = createMachine<
     idle: {
       on: {
         DIG: { target: "digging" },
+        DRILL: { target: "drilling" },
         NO_SHOVEL: { target: "noShovel" },
       },
     },
@@ -83,6 +84,29 @@ export const sandPlotMachine = createMachine<
       },
     },
     digging: {
+      on: {
+        FINISH_DIGGING: [
+          {
+            target: "treasureFound",
+            cond: (_: SandPlotContext, event: FinishDiggingEvent) => {
+              return !!event.discovered;
+            },
+            actions: assign<SandPlotContext, FinishDiggingEvent>({
+              discovered: (_, event) => event.discovered,
+              dugAt: (_, event) => event.dugAt,
+            }),
+          },
+          {
+            target: "treasureNotFound",
+            actions: assign<SandPlotContext, FinishDiggingEvent>({
+              discovered: (_, event) => event.discovered,
+              dugAt: (_, event) => event.dugAt,
+            }),
+          },
+        ],
+      },
+    },
+    drilling: {
       on: {
         FINISH_DIGGING: [
           {

--- a/src/features/treasureIsland/lib/sandPlotMachine.ts
+++ b/src/features/treasureIsland/lib/sandPlotMachine.ts
@@ -12,6 +12,7 @@ export type SandPlotState = {
     | "loading"
     | "idle"
     | "digging"
+    | "drilling"
     | "noShovel"
     | "treasureFound"
     | "treasureNotFound"
@@ -31,6 +32,7 @@ type SandPlotEvent =
   | FinishDiggingEvent
   | { type: "NO_SHOVEL" }
   | { type: "DIG" }
+  | { type: "DRILL" }
   | { type: "ACKNOWLEDGE" };
 
 export type MachineState = State<SandPlotContext, SandPlotEvent, SandPlotState>;


### PR DESCRIPTION
# Description

This replaces the treasure searching feature with a smoother UX and easier to understand functionality.

The mechanic now behaves similar to 'Sand Shovels'

1. Craft
2. Click on space on map
3. Find reward

**Excludes**

- Drill Icon
- Drilling animation (modal currently has placeholder text).

<img width="653" alt="Screen Shot 2023-02-01 at 1 41 11 pm" src="https://user-images.githubusercontent.com/11745561/215932368-b8489b24-28b5-4056-bc67-6c21a2db4341.png">
<img width="564" alt="Screen Shot 2023-02-01 at 1 41 15 pm" src="https://user-images.githubusercontent.com/11745561/215932374-fbaf984f-ce8f-4892-baac-de49f2b4e9bc.png">
