### PR TITLE
[FIX] Empty pontoon progress bar

### DIFF
--- a/src/features/game/expansion/components/Pontoon.tsx
+++ b/src/features/game/expansion/components/Pontoon.tsx
@@ -68,7 +68,9 @@ export const Pontoon: React.FC<Props> = ({ expansion }) => {
       {showTimers && (
         <ProgressBar
           seconds={secondsLeft}
-          percentage={secondsLeft / constructionTime}
+          percentage={
+            ((constructionTime - secondsLeft) / constructionTime) * 100
+          }
           type="progress"
           formatLength="medium"
           style={{


### PR DESCRIPTION
# Description

- fix pontoon bar always empty when expanding land\

![image](https://user-images.githubusercontent.com/107602352/219307872-2931f0c0-70d5-4b51-ae3d-05a8a13b2784.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- expand land.  Try expanding land with a short construction time so the progress bar display can be verified quickly
![image](https://user-images.githubusercontent.com/107602352/219308551-b091aabc-4112-454e-b2c2-c73433b7a5dc.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
