### PR TITLE
[FEAT] Standard Reset Times

### DIFF
--- a/src/features/pumpkinPlaza/components/DailyReward.tsx
+++ b/src/features/pumpkinPlaza/components/DailyReward.tsx
@@ -20,12 +20,26 @@ export const DailyReward: React.FC = () => {
 
   useUiRefresher();
 
-  const cooldown = 24 * 60 * 60 * 1000; // 1 day
+  const canOpen = (openedAt?: number) => {
+    if (!openedAt) return true;
+
+    const today = new Date().toISOString().substring(0, 10);
+
+    return new Date(openedAt).toISOString().substring(0, 10) !== today;
+  };
+
+  const date = new Date();
+
+  const nextRefreshInSeconds =
+    24 * 60 * 60 -
+    (date.getUTCHours() * 60 * 60 +
+      date.getUTCMinutes() * 60 +
+      date.getUTCSeconds());
 
   const collectedAt =
     gameState.context.state.pumpkinPlaza?.rewardCollectedAt ?? 0;
-  const readyInSeconds = (collectedAt + cooldown - Date.now()) / 1000;
-  const isReady = readyInSeconds <= 0;
+
+  const isReady = canOpen(collectedAt);
 
   const reveal = () => {
     gameService.send("REVEAL", {
@@ -68,8 +82,9 @@ export const DailyReward: React.FC = () => {
               }}
             />
             <span className="text-center">
-              Come back in {secondsToString(readyInSeconds, { length: "full" })}{" "}
-              for more rewards!
+              Come back in{" "}
+              {secondsToString(nextRefreshInSeconds, { length: "full" })} for
+              more rewards!
             </span>
           </div>
         </CloseButtonPanel>


### PR DESCRIPTION
# Description

This PR makes the reset times for Maneki Neko and the Plaza rewards standard with the other reset times at 00 UTC.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
