### PR TITLE
[FIX] Select treasure island tools in a more consistent way

### DIFF
--- a/src/features/treasureIsland/components/TreasureShopBuy.tsx
+++ b/src/features/treasureIsland/components/TreasureShopBuy.tsx
@@ -50,6 +50,11 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
     return state.balance.lessThan(price.mul(amount));
   };
 
+  const onToolClick = (seedName: TreasureToolName) => {
+    setSelectedName(seedName);
+    shortcutItem(seedName);
+  };
+
   const craft = (event: SyntheticEvent, amount = BUY_AMOUNT) => {
     event.stopPropagation();
     gameService.send("tool.crafted", {
@@ -116,7 +121,7 @@ export const TreasureShopBuy: React.FC<Props> = ({ onClose }) => {
             <Box
               isSelected={selectedName === toolName}
               key={toolName}
-              onClick={() => setSelectedName(toolName)}
+              onClick={() => onToolClick(toolName)}
               image={ITEM_DETAILS[toolName].image}
               count={inventory[toolName]}
             />


### PR DESCRIPTION
# Description

- shortcut item when selecting treasure islnad tool in shop
  - based on https://github.com/sunflower-land/sunflower-land/pull/2356 and https://github.com/sunflower-land/sunflower-land/pull/2383

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- select tools in treasure island shop
- buy tools in treasure island shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
