### PR TITLE
[FIX] Fix missing tool bug

### DIFF
--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -42,14 +42,6 @@ export const GameProvider: React.FC = ({ children }) => {
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
-    const originalShortcuts = getShortcuts();
-    const originalSelectedItem =
-      originalShortcuts.length > 0 ? originalShortcuts[0] : undefined;
-
-    // skip shortcut logic if selected item is the same
-    // to avoid unnecessary rerenders for components using useContext(Context)
-    if (originalSelectedItem === item) return;
-
     const items = cacheShortcuts(item);
 
     setShortcuts(items);

--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -74,11 +74,7 @@ export const Gold: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.gold[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(
-    gameService,
-    selectInventoryToolCount,
-    compareInventoryToolCount
-  );
+  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -75,11 +75,7 @@ export const Iron: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.iron[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(
-    gameService,
-    selectInventoryToolCount,
-    compareInventoryToolCount
-  );
+  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -73,11 +73,7 @@ export const Stone: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.stones[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(
-    gameService,
-    selectInventoryToolCount,
-    compareInventoryToolCount
-  );
+  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {


### PR DESCRIPTION
# Description

Rollback a few changes from https://github.com/sunflower-land/sunflower-land/commit/0444a3bff7b04b8c34853a480d7772c7c6cc1e84

When a player crafted a new tool and went to mine a rock, it was not picking up that a tool was selected.

This did not happen if a player already had the tool