### PR TITLE
[FIX] deposit item text position when there are less items in chest

### DIFF
--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -89,7 +89,7 @@ export const Chest: React.FC<Props> = ({
           Your chest is empty, discover rare items today!
         </span>
         <p className="underline text-xxs text-center mt-2 cursor-pointer">
-          Deposit item from your wallet
+          Deposit items from your wallet
         </p>
       </div>
     );
@@ -162,7 +162,7 @@ export const Chest: React.FC<Props> = ({
                   closeModal();
                 }}
               >
-                Deposit item from your wallet
+                Deposit items from your wallet
               </p>
             </div>
           )}

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -88,7 +88,7 @@ export const Chest: React.FC<Props> = ({
         <span className="text-xs text-center mt-2">
           Your chest is empty, discover rare items today!
         </span>
-        <p className="underline text-xxs mt-2 cursor-pointer">
+        <p className="underline text-xxs text-center mt-2 cursor-pointer">
           Deposit item from your wallet
         </p>
       </div>
@@ -154,15 +154,17 @@ export const Chest: React.FC<Props> = ({
             </div>
           )}
           {onDepositClick && (
-            <p
-              className="underline text-xxs ml-2 my-1 cursor-pointer"
-              onClick={() => {
-                onDepositClick();
-                closeModal();
-              }}
-            >
-              Deposit item from your wallet
-            </p>
+            <div className="flex w-full ml-1 my-1">
+              <p
+                className="underline text-xxs cursor-pointer"
+                onClick={() => {
+                  onDepositClick();
+                  closeModal();
+                }}
+              >
+                Deposit item from your wallet
+              </p>
+            </div>
           )}
         </>
       }


### PR DESCRIPTION
# Description

- fix deposit item text position when there are not a lot of items in chest

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/228456177-cbc399d2-9b36-4ed9-9ff3-065cff24d0df.png)|![image](https://user-images.githubusercontent.com/107602352/228456733-1602604f-fde9-472b-8632-521326e0b076.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- browse player chest items when there are 1-3 items in it

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
