### PR TITLE
[FIX] Incorrect useSelector comparer logic

### DIFF
--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -42,6 +42,14 @@ export const GameProvider: React.FC = ({ children }) => {
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
+    const originalShortcuts = getShortcuts();
+    const originalSelectedItem =
+      originalShortcuts.length > 0 ? originalShortcuts[0] : undefined;
+
+    // skip shortcut logic if selected item is the same
+    // to avoid unnecessary rerenders for components using useContext(Context)
+    if (originalSelectedItem === item) return;
+
     const items = cacheShortcuts(item);
 
     setShortcuts(items);

--- a/src/features/game/expansion/components/resources/Gold.tsx
+++ b/src/features/game/expansion/components/resources/Gold.tsx
@@ -44,8 +44,7 @@ const compareResource = (prev: Rock, next: Rock) => {
 const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
   return (
     prev.equals(next) ||
-    prev.greaterThanOrEqualTo(1) ||
-    next.greaterThanOrEqualTo(1)
+    prev.greaterThanOrEqualTo(1) == next.greaterThanOrEqualTo(1)
   );
 };
 
@@ -74,7 +73,11 @@ export const Gold: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.gold[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Iron.tsx
+++ b/src/features/game/expansion/components/resources/Iron.tsx
@@ -44,8 +44,7 @@ const compareResource = (prev: Rock, next: Rock) => {
 const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
   return (
     prev.equals(next) ||
-    prev.greaterThanOrEqualTo(1) ||
-    next.greaterThanOrEqualTo(1)
+    prev.greaterThanOrEqualTo(1) == next.greaterThanOrEqualTo(1)
   );
 };
 
@@ -75,7 +74,11 @@ export const Iron: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.iron[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {

--- a/src/features/game/expansion/components/resources/Stone.tsx
+++ b/src/features/game/expansion/components/resources/Stone.tsx
@@ -42,8 +42,7 @@ const compareResource = (prev: Rock, next: Rock) => {
 const compareInventoryToolCount = (prev: Decimal, next: Decimal) => {
   return (
     prev.equals(next) ||
-    prev.greaterThanOrEqualTo(1) ||
-    next.greaterThanOrEqualTo(1)
+    prev.greaterThanOrEqualTo(1) == next.greaterThanOrEqualTo(1)
   );
 };
 
@@ -73,7 +72,11 @@ export const Stone: React.FC<Props> = ({ id }) => {
     (state) => state.context.state.stones[id],
     compareResource
   );
-  const inventoryToolCount = useSelector(gameService, selectInventoryToolCount);
+  const inventoryToolCount = useSelector(
+    gameService,
+    selectInventoryToolCount,
+    compareInventoryToolCount
+  );
 
   // Reset the shake count when clicking outside of the component
   useEffect(() => {


### PR DESCRIPTION
# Description

Fixed issue mentioned in https://github.com/sunflower-land/sunflower-land/pull/2475

The compare logic `prev.greaterThanOrEqualTo(1) || next.greaterThanOrEqualTo(1)` was incorrect.  useSelector skips rerendering if the compare logic evaluates to true.  `prev.greaterThanOrEqualTo(1) || next.greaterThanOrEqualTo(1)` would evaluate to true if players have no tools at the beginning (`prev.greaterThanOrEqualTo(1) is false`) and purchase tools after (`prev.greaterThanOrEqualTo(1) is true`)  It has been corrected to `prev.greaterThanOrEqualTo(1) == next.greaterThanOrEqualTo(1)`, so the components will rerender only if there's a change of the mine-ability of the resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- have no tools to mine a resource, then buy some in the blacksmith and mine the corresponding resources
- have 1 tool to mine a resource, then mine the same resource again when the inventory is out of tools.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes