### PR TITLE
[FIX] Prevent subsettings menu getting stuck at certain views when clicking outside modal

### DIFF
--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -87,7 +87,7 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
   };
 
   return (
-    <Modal show={isOpen} onHide={onClose} centered>
+    <Modal show={isOpen} onHide={closeAndResetView} centered>
       {Content()}
     </Modal>
   );


### PR DESCRIPTION
# Description

- prevent subsettings view to stuck to the lost and found screen when clicking outside modal

This is a follow up of https://github.com/sunflower-land/sunflower-land/pull/2242 (https://github.com/sunflower-land/sunflower-land/pull/2242#issuecomment-1430423519)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click gear icon, click ..., click settings, click lost and found, close modal by clicking outside modal, then click gear icon, click ..., click settings, click lost and found again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
