### PR TITLE
[FIX] Spritesheet fixes

### DIFF
--- a/src/components/animation/SpriteAnimator.tsx
+++ b/src/components/animation/SpriteAnimator.tsx
@@ -236,7 +236,7 @@ class Spritesheet extends React.Component<Props> {
     };
 
     imgLoadSprite.onerror = () => {
-      throw new Error(`Failed to load image ${imgLoadSprite.src}`);
+      throw new Error(`Failed to load spritesheet image ${imgLoadSprite.src}`);
     };
   };
 

--- a/src/components/animation/SpriteAnimator.tsx
+++ b/src/components/animation/SpriteAnimator.tsx
@@ -8,9 +8,7 @@
  */
 import React from "react";
 import PropTypes from "prop-types";
-import * as CSS from "csstype";
 import { randomID } from "lib/utils/random";
-
 export class SpriteSheetInstance extends React.Component<Props> {
   play(): void;
   pause(): void;
@@ -50,7 +48,6 @@ export interface Props {
   autoplay?: boolean;
   loop?: boolean;
   hiddenWhenPaused?: boolean;
-  isResponsive?: boolean;
   startAt?: number;
   endAt?: number;
   background?: string;
@@ -83,7 +80,7 @@ class Spritesheet extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
 
-    const { isResponsive, startAt, endAt, fps, steps, direction } = props;
+    const { startAt, endAt, fps, steps, direction } = props;
 
     this.id = `react-responsive-spritesheet--${randomID()}`;
     this.spriteEl =
@@ -94,7 +91,6 @@ class Spritesheet extends React.Component<Props> {
       this.rows =
         null;
     this.intervalSprite = false;
-    this.isResponsive = isResponsive;
     this.startAt = this.setStartAt(startAt);
     this.endAt = this.setEndAt(endAt);
     this.fps = fps;
@@ -129,7 +125,6 @@ class Spritesheet extends React.Component<Props> {
       backgroundSize,
       backgroundRepeat,
       backgroundPosition,
-      hiddenWhenPaused,
       onClick,
       onDoubleClick,
       onMouseMove,
@@ -182,7 +177,7 @@ class Spritesheet extends React.Component<Props> {
       "div",
       {
         className: `react-responsive-spritesheet ${this.id} ${className}`,
-        style: { opacity: hiddenWhenPaused ? 0 : 1, ...style },
+        style,
         onClick: () => onClick(this.setInstance()),
         onDoubleClick: () => onDoubleClick(this.setInstance()),
         onMouseMove: () => onMouseMove(this.setInstance()),
@@ -205,6 +200,13 @@ class Spritesheet extends React.Component<Props> {
 
     const imgLoadSprite = new Image();
     imgLoadSprite.src = image;
+
+    this.spriteEl = document.querySelector(`.${this.id}`);
+    this.spriteElContainer = this.spriteEl.querySelector(
+      ".react-responsive-spritesheet-container"
+    );
+    this.resize(false);
+
     imgLoadSprite.onload = () => {
       if (document && document.querySelector(`.${this.id}`)) {
         this.imageSprite = imgLoadSprite;
@@ -217,20 +219,12 @@ class Spritesheet extends React.Component<Props> {
             ? 1
             : this.imageSprite.height / heightFrame;
 
-        this.spriteEl = document.querySelector(`.${this.id}`);
-        this.spriteElContainer = this.spriteEl.querySelector(
-          ".react-responsive-spritesheet-container"
-        );
         this.spriteElMove = this.spriteElContainer.querySelector(
           ".react-responsive-spritesheet-container__move"
         );
 
-        this.resize(false);
         window.addEventListener("resize", this.resize);
         this.moveImage(false);
-        setTimeout(() => {
-          this.resize(false);
-        }, 10);
 
         if (autoplay !== false) this.play(true);
 
@@ -249,20 +243,14 @@ class Spritesheet extends React.Component<Props> {
   resize = (callback = true) => {
     const { widthFrame, onResize } = this.props;
 
-    if (this.isResponsive) {
-      this.spriteScale = this.spriteEl.offsetWidth / widthFrame;
-      this.spriteElContainer.style.transform = `scale(${this.spriteScale})`;
-      this.spriteEl.style.height = `${this.getInfo("height")}px`;
-      if (callback && onResize) onResize(this.setInstance());
-    }
+    this.spriteScale = this.spriteEl.getBoundingClientRect().width / widthFrame;
+    this.spriteElContainer.style.transform = `scale(${this.spriteScale})`;
+    this.spriteEl.style.height = `${this.getInfo("height")}px`;
+    if (callback && onResize) onResize(this.setInstance());
   };
 
   play = (withTimeout = false) => {
-    const { onPlay, timeout, hiddenWhenPaused } = this.props;
-
-    if (hiddenWhenPaused) {
-      this.spriteEl.style.opacity = 1;
-    }
+    const { onPlay, timeout } = this.props;
 
     if (!this.isPlaying) {
       setTimeout(
@@ -334,11 +322,7 @@ class Spritesheet extends React.Component<Props> {
   };
 
   pause = () => {
-    const { onPause, hiddenWhenPaused } = this.props;
-
-    if (hiddenWhenPaused) {
-      this.spriteEl.style.opacity = 0;
-    }
+    const { onPause } = this.props;
 
     this.isPlaying = false;
     clearInterval(this.intervalSprite);
@@ -430,7 +414,6 @@ Spritesheet.propTypes = {
   image: PropTypes.string.isRequired,
   widthFrame: PropTypes.number.isRequired,
   heightFrame: PropTypes.number.isRequired,
-  isResponsive: PropTypes.bool,
   steps: PropTypes.number.isRequired,
   fps: PropTypes.number.isRequired,
   direction: PropTypes.string,
@@ -471,12 +454,10 @@ Spritesheet.propTypes = {
 Spritesheet.defaultProps = {
   className: "",
   style: {},
-  isResponsive: true,
   direction: "forward",
   timeout: 0,
   autoplay: true,
   loop: false,
-  hiddenWhenPaused: false,
   startAt: 0,
   endAt: false,
   background: "",

--- a/src/components/animation/SpriteAnimator.tsx
+++ b/src/components/animation/SpriteAnimator.tsx
@@ -9,6 +9,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { randomID } from "lib/utils/random";
+
 export class SpriteSheetInstance extends React.Component<Props> {
   play(): void;
   pause(): void;

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -110,7 +110,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
               heightFrame={HARVEST_PROC_ANIMATION.size}
               fps={HARVEST_PROC_ANIMATION.fps}
               steps={HARVEST_PROC_ANIMATION.steps}
-              hiddenWhenPaused={true}
+              onPause={() => setProcAnimation(<></>)}
             />
           );
         }
@@ -131,7 +131,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
               heightFrame={HARVEST_PROC_ANIMATION.size}
               fps={6}
               steps={HARVEST_PROC_ANIMATION.steps}
-              hiddenWhenPaused={true}
+              onPause={() => setProcAnimation(<></>)}
             />
           );
         }
@@ -141,7 +141,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
           content: `+${crop.amount || 1}`,
         });
       }
-    } catch (e: any) {
+    } catch (e) {
       // TODO - catch more elaborate errors
       displayPopover();
     }
@@ -250,7 +250,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
           icon: ITEM_DETAILS[selectedItem as CropName].image,
           content: `-1`,
         });
-      } catch (e: any) {
+      } catch (e) {
         // TODO - catch more elaborate errors
         displayPopover();
       }
@@ -287,7 +287,7 @@ export const Plot: React.FC<Props> = ({ plotIndex, expansionIndex }) => {
     // harvest crop
     try {
       harvestCrop(crop);
-    } catch (e: any) {
+    } catch (e) {
       // TODO - catch more elaborate errors
       displayPopover();
     }


### PR DESCRIPTION
# Description

- resize spritesheet when instantiated instead of onLoad image
  - no more spritesheet resize flickering when feeding chickens or reloaing page
- fix mini sprites
- remove crop firework animation instead of hiding them to improve game performance
- fix sprites having a slightly different scaling than the map because of the integer rounding for width

![image](https://user-images.githubusercontent.com/107602352/219328172-fbee9d24-9e05-45cf-b341-a4455cd79226.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- feed chickens
- reload page
- open modals with spritesheets (eg. expand island modal when there are no expansions available)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
