### PR TITLE
[FIX] Party island pixel scale

### DIFF
--- a/src/features/game/expansion/components/PartyIsland.tsx
+++ b/src/features/game/expansion/components/PartyIsland.tsx
@@ -259,14 +259,14 @@ export const PartyIsland: React.FC = () => {
         <img
           src={partyIsland}
           style={{
-            width: `${PIXEL_SCALE * 86}px`,
+            width: `${PIXEL_SCALE * 78}px`,
           }}
         />
         <div
           className="absolute"
           style={{
             left: `${GRID_WIDTH_PX * 1}px`,
-            bottom: `${GRID_WIDTH_PX * 5}px`,
+            bottom: `${GRID_WIDTH_PX * 4.5}px`,
           }}
         >
           <NPC
@@ -281,7 +281,7 @@ export const PartyIsland: React.FC = () => {
           src={SUNNYSIDE.icons.expression_chat}
           className="absolute animate-float"
           style={{
-            width: `${PIXEL_SCALE * 10}px`,
+            width: `${PIXEL_SCALE * 9}px`,
             top: `${PIXEL_SCALE * -4}px`,
             left: `${PIXEL_SCALE * 22}px`,
           }}
@@ -290,7 +290,7 @@ export const PartyIsland: React.FC = () => {
         <div
           className="absolute"
           style={{
-            left: `${GRID_WIDTH_PX * 5}px`,
+            left: `${GRID_WIDTH_PX * 4.5}px`,
             bottom: `${GRID_WIDTH_PX * 3.5}px`,
             transform: "scaleX(-1)",
           }}
@@ -305,7 +305,7 @@ export const PartyIsland: React.FC = () => {
         <div
           className="absolute"
           style={{
-            left: `${GRID_WIDTH_PX * 2.5}px`,
+            left: `${GRID_WIDTH_PX * 2}px`,
             bottom: `${GRID_WIDTH_PX * 3.5}px`,
           }}
         >


### PR DESCRIPTION
# Description

- standardize pixel scale for party island

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/229999931-0f546dcd-9088-4337-85d9-a8892b583d0c.png)|![image](https://user-images.githubusercontent.com/107602352/229999880-9617f138-dc11-4f56-8f77-aa55963609f6.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check main island

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
