### PR TITLE
[CHORE] Use custom components for workbench shop

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -2,7 +2,9 @@ import Decimal from "decimal.js-light";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { Ingredient } from "features/game/types/craftables";
+import { getKeys } from "features/game/types/craftables";
+import { CROP_SEEDS } from "features/game/types/crops";
+import { FRUIT_SEEDS } from "features/game/types/fruits";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React from "react";
@@ -42,7 +44,7 @@ interface HarvestsRequirementProps {
  * @param level The level requirements.
  */
 interface RequirementsProps {
-  resources?: Ingredient[];
+  resources?: Partial<Record<InventoryItemName, Decimal>>;
   sfl?: Decimal;
   showSflIfFree?: boolean;
   harvests?: HarvestsRequirementProps;
@@ -97,8 +99,11 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     const inventoryCount = gameState.inventory[details.item] ?? new Decimal(0);
     const limit = INITIAL_STOCK(gameState)[details.item];
+    const isSeed =
+      details.item in FRUIT_SEEDS() || details.item in CROP_SEEDS();
     const isInventoryFull =
-      limit === undefined ? false : inventoryCount.greaterThan(limit);
+      isSeed &&
+      (limit === undefined ? false : inventoryCount.greaterThan(limit));
 
     return (
       <div className="flex justify-center -mt-1.5 mb-1.5">
@@ -156,17 +161,18 @@ export const CraftingRequirements: React.FC<Props> = ({
     return (
       <div className="border-t border-white w-full my-2 pt-2 flex justify-between gap-x-3 gap-y-2 flex-wrap sm:flex-col sm:items-center sm:flex-nowrap">
         {/* Item ingredients requirements */}
-        {requirements.resources?.map((ingredient, index) => {
-          return (
+        {!!requirements.resources &&
+          getKeys(requirements.resources).map((ingredientName, index) => (
             <RequirementLabel
               key={index}
               type="item"
-              item={ingredient.item}
-              balance={gameState.inventory[ingredient.item] ?? new Decimal(0)}
-              requirement={ingredient.amount}
+              item={ingredientName}
+              balance={gameState.inventory[ingredientName] ?? new Decimal(0)}
+              requirement={
+                (requirements.resources ?? {})[ingredientName] ?? new Decimal(0)
+              }
             />
-          );
-        })}
+          ))}
 
         {/* SFL requirement */}
         {!!requirements.sfl &&

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -6,44 +6,26 @@ import { Modal } from "react-bootstrap";
 import token from "assets/icons/token_2.png";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel, Panel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 
-import { Stock } from "components/ui/Stock";
-import { Tab } from "components/ui/Tab";
 import { WorkbenchToolName, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { getKeys } from "features/game/types/craftables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Label } from "components/ui/Label";
 import { acknowledgeTutorial, hasShownTutorial } from "lib/tutorial";
 import { Tutorial } from "./Tutorial";
 import { Equipped } from "features/game/types/bumpkin";
-import classNames from "classnames";
 import { Restock } from "features/island/buildings/components/building/market/Restock";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 
 interface Props {
   isOpen: boolean;
   onClose: (e?: SyntheticEvent) => void;
 }
-
-const CloseButton = ({ onClose }: { onClose: (e: SyntheticEvent) => void }) => {
-  return (
-    <img
-      src={SUNNYSIDE.icons.close}
-      className="absolute cursor-pointer z-20"
-      onClick={onClose}
-      style={{
-        top: `${PIXEL_SCALE * 1}px`,
-        right: `${PIXEL_SCALE * 1}px`,
-        width: `${PIXEL_SCALE * 11}px`,
-      }}
-    />
-  );
-};
 
 export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
   const [selectedName, setSelectedName] = useState<WorkbenchToolName>("Axe");
@@ -123,16 +105,7 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
     });
   };
 
-  const labelState = () => {
-    if (stock?.equals(0)) {
-      return (
-        <Label type="danger" className="-mt-2 mb-1">
-          Sold out
-        </Label>
-      );
-    }
-    return <Stock item={{ name: selectedName }} inventoryFull={false} />;
-  };
+  const stock = state.stock[selectedName] || new Decimal(0);
 
   const Action = () => {
     if (stock?.equals(0)) {
@@ -143,7 +116,6 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
       <>
         <Button
           disabled={lessFunds() || lessIngredients() || stock?.lessThan(1)}
-          className="text-xxs sm:text-xs mt-1 whitespace-nowrap"
           onClick={(e) => craft(e)}
         >
           Craft 1
@@ -152,34 +124,30 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
     );
   };
 
-  const stock = state.stock[selectedName] || new Decimal(0);
-  // Price is added as an ingredient for layout purposes
-  const ingredientCount = getKeys(selected.ingredients).length + 1;
-
   return (
     <Modal centered show={isOpen} onHide={onClose}>
-      <Panel className="relative" hasTabs bumpkinParts={bumpkinParts}>
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 1}px`,
-            left: `${PIXEL_SCALE * 1}px`,
-            right: `${PIXEL_SCALE * 1}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={SUNNYSIDE.icons.hammer} className="h-5 mr-2" />
-            <span className="text-sm">Tools</span>
-          </Tab>
-          <CloseButton onClose={onClose} />
-        </div>
-        <div
-          style={{
-            minHeight: "200px",
-          }}
-        >
-          <div className="flex flex-col-reverse sm:flex-row">
-            <div className="w-full max-h-48 sm:max-h-96 sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
+      <CloseButtonPanel
+        bumpkinParts={bumpkinParts}
+        onClose={onClose}
+        tabs={[{ icon: SUNNYSIDE.icons.hammer, name: "Tools" }]}
+      >
+        <SplitScreenView
+          panel={
+            <CraftingRequirements
+              gameState={state}
+              stock={stock}
+              details={{
+                item: selectedName,
+              }}
+              requirements={{
+                sfl: price,
+                resources: selected.ingredients,
+              }}
+              actionView={Action()}
+            />
+          }
+          content={
+            <>
               {getKeys(WORKBENCH_TOOLS()).map((toolName) => (
                 <Box
                   isSelected={selectedName === toolName}
@@ -189,92 +157,10 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
                   count={inventory[toolName]}
                 />
               ))}
-            </div>
-            <OuterPanel className="flex flex-col w-full sm:flex-1">
-              <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-                {labelState()}
-                <div className="flex space-x-2 items-center my-1 sm:flex-col-reverse md:space-x-0">
-                  <img
-                    src={ITEM_DETAILS[selectedName].image}
-                    className="w-5 sm:w-8 sm:my-1"
-                    alt={selectedName}
-                  />
-                  <span className="text-center mb-1">{selectedName}</span>
-                </div>
-                <span className="text-xs sm:text-sm sm:text-center">
-                  {selected.description}
-                </span>
-                <div className="border-t border-white w-full my-2" />
-                <div className="flex w-full justify-between max-h-14 sm:max-h-full sm:flex-col sm:items-center">
-                  <div className="mb-1 flex flex-wrap sm:flex-nowrap w-[70%] sm:w-auto">
-                    {price?.gt(0) && (
-                      <div className="flex items-center space-x-1 shrink-0 w-1/2 sm:w-full sm:justify-center my-[1px] sm:mb-1">
-                        <div className="w-5">
-                          <img src={token} className="h-5 mr-1" />
-                        </div>
-                        <span
-                          className={classNames("text-xs text-center", {
-                            "text-red-500": lessFunds(),
-                          })}
-                        >
-                          {`${price?.toNumber()}`}
-                        </span>
-                      </div>
-                    )}
-                    {getKeys(selected.ingredients).map(
-                      (ingredientName, index) => {
-                        const item = ITEM_DETAILS[ingredientName];
-                        const inventoryAmount =
-                          inventory[ingredientName]?.toDecimalPlaces(1) || 0;
-                        const requiredAmount =
-                          selected.ingredients[ingredientName]?.toDecimalPlaces(
-                            1
-                          ) || 0;
-
-                        // Ingredient difference
-                        const lessIngredient = new Decimal(
-                          inventoryAmount
-                        ).lessThan(requiredAmount);
-
-                        // rendering item remnants
-                        const renderRemnants = () => {
-                          if (lessIngredient) {
-                            // if inventory items is less than required items
-                            return (
-                              <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-                            );
-                          }
-                          // if inventory items is equal to required items
-                          return (
-                            <span className="text-xs text-center">
-                              {`${requiredAmount}`}
-                            </span>
-                          );
-                        };
-
-                        return (
-                          <div
-                            className={`flex items-center space-x-1 ${
-                              ingredientCount > 2 ? "w-1/2" : "w-full"
-                            } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                            key={index}
-                          >
-                            <div className="w-5">
-                              <img src={item.image} className="h-5" />
-                            </div>
-                            {renderRemnants()}
-                          </div>
-                        );
-                      }
-                    )}
-                  </div>
-                </div>
-              </div>
-              {Action()}
-            </OuterPanel>
-          </div>
-        </div>
-      </Panel>
+            </>
+          }
+        />
+      </CloseButtonPanel>
     </Modal>
   );
 };


### PR DESCRIPTION
# Description

- use custom component for workbench tools crafting
  - components will be used in other shop and crafting modals
- display player inventory amount for resources (eg. show 2.9/3 wood instead of 3 wood if players have 2.9999 wood in inventory and the tool requires 3)
- fix incorrect display for resource amount (eg. show that player have not enough wood to craft if they have 2.9999 wood in inventory and the tool requires 3)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/227073864-f5696031-f606-42ac-aede-8f5d0ab12859.png)|![image](https://user-images.githubusercontent.com/107602352/227073847-c93ac5e8-cb2b-4d3d-a91d-043b75cfc923.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Buy tools in workbench

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
