### PR TITLE
[CHORE] Hayseed Hank UI improvements

### DIFF
--- a/src/features/helios/components/hayseedHank/HayseedHank.tsx
+++ b/src/features/helios/components/hayseedHank/HayseedHank.tsx
@@ -11,6 +11,8 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { hasShownTutorial } from "lib/tutorial";
+import { Bumpkin } from "features/game/types/game";
+import { isTaskComplete } from "./lib/HayseedHankTask";
 
 export const HayseedHank: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -27,8 +29,11 @@ export const HayseedHank: React.FC = () => {
     setIsOpen(true);
   };
 
+  const hayseedHank = gameState.context.state.hayseedHank;
+  const bumpkin = gameState.context.state.bumpkin as Bumpkin;
+
   return (
-    <MapPlacement x={-8} y={-9} height={3} width={4}>
+    <MapPlacement x={-7} y={-11} height={1} width={1}>
       <div
         className="relative w-full h-full cursor-pointer hover:img-highlight"
         onClick={handleClick}
@@ -36,9 +41,9 @@ export const HayseedHank: React.FC = () => {
         <div
           className="absolute"
           style={{
-            width: `${PIXEL_SCALE * 14}px`,
-            left: `${PIXEL_SCALE * 19}px`,
-            bottom: `${PIXEL_SCALE * 27}px`,
+            width: `${PIXEL_SCALE * 16}px`,
+            left: `${PIXEL_SCALE * 0}px`,
+            bottom: `${PIXEL_SCALE * 28}px`,
           }}
         >
           <NPC
@@ -47,13 +52,14 @@ export const HayseedHank: React.FC = () => {
             pants="Brown Suspenders"
             hair="Sun Spots"
           />
-          {!gameState.context.state.hayseedHank.progress && (
+          {(!gameState.context.state.hayseedHank.progress ||
+            isTaskComplete(hayseedHank, bumpkin)) && (
             <img
               src={SUNNYSIDE.icons.expression_alerted}
               className="absolute animate-float"
               style={{
-                width: `${PIXEL_SCALE * 3}px`,
-                bottom: `${PIXEL_SCALE * -4}px`,
+                width: `${PIXEL_SCALE * 4}px`,
+                bottom: `${PIXEL_SCALE * -3}px`,
                 left: `${PIXEL_SCALE * 7}px`,
               }}
             />
@@ -74,7 +80,6 @@ export const HayseedHank: React.FC = () => {
         >
           <HayseedHankModal
             onTutorialComplete={() => setTitle("Ready to work?")}
-            onClose={() => setIsOpen(false)}
           />
         </CloseButtonPanel>
       </Modal>

--- a/src/features/helios/components/hayseedHank/components/Chore.tsx
+++ b/src/features/helios/components/hayseedHank/components/Chore.tsx
@@ -15,6 +15,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Label } from "components/ui/Label";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Loading } from "features/auth/components";
+import { getProgress, isTaskComplete } from "../lib/HayseedHankTask";
 
 const PROGRESS_BAR_DIMENSIONS = {
   width: 80,
@@ -91,10 +92,7 @@ export const Chore: React.FC = () => {
     );
   }
 
-  const progress =
-    (bumpkin.activity?.[chore.activity] ?? 0) - hayseedHank.progress.startCount;
-
-  const isComplete = progress >= chore.requirement;
+  const progress = getProgress(hayseedHank, bumpkin);
 
   const progressWidth = Math.min(
     Math.floor(
@@ -200,7 +198,10 @@ export const Chore: React.FC = () => {
           </div>
         ))}
       </div>
-      <Button disabled={!isComplete} onClick={() => complete()}>
+      <Button
+        disabled={!isTaskComplete(hayseedHank, bumpkin)}
+        onClick={() => complete()}
+      >
         Complete
       </Button>
     </>

--- a/src/features/helios/components/hayseedHank/components/HayseedHankModal.tsx
+++ b/src/features/helios/components/hayseedHank/components/HayseedHankModal.tsx
@@ -6,12 +6,8 @@ import { Chore } from "./Chore";
 
 interface Props {
   onTutorialComplete: () => void;
-  onClose: () => void;
 }
-export const HayseedHankModal: React.FC<Props> = ({
-  onClose,
-  onTutorialComplete,
-}) => {
+export const HayseedHankModal: React.FC<Props> = ({ onTutorialComplete }) => {
   const { gameService } = useContext(Context);
 
   useEffect(() => {

--- a/src/features/helios/components/hayseedHank/lib/HayseedHankTask.test.ts
+++ b/src/features/helios/components/hayseedHank/lib/HayseedHankTask.test.ts
@@ -1,0 +1,93 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { BumpkinActivityName } from "features/game/types/bumpkinActivity";
+import { Bumpkin } from "features/game/types/game";
+import { getProgress, isTaskComplete } from "./HayseedHankTask";
+
+const BUMPKIN = TEST_FARM.bumpkin as Bumpkin;
+const HAYSEED_HANK = {
+  ...TEST_FARM.hayseedHank,
+  progress: {
+    bumpkinId: BUMPKIN.id,
+    startedAt: 1,
+    startCount: 10,
+  },
+  chore: {
+    activity: "Sunflower Harvested" as BumpkinActivityName,
+    description: "Harvest 20 Sunflowers",
+    requirement: 20,
+    reward: {
+      items: { "Solar Flare Ticket": 1 },
+    },
+  },
+};
+
+describe("getProgress", () => {
+  it("returns 0 if hayseed hank progress is not defined", () => {
+    expect(
+      getProgress({ ...HAYSEED_HANK, progress: undefined }, { ...BUMPKIN })
+    ).toBe(0);
+  });
+  it("returns 0 if bumpkin activity is not found and start count is 0", () => {
+    expect(
+      getProgress(
+        {
+          ...HAYSEED_HANK,
+          progress: {
+            bumpkinId: BUMPKIN.id,
+            startedAt: 1,
+            startCount: 0,
+          },
+        },
+        { ...BUMPKIN, activity: undefined }
+      )
+    ).toBe(0);
+  });
+  it("returns 3 if bumpkin harvested 13 sunflowers in total and task started when bumpkin harvested 10 sunflowers", () => {
+    expect(
+      getProgress(HAYSEED_HANK, {
+        ...BUMPKIN,
+        activity: {
+          "Sunflower Harvested": 13,
+        },
+      })
+    ).toBe(3);
+  });
+});
+
+describe("isTaskComplete", () => {
+  it("returns false if hayseed hank progress is not defined", () => {
+    expect(
+      isTaskComplete({ ...HAYSEED_HANK, progress: undefined }, { ...BUMPKIN })
+    ).toBe(false);
+  });
+  it("return false if player harvested 4/20 sunflowers", () => {
+    expect(
+      isTaskComplete(HAYSEED_HANK, {
+        ...BUMPKIN,
+        activity: {
+          "Sunflower Harvested": 4 + HAYSEED_HANK.progress.startCount,
+        },
+      })
+    ).toBeFalsy();
+  });
+  it("return true if player harvested 20/20 sunflowers", () => {
+    expect(
+      isTaskComplete(HAYSEED_HANK, {
+        ...BUMPKIN,
+        activity: {
+          "Sunflower Harvested": 20 + HAYSEED_HANK.progress.startCount,
+        },
+      })
+    ).toBeTruthy();
+  });
+  it("return true if player harvested 42/20 sunflowers", () => {
+    expect(
+      isTaskComplete(HAYSEED_HANK, {
+        ...BUMPKIN,
+        activity: {
+          "Sunflower Harvested": 42 + HAYSEED_HANK.progress.startCount,
+        },
+      })
+    ).toBeTruthy();
+  });
+});

--- a/src/features/helios/components/hayseedHank/lib/HayseedHankTask.ts
+++ b/src/features/helios/components/hayseedHank/lib/HayseedHankTask.ts
@@ -1,0 +1,14 @@
+import { Bumpkin, HayseedHank } from "features/game/types/game";
+
+export const getProgress = (hayseedHank: HayseedHank, bumpkin: Bumpkin) => {
+  if (!hayseedHank.progress) return 0;
+
+  return (
+    (bumpkin.activity?.[hayseedHank.chore.activity] ?? 0) -
+    hayseedHank.progress.startCount
+  );
+};
+
+export const isTaskComplete = (hayseedHank: HayseedHank, bumpkin: Bumpkin) => {
+  return getProgress(hayseedHank, bumpkin) >= hayseedHank.chore.requirement;
+};


### PR DESCRIPTION
# Description

- standardize pixel sizes
- hovering mouse around Garbage Trader won't highlight Hayseed Hank anymore
- show alert when Hayseed Hank task is complete

![image](https://user-images.githubusercontent.com/107602352/226263417-c17e1677-2bf2-41c0-b42c-3fc603ccf982.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- hovering and move mouse around Garbage Trader
  - the highlight won't flicker between Garbage Trader and Hayseed Hank anymore
- complete Hayseed Hank task
  - alert icon shows on top of Hayseed Hank NPC

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
