### PR TITLE
[CHORE] Tighten custom layouts

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -89,7 +89,7 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     if (stock.lessThanOrEqualTo(0)) {
       return (
-        <div className="flex justify-center -mt-1.5 mb-1.5">
+        <div className="flex justify-center mt-0 sm:mb-1">
           <Label type="danger">Sold out</Label>
         </div>
       );
@@ -101,7 +101,7 @@ export const CraftingRequirements: React.FC<Props> = ({
       limit === undefined ? false : inventoryCount.greaterThan(limit);
 
     return (
-      <div className="flex justify-center -mt-1.5 mb-1.5">
+      <div className="flex justify-center mt-0 sm:mb-1">
         <Label type={isInventoryFull ? "danger" : "info"}>
           {`${stock} ${isLimitedItem ? "left" : "in stock"}`}
         </Label>
@@ -119,7 +119,7 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     return (
       <>
-        <div className="flex space-x-2 justify-start mb-1 items-center sm:flex-col-reverse md:space-x-0">
+        <div className="flex space-x-2 justify-start items-center sm:flex-col-reverse md:space-x-0">
           {icon && (
             <div className="sm:mt-2">
               <SquareIcon icon={icon} width={14} />
@@ -127,7 +127,7 @@ export const CraftingRequirements: React.FC<Props> = ({
           )}
           <span className="sm:text-center">{title}</span>
         </div>
-        <span className="text-xs mt-1 whitespace-pre-line sm:text-center">
+        <span className="text-xs sm:mt-1 whitespace-pre-line sm:text-center">
           {description}
         </span>
       </>
@@ -214,7 +214,7 @@ export const CraftingRequirements: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col justify-center">
-      <div className="flex flex-col justify-center p-2 pb-0">
+      <div className="flex flex-col justify-center px-1 py-0">
         {getStock()}
         {getItemDetail()}
         {getBoosts()}

--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -119,7 +119,7 @@ export const ExpansionRequirements: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col justify-center">
-      <div className="flex flex-col justify-center p-2 pb-0">
+      <div className="flex flex-col justify-center px-1 py-0">
         {getItemDetail()}
         {getRequirements()}
       </div>

--- a/src/components/ui/layouts/FeedBumpkinDetails.tsx
+++ b/src/components/ui/layouts/FeedBumpkinDetails.tsx
@@ -50,7 +50,7 @@ export const FeedBumpkinDetails: React.FC<Props> = ({
 
     return (
       <>
-        <div className="flex space-x-2 justify-start mb-1 items-center sm:flex-col-reverse md:space-x-0">
+        <div className="flex space-x-2 justify-start items-center sm:flex-col-reverse md:space-x-0">
           {icon && (
             <div className="sm:mt-2">
               <SquareIcon icon={icon} width={14} />
@@ -58,7 +58,7 @@ export const FeedBumpkinDetails: React.FC<Props> = ({
           )}
           <span className="sm:text-center">{title}</span>
         </div>
-        <span className="text-xs mt-1 whitespace-pre-line sm:text-center">
+        <span className="text-xs sm:mt-1 whitespace-pre-line sm:text-center">
           {description}
         </span>
       </>
@@ -78,7 +78,7 @@ export const FeedBumpkinDetails: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col justify-center">
-      <div className="flex flex-col justify-center p-2 pb-0">
+      <div className="flex flex-col justify-center px-1 py-0">
         {getItemDetail()}
         {getProperties()}
       </div>

--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -72,10 +72,9 @@ export const InventoryItemDetails: React.FC<Props> = ({
     return (
       <>
         <div
-          className={classNames(
-            "flex space-x-2 justify-start mb-1 items-center",
-            { "sm:flex-col-reverse md:space-x-0": !wideLayout }
-          )}
+          className={classNames("flex space-x-2 justify-start items-center", {
+            "sm:flex-col-reverse md:space-x-0": !wideLayout,
+          })}
         >
           {icon && (
             <div className={classNames("", { "sm:mt-2": !wideLayout })}>
@@ -87,7 +86,7 @@ export const InventoryItemDetails: React.FC<Props> = ({
           </span>
         </div>
         <span
-          className={classNames("text-xs mt-1 whitespace-pre-line", {
+          className={classNames("text-xs sm:mt-1 whitespace-pre-line", {
             "sm:text-center": !wideLayout,
           })}
         >
@@ -143,7 +142,7 @@ export const InventoryItemDetails: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col justify-between h-full">
-      <div className="flex flex-col justify-center p-2 pb-0">
+      <div className="flex flex-col justify-center px-1 py-0">
         {getItemDetail()}
         {getProperties()}
       </div>

--- a/src/components/ui/layouts/ShopSellDetails.tsx
+++ b/src/components/ui/layouts/ShopSellDetails.tsx
@@ -50,7 +50,7 @@ export const ShopSellDetails: React.FC<Props> = ({
 
     return (
       <>
-        <div className="flex space-x-2 justify-start mb-1 items-center sm:flex-col-reverse md:space-x-0">
+        <div className="flex space-x-2 justify-start items-center sm:flex-col-reverse md:space-x-0">
           {icon && (
             <div className="sm:mt-2">
               <SquareIcon icon={icon} width={14} />
@@ -58,7 +58,7 @@ export const ShopSellDetails: React.FC<Props> = ({
           )}
           <span className="sm:text-center">{title}</span>
         </div>
-        <span className="text-xs mt-1 whitespace-pre-line sm:text-center">
+        <span className="text-xs sm:mt-1 whitespace-pre-line sm:text-center">
           {description}
         </span>
       </>
@@ -80,7 +80,7 @@ export const ShopSellDetails: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col justify-center">
-      <div className="flex flex-col justify-center p-2 pb-0">
+      <div className="flex flex-col justify-center px-1 py-0">
         {getItemDetail()}
         {getProperties()}
       </div>


### PR DESCRIPTION
# Description

- tighten the space for custom layouts so there are more spaces for mobile

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/227234682-ea913e91-0f7a-4f4d-9390-a2abf81068c8.png)|![image](https://user-images.githubusercontent.com/107602352/227234729-112da42a-88f3-4213-be00-f5eedf7100c3.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open feed bumpkin modal
- open land expansion modal
- open inventory and chest
- open seed/crop shop modal

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
