### PR TITLE
[FIX] False positive resource multiplying bug

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,14 @@ button:disabled {
   cursor: not-allowed;
 }
 
+img {
+  -webkit-user-drag: none;
+  -khtml-user-drag: none;
+  -moz-user-drag: none;
+  -o-user-drag: none;
+  user-drag: none;
+}
+
 #walletconnect-wrapper {
   all: initial;
 }


### PR DESCRIPTION
# Description

There was an apparent resource multiplying bug reported on Discord that was due to the user being able to select and drag images around in SFL. The resources that appeared to be multiplied would not save and it would error out but the visual aspect of the bug still existed since the user could drag/select images so I updated the CSS to make sure that all <img /> elements had the `user-drag: none` CSS property assigned to them

Fixes [https://discord.com/channels/880987707214544966/1042915516517470379/threads/1067376349532131388](https://discord.com/channels/880987707214544966/1042915516517470379/threads/1067376349532131388)

NOTE: Video is from this bug report on Discord. I did not record it.

https://user-images.githubusercontent.com/801056/217069881-fef2bf65-300b-4dab-a2ae-d2979aa95338.mov

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this locally after updating the CSS and spent about an hour trying to drag elements around and reproduce the reported bug. Also updated the styles on production via the Chrome Developer Console and tried to reproduce the bug with the CSS applied and could not reproduce it.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
