### PR TITLE
[FEAT] Block Heart of Davy Jones Withdraw when holes dug

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -105,9 +105,11 @@ function areAnyChickensFed(game: GoblinState): boolean {
 }
 
 function areAnyTreasureHolesDug(game: GoblinState): boolean {
-  return Object.values(game.treasureIsland?.holes ?? {}).some(
-    (hole) => hole.dugAt
-  );
+  return Object.values(game.treasureIsland?.holes ?? {}).some((hole) => {
+    const today = new Date().toISOString().substring(0, 10);
+
+    return new Date(hole.dugAt).toISOString().substring(0, 10) == today;
+  });
 }
 
 function hasCompletedAchievement(

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -104,6 +104,12 @@ function areAnyChickensFed(game: GoblinState): boolean {
   );
 }
 
+function areAnyTreasureHolesDug(game: GoblinState): boolean {
+  return Object.values(game.treasureIsland?.holes ?? {}).some(
+    (hole) => hole.dugAt
+  );
+}
+
 function hasCompletedAchievement(
   game: GoblinState,
   achievement: AchievementName
@@ -233,7 +239,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Lady Bug": false,
   "Cyborg Bear": true,
   "Collectible Bear": false,
-  "Heart of Davy Jones": true,
   "Heart Balloons": true,
   Flamingo: true,
   "Blossom Tree": true,
@@ -264,6 +269,7 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Tunnel Mole": (game) => !areAnyStonesMined(game),
   "Rocky the Mole": (game) => !areAnyIronsMined(game),
   Nugget: (game) => !areAnyGoldsMined(game),
+  "Heart of Davy Jones": (game) => !areAnyTreasureHolesDug(game),
 
   "Pirate Bounty": false,
   Pearl: false,


### PR DESCRIPTION
# Description

This PR blocks a player from withdrawing the Heart of Davy Jones when there is at least one treasure hole dug.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
