### PR TITLE
[FEAT] Dynamic Lantern Prices

### DIFF
--- a/src/features/dawnBreaker/DawnBreaker.tsx
+++ b/src/features/dawnBreaker/DawnBreaker.tsx
@@ -76,6 +76,7 @@ export const DawnBreaker: React.FC = () => {
         <PlayerBumpkin
           currentWeek={currentWeek}
           bumpkin={bumpkin as Bumpkin}
+          lanternsCraftedByWeek={lanternsCraftedByWeek}
           availableLantern={availableLantern}
           inventory={inventory}
         />

--- a/src/features/dawnBreaker/components/PlayerBumpkin.tsx
+++ b/src/features/dawnBreaker/components/PlayerBumpkin.tsx
@@ -91,7 +91,7 @@ export const PlayerBumpkin: React.FC<Props> = ({
       >
         {/* Shift NPC a little on week 8 to fit map position */}
         <div style={{ marginLeft: currentWeek === 8 ? "18px" : 0 }}>
-          <NPC parts={{ ...bumpkin.equipped }} onClick={handleOpen} />
+          <NPC parts={bumpkin.equipped} onClick={handleOpen} />
         </div>
       </MapPlacement>
       {availableLantern && (

--- a/src/features/dawnBreaker/components/PlayerBumpkin.tsx
+++ b/src/features/dawnBreaker/components/PlayerBumpkin.tsx
@@ -2,7 +2,12 @@ import React, { useContext, useState } from "react";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
-import { Bumpkin, Inventory, LanternOffering } from "features/game/types/game";
+import {
+  Bumpkin,
+  Inventory,
+  LanternOffering,
+  LanternsCraftedByWeek,
+} from "features/game/types/game";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { Week, bumpkinPositions } from "../lib/positions";
@@ -17,6 +22,7 @@ import { Button } from "components/ui/Button";
 
 interface Props {
   currentWeek: Week;
+  lanternsCraftedByWeek: LanternsCraftedByWeek;
   bumpkin: Bumpkin;
   inventory: Inventory;
   availableLantern?: LanternOffering;
@@ -27,6 +33,7 @@ const _balance = (state: MachineState) => state.context.state.balance;
 export const PlayerBumpkin: React.FC<Props> = ({
   bumpkin,
   availableLantern,
+  lanternsCraftedByWeek,
   inventory,
   currentWeek,
 }) => {
@@ -50,17 +57,28 @@ export const PlayerBumpkin: React.FC<Props> = ({
     handleClose();
   };
 
+  // Requirements are multiplied by the number of lanterns crafted + 1 (for the current week)
+  // eg. 1st lantern requires 1x, 2nd lantern requires 2x, 3rd lantern requires 3x, etc.
+  let multiplier = 1;
+  const lanternsCraftedThisWeek = lanternsCraftedByWeek[currentWeek];
+
+  if (lanternsCraftedThisWeek) {
+    multiplier = lanternsCraftedThisWeek + 1;
+  }
+
   const hasMissingIngredients = getKeys(
     availableLantern?.ingredients ?? {}
   ).some((name) => {
     const balance = inventory[name] ?? new Decimal(0);
-    const amount = availableLantern?.ingredients[name] ?? new Decimal(0);
+    const amount = (availableLantern?.ingredients[name] ?? new Decimal(0)).mul(
+      multiplier
+    );
 
     return balance.lt(amount);
   });
 
   const hasSflRequirement = balance.gte(
-    availableLantern?.sfl ?? new Decimal(0)
+    (availableLantern?.sfl ?? new Decimal(0)).mul(multiplier)
   );
   const disableCraft = hasMissingIngredients || !hasSflRequirement;
 
@@ -85,7 +103,7 @@ export const PlayerBumpkin: React.FC<Props> = ({
                 health goth. Health goth iceland meh XOXO, tousled meditation
                 dreamcatcher swag skateboard.
               </p>
-              <OuterPanel className="flex p-2 w-3/4 lg:w-1/2 mx-auto mt-3 mb-2">
+              <OuterPanel className="flex p-2 w-3/4 md:w-1/2 mx-auto mt-3 mb-2">
                 <div className="flex flex-1 items-center justify-center">
                   <img
                     src={ITEM_DETAILS[availableLantern.name].image}
@@ -97,7 +115,7 @@ export const PlayerBumpkin: React.FC<Props> = ({
                   {availableLantern.sfl && (
                     <RequirementLabel
                       type="sellForSfl"
-                      requirement={availableLantern.sfl}
+                      requirement={availableLantern.sfl.mul(multiplier)}
                     />
                   )}
                   {availableLantern.ingredients &&
@@ -106,9 +124,9 @@ export const PlayerBumpkin: React.FC<Props> = ({
                         key={name}
                         type="item"
                         item={name}
-                        requirement={
+                        requirement={(
                           availableLantern.ingredients[name] ?? new Decimal(0)
-                        }
+                        ).mul(multiplier)}
                         balance={inventory[name] ?? new Decimal(0)}
                       />
                     ))}

--- a/src/features/game/events/landExpansion/craftLantern.test.ts
+++ b/src/features/game/events/landExpansion/craftLantern.test.ts
@@ -1,10 +1,10 @@
 import Decimal from "decimal.js-light";
-import { TEST_FARM } from "features/game/lib/constants";
 import {
   LanternOffering,
   LanternsCraftedByWeek,
 } from "features/game/types/game";
 import { craftLantern } from "./craftLantern";
+import { TEST_FARM } from "features/game/lib/constants";
 
 const availableLantern: LanternOffering = {
   name: "Radiance Lantern",
@@ -124,6 +124,126 @@ describe("craftLantern", () => {
     expect(state.inventory.Wood).toEqual(new Decimal(0));
   });
 
+  it("requires 2x the requirements for the second lantern crafted during a week", () => {
+    // Requirements x2
+    // sfl: new Decimal(100),
+    // Carrot: new Decimal(400),
+    // Cauliflower: new Decimal(80),
+    // Beetroot: new Decimal(60),
+    // Cabbage: new Decimal(200),
+    // Wood: new Decimal(20),
+    const state = craftLantern({
+      state: {
+        ...TEST_FARM,
+        dawnBreaker: {
+          currentWeek,
+          availableLantern,
+          lanternsCraftedByWeek: {
+            [currentWeek]: 1,
+          } as LanternsCraftedByWeek,
+        },
+        balance: new Decimal(200),
+        inventory: {
+          Carrot: new Decimal(500),
+          Cauliflower: new Decimal(100),
+          Beetroot: new Decimal(100),
+          Cabbage: new Decimal(300),
+          Wood: new Decimal(50),
+          "Radiance Lantern": new Decimal(4),
+        },
+      },
+      action: {
+        type: "lantern.crafted",
+        name: "Radiance Lantern",
+      },
+    });
+
+    expect(state.inventory["Radiance Lantern"]).toEqual(new Decimal(5));
+    expect(state.balance).toEqual(new Decimal(100));
+    expect(state.inventory.Carrot).toEqual(new Decimal(100));
+    expect(state.inventory.Cauliflower).toEqual(new Decimal(20));
+    expect(state.inventory.Beetroot).toEqual(new Decimal(40));
+    expect(state.inventory.Cabbage).toEqual(new Decimal(100));
+    expect(state.inventory.Wood).toEqual(new Decimal(30));
+  });
+
+  it("requires 3x the requirements for the third lantern crafted during a week", () => {
+    // Requirements x3
+    // sfl: new Decimal(150),
+    // Carrot: new Decimal(600),
+    // Cauliflower: new Decimal(120),
+    // Beetroot: new Decimal(90),
+    // Cabbage: new Decimal(300),
+    // Wood: new Decimal(30),
+    const state = craftLantern({
+      state: {
+        ...TEST_FARM,
+        dawnBreaker: {
+          currentWeek,
+          availableLantern,
+          lanternsCraftedByWeek: {
+            [currentWeek]: 2,
+          } as LanternsCraftedByWeek,
+        },
+        balance: new Decimal(200),
+        inventory: {
+          Carrot: new Decimal(601),
+          Cauliflower: new Decimal(150),
+          Beetroot: new Decimal(100),
+          Cabbage: new Decimal(301),
+          Wood: new Decimal(50),
+          "Radiance Lantern": new Decimal(4),
+        },
+      },
+      action: {
+        type: "lantern.crafted",
+        name: "Radiance Lantern",
+      },
+    });
+
+    expect(state.inventory["Radiance Lantern"]).toEqual(new Decimal(5));
+    expect(state.balance).toEqual(new Decimal(50));
+    expect(state.inventory.Carrot).toEqual(new Decimal(1));
+    expect(state.inventory.Cauliflower).toEqual(new Decimal(30));
+    expect(state.inventory.Beetroot).toEqual(new Decimal(10));
+    expect(state.inventory.Cabbage).toEqual(new Decimal(1));
+    expect(state.inventory.Wood).toEqual(new Decimal(20));
+  });
+
+  it("halves sfl cost if player has a Dawn Breaker Banner (Season Pass)", () => {
+    const state = craftLantern({
+      state: {
+        ...TEST_FARM,
+        dawnBreaker: {
+          currentWeek,
+          availableLantern,
+          lanternsCraftedByWeek: {} as LanternsCraftedByWeek,
+        },
+        balance: new Decimal(200),
+        inventory: {
+          "Dawn Breaker Banner": new Decimal(1),
+          Carrot: new Decimal(201),
+          Cauliflower: new Decimal(41),
+          Beetroot: new Decimal(31),
+          Cabbage: new Decimal(101),
+          Wood: new Decimal(10),
+        },
+      },
+      action: {
+        type: "lantern.crafted",
+        name: "Radiance Lantern",
+      },
+    });
+
+    expect(state.inventory["Radiance Lantern"]).toEqual(new Decimal(1));
+    expect(state.balance).toEqual(new Decimal(162.5));
+    expect(state.inventory.Carrot).toEqual(new Decimal(1));
+    expect(state.inventory.Cauliflower).toEqual(new Decimal(1));
+    expect(state.inventory.Beetroot).toEqual(new Decimal(1));
+    expect(state.inventory.Cabbage).toEqual(new Decimal(1));
+    expect(state.inventory.Wood).toEqual(new Decimal(0));
+  });
+
   it("adds activity to bumpkin", () => {
     const state = craftLantern({
       state: {
@@ -190,13 +310,14 @@ describe("craftLantern", () => {
             [currentWeek]: 1,
           } as LanternsCraftedByWeek,
         },
-        balance: new Decimal(51),
+        balance: new Decimal(100),
         inventory: {
-          Carrot: new Decimal(201),
-          Cauliflower: new Decimal(41),
-          Beetroot: new Decimal(31),
-          Cabbage: new Decimal(101),
-          Wood: new Decimal(10),
+          Carrot: new Decimal(500),
+          Cauliflower: new Decimal(100),
+          Beetroot: new Decimal(100),
+          Cabbage: new Decimal(300),
+          Wood: new Decimal(50),
+          "Radiance Lantern": new Decimal(4),
         },
       },
       action: {

--- a/src/features/game/events/landExpansion/craftLantern.ts
+++ b/src/features/game/events/landExpansion/craftLantern.ts
@@ -28,19 +28,33 @@ export const craftLantern = ({ state, action }: Options): GameState => {
   const { availableLantern, currentWeek, lanternsCraftedByWeek } =
     copy.dawnBreaker;
 
-  const { startAt, ingredients, sfl: requiredSFL } = availableLantern;
+  const { ingredients, sfl: requiredSFL } = availableLantern;
+
+  // Requirements are multiplied by the number of lanterns crafted + 1 (for the current week)
+  // eg. 1st lantern requires 1x, 2nd lantern requires 2x, 3rd lantern requires 3x, etc.
+  const multiplier = lanternsCraftedByWeek[currentWeek]
+    ? lanternsCraftedByWeek[currentWeek] + 1
+    : 1;
 
   if (requiredSFL) {
-    if (copy.balance.lt(requiredSFL)) {
+    let cost = requiredSFL.mul(multiplier);
+
+    // Season Pass holders get a 25% discount on SFL
+    if (copy.inventory["Dawn Breaker Banner"]) {
+      cost = cost.mul(0.75);
+    }
+
+    if (copy.balance.lt(cost)) {
       throw new Error("Insufficient SFL balance");
     }
 
-    copy.balance = copy.balance.sub(requiredSFL);
+    copy.balance = copy.balance.sub(cost);
   }
 
   const subtractedInventory = getKeys(ingredients).reduce((inventory, name) => {
     const count = inventory[name] ?? new Decimal(0);
-    const amount = ingredients[name] ?? new Decimal(0);
+    const amount = (ingredients[name] ?? new Decimal(0)).mul(multiplier);
+
     if (count.lt(amount)) {
       throw new Error(`Insufficient ingredient: ${name}`);
     }

--- a/src/features/game/events/landExpansion/craftLantern.ts
+++ b/src/features/game/events/landExpansion/craftLantern.ts
@@ -32,9 +32,12 @@ export const craftLantern = ({ state, action }: Options): GameState => {
 
   // Requirements are multiplied by the number of lanterns crafted + 1 (for the current week)
   // eg. 1st lantern requires 1x, 2nd lantern requires 2x, 3rd lantern requires 3x, etc.
-  const multiplier = lanternsCraftedByWeek[currentWeek]
-    ? lanternsCraftedByWeek[currentWeek] + 1
-    : 1;
+  let multiplier = 1;
+  const currentCraftCount = lanternsCraftedByWeek[currentWeek];
+
+  if (currentCraftCount) {
+    multiplier = currentCraftCount + 1;
+  }
 
   if (requiredSFL) {
     let cost = requiredSFL.mul(multiplier);

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -445,7 +445,7 @@ export type LanternOffering = {
   ingredients: LanternIngredients;
 };
 
-export type LanternsCraftedByWeek = Record<string, number>;
+export type LanternsCraftedByWeek = Partial<Record<Week, number>>;
 
 export type DawnBreaker = {
   currentWeek: Week;


### PR DESCRIPTION
# Description

Add dynamic prices for lanterns. Lantern requirements will multiply by the number crafted that week.
eg. 1st lantern requires 1x, 2nd lantern requires 2x, 3rd lantern requires 3x, etc.

Also add 25% discount for pass holders.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally against api

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
