### PR TITLE
[FEAT] Do not show time limited item if expired

### DIFF
--- a/src/features/treasureIsland/components/TreasureTrove.tsx
+++ b/src/features/treasureIsland/components/TreasureTrove.tsx
@@ -30,7 +30,7 @@ const TREASURE_TROVE_ITEMS = getEntries(TREASURES)
       RarityOrder[treasureA.type] - RarityOrder[treasureB.type]
   );
 
-const TIME_LIMITED_TREASURE_END_DATE =
+const TIME_LIMITED_TREASURE_END_SECONDS =
   (TIME_LIMITED_TREASURE.endDate - Date.now()) / 1000;
 
 const TreasureTroveItem: React.FC<{
@@ -86,28 +86,30 @@ export const TreasureTrove: React.FC = () => {
             className="flex flex-col p-2 overflow-y-auto scrollable overflow-x-hidden divide-y-2 divide-dashed divide-brown-600"
             style={{ maxHeight: 400 }}
           >
-            <div className="pb-2">
-              <div className="flex items-start justify-between pb-2">
-                <span className="text-xs italic">Time Limited Treasure!</span>
-                <Label
-                  type="info"
-                  className="flex items-center whitespace-nowrap"
-                >
-                  <img
-                    src={SUNNYSIDE.icons.stopwatch}
-                    className="w-3 left-0 mr-1"
-                  />
-                  {`${secondsToString(TIME_LIMITED_TREASURE_END_DATE, {
-                    length: "medium",
-                    isShortFormat: true,
-                  })} left`}
-                </Label>
+            {TIME_LIMITED_TREASURE_END_SECONDS > 0 && (
+              <div className="pb-2">
+                <div className="flex items-start justify-between pb-2">
+                  <span className="text-xs italic">Time Limited Treasure!</span>
+                  <Label
+                    type="info"
+                    className="flex items-center whitespace-nowrap"
+                  >
+                    <img
+                      src={SUNNYSIDE.icons.stopwatch}
+                      className="w-3 left-0 mr-1"
+                    />
+                    {`${secondsToString(TIME_LIMITED_TREASURE_END_SECONDS, {
+                      length: "medium",
+                      isShortFormat: true,
+                    })} left`}
+                  </Label>
+                </div>
+                <TreasureTroveItem
+                  treasureName={TIME_LIMITED_TREASURE.name}
+                  rarity={TREASURES[TIME_LIMITED_TREASURE.name].type}
+                />
               </div>
-              <TreasureTroveItem
-                treasureName={TIME_LIMITED_TREASURE.name}
-                rarity={TREASURES[TIME_LIMITED_TREASURE.name].type}
-              />
-            </div>
+            )}
 
             <div className="pt-2 space-y-2">
               {TREASURE_TROVE_ITEMS.map(([name, treasure]) => (


### PR DESCRIPTION
# Description

Prevents the time limited item from rendering if the time has expired.

Question:
**Should I be using the UI refresher hook here?**

With Time Left:
![with time left](https://user-images.githubusercontent.com/41215134/216889731-900fc759-26e3-42ee-80d6-6a369624f572.png)

Without Time Left:
![without time left](https://user-images.githubusercontent.com/41215134/216889753-bd0f2a9e-b3c5-416c-95b3-50e6027d3b1f.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
