### PR TITLE
[CHORE] Use custom components for cooking station recipes

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -2,7 +2,9 @@ import Decimal from "decimal.js-light";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { GoblinState } from "features/game/lib/goblinMachine";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { Ingredient } from "features/game/types/craftables";
+import { getKeys } from "features/game/types/craftables";
+import { CROP_SEEDS } from "features/game/types/crops";
+import { FRUIT_SEEDS } from "features/game/types/fruits";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React from "react";
@@ -42,7 +44,7 @@ interface HarvestsRequirementProps {
  * @param level The level requirements.
  */
 interface RequirementsProps {
-  resources?: Ingredient[];
+  resources?: Partial<Record<InventoryItemName, Decimal>>;
   sfl?: Decimal;
   showSflIfFree?: boolean;
   harvests?: HarvestsRequirementProps;
@@ -97,8 +99,11 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     const inventoryCount = gameState.inventory[details.item] ?? new Decimal(0);
     const limit = INITIAL_STOCK(gameState)[details.item];
+    const isSeed =
+      details.item in FRUIT_SEEDS() || details.item in CROP_SEEDS();
     const isInventoryFull =
-      limit === undefined ? false : inventoryCount.greaterThan(limit);
+      isSeed &&
+      (limit === undefined ? false : inventoryCount.greaterThan(limit));
 
     return (
       <div className="flex justify-center -mt-1.5 mb-1.5">
@@ -156,17 +161,18 @@ export const CraftingRequirements: React.FC<Props> = ({
     return (
       <div className="border-t border-white w-full my-2 pt-2 flex justify-between gap-x-3 gap-y-2 flex-wrap sm:flex-col sm:items-center sm:flex-nowrap">
         {/* Item ingredients requirements */}
-        {requirements.resources?.map((ingredient, index) => {
-          return (
+        {!!requirements.resources &&
+          getKeys(requirements.resources).map((ingredientName, index) => (
             <RequirementLabel
               key={index}
               type="item"
-              item={ingredient.item}
-              balance={gameState.inventory[ingredient.item] ?? new Decimal(0)}
-              requirement={ingredient.amount}
+              item={ingredientName}
+              balance={gameState.inventory[ingredientName] ?? new Decimal(0)}
+              requirement={
+                (requirements.resources ?? {})[ingredientName] ?? new Decimal(0)
+              }
             />
-          );
-        })}
+          ))}
 
         {/* SFL requirement */}
         {!!requirements.sfl &&

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -2,21 +2,13 @@ import React, { Dispatch, SetStateAction, useContext } from "react";
 import { useActor } from "@xstate/react";
 import Decimal from "decimal.js-light";
 
-import levelup from "assets/icons/level_up.png";
-
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
 import { Button } from "components/ui/Button";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
 import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getKeys } from "features/game/types/craftables";
-import {
-  Cookable,
-  CookableName,
-  COOKABLES,
-} from "features/game/types/consumables";
-import { Label } from "components/ui/Label";
+import { Cookable, CookableName } from "features/game/types/consumables";
 
 import { InProgressInfo } from "../building/InProgressInfo";
 import { MachineInterpreter } from "../../lib/craftingMachine";
@@ -25,9 +17,8 @@ import {
   getFoodExpBoost,
 } from "features/game/expansion/lib/boosts";
 import { Bumpkin } from "features/game/types/game";
-import { secondsToString } from "lib/utils/time";
-import { SUNNYSIDE } from "assets/sunnyside";
-import { setPrecision } from "lib/utils/formatNumber";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 
 interface Props {
   selected: Cookable;
@@ -104,122 +95,55 @@ export const Recipes: React.FC<Props> = ({
     );
   };
 
-  const ingredientCount = getKeys(selected.ingredients).length;
-  const xpAmount = getFoodExpBoost(
-    selected,
-    state.bumpkin as Bumpkin,
-    state.collectibles
-  );
-
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <div className="w-full max-h-48 sm:max-h-96 sm:w-3/5 h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1">
-        {craftingService && (
-          <InProgressInfo craftingService={craftingService} onClose={onClose} />
-        )}
-        {crafting && <p className="mb-2">Recipes</p>}
-        <div className="flex flex-wrap h-fit">
-          {recipes.map((item) => (
-            <Box
-              isSelected={selected.name === item.name}
-              key={item.name}
-              onClick={() => setSelected(item)}
-              image={ITEM_DETAILS[item.name].image}
-              count={inventory[item.name]}
-            />
-          ))}
-        </div>
-      </div>
-      <OuterPanel className="flex flex-col w-full sm:flex-1">
-        <div className="flex p-1 items-end">
-          <div className="flex flex-col justify-between w-full sm:items-center">
-            <div className="flex items-center space-x-2 sm:flex-col-reverse">
-              <img
-                src={ITEM_DETAILS[selected.name].image}
-                className="h-6 img-highlight mt-1 sm:h-12"
-                alt={selected.name}
+    <>
+      <SplitScreenView
+        panel={
+          <CraftingRequirements
+            gameState={state}
+            details={{
+              item: selected.name,
+            }}
+            requirements={{
+              resources: selected.ingredients,
+              xp: new Decimal(
+                getFoodExpBoost(
+                  selected,
+                  state.bumpkin as Bumpkin,
+                  state.collectibles
+                )
+              ),
+              timeSeconds: getCookingTime(
+                selected.cookingSeconds,
+                state.bumpkin
+              ),
+            }}
+            actionView={Action()}
+          />
+        }
+        content={
+          <>
+            {craftingService && (
+              <InProgressInfo
+                craftingService={craftingService}
+                onClose={onClose}
               />
-              <p className="sm:text-center sm:mb-1">{selected.name}</p>
+            )}
+            {crafting && <p className="mb-2 w-full">Recipes</p>}
+            <div className="flex flex-wrap h-fit">
+              {recipes.map((item) => (
+                <Box
+                  isSelected={selected.name === item.name}
+                  key={item.name}
+                  onClick={() => setSelected(item)}
+                  image={ITEM_DETAILS[item.name].image}
+                  count={inventory[item.name]}
+                />
+              ))}
             </div>
-            <span className="text-xxs mt-2 sm:text-center">
-              {COOKABLES[selected.name].description}
-            </span>
-          </div>
-        </div>
-        <div className="border-t border-white w-full my-2" />
-        <div className="flex justify-between px-1 max-h-14 sm:max-h-full sm:flex-col sm:items-center">
-          <div className="mb-1 flex flex-col flex-wrap sm:flex-nowrap w-[70%] sm:w-auto">
-            {getKeys(selected.ingredients).map((name, index) => {
-              const item = ITEM_DETAILS[name];
-              const inventoryAmount =
-                inventory[name]?.toDecimalPlaces(1, Decimal.ROUND_FLOOR) || 0;
-              const requiredAmount =
-                selected.ingredients[name]?.toDecimalPlaces(
-                  1,
-                  Decimal.ROUND_FLOOR
-                ) || new Decimal(0);
-
-              // Ingredient difference
-              const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                requiredAmount
-              );
-
-              // rendering item remnants
-              const renderRemnants = () => {
-                if (lessIngredient) {
-                  // if inventory items is less than required items
-                  return (
-                    <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-                  );
-                }
-
-                return (
-                  <span className="text-xs text-center">
-                    {`${requiredAmount}`}
-                  </span>
-                );
-              };
-
-              return (
-                <div
-                  className={`flex items-center space-x-1 ${
-                    ingredientCount > 2 ? "w-1/2" : "w-full"
-                  } shrink-0 sm:justify-center my-[1px] sm:w-full sm:mb-1`}
-                  key={index}
-                >
-                  <div className="w-5">
-                    <img src={item.image} className="h-5" />
-                  </div>
-                  {renderRemnants()}
-                </div>
-              );
-            })}
-          </div>
-          <div className="flex flex-col space-y-2 items-start w-[30%] sm:w-full sm:items-center sm:mb-1">
-            <div className="flex justify-between">
-              <img src={levelup} className="h-5 mr-2" />
-              <span className="text-xs whitespace-nowrap">
-                {setPrecision(new Decimal(xpAmount), 2).toString()}
-                xp
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <img src={SUNNYSIDE.icons.stopwatch} className="h-5 mr-1" />
-              <span className="text-xs whitespace-nowrap">
-                {secondsToString(
-                  getCookingTime(selected.cookingSeconds, state.bumpkin),
-                  {
-                    length: "medium",
-                    isShortFormat: true,
-                    removeTrailingZeros: true,
-                  }
-                )}
-              </span>
-            </div>
-          </div>
-        </div>
-        {Action()}
-      </OuterPanel>
-    </div>
+          </>
+        }
+      />
+    </>
   );
 };


### PR DESCRIPTION
# Description

- use custom component for food crafting
  - components will be used in other shop and crafting modals
- display player inventory amount for resources (eg. show 29.9/15 cauliflower instead of 29 cauliflower if players have 29.9999 cauliflower in inventory and the food requires 15)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/227079891-0034cb47-aa68-4c35-9a18-dfa28e5e5c14.png)|![image](https://user-images.githubusercontent.com/107602352/227079909-e4564bfa-a4c7-4d59-8be3-1309786a090d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Browse recipes and cook food in kitchen, deli, fire pit, bakery and smoothie shack

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
