### PR TITLE
[CHORE] Use custom components for treasure island shop

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -2,7 +2,9 @@ import Decimal from "decimal.js-light";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { Ingredient } from "features/game/types/craftables";
+import { getKeys } from "features/game/types/craftables";
+import { CROP_SEEDS } from "features/game/types/crops";
+import { FRUIT_SEEDS } from "features/game/types/fruits";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React from "react";
@@ -42,7 +44,7 @@ interface HarvestsRequirementProps {
  * @param level The level requirements.
  */
 interface RequirementsProps {
-  resources?: Ingredient[];
+  resources?: Partial<Record<InventoryItemName, Decimal>>;
   sfl?: Decimal;
   showSflIfFree?: boolean;
   harvests?: HarvestsRequirementProps;
@@ -97,8 +99,11 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     const inventoryCount = gameState.inventory[details.item] ?? new Decimal(0);
     const limit = INITIAL_STOCK(gameState)[details.item];
+    const isSeed =
+      details.item in FRUIT_SEEDS() || details.item in CROP_SEEDS();
     const isInventoryFull =
-      limit === undefined ? false : inventoryCount.greaterThan(limit);
+      isSeed &&
+      (limit === undefined ? false : inventoryCount.greaterThan(limit));
 
     return (
       <div className="flex justify-center -mt-1.5 mb-1.5">
@@ -156,17 +161,18 @@ export const CraftingRequirements: React.FC<Props> = ({
     return (
       <div className="border-t border-white w-full my-2 pt-2 flex justify-between gap-x-3 gap-y-2 flex-wrap sm:flex-col sm:items-center sm:flex-nowrap">
         {/* Item ingredients requirements */}
-        {requirements.resources?.map((ingredient, index) => {
-          return (
+        {!!requirements.resources &&
+          getKeys(requirements.resources).map((ingredientName, index) => (
             <RequirementLabel
               key={index}
               type="item"
-              item={ingredient.item}
-              balance={gameState.inventory[ingredient.item] ?? new Decimal(0)}
-              requirement={ingredient.amount}
+              item={ingredientName}
+              balance={gameState.inventory[ingredientName] ?? new Decimal(0)}
+              requirement={
+                (requirements.resources ?? {})[ingredientName] ?? new Decimal(0)
+              }
             />
-          );
-        })}
+          ))}
 
         {/* SFL requirement */}
         {!!requirements.sfl &&

--- a/src/features/treasureIsland/components/TreasureShop.tsx
+++ b/src/features/treasureIsland/components/TreasureShop.tsx
@@ -6,7 +6,7 @@ import shadow from "assets/npcs/shadow.png";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Modal } from "react-bootstrap";
-import { TreasureShopBuy as TreasureShopItems } from "./TreasureShopBuy";
+import { TreasureShopBuy } from "./TreasureShopBuy";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { TreasureShopSell } from "./TreasureShopSell";
@@ -80,9 +80,7 @@ export const TreasureShop: React.FC = () => {
             },
           ]}
         >
-          {tab === 0 && (
-            <TreasureShopItems onClose={() => setShowModal(false)} />
-          )}
+          {tab === 0 && <TreasureShopBuy onClose={() => setShowModal(false)} />}
           {tab === 1 && <TreasureShopSell />}
         </CloseButtonPanel>
       </Modal>

--- a/src/features/treasureIsland/components/TreasureShopBuy.tsx
+++ b/src/features/treasureIsland/components/TreasureShopBuy.tsx
@@ -1,28 +1,25 @@
 import React, { SyntheticEvent, useContext, useState } from "react";
 import { useActor } from "@xstate/react";
-import classNames from "classnames";
 import Decimal from "decimal.js-light";
 
 import token from "assets/icons/token_2.png";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 
-import { Stock } from "components/ui/Stock";
 import { TreasureToolName, TREASURE_TOOLS } from "features/game/types/tools";
 import { getKeys } from "features/game/types/craftables";
-import { Label } from "components/ui/Label";
 import { Restock } from "features/island/buildings/components/building/market/Restock";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 
 interface Props {
   onClose: (e?: SyntheticEvent) => void;
 }
 
-// Can only by shovels in amounts of 5
 const BUY_AMOUNT = 1;
 
 export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
@@ -87,7 +84,6 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
           disabled={
             lessFunds() || lessIngredients() || stock?.lessThan(BUY_AMOUNT)
           }
-          className="text-xs mt-1 whitespace-nowrap"
           onClick={(e) => craft(e)}
         >
           Craft
@@ -96,30 +92,26 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
     );
   };
 
-  const labelState = () => {
-    if (stock?.equals(0)) {
-      return (
-        <Label type="danger" className="-mt-2 mb-1">
-          Sold out
-        </Label>
-      );
-    }
-
-    return <Stock item={{ name: selectedName }} inventoryFull={false} />;
-  };
-
   const stock = state.stock[selectedName] || new Decimal(0);
-  const ingredientCount =
-    getKeys(selected.ingredients).length + price.toNumber();
 
   return (
-    <div
-      style={{
-        minHeight: "200px",
-      }}
-    >
-      <div className="flex flex-col-reverse sm:flex-row">
-        <div className="w-full max-h-48 sm:max-h-96 sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          stock={stock}
+          details={{
+            item: selectedName,
+          }}
+          requirements={{
+            sfl: price,
+            resources: selected.ingredients,
+          }}
+          actionView={Action()}
+        />
+      }
+      content={
+        <>
           {getKeys(TREASURE_TOOLS).map((toolName) => (
             <Box
               isSelected={selectedName === toolName}
@@ -129,88 +121,8 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
               count={inventory[toolName]}
             />
           ))}
-        </div>
-        <OuterPanel className="flex flex-col w-full sm:flex-1">
-          <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-            {labelState()}
-            <div className="flex space-x-2 items-center my-1 sm:flex-col-reverse md:space-x-0">
-              <img
-                src={ITEM_DETAILS[selectedName].image}
-                className="w-5 sm:w-8 sm:my-1"
-                alt={selectedName}
-              />
-              <span className="text-center mb-1">{selectedName}</span>
-            </div>
-            <span className="text-xs sm:text-sm sm:text-center">
-              {selected.description}
-            </span>
-            <div className="border-t border-white w-full my-2" />
-            <div className="flex w-full justify-between max-h-14 sm:max-h-full sm:flex-col sm:items-center">
-              <div className="mb-1 flex flex-wrap sm:flex-nowrap w-[70%] sm:w-auto">
-                {price?.gt(0) && (
-                  <div className="flex items-center space-x-1 shrink-0 w-1/2 sm:w-full sm:justify-center my-[1px] sm:mb-1">
-                    <div className="w-5">
-                      <img src={token} className="h-5 mr-1" />
-                    </div>
-                    <span
-                      className={classNames("text-xs text-center", {
-                        "text-red-500": lessFunds(),
-                      })}
-                    >
-                      {`${price?.toNumber()}`}
-                    </span>
-                  </div>
-                )}
-                {getKeys(selected.ingredients).map((ingredientName, index) => {
-                  const item = ITEM_DETAILS[ingredientName];
-                  const inventoryAmount =
-                    inventory[ingredientName]?.toDecimalPlaces(1) || 0;
-                  const requiredAmount =
-                    selected.ingredients[ingredientName]
-                      ?.mul(BUY_AMOUNT)
-                      ?.toDecimalPlaces(1) || 0;
-
-                  // Ingredient difference
-                  const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                    requiredAmount
-                  );
-
-                  // rendering item remnants
-                  const renderRemnants = () => {
-                    if (lessIngredient) {
-                      // if inventory items is less than required items
-                      return (
-                        <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-                      );
-                    }
-                    // if inventory items is equal to required items
-                    return (
-                      <span className="text-xs text-center">
-                        {`${requiredAmount}`}
-                      </span>
-                    );
-                  };
-
-                  return (
-                    <div
-                      className={`flex items-center space-x-1 ${
-                        ingredientCount > 2 ? "w-1/2" : "w-full"
-                      } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                      key={index}
-                    >
-                      <div className="w-5">
-                        <img src={item.image} className="h-5" />
-                      </div>
-                      {renderRemnants()}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-          {Action()}
-        </OuterPanel>
-      </div>
-    </div>
+        </>
+      }
+    />
   );
 };

--- a/src/features/treasureIsland/components/TreasureShopSell.tsx
+++ b/src/features/treasureIsland/components/TreasureShopSell.tsx
@@ -1,11 +1,9 @@
 import React, { useContext, useState } from "react";
-import classNames from "classnames";
 import { useActor } from "@xstate/react";
 
 import token from "assets/icons/token_2.png";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 
 import { Context } from "features/game/GameProvider";
@@ -18,6 +16,8 @@ import {
   BEACH_BOUNTY_TREASURE,
 } from "features/game/types/treasure";
 import { getSellPrice } from "features/game/events/landExpansion/treasureSold";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { ShopSellDetails } from "components/ui/layouts/ShopSellDetails";
 
 export const TreasureShopSell: React.FC = () => {
   const beachBountyTreasure = getKeys(BEACH_BOUNTY_TREASURE).sort((a, b) =>
@@ -56,54 +56,36 @@ export const TreasureShopSell: React.FC = () => {
     });
   };
 
-  const Action = () => {
-    return (
-      <div className="flex space-x-1 w-full sm:flex-col sm:space-x-0 sm:space-y-1">
-        <Button
-          disabled={amount.lt(1)}
-          className="text-xxs sm:text-xs"
-          onClick={() => sell(1)}
-        >
-          Sell
-        </Button>
-      </div>
-    );
-  };
-
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <div className="w-full max-h-48 sm:max-h-96 sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
-        {beachBountyTreasure.map((name: BeachBountyTreasure) => (
-          <Box
-            isSelected={selectedName === name}
-            key={name}
-            onClick={() => setSelectedName(name)}
-            image={ITEM_DETAILS[name].image}
-            count={inventory[name] || new Decimal(0)}
-          />
-        ))}
-      </div>
-      <OuterPanel className="w-full flex flex-1 flex-col justify-between">
-        <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-          <div className="flex space-x-2 items-center mt-1 sm:flex-col-reverse md:space-x-0">
-            <img
-              src={ITEM_DETAILS[selectedName].image}
-              className="w-5 sm:w-8 sm:my-1"
-              alt={selectedName}
+    <SplitScreenView
+      panel={
+        <ShopSellDetails
+          details={{
+            item: selectedName,
+          }}
+          properties={{
+            sfl: price,
+          }}
+          actionView={
+            <Button disabled={amount.lt(1)} onClick={() => sell(1)}>
+              Sell
+            </Button>
+          }
+        />
+      }
+      content={
+        <>
+          {beachBountyTreasure.map((name: BeachBountyTreasure) => (
+            <Box
+              isSelected={selectedName === name}
+              key={name}
+              onClick={() => setSelectedName(name)}
+              image={ITEM_DETAILS[name].image}
+              count={inventory[name] || new Decimal(0)}
             />
-            <span className="text-center mb-1">{selectedName}</span>
-          </div>
-          <div className="border-t border-white w-full my-2 pt-2 flex justify-between sm:flex-col sm:space-y-2 sm:items-center">
-            <div className="flex space-x-1 justify-center items-center">
-              <img src={token} className="h-4 sm:h-5" />
-              <span className={classNames("text-xs text-center")}>
-                {price.toNumber()}
-              </span>
-            </div>
-          </div>
-        </div>
-        {Action()}
-      </OuterPanel>
-    </div>
+          ))}
+        </>
+      }
+    />
   );
 };


### PR DESCRIPTION
# Description

- use custom component for treasure island tools crafting and bounty selling shop
  - components will be used in other shop and crafting modals
- display player inventory amount for resources (eg. show 1.9/2 wood instead of 2 wood if players have 1.9999 wood in inventory and the tool requires 2)
- fix incorrect display for resource amount (eg. show that player have not enough wood to craft if they have 1.9999 wood in inventory and the tool requires 2)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/226512648-a2f311f3-a8d9-4a19-b908-31c7f2d0f163.png)|![image](https://user-images.githubusercontent.com/107602352/226512687-37a737b3-17c0-413c-bc84-bea11c943e43.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Buy and sell items in treasure island shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
