### PR TITLE
[CHORE] (Performance Improvements) Add comparers to useSelector for r…

### DIFF
--- a/src/features/farming/animals/components/MutantChickenModal.tsx
+++ b/src/features/farming/animals/components/MutantChickenModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Modal from "react-bootstrap/esm/Modal";
 import { Panel } from "components/ui/Panel";
-import { Inventory, MutantChicken } from "features/game/types/game";
+import { MutantChicken } from "features/game/types/game";
 
 import richChicken from "assets/animals/chickens/rich_chicken.png";
 import fatChicken from "assets/animals/chickens/fat_chicken.png";
@@ -33,17 +33,9 @@ interface Props {
   type: MutantChicken;
   show: boolean;
   onContinue: () => void;
-  inventory: Inventory;
 }
 
-export const MutantChickenModal = ({
-  type,
-  show,
-  onContinue,
-  inventory,
-}: Props) => {
-  // Boosts don't stack so only show boost information if the user doesn't already have the mutant
-  const showDescription = !inventory[type];
+export const MutantChickenModal = ({ type, show, onContinue }: Props) => {
   return (
     <Modal show={show} centered>
       <Panel>
@@ -53,15 +45,11 @@ export const MutantChickenModal = ({
             <img src={mutants[type].image} style={{ width: "50px" }} />
           </div>
           <p className="text-sm mb-2">{`Congratulations, your chicken has laid a very rare mutant chicken!`}</p>
-          {showDescription && (
-            <p className="text-sm mb-2">{mutants[type].description}</p>
-          )}
+          <p className="text-sm mb-2">{mutants[type].description}</p>
         </div>
 
         <div className="flex">
-          <Button className="text-sm" onClick={onContinue}>
-            Continue
-          </Button>
+          <Button onClick={onContinue}>Continue</Button>
         </div>
       </Panel>
     </Modal>

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -42,6 +42,14 @@ export const GameProvider: React.FC = ({ children }) => {
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
+    const originalShortcuts = getShortcuts();
+    const originalSelectedItem =
+      originalShortcuts.length > 0 ? originalShortcuts[0] : undefined;
+
+    // skip shortcut logic if selected item is the same
+    // to avoid unnecessary rerenders for components using useContext(Context)
+    if (originalSelectedItem === item) return;
+
     const items = cacheShortcuts(item);
 
     setShortcuts(items);

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -41,15 +41,22 @@ const INITIAL_SUPPORTED_PLOTS = 15;
 // Each well can support an additional 8 plots
 const WELL_PLOT_SUPPORT = 8;
 
+export const getCompletedWellCount = (
+  buildings: Partial<Record<BuildingName, PlacedItem[]>>
+) => {
+  return (
+    buildings["Water Well"]?.filter((well) => well.readyAt < Date.now())
+      .length ?? 0
+  );
+};
+
 export function isPlotFertile({
   plotIndex,
   crops,
   buildings,
 }: IsPlotFertile): boolean {
-  // Get the well count
-  const wellCount =
-    buildings["Water Well"]?.filter((well) => well.readyAt < Date.now())
-      .length ?? 0;
+  // get the well count
+  const wellCount = getCompletedWellCount(buildings);
   const cropsWellCanWater =
     wellCount * WELL_PLOT_SUPPORT + INITIAL_SUPPORTED_PLOTS;
 

--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -30,12 +30,24 @@ import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import Decimal from "decimal.js-light";
 import { MachineState } from "features/game/lib/gameMachine";
+import { Rock } from "features/game/types/game";
 
 const HITS = 3;
 const tool = "Iron Pickaxe";
 
 const selectInventoryToolCount = (state: MachineState) =>
   state.context.state.inventory[tool] ?? new Decimal(0);
+
+const compareResource = (prev: Rock, next: Rock) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
+  return (
+    prev.equals(next) ||
+    prev.greaterThanOrEqualTo(1) ||
+    next.greaterThanOrEqualTo(1)
+  );
+};
 
 interface Props {
   id: string;
@@ -59,9 +71,14 @@ export const Gold: React.FC<Props> = ({ id }) => {
 
   const resource = useSelector(
     gameService,
-    (state) => state.context.state.gold[id]
+    (state) => state.context.state.gold[id],
+    compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -30,12 +30,24 @@ import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import Decimal from "decimal.js-light";
 import { MachineState } from "features/game/lib/gameMachine";
+import { Rock } from "features/game/types/game";
 
 const HITS = 3;
 const tool = "Stone Pickaxe";
 
 const selectInventoryToolCount = (state: MachineState) =>
   state.context.state.inventory[tool] ?? new Decimal(0);
+
+const compareResource = (prev: Rock, next: Rock) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
+  return (
+    prev.equals(next) ||
+    prev.greaterThanOrEqualTo(1) ||
+    next.greaterThanOrEqualTo(1)
+  );
+};
 
 interface Props {
   id: string;
@@ -60,9 +72,14 @@ export const Iron: React.FC<Props> = ({ id }) => {
 
   const resource = useSelector(
     gameService,
-    (state) => state.context.state.iron[id]
+    (state) => state.context.state.iron[id],
+    compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -28,12 +28,24 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import { MachineState } from "features/game/lib/gameMachine";
+import { Rock } from "features/game/types/game";
 
 const HITS = 3;
 const tool = "Pickaxe";
 
 const selectInventoryToolCount = (state: MachineState) =>
   state.context.state.inventory[tool] ?? new Decimal(0);
+
+const compareResource = (prev: Rock, next: Rock) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
+  return (
+    prev.equals(next) ||
+    prev.greaterThanOrEqualTo(1) ||
+    next.greaterThanOrEqualTo(1)
+  );
+};
 
 interface Props {
   id: string;
@@ -58,9 +70,14 @@ export const Stone: React.FC<Props> = ({ id }) => {
 
   const resource = useSelector(
     gameService,
-    (state) => state.context.state.stones[id]
+    (state) => state.context.state.stones[id],
+    compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -1,4 +1,4 @@
-import { useActor, useInterpret, useSelector } from "@xstate/react";
+import { useInterpret, useSelector } from "@xstate/react";
 import React, { useContext, useState } from "react";
 import classNames from "classnames";
 
@@ -26,8 +26,8 @@ import { MutantChicken } from "features/game/types/craftables";
 import {
   ChickenContext,
   chickenMachine,
-  MachineInterpreter,
-  MachineState,
+  MachineInterpreter as ChickenMachineInterpreter,
+  MachineState as ChickenMachineState,
 } from "features/farming/animals/chickenMachine";
 import { MutantChickenModal } from "features/farming/animals/components/MutantChickenModal";
 import { Modal } from "react-bootstrap";
@@ -36,9 +36,9 @@ import { getShortcuts } from "features/farming/hud/lib/shortcuts";
 import { getWheatRequiredToFeed } from "features/game/events/landExpansion/feedChicken";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "../plots/lib/plant";
-interface Props {
-  id: string;
-}
+import { Collectibles, Chicken as ChickenType } from "features/game/types/game";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { MachineState as GameMachineState } from "features/game/lib/gameMachine";
 
 const getPercentageComplete = (fedAt?: number) => {
   if (!fedAt) return 0;
@@ -50,13 +50,18 @@ const getPercentageComplete = (fedAt?: number) => {
   return Math.ceil((timePassedSinceFed / CHICKEN_TIME_TO_EGG) * 100);
 };
 
+const selectTimeToEgg = (state: ChickenMachineState) => state.context.timeToEgg;
+const selectTimeElapsed = (state: ChickenMachineState) =>
+  state.context.timeElapsed;
+
 interface TimeToEggProps {
-  service: MachineInterpreter;
+  service: ChickenMachineInterpreter;
   showTimeToEgg: boolean;
 }
 
 const TimeToEgg = ({ showTimeToEgg, service }: TimeToEggProps) => {
-  const [{ context }] = useActor(service);
+  const timeToEgg = useSelector(service, selectTimeToEgg);
+  const timeElapsed = useSelector(service, selectTimeElapsed);
 
   return (
     <InnerPanel
@@ -74,7 +79,7 @@ const TimeToEgg = ({ showTimeToEgg, service }: TimeToEggProps) => {
           <span>Egg</span>
         </div>
         <span className="flex-1">
-          {secondsToString(context.timeToEgg - context.timeElapsed, {
+          {secondsToString(timeToEgg - timeElapsed, {
             length: "medium",
           })}
         </span>
@@ -83,22 +88,65 @@ const TimeToEgg = ({ showTimeToEgg, service }: TimeToEggProps) => {
   );
 };
 
-const isHungry = (state: MachineState) => state.matches("hungry");
-const isEating = (state: MachineState) => state.matches("eating");
-const isSleeping = (state: MachineState) => state.matches({ fed: "sleeping" });
-const isHappy = (state: MachineState) => state.matches({ fed: "happy" });
-const isEggReady = (state: MachineState) => state.matches("eggReady");
-const isEggLaid = (state: MachineState) => state.matches("eggLaid");
+const HasWheat = (
+  inventoryWheatCount: Decimal,
+  collectibles: Collectibles,
+  selectedItem?: string
+) => {
+  const wheatRequired = getWheatRequiredToFeed(collectibles);
 
-export const Chicken: React.FC<Props> = ({ id }) => {
+  // has enough wheat to feed chickens
+
+  if (wheatRequired.lte(0)) return true;
+
+  return selectedItem === "Wheat" && inventoryWheatCount.gte(wheatRequired);
+};
+
+const isHungry = (state: ChickenMachineState) => state.matches("hungry");
+const isEating = (state: ChickenMachineState) => state.matches("eating");
+const isSleeping = (state: ChickenMachineState) =>
+  state.matches({ fed: "sleeping" });
+const isHappy = (state: ChickenMachineState) => state.matches({ fed: "happy" });
+const isEggReady = (state: ChickenMachineState) => state.matches("eggReady");
+const isEggLaid = (state: ChickenMachineState) => state.matches("eggLaid");
+const selectInventoryWheatCount = (state: GameMachineState) =>
+  state.context.state.inventory.Wheat ?? new Decimal(0);
+const selectCollectibles = (state: GameMachineState) =>
+  state.context.state.collectibles;
+
+const compareChicken = (prev: ChickenType, next: ChickenType) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+const compareCollectibles = (prev: Collectibles, next: Collectibles) =>
+  isCollectibleBuilt("Gold Egg", prev) ===
+    isCollectibleBuilt("Gold Egg", next) &&
+  isCollectibleBuilt("Fat Chicken", prev) ===
+    isCollectibleBuilt("Fat Chicken", next);
+
+interface Props {
+  id: string;
+}
+
+const ChickenComponent: React.FC<Props> = ({ id }) => {
   const { gameService, selectedItem, showTimers } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
 
-  const chicken = state.chickens[id];
+  const chicken = useSelector(
+    gameService,
+    (state) => state.context.state.chickens[id],
+    compareChicken
+  );
+  const collectibles = useSelector(
+    gameService,
+    selectCollectibles,
+    compareCollectibles
+  );
+  const inventoryWheatCount = useSelector(
+    gameService,
+    selectInventoryWheatCount,
+    (prev: Decimal, next: Decimal) =>
+      HasWheat(prev, collectibles, selectedItem) ===
+      HasWheat(next, collectibles, selectedItem)
+  );
 
   const percentageComplete = getPercentageComplete(chicken?.fedAt);
 
@@ -108,7 +156,7 @@ export const Chicken: React.FC<Props> = ({ id }) => {
   const chickenService = useInterpret(chickenMachine, {
     // If chicken is already brewing an egg then add that to the chicken machine context
     context: chickenContext,
-  }) as unknown as MachineInterpreter;
+  }) as unknown as ChickenMachineInterpreter;
 
   // As per xstate docs:
   // To use a piece of state from the service inside a render, use the useSelector(...) hook to subscribe to it
@@ -164,13 +212,9 @@ export const Chicken: React.FC<Props> = ({ id }) => {
   };
 
   const feed = async () => {
-    const currentWheatAmount = state.inventory.Wheat ?? new Decimal(0);
-    const wheatRequired = getWheatRequiredToFeed(state.collectibles);
+    const hasWheat = HasWheat(inventoryWheatCount, collectibles, selectedItem);
 
-    if (
-      (wheatRequired.gt(0) && selectedItem !== "Wheat") ||
-      currentWheatAmount.lt(wheatRequired)
-    ) {
+    if (!hasWheat) {
       setShowPopover(true);
       await new Promise((resolve) => setTimeout(resolve, POPOVER_TIME_MS));
       setShowPopover(false);
@@ -434,7 +478,6 @@ export const Chicken: React.FC<Props> = ({ id }) => {
           show={showMutantModal}
           type={chicken.reward?.items?.[0].name as MutantChicken}
           onContinue={handleContinue}
-          inventory={state.inventory}
         />
       )}
 
@@ -456,3 +499,5 @@ export const Chicken: React.FC<Props> = ({ id }) => {
     </>
   );
 };
+
+export const Chicken = React.memo(ChickenComponent);

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -13,14 +13,48 @@ import { getRequiredAxeAmount } from "features/game/events/landExpansion/fruitTr
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
+import {
+  Collectibles,
+  InventoryItemName,
+  PlantedFruit,
+} from "features/game/types/game";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
-const selectInventory = (state: MachineState) => state.context.state.inventory;
-const selectCollectibles = (state: MachineState) =>
-  state.context.state.collectibles;
+const HasAxes = (
+  inventory: Partial<Record<InventoryItemName, Decimal>>,
+  collectibles: Collectibles,
+  fruit?: PlantedFruit,
+  selectedItem?: string
+) => {
+  const axesNeeded = getRequiredAxeAmount(
+    fruit?.name as FruitName,
+    inventory,
+    collectibles
+  );
+
+  // has enough axes to chop the tree
+
+  if (axesNeeded.lte(0)) return true;
+
+  return (
+    selectedItem === "Axe" && (inventory.Axe ?? new Decimal(0)).gte(axesNeeded)
+  );
+};
+
 const isPlaying = (state: MachineState) =>
   state.matches("playingGuestGame") ||
   state.matches("playingFullGame") ||
   state.matches("autosaving");
+const selectInventory = (state: MachineState) => state.context.state.inventory;
+const selectCollectibles = (state: MachineState) =>
+  state.context.state.collectibles;
+
+const compareFruit = (prev?: PlantedFruit, next?: PlantedFruit) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+const compareCollectibles = (prev: Collectibles, next: Collectibles) =>
+  isCollectibleBuilt("Foreman Beaver", prev) ===
+  isCollectibleBuilt("Foreman Beaver", next);
 
 interface Props {
   id: string;
@@ -32,13 +66,24 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
   const [showInfo, setShowInfo] = useState(false);
   const [playAnimation, setPlayAnimation] = useState(false);
 
-  const inventory = useSelector(gameService, selectInventory);
-  const collectibles = useSelector(gameService, selectCollectibles);
-  const playing = useSelector(gameService, isPlaying);
   const fruit = useSelector(
     gameService,
-    (state) => state.context.state.fruitPatches[id]?.fruit
+    (state) => state.context.state.fruitPatches[id]?.fruit,
+    compareFruit
   );
+  const collectibles = useSelector(
+    gameService,
+    selectCollectibles,
+    compareCollectibles
+  );
+  const inventory = useSelector(
+    gameService,
+    selectInventory,
+    (prev, next) =>
+      HasAxes(prev, collectibles, fruit, selectedItem) ===
+      HasAxes(next, collectibles, fruit, selectedItem)
+  );
+  const playing = useSelector(gameService, isPlaying);
 
   const displayInformation = async () => {
     // First click show error
@@ -68,17 +113,7 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
 
   const removeTree = () => {
     try {
-      const axesNeeded = getRequiredAxeAmount(
-        fruit?.name as FruitName,
-        inventory,
-        collectibles
-      );
-      const axeAmount = inventory.Axe ?? new Decimal(0);
-
-      // Has enough axes to chop the tree
-      const hasAxes =
-        (selectedItem === "Axe" || axesNeeded.eq(0)) &&
-        axeAmount.gte(axesNeeded);
+      const hasAxes = HasAxes(inventory, collectibles, fruit, selectedItem);
 
       if (!hasAxes) {
         return displayInformation();

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -1,11 +1,19 @@
 import React, { useContext, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
-import { Reward, FERTILISERS, PlantedCrop } from "features/game/types/game";
+import {
+  Reward,
+  FERTILISERS,
+  PlantedCrop,
+  PlacedItem,
+} from "features/game/types/game";
 import { CROPS } from "features/game/types/crops";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { harvestAudio, plantAudio } from "lib/utils/sfx";
-import { isPlotFertile } from "features/game/events/landExpansion/plant";
+import {
+  getCompletedWellCount,
+  isPlotFertile,
+} from "features/game/events/landExpansion/plant";
 import Spritesheet from "components/animation/SpriteAnimator";
 import { HARVEST_PROC_ANIMATION } from "features/island/plots/lib/plant";
 import { isReadyToHarvest } from "features/game/events/landExpansion/harvest";
@@ -15,9 +23,17 @@ import { ChestReward } from "../common/chest-reward/ChestReward";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
+import { BuildingName } from "features/game/types/buildings";
 
 const selectCrops = (state: MachineState) => state.context.state.crops;
 const selectBuildings = (state: MachineState) => state.context.state.buildings;
+
+const compareBuildings = (
+  prev: Partial<Record<BuildingName, PlacedItem[]>>,
+  next: Partial<Record<BuildingName, PlacedItem[]>>
+) => {
+  return getCompletedWellCount(prev) === getCompletedWellCount(next);
+};
 
 interface Props {
   id: string;
@@ -29,8 +45,10 @@ export const Plot: React.FC<Props> = ({ id }) => {
   const [reward, setReward] = useState<Reward>();
   const clickedAt = useRef<number>(0);
 
-  const crops = useSelector(gameService, selectCrops);
-  const buildings = useSelector(gameService, selectBuildings);
+  const crops = useSelector(gameService, selectCrops, (prev, next) => {
+    return JSON.stringify(prev[id].crop) === JSON.stringify(next[id].crop);
+  });
+  const buildings = useSelector(gameService, selectBuildings, compareBuildings);
 
   const crop = crops?.[id]?.crop;
 


### PR DESCRIPTION
# Description

- add compareres for useSelector for crop, fruit tree, tree, stone, iron, gold and chicken components.
  - these components will not unnecessary rerender with changes in the gamestate.

Based on the discussions of https://github.com/sunflower-land/sunflower-land/pull/2445 and changes in https://github.com/sunflower-land/sunflower-land/pull/2454

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Perform state changes throughout the game.  Crop, fruit tree, tree, stone, iron, gold and chicken components should barely rerender (try adding console logs)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
