### PR TITLE
[FIX] Prevent subsettings menu getting stuck at certain views

### DIFF
--- a/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
+++ b/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
@@ -49,7 +49,6 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
   const [showCommunityGardenModal, setShowCommunityGardenModal] =
     useState(false);
   const [showHowToPlay, setShowHowToPlay] = useState(useIsNewFarm());
-  const [showLostAndFoundModal, setShowLostAndFoundModal] = useState(false);
   const [showCaptcha, setShowCaptcha] = useState(false);
   const [menuLevel, setMenuLevel] = useState(MENU_LEVELS.ROOT);
   const [loadingOnRamp, setLoadingOnRamp] = useState(false);

--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -26,6 +26,11 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
     "settings"
   );
 
+  const closeAndResetView = () => {
+    onClose();
+    setView("settings");
+  };
+
   const onLogout = () => {
     onClose();
     authService.send("LOGOUT"); // hack used to avoid redundancy
@@ -40,19 +45,13 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
     if (view === "transfer") {
       return (
         <Panel className="p-0">
-          <TransferAccount
-            isOpen={true}
-            onClose={() => {
-              onClose();
-              setView("settings");
-            }}
-          />
+          <TransferAccount isOpen={true} onClose={closeAndResetView} />
         </Panel>
       );
     }
 
     if (view === "lost-and-found") {
-      return <LostAndFound onClose={onClose} />;
+      return <LostAndFound onClose={closeAndResetView} />;
     }
 
     return (


### PR DESCRIPTION
# Description

- prevent subsettings view to stuck to the lost and found screen

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click gear icon, click ..., click settings, click lost and found, close modal, then click gear icon, click ..., click settings, click lost and found again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
