### PR TITLE
[FEAT] Landscaping Dig Up

### DIFF
--- a/src/assets/sunnyside.ts
+++ b/src/assets/sunnyside.ts
@@ -25,6 +25,7 @@ export const SUNNYSIDE = {
     disc_large: `${CONFIG.PROTECTED_IMAGE_URL}/icons/disc_large.png`,
     disc: `${CONFIG.PROTECTED_IMAGE_URL}/icons/disc.png`,
     drag: `${CONFIG.PROTECTED_IMAGE_URL}/icons/drag.png`,
+    dragging: `${CONFIG.PROTECTED_IMAGE_URL}/icons/dragging.png`,
     expand: `${CONFIG.PROTECTED_IMAGE_URL}/icons/expand.png`,
     expression_alerted: `${CONFIG.PROTECTED_IMAGE_URL}/icons/expression_alerted.png`,
     expression_chat: `${CONFIG.PROTECTED_IMAGE_URL}/icons/expression_chat.png`,

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -150,6 +150,7 @@ import { moveIron, MoveIronAction } from "./landExpansion/moveIron";
 import { moveStone, MoveStoneAction } from "./landExpansion/moveStone";
 import { moveGold, MoveGoldAction } from "./landExpansion/moveGold";
 import { pickMushroom, PickMushroomAction } from "./landExpansion/pickMushroom";
+import { moveChicken, MoveChickenAction } from "./landExpansion/moveChicken";
 
 export type PlayingEvent =
   | TradeAction
@@ -174,7 +175,6 @@ export type PlayingEvent =
   | CraftToolAction
   | buyDecorationAction
   | SellCropAction
-  | RemoveChickenAction
   | BeanBoughtAction
   | CollectCropRewardAction
   | CollectTreeRewardAction
@@ -191,7 +191,11 @@ export type PlayingEvent =
   | ExpandLandAction
   | ConversationEnded
   | MessageRead
-  | PickMushroomAction;
+  | PickMushroomAction
+  // TODO - remove once landscaping is released
+  | RemoveBuildingAction
+  | RemoveCollectibleAction
+  | RemoveChickenAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -215,8 +219,10 @@ export type PlacementEvent =
   | MoveIronAction
   | MoveStoneAction
   | MoveGoldAction
+  | MoveChickenAction
   | RemoveBuildingAction
-  | RemoveCollectibleAction;
+  | RemoveCollectibleAction
+  | RemoveChickenAction;
 
 export type GameEvent = PlayingEvent | PlacementEvent;
 export type GameEventName<T> = Extract<T, { type: string }>["type"];
@@ -266,7 +272,6 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "decoration.bought": buyDecoration,
   "crop.sold": sellCrop,
 
-  "chicken.removed": removeChicken,
   "bean.bought": beanBought,
   "cropReward.collected": collectCropReward,
   "treeReward.collected": collectTreeReward,
@@ -283,6 +288,10 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "conversation.ended": endConversation,
   "message.read": readMessage,
   "mushroom.picked": pickMushroom,
+  // TODO - remove once landscaping is released
+  "building.removed": removeBuilding,
+  "collectible.removed": removeCollectible,
+  "chicken.removed": removeChicken,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
@@ -307,8 +316,10 @@ export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "iron.moved": moveIron,
   "stone.moved": moveStone,
   "gold.moved": moveGold,
+  "chicken.moved": moveChicken,
   "building.removed": removeBuilding,
   "collectible.removed": removeCollectible,
+  "chicken.removed": removeChicken,
 };
 
 export const EVENTS = { ...PLAYING_EVENTS, ...PLACEMENT_EVENTS };

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -174,8 +174,6 @@ export type PlayingEvent =
   | CraftToolAction
   | buyDecorationAction
   | SellCropAction
-  | RemoveBuildingAction
-  | RemoveCollectibleAction
   | RemoveChickenAction
   | BeanBoughtAction
   | CollectCropRewardAction
@@ -216,7 +214,9 @@ export type PlacementEvent =
   | MoveTreeAction
   | MoveIronAction
   | MoveStoneAction
-  | MoveGoldAction;
+  | MoveGoldAction
+  | RemoveBuildingAction
+  | RemoveCollectibleAction;
 
 export type GameEvent = PlayingEvent | PlacementEvent;
 export type GameEventName<T> = Extract<T, { type: string }>["type"];
@@ -265,8 +265,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "tool.crafted": craftTool,
   "decoration.bought": buyDecoration,
   "crop.sold": sellCrop,
-  "building.removed": removeBuilding,
-  "collectible.removed": removeCollectible,
+
   "chicken.removed": removeChicken,
   "bean.bought": beanBought,
   "cropReward.collected": collectCropReward,
@@ -308,6 +307,8 @@ export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "iron.moved": moveIron,
   "stone.moved": moveStone,
   "gold.moved": moveGold,
+  "building.removed": removeBuilding,
+  "collectible.removed": removeCollectible,
 };
 
 export const EVENTS = { ...PLAYING_EVENTS, ...PLACEMENT_EVENTS };

--- a/src/features/game/events/landExpansion/moveChicken.ts
+++ b/src/features/game/events/landExpansion/moveChicken.ts
@@ -1,0 +1,47 @@
+import { Coordinates } from "features/game/expansion/components/MapPlacement";
+import { GameState } from "features/game/types/game";
+import cloneDeep from "lodash.clonedeep";
+
+export enum MOVE_CHICKEN_ERRORS {
+  NO_BUMPKIN = "You do not have a Bumpkin!",
+  CHICKEN_NOT_PLACED = "This chicken is not placed!",
+}
+
+export type MoveChickenAction = {
+  type: "chicken.moved";
+  coordinates: Coordinates;
+  id: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: MoveChickenAction;
+  createdAt?: number;
+};
+
+export function moveChicken({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  const stateCopy = cloneDeep(state) as GameState;
+  const chickens = stateCopy.chickens;
+
+  if (stateCopy.bumpkin === undefined) {
+    throw new Error(MOVE_CHICKEN_ERRORS.NO_BUMPKIN);
+  }
+
+  if (!chickens[action.id]?.coordinates) {
+    throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
+  }
+
+  const coordinates = chickens[action.id].coordinates;
+  if (!coordinates) {
+    throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
+  }
+
+  coordinates.x = action.coordinates.x;
+  coordinates.y = action.coordinates.y;
+
+  return stateCopy;
+}

--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -88,7 +88,7 @@ describe("removeBuilding", () => {
         },
         action: {
           type: "building.removed",
-          building: "Bakery",
+          name: "Bakery",
           id: "1",
         },
       })
@@ -113,7 +113,7 @@ describe("removeBuilding", () => {
         },
         action: {
           type: "building.removed",
-          building: "Bakery",
+          name: "Bakery",
           id: "1",
         },
       })
@@ -141,7 +141,7 @@ describe("removeBuilding", () => {
         },
         action: {
           type: "building.removed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           id: "123",
         },
       })
@@ -169,7 +169,7 @@ describe("removeBuilding", () => {
         },
         action: {
           type: "building.removed",
-          building: "Fire Pit",
+          name: "Fire Pit",
           id: "123",
         },
       })
@@ -208,7 +208,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         id: "123",
       },
     });
@@ -252,7 +252,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Fire Pit",
+        name: "Fire Pit",
         id: "123",
       },
     });
@@ -300,7 +300,7 @@ describe("removeBuilding", () => {
   //       },
   //       action: {
   //         type: "building.removed",
-  //         building: "Water Well",
+  //         name: "Water Well",
   //         id: "123",
   //       },
   //     })
@@ -336,7 +336,7 @@ describe("removeBuilding", () => {
   //       },
   //       action: {
   //         type: "building.removed",
-  //         building: "Water Well",
+  //         name: "Water Well",
   //         id: "123",
   //       },
   //     })
@@ -409,7 +409,7 @@ describe("removeBuilding", () => {
   //       },
   //       action: {
   //         type: "building.removed",
-  //         building: "Water Well",
+  //         name: "Water Well",
   //         id: "123",
   //       },
   //     })
@@ -450,7 +450,7 @@ describe("removeBuilding", () => {
   //       },
   //       action: {
   //         type: "building.removed",
-  //         building: "Water Well",
+  //         name: "Water Well",
   //         id: "123",
   //       },
   //     })
@@ -522,7 +522,7 @@ describe("removeBuilding", () => {
   //     },
   //     action: {
   //       type: "building.removed",
-  //       building: "Water Well",
+  //       name: "Water Well",
   //       id: "123",
   //     },
   //   });
@@ -557,7 +557,7 @@ describe("removeBuilding", () => {
         state: gameState,
         action: {
           type: "building.removed",
-          building: "Hen House",
+          name: "Hen House",
           id: "123",
         },
       })
@@ -585,7 +585,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Hen House",
+        name: "Hen House",
         id: "123",
       },
     });
@@ -620,7 +620,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Hen House",
+        name: "Hen House",
         id: "123",
       },
     });
@@ -665,7 +665,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Hen House",
+        name: "Hen House",
         id: "123",
       },
     });
@@ -704,7 +704,7 @@ describe("removeBuilding", () => {
       },
       action: {
         type: "building.removed",
-        building: "Hen House",
+        name: "Hen House",
         id: "123",
       },
     });

--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -120,34 +120,6 @@ describe("removeBuilding", () => {
     ).toThrow(REMOVE_BUILDING_ERRORS.INVALID_BUILDING);
   });
 
-  it("does not remove if not enough Rusty Shovel in inventory", () => {
-    expect(() =>
-      removeBuilding({
-        state: {
-          ...GAME_STATE,
-          inventory: {
-            "Rusty Shovel": new Decimal(0),
-          },
-          buildings: {
-            "Fire Pit": [
-              {
-                id: "123",
-                coordinates: { x: 1, y: 1 },
-                createdAt: 0,
-                readyAt: 0,
-              },
-            ],
-          },
-        },
-        action: {
-          type: "building.removed",
-          name: "Fire Pit",
-          id: "123",
-        },
-      })
-    ).toThrow(REMOVE_BUILDING_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
-  });
-
   it("does not remove a building if it's under construction", () => {
     expect(() =>
       removeBuilding({

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -1,4 +1,3 @@
-import Decimal from "decimal.js-light";
 import { BuildingName } from "features/game/types/buildings";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/craftables";
@@ -17,7 +16,7 @@ export enum REMOVE_BUILDING_ERRORS {
 
 export type RemoveBuildingAction = {
   type: "building.removed";
-  building: BuildingName;
+  name: BuildingName;
   id: string;
 };
 
@@ -127,7 +126,7 @@ export function removeBuilding({
 }: Options): GameState {
   const stateCopy = cloneDeep(state) as GameState;
   const { buildings, inventory, bumpkin } = stateCopy;
-  const buildingGroup = buildings[action.building];
+  const buildingGroup = buildings[action.name];
 
   if (bumpkin === undefined) {
     throw new Error(REMOVE_BUILDING_ERRORS.NO_BUMPKIN);
@@ -149,17 +148,11 @@ export function removeBuilding({
     throw new Error(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
   }
 
-  const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
-
-  if (shovelAmount.lessThan(1)) {
-    throw new Error(REMOVE_BUILDING_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
-  }
-
-  stateCopy.buildings[action.building] = buildingGroup.filter(
+  stateCopy.buildings[action.name] = buildingGroup.filter(
     (building) => building.id !== buildingToRemove.id
   );
 
-  if (action.building === "Water Well") {
+  if (action.name === "Water Well") {
     const { plots, hasUnsupportedCrops } = removeUnsupportedCrops(stateCopy);
     if (hasUnsupportedCrops) {
       throw new Error(REMOVE_BUILDING_ERRORS.WATER_WELL_REMOVE_CROPS);
@@ -168,7 +161,7 @@ export function removeBuilding({
     stateCopy.crops = plots;
   }
 
-  if (action.building === "Hen House") {
+  if (action.name === "Hen House") {
     if (areUnsupportedChickensBrewing(stateCopy)) {
       throw new Error(REMOVE_BUILDING_ERRORS.HEN_HOUSE_REMOVE_BREWING_CHICKEN);
     }
@@ -177,8 +170,6 @@ export function removeBuilding({
   }
 
   bumpkin.activity = trackActivity("Building Removed", bumpkin.activity);
-
-  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -149,10 +149,10 @@ export function removeBuilding({
     throw new Error(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
   }
 
+  // TODO - remove once landscaping is launched
   const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
-
-  if (shovelAmount.lessThan(1)) {
-    throw new Error(REMOVE_BUILDING_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
+  if (shovelAmount.gte(1)) {
+    inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
   }
 
   stateCopy.buildings[action.name] = buildingGroup.filter(
@@ -177,8 +177,6 @@ export function removeBuilding({
   }
 
   bumpkin.activity = trackActivity("Building Removed", bumpkin.activity);
-
-  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { BuildingName } from "features/game/types/buildings";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/craftables";
@@ -148,6 +149,12 @@ export function removeBuilding({
     throw new Error(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
   }
 
+  const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
+
+  if (shovelAmount.lessThan(1)) {
+    throw new Error(REMOVE_BUILDING_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
+  }
+
   stateCopy.buildings[action.name] = buildingGroup.filter(
     (building) => building.id !== buildingToRemove.id
   );
@@ -170,6 +177,8 @@ export function removeBuilding({
   }
 
   bumpkin.activity = trackActivity("Building Removed", bumpkin.activity);
+
+  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/removeChicken.test.ts
+++ b/src/features/game/events/landExpansion/removeChicken.test.ts
@@ -61,24 +61,6 @@ describe("removeChicken", () => {
     ).toThrow(REMOVE_CHICKEN_ERRORS.CHICKEN_BREWING_EGG);
   });
 
-  it("does not remove if not enough Rusty Shovel in inventory", () => {
-    expect(() =>
-      removeChicken({
-        state: {
-          ...GAME_STATE,
-          inventory: {
-            "Rusty Shovel": new Decimal(0),
-          },
-          chickens: makeChickensStateObject(10),
-        },
-        action: {
-          type: "chicken.removed",
-          id: "5",
-        },
-      })
-    ).toThrow(REMOVE_CHICKEN_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
-  });
-
   it("removes a chicken", () => {
     const state = {
       ...GAME_STATE,
@@ -118,23 +100,5 @@ describe("removeChicken", () => {
       coordinates: { x: 4, y: 4 },
       multiplier: 1,
     });
-  });
-
-  it("uses one Rusty Shovel per chicken removed", () => {
-    const gameState = removeChicken({
-      state: {
-        ...GAME_STATE,
-        inventory: {
-          "Rusty Shovel": new Decimal(2),
-        },
-        chickens: makeChickensStateObject(5),
-      },
-      action: {
-        type: "chicken.removed",
-        id: "4",
-      },
-    });
-
-    expect(gameState.inventory["Rusty Shovel"]).toEqual(new Decimal(1));
   });
 });

--- a/src/features/game/events/landExpansion/removeChicken.ts
+++ b/src/features/game/events/landExpansion/removeChicken.ts
@@ -5,7 +5,6 @@ import cloneDeep from "lodash.clonedeep";
 export enum REMOVE_CHICKEN_ERRORS {
   INVALID_CHICKEN = "This chicken does not exist",
   CHICKEN_BREWING_EGG = "This chicken is brewing an egg",
-  NO_RUSTY_SHOVEL_AVAILABLE = "No Rusty Shovel available!",
 }
 
 export type RemoveChickenAction = {
@@ -35,15 +34,13 @@ export function removeChicken({ state, action }: Options) {
     throw new Error(REMOVE_CHICKEN_ERRORS.CHICKEN_BREWING_EGG);
   }
 
+  // TODO - remove once landscaping is launched
   const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
-
-  if (shovelAmount.lessThan(1)) {
-    throw new Error(REMOVE_CHICKEN_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
+  if (shovelAmount.gte(1)) {
+    inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
   }
 
   delete chickens[action.id];
-
-  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/removeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.test.ts
@@ -67,34 +67,6 @@ describe("removeCollectible", () => {
     ).toThrow(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
   });
 
-  it("does not remove if not enough Rusty Shovel in inventory", () => {
-    expect(() =>
-      removeCollectible({
-        state: {
-          ...GAME_STATE,
-          inventory: {
-            "Rusty Shovel": new Decimal(0),
-          },
-          collectibles: {
-            Nugget: [
-              {
-                id: "123",
-                createdAt: 0,
-                coordinates: { x: 1, y: 1 },
-                readyAt: 0,
-              },
-            ],
-          },
-        },
-        action: {
-          type: "collectible.removed",
-          name: "Nugget",
-          id: "123",
-        },
-      })
-    ).toThrow(REMOVE_COLLECTIBLE_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
-  });
-
   it("removes a collectible and does not affect collectibles of the same type", () => {
     const gameState = removeCollectible({
       state: {

--- a/src/features/game/events/landExpansion/removeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.test.ts
@@ -35,7 +35,7 @@ describe("removeCollectible", () => {
         },
         action: {
           type: "collectible.removed",
-          collectible: "Algerian Flag",
+          name: "Algerian Flag",
           id: "1",
         },
       })
@@ -60,7 +60,7 @@ describe("removeCollectible", () => {
         },
         action: {
           type: "collectible.removed",
-          collectible: "Nugget",
+          name: "Nugget",
           id: "1",
         },
       })
@@ -88,7 +88,7 @@ describe("removeCollectible", () => {
         },
         action: {
           type: "collectible.removed",
-          collectible: "Nugget",
+          name: "Nugget",
           id: "123",
         },
       })
@@ -127,7 +127,7 @@ describe("removeCollectible", () => {
       },
       action: {
         type: "collectible.removed",
-        collectible: "Nugget",
+        name: "Nugget",
         id: "123",
       },
     });
@@ -168,7 +168,7 @@ describe("removeCollectible", () => {
       },
       action: {
         type: "collectible.removed",
-        collectible: "Nugget",
+        name: "Nugget",
         id: "123",
       },
     });
@@ -210,7 +210,7 @@ describe("removeCollectible", () => {
         state: gameState,
         action: {
           type: "collectible.removed",
-          collectible: "Chicken Coop",
+          name: "Chicken Coop",
           id: "123",
         },
       })
@@ -248,7 +248,7 @@ describe("removeCollectible", () => {
       },
       action: {
         type: "collectible.removed",
-        collectible: "Chicken Coop",
+        name: "Chicken Coop",
         id: "123",
       },
     });
@@ -293,7 +293,7 @@ describe("removeCollectible", () => {
       },
       action: {
         type: "collectible.removed",
-        collectible: "Chicken Coop",
+        name: "Chicken Coop",
         id: "123",
       },
     });
@@ -322,7 +322,7 @@ describe("removeCollectible", () => {
       },
       action: {
         type: "collectible.removed",
-        collectible: "Rock Golem",
+        name: "Rock Golem",
         id: "123",
       },
     });

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { CollectibleName } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
@@ -27,7 +28,6 @@ type Options = {
 };
 
 export function removeCollectible({ state, action }: Options) {
-  console.log({ remove: action });
   const stateCopy = cloneDeep(state) as GameState;
 
   const { collectibles, inventory, bumpkin } = stateCopy;
@@ -47,6 +47,12 @@ export function removeCollectible({ state, action }: Options) {
 
   if (!collectibleToRemove) {
     throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
+  }
+
+  const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
+
+  if (shovelAmount.lessThan(1)) {
+    throw new Error(REMOVE_COLLECTIBLE_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
   }
 
   stateCopy.collectibles[action.name] = collectibleGroup.filter(
@@ -69,6 +75,8 @@ export function removeCollectible({ state, action }: Options) {
   }
 
   bumpkin.activity = trackActivity("Collectible Removed", bumpkin.activity);
+
+  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -49,10 +49,10 @@ export function removeCollectible({ state, action }: Options) {
     throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
   }
 
+  // TODO - remove once landscaping is launched
   const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
-
-  if (shovelAmount.lessThan(1)) {
-    throw new Error(REMOVE_COLLECTIBLE_ERRORS.NO_RUSTY_SHOVEL_AVAILABLE);
+  if (shovelAmount.gte(1)) {
+    inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
   }
 
   stateCopy.collectibles[action.name] = collectibleGroup.filter(
@@ -75,8 +75,6 @@ export function removeCollectible({ state, action }: Options) {
   }
 
   bumpkin.activity = trackActivity("Collectible Removed", bumpkin.activity);
-
-  inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
 
   return stateCopy;
 }

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -151,7 +151,14 @@ const getIslandElements = ({
             height={height}
             width={width}
           >
-            <ChickenElement key={`chicken-${id}`} id={id} />
+            <ChickenElement
+              key={`chicken-${id}`}
+              id={id}
+              coordinates={{
+                x,
+                y,
+              }}
+            />
           </MapPlacement>
         );
       })

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -19,7 +19,6 @@ import { Building } from "features/island/buildings/components/building/Building
 import { Collectible } from "features/island/collectibles/Collectible";
 import { Water } from "./components/Water";
 import { DirtRenderer } from "./components/DirtRenderer";
-import { Equipped as BumpkinParts } from "../types/bumpkin";
 import { Chicken } from "../types/game";
 import { Chicken as ChickenElement } from "features/island/chickens/Chicken";
 import { Hud } from "features/island/hud/Hud";
@@ -44,10 +43,8 @@ const getIslandElements = ({
   gold,
   fruitPatches,
   crops,
-  bumpkinParts,
   isRustyShovelSelected,
   showTimers,
-  isEditing,
   grid,
   mushrooms,
   isFirstRender,
@@ -62,10 +59,8 @@ const getIslandElements = ({
   gold: GameState["gold"];
   crops: GameState["crops"];
   fruitPatches: GameState["fruitPatches"];
-  bumpkinParts: BumpkinParts | undefined;
   isRustyShovelSelected: boolean;
   showTimers: boolean;
-  isEditing?: boolean;
   grid: GameGrid;
   mushrooms: GameState["mushrooms"]["mushrooms"];
   isFirstRender: boolean;
@@ -400,9 +395,21 @@ export const Land: React.FC = () => {
           })}
         >
           <LandBase expandedCount={expansionCount} />
-          <UpcomingExpansion />
           <DirtRenderer grid={gameGrid} />
-          <Water level={expansionCount} />
+
+          {!gameState.isLandscaping && <Water level={expansionCount} />}
+          {!gameState.isLandscaping && <UpcomingExpansion />}
+          {!gameState.isLandscaping && (
+            <IslandTravel
+              bumpkin={bumpkin}
+              isVisiting={visiting}
+              inventory={inventory}
+              travelAllowed={!autosaving}
+              onTravelDialogOpened={() => gameService.send("SAVE")}
+              x={boatCoordinates.x}
+              y={boatCoordinates.y}
+            />
+          )}
 
           {/* Sort island elements by y axis */}
           {getIslandElements({
@@ -416,24 +423,13 @@ export const Land: React.FC = () => {
             gold,
             fruitPatches,
             crops,
-            bumpkinParts: bumpkin?.equipped,
             isRustyShovelSelected: shortcuts[0] === "Rusty Shovel",
             showTimers: showTimers,
-            isEditing: editing,
             grid,
             mushrooms: mushrooms.mushrooms,
             isFirstRender,
           }).sort((a, b) => b.props.y - a.props.y)}
         </div>
-        <IslandTravel
-          bumpkin={bumpkin}
-          isVisiting={visiting}
-          inventory={inventory}
-          travelAllowed={!autosaving}
-          onTravelDialogOpened={() => gameService.send("SAVE")}
-          x={boatCoordinates.x}
-          y={boatCoordinates.y}
-        />
 
         {gameState.isLandscaping && <Placeable />}
       </div>

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -16,7 +16,6 @@ import {
   ANIMAL_DIMENSIONS,
   COLLECTIBLES_DIMENSIONS,
 } from "features/game/types/craftables";
-import { BUILDING_COMPONENTS } from "features/island/buildings/components/building/Building";
 import { COLLECTIBLE_COMPONENTS } from "features/island/collectibles/Collectible";
 import { Chicken } from "features/island/chickens/Chicken";
 
@@ -25,8 +24,12 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { READONLY_RESOURCE_COMPONENTS } from "features/island/resources/Resource";
 import { getGameGrid } from "./lib/makeGrid";
+import {
+  BUILDING_COMPONENTS,
+  READONLY_BUILDINGS,
+} from "features/island/buildings/components/building/BuildingComponents";
 
-const PLACEABLES: Record<PlaceableName, React.FC<any>> = {
+export const PLACEABLES: Record<PlaceableName, React.FC<any>> = {
   Chicken: () => <Chicken id="123" />, // Temp id for placing, when placed action will assign a random UUID and the temp one will be overridden.
   ...BUILDING_COMPONENTS,
   ...COLLECTIBLE_COMPONENTS,
@@ -37,50 +40,7 @@ const PLACEABLES: Record<PlaceableName, React.FC<any>> = {
       style={{ width: `${PIXEL_SCALE * 22}px` }}
     />
   ),
-  "Fire Pit": () => (
-    <img
-      src={ITEM_DETAILS["Fire Pit"].image}
-      style={{ width: `${PIXEL_SCALE * 47}px` }}
-    />
-  ),
-  Kitchen: () => (
-    <img
-      src={ITEM_DETAILS["Kitchen"].image}
-      style={{ width: `${PIXEL_SCALE * 63}px` }}
-    />
-  ),
-  Workbench: () => (
-    <img
-      src={ITEM_DETAILS["Workbench"].image}
-      className="relative"
-      style={{ width: `${PIXEL_SCALE * 47}px`, bottom: `${PIXEL_SCALE * 2}px` }}
-    />
-  ),
-  Market: () => (
-    <img
-      src={ITEM_DETAILS["Market"].image}
-      className="relative"
-      style={{ width: `${PIXEL_SCALE * 48}px`, bottom: `${PIXEL_SCALE * 6}px` }}
-    />
-  ),
-  "Hen House": () => (
-    <img
-      src={ITEM_DETAILS["Hen House"].image}
-      className="relative"
-      style={{ width: `${PIXEL_SCALE * 61}px`, bottom: `${PIXEL_SCALE * 2}px` }}
-    />
-  ),
-  "Town Center": () => (
-    <img
-      src={ITEM_DETAILS["Town Center"].image}
-      className="relative"
-      style={{
-        width: `${PIXEL_SCALE * 62}px`,
-        left: `${PIXEL_SCALE * 2}px`,
-        bottom: `${PIXEL_SCALE * 2}px`,
-      }}
-    />
-  ),
+  ...READONLY_BUILDINGS,
 };
 
 // TODO - get dynamic bounds for placeable

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -30,7 +30,7 @@ import {
 } from "features/island/buildings/components/building/BuildingComponents";
 
 export const PLACEABLES: Record<PlaceableName, React.FC<any>> = {
-  Chicken: () => <Chicken id="123" />, // Temp id for placing, when placed action will assign a random UUID and the temp one will be overridden.
+  Chicken: () => <Chicken coordinates={{ x: 0, y: 0 }} id="123" />, // Temp id for placing, when placed action will assign a random UUID and the temp one will be overridden.
   ...BUILDING_COMPONENTS,
   ...COLLECTIBLE_COMPONENTS,
   ...READONLY_RESOURCE_COMPONENTS,

--- a/src/features/game/expansion/placeable/RemovePlaceableModal.tsx
+++ b/src/features/game/expansion/placeable/RemovePlaceableModal.tsx
@@ -37,12 +37,12 @@ export const RemovePlaceableModal: React.FC<Props> = ({
   const handleRemove = () => {
     if (type === "building") {
       gameService.send("building.removed", {
-        building: name,
+        name: name,
         id: placeableId,
       });
     } else {
       gameService.send("collectible.removed", {
-        collectible: name,
+        name: name,
         id: placeableId,
       });
     }

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -49,7 +49,7 @@ export interface Context {
   action?: GameEventName<PlacementEvent>;
   coordinates: Coordinates;
   collisionDetected: boolean;
-  placeable?: BuildingName | CollectibleName;
+  placeable?: BuildingName | CollectibleName | "Chicken";
   hasLandscapingAccess: boolean;
 
   multiple?: boolean;
@@ -340,7 +340,9 @@ export const landscapingMachine = createMachine<
               },
               {
                 target: ["#saving.done", "done"],
-                cond: (context) => !context.hasLandscapingAccess,
+                cond: (context) =>
+                  !context.hasLandscapingAccess ||
+                  context.placeable === "Chicken",
                 actions: [
                   sendParent(
                     ({ placeable, action, coordinates: { x, y } }) =>

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -3,6 +3,7 @@ import { GameEventName, PlacementEvent } from "features/game/events";
 import {
   BUILDINGS_DIMENSIONS,
   BuildingName,
+  PlaceableName,
 } from "features/game/types/buildings";
 import { CollectibleName } from "features/game/types/craftables";
 import { assign, createMachine, Interpreter, sendParent, State } from "xstate";
@@ -89,6 +90,13 @@ type PlaceEvent = {
   nextWillCollide?: boolean;
 };
 
+type RemoveEvent = {
+  type: "REMOVE";
+  event: GameEventName<PlacementEvent>;
+  id: string;
+  name: PlaceableName;
+};
+
 type ConstructEvent = {
   type: "CONSTRUCT";
   actionName: PlacementEvent;
@@ -124,6 +132,7 @@ export type BlockchainEvent =
   | SaveEvent
   | GuestSaveEvent
   | MoveEvent
+  | RemoveEvent
   | { type: "CANCEL" }
   | { type: "BACK" };
 
@@ -269,6 +278,20 @@ export const landscapingMachine = createMachine<
             },
             BUILD: {
               target: "idle",
+            },
+            REMOVE: {
+              target: "idle",
+              actions: [
+                sendParent(
+                  (_context, event: RemoveEvent) =>
+                    ({
+                      type: event.event,
+                      name: event.name,
+                      id: event.id,
+                    } as PlacementEvent)
+                ),
+                assign({ moving: undefined }),
+              ],
             },
           },
         },

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -290,7 +290,7 @@ export const landscapingMachine = createMachine<
                       id: event.id,
                     } as PlacementEvent)
                 ),
-                assign({ moving: undefined }),
+                assign({ moving: (_) => undefined }),
               ],
             },
           },

--- a/src/features/game/expansion/placeable/lib/makeGrid.ts
+++ b/src/features/game/expansion/placeable/lib/makeGrid.ts
@@ -29,7 +29,6 @@ export function getGameGrid({
     grid[coords.x][coords.y] = "Dirt Path";
   });
 
-  console.log({ collectibles });
   getKeys(collectibles).forEach((name) => {
     collectibles[name]?.forEach(({ coordinates }) => {
       if (!grid[coordinates.x]) {

--- a/src/features/game/expansion/placeable/lib/makeGrid.ts
+++ b/src/features/game/expansion/placeable/lib/makeGrid.ts
@@ -29,6 +29,7 @@ export function getGameGrid({
     grid[coords.x][coords.y] = "Dirt Path";
   });
 
+  console.log({ collectibles });
   getKeys(collectibles).forEach((name) => {
     collectibles[name]?.forEach(({ coordinates }) => {
       if (!grid[coordinates.x]) {

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -634,12 +634,6 @@ export function startGame(authContext: AuthContext) {
             {
               target: "noTownCenter",
               cond: (context: Context) => {
-                console.log({
-                  test: context.state.buildings["Town Center"],
-                  val:
-                    (context.state.buildings["Town Center"] ?? []).length === 0,
-                });
-
                 return (
                   (context.state.buildings["Town Center"] ?? []).length === 0
                 );

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -275,6 +275,7 @@ export const OFFLINE_FARM: GameState = {
     Wood: new Decimal(100),
     Stone: new Decimal(50),
     Axe: new Decimal(10),
+    "Rusty Shovel": new Decimal(5),
     "Maneki Neko": new Decimal(2),
     "Lunar Calendar": new Decimal(1),
     "Pablo The Bunny": new Decimal(1),
@@ -295,7 +296,12 @@ export const OFFLINE_FARM: GameState = {
 
   bumpkin: INITIAL_BUMPKIN,
 
-  chickens: {},
+  chickens: {
+    "1": {
+      multiplier: 1,
+      coordinates: { x: 4, y: 4 },
+    },
+  },
 
   airdrops: [],
 

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -2,31 +2,19 @@ import React, { useContext, useState } from "react";
 
 import { BuildingName } from "features/game/types/buildings";
 import { BuildingProduct } from "features/game/types/game";
-import { FirePit } from "./firePit/FirePit";
 import { Bar } from "components/ui/ProgressBar";
-import { WithCraftingMachine } from "./WithCraftingMachine";
-import { Market } from "./market/Market";
-import { WorkBench } from "./workBench/WorkBench";
-import { Tent } from "./tent/Tent";
-import { WaterWell } from "./waterWell/WaterWell";
-import { ChickenHouse } from "./henHouse/HenHouse";
-import { Bakery } from "./bakery/Bakery";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
-import { Kitchen } from "./kitchen/Kitchen";
-import { Deli } from "./deli/Deli";
 import { Modal } from "react-bootstrap";
 import { RemovePlaceableModal } from "features/game/expansion/placeable/RemovePlaceableModal";
 import { PIXEL_SCALE } from "features/game/lib/constants";
-import { SmoothieShack } from "./smoothieShack/SmoothieShack";
-import { Warehouse } from "./warehouse/Warehouse";
-import { Toolshed } from "./toolshed/Toolshed";
-import { TownCenter } from "./townCenter/TownCenter";
 import { useSelector } from "@xstate/react";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { MoveableComponent } from "features/island/collectibles/MovableComponent";
 import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
+import { PLACEABLES } from "features/game/expansion/placeable/Placeable";
+import { BUILDING_COMPONENTS } from "./BuildingComponents";
 
 interface Prop {
   name: BuildingName;
@@ -45,64 +33,6 @@ export interface BuildingProps {
   isBuilt?: boolean;
   onRemove?: () => void;
 }
-
-export const BUILDING_COMPONENTS: Record<
-  BuildingName,
-  React.FC<BuildingProps>
-> = {
-  "Fire Pit": ({
-    buildingId,
-    craftingState,
-    isBuilt,
-    onRemove,
-  }: BuildingProps) => (
-    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
-      <FirePit buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
-    </WithCraftingMachine>
-  ),
-  Workbench: WorkBench,
-  Bakery: ({ buildingId, craftingState, isBuilt, onRemove }: BuildingProps) => (
-    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
-      <Bakery buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
-    </WithCraftingMachine>
-  ),
-  Market: Market,
-  Tent: Tent,
-  "Town Center": TownCenter,
-  "Water Well": WaterWell,
-  Warehouse: Warehouse,
-  Toolshed: Toolshed,
-  "Hen House": ChickenHouse,
-  Kitchen: ({
-    buildingId,
-    craftingState,
-    isBuilt,
-    onRemove,
-  }: BuildingProps) => (
-    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
-      <Kitchen buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
-    </WithCraftingMachine>
-  ),
-  Deli: ({ buildingId, craftingState, isBuilt, onRemove }: BuildingProps) => (
-    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
-      <Deli buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
-    </WithCraftingMachine>
-  ),
-  "Smoothie Shack": ({
-    buildingId,
-    craftingState,
-    isBuilt,
-    onRemove,
-  }: BuildingProps) => (
-    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
-      <SmoothieShack
-        buildingId={buildingId}
-        isBuilt={isBuilt}
-        onRemove={onRemove}
-      />
-    </WithCraftingMachine>
-  ),
-};
 
 const InProgressBuilding: React.FC<Prop> = ({
   name,
@@ -229,9 +159,13 @@ export const Building: React.FC<Prop> = (props) => {
   const landscaping = useSelector(gameService, isLandscaping);
 
   if (landscaping) {
+    // In Landscaping mode, use readonly building
     return (
       <MoveableComponent id={props.id} {...(props as any)}>
-        <BuildingComponent {...props} />
+        {PLACEABLES[props.name]({
+          coordinates: props.coordinates,
+          grid: {},
+        })}
       </MoveableComponent>
     );
   }

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -13,7 +13,6 @@ import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { MoveableComponent } from "features/island/collectibles/MovableComponent";
 import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
-import { PLACEABLES } from "features/game/expansion/placeable/Placeable";
 import { BUILDING_COMPONENTS } from "./BuildingComponents";
 
 interface Prop {
@@ -24,7 +23,7 @@ interface Prop {
   crafting?: BuildingProduct;
   isRustyShovelSelected: boolean;
   showTimers: boolean;
-  coordinates?: Coordinates;
+  coordinates: Coordinates;
 }
 
 export interface BuildingProps {
@@ -96,6 +95,7 @@ const BuildingComponent: React.FC<Prop> = ({
   crafting,
   isRustyShovelSelected,
   showTimers,
+  coordinates,
 }) => {
   const [showRemoveModal, setShowRemoveModal] = useState(false);
 
@@ -128,6 +128,7 @@ const BuildingComponent: React.FC<Prop> = ({
           createdAt={createdAt}
           isRustyShovelSelected={false}
           showTimers={showTimers}
+          coordinates={coordinates}
         />
       ) : (
         <BuildingPlaced
@@ -161,11 +162,12 @@ export const Building: React.FC<Prop> = (props) => {
   if (landscaping) {
     // In Landscaping mode, use readonly building
     return (
-      <MoveableComponent id={props.id} {...(props as any)}>
-        {PLACEABLES[props.name]({
-          coordinates: props.coordinates,
-          grid: {},
-        })}
+      <MoveableComponent
+        id={props.id}
+        name={props.name}
+        coordinates={props.coordinates}
+      >
+        <BuildingComponent {...props} />
       </MoveableComponent>
     );
   }

--- a/src/features/island/buildings/components/building/BuildingComponents.tsx
+++ b/src/features/island/buildings/components/building/BuildingComponents.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+import { BuildingName } from "features/game/types/buildings";
+import { BuildingProduct } from "features/game/types/game";
+import { FirePit } from "./firePit/FirePit";
+import { WithCraftingMachine } from "./WithCraftingMachine";
+import { Market } from "./market/Market";
+import { WorkBench } from "./workBench/WorkBench";
+import { Tent } from "./tent/Tent";
+import { WaterWell } from "./waterWell/WaterWell";
+import { ChickenHouse } from "./henHouse/HenHouse";
+import { Bakery } from "./bakery/Bakery";
+
+import { Kitchen } from "./kitchen/Kitchen";
+import { Deli } from "./deli/Deli";
+
+import { SmoothieShack } from "./smoothieShack/SmoothieShack";
+import { Warehouse } from "./warehouse/Warehouse";
+import { Toolshed } from "./toolshed/Toolshed";
+import { TownCenter } from "./townCenter/TownCenter";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+export interface BuildingProps {
+  buildingId: string;
+  craftingState?: BuildingProduct;
+  isBuilt?: boolean;
+  onRemove?: () => void;
+}
+
+export const BUILDING_COMPONENTS: Record<
+  BuildingName,
+  React.FC<BuildingProps>
+> = {
+  "Fire Pit": ({
+    buildingId,
+    craftingState,
+    isBuilt,
+    onRemove,
+  }: BuildingProps) => (
+    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
+      <FirePit buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
+    </WithCraftingMachine>
+  ),
+  Workbench: WorkBench,
+  Bakery: ({ buildingId, craftingState, isBuilt, onRemove }: BuildingProps) => (
+    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
+      <Bakery buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
+    </WithCraftingMachine>
+  ),
+  Market: Market,
+  Tent: Tent,
+  "Town Center": TownCenter,
+  "Water Well": WaterWell,
+  Warehouse: Warehouse,
+  Toolshed: Toolshed,
+  "Hen House": ChickenHouse,
+  Kitchen: ({
+    buildingId,
+    craftingState,
+    isBuilt,
+    onRemove,
+  }: BuildingProps) => (
+    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
+      <Kitchen buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
+    </WithCraftingMachine>
+  ),
+  Deli: ({ buildingId, craftingState, isBuilt, onRemove }: BuildingProps) => (
+    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
+      <Deli buildingId={buildingId} isBuilt={isBuilt} onRemove={onRemove} />
+    </WithCraftingMachine>
+  ),
+  "Smoothie Shack": ({
+    buildingId,
+    craftingState,
+    isBuilt,
+    onRemove,
+  }: BuildingProps) => (
+    <WithCraftingMachine buildingId={buildingId} craftingState={craftingState}>
+      <SmoothieShack
+        buildingId={buildingId}
+        isBuilt={isBuilt}
+        onRemove={onRemove}
+      />
+    </WithCraftingMachine>
+  ),
+};
+
+export const READONLY_BUILDINGS: Record<BuildingName, React.FC<any>> = {
+  ...BUILDING_COMPONENTS,
+  "Fire Pit": () => (
+    <img
+      src={ITEM_DETAILS["Fire Pit"].image}
+      style={{ width: `${PIXEL_SCALE * 47}px` }}
+    />
+  ),
+  Kitchen: () => (
+    <img
+      src={ITEM_DETAILS["Kitchen"].image}
+      style={{ width: `${PIXEL_SCALE * 63}px` }}
+    />
+  ),
+  Workbench: () => (
+    <img
+      src={ITEM_DETAILS["Workbench"].image}
+      className="relative"
+      style={{ width: `${PIXEL_SCALE * 47}px`, bottom: `${PIXEL_SCALE * 2}px` }}
+    />
+  ),
+  Market: () => (
+    <img
+      src={ITEM_DETAILS["Market"].image}
+      className="relative"
+      style={{ width: `${PIXEL_SCALE * 48}px`, bottom: `${PIXEL_SCALE * 6}px` }}
+    />
+  ),
+  "Hen House": () => (
+    <img
+      src={ITEM_DETAILS["Hen House"].image}
+      className="relative"
+      style={{ width: `${PIXEL_SCALE * 61}px`, bottom: `${PIXEL_SCALE * 2}px` }}
+    />
+  ),
+  "Town Center": () => (
+    <img
+      src={ITEM_DETAILS["Town Center"].image}
+      className="relative"
+      style={{
+        width: `${PIXEL_SCALE * 62}px`,
+        left: `${PIXEL_SCALE * 2}px`,
+        bottom: `${PIXEL_SCALE * 2}px`,
+      }}
+    />
+  ),
+};

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -39,6 +39,9 @@ import { CROP_LIFECYCLE } from "../plots/lib/plant";
 import { Collectibles, Chicken as ChickenType } from "features/game/types/game";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { MachineState as GameMachineState } from "features/game/lib/gameMachine";
+import { MachineState } from "features/game/expansion/placeable/landscapingMachine";
+import { MoveableComponent } from "../collectibles/MovableComponent";
+import { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 const getPercentageComplete = (fedAt?: number) => {
   if (!fedAt) return 0;
@@ -125,6 +128,7 @@ const compareCollectibles = (prev: Collectibles, next: Collectibles) =>
 
 interface Props {
   id: string;
+  coordinates: Coordinates;
 }
 
 const ChickenComponent: React.FC<Props> = ({ id }) => {
@@ -500,4 +504,25 @@ const ChickenComponent: React.FC<Props> = ({ id }) => {
   );
 };
 
-export const Chicken = React.memo(ChickenComponent);
+const isLandscaping = (state: MachineState) => state.matches("landscaping");
+
+export const Chicken: React.FC<Props> = (props) => {
+  const { gameService } = useContext(Context);
+
+  const landscaping = useSelector(gameService, isLandscaping);
+
+  if (landscaping) {
+    // In Landscaping mode, use readonly building
+    return (
+      <MoveableComponent
+        name="Chicken"
+        coordinates={props.coordinates}
+        id={props.id}
+      >
+        <ChickenComponent {...props} />
+      </MoveableComponent>
+    );
+  }
+
+  return <ChickenComponent {...props} />;
+};

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -18,7 +18,10 @@ import {
   MachineInterpreter,
   MachineState,
 } from "features/game/expansion/placeable/landscapingMachine";
-import { BUILDINGS_DIMENSIONS } from "features/game/types/buildings";
+import {
+  BUILDINGS_DIMENSIONS,
+  BuildingName,
+} from "features/game/types/buildings";
 import { GameEventName, PlacementEvent } from "features/game/events";
 import { RESOURCES, ResourceName } from "features/game/types/resources";
 import { InventoryItemName } from "features/game/types/game";
@@ -83,7 +86,7 @@ export function getRemoveAction(
 }
 
 export interface MovableProps {
-  name: CollectibleName | "Chicken";
+  name: CollectibleName | BuildingName | "Chicken";
   id: string;
   coordinates: Coordinates;
 }

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -7,7 +7,7 @@ import {
   CollectibleName,
 } from "features/game/types/craftables";
 
-import { GRID_WIDTH_PX } from "features/game/lib/constants";
+import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
@@ -24,6 +24,9 @@ import { GameEventName, PlacementEvent } from "features/game/events";
 import { RESOURCES, ResourceName } from "features/game/types/resources";
 import { InventoryItemName } from "features/game/types/game";
 import { removePlaceable } from "./lib/placing";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 
 export const RESOURCE_MOVE_EVENTS: Record<
   ResourceName,
@@ -54,6 +57,28 @@ function getMoveAction(name: InventoryItemName): GameEventName<PlacementEvent> {
   throw new Error("No matching move event");
 }
 
+export function getRemoveAction(
+  name: InventoryItemName
+): GameEventName<PlacementEvent> | null {
+  if (name in BUILDINGS_DIMENSIONS) {
+    return "building.removed";
+  }
+
+  if (name in RESOURCES) {
+    return null;
+  }
+
+  if (name === "Chicken") {
+    return null;
+  }
+
+  if (name in COLLECTIBLES_DIMENSIONS) {
+    return "collectible.removed";
+  }
+
+  return null;
+}
+
 export interface MovableProps {
   name: CollectibleName;
   id: string;
@@ -77,23 +102,45 @@ export const MoveableComponent: React.FC<MovableProps> = ({
   children,
 }) => {
   const nodeRef = useRef(null);
+  const [isMobile] = useIsMobile();
   const { gameService } = useContext(Context);
   const [isColliding, setIsColliding] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [counts, setCounts] = useState(0);
   const isActive = useRef(false);
+  const [showRemoveConfirmation, setShowRemoveConfirmation] = useState(false);
 
   const landscapingMachine = gameService.state.children
     .landscaping as MachineInterpreter;
 
   const movingItem = useSelector(landscapingMachine, getMovingItem);
 
+  const isSelected = movingItem?.id === id && movingItem?.name === name;
+  const removeAction = !isMobile && getRemoveAction(name);
+
+  const remove = () => {
+    if (!removeAction) {
+      return;
+    }
+
+    if (showRemoveConfirmation) {
+      console.log("REMOVE");
+      landscapingMachine.send("REMOVE", {
+        event: removeAction,
+        id: id,
+        name: name,
+      });
+    } else {
+      setShowRemoveConfirmation(true);
+    }
+  };
   useEffect(() => {
-    if (isActive.current && movingItem?.id !== id) {
+    if (isActive.current && !isSelected) {
       console.log("Reset");
       // Reset
       setCounts((prev) => prev + 1);
       setIsColliding(false);
+      setShowRemoveConfirmation(false);
       isActive.current = false;
     }
   }, [movingItem]);
@@ -129,6 +176,7 @@ export const MoveableComponent: React.FC<MovableProps> = ({
         key={`${coordinates?.x}-${coordinates?.y}-${counts}`}
         nodeRef={nodeRef}
         grid={[GRID_WIDTH_PX, GRID_WIDTH_PX]}
+        allowAnyClick
         onMouseDown={() => {
           console.log("Mouse down");
           landscapingMachine.send("MOVE", {
@@ -136,7 +184,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
             id,
           });
           isActive.current = true;
-          setIsDragging(true);
         }}
         onStart={(_, data) => {
           const x = Math.round(data.x);
@@ -155,14 +202,23 @@ export const MoveableComponent: React.FC<MovableProps> = ({
           const y = coordinates.y + yDiff;
           console.log({ x, y });
           detect({ x, y });
+          setIsDragging(true);
           // setShowHint(false);
         }}
         onStop={(_, data) => {
+          setIsDragging(false);
+
           const xDiff = Math.round((origin.current.x + data.x) / GRID_WIDTH_PX);
           const yDiff = Math.round((origin.current.y - data.y) / GRID_WIDTH_PX);
 
           const x = coordinates.x + xDiff;
           const y = coordinates.y + yDiff;
+
+          const hasMoved = x !== coordinates.x || y !== coordinates.y;
+          if (!hasMoved) {
+            return;
+          }
+
           console.log({ xDiff, yDiff, origin });
 
           const game = removePlaceable({
@@ -178,6 +234,7 @@ export const MoveableComponent: React.FC<MovableProps> = ({
           });
 
           if (!collisionDetected) {
+            console.log({ move: name });
             gameService.send(getMoveAction(name), {
               // Don't send name for resource events
               ...(name in RESOURCE_MOVE_EVENTS ? {} : { name }),
@@ -188,21 +245,100 @@ export const MoveableComponent: React.FC<MovableProps> = ({
               id,
             });
           }
-
-          setIsDragging(false);
         }}
       >
         <div
           ref={nodeRef}
           data-prevent-drag-scroll
-          className={classNames("h-full", {
+          className={classNames("h-full relative", {
             "cursor-grabbing": isDragging,
             "cursor-pointer": !isDragging,
           })}
+          onBlur={() => {
+            if (isSelected) {
+              console.log("Blur");
+            }
+          }}
         >
+          {isSelected && (
+            <div
+              className="absolute z-10 flex"
+              style={{
+                right: `${PIXEL_SCALE * -(removeAction ? 34 : 12)}px`,
+                top: `${PIXEL_SCALE * -12}px`,
+              }}
+            >
+              <div
+                className="relative mr-2"
+                style={{
+                  width: `${PIXEL_SCALE * 18}px`,
+                }}
+              >
+                <img className="w-full" src={SUNNYSIDE.icons.disc} />
+                {isDragging ? (
+                  <img
+                    className="absolute"
+                    src={SUNNYSIDE.icons.dragging}
+                    style={{
+                      width: `${PIXEL_SCALE * 12}px`,
+                      right: `${PIXEL_SCALE * 4}px`,
+                      top: `${PIXEL_SCALE * 4}px`,
+                    }}
+                  />
+                ) : (
+                  <img
+                    className="absolute"
+                    src={SUNNYSIDE.icons.drag}
+                    style={{
+                      width: `${PIXEL_SCALE * 14}px`,
+                      right: `${PIXEL_SCALE * 2}px`,
+                      top: `${PIXEL_SCALE * 2}px`,
+                    }}
+                  />
+                )}
+              </div>
+              {!!removeAction && (
+                <div
+                  className="relative cursor-pointer"
+                  style={{
+                    width: `${PIXEL_SCALE * 18}px`,
+                  }}
+                  onClick={(e) => {
+                    console.log("On clik");
+                    remove();
+                    e.preventDefault();
+                  }}
+                >
+                  <img className="w-full" src={SUNNYSIDE.icons.disc} />
+                  {isSelected && showRemoveConfirmation ? (
+                    <img
+                      className="absolute"
+                      src={SUNNYSIDE.icons.confirm}
+                      style={{
+                        width: `${PIXEL_SCALE * 12}px`,
+                        right: `${PIXEL_SCALE * 3}px`,
+                        top: `${PIXEL_SCALE * 3}px`,
+                      }}
+                    />
+                  ) : (
+                    <img
+                      className="absolute"
+                      src={ITEM_DETAILS["Rusty Shovel"].image}
+                      style={{
+                        width: `${PIXEL_SCALE * 12}px`,
+                        right: `${PIXEL_SCALE * 3}px`,
+                        top: `${PIXEL_SCALE * 3}px`,
+                      }}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           <div
             className={classNames("h-full", {
               "bg-red-500 bg-opacity-75": isColliding,
+              "bg-green-300 bg-opacity-50": !isColliding && isSelected,
             })}
           >
             {children}

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -124,7 +124,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
     }
 
     if (showRemoveConfirmation) {
-      console.log("REMOVE");
       landscapingMachine.send("REMOVE", {
         event: removeAction,
         id: id,
@@ -136,7 +135,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
   };
   useEffect(() => {
     if (isActive.current && !isSelected) {
-      console.log("Reset");
       // Reset
       setCounts((prev) => prev + 1);
       setIsColliding(false);
@@ -178,7 +176,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
         grid={[GRID_WIDTH_PX, GRID_WIDTH_PX]}
         allowAnyClick
         onMouseDown={() => {
-          console.log("Mouse down");
           landscapingMachine.send("MOVE", {
             name,
             id,
@@ -189,21 +186,15 @@ export const MoveableComponent: React.FC<MovableProps> = ({
           const x = Math.round(data.x);
           const y = Math.round(-data.y);
           origin.current = { x, y };
-          console.log({ x, y });
-          // reset
-          // send("DRAG");
         }}
         onDrag={(_, data) => {
           const xDiff = Math.round((origin.current.x + data.x) / GRID_WIDTH_PX);
           const yDiff = Math.round((origin.current.y - data.y) / GRID_WIDTH_PX);
 
-          console.log({ coordinates });
           const x = coordinates.x + xDiff;
           const y = coordinates.y + yDiff;
-          console.log({ x, y });
           detect({ x, y });
           setIsDragging(true);
-          // setShowHint(false);
         }}
         onStop={(_, data) => {
           setIsDragging(false);
@@ -219,8 +210,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
             return;
           }
 
-          console.log({ xDiff, yDiff, origin });
-
           const game = removePlaceable({
             state: gameService.state.context.state,
             id,
@@ -234,7 +223,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
           });
 
           if (!collisionDetected) {
-            console.log({ move: name });
             gameService.send(getMoveAction(name), {
               // Don't send name for resource events
               ...(name in RESOURCE_MOVE_EVENTS ? {} : { name }),
@@ -254,11 +242,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
             "cursor-grabbing": isDragging,
             "cursor-pointer": !isDragging,
           })}
-          onBlur={() => {
-            if (isSelected) {
-              console.log("Blur");
-            }
-          }}
         >
           {isSelected && (
             <div
@@ -304,7 +287,6 @@ export const MoveableComponent: React.FC<MovableProps> = ({
                     width: `${PIXEL_SCALE * 18}px`,
                   }}
                   onClick={(e) => {
-                    console.log("On clik");
                     remove();
                     e.preventDefault();
                   }}

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -175,11 +175,22 @@ export const MoveableComponent: React.FC<MovableProps> = ({
         nodeRef={nodeRef}
         grid={[GRID_WIDTH_PX, GRID_WIDTH_PX]}
         allowAnyClick
+        // Mobile must click first, before dragging
+        disabled={isMobile && !isSelected}
         onMouseDown={() => {
+          // Mobile must click first, before dragging
+
+          if (isMobile && !isActive.current) {
+            isActive.current = true;
+
+            return;
+          }
+
           landscapingMachine.send("MOVE", {
             name,
             id,
           });
+
           isActive.current = true;
         }}
         onStart={(_, data) => {

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -11,7 +11,6 @@ import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { GameGrid } from "features/game/expansion/placeable/lib/makeGrid";
 import Draggable from "react-draggable";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { useSelector } from "@xstate/react";
@@ -54,6 +53,10 @@ function getMoveAction(name: InventoryItemName): GameEventName<PlacementEvent> {
     return "collectible.moved";
   }
 
+  if (name === "Chicken") {
+    return "chicken.moved";
+  }
+
   throw new Error("No matching move event");
 }
 
@@ -69,7 +72,7 @@ export function getRemoveAction(
   }
 
   if (name === "Chicken") {
-    return null;
+    return "chicken.removed";
   }
 
   if (name in COLLECTIBLES_DIMENSIONS) {
@@ -80,16 +83,9 @@ export function getRemoveAction(
 }
 
 export interface MovableProps {
-  name: CollectibleName;
+  name: CollectibleName | "Chicken";
   id: string;
-  readyAt: number;
-  createdAt: number;
   coordinates: Coordinates;
-  grid: GameGrid;
-  height?: number;
-  width?: number;
-  x: number;
-  y: number;
 }
 
 const isMoving = (state: MachineState) => state.matches("editing.moving");

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -55,7 +55,6 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
     setShowRemoveConfirmation(false);
   }, [selectedItem]);
 
-  console.log({ isMobile });
   const remove = () => {
     const action = getRemoveAction(selectedItem as InventoryItemName);
     if (!action) {

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Balance } from "components/Balance";
-import { useActor } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { BlockBucks } from "./components/BlockBucks";
 import Decimal from "decimal.js-light";
@@ -16,6 +16,7 @@ import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 
 import {
   MachineInterpreter,
+  MachineState,
   placeEvent,
 } from "features/game/expansion/placeable/landscapingMachine";
 import { Label } from "components/ui/Label";
@@ -31,12 +32,23 @@ import { LandscapingIntroduction } from "./components/LandscapingIntroduction";
 import { getRemoveAction } from "../collectibles/MovableComponent";
 import { InventoryItemName } from "features/game/types/game";
 
+const compareBalance = (prev: Decimal, next: Decimal) => {
+  return prev.eq(next);
+};
+
+const compareBlockBucks = (prev: Decimal, next: Decimal) => {
+  const previous = prev ?? new Decimal(0);
+  const current = next ?? new Decimal(0);
+  return previous.eq(current);
+};
+
+const selectMovingItem = (state: MachineState) => state.context.moving;
+const isIdle = (state: MachineState) => state.matches({ editing: "idle" });
+
 const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
   const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
   const [isMobile] = useIsMobile();
 
-  const [showChest, setShowChest] = useState(false);
   const [showDecorations, setShowDecorations] = useState(false);
   const [showEquipment, setShowEquipment] = useState(false);
   const [showBuildings, setShowBuildings] = useState(false);
@@ -44,19 +56,31 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
 
   const child = gameService.state.children.landscaping as MachineInterpreter;
 
-  const [state, send] = useActor(child);
+  const balance = useSelector(
+    gameService,
+    (state) => state.context.state.balance,
+    compareBalance
+  );
 
-  const chestItems = getChestItems(gameState.context.state);
+  const blockBucks = useSelector(
+    gameService,
+    (state) => state.context.state.inventory["Block Buck"] ?? new Decimal(0),
+    compareBlockBucks
+  );
 
-  const selectedItem = state.context.moving?.name;
-  const showRemove = isMobile && selectedItem && getRemoveAction(selectedItem);
+  const selectedItem = useSelector(child, selectMovingItem);
+  const idle = useSelector(child, isIdle);
+
+  console.log({ idle });
+  const showRemove =
+    isMobile && selectedItem && getRemoveAction(selectedItem.name);
 
   useEffect(() => {
     setShowRemoveConfirmation(false);
   }, [selectedItem]);
 
   const remove = () => {
-    const action = getRemoveAction(selectedItem as InventoryItemName);
+    const action = getRemoveAction(selectedItem?.name as InventoryItemName);
     if (!action) {
       return;
     }
@@ -64,8 +88,8 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
     if (showRemoveConfirmation) {
       child.send("REMOVE", {
         event: action,
-        id: state.context.moving?.id,
-        name: selectedItem,
+        id: selectedItem?.id,
+        name: selectedItem?.name,
       });
     } else {
       setShowRemoveConfirmation(true);
@@ -78,18 +102,13 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
       aria-label="Hud"
       className="absolute z-40"
     >
-      <Balance balance={gameState.context.state.balance} />
-      <BlockBucks
-        blockBucks={
-          gameState.context.state.inventory["Block Buck"] ?? new Decimal(0)
-        }
-        isFullUser={false}
-      />
+      <Balance balance={balance} />
+      <BlockBucks blockBucks={blockBucks} isFullUser={false} />
 
       <LandscapingIntroduction />
 
       <>
-        {state.matches({ editing: "idle" }) && (
+        {idle && (
           <>
             <div
               className="fixed flex z-50 flex-col"
@@ -102,7 +121,7 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
               }}
             >
               <div
-                onClick={() => send("CANCEL")}
+                onClick={() => child.send("CANCEL")}
                 className="w-full z-10 cursor-pointer hover:img-highlight relative"
                 style={{
                   width: `${PIXEL_SCALE * 22}px`,
@@ -214,41 +233,15 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
                   }}
                 />
               </div>
-              <div
-                onClick={() => setShowChest(true)}
-                className="z-50 cursor-pointer hover:img-highlight relative"
-                style={{
-                  width: `${PIXEL_SCALE * 22}px`,
-                  height: `${PIXEL_SCALE * 22}px`,
-                  marginBottom: `${PIXEL_SCALE * 4}px`,
+              <Chest
+                onPlaceChestItem={(selected) => {
+                  child.send("SELECT", {
+                    action: placeEvent(selected),
+                    placeable: selected,
+                    multiple: true,
+                  });
                 }}
-              >
-                <img
-                  src={SUNNYSIDE.ui.round_button}
-                  className="absolute"
-                  style={{
-                    width: `${PIXEL_SCALE * 22}px`,
-                  }}
-                />
-                <img
-                  src={chest}
-                  className="absolute"
-                  style={{
-                    top: `${PIXEL_SCALE * 5}px`,
-                    left: `${PIXEL_SCALE * 5}px`,
-                    width: `${PIXEL_SCALE * 12}px`,
-                  }}
-                />
-                <Label
-                  type="default"
-                  className="px-0.5 text-xxs absolute -top-2 -right-2"
-                >
-                  {getKeys(chestItems).reduce(
-                    (acc, key) => acc + (chestItems[key]?.toNumber() ?? 0),
-                    0
-                  )}
-                </Label>
-              </div>
+              />
             </div>
           </>
         )}
@@ -306,39 +299,81 @@ const LandscapingHudComponent: React.FC<{ isFarming: boolean }> = () => {
         </div>
       )}
 
-      <LandscapingChest
-        state={gameState.context.state}
-        onHide={() => setShowChest(false)}
-        show={showChest}
-        onPlace={(selected) => {
-          child.send("SELECT", {
-            action: placeEvent(selected),
-            placeable: selected,
-            multiple: true,
-          });
-        }}
-      />
-
       <CraftDecorationsModal
         onHide={() => setShowDecorations(false)}
         show={showDecorations}
-        state={gameState.context.state}
       />
 
       <CraftEquipmentModal
         onHide={() => setShowEquipment(false)}
         show={showEquipment}
-        state={gameState.context.state}
       />
 
       <CraftBuildingModal
         onHide={() => setShowBuildings(false)}
         show={showBuildings}
-        state={gameState.context.state}
       />
 
       <PlaceableController />
     </div>
+  );
+};
+
+const Chest: React.FC<{
+  onPlaceChestItem: (item: InventoryItemName) => void;
+}> = ({ onPlaceChestItem }) => {
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+
+  const [showChest, setShowChest] = useState(false);
+
+  const chestItems = getChestItems(gameState.context.state);
+
+  return (
+    <>
+      <div
+        onClick={() => setShowChest(true)}
+        className="z-50 cursor-pointer hover:img-highlight relative"
+        style={{
+          width: `${PIXEL_SCALE * 22}px`,
+          height: `${PIXEL_SCALE * 22}px`,
+          marginBottom: `${PIXEL_SCALE * 4}px`,
+        }}
+      >
+        <img
+          src={SUNNYSIDE.ui.round_button}
+          className="absolute"
+          style={{
+            width: `${PIXEL_SCALE * 22}px`,
+          }}
+        />
+        <img
+          src={chest}
+          className="absolute"
+          style={{
+            top: `${PIXEL_SCALE * 5}px`,
+            left: `${PIXEL_SCALE * 5}px`,
+            width: `${PIXEL_SCALE * 12}px`,
+          }}
+        />
+        <Label
+          type="default"
+          className="px-0.5 text-xxs absolute -top-2 -right-2"
+        >
+          {getKeys(chestItems).reduce(
+            (acc, key) => acc + (chestItems[key]?.toNumber() ?? 0),
+            0
+          )}
+        </Label>
+      </div>
+
+      <LandscapingChest
+        state={gameState.context.state}
+        onHide={() => setShowChest(false)}
+        show={showChest}
+        onPlace={onPlaceChestItem}
+      />
+    </>
   );
 };
 

--- a/src/features/island/hud/components/buildings/CraftBuilding.tsx
+++ b/src/features/island/hud/components/buildings/CraftBuilding.tsx
@@ -50,11 +50,7 @@ export const CraftBuilding: React.FC<Props> = ({ state }) => {
         </div>
       </div>
 
-      <CraftBuildingModal
-        show={isOpen}
-        onHide={() => setIsOpen(false)}
-        state={state}
-      />
+      <CraftBuildingModal show={isOpen} onHide={() => setIsOpen(false)} />
     </>
   );
 };

--- a/src/features/island/hud/components/buildings/CraftBuildingModal.tsx
+++ b/src/features/island/hud/components/buildings/CraftBuildingModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameState, InventoryItemName } from "features/game/types/game";
+import { InventoryItemName } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Modal } from "react-bootstrap";
@@ -10,18 +10,13 @@ import { NPC_WEARABLES } from "lib/npcs";
 interface Props {
   show: boolean;
   onHide: () => void;
-  state: GameState;
 }
 
 export type TabItems = Record<string, { items: object }>;
 
 export type Inventory = Partial<Record<InventoryItemName, Decimal>>;
 
-export const CraftBuildingModal: React.FC<Props> = ({
-  show,
-  onHide,
-  state,
-}) => {
+export const CraftBuildingModal: React.FC<Props> = ({ show, onHide }) => {
   return (
     <Modal size="lg" centered show={show} onHide={onHide}>
       <CloseButtonPanel

--- a/src/features/island/hud/components/decorations/CraftDecorations.tsx
+++ b/src/features/island/hud/components/decorations/CraftDecorations.tsx
@@ -1,16 +1,11 @@
 import React, { useState } from "react";
 
-import { GameState } from "features/game/types/game";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
 
 import { CraftDecorationsModal } from "./CraftDecorationsModal";
 
-interface Props {
-  state: GameState;
-}
-
-export const CraftDecorations: React.FC<Props> = ({ state }) => {
+export const CraftDecorations: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -50,11 +45,7 @@ export const CraftDecorations: React.FC<Props> = ({ state }) => {
         </div>
       </div>
 
-      <CraftDecorationsModal
-        show={isOpen}
-        onHide={() => setIsOpen(false)}
-        state={state}
-      />
+      <CraftDecorationsModal show={isOpen} onHide={() => setIsOpen(false)} />
     </>
   );
 };

--- a/src/features/island/hud/components/decorations/CraftDecorationsModal.tsx
+++ b/src/features/island/hud/components/decorations/CraftDecorationsModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameState, InventoryItemName } from "features/game/types/game";
+import { InventoryItemName } from "features/game/types/game";
 import sunflower from "assets/decorations/potted_sunflower.png";
 import Decimal from "decimal.js-light";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
@@ -10,18 +10,13 @@ import { NPC_WEARABLES } from "lib/npcs";
 interface Props {
   show: boolean;
   onHide: () => void;
-  state: GameState;
 }
 
 export type TabItems = Record<string, { items: object }>;
 
 export type Inventory = Partial<Record<InventoryItemName, Decimal>>;
 
-export const CraftDecorationsModal: React.FC<Props> = ({
-  show,
-  onHide,
-  state,
-}) => {
+export const CraftDecorationsModal: React.FC<Props> = ({ show, onHide }) => {
   return (
     <Modal size="lg" centered show={show} onHide={onHide}>
       <CloseButtonPanel

--- a/src/features/island/hud/components/equipment/CraftEquipment.tsx
+++ b/src/features/island/hud/components/equipment/CraftEquipment.tsx
@@ -1,16 +1,11 @@
 import React, { useState } from "react";
 
-import { GameState } from "features/game/types/game";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
 
 import { CraftEquipmentModal } from "./CraftEquipmentModal";
 
-interface Props {
-  state: GameState;
-}
-
-export const CraftEquipment: React.FC<Props> = ({ state }) => {
+export const CraftEquipment: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -50,11 +45,7 @@ export const CraftEquipment: React.FC<Props> = ({ state }) => {
         </div>
       </div>
 
-      <CraftEquipmentModal
-        show={isOpen}
-        onHide={() => setIsOpen(false)}
-        state={state}
-      />
+      <CraftEquipmentModal show={isOpen} onHide={() => setIsOpen(false)} />
     </>
   );
 };

--- a/src/features/island/hud/components/equipment/CraftEquipmentModal.tsx
+++ b/src/features/island/hud/components/equipment/CraftEquipmentModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameState, InventoryItemName } from "features/game/types/game";
+import { InventoryItemName } from "features/game/types/game";
 import lightning from "assets/icons/lightning.png";
 import Decimal from "decimal.js-light";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
@@ -10,18 +10,13 @@ import { NPC_WEARABLES } from "lib/npcs";
 interface Props {
   show: boolean;
   onHide: () => void;
-  state: GameState;
 }
 
 export type TabItems = Record<string, { items: object }>;
 
 export type Inventory = Partial<Record<InventoryItemName, Decimal>>;
 
-export const CraftEquipmentModal: React.FC<Props> = ({
-  show,
-  onHide,
-  state,
-}) => {
+export const CraftEquipmentModal: React.FC<Props> = ({ show, onHide }) => {
   return (
     <Modal size="lg" centered show={show} onHide={onHide}>
       <CloseButtonPanel


### PR DESCRIPTION
# Description

This PR includes support for removing items for free in landscaping mode. Players must double click to confirm.

On Desktop, the remove icon appears next to where you select. This allows for quicker removals.

<img width="217" alt="Screen Shot 2023-04-21 at 10 05 23 am" src="https://user-images.githubusercontent.com/11745561/233511060-1fc4a9a9-4b92-4533-a981-b7fa7e5b3d80.png">


On Mobile, to save space, this remove icon appears in bottom right.

<img width="362" alt="Screen Shot 2023-04-21 at 10 05 44 am" src="https://user-images.githubusercontent.com/11745561/233511097-91bfc673-f6bf-4122-bd0c-a071deb9f256.png">

## TODO

Update APIs to no longer require Rusty Shovel
