### PR TITLE
[FIX] Buildings can be removed if rusty shovel is deselected

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -30,6 +30,7 @@ import { IslandTravel } from "./components/travel/IslandTravel";
 import { BumpkinTutorial } from "./BumpkinTutorial";
 import { Placeable } from "./placeable/Placeable";
 import { EasterEgg } from "features/bunnyTrove/components/EasterEgg";
+import { getShortcuts } from "features/farming/hud/lib/shortcuts";
 
 const getIslandElements = ({
   buildings,
@@ -42,6 +43,7 @@ const getIslandElements = ({
   fruitPatches,
   crops,
   bumpkinParts,
+  isRustyShovelSelected,
   isEditing,
 }: {
   expansionConstruction?: ExpansionConstruction;
@@ -55,6 +57,7 @@ const getIslandElements = ({
   crops: GameState["crops"];
   fruitPatches: GameState["fruitPatches"];
   bumpkinParts: BumpkinParts | undefined;
+  isRustyShovelSelected: boolean;
   isEditing?: boolean;
 }) => {
   const mapPlacements: Array<JSX.Element> = [];
@@ -102,7 +105,11 @@ const getIslandElements = ({
               width={width}
               isEditing={isEditing}
             >
-              <Building building={building} name={name as BuildingName} />
+              <Building
+                building={building}
+                name={name as BuildingName}
+                isRustyShovelSelected={isRustyShovelSelected}
+              />
             </MapPlacement>
           );
         });
@@ -133,6 +140,7 @@ const getIslandElements = ({
                 id={id}
                 readyAt={readyAt}
                 createdAt={createdAt}
+                isRustyShovelSelected={isRustyShovelSelected}
               />
             </MapPlacement>
           );
@@ -330,6 +338,8 @@ export const Land: React.FC = () => {
     y: expansionCount >= 7 ? -10.5 : -4.5,
   };
 
+  const shortcuts = getShortcuts();
+
   const eggs = easterHunt?.eggs || [];
   const mainEggs = eggs.filter((egg) => egg && egg.island === "Main");
 
@@ -362,6 +372,7 @@ export const Land: React.FC = () => {
             fruitPatches,
             crops,
             bumpkinParts: bumpkin?.equipped,
+            isRustyShovelSelected: shortcuts[0] === "Rusty Shovel",
             isEditing: gameState.isEditing,
           }).sort((a, b) => b.props.y - a.props.y)}
         </div>


### PR DESCRIPTION
# Description

- fix issue where rusty shovel is just deselected but clicking a building will show up the remove modal.  Opposite is true (just selected rusty shovel but the modal isn't showing)
  - the issue is affecting buildings only, not collectibles.  This is because of `React.memo` that is introduced in https://github.com/sunflower-land/sunflower-land/pull/2401 in both buildings and collectibles.  Collectibles has `useContext(Context)` in the root component which causes the memo to rerender when the game state changes (including selecting items), however buildings has `useContext(Context)` in a subcomponent (building in progress).  Therefore switching tools will not rerender buildings which causes this issue.
- move `useContext(Context)` for collectibles to subcomponent (collectible in progress) so gamestate changes will not rerender collectables
- define `isRustyShovelSelected` logic in `Land` component and pass it down to collectables and buildings, so if `isRustyShovelSelected` is updated the collectables and buildings will both rerender
  - that means if the user switches from a non-rusty-shovel tool to another non-rusty-shovel tool (eg. selecting apple seeds then selecting pickaxes), the collectables and buildings won't rerender!

![image](https://user-images.githubusercontent.com/107602352/230554550-c14638ed-815e-4e64-8178-d1f0c6edc635.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- use rusty shovel on placeables while placeables in progress: cursor should not be cursor-pointer and players cannot remove placeable
- use rusy shovel on placeables while placeables progress is done: cursor should be cursor-pointer, placeabls are highlighted on hover, and players can remove placeable
- for placeables where progress is done, try switching between rusty shovel and non-rusty-shovel in the shorcuts
  - when rusty shovel is selected, the remove modal should always show
  - when rusty shovel is not selected, the remove modal should always not show

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
