### PR TITLE
[FIX] Treasure Hole Recovery

### DIFF
--- a/src/features/game/expansion/components/PirateChest.tsx
+++ b/src/features/game/expansion/components/PirateChest.tsx
@@ -31,9 +31,9 @@ export const PirateChest: React.FC = () => {
   const canCollect = (openedAt?: number) => {
     if (!openedAt) return true;
 
-    const today = new Date().getUTCDay();
+    const today = new Date().toISOString().substring(0, 10);
 
-    return new Date(openedAt).getUTCDay() !== today;
+    return new Date(openedAt).toISOString().substring(0, 10) !== today;
   };
 
   const nextRefreshInSeconds =

--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -215,6 +215,8 @@ export const SandPlot: React.FC<{
       (holeId) => !canDig(holes[holeId]?.dugAt)
     ).length;
 
+    console.log({ holesDug, max: getMaxHolesPerDay(collectibles) });
+
     if (holesDug >= getMaxHolesPerDay(collectibles)) {
       setShowMaxHolesModal(true);
       return;

--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -215,8 +215,6 @@ export const SandPlot: React.FC<{
       (holeId) => !canDig(holes[holeId]?.dugAt)
     ).length;
 
-    console.log({ holesDug, max: getMaxHolesPerDay(collectibles) });
-
     if (holesDug >= getMaxHolesPerDay(collectibles)) {
       setShowMaxHolesModal(true);
       return;

--- a/src/features/treasureIsland/lib/sandPlotMachine.ts
+++ b/src/features/treasureIsland/lib/sandPlotMachine.ts
@@ -46,10 +46,6 @@ export const canDig = (dugAt?: number) => {
   if (!dugAt) return true;
 
   const today = new Date().toISOString().substring(0, 10);
-  console.log({
-    today,
-    dugAt: new Date(dugAt).toISOString().substring(0, 10),
-  });
 
   return new Date(dugAt).toISOString().substring(0, 10) !== today;
 };

--- a/src/features/treasureIsland/lib/sandPlotMachine.ts
+++ b/src/features/treasureIsland/lib/sandPlotMachine.ts
@@ -45,9 +45,13 @@ export type MachineInterpreter = Interpreter<
 export const canDig = (dugAt?: number) => {
   if (!dugAt) return true;
 
-  const today = new Date().getUTCDay();
+  const today = new Date().toISOString().substring(0, 10);
+  console.log({
+    today,
+    dugAt: new Date(dugAt).toISOString().substring(0, 10),
+  });
 
-  return new Date(dugAt).getUTCDay() !== today;
+  return new Date(dugAt).toISOString().substring(0, 10) !== today;
 };
 
 /**


### PR DESCRIPTION
# Description

Previous calculations were relying on the day of the week to check if they can dig again.

Unfortunately this caused an error if people waited 1 week between digging treasures.