### PR TITLE
[FIX] Return shortcutItem call on buy/craft action in Market/Workbench

### DIFF
--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -3,7 +3,7 @@ import { CHORES } from "../types/chores";
 import { Bumpkin, GameState, Inventory, LandExpansion } from "../types/game";
 
 const INITIAL_STOCK: Inventory = {
-  "Sunflower Seed": new Decimal(0),
+  "Sunflower Seed": new Decimal(400),
   "Potato Seed": new Decimal(200),
   "Pumpkin Seed": new Decimal(100),
   "Carrot Seed": new Decimal(100),

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -72,6 +72,8 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       icon: ITEM_DETAILS[selectedName].image,
       content: `+${amount}`,
     });
+
+    shortcutItem(selectedName);
   };
 
   const lessFunds = (amount = 1) => {

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -105,6 +105,8 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
         content: `-${selected.ingredients[name]?.mul(amount)}`,
       });
     });
+
+    shortcutItem(selectedName);
   };
 
   const stock = state.stock[selectedName] || new Decimal(0);


### PR DESCRIPTION
# Description

Sunflower seeds were not selected when you buy sunflower seeds right after opening market since there were no select action, only buy.
Same for axe and workbench.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
