### PR TITLE
[CHORE] Use custom components for helios decorations shop

### DIFF
--- a/src/features/helios/components/decorations/Decorations.tsx
+++ b/src/features/helios/components/decorations/Decorations.tsx
@@ -16,43 +16,46 @@ export const Decorations: React.FC = () => {
   const handleClick = () => {
     setIsOpen(true);
   };
+
   return (
-    <MapPlacement x={-6} y={-5} height={3} width={5}>
-      <div
-        className="relative w-full h-full cursor-pointer hover:img-highlight"
-        onClick={handleClick}
-      >
-        <img
-          src={shadow}
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 15}px`,
-            left: `${PIXEL_SCALE * 2}px`,
-            bottom: `${PIXEL_SCALE * 4}px`,
-          }}
-        />
-        <img
-          src={retroGirl}
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 14}px`,
-            left: `${PIXEL_SCALE * 2}px`,
-            bottom: `${PIXEL_SCALE * 6}px`,
-          }}
-        />
-        <img
-          src={building}
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 50}px`,
-            right: `${PIXEL_SCALE * 8}px`,
-            bottom: `${PIXEL_SCALE * 6}px`,
-          }}
-        />
-      </div>
+    <>
+      <MapPlacement x={-6} y={-5} height={3} width={5}>
+        <div
+          className="relative w-full h-full cursor-pointer hover:img-highlight"
+          onClick={handleClick}
+        >
+          <img
+            src={shadow}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 15}px`,
+              left: `${PIXEL_SCALE * 2}px`,
+              bottom: `${PIXEL_SCALE * 4}px`,
+            }}
+          />
+          <img
+            src={retroGirl}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 14}px`,
+              left: `${PIXEL_SCALE * 2}px`,
+              bottom: `${PIXEL_SCALE * 6}px`,
+            }}
+          />
+          <img
+            src={building}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 50}px`,
+              right: `${PIXEL_SCALE * 8}px`,
+              bottom: `${PIXEL_SCALE * 6}px`,
+            }}
+          />
+        </div>
+      </MapPlacement>
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
         <DecorationShopItems onClose={() => setIsOpen(false)} />
       </Modal>
-    </MapPlacement>
+    </>
   );
 };

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -1,30 +1,23 @@
 import React, { useContext, useState } from "react";
-import classNames from "classnames";
 import { useActor } from "@xstate/react";
 
-import token from "assets/icons/token_2.png";
 import tokenStatic from "assets/icons/token_2.png";
 
 import { Box } from "components/ui/Box";
-import { OuterPanel } from "components/ui/Panel";
 
 import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ToastContext } from "features/game/toast/ToastQueueProvider";
-import { Decimal } from "decimal.js-light";
 import {
   Decoration,
   HELIOS_DECORATIONS,
 } from "features/game/types/decorations";
 import { Button } from "components/ui/Button";
-import { Label } from "components/ui/Label";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 
-interface Props {
-  onClose: () => void;
-}
-
-export const DecorationItems: React.FC<Props> = ({ onClose }) => {
+export const DecorationItems: React.FC = () => {
   const [selected, setSelected] = useState<Decoration>(
     HELIOS_DECORATIONS()["White Tulips"]
   );
@@ -38,6 +31,18 @@ export const DecorationItems: React.FC<Props> = ({ onClose }) => {
   const inventory = state.inventory;
 
   const price = selected.sfl;
+
+  const lessFunds = () => {
+    if (!price) return false;
+
+    return state.balance.lessThan(price.toString());
+  };
+
+  const lessIngredients = () =>
+    getKeys(selected.ingredients).some((name) =>
+      selected.ingredients[name]?.greaterThan(inventory[name] || 0)
+    );
+
   const buy = () => {
     gameService.send("decoration.bought", {
       item: selected.name,
@@ -47,127 +52,53 @@ export const DecorationItems: React.FC<Props> = ({ onClose }) => {
       icon: tokenStatic,
       content: `-${selected.sfl?.toString()}`,
     });
+    getKeys(selected.ingredients).map((name) => {
+      const ingredient = ITEM_DETAILS[name];
+      setToast({
+        icon: ingredient.image,
+        content: `-${selected.ingredients[name]}`,
+      });
+    });
+    setToast({
+      icon: ITEM_DETAILS[selected.name].image,
+      content: "+1",
+    });
 
     shortcutItem(selected.name);
   };
 
-  const lessFunds = () => {
-    if (!price) return false;
-
-    return state.balance.lessThan(price.toString());
-  };
-
-  const renderRemnants = (
-    missingIngredients: boolean,
-    inventoryAmount: Decimal,
-    requiredAmount: Decimal
-  ) => {
-    if (missingIngredients) {
-      // if inventory items is less than required items
-      return (
-        <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-      );
-    } else {
-      // if inventory items is equal to required items
-      return <span className="text-xs text-center">{`${requiredAmount}`}</span>;
-    }
-  };
-
-  const lessIngredients = () => {
-    return getKeys(selected.ingredients).some((ingredientName) => {
-      const inventoryAmount =
-        inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-      const requiredAmount =
-        selected.ingredients[ingredientName]?.toDecimalPlaces(1) ||
-        new Decimal(0);
-      return new Decimal(inventoryAmount).lessThan(requiredAmount);
-    });
-  };
-
-  // Price is added as an ingredient for layout purposes
-  const ingredientCount = getKeys(selected.ingredients).length + 1;
-
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <div className="w-full sm:w-3/5 h-fit max-h-48 sm:max-h-96 overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap">
-        {Object.values(HELIOS_DECORATIONS()).map((item: Decoration) => (
-          <Box
-            isSelected={selected.name === item.name}
-            key={item.name}
-            onClick={() => setSelected(item)}
-            image={ITEM_DETAILS[item.name].image}
-            count={inventory[item.name]}
-          />
-        ))}
-      </div>
-      <OuterPanel className="w-full flex-1">
-        <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-          <div className="flex space-x-2 items-center mt-1 sm:flex-col-reverse md:space-x-0">
-            <img
-              src={ITEM_DETAILS[selected.name].image}
-              className="w-5 sm:w-8 sm:my-1"
-              alt={selected.name}
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          details={{
+            item: selected.name,
+          }}
+          requirements={{
+            sfl: price,
+            resources: selected.ingredients,
+          }}
+          actionView={
+            <Button disabled={lessFunds() || lessIngredients()} onClick={buy}>
+              Buy
+            </Button>
+          }
+        />
+      }
+      content={
+        <>
+          {Object.values(HELIOS_DECORATIONS()).map((item: Decoration) => (
+            <Box
+              isSelected={selected.name === item.name}
+              key={item.name}
+              onClick={() => setSelected(item)}
+              image={ITEM_DETAILS[item.name].image}
+              count={inventory[item.name]}
             />
-            <span className="sm:text-center mb-1">{selected.name}</span>
-          </div>
-          <div className="border-t border-white w-full my-2" />
-          <div className="flex w-full justify-between max-h-14 sm:max-h-full sm:flex-col sm:items-center">
-            <div className="mb-1 flex flex-wrap sm:flex-nowrap w-[70%] sm:w-auto">
-              <div className="flex items-center space-x-1 shrink-0 w-1/2 sm:w-full sm:justify-center my-[1px] sm:mb-1">
-                <div className="w-5">
-                  <img src={token} className="h-5 mr-1" />
-                </div>
-                <span
-                  className={classNames("text-xs text-center", {
-                    "text-red-500": lessFunds(),
-                  })}
-                >
-                  {`${price}`}
-                </span>
-              </div>
-              {getKeys(selected.ingredients).map((ingredientName, index) => {
-                const item = ITEM_DETAILS[ingredientName];
-                const inventoryAmount =
-                  inventory[ingredientName]?.toDecimalPlaces(1) ||
-                  new Decimal(0);
-                const requiredAmount =
-                  selected.ingredients[ingredientName]?.toDecimalPlaces(1) ||
-                  new Decimal(0);
-
-                // Ingredient difference
-                const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                  requiredAmount
-                );
-
-                return (
-                  <div
-                    className={`flex items-center space-x-1 ${
-                      ingredientCount > 2 ? "w-1/2" : "w-full"
-                    } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                    key={index}
-                  >
-                    <div className="w-5">
-                      <img src={item.image} className="h-5" />
-                    </div>
-                    {renderRemnants(
-                      lessIngredient,
-                      inventoryAmount,
-                      requiredAmount
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-        <Button
-          disabled={lessFunds() || lessIngredients()}
-          className="text-xxs sm:text-xs mt-1"
-          onClick={() => buy()}
-        >
-          Buy
-        </Button>
-      </OuterPanel>
-    </div>
+          ))}
+        </>
+      }
+    />
   );
 };

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -76,8 +76,8 @@ export const DecorationItems: React.FC = () => {
             item: selected.name,
           }}
           requirements={{
-            sfl: price,
             resources: selected.ingredients,
+            sfl: price,
           }}
           actionView={
             <Button disabled={lessFunds() || lessIngredients()} onClick={buy}>

--- a/src/features/helios/components/decorations/component/DecorationShopItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationShopItems.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 
-import { Panel } from "components/ui/Panel";
-import { Tab } from "components/ui/Tab";
 import { DecorationItems } from "./DecorationItems";
-import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 interface Props {
   onClose: () => void;
@@ -12,9 +10,7 @@ interface Props {
 
 export const DecorationShopItems: React.FC<Props> = ({ onClose }) => {
   return (
-    <Panel
-      className="relative"
-      hasTabs
+    <CloseButtonPanel
       bumpkinParts={{
         body: "Beige Farmer Potion",
         hair: "Red Long Hair",
@@ -24,31 +20,10 @@ export const DecorationShopItems: React.FC<Props> = ({ onClose }) => {
         background: "Farm Background",
         shoes: "Black Farmer Boots",
       }}
+      tabs={[{ icon: SUNNYSIDE.icons.seeds, name: "Decorations" }]}
+      onClose={onClose}
     >
-      <div
-        className="absolute flex"
-        style={{
-          top: `${PIXEL_SCALE * 1}px`,
-          left: `${PIXEL_SCALE * 1}px`,
-          right: `${PIXEL_SCALE * 1}px`,
-        }}
-      >
-        <Tab isActive>
-          <img src={SUNNYSIDE.icons.seeds} className="h-5 mr-2" />
-          <span className="text-sm">Decorations</span>
-        </Tab>
-        <img
-          src={SUNNYSIDE.icons.close}
-          className="absolute cursor-pointer z-20"
-          onClick={onClose}
-          style={{
-            top: `${PIXEL_SCALE * 1}px`,
-            right: `${PIXEL_SCALE * 1}px`,
-            width: `${PIXEL_SCALE * 11}px`,
-          }}
-        />
-      </div>
-      <DecorationItems onClose={onClose} />
-    </Panel>
+      <DecorationItems />
+    </CloseButtonPanel>
   );
 };


### PR DESCRIPTION
# Description

- use custom component for helios decorations shop
- move modal outside of component to avoid unwanted modal refreshes
- display player inventory amount for resources (eg. show 399.9/200 potatoes instead of 200 apples if players have 399.9999 potatoes in inventory and the item requires 200 potatoes)
- fix issue where player does not have enough resources but the craft button is still enabled (craft button should be disabled if players have 199.9999 potatoes in inventory and the item requires 200 potatoes)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/227978864-e2df898a-1b81-462f-ac82-2e74ee6a241c.png)|![image](https://user-images.githubusercontent.com/107602352/227978903-c18ac0be-9f6e-4e2f-a13e-81862fd39bfa.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Buy items in helios decorations shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
