### PR TITLE
[FIX] Prevent default drag on Moveable component

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -216,7 +216,6 @@ export const TEST_FARM: GameState = {
     "Iron Pickaxe": new Decimal(5),
     "Trading Ticket": new Decimal(50),
     "Chef Hat": new Decimal(1),
-    "Human War Banner": new Decimal(1),
     "Boiled Eggs": new Decimal(3),
     "Sunflower Cake": new Decimal(1),
     "Basic Land": new Decimal(1),

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -328,7 +328,7 @@ export const MoveableComponent: React.FC<MovableProps> = ({
             </div>
           )}
           <div
-            className={classNames("h-full", {
+            className={classNames("h-full pointer-events-none", {
               "bg-red-500 bg-opacity-75": isColliding,
               "bg-green-300 bg-opacity-50": !isColliding && isSelected,
             })}


### PR DESCRIPTION
# Description

On firefox, my browser default is dragging the image of some collectibles, rather than using our custom drag.

See the ghost bear in the screenshot below:

![ghostbear](https://user-images.githubusercontent.com/41215134/234423661-0625ebd3-c574-4afe-93db-74e444054f01.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Art mode

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
