### PR TITLE
[FIX] Prevent travel modal scroll to jump on autosave

### DIFF
--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -1,5 +1,5 @@
 import { sequence } from "0xsequence";
-import { createMachine, Interpreter, assign } from "xstate";
+import { createMachine, Interpreter, State, assign } from "xstate";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 
 import { loadBanDetails } from "features/game/actions/bans";
@@ -199,6 +199,8 @@ export type MachineInterpreter = Interpreter<
   BlockchainEvent,
   BlockchainState
 >;
+
+export type AuthMachineState = State<Context, BlockchainEvent, BlockchainState>;
 
 export const authMachine = createMachine<
   Context,

--- a/src/features/game/expansion/components/travel/IslandList.tsx
+++ b/src/features/game/expansion/components/travel/IslandList.tsx
@@ -1,22 +1,23 @@
 import React, { useContext, useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useSelector } from "@xstate/react";
+import classNames from "classnames";
+
 import * as Auth from "features/auth/lib/Provider";
 import { OuterPanel } from "components/ui/Panel";
 import { BumpkinLevel, getBumpkinLevel } from "features/game/lib/level";
 import { Bumpkin, Inventory } from "features/game/types/game";
+import { VisitLandExpansionForm } from "../VisitLandExpansionForm";
+import { Label } from "components/ui/Label";
+import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 
 import lockIcon from "assets/skills/lock.png";
 import levelUpIcon from "assets/icons/level_up.png";
-
 import goblin from "assets/buildings/goblin_sign.png";
 import sunflorea from "assets/land/islands/sunflorea.png";
 import snowman from "assets/npcs/snowman.png";
 import land from "assets/land/islands/island.webp";
 import bunnyfower from "assets/events/easter/2023/decorations/bunnyflower.png";
-import { VisitLandExpansionForm } from "../VisitLandExpansionForm";
-import { useActor } from "@xstate/react";
-import { Label } from "components/ui/Label";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { SUNNYSIDE } from "assets/sunnyside";
 
 interface Island {
@@ -32,12 +33,14 @@ interface IslandProps extends Island {
   bumpkin: Bumpkin | undefined;
   currentPath: string;
   isGuest: boolean;
+  disabled: boolean;
 }
 
 interface IslandListProps {
   bumpkin: Bumpkin | undefined;
   showVisitList: boolean;
   inventory: Inventory;
+  travelAllowed: boolean;
 }
 
 const IslandListItem: React.FC<IslandProps> = ({
@@ -50,6 +53,7 @@ const IslandListItem: React.FC<IslandProps> = ({
   comingSoon,
   currentPath,
   isGuest,
+  disabled,
 }) => {
   const navigate = useNavigate();
   const onSameIsland = path === currentPath;
@@ -57,64 +61,53 @@ const IslandListItem: React.FC<IslandProps> = ({
     !bumpkin || getBumpkinLevel(bumpkin.experience) < levelRequired;
   const guestDenied = guestAccess === false && isGuest;
   const cannotNavigate =
-    (bumpkin && notEnoughLevel) || onSameIsland || comingSoon || guestDenied;
+    notEnoughLevel || onSameIsland || comingSoon || guestDenied || disabled;
 
-  if (cannotNavigate) {
-    // Disabled item
-    return (
-      <div>
-        <OuterPanel className="flex relative items-center py-2 mb-1 opacity-70">
-          {image && (
-            <div className="w-16 justify-center flex mr-2">
-              <img src={image} className="h-9" />
-            </div>
-          )}
-          <div className="flex-1 flex flex-col justify-center">
-            <div className="flex gap-2 items-center mb-1">
-              {(notEnoughLevel || comingSoon) && (
-                <img src={lockIcon} className="h-4" />
-              )}
-              <span className="text-sm">{name}</span>
-            </div>
-
-            <div className="flex gap-2 items-center">
-              {/* Current island */}
-              {onSameIsland && <Label type="info">You are here</Label>}
-              {/* Level requirement */}
-              {notEnoughLevel && (
-                <Label
-                  type="danger"
-                  className="flex gap-2 items-center whitespace-nowrap"
-                >
-                  <img src={levelUpIcon} className="h-4" />
-                  Lvl {levelRequired}
-                </Label>
-              )}
-              {guestDenied && !comingSoon && (
-                <Label type="info">Full access required</Label>
-              )}
-              {/* Coming soon */}
-              {comingSoon && <Label type="warning">Coming soon</Label>}
-            </div>
-          </div>
-        </OuterPanel>
-      </div>
-    );
-  }
+  const onClick = () => {
+    if (!cannotNavigate) {
+      navigate(path);
+    }
+  };
 
   return (
-    <div onClick={() => navigate(path)}>
-      <OuterPanel className="flex relative items-center py-2 mb-1 cursor-pointer hover:bg-brown-200">
-        {image && (
-          <div className="w-16 justify-center flex mr-2">
-            <img src={image} className="h-9" />
-          </div>
-        )}
-        <div className="flex-1 flex flex-col justify-center">
+    <OuterPanel
+      onClick={onClick}
+      className={classNames(
+        "flex relative items-center py-2 mb-1",
+        cannotNavigate ? "opacity-70" : "cursor-pointer hover:bg-brown-200"
+      )}
+    >
+      {image && (
+        <div className="w-16 justify-center flex mr-2">
+          <img src={image} className="h-9" />
+        </div>
+      )}
+      <div className="flex-1 flex flex-col justify-center">
+        <div className="flex gap-2 items-center mb-1">
+          {(notEnoughLevel || comingSoon) && (
+            <img src={lockIcon} className="h-4" />
+          )}
           <span className="text-sm">{name}</span>
         </div>
-      </OuterPanel>
-    </div>
+
+        <div className="flex gap-2 items-center">
+          {/* Current island */}
+          {onSameIsland && <Label type="info">You are here</Label>}
+          {/* Level requirement */}
+          {notEnoughLevel && (
+            <Label type="danger" className="flex gap-2 items-center">
+              <img src={levelUpIcon} className="h-4" />
+              Lvl {levelRequired}
+            </Label>
+          )}
+          {guestDenied && !comingSoon && (
+            <Label type="info">Full access required</Label>
+          )}
+          {/* Coming soon */}
+          {comingSoon && <Label type="warning">Coming soon</Label>}
+        </div>
+      </div>
+    </OuterPanel>
   );
 };
 
@@ -139,15 +132,21 @@ export const IslandList: React.FC<IslandListProps> = ({
   bumpkin,
   showVisitList,
   inventory,
+  travelAllowed,
 }) => {
   const { authService } = useContext(Auth.Context);
-  const [authState, send] = useActor(authService);
+  const userType = useSelector(authService, (state) => state.context.user.type);
+  const farmId = useSelector(
+    authService,
+    (state) => state.context.user.farmId || "guest"
+  );
+  const state = useSelector(authService, (state) => ({
+    isAuthorised: state.matches({ connected: "authorised" }),
+    isVisiting: state.matches("visiting"),
+  }));
 
-  const { id } = useParams();
   const location = useLocation();
   const [view, setView] = useState<"list" | "visitForm">("list");
-
-  const farmId = id ?? "guest";
 
   const islands: Island[] = [
     {
@@ -169,7 +168,7 @@ export const IslandList: React.FC<IslandListProps> = ({
       levelRequired: 1 as BumpkinLevel,
       guestAccess: false,
       image: bunnyfower,
-      path: `/land/${id}/bunny-trove`,
+      path: `/land/${farmId}/bunny-trove`,
     },
     {
       name: "Goblin Retreat",
@@ -203,8 +202,7 @@ export const IslandList: React.FC<IslandListProps> = ({
     },
     {
       name: "Snow Kingdom",
-      // Originally it was 50, but BumpkinLevel type has restrictions(current max is 40)
-      levelRequired: 40,
+      levelRequired: 50 as BumpkinLevel,
       guestAccess: false,
       image: snowman,
       path: `/snow/${farmId}`,
@@ -213,12 +211,13 @@ export const IslandList: React.FC<IslandListProps> = ({
   ];
 
   // NOTE: If you're visiting without a session then just show the form by default as there is no option to return to a farm
-  const unAuthenticatedVisit = authState.matches("visiting");
-  if (view === "visitForm" || unAuthenticatedVisit) {
+  if (view === "visitForm" || state.isVisiting) {
     return (
       <VisitLandExpansionForm
         onBack={
-          unAuthenticatedVisit ? () => send("RETURN") : () => setView("list")
+          state.isVisiting
+            ? () => authService.send("RETURN")
+            : () => setView("list")
         }
       />
     );
@@ -227,16 +226,17 @@ export const IslandList: React.FC<IslandListProps> = ({
   if (showVisitList) {
     return (
       <>
-        {authState.matches({ connected: "authorised" }) && (
+        {state.isAuthorised && (
           <IslandListItem
             name="Home"
             image={CROP_LIFECYCLE.Sunflower.ready}
             levelRequired={1}
             guestAccess={true}
-            isGuest={authState.context.user.type === "GUEST"}
-            path={`/land/${authState.context.user.farmId}`}
+            isGuest={userType === "GUEST"}
+            path={`/land/${farmId}`}
             bumpkin={bumpkin}
             currentPath={location.pathname}
+            disabled={!travelAllowed}
           />
         )}
         <VisitFriendListItem onClick={() => setView("visitForm")} />
@@ -253,9 +253,10 @@ export const IslandList: React.FC<IslandListProps> = ({
         <IslandListItem
           key={item.name}
           {...item}
-          isGuest={authState.context.user.type === "GUEST"}
+          isGuest={userType === "GUEST"}
           bumpkin={bumpkin}
           currentPath={location.pathname}
+          disabled={!travelAllowed}
         />
       ))}
       {!hideVisitOption && (

--- a/src/features/game/expansion/components/travel/IslandList.tsx
+++ b/src/features/game/expansion/components/travel/IslandList.tsx
@@ -10,6 +10,7 @@ import { Bumpkin, Inventory } from "features/game/types/game";
 import { VisitLandExpansionForm } from "../VisitLandExpansionForm";
 import { Label } from "components/ui/Label";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { AuthMachineState } from "features/auth/lib/authMachine";
 
 import lockIcon from "assets/skills/lock.png";
 import levelUpIcon from "assets/icons/level_up.png";
@@ -128,6 +129,14 @@ const VisitFriendListItem: React.FC<{ onClick: () => void }> = ({
   );
 };
 
+const userTypeSelector = (state: AuthMachineState) => state.context.user.type;
+const farmIdSelector = (state: AuthMachineState) =>
+  state.context.user.farmId ?? "guest";
+const stateSelector = (state: AuthMachineState) => ({
+  isAuthorised: state.matches({ connected: "authorised" }),
+  isVisiting: state.matches("visiting"),
+});
+
 export const IslandList: React.FC<IslandListProps> = ({
   bumpkin,
   showVisitList,
@@ -135,15 +144,9 @@ export const IslandList: React.FC<IslandListProps> = ({
   travelAllowed,
 }) => {
   const { authService } = useContext(Auth.Context);
-  const userType = useSelector(authService, (state) => state.context.user.type);
-  const farmId = useSelector(
-    authService,
-    (state) => state.context.user.farmId || "guest"
-  );
-  const state = useSelector(authService, (state) => ({
-    isAuthorised: state.matches({ connected: "authorised" }),
-    isVisiting: state.matches("visiting"),
-  }));
+  const userType = useSelector(authService, userTypeSelector);
+  const farmId = useSelector(authService, farmIdSelector);
+  const state = useSelector(authService, stateSelector);
 
   const location = useLocation();
   const [view, setView] = useState<"list" | "visitForm">("list");

--- a/src/features/game/expansion/components/travel/IslandTravelModal.tsx
+++ b/src/features/game/expansion/components/travel/IslandTravelModal.tsx
@@ -65,20 +65,18 @@ export const IslandTravelModal: React.FC<IslandTravelModalProps> = ({
         bumpkinParts={bumpkinParts}
         onClose={onClose}
       >
-        {travelAllowed && (
-          <div
-            style={{ maxHeight: CONTENT_HEIGHT }}
-            className="w-full pr-1 pt-2.5 overflow-y-auto scrollable"
-          >
-            <IslandList
-              bumpkin={bumpkin}
-              showVisitList={isVisiting}
-              inventory={inventory}
-            />
-          </div>
-        )}
-
-        {!travelAllowed && <span className="loading">Loading</span>}
+        <div
+          style={{ maxHeight: CONTENT_HEIGHT }}
+          className="w-full pr-1 pt-2.5 overflow-y-auto scrollable"
+        >
+          {!travelAllowed && <span className="loading">Saving</span>}
+          <IslandList
+            bumpkin={bumpkin}
+            showVisitList={isVisiting}
+            inventory={inventory}
+            travelAllowed={travelAllowed}
+          />
+        </div>
       </CloseButtonPanel>
     </Modal>
   );


### PR DESCRIPTION
# Description

Travel modal during autosave was scrolled to top.

Before:

https://user-images.githubusercontent.com/9656961/229831002-78e62418-02d9-4f89-ac9c-c0a5ddb509e3.mp4

After:


https://user-images.githubusercontent.com/9656961/229831060-5fc3ccee-03c4-4828-bdc5-00f4ca45def1.mp4


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

manual test + yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



