### PR TITLE
[FIX] Add Treasure island item limits

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -71,7 +71,7 @@ const maxItems: Inventory = {
   "Human Bear": new Decimal(10),
   "Whale Bear": new Decimal(10),
 
-  //Tresuare Island Beach Bounty
+  //Treasure Island Beach Bounty
   "Pirate Bounty": new Decimal(10),
   Pearl: new Decimal(10),
   Coral: new Decimal(10),

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -52,6 +52,36 @@ const maxItems: Inventory = {
   "Rapid Growth": new Decimal(100),
   "Red Envelope": new Decimal(100),
 
+  //Treasure Island Decorations
+  "Abandoned Bear": new Decimal(10),
+
+  "Turtle Bear": new Decimal(10),
+  "T-Rex Skull": new Decimal(10),
+  "Sunflower Coin": new Decimal(10),
+  Foliant: new Decimal(10),
+  "Skeleton King Staff": new Decimal(10),
+  "Lifeguard Bear": new Decimal(10),
+  "Snorkel Bear": new Decimal(10),
+  "Parasaur Skull": new Decimal(10),
+  "Golden Bear Head": new Decimal(10),
+  "Pirate Bear": new Decimal(10),
+  "Goblin Bear": new Decimal(10),
+  Galleon: new Decimal(10),
+  "Dinosaur Bone": new Decimal(10),
+  "Human Bear": new Decimal(10),
+  "Whale Bear": new Decimal(10),
+
+  //Tresuare Island Beach Bounty
+  "Pirate Bounty": new Decimal(10),
+  Pearl: new Decimal(10),
+  Coral: new Decimal(10),
+  "Clam Shell": new Decimal(10),
+  Pipi: new Decimal(10),
+  Starfish: new Decimal(10),
+  Seaweed: new Decimal(10),
+  "Sea Cucumber": new Decimal(10),
+  Crab: new Decimal(10),
+
   // Max of 1000 food item
   ...(Object.keys(FOODS()) as InventoryItemName[]).reduce(
     (acc, name) => ({


### PR DESCRIPTION
# Description

Treasure Island items does not have a limit set, so when players dig and get their 10th item AS-01 error appears.


BTW commons items limit should be increased, Craig should be 30 per sync.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost with landData of 11 Craig

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]

