### PR TITLE
[CHORE] Simplify CloseablePanel props

### DIFF
--- a/src/features/community/arcade/ArcadeModal.tsx
+++ b/src/features/community/arcade/ArcadeModal.tsx
@@ -21,8 +21,7 @@ export const ArcadeModal: React.FC<Props> = ({ isOpen, onClose }) => {
     <Modal centered show={isOpen} onHide={onClose}>
       <CloseButtonPanel
         onClose={onClose}
-        showBackButton={!!activeWindow}
-        onBack={() => setActiveWindow(null)}
+        onBack={activeWindow ? () => setActiveWindow(null) : undefined}
         title={activeWindow || "Mini SFL Games"}
       >
         {/* Menu */}

--- a/src/features/farming/animals/components/RemoveChickenModal.tsx
+++ b/src/features/farming/animals/components/RemoveChickenModal.tsx
@@ -69,7 +69,7 @@ export const RemoveChickenModal: React.FC<Props> = ({
   };
 
   return (
-    <CloseButtonPanel showCloseButton={false} title="Remove this Chicken?">
+    <CloseButtonPanel title="Remove this Chicken?">
       <div className="flex flex-col items-center">
         <div className="flex space-x-2 items-center justify-center mb-2">
           <SquareIcon icon={ITEM_DETAILS["Rusty Shovel"].image} width={14} />

--- a/src/features/game/components/CloseablePanel.tsx
+++ b/src/features/game/components/CloseablePanel.tsx
@@ -13,13 +13,33 @@ export interface PanelTabs {
   name: string;
 }
 
+/**
+ * The base props for closeable panels that may have a close button.
+ * @param showCloseButton The item resources requirements.
+ * @param onClose The SFL requirements.
+ */
+interface HasCloseButtonProps {
+  showCloseButton?: boolean;
+  onClose: () => void;
+}
+
+/**
+ * The base props for closeable panels that do not have a close button for good.
+ * @param showCloseButton The item resources requirements.
+ * @param onClose The SFL requirements.
+ */
+interface NoCloseButtonProps {
+  showCloseButton: false;
+  onClose?: () => void;
+}
+
+type CloseButtonProps = HasCloseButtonProps | NoCloseButtonProps;
+
 interface Props {
   tabs?: PanelTabs[];
   currentTab?: number;
   setCurrentTab?: React.Dispatch<React.SetStateAction<number>>;
   title?: string;
-  showCloseButton?: boolean;
-  onClose?: () => void;
   showBackButton?: boolean;
   onBack?: () => void;
   bumpkinParts?: Partial<Equipped>;
@@ -40,13 +60,13 @@ interface Props {
  * @className Additional class name for the parent panel.
  * @children The panel children content.
  */
-export const CloseButtonPanel: React.FC<Props> = ({
+export const CloseButtonPanel: React.FC<Props & CloseButtonProps> = ({
   tabs,
   currentTab = 0,
   setCurrentTab,
   title,
   showCloseButton = true,
-  onClose,
+  onClose = undefined,
   showBackButton = false,
   onBack,
   bumpkinParts,

--- a/src/features/game/components/CloseablePanel.tsx
+++ b/src/features/game/components/CloseablePanel.tsx
@@ -13,34 +13,12 @@ export interface PanelTabs {
   name: string;
 }
 
-/**
- * The base props for closeable panels that may have a close button.
- * @param showCloseButton The item resources requirements.
- * @param onClose The SFL requirements.
- */
-interface HasCloseButtonProps {
-  showCloseButton?: boolean;
-  onClose: () => void;
-}
-
-/**
- * The base props for closeable panels that do not have a close button for good.
- * @param showCloseButton The item resources requirements.
- * @param onClose The SFL requirements.
- */
-interface NoCloseButtonProps {
-  showCloseButton: false;
-  onClose?: () => void;
-}
-
-type CloseButtonProps = HasCloseButtonProps | NoCloseButtonProps;
-
 interface Props {
   tabs?: PanelTabs[];
   currentTab?: number;
   setCurrentTab?: React.Dispatch<React.SetStateAction<number>>;
   title?: string;
-  showBackButton?: boolean;
+  onClose?: () => void;
   onBack?: () => void;
   bumpkinParts?: Partial<Equipped>;
   className?: string;
@@ -52,30 +30,29 @@ interface Props {
  * @currentTab The current selected tab index of the panel. Default is 0.
  * @setCurrentTab Dispatch method to set the current selected tab index.
  * @title The panel title.
- * @showCloseButton Whether to show the close button for the panel or not. Default is true.
- * @onClose The close panel method.
- * @showCloseButton Whether to show the back button for the panel or not. Default is true.
- * @onClose The back button method.
+ * @onClose The close panel method.  Close button will show if this is set.
+ * @onBack The back button method.  Back button will show if this is set.
  * @bumpkinParts The list of bumpkin parts for the modal.
  * @className Additional class name for the parent panel.
  * @children The panel children content.
  */
-export const CloseButtonPanel: React.FC<Props & CloseButtonProps> = ({
+export const CloseButtonPanel: React.FC<Props> = ({
   tabs,
   currentTab = 0,
   setCurrentTab,
   title,
-  showCloseButton = true,
-  onClose = undefined,
-  showBackButton = false,
+  onClose,
   onBack,
   bumpkinParts,
-  children,
   className,
+  children,
 }) => {
   const handleTabClick = (index: number) => {
     setCurrentTab && setCurrentTab(index);
   };
+
+  const showCloseButton = !!onClose;
+  const showBackButton = !!onBack;
 
   return (
     <Panel

--- a/src/features/game/expansion/placeable/RemovePlaceableModal.tsx
+++ b/src/features/game/expansion/placeable/RemovePlaceableModal.tsx
@@ -127,7 +127,7 @@ export const RemovePlaceableModal: React.FC<Props> = ({
   };
 
   return (
-    <CloseButtonPanel showCloseButton={false} title={`Remove this ${name}?`}>
+    <CloseButtonPanel title={`Remove this ${name}?`}>
       <div className="flex flex-col items-center">
         <div className="flex space-x-2 items-center justify-center mb-2">
           <SquareIcon icon={ITEM_DETAILS["Rusty Shovel"].image} width={14} />

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -22,7 +22,6 @@ export const ChatUI: React.FC<Props> = ({ onMessage, game }) => {
     >
       <CloseButtonPanel
         className="w-full sm:w-[30rem]"
-        showCloseButton={false}
         tabs={[
           { icon: SUNNYSIDE.icons.expression_chat, name: "Chat" },
           { icon: SUNNYSIDE.icons.heart, name: "Reactions" },

--- a/src/features/pumpkinPlaza/components/DailyReward.tsx
+++ b/src/features/pumpkinPlaza/components/DailyReward.tsx
@@ -76,14 +76,14 @@ export const DailyReward: React.FC = () => {
       </Modal>
       {gameState.matches("revealing") && (
         <Modal show centered>
-          <CloseButtonPanel showCloseButton={false}>
+          <CloseButtonPanel>
             <Revealing icon={SUNNYSIDE.decorations.treasure_chest} />
           </CloseButtonPanel>
         </Modal>
       )}
       {gameState.matches("revealed") && (
         <Modal show centered>
-          <CloseButtonPanel showCloseButton={false}>
+          <CloseButtonPanel>
             <Revealed />
           </CloseButtonPanel>
         </Modal>

--- a/src/features/treasureIsland/components/BeachConstruction.tsx
+++ b/src/features/treasureIsland/components/BeachConstruction.tsx
@@ -39,6 +39,7 @@ export const BeachConstruction: React.FC = () => {
             tool: "Hammer",
             hair: "Sun Spots",
           }}
+          onClose={() => setShowModal(false)}
         >
           <div className="p-2">
             <p className="mb-2 text-sm">

--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -288,7 +288,7 @@ export const SandPlot: React.FC<{
           />
         </div>
         <Modal centered show={treasureFound}>
-          <CloseButtonPanel showCloseButton={false}>
+          <CloseButtonPanel>
             <Revealed onAcknowledged={handleAcknowledgeTreasureFound} />
           </CloseButtonPanel>
         </Modal>


### PR DESCRIPTION
# Description

- fix treasure island hammer guy close button not closing modal

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- close any panels that uses the `CloseButtonPanel` component

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
