### PR TITLE
[FIX] Sell 10 check for garbage sale

### DIFF
--- a/src/features/helios/components/garbageCollector/components/GarbageSale.tsx
+++ b/src/features/helios/components/garbageCollector/components/GarbageSale.tsx
@@ -47,7 +47,7 @@ export const GarbageSale: React.FC = () => {
         <Button disabled={amount.lt(1)} onClick={() => sell(1)}>
           Sell 1
         </Button>
-        <Button disabled={amount.lt(1)} onClick={() => sell(10)}>
+        <Button disabled={amount.lt(10)} onClick={() => sell(10)}>
           Sell 10
         </Button>
       </div>


### PR DESCRIPTION
# Description

- fix sell 10 button not disabled for garbage sale when the selected item has less than 10 in inventory

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/231962244-3e82947a-cb09-4f14-863e-498de81fe607.png)|![image](https://user-images.githubusercontent.com/107602352/231962287-4ecc7d96-3c84-43aa-b692-8ac161db33cf.png)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- have 1-10 of a certain item in inventory that is in the garbage sale shop, and select that item in garbage sale shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
