### PR TITLE
[FIX]: Count drilled activity to Pirate Quest 1

### DIFF
--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -64,6 +64,7 @@ export type BumpkinActivityName =
   | "Crop Fertilised"
   | "Crop Removed"
   | "Treasure Dug"
+  | "Treasure Drilled"
   | "Treasure Searched";
 
 export function trackActivity(

--- a/src/features/game/types/quests.ts
+++ b/src/features/game/types/quests.ts
@@ -52,7 +52,8 @@ export const QUESTS: Record<QuestName, Quest> = {
   "Pirate Quest 1": {
     description: "Dig 30 holes",
     progress: (gameState: GameState) =>
-      gameState.bumpkin?.activity?.["Treasure Dug"] || 0,
+      (gameState.bumpkin?.activity?.["Treasure Dug"] || 0) +
+      (gameState.bumpkin?.activity?.["Treasure Drilled"] || 0),
     requirement: 30,
     wearable: "Striped Blue Shirt",
     deadline: new Date(Date.now() + 10000000000).toISOString(),


### PR DESCRIPTION
# Description

Add `Treasure Drilled` activity to Pirate Quest 1 (Dig 30 holes)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
