### PR TITLE
[CHORE] Use custom components for helios blacksmith

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -59,7 +59,7 @@ interface RequirementsProps {
  * @param stock The stock of the item available to craft.  Undefined if the stock is unlimited.
  * @param isLimitedItem true if the item quantity is limited to a certain number in the blockchain, else false. Defaults to false.
  * @param details The item details.
- * @param boosts The available boosts of the item.
+ * @param boost The available boost of the item.
  * @param requirements The item quantity requirement.
  * @param actionView The view for displaying the crafting action.
  */
@@ -68,7 +68,7 @@ interface Props {
   stock?: Decimal;
   isLimitedItem?: boolean;
   details: ItemDetailsProps;
-  boosts?: string[];
+  boost?: string;
   requirements?: RequirementsProps;
   actionView?: JSX.Element;
 }
@@ -82,7 +82,7 @@ export const CraftingRequirements: React.FC<Props> = ({
   stock,
   isLimitedItem = false,
   details,
-  boosts = [],
+  boost: boost,
   requirements,
   actionView,
 }: Props) => {
@@ -139,18 +139,14 @@ export const CraftingRequirements: React.FC<Props> = ({
     );
   };
 
-  const getBoosts = () => {
-    if (!boosts) return <></>;
+  const getBoost = () => {
+    if (!boost) return <></>;
 
     return (
       <div className="flex flex-col space-y-1 mt-2">
-        {boosts.map((boost, index) => {
-          return (
-            <div key={index} className="flex justify-start sm:justify-center">
-              <Label type="info">{boost}</Label>
-            </div>
-          );
-        })}
+        <div className="flex justify-start sm:justify-center">
+          <Label type="info">{boost}</Label>
+        </div>
       </div>
     );
   };
@@ -223,7 +219,7 @@ export const CraftingRequirements: React.FC<Props> = ({
       <div className="flex flex-col justify-center px-1 py-0">
         {getStock()}
         {getItemDetail()}
-        {getBoosts()}
+        {getBoost()}
         {getRequirements()}
       </div>
       {actionView}

--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -82,7 +82,7 @@ export const CraftingRequirements: React.FC<Props> = ({
   stock,
   isLimitedItem = false,
   details,
-  boost: boost,
+  boost,
   requirements,
   actionView,
 }: Props) => {

--- a/src/features/helios/Helios.tsx
+++ b/src/features/helios/Helios.tsx
@@ -67,7 +67,7 @@ export const Helios: React.FC = () => {
         />
         <Decorations />
         <GrubShop />
-        <HeliosBlacksmith inventory={gameState.context.state.inventory} />
+        <HeliosBlacksmith />
         <Potions />
         <GarbageCollector />
         <ExoticShop />

--- a/src/features/helios/components/blacksmith/HeliosBlacksmith.tsx
+++ b/src/features/helios/components/blacksmith/HeliosBlacksmith.tsx
@@ -7,91 +7,58 @@ import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 
 import building from "assets/buildings/blacksmith_building.gif";
 
-import { Panel } from "components/ui/Panel";
-import { Tab } from "components/ui/Tab";
 import { HeliosBlacksmithItems } from "./component/HeliosBlacksmithItems";
-import { Inventory } from "features/game/types/game";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
-type Props = {
-  inventory: Inventory;
-};
-
-export const HeliosBlacksmith: React.FC<Props> = ({ inventory }) => {
+export const HeliosBlacksmith: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleClick = () => {
     setIsOpen(true);
   };
 
-  const Content = () => {
-    return (
-      <Panel
-        bumpkinParts={{
-          body: "Beige Farmer Potion",
-          hair: "Blacksmith Hair",
-          pants: "Brown Suspenders",
-          shirt: "Red Farmer Shirt",
-          tool: "Hammer",
-          background: "Farm Background",
-          shoes: "Black Farmer Boots",
-        }}
-        className="relative"
-        hasTabs
-      >
-        <div
-          className="absolute flex"
-          style={{
-            top: `${PIXEL_SCALE * 1}px`,
-            left: `${PIXEL_SCALE * 1}px`,
-            right: `${PIXEL_SCALE * 1}px`,
-          }}
-        >
-          <Tab isActive>
-            <img src={SUNNYSIDE.icons.hammer} className="h-5 mr-2" />
-            <span className="text-sm">Craft</span>
-          </Tab>
-          <img
-            src={SUNNYSIDE.icons.close}
-            className="absolute cursor-pointer z-20"
-            onClick={() => setIsOpen(false)}
-            style={{
-              top: `${PIXEL_SCALE * 1}px`,
-              right: `${PIXEL_SCALE * 1}px`,
-              width: `${PIXEL_SCALE * 11}px`,
-            }}
-          />
-        </div>
-        <HeliosBlacksmithItems onClose={() => setIsOpen(false)} />
-      </Panel>
-    );
-  };
-
   return (
-    <MapPlacement x={-8} y={0} height={4} width={6}>
-      <div
-        className="relative w-full h-full cursor-pointer hover:img-highlight"
-        onClick={handleClick}
-      >
+    <>
+      <MapPlacement x={-8} y={0} height={4} width={6}>
         <div
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 98}px`,
-            bottom: `${PIXEL_SCALE * 6}px`,
-            left: `${PIXEL_SCALE * -1}px`,
-          }}
+          className="relative w-full h-full cursor-pointer hover:img-highlight"
+          onClick={handleClick}
         >
-          <img
-            src={building}
+          <div
+            className="absolute"
             style={{
               width: `${PIXEL_SCALE * 98}px`,
+              bottom: `${PIXEL_SCALE * 6}px`,
+              left: `${PIXEL_SCALE * -1}px`,
             }}
-          />
+          >
+            <img
+              src={building}
+              style={{
+                width: `${PIXEL_SCALE * 98}px`,
+              }}
+            />
+          </div>
         </div>
-      </div>
+      </MapPlacement>
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
-        <Content />
+        <CloseButtonPanel
+          bumpkinParts={{
+            body: "Beige Farmer Potion",
+            hair: "Blacksmith Hair",
+            pants: "Brown Suspenders",
+            shirt: "Red Farmer Shirt",
+            tool: "Hammer",
+            background: "Farm Background",
+            shoes: "Black Farmer Boots",
+          }}
+          tabs={[{ icon: SUNNYSIDE.icons.hammer, name: "Craft" }]}
+          onClose={() => setIsOpen(false)}
+        >
+          <HeliosBlacksmithItems />
+        </CloseButtonPanel>
       </Modal>
-    </MapPlacement>
+    </>
   );
 };

--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -2,194 +2,98 @@ import React, { useContext, useState } from "react";
 import { useActor } from "@xstate/react";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
 
 import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
-import { Decimal } from "decimal.js-light";
 
 import { Button } from "components/ui/Button";
-import { Label } from "components/ui/Label";
 import {
   HeliosBlacksmithItem,
   HELIOS_BLACKSMITH_ITEMS,
 } from "features/game/types/collectibles";
-import { INITIAL_STOCK } from "features/game/lib/constants";
-import { Stock } from "components/ui/Stock";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 
-interface Props {
-  onClose: () => void;
-}
-
-export const HeliosBlacksmithItems: React.FC<Props> = ({ onClose }) => {
-  const [selected, setSelected] =
+export const HeliosBlacksmithItems: React.FC = () => {
+  const [selectedName, setSelectedName] =
     useState<HeliosBlacksmithItem>("Immortal Pear");
   const { setToast } = useContext(ToastContext);
   const { gameService, shortcutItem } = useContext(Context);
   const [
     {
       context: { state },
-      value,
     },
   ] = useActor(gameService);
   const inventory = state.inventory;
 
-  const item = HELIOS_BLACKSMITH_ITEMS[selected];
-  const isAlreadyCrafted = state.inventory[selected]?.greaterThanOrEqualTo(1);
+  const selectedItem = HELIOS_BLACKSMITH_ITEMS[selectedName];
+  const isAlreadyCrafted = inventory[selectedName]?.greaterThanOrEqualTo(1);
+
+  const lessIngredients = () =>
+    getKeys(selectedItem.ingredients).some((name) =>
+      selectedItem.ingredients[name]?.greaterThan(inventory[name] || 0)
+    );
 
   const craft = () => {
     gameService.send("collectible.crafted", {
-      name: selected,
+      name: selectedName,
     });
 
-    getKeys(item.ingredients).map((name) => {
+    getKeys(selectedItem.ingredients).map((name) => {
       const ingredient = ITEM_DETAILS[name];
       setToast({
         icon: ingredient.image,
-        content: `-${item.ingredients[name]}`,
+        content: `-${selectedItem.ingredients[name]}`,
       });
     });
     setToast({
-      icon: ITEM_DETAILS[selected].image,
+      icon: ITEM_DETAILS[selectedName].image,
       content: "+1",
     });
 
-    shortcutItem(selected);
+    shortcutItem(selectedName);
   };
-
-  const renderRemnants = (
-    missingIngredients: boolean,
-    inventoryAmount: Decimal,
-    requiredAmount: Decimal
-  ) => {
-    if (missingIngredients) {
-      // if inventory items is less than required items
-      return (
-        <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-      );
-    } else {
-      // if inventory items is equal to required items
-      return <span className="text-xs text-center">{`${requiredAmount}`}</span>;
-    }
-  };
-
-  const stock = state.stock[selected] || new Decimal(0);
-
-  const labelState = () => {
-    const max = INITIAL_STOCK(state)[selected];
-    const inventoryCount = inventory[selected] ?? new Decimal(0);
-    const inventoryFull = max ? inventoryCount.gt(max) : true;
-
-    if (stock?.equals(0)) {
-      return (
-        <Label type="danger" className="-mt-2 mb-1">
-          Sold out
-        </Label>
-      );
-    }
-
-    return <Stock item={{ name: selected }} inventoryFull={inventoryFull} />;
-  };
-
-  const lessIngredients = () => {
-    return getKeys(item.ingredients).some((ingredientName) => {
-      const inventoryAmount =
-        inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-      const requiredAmount =
-        item.ingredients[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-      return new Decimal(inventoryAmount).lessThan(requiredAmount);
-    });
-  };
-
-  // Price is added as an ingredient for layout purposes
-  const ingredientCount = getKeys(item.ingredients).length + 1;
 
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <div className="w-full sm:w-3/5 h-fit max-h-48 sm:max-h-96 overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
-        {getKeys(HELIOS_BLACKSMITH_ITEMS).map((name: HeliosBlacksmithItem) => (
-          <Box
-            isSelected={selected === name}
-            key={name}
-            onClick={() => setSelected(name)}
-            image={ITEM_DETAILS[name].image}
-            count={inventory[name]}
-          />
-        ))}
-      </div>
-      <OuterPanel className="w-full flex-1">
-        <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-          {labelState()}
-          <div className="flex space-x-2 items-center mt-1 sm:flex-col-reverse md:space-x-0">
-            <img
-              src={ITEM_DETAILS[selected].image}
-              className="w-5 sm:w-8 sm:my-1"
-              alt={selected}
-            />
-            <span className="sm:text-center mb-1">{selected}</span>
-          </div>
-          <span className="text-xs sm:text-center mb-1">
-            {item.description}
-          </span>
-
-          <Label className="mt-1 md:text-center" type="info">
-            {item.boost}
-          </Label>
-
-          <div className="border-t border-white w-full my-2" />
-          <div className="flex w-full justify-between max-h-14 sm:max-h-full sm:flex-col sm:items-center">
-            <div className="mb-1 flex flex-wrap sm:flex-nowrap w-[70%] sm:w-auto">
-              {getKeys(item.ingredients).map((ingredientName, index) => {
-                const details = ITEM_DETAILS[ingredientName];
-                const inventoryAmount =
-                  inventory[ingredientName]?.toDecimalPlaces(1) ||
-                  new Decimal(0);
-                const requiredAmount =
-                  item.ingredients?.[ingredientName]?.toDecimalPlaces(1) ||
-                  new Decimal(0);
-
-                // Ingredient difference
-                const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                  requiredAmount
-                );
-
-                return (
-                  <div
-                    className={`flex items-center space-x-1 ${
-                      ingredientCount > 2 ? "w-1/2" : "w-full"
-                    } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                    key={index}
-                  >
-                    <div className="w-5">
-                      <img src={details.image} className="h-5" />
-                    </div>
-                    {renderRemnants(
-                      lessIngredient,
-                      inventoryAmount,
-                      requiredAmount
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-        {isAlreadyCrafted ? (
-          <p className="text-xxs sm:text-xs text-center my-1">
-            Already crafted!
-          </p>
-        ) : (
-          <Button
-            disabled={stock?.lessThan(1) || lessIngredients()}
-            className="text-xxs sm:text-xs mt-1"
-            onClick={() => craft()}
-          >
-            Craft
-          </Button>
-        )}
-      </OuterPanel>
-    </div>
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          details={{
+            item: selectedName,
+          }}
+          boost={selectedItem.boost}
+          requirements={{
+            resources: selectedItem.ingredients,
+          }}
+          actionView={
+            isAlreadyCrafted ? (
+              <p className="text-xxs text-center mb-1">Already crafted!</p>
+            ) : (
+              <Button disabled={lessIngredients()} onClick={craft}>
+                Craft
+              </Button>
+            )
+          }
+        />
+      }
+      content={
+        <>
+          {getKeys(HELIOS_BLACKSMITH_ITEMS).map(
+            (name: HeliosBlacksmithItem) => (
+              <Box
+                isSelected={selectedName === name}
+                key={name}
+                onClick={() => setSelectedName(name)}
+                image={ITEM_DETAILS[name].image}
+                count={inventory[name]}
+              />
+            )
+          )}
+        </>
+      }
+    />
   );
 };

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -96,54 +96,49 @@ export const Recipes: React.FC<Props> = ({
   };
 
   return (
-    <>
-      <SplitScreenView
-        panel={
-          <CraftingRequirements
-            gameState={state}
-            details={{
-              item: selected.name,
-            }}
-            requirements={{
-              resources: selected.ingredients,
-              xp: new Decimal(
-                getFoodExpBoost(
-                  selected,
-                  state.bumpkin as Bumpkin,
-                  state.collectibles
-                )
-              ),
-              timeSeconds: getCookingTime(
-                selected.cookingSeconds,
-                state.bumpkin
-              ),
-            }}
-            actionView={Action()}
-          />
-        }
-        content={
-          <>
-            {craftingService && (
-              <InProgressInfo
-                craftingService={craftingService}
-                onClose={onClose}
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          details={{
+            item: selected.name,
+          }}
+          requirements={{
+            resources: selected.ingredients,
+            xp: new Decimal(
+              getFoodExpBoost(
+                selected,
+                state.bumpkin as Bumpkin,
+                state.collectibles
+              )
+            ),
+            timeSeconds: getCookingTime(selected.cookingSeconds, state.bumpkin),
+          }}
+          actionView={Action()}
+        />
+      }
+      content={
+        <>
+          {craftingService && (
+            <InProgressInfo
+              craftingService={craftingService}
+              onClose={onClose}
+            />
+          )}
+          {crafting && <p className="mb-2 w-full">Recipes</p>}
+          <div className="flex flex-wrap h-fit">
+            {recipes.map((item) => (
+              <Box
+                isSelected={selected.name === item.name}
+                key={item.name}
+                onClick={() => setSelected(item)}
+                image={ITEM_DETAILS[item.name].image}
+                count={inventory[item.name]}
               />
-            )}
-            {crafting && <p className="mb-2 w-full">Recipes</p>}
-            <div className="flex flex-wrap h-fit">
-              {recipes.map((item) => (
-                <Box
-                  isSelected={selected.name === item.name}
-                  key={item.name}
-                  onClick={() => setSelected(item)}
-                  image={ITEM_DETAILS[item.name].image}
-                  count={inventory[item.name]}
-                />
-              ))}
-            </div>
-          </>
-        }
-      />
-    </>
+            ))}
+          </div>
+        </>
+      }
+    />
   );
 };


### PR DESCRIPTION
# Description

- use custom component for helios blacksmith
- move modal outside of component to avoid unwanted modal refreshes
- display player inventory amount for resources (eg. show 19.9/10 apples instead of 10 apples if players have 19.9999 apples in inventory and the item requires 10 apples)
- fix issue where player does not have enough resources but the craft button is still enabled (craft button should be disabled if players have 9.9999 apples in inventory and the item requires 10 apples)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/227813644-6eed7b91-d552-4873-bd89-7659e94ef538.png)|![image](https://user-images.githubusercontent.com/107602352/227813611-e2682e73-e0aa-4215-b676-1c061fc23c8d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Buy items in helios blacksmith

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
