### PR TITLE
[FIX] Incorrect fruit time display

### DIFF
--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { FruitSeedName, FRUIT_SEEDS } from "features/game/types/fruits";
 import { FruitPatch, GameState } from "features/game/types/game";
-import { plantFruit } from "./fruitPlanted";
+import { getFruitTime, plantFruit } from "./fruitPlanted";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -543,5 +543,38 @@ describe("fruitPlanted", () => {
       },
     });
     expect(state.bumpkin?.activity?.["Apple Seed Planted"]).toEqual(amount);
+  });
+});
+
+describe("getFruitTime", () => {
+  it("applies a 50% speed boost with Squirrel Monkey placed for orange seeds", () => {
+    const seed = "Orange Seed";
+    const orangePlantSeconds = FRUIT_SEEDS()[seed].plantSeconds;
+    const time = getFruitTime(seed, {
+      "Squirrel Monkey": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "123",
+          readyAt: 0,
+        },
+      ],
+    });
+    expect(time).toEqual(orangePlantSeconds * 0.5);
+  });
+  it("does not apply a 50% speed boost with Squirrel Monkey placed for other seeds", () => {
+    const seed = "Apple Seed";
+    const applePlantSeconds = FRUIT_SEEDS()[seed].plantSeconds;
+    const time = getFruitTime(seed, {
+      "Squirrel Monkey": [
+        {
+          coordinates: { x: 0, y: 0 },
+          createdAt: 0,
+          id: "123",
+          readyAt: 0,
+        },
+      ],
+    });
+    expect(time).toEqual(applePlantSeconds);
   });
 });

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -27,7 +27,7 @@ function getPlantedAt(
   collectibles: Collectibles,
   createdAt: number
 ) {
-  if (!fruitSeedName) return 0;
+  if (!fruitSeedName) return createdAt;
 
   const fruitTime = FRUIT_SEEDS()[fruitSeedName].plantSeconds;
   const boostedTime = getFruitTime(fruitSeedName, collectibles);

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import {
-  FruitName,
   FruitSeedName,
   FRUIT_SEEDS,
   isFruitSeed,
@@ -24,24 +23,39 @@ function getHarvestsLeft() {
 }
 
 function getPlantedAt(
-  fruitName: FruitName,
+  fruitSeedName: FruitSeedName,
   collectibles: Collectibles,
   createdAt: number
 ) {
+  if (!fruitSeedName) return 0;
+
+  const fruitTime = FRUIT_SEEDS()[fruitSeedName].plantSeconds;
+  const boostedTime = getFruitTime(fruitSeedName, collectibles);
+
+  const offset = fruitTime - boostedTime;
+
+  return createdAt - offset * 1000;
+}
+
+/**
+ * Based on boosts, how long a fruit will take to grow
+ */
+export const getFruitTime = (
+  fruitSeedName: FruitSeedName,
+  collectibles: Collectibles
+) => {
+  let seconds = FRUIT_SEEDS()[fruitSeedName]?.plantSeconds ?? 0;
+
+  // Squirrel Monkey: 50% reduction
   if (
-    fruitName === "Orange" &&
+    fruitSeedName === "Orange Seed" &&
     isCollectibleBuilt("Squirrel Monkey", collectibles)
   ) {
-    const orangeTimeInMilliseconds =
-      FRUIT_SEEDS()["Orange Seed"].plantSeconds * 1000;
-
-    const offset = orangeTimeInMilliseconds / 2;
-
-    return createdAt - offset;
+    seconds = seconds * 0.5;
   }
 
-  return createdAt;
-}
+  return seconds;
+};
 
 type Options = {
   state: Readonly<GameState>;
@@ -119,7 +133,7 @@ export function plantFruit({
 
   patch.fruit = {
     name: fruitName,
-    plantedAt: getPlantedAt(fruitName, stateCopy.collectibles, createdAt),
+    plantedAt: getPlantedAt(action.seed, stateCopy.collectibles, createdAt),
     amount: getFruitYield(fruitName, stateCopy.collectibles),
     harvestedAt: 0,
     // Value will be overridden by BE

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -71,7 +71,7 @@ export function isPlotFertile({
 }
 
 /**
- * Based on boosts, how long a crop will take
+ * Based on boosts, how long a crop will take to grow
  */
 export const getCropTime = (
   crop: CropName,
@@ -83,17 +83,20 @@ export const getCropTime = (
   const { necklace } = equipped;
   let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
 
+  // Legacy Seed Specialist skill: 10% reduction
   if (inventory["Seed Specialist"]?.gte(1)) {
     seconds = seconds * 0.9;
   }
 
+  // Mysterious Parsnip: 50% reduction
   if (
     crop === "Parsnip" &&
     isCollectibleBuilt("Mysterious Parsnip", collectibles)
   ) {
     seconds = seconds * 0.5;
   }
-  //Bumpkin Wearable Boost
+
+  // Bumpkin Wearable Boost
   if (crop === "Carrot" && necklace === "Carrot Amulet") {
     seconds = seconds * 0.8;
   }
@@ -107,16 +110,17 @@ export const getCropTime = (
     seconds = seconds * 0.85;
   }
 
+  // Cultivator skill: 5% reduction
   if (skills["Cultivator"]) {
     seconds = seconds * 0.95;
   }
 
-  //If lunar calender: 10% reduction
+  // Lunar calender: 10% reduction
   if (isCollectibleBuilt("Lunar Calendar", collectibles)) {
     seconds = seconds * 0.9;
   }
 
-  // If Cabbage Girl: 50% reduction
+  // Cabbage Girl: 50% reduction
   if (crop === "Cabbage" && isCollectibleBuilt("Cabbage Girl", collectibles)) {
     seconds = seconds * 0.5;
   }
@@ -142,13 +146,9 @@ export function getPlantedAt({
   bumpkin,
   createdAt,
 }: GetPlantedAtArgs): number {
-  const item = CROPS()[crop];
+  if (!crop) return 0;
 
-  if (!crop) {
-    return 0;
-  }
-
-  const cropTime = item.harvestSeconds;
+  const cropTime = CROPS()[crop].harvestSeconds;
   const boostedTime = getCropTime(crop, inventory, collectibles, bumpkin);
 
   const offset = cropTime - boostedTime;

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -27,11 +27,12 @@ import { makeBulkSeedBuyAmount } from "./lib/makeBulkSeedBuyAmount";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { SeedName, SEEDS } from "features/game/types/seeds";
 import { Bumpkin, Inventory } from "features/game/types/game";
-import { FRUIT } from "features/game/types/fruits";
+import { FRUIT, FruitSeedName } from "features/game/types/fruits";
 import { Label } from "components/ui/Label";
 import { Restock } from "features/island/buildings/components/building/market/Restock";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getFruitHarvests } from "features/game/events/landExpansion/utils";
+import { getFruitTime } from "features/game/events/landExpansion/fruitPlanted";
 
 interface Props {
   onClose: () => void;
@@ -167,25 +168,23 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
   const yields = SEEDS()[selectedName].yield;
 
   const getPlantSeconds = () => {
+    let seconds = 0;
+
     if (yields in FRUIT())
-      return secondsToString(SEEDS()[selectedName].plantSeconds, {
-        length: "medium",
-        removeTrailingZeros: true,
-      });
+      seconds = getFruitTime(selectedName as FruitSeedName, collectibles);
 
     if (yields in CROPS())
-      return secondsToString(
-        getCropTime(
-          yields as CropName,
-          inventory,
-          collectibles,
-          state.bumpkin as Bumpkin
-        ),
-        {
-          length: "medium",
-          removeTrailingZeros: true,
-        }
+      seconds = getCropTime(
+        yields as CropName,
+        inventory,
+        collectibles,
+        state.bumpkin as Bumpkin
       );
+
+    return secondsToString(seconds, {
+      length: "medium",
+      removeTrailingZeros: true,
+    });
   };
 
   const harvestCount = () => {

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -15,7 +15,7 @@ import { getBasketItems } from "./utils/inventory";
 import { RESOURCES } from "features/game/types/resources";
 import { ConsumableName, CONSUMABLES } from "features/game/types/consumables";
 import { BEANS } from "features/game/types/beans";
-import { FRUIT, FRUIT_SEEDS } from "features/game/types/fruits";
+import { FRUIT, FruitSeedName, FRUIT_SEEDS } from "features/game/types/fruits";
 import { SplitScreenView } from "components/ui/SplitScreenView";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { InventoryItemDetails } from "components/ui/layouts/InventoryItemDetails";
@@ -26,6 +26,7 @@ import Decimal from "decimal.js-light";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BEACH_BOUNTY_TREASURE } from "features/game/types/treasure";
 import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
+import { getFruitTime } from "features/game/events/landExpansion/fruitPlanted";
 
 interface Prop {
   gameState: GameState;
@@ -63,7 +64,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
 
   const getHarvestTime = (seedName: SeedName) => {
     if (isFruitSeed(selected)) {
-      return SEEDS()[seedName].plantSeconds;
+      return getFruitTime(seedName as FruitSeedName, collectibles);
     }
 
     const crop = SEEDS()[seedName].yield as CropName;


### PR DESCRIPTION
# Description

- fix incorrect fruit time display for seed shop and inventory when Squirrel Money is planted

![image](https://user-images.githubusercontent.com/107602352/223325300-1beb974b-ea06-4a61-a37a-f1806581e47a.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- have Squirrel Money planted in the farm, then
  - check orange seed in seed shop
  - check orange seed in inventory
  - check other seeds in seed shop and inventory

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes