### PR TITLE
[FIX] Possible error when clicking treasure island holes too fast

### DIFF
--- a/src/features/treasureIsland/components/SandPlot.tsx
+++ b/src/features/treasureIsland/components/SandPlot.tsx
@@ -211,6 +211,10 @@ export const SandPlot: React.FC<{
 
   const handleDig = () => {
     const holes = gameState.context.state.treasureIsland?.holes ?? {};
+
+    // do not allow digging the same hole twice
+    if (holes[id]) return;
+
     const holesDug = getKeys(holes).filter(
       (holeId) => !canDig(holes[holeId]?.dugAt)
     ).length;
@@ -221,6 +225,11 @@ export const SandPlot: React.FC<{
     }
 
     if (hasSandShovel) {
+      setToast({
+        icon: ITEM_DETAILS["Sand Shovel"].image,
+        content: `-1`,
+      });
+
       gameService.send("REVEAL", {
         event: {
           type: "treasure.dug",
@@ -234,6 +243,11 @@ export const SandPlot: React.FC<{
     }
 
     if (hasSandDrill) {
+      setToast({
+        icon: ITEM_DETAILS["Sand Drill"].image,
+        content: `-1`,
+      });
+
       gameService.send("REVEAL", {
         event: {
           type: "treasure.drilled",


### PR DESCRIPTION
# Description

- fix issue where confirming treasure island loot then immediately clicking the same hole throws an error
- added -1 toasts when using sand shovels and sand drills

![image](https://user-images.githubusercontent.com/107602352/228445073-77c98e6c-fe12-40d2-a6fc-7ce0aa9ebaae.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- dig using sand shovels and sand drills
- to check if the error occurs, follow these steps:
  - use sand shovel until a treasure is found, or use a sand drill
  - a confirmation will show for the treasure loot.  Confirm the loot and immediately click the same hole where the loot is coming from

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
