### PR TITLE
[FIX] Some collectables layout

### DIFF
--- a/src/features/island/collectibles/Collectible.tsx
+++ b/src/features/island/collectibles/Collectible.tsx
@@ -80,7 +80,7 @@ import { CollectibleBear } from "./components/CollectibleBear";
 import { CyborgBear } from "./components/CyborgBear";
 import { ManekiNeko } from "./components/ManekiNeko";
 import { LadyBug } from "./components/LadyBug";
-import { BlackBear } from "./components/BlackBear";
+import { BlackBearry } from "./components/BlackBearry";
 import { SquirrelMonkey } from "./components/SquirrelMonkey";
 import { TikiTotem } from "./components/TikiTotem";
 import { LunarCalendar } from "./components/LunarCalendar";
@@ -245,7 +245,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
   "Immortal Pear": ImmortalPear,
   "Lady Bug": LadyBug,
   "Squirrel Monkey": SquirrelMonkey,
-  "Black Bearry": BlackBear,
+  "Black Bearry": BlackBearry,
   "Ayam Cemani": AyamCemani,
   "Collectible Bear": CollectibleBear,
   "Cyborg Bear": CyborgBear,

--- a/src/features/island/collectibles/components/BlackBearry.tsx
+++ b/src/features/island/collectibles/components/BlackBearry.tsx
@@ -1,31 +1,30 @@
 import React from "react";
 
 import blackBear from "assets/sfts/black_bear.gif";
-import shadow from "assets/npcs/shadow.png";
+import shadow from "assets/npcs/shadow16px.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
-export const BlackBear: React.FC = () => {
+export const BlackBearry: React.FC = () => {
   return (
     <>
+      <img
+        src={shadow}
+        style={{
+          width: `${PIXEL_SCALE * 16}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 0}px`,
+        }}
+        className="absolute pointer-events-none"
+      />
       <img
         src={blackBear}
         style={{
           width: `${PIXEL_SCALE * 16}px`,
-          bottom: `${PIXEL_SCALE * 4}px`,
+          bottom: `${PIXEL_SCALE * 2}px`,
           left: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute"
-        alt="Basic Bear"
-      />
-      <img
-        src={shadow}
-        style={{
-          width: `${PIXEL_SCALE * 14}px`,
-          bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 1}px`,
-        }}
-        className="absolute"
-        alt="Basic Bear"
+        className="absolute pointer-events-none"
+        alt="Black Bearry"
       />
     </>
   );

--- a/src/features/island/collectibles/components/BlossomTree.tsx
+++ b/src/features/island/collectibles/components/BlossomTree.tsx
@@ -13,7 +13,7 @@ export const BlossomTree: React.FC = () => {
           bottom: `${PIXEL_SCALE * 0}px`,
           left: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute"
+        className="absolute pointer-events-none"
         alt="Blossom Tree"
       />
     </>

--- a/src/features/island/collectibles/components/CabbageBoy.tsx
+++ b/src/features/island/collectibles/components/CabbageBoy.tsx
@@ -6,12 +6,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const CabbageBoy: React.FC = () => {
   return (
-    <div
-      className="absolute top-0 left-0 h-full"
-      style={{
-        width: `${PIXEL_SCALE * 16}px`,
-      }}
-    >
+    <>
       <img
         src={shadow}
         style={{
@@ -29,6 +24,6 @@ export const CabbageBoy: React.FC = () => {
         className="absolute left-0 pointer-events-none"
         alt="Cabbage Boy"
       />
-    </div>
+    </>
   );
 };

--- a/src/features/island/collectibles/components/CabbageGirl.tsx
+++ b/src/features/island/collectibles/components/CabbageGirl.tsx
@@ -6,12 +6,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const CabbageGirl: React.FC = () => {
   return (
-    <div
-      className="absolute top-0 left-0 h-full"
-      style={{
-        width: `${PIXEL_SCALE * 16}px`,
-      }}
-    >
+    <>
       <img
         src={shadow}
         style={{
@@ -29,6 +24,6 @@ export const CabbageGirl: React.FC = () => {
         className="absolute left-0 pointer-events-none"
         alt="Cabbage Girl"
       />
-    </div>
+    </>
   );
 };

--- a/src/features/island/collectibles/components/CarrotSword.tsx
+++ b/src/features/island/collectibles/components/CarrotSword.tsx
@@ -6,7 +6,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 export const CarrotSword: React.FC = () => {
   return (
     <div
-      className="absolute"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 20}px`,
         bottom: `${PIXEL_SCALE * 0}px`,

--- a/src/features/island/collectibles/components/EasterBunny.tsx
+++ b/src/features/island/collectibles/components/EasterBunny.tsx
@@ -11,7 +11,7 @@ export const EasterBunny: React.FC = () => {
         width: `${PIXEL_SCALE * 32}px`,
         bottom: "0px",
       }}
-      className="absolute"
+      className="absolute pointer-events-none"
       alt="Easter Bunny"
     />
   );

--- a/src/features/island/collectibles/components/LadyBug.tsx
+++ b/src/features/island/collectibles/components/LadyBug.tsx
@@ -6,12 +6,7 @@ import shadow from "assets/npcs/shadow.png";
 
 export const LadyBug: React.FC = () => {
   return (
-    <div
-      className="absolute top-0 left-0 h-full"
-      style={{
-        width: `${PIXEL_SCALE * 16}px`,
-      }}
-    >
+    <>
       <img
         src={shadow}
         style={{
@@ -28,6 +23,6 @@ export const LadyBug: React.FC = () => {
         className="absolute left-0 pointer-events-none"
         alt="Lady Bug"
       />
-    </div>
+    </>
   );
 };

--- a/src/features/island/collectibles/components/LunarCalendar.tsx
+++ b/src/features/island/collectibles/components/LunarCalendar.tsx
@@ -9,11 +9,11 @@ export const LunarCalendar: React.FC = () => {
       <img
         src={lunarCalendar}
         style={{
-          width: `${PIXEL_SCALE * 13}px`,
-          bottom: `${PIXEL_SCALE * 1}px`,
-          left: `${PIXEL_SCALE * 1}px`,
+          width: `${PIXEL_SCALE * 15}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute"
+        className="absolute pointer-events-none"
         alt="Lunar Calendar"
       />
     </>

--- a/src/features/island/collectibles/components/SquirrelMonkey.tsx
+++ b/src/features/island/collectibles/components/SquirrelMonkey.tsx
@@ -8,12 +8,21 @@ import Spritesheet from "components/animation/SpriteAnimator";
 export const SquirrelMonkey: React.FC = () => {
   return (
     <>
+      <img
+        src={shadow}
+        style={{
+          width: `${PIXEL_SCALE * 15}px`,
+          bottom: `${PIXEL_SCALE * 5}px`,
+          left: `${PIXEL_SCALE * 7}px`,
+        }}
+        className="absolute pointer-events-none"
+      />
       <Spritesheet
-        className="absolute z-20"
+        className="absolute pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 26}px`,
           bottom: `${PIXEL_SCALE * 0}px`,
-          left: `${0}px`,
+          left: `${PIXEL_SCALE * 4}px`,
           imageRendering: "pixelated",
         }}
         image={sheet}
@@ -21,19 +30,9 @@ export const SquirrelMonkey: React.FC = () => {
         heightFrame={32}
         fps={12}
         steps={9}
-        direction={`forward`}
+        direction="forward"
         autoplay={true}
         loop={true}
-      />
-      <img
-        src={shadow}
-        style={{
-          width: `${PIXEL_SCALE * 14}px`,
-          bottom: `${PIXEL_SCALE * 5}px`,
-          left: `${PIXEL_SCALE * 4}px`,
-        }}
-        className="absolute"
-        alt="Basic Bear"
       />
     </>
   );

--- a/src/features/island/collectibles/components/TikiTotem.tsx
+++ b/src/features/island/collectibles/components/TikiTotem.tsx
@@ -10,10 +10,10 @@ export const TikiTotem: React.FC = () => {
         src={tikiTotem}
         style={{
           width: `${PIXEL_SCALE * 13}px`,
-          bottom: `${PIXEL_SCALE * 1}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
           left: `${PIXEL_SCALE * 1}px`,
         }}
-        className="absolute"
+        className="absolute pointer-events-none"
         alt="Tiki Totem"
       />
     </>


### PR DESCRIPTION
# Description

fixes for some collectibles (more to come):
- make sure collectibles
  - have correct pixel size and pixel placement
  - not visually obstructing other island items that are outside their respective grids as much as possible
  - not obstructing click events that are outside their respective grids (adding pointer-events-none)

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/231938752-57ca58ab-836d-4036-886f-b4231271be56.png)|![image](https://user-images.githubusercontent.com/107602352/231938767-c62b9ed5-5c58-405b-83db-e777755d250e.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- place collectibles that are modified in this PR

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
