### PR TITLE
[FIX] Autosave and Block Travel when Leaving Treasure Island

### DIFF
--- a/src/features/community/components/CommunityGarden.tsx
+++ b/src/features/community/components/CommunityGarden.tsx
@@ -40,7 +40,12 @@ export const CommunityGarden: React.FC = () => {
         <Arcade />
       </MapPlacement>
 
-      <IslandTravel bumpkin={bumpkin} x={-4} y={-9} />
+      <IslandTravel
+        bumpkin={bumpkin}
+        x={-4}
+        y={-9}
+        travelAllowed // CommunityGarden always allowed because gameState doesn't get altered (and no autosaving needed).
+      />
     </>
   );
 };

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -430,7 +430,7 @@ export const Land: React.FC = () => {
           bumpkin={bumpkin}
           isVisiting={gameState.matches("visiting")}
           inventory={gameState.context.state.inventory}
-          isTravelAllowed={!gameState.matches("autosaving")}
+          travelAllowed={!gameState.matches("autosaving")}
           onTravelDialogOpened={() => gameService.send("SAVE")}
           x={boatCoordinates.x}
           y={boatCoordinates.y}

--- a/src/features/game/expansion/components/travel/IslandTravel.tsx
+++ b/src/features/game/expansion/components/travel/IslandTravel.tsx
@@ -9,7 +9,7 @@ interface IslandTravelProps {
   bumpkin: Bumpkin | undefined;
   inventory?: Inventory;
   isVisiting?: boolean;
-  isTravelAllowed?: boolean;
+  travelAllowed: boolean;
   onTravelDialogOpened?: () => void;
   x: number;
   y: number;
@@ -21,7 +21,7 @@ export const IslandTravel: React.FC<IslandTravelProps> = ({
   x,
   y,
   isVisiting = false,
-  isTravelAllowed = true,
+  travelAllowed,
   onTravelDialogOpened,
 }) => {
   const [openIslandList, setOpenIslandList] = useState(false);
@@ -51,7 +51,7 @@ export const IslandTravel: React.FC<IslandTravelProps> = ({
         inventory={inventory ?? {}}
         onShow={onTravelDialogOpened}
         isVisiting={isVisiting}
-        isTravelAllowed={isTravelAllowed}
+        travelAllowed={travelAllowed}
         onClose={() => setOpenIslandList(false)}
       />
     </>

--- a/src/features/game/expansion/components/travel/IslandTravelModal.tsx
+++ b/src/features/game/expansion/components/travel/IslandTravelModal.tsx
@@ -17,7 +17,7 @@ interface IslandTravelModalProps {
   bumpkin: Bumpkin | undefined;
   inventory: Inventory;
   isVisiting?: boolean;
-  isTravelAllowed?: boolean;
+  travelAllowed: boolean;
   onShow?: () => void;
   onClose: () => void;
 }
@@ -26,7 +26,7 @@ export const IslandTravelModal: React.FC<IslandTravelModalProps> = ({
   bumpkin,
   inventory,
   isVisiting = false,
-  isTravelAllowed = true,
+  travelAllowed,
   isOpen,
   onShow,
   onClose,
@@ -65,7 +65,7 @@ export const IslandTravelModal: React.FC<IslandTravelModalProps> = ({
         bumpkinParts={bumpkinParts}
         onClose={onClose}
       >
-        {isTravelAllowed && (
+        {travelAllowed && (
           <div
             style={{ maxHeight: CONTENT_HEIGHT }}
             className="w-full pr-1 pt-2.5 overflow-y-auto scrollable"
@@ -77,7 +77,8 @@ export const IslandTravelModal: React.FC<IslandTravelModalProps> = ({
             />
           </div>
         )}
-        {!isTravelAllowed && <span className="loading">Loading</span>}
+
+        {!travelAllowed && <span className="loading">Loading</span>}
       </CloseButtonPanel>
     </Modal>
   );

--- a/src/features/game/expansion/components/travel/ValentinesIslandTravel.tsx
+++ b/src/features/game/expansion/components/travel/ValentinesIslandTravel.tsx
@@ -9,7 +9,7 @@ interface Props {
   bumpkin: Bumpkin | undefined;
   inventory?: Inventory;
   isVisiting?: boolean;
-  isTravelAllowed?: boolean;
+  travelAllowed: boolean;
   onTravelDialogOpened?: () => void;
   x: number;
   y: number;
@@ -23,7 +23,7 @@ export const ValentinesIslandTravel = ({
   x,
   y,
   isVisiting = false,
-  isTravelAllowed = true,
+  travelAllowed,
   onTravelDialogOpened,
   customBoat,
   customWidth,
@@ -74,7 +74,7 @@ export const ValentinesIslandTravel = ({
         inventory={inventory ?? {}}
         onShow={onTravelDialogOpened}
         isVisiting={isVisiting}
-        isTravelAllowed={isTravelAllowed}
+        travelAllowed={travelAllowed}
         onClose={() => setOpenIslandList(false)}
       />
     </>

--- a/src/features/helios/Helios.tsx
+++ b/src/features/helios/Helios.tsx
@@ -79,7 +79,7 @@ export const Helios: React.FC = () => {
           x={3.5}
           y={-17}
           onTravelDialogOpened={() => gameService.send("SAVE")}
-          isTravelAllowed={!gameState.matches("autosaving")}
+          travelAllowed={!gameState.matches("autosaving")}
         />
       </div>
       <Hud isFarming={false} />

--- a/src/features/pumpkinPlaza/PumpkinPlaza.tsx
+++ b/src/features/pumpkinPlaza/PumpkinPlaza.tsx
@@ -125,6 +125,8 @@ export const PumpkinPlaza: React.FC = () => {
           bumpkin={gameState.context.state.bumpkin}
           x={0}
           y={-21}
+          onTravelDialogOpened={() => gameService.send("SAVE")}
+          travelAllowed={!gameState.matches("autosaving")}
         />
 
         <ChatUI

--- a/src/features/retreat/components/islandTravel/IslandTravelWrapper.tsx
+++ b/src/features/retreat/components/islandTravel/IslandTravelWrapper.tsx
@@ -15,6 +15,7 @@ export const IslandTravelWrapper = () => {
       bumpkin={bumpkin}
       x={-2}
       y={-15}
+      travelAllowed // GoblinRetreat always allowed because gameState doesn't get altered (and no autosaving needed).
     />
   );
 };

--- a/src/features/snowKingdom/IslandTravelWrapper.tsx
+++ b/src/features/snowKingdom/IslandTravelWrapper.tsx
@@ -15,6 +15,8 @@ export const IslandTravelWrapper = () => {
       bumpkin={bumpkin}
       x={-2}
       y={-14}
+      onTravelDialogOpened={() => gameService.send("SAVE")}
+      travelAllowed={!gameState.matches("autosaving")}
     />
   );
 };

--- a/src/features/stoneHaven/components/IslandTravelWrapper.tsx
+++ b/src/features/stoneHaven/components/IslandTravelWrapper.tsx
@@ -15,6 +15,8 @@ export const IslandTravelWrapper = () => {
       bumpkin={bumpkin}
       x={0}
       y={-9}
+      onTravelDialogOpened={() => gameService.send("SAVE")}
+      travelAllowed={!gameState.matches("autosaving")}
     />
   );
 };

--- a/src/features/treasureIsland/components/IslandTravelWrapper.tsx
+++ b/src/features/treasureIsland/components/IslandTravelWrapper.tsx
@@ -15,6 +15,8 @@ export const IslandTravelWrapper = () => {
       bumpkin={bumpkin}
       x={-2}
       y={-12}
+      onTravelDialogOpened={() => gameService.send("SAVE")}
+      travelAllowed={!gameState.matches("autosaving")}
     />
   );
 };

--- a/src/features/valentineIsland/ValentineIsland.tsx
+++ b/src/features/valentineIsland/ValentineIsland.tsx
@@ -58,7 +58,7 @@ export const ValentineIsland: React.FC = () => {
           x={-8}
           y={-4.5}
           onTravelDialogOpened={() => gameService.send("SAVE")}
-          isTravelAllowed={!gameState.matches("autosaving")}
+          travelAllowed={!gameState.matches("autosaving")}
           customBoat={boat}
           customWidth={54}
         />


### PR DESCRIPTION
# Description

### Problem Summary:
1. Buy a shovel at Treasure Island (or sell loot, same problem).
2. Immediately travel to Goblin Retreat

### Expected Result:
- GameState updates, and shovel is added to game inventory.

### Actual Result:
- GameState reverts because no autoSave action completed before traveling.

### Changes Made:
- Similar to other islands, will now block traveling with "Loading..." text and trigger an auto-save when leaving Treasure Island.
- Renamed "isTravelAllowed" to "travelAllowed" for simplicity.
- In an effort to reduce future dev mistakes around this, I changed the "travelAllowed" prop to now be required while using the IslandTravel component.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally by buying sandShovel at treasure island, then quickly hopping into the boat and traveling to retreat. Travel was successfully blocked by "Loading..." text until the saving was complete.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
