### PR TITLE
[FIX] Show Land Number after Autosave

### DIFF
--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -141,6 +141,8 @@ export async function autosave(request: Request) {
     changeset: any;
   }>(response);
 
+  farm.id = request.farmId;
+
   const game = makeGame(farm);
 
   return { verified: true, farm: game, changeset };


### PR DESCRIPTION
# Description

Fixes Land ID disappearing after autosave. Cause is server response doesn't return farm id (which makes sense since the request involves farm id itself).

Resolution: attach request farm id to farm response object.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
