### PR TITLE
[FIX] Display required SFL on workbench craft

### DIFF
--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -131,8 +131,9 @@ export const DetailView: React.FC<Props> = ({
   };
 
   const showIngredients = () => {
-    if (!buildingToConstruct.ingredients.length && !buildingToConstruct.sfl)
+    if (!buildingToConstruct.ingredients.length && !buildingToConstruct.sfl) {
       return null;
+    }
 
     return (
       <div className="border-t border-white w-full mt-2 pt-1 mb-2 text-center">

--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -131,7 +131,8 @@ export const DetailView: React.FC<Props> = ({
   };
 
   const showIngredients = () => {
-    if (buildingToConstruct.ingredients.length === 0) return null;
+    if (!buildingToConstruct.ingredients.length && !buildingToConstruct.sfl)
+      return null;
 
     return (
       <div className="border-t border-white w-full mt-2 pt-1 mb-2 text-center">


### PR DESCRIPTION
# Description

Required SFL was not displayed in Buildings modal for Workbench.

Before:
![image](https://user-images.githubusercontent.com/9656961/216313832-c9b52bc5-6a83-40e4-8c00-740446697aa3.png)


After:
![image](https://user-images.githubusercontent.com/9656961/216313763-63fa81f9-4848-46c1-afe1-97c31408010d.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
