### PR TITLE
[FIX] Add optional chaining to prevent crash

### DIFF
--- a/src/features/retreat/components/bank/RetreatBank.tsx
+++ b/src/features/retreat/components/bank/RetreatBank.tsx
@@ -50,7 +50,7 @@ export const RetreatBank: React.FC = () => {
       </div>
       <Modal show={isOpen} onHide={() => setIsOpen(false)} centered>
         <BankModal
-          farmAddress={goblinService.state.context.state.farmAddress as string}
+          farmAddress={goblinService.state?.context.state.farmAddress as string}
           onClose={() => setIsOpen(false)}
         />
       </Modal>


### PR DESCRIPTION
# Description

- add `?.` operator to prevent crash when `goblinService.state` is not defined yet (eg. running Sunflower Land locally without a test farm and visiting goblin village)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- run Sunflower Land locally while commenting out `VITE_API_URL` and visit goblin village

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
