### PR TITLE
[FIX] Add price per unit to buying confirmation modal

### DIFF
--- a/src/features/goblins/trader/buying/components/Confirming.tsx
+++ b/src/features/goblins/trader/buying/components/Confirming.tsx
@@ -63,7 +63,7 @@ export const Confirming: React.FC<ConfirmProps> = ({
         </div>
         <div className="flex items-center">
           <span className="text-xs sm:text-sm whitespace-nowrap w-1/2">
-            Price per Unit
+            Price per unit
           </span>
           <div className="flex items-center w-1/2">
             <img src={token} className="w-6" />

--- a/src/features/goblins/trader/buying/components/Confirming.tsx
+++ b/src/features/goblins/trader/buying/components/Confirming.tsx
@@ -32,6 +32,11 @@ export const Confirming: React.FC<ConfirmProps> = ({
   const buyerPays = Math.round(price * 100) / 100;
   const goblinFee = Math.round(listing.sfl * listing.tax * 100) / 100;
   const sellerReceives = Math.round(listing.sfl * 100) / 100;
+  const pricePerUnit = (
+    ((listing.sfl + listing.sfl * listing.tax) * 100) /
+    100 /
+    listing.resourceAmount
+  ).toFixed(3);
 
   const insufficientFunds = balance.lt(new Decimal(price));
 
@@ -54,6 +59,15 @@ export const Confirming: React.FC<ConfirmProps> = ({
                 "text-error": insufficientFunds,
               })}
             >{`${buyerPays} SFL`}</span>
+          </div>
+        </div>
+        <div className="flex items-center">
+          <span className="text-xs sm:text-sm whitespace-nowrap w-1/2">
+            Price per Unit
+          </span>
+          <div className="flex items-center w-1/2">
+            <img src={token} className="w-6" />
+            <span className="py-2 pl-2 whitespace-nowrap">{`${pricePerUnit} SFL`}</span>
           </div>
         </div>
         <div className="flex items-center">


### PR DESCRIPTION
# Description

Adds price per unit to buying confirmation modal.

<img width="545" alt="ppu" src="https://user-images.githubusercontent.com/41215134/226241235-e40af67b-df76-4c39-bf8c-7443cca00bf0.png">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
