### PR TITLE
[CHORE] Use CloseablePanel for cooking stations

### DIFF
--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
 import { getKeys } from "features/game/types/craftables";
 import chefHat from "src/assets/icons/chef_hat.png";
@@ -11,10 +10,8 @@ import {
   CookableName,
   COOKABLES,
 } from "features/game/types/consumables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Tab } from "components/ui/Tab";
 import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
-import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   isOpen: boolean;
@@ -46,7 +43,7 @@ export const BakeryModal: React.FC<Props> = ({
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel
+      <CloseButtonPanel
         bumpkinParts={{
           body: "Goblin Potion",
           hair: "Sun Spots",
@@ -57,31 +54,9 @@ export const BakeryModal: React.FC<Props> = ({
           hat: "Chef Hat",
           shoes: "Black Farmer Boots",
         }}
-        hasTabs
+        tabs={[{ icon: chefHat, name: "Bakery" }]}
+        onClose={onClose}
       >
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 3}px`,
-            left: `${PIXEL_SCALE * 3}px`,
-            right: `${PIXEL_SCALE * 3}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={chefHat} className="h-5 mr-2" />
-            <span className="text-sm">Bakery</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={onClose}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
         <Recipes
           selected={selected}
           setSelected={setSelected}
@@ -91,7 +66,7 @@ export const BakeryModal: React.FC<Props> = ({
           crafting={crafting}
           craftingService={craftingService}
         />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
 import { getKeys } from "features/game/types/craftables";
 import chefHat from "src/assets/icons/chef_hat.png";
@@ -11,10 +10,8 @@ import {
   CookableName,
   COOKABLES,
 } from "features/game/types/consumables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Tab } from "components/ui/Tab";
 import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
-import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   isOpen: boolean;
@@ -46,7 +43,7 @@ export const DeliModal: React.FC<Props> = ({
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel
+      <CloseButtonPanel
         bumpkinParts={{
           body: "Beige Farmer Potion",
           hair: "Parlour Hair",
@@ -56,31 +53,9 @@ export const DeliModal: React.FC<Props> = ({
           background: "Farm Background",
           shoes: "Black Farmer Boots",
         }}
-        hasTabs
+        tabs={[{ icon: chefHat, name: "Deli" }]}
+        onClose={onClose}
       >
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 3}px`,
-            left: `${PIXEL_SCALE * 3}px`,
-            right: `${PIXEL_SCALE * 3}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={chefHat} className="h-5 mr-2" />
-            <span className="text-sm">Deli</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={onClose}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
         <Recipes
           selected={selected}
           setSelected={setSelected}
@@ -90,7 +65,7 @@ export const DeliModal: React.FC<Props> = ({
           crafting={crafting}
           craftingService={craftingService}
         />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
 import { getKeys } from "features/game/types/craftables";
 
@@ -12,13 +11,11 @@ import {
   CookableName,
   COOKABLES,
 } from "features/game/types/consumables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Tab } from "components/ui/Tab";
 import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
 import { Equipped } from "features/game/types/bumpkin";
 import { acknowledgeTutorial, hasShownTutorial } from "lib/tutorial";
 import { Tutorial } from "./Tutorial";
-import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   isOpen: boolean;
@@ -77,30 +74,11 @@ export const FirePitModal: React.FC<Props> = ({
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel bumpkinParts={bumpkinParts} hasTabs>
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 3}px`,
-            left: `${PIXEL_SCALE * 3}px`,
-            right: `${PIXEL_SCALE * 3}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={chefHat} className="h-5 mr-2" />
-            <span className="text-sm whitespace-nowrap">Fire Pit</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={onClose}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
+      <CloseButtonPanel
+        bumpkinParts={bumpkinParts}
+        tabs={[{ icon: chefHat, name: "Fire Pit" }]}
+        onClose={onClose}
+      >
         <Recipes
           selected={selected}
           setSelected={setSelected}
@@ -110,7 +88,7 @@ export const FirePitModal: React.FC<Props> = ({
           crafting={!!crafting}
           craftingService={craftingService}
         />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
 import { getKeys } from "features/game/types/craftables";
 import chefHat from "src/assets/icons/chef_hat.png";
@@ -11,10 +10,8 @@ import {
   CookableName,
   COOKABLES,
 } from "features/game/types/consumables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Tab } from "components/ui/Tab";
 import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
-import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   isOpen: boolean;
@@ -46,8 +43,7 @@ export const KitchenModal: React.FC<Props> = ({
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel
-        hasTabs
+      <CloseButtonPanel
         bumpkinParts={{
           body: "Light Brown Farmer Potion",
           hair: "Explorer Hair",
@@ -57,30 +53,9 @@ export const KitchenModal: React.FC<Props> = ({
           background: "Farm Background",
           shoes: "Black Farmer Boots",
         }}
+        tabs={[{ icon: chefHat, name: "Kitchen" }]}
+        onClose={onClose}
       >
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 3}px`,
-            left: `${PIXEL_SCALE * 3}px`,
-            right: `${PIXEL_SCALE * 3}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={chefHat} className="h-5 mr-2" />
-            <span className="text-sm">Kitchen</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={onClose}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
         <Recipes
           selected={selected}
           setSelected={setSelected}
@@ -90,7 +65,7 @@ export const KitchenModal: React.FC<Props> = ({
           crafting={crafting}
           craftingService={craftingService}
         />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };

--- a/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
+++ b/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import { Panel } from "components/ui/Panel";
 import { Modal } from "react-bootstrap";
 import { getKeys } from "features/game/types/craftables";
 import chefHat from "src/assets/icons/chef_hat.png";
@@ -11,10 +10,8 @@ import {
   CookableName,
   COOKABLES,
 } from "features/game/types/consumables";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Tab } from "components/ui/Tab";
 import { MachineInterpreter } from "features/island/buildings/lib/craftingMachine";
-import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   isOpen: boolean;
@@ -46,7 +43,7 @@ export const SmoothieShackModal: React.FC<Props> = ({
 
   return (
     <Modal show={isOpen} onHide={onClose} centered>
-      <Panel
+      <CloseButtonPanel
         bumpkinParts={{
           body: "Light Brown Farmer Potion",
           hair: "Brown Long Hair",
@@ -56,32 +53,9 @@ export const SmoothieShackModal: React.FC<Props> = ({
           background: "Farm Background",
           shoes: "Black Farmer Boots",
         }}
-        hasTabs
+        tabs={[{ icon: chefHat, name: "Smoothie Shack" }]}
+        onClose={onClose}
       >
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 3}px`,
-            left: `${PIXEL_SCALE * 3}px`,
-            right: `${PIXEL_SCALE * 3}px`,
-          }}
-        >
-          <Tab isActive>
-            {/* Add glass of juice as icon */}
-            <img src={chefHat} className="h-5 mr-2" />
-            <span className="text-sm">Smoothie Shack</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={onClose}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
         <Recipes
           selected={selected}
           setSelected={setSelected}
@@ -91,7 +65,7 @@ export const SmoothieShackModal: React.FC<Props> = ({
           crafting={crafting}
           craftingService={craftingService}
         />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };


### PR DESCRIPTION
# Description

- use custom component for cooking station modals

![image](https://user-images.githubusercontent.com/107602352/227076628-79f1cf24-62e8-4a24-9523-09e89a8c6ca9.png)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

open and close kitchen, deli, fire pit, bakery and smoothie shack

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
