### PR TITLE
[FIX] Update HUD

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -43,7 +43,6 @@ import { Studios } from "features/studios/Studios";
 import { Rules } from "../components/Rules";
 import { PumpkinPlaza } from "features/pumpkinPlaza/PumpkinPlaza";
 import { hasFeatureAccess } from "lib/flags";
-import { Hud } from "features/island/hud/Hud";
 
 const AUTO_SAVE_INTERVAL = 1000 * 30; // autosave every 30 seconds
 const SHOW_MODAL: Record<StateValues, boolean> = {
@@ -217,9 +216,6 @@ export const Game: React.FC = () => {
               <Route path="*" element={<IslandNotFound />} />
             </Routes>
           </PlaceableOverlay>
-        </div>
-        <div className="absolute z-20">
-          <Hud />
         </div>
       </>
     );

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -34,6 +34,7 @@ import { Chicken as ChickenElement } from "features/island/chickens/Chicken";
 import { BUMPKIN_POSITION } from "features/island/bumpkin/types/character";
 import { IslandTravel } from "features/game/expansion/components/travel/IslandTravel";
 import { BumpkinTutorial } from "./BumpkinTutorial";
+import { Hud } from "features/island/hud/Hud";
 
 type ExpansionProps = Pick<
   LandExpansion,
@@ -399,44 +400,47 @@ export const Land: React.FC = () => {
   };
 
   return (
-    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-      <div
-        className={classNames("relative w-full h-full", {
-          "pointer-events-none": gameState.matches("visiting"),
-        })}
-      >
-        <LandBase expandedCount={expandedCount} />
-        <UpcomingExpansion gameState={state} />
-        <DirtRenderer
-          expansions={expansions.filter((e) => e.readyAt < Date.now())}
+    <>
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <div
+          className={classNames("relative w-full h-full", {
+            "pointer-events-none": gameState.matches("visiting"),
+          })}
+        >
+          <LandBase expandedCount={expandedCount} />
+          <UpcomingExpansion gameState={state} />
+          <DirtRenderer
+            expansions={expansions.filter((e) => e.readyAt < Date.now())}
+          />
+
+          <Water level={expandedCount} />
+
+          {/* Sort island elements by y axis */}
+          {getIslandElements({
+            expansions,
+            buildings,
+            collectibles,
+            chickens,
+            bumpkinParts: gameState.context.state.bumpkin?.equipped,
+            isEditing,
+          }).sort((a, b) => b.props.y - a.props.y)}
+        </div>
+        <IslandTravel
+          key="island-travel"
+          bumpkin={bumpkin}
+          isVisiting={gameState.matches("visiting")}
+          inventory={gameState.context.state.inventory}
+          isTravelAllowed={!gameState.matches("autosaving")}
+          onTravelDialogOpened={() => gameService.send("SAVE")}
+          x={boatCoordinates.x}
+          y={boatCoordinates.y}
         />
 
-        <Water level={expandedCount} />
+        <BumpkinTutorial bumpkinParts={bumpkin?.equipped} />
 
-        {/* Sort island elements by y axis */}
-        {getIslandElements({
-          expansions,
-          buildings,
-          collectibles,
-          chickens,
-          bumpkinParts: gameState.context.state.bumpkin?.equipped,
-          isEditing,
-        }).sort((a, b) => b.props.y - a.props.y)}
+        {gameState.matches("editing") && <Placeable />}
       </div>
-      <IslandTravel
-        key="island-travel"
-        bumpkin={bumpkin}
-        isVisiting={gameState.matches("visiting")}
-        inventory={gameState.context.state.inventory}
-        isTravelAllowed={!gameState.matches("autosaving")}
-        onTravelDialogOpened={() => gameService.send("SAVE")}
-        x={boatCoordinates.x}
-        y={boatCoordinates.y}
-      />
-
-      <BumpkinTutorial bumpkinParts={bumpkin?.equipped} />
-
-      {gameState.matches("editing") && <Placeable />}
-    </div>
+      <Hud isFarming />
+    </>
   );
 };

--- a/src/features/helios/Helios.tsx
+++ b/src/features/helios/Helios.tsx
@@ -19,6 +19,7 @@ import { CommunityGardenEntry } from "./components/CommunityGardenEntry";
 // random seal spawn spots
 import { randomInt } from "lib/utils/random";
 import { LostSeal } from "features/community/seal/Seal";
+import { Hud } from "features/island/hud/Hud";
 
 const spawn = [
   [30, 15],
@@ -37,7 +38,7 @@ export const Helios: React.FC = () => {
   const [gameState] = useActor(gameService);
   const { state } = gameState.context;
   const { bumpkin } = state;
-  const [sealSpawn, setSealSpawn] = useState(getRandomSpawn());
+  const [sealSpawn] = useState(getRandomSpawn());
 
   const [scrollIntoView] = useScrollIntoView();
 
@@ -81,6 +82,7 @@ export const Helios: React.FC = () => {
           isTravelAllowed={!gameState.matches("autosaving")}
         />
       </div>
+      <Hud isFarming={false} />
     </>
   );
 };

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -15,7 +15,7 @@ import { InventoryItemName } from "features/game/types/game";
  * Heads up display - a concept used in games for the small overlaid display of information.
  * Balances, Inventory, actions etc.
  */
-export const Hud: React.FC = () => {
+export const Hud: React.FC<{ isFarming: boolean }> = ({ isFarming }) => {
   const { gameService, shortcutItem, selectedItem } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -23,7 +23,11 @@ export const Hud: React.FC = () => {
   const landId = gameState.context.state.id;
 
   return (
-    <div data-html2canvas-ignore="true" aria-label="Hud">
+    <div
+      data-html2canvas-ignore="true"
+      aria-label="Hud"
+      className="absolute z-40"
+    >
       {isEditing ? (
         <PlaceableController />
       ) : (
@@ -33,7 +37,7 @@ export const Hud: React.FC = () => {
           <Buildings />
           <Save />
           <BumpkinProfile />
-          <Settings isFarming={true} />
+          <Settings isFarming={isFarming} />
         </>
       )}
       <div hidden={isEditing}>
@@ -48,7 +52,7 @@ export const Hud: React.FC = () => {
             });
           }}
           isSaving={gameState.matches("autosaving")}
-          isFarming
+          isFarming={isFarming}
         />
       </div>
     </div>

--- a/src/features/island/hud/components/Settings.tsx
+++ b/src/features/island/hud/components/Settings.tsx
@@ -17,6 +17,7 @@ import {
   getGoblinSongCount,
 } from "assets/songs/playlist";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { useLocation } from "react-router-dom";
 
 const buttonWidth = PIXEL_SCALE * 22;
 const buttonHeight = PIXEL_SCALE * 23;
@@ -32,6 +33,10 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
   const [showMoreButtons, setShowMoreButtons] = useState(false);
   const [openAudioMenu, setOpenAudioMenu] = useState(false);
   const [openSettingsMenu, setOpenSettingsMenu] = useState(false);
+  const { pathname } = useLocation();
+  // The actions included in this more buttons should not be shown if the player is in goblin retreat or visiting another farm
+  const showLimitedButtons =
+    pathname.includes("retreat") || pathname.includes("visit");
 
   const cogRef = useRef<HTMLDivElement>(null);
 
@@ -184,7 +189,7 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
     gearButton,
     ...(isFarming ? [progressBarButton] : []),
     audioButton,
-    ...(isFarming ? [moreButton] : []),
+    ...(!showLimitedButtons ? [moreButton] : []),
   ];
 
   return (

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -9,6 +9,7 @@ import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getChestItems } from "./utils/inventory";
 import { KNOWN_IDS } from "features/game/types";
+import { useLocation } from "react-router-dom";
 
 interface Props {
   state: GameState;
@@ -28,6 +29,10 @@ export const Inventory: React.FC<Props> = ({
   onPlace,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const { pathname } = useLocation();
+  // The actions included in this more buttons should not be shown if the player is in goblin retreat or visiting another farm
+  const limitedInventory =
+    pathname.includes("retreat") || pathname.includes("visit");
 
   const [selectedChestItem, setSelectedChestItem] = useState<InventoryItemName>(
     getKeys(getChestItems(state)).sort((a, b) => KNOWN_IDS[a] - KNOWN_IDS[b])[0]
@@ -89,7 +94,7 @@ export const Inventory: React.FC<Props> = ({
         isFarming={isFarming}
       />
 
-      {isFarming && (
+      {!limitedInventory && (
         <div
           className="flex flex-col items-center"
           style={{

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -15,7 +15,7 @@ interface Props {
   selectedItem: InventoryItemName;
   shortcutItem?: (item: InventoryItemName) => void;
   onPlace?: (item: InventoryItemName) => void;
-  isFarming?: boolean;
+  isFarming: boolean;
   isSaving?: boolean;
 }
 
@@ -86,6 +86,7 @@ export const Inventory: React.FC<Props> = ({
         onSelectChestItem={setSelectedChestItem}
         onPlace={onPlace}
         isSaving={isSaving}
+        isFarming={isFarming}
       />
 
       {isFarming && (

--- a/src/features/island/hud/components/inventory/InventoryItemsModal.tsx
+++ b/src/features/island/hud/components/inventory/InventoryItemsModal.tsx
@@ -18,6 +18,7 @@ interface Props {
   onSelectChestItem: (name: InventoryItemName) => void;
   onPlace?: (name: InventoryItemName) => void;
   isSaving?: boolean;
+  isFarming: boolean;
 }
 
 export type TabItems = Record<string, { items: object }>;
@@ -34,6 +35,7 @@ export const InventoryItemsModal: React.FC<Props> = ({
   onSelectChestItem,
   onPlace,
   isSaving,
+  isFarming,
 }) => {
   const [currentTab, setCurrentTab] = useState<number>(0);
 
@@ -61,7 +63,7 @@ export const InventoryItemsModal: React.FC<Props> = ({
             selected={selectedChestItem}
             onSelect={onSelectChestItem}
             closeModal={onHide}
-            onPlace={onPlace}
+            onPlace={isFarming ? onPlace : undefined}
             isSaving={isSaving}
           />
         )}

--- a/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
+++ b/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
@@ -44,7 +44,6 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
   const [showShareModal, setShowShareModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [showAddSFLModal, setShowAddSFLModal] = useState(false);
-  const [showLandExpansionModal, setShowLandExpansionModal] = useState(false);
   const [showDiscordModal, setShowDiscordModal] = useState(false);
   const [showCommunityGardenModal, setShowCommunityGardenModal] =
     useState(false);

--- a/src/features/pumpkinPlaza/PumpkinPlaza.tsx
+++ b/src/features/pumpkinPlaza/PumpkinPlaza.tsx
@@ -14,6 +14,7 @@ import { GRID_WIDTH_PX } from "features/game/lib/constants";
 import { DailyReward } from "./components/DailyReward";
 import { IslandTravel } from "features/game/expansion/components/travel/IslandTravel";
 import { randomInt } from "lib/utils/random";
+import { Hud } from "features/island/hud/Hud";
 
 // Spawn players in different areas
 const randomXOffset = randomInt(0, 50);
@@ -59,82 +60,85 @@ export const PumpkinPlaza: React.FC = () => {
 
   // Load data
   return (
-    <div
-      className="absolute"
-      style={{
-        width: `${84 * GRID_WIDTH_PX}px`,
-        height: `${56 * GRID_WIDTH_PX}px`,
-      }}
-      // TODO dynamic game board size based on tile dimensions
-    >
-      <img
-        src={background}
-        className="h-auto absolute "
+    <>
+      <div
+        className="absolute"
         style={{
           width: `${84 * GRID_WIDTH_PX}px`,
           height: `${56 * GRID_WIDTH_PX}px`,
         }}
-      />
-      <Modal
-        show={
-          chatState.matches("initialising") || chatState.matches("connecting")
-        }
-        centered
+        // TODO dynamic game board size based on tile dimensions
       >
-        <Panel>
-          <span className="loading">Connecting</span>
-        </Panel>
-      </Modal>
+        <img
+          src={background}
+          className="h-auto absolute "
+          style={{
+            width: `${84 * GRID_WIDTH_PX}px`,
+            height: `${56 * GRID_WIDTH_PX}px`,
+          }}
+        />
+        <Modal
+          show={
+            chatState.matches("initialising") || chatState.matches("connecting")
+          }
+          centered
+        >
+          <Panel>
+            <span className="loading">Connecting</span>
+          </Panel>
+        </Modal>
 
-      <Modal show={chatState.matches("loadingPlayers")} centered>
-        <Panel>
-          <span className="loading">Loading Players</span>
-        </Panel>
-      </Modal>
+        <Modal show={chatState.matches("loadingPlayers")} centered>
+          <Panel>
+            <span className="loading">Loading Players</span>
+          </Panel>
+        </Modal>
 
-      <Modal show={chatState.matches("disconnected")} centered>
-        <Panel>
-          <span>Disconnected</span>
-        </Panel>
-      </Modal>
-      <Modal show={chatState.matches("error")} centered>
-        <Panel>
-          <span>Error</span>
-        </Panel>
-      </Modal>
+        <Modal show={chatState.matches("disconnected")} centered>
+          <Panel>
+            <span>Disconnected</span>
+          </Panel>
+        </Modal>
+        <Modal show={chatState.matches("error")} centered>
+          <Panel>
+            <span>Error</span>
+          </Panel>
+        </Modal>
 
-      <div className="absolute inset-0 cursor-pointer" onClick={walk} />
+        <div className="absolute inset-0 cursor-pointer" onClick={walk} />
 
-      <Bumpkins
-        messages={chatState.context.messages}
-        discoveries={chatState.context.discoveries}
-        bumpkin={chatState.context.bumpkin}
-        websocketService={websocketService}
-        position={chatState.context.currentPosition}
-        lastPosition={chatState.context.lastPosition}
-        bumpkins={chatState.context.bumpkins}
-        onVisit={(id) => gameService.send({ type: "VISIT", landId: id })}
-      />
+        <Bumpkins
+          messages={chatState.context.messages}
+          discoveries={chatState.context.discoveries}
+          bumpkin={chatState.context.bumpkin}
+          websocketService={websocketService}
+          position={chatState.context.currentPosition}
+          lastPosition={chatState.context.lastPosition}
+          bumpkins={chatState.context.bumpkins}
+          onVisit={(id) => gameService.send({ type: "VISIT", landId: id })}
+        />
 
-      <DailyReward />
+        <DailyReward />
 
-      <IslandTravel
-        inventory={gameState.context.state.inventory}
-        bumpkin={gameState.context.state.bumpkin}
-        x={0}
-        y={-21}
-      />
+        <IslandTravel
+          inventory={gameState.context.state.inventory}
+          bumpkin={gameState.context.state.bumpkin}
+          x={0}
+          y={-21}
+        />
 
-      <ChatUI
-        onMessage={({ reaction, text }) => {
-          websocketService.send("SEND_CHAT_MESSAGE", {
-            text,
-            reaction,
-          });
-        }}
-        game={chatState.context.game}
-      />
-      {/* )} */}
-    </div>
+        <ChatUI
+          onMessage={({ reaction, text }) => {
+            websocketService.send("SEND_CHAT_MESSAGE", {
+              text,
+              reaction,
+            });
+          }}
+          game={chatState.context.game}
+        />
+        {/* )} */}
+      </div>
+      <Hud isFarming={false} />
+    </>
   );
 };

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -16,9 +16,8 @@ export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
 
   return (
     <div
-      className="w-full flex justify-center fixed bottom-4 pl-2 pr-[73.5px] md:pr-2"
-      style={{ zIndex: 999 }}
-      onClick={() => console.log("parent clicked")}
+      className="w-full flex justify-center fixed bottom-14 md:bottom-4 pl-2 pr-[73.5px] md:pr-2 z-40"
+      onClick={console.log}
     >
       <CloseButtonPanel
         className="w-full sm:w-[30rem]"

--- a/src/features/retreat/components/hud/GoblinInventory.tsx
+++ b/src/features/retreat/components/hud/GoblinInventory.tsx
@@ -71,6 +71,7 @@ export const GoblinInventory: React.FC<Props> = ({ state }) => {
         onSelectBasketItem={setSelectedBasketItem}
         selectedChestItem={selectedChestItem}
         onSelectChestItem={setSelectedChestItem}
+        isFarming={false}
       />
     </div>
   );

--- a/src/features/treasureIsland/TreasureIsland.tsx
+++ b/src/features/treasureIsland/TreasureIsland.tsx
@@ -15,6 +15,7 @@ import { SandPlot } from "./components/SandPlot";
 import { BeachConstruction } from "./components/BeachConstruction";
 import { PirateQuest } from "features/game/expansion/components/PirateQuest";
 import { TreasureTrove } from "./components/TreasureTrove";
+import { Hud } from "features/island/hud/Hud";
 
 export const CLICKABLE_COORDINATES: Coordinates[] = [];
 
@@ -73,6 +74,7 @@ export const TreasureIsland: React.FC = () => {
         <PirateQuest />
         <TreasureTrove />
       </div>
+      <Hud isFarming={false} />
     </>
   );
 };


### PR DESCRIPTION
# Description

This PR modifies the Hud so that we can show a modified Hud when not farming.

The modified Hud now shows in Helios, Pumpkin Plaza, and Treasure Island. You're still able to action More actions from these pages because they're running the `gameMachine`. These actions are blocked when visiting though.

Goblin Retreat has not been changed.



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visit all different islands and test Hud actions. You should only see the option to place a collectible when on your own farm.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
