### PR TITLE
[FIX] Fix broken URL in Deposit Modal

### DIFF
--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -245,7 +245,7 @@ export const Deposit: React.FC<Props> = ({
               <a
                 target="_blank"
                 className="underline text-xxs hover:text-blue-500"
-                href={`https://app.gitbook.com/o/bntEYvEP4dzoxNUbvnHA/s/IWGEodCG0c07OUY9iW9t/~/changes/297/economy/depositing-and-custody#cant-see-the-items-you-deposited`}
+                href={`https://docs.sunflower-land.com/economy/depositing-and-custody#cant-see-the-items-you-deposited`}
                 rel="noreferrer"
               >
                 {`Deposit didn't arrive?`}


### PR DESCRIPTION
# Description

The previous URL was redirecting to the "admin" version of the docs, which prevented access, I replaced it with the correct URL which is `https://docs.sunflower-land.com/economy/depositing-and-custody#cant-see-the-items-you-deposited`

![image](https://user-images.githubusercontent.com/63975424/219634112-724bb365-c5c8-40fa-bf28-8ba9bc1903c8.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`yarn test`
![image](https://user-images.githubusercontent.com/63975424/219635063-98b4af48-e7fc-4668-a2f8-3ccfffa2c9d6.png)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
