### PR TITLE
[FIX] Remove max inventory limit on sand tools

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -66,6 +66,7 @@ export const INITIAL_STOCK: Inventory = {
   "Rusty Shovel": new Decimal(10),
   "Power Shovel": new Decimal(5),
   "Sand Shovel": new Decimal(20),
+  "Sand Drill": new Decimal(5),
 
   // One off items
   "Pumpkin Soup": new Decimal(1),

--- a/src/features/treasureIsland/TreasureIsland.tsx
+++ b/src/features/treasureIsland/TreasureIsland.tsx
@@ -20,7 +20,7 @@ import { PirateChest } from "features/game/expansion/components/PirateChest";
 
 export const CLICKABLE_COORDINATES: Coordinates[] = [];
 
-// Create the coordinates for the 7x7 grid of plots
+// Create the coordinates for the 8x8 grid of plots
 const START = { x: -3, y: 4 };
 const END = { x: 4, y: -3 };
 for (let y = START.y; y >= END.y; y--) {

--- a/src/features/treasureIsland/components/TreasureShopBuy.tsx
+++ b/src/features/treasureIsland/components/TreasureShopBuy.tsx
@@ -18,7 +18,6 @@ import { TreasureToolName, TREASURE_TOOLS } from "features/game/types/tools";
 import { getKeys } from "features/game/types/craftables";
 import { Label } from "components/ui/Label";
 import { Delayed } from "features/island/buildings/components/building/market/Delayed";
-import { INITIAL_STOCK } from "features/game/lib/constants";
 
 interface Props {
   onClose: (e?: SyntheticEvent) => void;
@@ -131,10 +130,6 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
   };
 
   const labelState = () => {
-    const max = INITIAL_STOCK[selectedName];
-    const inventoryCount = inventory[selectedName] ?? new Decimal(0);
-    const inventoryFull = max ? inventoryCount.gt(max) : true;
-
     if (stock?.equals(0)) {
       return (
         <Label type="danger" className="-mt-2 mb-1">
@@ -142,9 +137,8 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
         </Label>
       );
     }
-    return (
-      <Stock item={{ name: selectedName }} inventoryFull={inventoryFull} />
-    );
+
+    return <Stock item={{ name: selectedName }} inventoryFull={false} />;
   };
 
   const stock = state.stock[selectedName] || new Decimal(0);


### PR DESCRIPTION
# Description

We dont have inventory limit on tools.

Before:
![image](https://user-images.githubusercontent.com/9656961/216945698-919fe7b7-ca44-4d25-80ca-4b6054d66abf.png)

After:
![image](https://user-images.githubusercontent.com/9656961/216945167-15a1e9a2-8062-4474-abe9-fa58b5b1555d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
