### PR TITLE
[FIX] Buildings repositioning

### DIFF
--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -4,7 +4,7 @@ import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/craftables";
 import { Chicken, GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
-import { getSupportedChickens, removeItem } from "./utils";
+import { getSupportedChickens } from "./utils";
 
 export enum REMOVE_BUILDING_ERRORS {
   INVALID_BUILDING = "This building does not exist",
@@ -157,15 +157,13 @@ export function removeBuilding({
     throw new Error(REMOVE_BUILDING_ERRORS.INVALID_BUILDING);
   }
 
-  const buildingIndex = buildingGroup?.findIndex(
-    (building) => building.id == action.id
+  const buildingToRemove = buildingGroup.find(
+    (building) => building.id === action.id
   );
 
-  if (buildingIndex === -1) {
+  if (!buildingToRemove) {
     throw new Error(REMOVE_BUILDING_ERRORS.INVALID_BUILDING);
   }
-
-  const buildingToRemove = buildingGroup[buildingIndex];
 
   if (buildingToRemove.readyAt > createdAt) {
     throw new Error(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
@@ -177,9 +175,8 @@ export function removeBuilding({
     throw new Error(REMOVE_BUILDING_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
   }
 
-  stateCopy.buildings[action.building] = removeItem(
-    buildingGroup,
-    buildingGroup[buildingIndex]
+  stateCopy.buildings[action.building] = buildingGroup.filter(
+    (building) => building.id !== buildingToRemove.id
   );
 
   if (action.building === "Water Well") {

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -7,7 +7,6 @@ import {
   areUnsupportedChickensBrewing,
   removeUnsupportedChickens,
 } from "./removeBuilding";
-import { removeItem } from "./utils";
 
 export enum REMOVE_COLLECTIBLE_ERRORS {
   INVALID_COLLECTIBLE = "This collectible does not exist",
@@ -42,11 +41,11 @@ export function removeCollectible({ state, action }: Options) {
     throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
   }
 
-  const collectibleIndex = collectibleGroup?.findIndex(
-    (collectible) => collectible.id == action.id
+  const collectibleToRemove = collectibleGroup.find(
+    (collectible) => collectible.id === action.id
   );
 
-  if (collectibleIndex === -1) {
+  if (!collectibleToRemove) {
     throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
   }
 
@@ -56,13 +55,12 @@ export function removeCollectible({ state, action }: Options) {
     throw new Error(REMOVE_COLLECTIBLE_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
   }
 
-  stateCopy.collectibles[action.collectible] = removeItem(
-    collectibleGroup,
-    collectibleGroup[collectibleIndex]
+  stateCopy.collectibles[action.collectible] = collectibleGroup.filter(
+    (collectible) => collectible.id !== collectibleToRemove.id
   );
 
   // Remove collectible key if there are none placed
-  if (!stateCopy.collectibles[action.collectible]) {
+  if (!stateCopy.collectibles[action.collectible]?.length) {
     delete stateCopy.collectibles[action.collectible];
   }
 

--- a/src/features/game/events/landExpansion/utils.ts
+++ b/src/features/game/events/landExpansion/utils.ts
@@ -32,14 +32,3 @@ export const getSupportedChickens = (state: Readonly<GameState>) => {
 
   return capacity;
 };
-
-export const removeItem = <T>(
-  arr: Array<T>,
-  value: T
-): Array<T> | undefined => {
-  const index = arr.indexOf(value);
-  if (index > -1) {
-    arr.splice(index, 1);
-  }
-  return arr.length ? arr : undefined;
-};

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -168,12 +168,14 @@ function detectPlaceableCollision(state: GameState, boundingBox: BoundingBox) {
     const items = placed[name] as PlacedItem[];
     const dimensions = PLACEABLE_DIMENSIONS[name];
 
-    return items.map((item) => ({
-      x: item.coordinates.x,
-      y: item.coordinates.y,
-      height: dimensions.height,
-      width: dimensions.width,
-    }));
+    return items
+      ? items.map((item) => ({
+          x: item.coordinates.x,
+          y: item.coordinates.y,
+          height: dimensions.height,
+          width: dimensions.width,
+        }))
+      : [];
   });
 
   return boundingBoxes.some((resourceBoundingBox) =>

--- a/src/features/game/expansion/placeable/lib/removeCondition.ts
+++ b/src/features/game/expansion/placeable/lib/removeCondition.ts
@@ -2,7 +2,6 @@ import {
   areUnsupportedChickensBrewing,
   removeUnsupportedCrops,
 } from "features/game/events/landExpansion/removeBuilding";
-import { removeItem } from "features/game/events/landExpansion/utils";
 import { PlaceableName } from "features/game/types/buildings";
 import { GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
@@ -22,23 +21,26 @@ export const isRemovable = (
   if (name === "Hen House" || name === "Water Well") {
     const stateCopy = cloneDeep(gameState);
     const buildingGroup = stateCopy.buildings[name];
+
     if (!buildingGroup) {
       return false;
     }
 
-    const buildingIndex = buildingGroup?.findIndex(
-      (building) => building.id == placeableId
+    const buildingToRemove = buildingGroup.find(
+      (building) => building.id === placeableId
     );
-    if (buildingIndex === -1) {
+
+    if (!buildingToRemove) {
       return false;
     }
 
-    stateCopy.buildings[name] = removeItem(
-      buildingGroup,
-      buildingGroup[buildingIndex]
+    stateCopy.buildings[name] = buildingGroup.filter(
+      (building) => building.id !== buildingToRemove.id
     );
 
-    if (name === "Hen House") return !areUnsupportedChickensBrewing(stateCopy);
+    if (name === "Hen House") {
+      return !areUnsupportedChickensBrewing(stateCopy);
+    }
 
     const { hasUnsupportedCrops } = removeUnsupportedCrops(stateCopy);
     return !hasUnsupportedCrops;
@@ -47,21 +49,23 @@ export const isRemovable = (
   if (name === "Chicken Coop") {
     const stateCopy = cloneDeep(gameState);
     const collectibleGroup = stateCopy.collectibles[name];
+
     if (!collectibleGroup) {
       return false;
     }
 
-    const buildingIndex = collectibleGroup?.findIndex(
-      (collectible) => collectible.id == placeableId
+    const collectibleToRemove = collectibleGroup.find(
+      (collectible) => collectible.id === placeableId
     );
-    if (buildingIndex === -1) {
+
+    if (!collectibleToRemove) {
       return false;
     }
 
-    stateCopy.collectibles[name] = removeItem(
-      collectibleGroup,
-      collectibleGroup[buildingIndex]
+    stateCopy.collectibles[name] = collectibleGroup.filter(
+      (collectible) => collectible.id !== collectibleToRemove.id
     );
+
     return !areUnsupportedChickensBrewing(stateCopy);
   }
 

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -268,11 +268,14 @@ const INITIAL_BUMPKIN: Bumpkin = {
 export const OFFLINE_FARM: GameState = {
   balance: new Decimal(10),
   inventory: {
+    "Fire Pit": new Decimal(1),
+    Market: new Decimal(1),
     Artist: new Decimal(1),
     Sunflower: new Decimal(2999),
     Wood: new Decimal(100),
     Stone: new Decimal(50),
     Axe: new Decimal(10),
+    "Rusty Shovel": new Decimal(10),
     "Bumpkin Salad": new Decimal(1),
     "Beta Pass": new Decimal(1),
     "Peeled Potato": new Decimal(1),


### PR DESCRIPTION
# Description

It was not possible to reposition building without page refresh.
After digging building up state contained undefined, but collisionDetection tries to call map on it.

Also removed 'removeItem' function since it modified array in place, but also returned an array, which is confusing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
