### PR TITLE
[FIX] Added boost info, disabled withdrawal for 'Cabbage Boy/Girl' SFTs

### DIFF
--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -192,6 +192,7 @@ export const GOBLIN_BLACKSMITH_ITEMS: Record<
       "Solar Flare Ticket": new Decimal(750),
     },
     supply: 1000,
+    boost: "+0.25 Cabbage",
   },
   "Cabbage Girl": {
     description: "Shhh it's sleeping",
@@ -201,6 +202,7 @@ export const GOBLIN_BLACKSMITH_ITEMS: Record<
       "Solar Flare Ticket": new Decimal(1000),
     },
     supply: 350,
+    boost: "50% Faster Cabbages",
   },
   "Collectible Bear": {
     description: "A prized possession still in mint condition!",

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -218,8 +218,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Engine Core": false,
   Observatory: true,
   "Christmas Snow Globe": true,
-  "Cabbage Boy": true,
-  "Cabbage Girl": true,
   "Chef Bear": true,
   "Construction Bear": true,
   "Angel Bear": true,
@@ -240,7 +238,6 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Squirrel Monkey": false,
   "Lady Bug": false,
   "Cyborg Bear": true,
-  "Collectible Bear": false,
   "Heart Balloons": true,
   Flamingo: true,
   "Blossom Tree": true,
@@ -308,6 +305,9 @@ export const WITHDRAWABLES: Record<InventoryItemName, WithdrawCondition> = {
   "Beach Ball": false,
   "Palm Tree": false,
   Karkinos: false,
+  "Cabbage Boy": false,
+  "Cabbage Girl": false,
+  "Collectible Bear": false,
 };
 
 // Explicit false check is important, as we also want to check if it's a bool.


### PR DESCRIPTION
# Description

Added boost info, disabled withdrawal for 'Cabbage Boy/Girl' SFTs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

n/a

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
