### PR TITLE
[FIX] Crash when visiting basket without any selected itmes

### DIFF
--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -57,7 +57,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     );
   }
 
-  const selectedItem = selected ?? getKeys(basketMap)[0];
+  const selectedItem = selected ?? getKeys(basketMap)[0] ?? "Sunflower Seed";
 
   const isFruitSeed = (
     selected: InventoryItemName
@@ -150,7 +150,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
               xp: isFood(selectedItem)
                 ? new Decimal(
                     getFoodExpBoost(
-                      CONSUMABLES[selected as ConsumableName],
+                      CONSUMABLES[selectedItem as ConsumableName],
                       gameState.bumpkin as Bumpkin,
                       gameState.collectibles
                     )


### PR DESCRIPTION
# Description

- fix crash when users has no items selected in their inventory.  Several players got this issue.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- clear browser cache and have only food items in the inventory

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
