### PR TITLE
[FEAT] Show more details about skills and achievements in bumpkin modal

### DIFF
--- a/src/features/bumpkins/components/AchievementBadge.tsx
+++ b/src/features/bumpkins/components/AchievementBadge.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { InnerPanel } from "components/ui/Panel";
+import { AchievementName } from "features/game/types/achievements";
+import { Box } from "components/ui/Box";
+import { detectMobile } from "lib/utils/hooks/useIsMobile";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+export const AchievementBadge: React.FC<{
+  achievement: AchievementName;
+}> = ({ achievement }) => {
+  const image = ITEM_DETAILS[achievement].image;
+  const name = achievement;
+  const description = ITEM_DETAILS[achievement].description;
+
+  const [showTooltip, setShowTooltip] = useState(false);
+  const isMobile = detectMobile();
+
+  return (
+    <div key={achievement} className="relative">
+      <div
+        className="flex justify-center m-1"
+        style={{
+          height: `${PIXEL_SCALE * 19}px`,
+          width: `${PIXEL_SCALE * 18}px`,
+          margin: `${PIXEL_SCALE * 1.5}px`,
+        }}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        <Box image={image} />
+      </div>
+      {!isMobile && showTooltip && (
+        <InnerPanel
+          className={"absolute top-100 w-64 left-0 z-50 pointer-events-none"}
+        >
+          <div className="mx-1 p-1">
+            <h2 className="text-xs text-amber-400">{name}</h2>
+            <p className="text-xxs">{description}</p>
+          </div>
+        </InnerPanel>
+      )}
+    </div>
+  );
+};

--- a/src/features/bumpkins/components/AchievementBadges.tsx
+++ b/src/features/bumpkins/components/AchievementBadges.tsx
@@ -1,27 +1,13 @@
 import React from "react";
 import { getKeys } from "features/game/types/craftables";
 import { Bumpkin } from "features/game/types/game";
-import { ITEM_DETAILS } from "features/game/types/images";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { setImageWidth } from "lib/images";
+import { AchievementBadge } from "features/bumpkins/components/AchievementBadge";
 
 export const AchievementBadges: React.FC<{
   achievements?: Bumpkin["achievements"];
 }> = ({ achievements = {} }) => {
   const badges = getKeys(achievements).map((name) => {
-    return (
-      <img
-        key={name}
-        src={ITEM_DETAILS[name].image}
-        alt={name}
-        style={{
-          opacity: 0,
-          marginRight: `${PIXEL_SCALE * 2}px`,
-          marginBottom: `${PIXEL_SCALE * 2}px`,
-        }}
-        onLoad={(e) => setImageWidth(e.currentTarget)}
-      />
-    );
+    return <AchievementBadge key={name} achievement={name} />;
   });
 
   if (badges.length === 0) {

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -251,6 +251,7 @@ export const BumpkinModal: React.FC<Props> = ({
                 <span className="text-xxs underline">View all</span>
               </div>
               <SkillBadges inventory={inventory} bumpkin={bumpkin as Bumpkin} />
+              <div className="flex items-center mb-1 justify-between"></div>
             </InnerPanel>
           </div>
 

--- a/src/features/bumpkins/components/SkillBadge.tsx
+++ b/src/features/bumpkins/components/SkillBadge.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { ITEM_DETAILS } from "features/game/types/images";
+import {
+  BUMPKIN_SKILL_TREE,
+  BumpkinSkillName,
+} from "features/game/types/bumpkinSkills";
+import { InventoryItemName } from "features/game/types/game";
+import { InnerPanel } from "components/ui/Panel";
+import classNames from "classnames";
+import { detectMobile } from "lib/utils/hooks/useIsMobile";
+import { Box } from "components/ui/Box";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+export const SkillBadge: React.FC<{
+  skill?: BumpkinSkillName | undefined;
+  item?: InventoryItemName | undefined;
+}> = ({ skill, item }) => {
+  let image = null;
+  let name = "";
+  let description = "";
+  let titleColor = "text-white";
+  if (skill !== undefined) {
+    image = BUMPKIN_SKILL_TREE[skill].image;
+    name = BUMPKIN_SKILL_TREE[skill].name;
+    description = BUMPKIN_SKILL_TREE[skill].boosts;
+  } else if (item !== undefined) {
+    image = ITEM_DETAILS[item].image;
+    name = item;
+    description = ITEM_DETAILS[item].description;
+    titleColor = "text-amber-500";
+  }
+
+  const [showTooltip, setShowTooltip] = useState(false);
+  const isMobile = detectMobile();
+
+  return (
+    <div
+      key={skill}
+      className="relative flex justify-center"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      style={{
+        height: `${PIXEL_SCALE * 19}px`,
+        width: `${PIXEL_SCALE * 18}px`,
+        margin: `${PIXEL_SCALE * 1.5}px`,
+      }}
+    >
+      <Box image={image} className={"m-0"} />
+      {!isMobile && showTooltip && (
+        <InnerPanel
+          className={"absolute top-100 w-64 left-0 z-50 pointer-events-none"}
+        >
+          <div className="mx-1 p-1">
+            <h2 className={classNames("text-xs", titleColor)}>{name}</h2>
+            <p className="text-xxs">{description}</p>
+          </div>
+        </InnerPanel>
+      )}
+    </div>
+  );
+};

--- a/src/features/bumpkins/components/SkillBadges.tsx
+++ b/src/features/bumpkins/components/SkillBadges.tsx
@@ -1,17 +1,15 @@
 import React from "react";
-import { PIXEL_SCALE } from "features/game/lib/constants";
 import {
   Bumpkin,
   Inventory,
   InventoryItemName,
 } from "features/game/types/game";
-import { ITEM_DETAILS } from "features/game/types/images";
 import { SKILL_TREE } from "features/game/types/skills";
-import { setImageWidth } from "lib/images";
 import {
   BUMPKIN_SKILL_TREE,
   BumpkinSkillName,
 } from "features/game/types/bumpkinSkills";
+import { SkillBadge } from "features/bumpkins/components/SkillBadge";
 
 export const SkillBadges: React.FC<{
   inventory: Inventory;
@@ -27,19 +25,7 @@ export const SkillBadges: React.FC<{
 
   const badges = BADGES.map((badge) => {
     if (inventory[badge]) {
-      return (
-        <img
-          key={badge}
-          src={ITEM_DETAILS[badge].image}
-          alt={badge}
-          style={{
-            opacity: 0,
-            marginRight: `${PIXEL_SCALE * 2}px`,
-            marginBottom: `${PIXEL_SCALE * 2}px`,
-          }}
-          onLoad={(e) => setImageWidth(e.currentTarget)}
-        />
-      );
+      return <SkillBadge item={badge} />;
     }
 
     return null;
@@ -47,19 +33,7 @@ export const SkillBadges: React.FC<{
 
   const skills = SKILLS.map((skill) => {
     if (bumpkin.skills[skill]) {
-      return (
-        <img
-          key={skill}
-          src={BUMPKIN_SKILL_TREE[skill].image}
-          alt={skill}
-          style={{
-            opacity: 0,
-            marginRight: `${PIXEL_SCALE * 2}px`,
-            marginBottom: `${PIXEL_SCALE * 2}px`,
-          }}
-          onLoad={(e) => setImageWidth(e.currentTarget)}
-        />
-      );
+      return <SkillBadge skill={skill} />;
     }
 
     return null;
@@ -68,5 +42,9 @@ export const SkillBadges: React.FC<{
   const totalSkills = [...badges, ...skills];
   if (totalSkills.length === 0) return null;
 
-  return <div className="flex flex-wrap items-center">{totalSkills}</div>;
+  return (
+    <>
+      <div className="flex flex-wrap items-center">{totalSkills}</div>
+    </>
+  );
 };


### PR DESCRIPTION
# Description

This PR shows more details about skills and achievements in bumpkim modal. Also The Legacy Skills has different color of title than other skills.

On mobile tooltips are disabled.

![modal](https://user-images.githubusercontent.com/54077079/216976374-9ad0a5ec-025e-46bf-a6f8-d36f305478ec.png)




## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Localy show bumpkin modal.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
