### PR TITLE
[FIX] Do not shortcut item when feeding bumpkin

### DIFF
--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -61,8 +61,6 @@ export const Feed: React.FC<Props> = ({ food, onFeed }) => {
       icon: ITEM_DETAILS[food.name].image,
       content: `-1`,
     });
-
-    shortcutItem(food.name);
   };
 
   if (!selected) {


### PR DESCRIPTION
# Description

- do not put food item to shortcut when feeding bumpkin
  - no point to select food item after eating it.  Selecting item might interrupt workflow such as planting seeds

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- eat food

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
