### PR TITLE
[FIX] Has sold logic

### DIFF
--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -15,6 +15,19 @@ import { Conversation } from "features/farming/mail/components/Conversation";
 import { CONVERSATIONS } from "features/game/types/conversations";
 import { Panel } from "components/ui/Panel";
 import { NPC_WEARABLES } from "lib/npcs";
+import { getKeys } from "features/game/types/craftables";
+import { CROPS } from "features/game/types/crops";
+import { Bumpkin } from "features/game/types/game";
+
+const hasSoldCropsBefore = (bumpkin?: Bumpkin) => {
+  if (!bumpkin) return false;
+
+  const { activity = {} } = bumpkin;
+
+  return !!getKeys(CROPS()).find((crop) =>
+    getKeys(activity).includes(`${crop} Sold`)
+  );
+};
 
 export const Market: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -37,6 +50,8 @@ export const Market: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
       return;
     }
   };
+
+  const hasSoldBefore = hasSoldCropsBefore(gameState.context.state.bumpkin);
 
   return (
     <>
@@ -88,9 +103,7 @@ export const Market: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
         ) : (
           <ShopItems
             onClose={() => setIsOpen(false)}
-            hasSoldBefore={
-              !!gameState.context.state.bumpkin?.activity?.["Sunflower Sold"]
-            }
+            hasSoldBefore={hasSoldBefore}
           />
         )}
       </Modal>


### PR DESCRIPTION
# Description

There was a change in the onboarding work that showed an animation on the Sell tab if a player had not sold a Sunflower before. This animation was showing for regular players without the onboarding context so it was confusing. I have changed the logic to only show if a player has never sold anything at the market.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
