### PR TITLE
[FIX] Add retry attempts for loading on chain for deposit

### DIFF
--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -160,8 +160,12 @@ export const Deposit: React.FC<Props> = ({
     <>
       {status === "loading" && <Loading />}
       {status === "loaded" && emptyWallet && (
-        <div className="p-2">
+        <div className="p-2 space-y-2">
           <p>No SFL or Collectibles Found!</p>
+          <div className="flex text-[12px] sm:text-xs mb-3 space-x-1">
+            <span className="whitespace-nowrap">Farm address:</span>
+            <CopyAddress address={farmAddress} />
+          </div>
         </div>
       )}
       {status === "loaded" && !emptyWallet && (

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -77,7 +77,7 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
   if (showTutorial) {
     return (
       <Modal show={isOpen} onHide={acknowledge} centered>
-        <Tutorial onClose={acknowledge} bumpkinParts={bumpkinParts} />;
+        <Tutorial onClose={acknowledge} bumpkinParts={bumpkinParts} />
       </Modal>
     );
   }

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Balance } from "components/Balance";
 import { useActor } from "@xstate/react";
+import * as AuthProvider from "features/auth/lib/Provider";
 import { Context } from "features/game/GameProvider";
 import { Settings } from "./components/Settings";
 import { Inventory } from "./components/inventory/Inventory";
@@ -21,6 +22,7 @@ import { Deposit } from "features/goblins/bank/components/Deposit";
  * Balances, Inventory, actions etc.
  */
 export const Hud: React.FC<{ isFarming: boolean }> = ({ isFarming }) => {
+  const { authService } = useContext(AuthProvider.Context);
   const { gameService, shortcutItem, selectedItem } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -39,7 +41,7 @@ export const Hud: React.FC<{ isFarming: boolean }> = ({ isFarming }) => {
 
   const isEditing = gameState.matches("editing");
   const landId = gameState.context.state.id;
-  const farmAddress = gameState.context.state.farmAddress as string;
+  const farmAddress = authService.state.context.address as string;
 
   return (
     <div

--- a/src/features/retreat/Hud.tsx
+++ b/src/features/retreat/Hud.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import * as AuthProvider from "features/auth/lib/Provider";
 
 import { Balance } from "components/Balance";
 import { useActor } from "@xstate/react";
@@ -18,6 +19,7 @@ import { Deposit } from "features/goblins/bank/components/Deposit";
  * Balances, Inventory, actions etc.
  */
 export const Hud: React.FC = () => {
+  const { authService } = useContext(AuthProvider.Context);
   const { goblinService } = useContext(Context);
   const [goblinState] = useActor(goblinService);
   const [showDepositModal, setShowDepositModal] = useState(false);
@@ -40,7 +42,7 @@ export const Hud: React.FC = () => {
     setShowDepositModal(true);
   };
 
-  const farmAddress = state.farmAddress as string;
+  const farmAddress = authService.state.context.address as string;
 
   return (
     <div data-html2canvas-ignore="true" aria-label="Hud">

--- a/src/lib/blockchain/Token.ts
+++ b/src/lib/blockchain/Token.ts
@@ -12,18 +12,28 @@ import Decimal from "decimal.js-light";
 export async function sflBalanceOf(
   web3: Web3,
   account: string,
-  address: string
-) {
-  const balance = await (
-    new web3.eth.Contract(
-      TokenJSON as AbiItem[],
-      CONFIG.TOKEN_CONTRACT as string
-    ) as unknown as SunflowerLandToken
-  ).methods
-    .balanceOf(address)
-    .call({ from: account });
+  address: string,
+  attempts = 0
+): Promise<string> {
+  try {
+    const balance = await (
+      new web3.eth.Contract(
+        TokenJSON as AbiItem[],
+        CONFIG.TOKEN_CONTRACT as string
+      ) as unknown as SunflowerLandToken
+    ).methods
+      .balanceOf(address)
+      .call({ from: account });
 
-  return balance;
+    return balance;
+  } catch (e) {
+    const error = parseMetamaskError(e);
+    if (attempts < 3) {
+      return await sflBalanceOf(web3, account, address, attempts + 1);
+    }
+
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
# Description

This fix adds retry attempts for loading on chain data for the deposit modal. It also reads the farm address from the authservice to prevent the disappearing address.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open deposit modal from all locations. Confirm it loads, perform actions on the farm and open again to make sure farm address is always visable.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
