### PR TITLE
[FIX] Tools bulk crafting button not disabled if not enough ingredients

### DIFF
--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -114,21 +114,24 @@ export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
   const bulkToolCraftAmount = makeBulkBuyAmount(stock);
 
   const Action = () => {
-    if (stock?.equals(0)) {
+    if (stock.equals(0)) {
       return <Restock onClose={onClose}></Restock>;
     }
 
     return (
       <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
         <Button
-          disabled={lessFunds() || lessIngredients() || stock?.lessThan(1)}
+          disabled={lessFunds() || lessIngredients() || stock.lessThan(1)}
           onClick={(e) => craft(e, 1)}
         >
           Craft 1
         </Button>
         {bulkToolCraftAmount > 1 && (
           <Button
-            disabled={lessFunds() || lessIngredients() || stock?.lessThan(1)}
+            disabled={
+              lessFunds(bulkToolCraftAmount) ||
+              lessIngredients(bulkToolCraftAmount)
+            }
             onClick={(e) => craft(e, bulkToolCraftAmount)}
           >
             Craft {bulkToolCraftAmount}


### PR DESCRIPTION
# Description

- fix workbench tools bulk crafting button disabled condition

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/228448768-6182d6ba-0a58-406f-9603-fb40d9fc0b19.png)|![image](https://user-images.githubusercontent.com/107602352/228448728-73c044ba-e574-4c53-9c8b-e5cf43429b34.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- bulk craft tools when there are enough ingredients to craft 1 tool but not enough to craft the bulk amount

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
