### PR TITLE
[CHORE] Use custom components for goblin village crafting stations

### DIFF
--- a/src/features/retreat/Game.tsx
+++ b/src/features/retreat/Game.tsx
@@ -143,9 +143,7 @@ export const Game = () => {
               <RetreatStorageHouse />
               <RetreatHotAirBalloon />
               <RetreatTailor />
-              <RetreatBlacksmith
-                inventory={goblinState.context.state.inventory}
-              />
+              <RetreatBlacksmith />
               {/* <Auctioneer /> */}
               <RetreatPirate />
               <Resale />

--- a/src/features/retreat/components/blacksmith/RetreatBlacksmith.tsx
+++ b/src/features/retreat/components/blacksmith/RetreatBlacksmith.tsx
@@ -7,15 +7,10 @@ import { blacksmithAudio } from "lib/utils/sfx";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { Modal } from "react-bootstrap";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { Inventory } from "features/game/types/game";
 import { GoblinBlacksmithItems } from "./components/GoblinBlacksmithItems";
 import { SUNNYSIDE } from "assets/sunnyside";
 
-interface Props {
-  inventory: Inventory;
-}
-
-export const RetreatBlacksmith: React.FC<Props> = ({ inventory }) => {
+export const RetreatBlacksmith: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const openBlacksmith = () => {
@@ -27,34 +22,36 @@ export const RetreatBlacksmith: React.FC<Props> = ({ inventory }) => {
   };
 
   return (
-    <MapPlacement x={3} y={-2} height={5} width={8}>
-      <div
-        className="relative w-full h-full cursor-pointer hover:img-highlight"
-        onClick={openBlacksmith}
-      >
-        <img
-          src={blacksmith}
-          alt="market"
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 121}px`,
-            right: `${PIXEL_SCALE * 1}px`,
-            bottom: `${PIXEL_SCALE * 6}px`,
-          }}
-        />
+    <>
+      <MapPlacement x={3} y={-2} height={5} width={8}>
         <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            bottom: `${PIXEL_SCALE * 3}px`,
-          }}
+          className="relative w-full h-full cursor-pointer hover:img-highlight"
+          onClick={openBlacksmith}
         >
-          <Action
-            className="pointer-events-none"
-            text="Craft"
-            icon={SUNNYSIDE.icons.hammer}
+          <img
+            src={blacksmith}
+            alt="market"
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 121}px`,
+              right: `${PIXEL_SCALE * 1}px`,
+              bottom: `${PIXEL_SCALE * 6}px`,
+            }}
           />
+          <div
+            className="flex justify-center absolute w-full pointer-events-none"
+            style={{
+              bottom: `${PIXEL_SCALE * 3}px`,
+            }}
+          >
+            <Action
+              className="pointer-events-none"
+              text="Craft"
+              icon={SUNNYSIDE.icons.hammer}
+            />
+          </div>
         </div>
-      </div>
+      </MapPlacement>
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
         <CloseButtonPanel
           bumpkinParts={{
@@ -72,6 +69,6 @@ export const RetreatBlacksmith: React.FC<Props> = ({ inventory }) => {
           <GoblinBlacksmithItems onClose={() => setIsOpen(false)} />
         </CloseButtonPanel>
       </Modal>
-    </MapPlacement>
+    </>
   );
 };

--- a/src/features/retreat/components/blacksmith/components/GoblinBlacksmithItems.tsx
+++ b/src/features/retreat/components/blacksmith/components/GoblinBlacksmithItems.tsx
@@ -4,24 +4,21 @@ import { useActor } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getKeys } from "features/game/types/craftables";
-import { GameState, InventoryItemName } from "features/game/types/game";
+import { InventoryItemName } from "features/game/types/game";
 import { ItemSupply, totalSupply } from "lib/blockchain/Inventory";
 import { Context } from "features/game/GoblinProvider";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { Button } from "components/ui/Button";
-import { OuterPanel } from "components/ui/Panel";
 import Decimal from "decimal.js-light";
 
-import { Label } from "components/ui/Label";
 import {
-  GoblinBlacksmithCraftable,
   GoblinBlacksmithItemName,
   GOBLIN_BLACKSMITH_ITEMS,
 } from "features/game/types/collectibles";
-import { SquareIcon } from "components/ui/SquareIcon";
-
-const TAB_CONTENT_HEIGHT = 364;
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
+import { Loading } from "features/auth/components";
 
 const API_URL = CONFIG.API_URL;
 
@@ -34,34 +31,6 @@ const ALLOW_MULTIPLE_MINTS: InventoryItemName[] = [
 interface Props {
   onClose: () => void;
 }
-
-const Items: React.FC<{
-  items: Partial<Record<GoblinBlacksmithItemName, GoblinBlacksmithCraftable>>;
-  selected: InventoryItemName;
-  inventory: GameState["inventory"];
-  onClick: (name: GoblinBlacksmithItemName) => void;
-}> = ({ items, selected, inventory, onClick }) => {
-  return (
-    <div
-      className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
-      style={{ maxHeight: TAB_CONTENT_HEIGHT }}
-    >
-      <div className="flex flex-wrap h-fit">
-        {getKeys(items)
-          .filter((name) => !GOBLIN_BLACKSMITH_ITEMS[name].disabled)
-          .map((name) => (
-            <Box
-              isSelected={selected === name}
-              key={name}
-              onClick={() => onClick(name)}
-              image={ITEM_DETAILS[name].image}
-              count={inventory[name]}
-            />
-          ))}
-      </div>
-    </div>
-  );
-};
 
 export const GoblinBlacksmithItems: React.FC<Props> = ({ onClose }) => {
   const { goblinService } = useContext(Context);
@@ -97,18 +66,12 @@ export const GoblinBlacksmithItems: React.FC<Props> = ({ onClose }) => {
 
   const inventory = state.inventory;
 
-  const selected = GOBLIN_BLACKSMITH_ITEMS[selectedName];
+  const selectedItem = GOBLIN_BLACKSMITH_ITEMS[selectedName];
 
-  const lessIngredients = () => {
-    return getKeys(selected.ingredients).some((ingredientName) => {
-      const inventoryAmount =
-        inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-      const requiredAmount =
-        selected.ingredients[ingredientName]?.toDecimalPlaces(1) ||
-        new Decimal(0);
-      return new Decimal(inventoryAmount).lessThan(requiredAmount);
-    });
-  };
+  const lessIngredients = () =>
+    getKeys(selectedItem.ingredients).some((name) =>
+      selectedItem.ingredients[name]?.greaterThan(inventory[name] || 0)
+    );
 
   const craft = async () => {
     goblinService.send("MINT", { item: selectedName, captcha: "" });
@@ -118,137 +81,73 @@ export const GoblinBlacksmithItems: React.FC<Props> = ({ onClose }) => {
   if (isLoading) {
     return (
       <div className="h-60">
-        <span className="loading">Loading</span>
+        <Loading />
       </div>
     );
   }
 
   let amountLeft = 0;
 
-  if (supply && selected.supply) {
-    amountLeft = selected.supply - supply[selectedName]?.toNumber();
+  if (supply && selectedItem.supply) {
+    amountLeft = selectedItem.supply - supply[selectedName]?.toNumber();
   }
 
   const soldOut = amountLeft <= 0;
 
-  const renderRemnants = (
-    missingIngredients: boolean,
-    inventoryAmount: Decimal,
-    requiredAmount: Decimal
-  ) => {
-    if (missingIngredients) {
-      // if inventory items is less than required items
-      return (
-        <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-      );
-    } else {
-      // if inventory items is equal to required items
-      return <span className="text-xs text-center">{`${requiredAmount}`}</span>;
-    }
-  };
-
   const Action = () => {
-    if (soldOut) return null;
+    if (soldOut) return <></>;
 
-    if (selected.disabled) {
-      return <span className="text-xs text-center block">Coming soon</span>;
-    }
+    if (selectedItem.disabled)
+      return <span className="text-xxs text-center my-1">Coming soon</span>;
 
     if (
       mintedAtTimes[selectedName] &&
       !ALLOW_MULTIPLE_MINTS.includes(selectedName)
     )
-      return (
-        <div className="flex flex-col text-center mt-2 border-y border-white w-full">
-          <p className="text-xxs my-2">Already minted!</p>
-        </div>
-      );
+      return <span className="text-xxs text-center my-1">Already minted!</span>;
 
     return (
-      <>
-        <Button
-          disabled={lessIngredients() || selected.ingredients === undefined}
-          className="text-xs mt-1"
-          onClick={() => craft()}
-        >
-          Craft
-        </Button>
-      </>
+      <Button
+        disabled={lessIngredients() || selectedItem.ingredients === undefined}
+        onClick={craft}
+      >
+        Craft
+      </Button>
     );
   };
 
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <Items
-        items={GOBLIN_BLACKSMITH_ITEMS}
-        selected={selectedName}
-        inventory={inventory}
-        onClick={setSelectedName}
-      />
-      <OuterPanel className="w-full flex-1">
-        <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-          {soldOut && (
-            <Label type="danger" className="-mt-2 mb-1">
-              Sold out
-            </Label>
-          )}
-          {!!selected.supply && amountLeft > 0 && (
-            <Label type="info" className="-mt-2 mb-1">
-              {`${amountLeft} left`}
-            </Label>
-          )}
-          <div className="flex space-x-2 items-center mt-1 sm:flex-col-reverse md:space-x-0">
-            <img
-              src={ITEM_DETAILS[selectedName].image}
-              className="w-5 sm:w-8 sm:my-1"
-              alt={selectedName}
-            />
-            <span className="sm:text-center mb-1">{selectedName}</span>
-          </div>
-          <span className="text-xs sm:text-center mb-1">
-            {selected.description}
-          </span>
-          {!!selected.boost && (
-            <Label className="mt-1 md:text-center" type="info">
-              {selected.boost}
-            </Label>
-          )}
-          <div className="border-t border-white w-full mt-2 pt-1 text-center">
-            {getKeys(selected.ingredients).map((ingredientName, index) => {
-              const details = ITEM_DETAILS[ingredientName];
-              const inventoryAmount =
-                inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-              const requiredAmount =
-                selected.ingredients?.[ingredientName]?.toDecimalPlaces(1) ||
-                new Decimal(0);
-
-              // Ingredient difference
-              const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                requiredAmount
-              );
-
-              const ingredientCount = getKeys(selected.ingredients).length + 1;
-
-              return (
-                <div
-                  className={`flex items-center space-x-1 ${
-                    ingredientCount > 2 ? "w-1/2" : "w-full"
-                  } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                  key={index}
-                >
-                  <SquareIcon icon={details.image} width={7} />
-                  {renderRemnants(
-                    lessIngredient,
-                    inventoryAmount,
-                    requiredAmount
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-        {Action()}
-      </OuterPanel>
-    </div>
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          stock={new Decimal(amountLeft)}
+          isLimitedItem={true}
+          details={{
+            item: selectedName,
+          }}
+          boost={selectedItem.boost}
+          requirements={{
+            resources: selectedItem.ingredients,
+          }}
+          actionView={Action()}
+        />
+      }
+      content={
+        <>
+          {getKeys(GOBLIN_BLACKSMITH_ITEMS)
+            .filter((name) => !GOBLIN_BLACKSMITH_ITEMS[name].disabled)
+            .map((name) => (
+              <Box
+                isSelected={selectedName === name}
+                key={name}
+                onClick={() => setSelectedName(name)}
+                image={ITEM_DETAILS[name].image}
+                count={inventory[name]}
+              />
+            ))}
+        </>
+      }
+    />
   );
 };

--- a/src/features/retreat/components/pirate/RetreatPirate.tsx
+++ b/src/features/retreat/components/pirate/RetreatPirate.tsx
@@ -33,34 +33,36 @@ export const RetreatPirate: React.FC = () => {
   };
 
   return (
-    <MapPlacement x={16} y={-3} height={3} width={2}>
-      <div
-        className="relative w-full h-full cursor-pointer hover:img-highlight"
-        onClick={openPirate}
-      >
-        <NPC {...bumpkin} />
-        <img
-          src={SUNNYSIDE.decorations.treasure_chest}
-          className="absolute"
-          style={{
-            width: `${PIXEL_SCALE * 16}px`,
-            left: `${GRID_WIDTH_PX * 1}px`,
-            top: `${GRID_WIDTH_PX * 1}px`,
-          }}
-        />
+    <>
+      <MapPlacement x={16} y={-3} height={3} width={2}>
         <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            bottom: `${PIXEL_SCALE * -3}px`,
-          }}
+          className="relative w-full h-full cursor-pointer hover:img-highlight"
+          onClick={openPirate}
         >
-          <Action
-            className="pointer-events-none"
-            text="Pirate"
-            icon={SUNNYSIDE.icons.basket}
+          <NPC {...bumpkin} />
+          <img
+            src={SUNNYSIDE.decorations.treasure_chest}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 16}px`,
+              left: `${GRID_WIDTH_PX * 1}px`,
+              top: `${GRID_WIDTH_PX * 1}px`,
+            }}
           />
+          <div
+            className="flex justify-center absolute w-full pointer-events-none"
+            style={{
+              bottom: `${PIXEL_SCALE * -3}px`,
+            }}
+          >
+            <Action
+              className="pointer-events-none"
+              text="Pirate"
+              icon={SUNNYSIDE.icons.basket}
+            />
+          </div>
         </div>
-      </div>
+      </MapPlacement>
       <Modal centered show={isOpen} onHide={() => setIsOpen(false)}>
         <CloseButtonPanel
           bumpkinParts={bumpkin}
@@ -70,6 +72,6 @@ export const RetreatPirate: React.FC = () => {
           <GoblinPirateItems onClose={() => setIsOpen(false)} />
         </CloseButtonPanel>
       </Modal>
-    </MapPlacement>
+    </>
   );
 };

--- a/src/features/retreat/components/pirate/components/GoblinPirateItems.tsx
+++ b/src/features/retreat/components/pirate/components/GoblinPirateItems.tsx
@@ -4,58 +4,26 @@ import { useActor } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getKeys } from "features/game/types/craftables";
-import { GameState, InventoryItemName } from "features/game/types/game";
 import { ItemSupply, totalSupply } from "lib/blockchain/Inventory";
 import { Context } from "features/game/GoblinProvider";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { Button } from "components/ui/Button";
-import { OuterPanel } from "components/ui/Panel";
 import Decimal from "decimal.js-light";
 
-import { Label } from "components/ui/Label";
 import {
-  GoblinPirateCraftable,
   GoblinPirateItemName,
   GOBLIN_PIRATE_ITEMS,
 } from "features/game/types/collectibles";
-import { SquareIcon } from "components/ui/SquareIcon";
-
-const TAB_CONTENT_HEIGHT = 364;
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
+import { Loading } from "features/auth/components";
 
 const API_URL = CONFIG.API_URL;
 
 interface Props {
   onClose: () => void;
 }
-
-const Items: React.FC<{
-  items: Partial<Record<GoblinPirateItemName, GoblinPirateCraftable>>;
-  selected: InventoryItemName;
-  inventory: GameState["inventory"];
-  onClick: (name: GoblinPirateItemName) => void;
-}> = ({ items, selected, inventory, onClick }) => {
-  return (
-    <div
-      className="w-full sm:w-3/5 h-fit h-fit overflow-y-auto scrollable overflow-x-hidden p-1 mt-1 sm:mt-0 sm:mr-1 flex flex-wrap"
-      style={{ maxHeight: TAB_CONTENT_HEIGHT }}
-    >
-      <div className="flex flex-wrap h-fit">
-        {getKeys(items)
-          .filter((name) => !GOBLIN_PIRATE_ITEMS[name].disabled)
-          .map((name) => (
-            <Box
-              isSelected={selected === name}
-              key={name}
-              onClick={() => onClick(name)}
-              image={ITEM_DETAILS[name].image}
-              count={inventory[name]}
-            />
-          ))}
-      </div>
-    </div>
-  );
-};
 
 export const GoblinPirateItems: React.FC<Props> = ({ onClose }) => {
   const { goblinService } = useContext(Context);
@@ -91,18 +59,12 @@ export const GoblinPirateItems: React.FC<Props> = ({ onClose }) => {
 
   const inventory = state.inventory;
 
-  const selected = GOBLIN_PIRATE_ITEMS[selectedName];
+  const selectedItem = GOBLIN_PIRATE_ITEMS[selectedName];
 
-  const lessIngredients = () => {
-    return getKeys(selected.ingredients).some((ingredientName) => {
-      const inventoryAmount =
-        inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-      const requiredAmount =
-        selected.ingredients[ingredientName]?.toDecimalPlaces(1) ||
-        new Decimal(0);
-      return new Decimal(inventoryAmount).lessThan(requiredAmount);
-    });
-  };
+  const lessIngredients = () =>
+    getKeys(selectedItem.ingredients).some((name) =>
+      selectedItem.ingredients[name]?.greaterThan(inventory[name] || 0)
+    );
 
   const craft = async () => {
     goblinService.send("MINT", { item: selectedName, captcha: "" });
@@ -112,136 +74,71 @@ export const GoblinPirateItems: React.FC<Props> = ({ onClose }) => {
   if (isLoading) {
     return (
       <div className="h-60">
-        <span className="loading">Loading</span>
+        <Loading />
       </div>
     );
   }
 
   let amountLeft = 0;
 
-  if (supply && selected.supply) {
-    amountLeft = selected.supply - supply[selectedName]?.toNumber();
+  if (supply && selectedItem.supply) {
+    amountLeft = selectedItem.supply - supply[selectedName]?.toNumber();
   }
 
   const soldOut = amountLeft <= 0;
 
-  const renderRemnants = (
-    missingIngredients: boolean,
-    inventoryAmount: Decimal,
-    requiredAmount: Decimal
-  ) => {
-    if (missingIngredients) {
-      // if inventory items is less than required items
-      return (
-        <Label type="danger">{`${inventoryAmount}/${requiredAmount}`}</Label>
-      );
-    } else {
-      // if inventory items is equal to required items
-      return <span className="text-xs text-center">{`${requiredAmount}`}</span>;
-    }
-  };
-
   const Action = () => {
-    if (soldOut) return null;
+    if (soldOut) return <></>;
 
-    if (selected.disabled) {
-      return <span className="text-xs text-center block">Coming soon</span>;
+    if (selectedItem.disabled) {
+      return <span className="text-xxs text-center my-1">Coming soon</span>;
     }
-
-    console.log(mintedAtTimes[selectedName]);
 
     if (mintedAtTimes[selectedName])
-      return (
-        <div className="flex flex-col text-center mt-2 border-y border-white w-full">
-          <p className="text-xxs my-2">Already minted!</p>
-        </div>
-      );
+      return <span className="text-xxs text-center my-1">Already minted!</span>;
 
     return (
-      <>
-        <Button
-          disabled={lessIngredients() || selected.ingredients === undefined}
-          className="text-xs mt-1"
-          onClick={() => craft()}
-        >
-          Craft
-        </Button>
-      </>
+      <Button
+        disabled={lessIngredients() || selectedItem.ingredients === undefined}
+        onClick={craft}
+      >
+        Craft
+      </Button>
     );
   };
 
   return (
-    <div className="flex flex-col-reverse sm:flex-row">
-      <Items
-        items={GOBLIN_PIRATE_ITEMS}
-        selected={selectedName}
-        inventory={inventory}
-        onClick={setSelectedName}
-      />
-      <OuterPanel className="w-full flex-1">
-        <div className="flex flex-col justify-center items-start sm:items-center p-2 pb-0 relative">
-          {soldOut && (
-            <Label type="danger" className="-mt-2 mb-1">
-              Sold out
-            </Label>
-          )}
-          {!!selected.supply && amountLeft > 0 && (
-            <Label type="info" className="-mt-2 mb-1">
-              {`${amountLeft} left`}
-            </Label>
-          )}
-          <div className="flex space-x-2 items-center mt-1 sm:flex-col-reverse md:space-x-0">
-            <img
-              src={ITEM_DETAILS[selectedName].image}
-              className="w-5 sm:w-8 sm:my-1"
-              alt={selectedName}
-            />
-            <span className="sm:text-center mb-1">{selectedName}</span>
-          </div>
-          <span className="text-xs sm:text-center mb-1">
-            {selected.description}
-          </span>
-          {!!selected.boost && (
-            <Label className="mt-1 md:text-center" type="info">
-              {selected.boost}
-            </Label>
-          )}
-          <div className="border-t border-white w-full mt-2 pt-1 text-center">
-            {getKeys(selected.ingredients).map((ingredientName, index) => {
-              const details = ITEM_DETAILS[ingredientName];
-              const inventoryAmount =
-                inventory[ingredientName]?.toDecimalPlaces(1) || new Decimal(0);
-              const requiredAmount =
-                selected.ingredients?.[ingredientName]?.toDecimalPlaces(1) ||
-                new Decimal(0);
-
-              // Ingredient difference
-              const lessIngredient = new Decimal(inventoryAmount).lessThan(
-                requiredAmount
-              );
-
-              const ingredientCount = getKeys(selected.ingredients).length + 1;
-
-              return (
-                <div
-                  className={`flex items-center space-x-1 ${
-                    ingredientCount > 2 ? "w-1/2" : "w-full"
-                  } shrink-0 sm:justify-center my-[1px] sm:mb-1 sm:w-full`}
-                  key={index}
-                >
-                  <SquareIcon icon={details.image} width={7} />
-                  {renderRemnants(
-                    lessIngredient,
-                    inventoryAmount,
-                    requiredAmount
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-        {Action()}
-      </OuterPanel>
-    </div>
+    <SplitScreenView
+      panel={
+        <CraftingRequirements
+          gameState={state}
+          stock={new Decimal(amountLeft)}
+          isLimitedItem={true}
+          details={{
+            item: selectedName,
+          }}
+          boost={selectedItem.boost}
+          requirements={{
+            resources: selectedItem.ingredients,
+          }}
+          actionView={Action()}
+        />
+      }
+      content={
+        <>
+          {getKeys(GOBLIN_PIRATE_ITEMS)
+            .filter((name) => !GOBLIN_PIRATE_ITEMS[name].disabled)
+            .map((name) => (
+              <Box
+                isSelected={selectedName === name}
+                key={name}
+                onClick={() => setSelectedName(name)}
+                image={ITEM_DETAILS[name].image}
+                count={inventory[name]}
+              />
+            ))}
+        </>
+      }
+    />
   );
 };


### PR DESCRIPTION
# Description

- use custom component for goblin blacksmith and goblin pirate items shop
- move modal outside of component to avoid unwanted modal refreshes
- display player inventory amount for resources (eg. show 99.9/30 wood instead of 30 wood if players have 99.9999 wood in inventory and the item requires 30 wood)
- fix issue where player does not have enough resources but the craft button is still enabled (craft button should be disabled if players have 29.9999 wood in inventory and the item requires 30 wood)
- minor layout improvements

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/228438782-55493e7d-3d81-4ddf-a051-b847f0dccef2.png)|![image](https://user-images.githubusercontent.com/107602352/228438711-e3ca9f8a-df6d-4cf5-9f13-9f92599de9c7.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Craft items in goblin blacksmith and goblin pirate item shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
