### PR TITLE
[FEAT] Add Discard tab to Garbage Collector in Helios

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -118,6 +118,10 @@ import {
 import { sellTreasure, SellTreasureAction } from "./landExpansion/treasureSold";
 import { restock, RestockAction } from "./landExpansion/restock";
 import { sellGarbage, SellGarbageAction } from "./landExpansion/garbageSold";
+import {
+  discardGarbage,
+  DiscardGarbageAction,
+} from "./landExpansion/garbageDiscard";
 import { startChore, StartChoreAction } from "./landExpansion/startChore";
 import {
   completeChore,
@@ -190,6 +194,7 @@ export type PlayingEvent =
   | SellTreasureAction
   | RestockAction
   | SellGarbageAction
+  | DiscardGarbageAction
   // Chores
   | StartChoreAction
   | CompleteChoreAction
@@ -289,6 +294,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "treasure.sold": sellTreasure,
   "shops.restocked": restock,
   "garbage.sold": sellGarbage,
+  "garbage.discarded": discardGarbage,
   "chore.completed": completeChore,
   "chore.started": startChore,
   "chore.skipped": skipChore,

--- a/src/features/game/events/landExpansion/garbageDiscard.ts
+++ b/src/features/game/events/landExpansion/garbageDiscard.ts
@@ -1,0 +1,57 @@
+import Decimal from "decimal.js-light";
+import { trackActivity } from "features/game/types/bumpkinActivity";
+import { GameState } from "features/game/types/game";
+import { DISCARD, DiscardName } from "features/game/types/garbage";
+
+import { setPrecision } from "lib/utils/formatNumber";
+import cloneDeep from "lodash.clonedeep";
+
+export type DiscardGarbageAction = {
+  type: "garbage.discarded";
+  item: DiscardName;
+  amount: number;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: DiscardGarbageAction;
+};
+
+export function discardGarbage({ state, action }: Options) {
+  const statecopy = cloneDeep(state);
+  const { item, amount } = action;
+
+  const { bumpkin, inventory, balance } = statecopy;
+
+  if (!bumpkin) {
+    throw new Error("You do not have a Bumpkin");
+  }
+  if (!(DISCARD.indexOf(item) > -1)) {
+    throw new Error("Not discardable");
+  }
+
+  if (!new Decimal(amount).isInteger()) {
+    throw new Error("Invalid amount");
+  }
+
+  const count = inventory[item] || new Decimal(0);
+
+  if (count.lessThan(amount)) {
+    throw new Error("Insufficient quantity to sell");
+  }
+
+  bumpkin.activity = trackActivity(
+    `${item} Discarded`,
+    bumpkin?.activity,
+    new Decimal(amount)
+  );
+
+  return {
+    ...statecopy,
+    bumpkin,
+    inventory: {
+      ...inventory,
+      [item]: setPrecision(count.sub(amount)),
+    },
+  };
+}

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -21,6 +21,8 @@ type SellableName =
   | FruitName
   | GarbageName;
 
+type DiscardableName = SeedName;
+
 type Recipes = Food | CookableName;
 type Edibles = Food | ConsumableName;
 
@@ -37,6 +39,7 @@ export type CraftedEvent = `${
   | LanternName} Crafted`;
 export type ConsumableEvent = `${ConsumableName} Collected`;
 export type SellEvent = `${SellableName} Sold`;
+export type DiscardEvent = `${DiscardableName} Discarded`;
 export type TreasureEvent = `${TreasureName} Dug`;
 
 export type BumpkinActivityName =
@@ -46,6 +49,7 @@ export type BumpkinActivityName =
   | CraftedEvent
   | ConsumableEvent
   | SellEvent
+  | DiscardEvent
   | HarvestEvent
   | PlantFruitEvent
   | TreasureEvent

--- a/src/features/game/types/garbage.ts
+++ b/src/features/game/types/garbage.ts
@@ -60,3 +60,36 @@ export const GARBAGE: Record<GarbageName, Garbage> = {
     sellPrice: marketRate(1),
   },
 };
+
+export type DiscardName =
+  | "Sunflower Seed"
+  | "Potato Seed"
+  | "Pumpkin Seed"
+  | "Carrot Seed"
+  | "Cabbage Seed"
+  | "Beetroot Seed"
+  | "Cauliflower Seed"
+  | "Parsnip Seed"
+  | "Eggplant Seed"
+  | "Radish Seed"
+  | "Wheat Seed"
+  | "Apple Seed"
+  | "Blueberry Seed"
+  | "Orange Seed";
+
+export const DISCARD: DiscardName[] = [
+  "Sunflower Seed",
+  "Potato Seed",
+  "Pumpkin Seed",
+  "Carrot Seed",
+  "Cabbage Seed",
+  "Beetroot Seed",
+  "Cauliflower Seed",
+  "Parsnip Seed",
+  "Eggplant Seed",
+  "Radish Seed",
+  "Wheat Seed",
+  "Apple Seed",
+  "Blueberry Seed",
+  "Orange Seed",
+];

--- a/src/features/helios/components/garbageCollector/GarbageCollector.tsx
+++ b/src/features/helios/components/garbageCollector/GarbageCollector.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
@@ -11,9 +11,11 @@ import { NPC } from "features/island/bumpkin/components/NPC";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { GarbageCollectorModal } from "./components/GarbageCollectorModal";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { GarbageDiscard } from "./components/GarbageDiscard";
 
 export const GarbageCollector: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [currentTab, setCurrentTab] = useState<number>(0);
 
   const handleClick = () => {
     setIsOpen(true);
@@ -78,9 +80,16 @@ export const GarbageCollector: React.FC = () => {
               icon: ITEM_DETAILS["Solar Flare Ticket"].image,
               name: "Sell",
             },
+            {
+              icon: ITEM_DETAILS["Sunflower Seed"].image,
+              name: "Discard",
+            },
           ]}
+          currentTab={currentTab}
+          setCurrentTab={setCurrentTab}
         >
-          <GarbageCollectorModal />
+          {currentTab === 0 && <GarbageCollectorModal />}
+          {currentTab === 1 && <GarbageDiscard />}
         </CloseButtonPanel>
       </Modal>
     </>

--- a/src/features/helios/components/garbageCollector/components/GarbageDiscard.tsx
+++ b/src/features/helios/components/garbageCollector/components/GarbageDiscard.tsx
@@ -1,0 +1,77 @@
+import React, { useContext, useState } from "react";
+import { useActor } from "@xstate/react";
+
+import { Box } from "components/ui/Box";
+import { Button } from "components/ui/Button";
+
+import { Context } from "features/game/GameProvider";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { Decimal } from "decimal.js-light";
+
+import { DISCARD, DiscardName } from "features/game/types/garbage";
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { ShopSellDetails } from "components/ui/layouts/ShopSellDetails";
+
+export const GarbageDiscard: React.FC = () => {
+  const [selectedName, setSelectedName] = useState<DiscardName>(DISCARD[0]);
+
+  const { gameService } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
+
+  const inventory = state.inventory;
+
+  const amount = inventory[selectedName] || new Decimal(0);
+
+  const discard = (amount = 1) => {
+    gameService.send("garbage.discarded", {
+      item: selectedName,
+      amount,
+    });
+  };
+
+  const Action = () => {
+    return (
+      <div className="flex space-x-1 w-full sm:flex-col sm:space-x-0 sm:space-y-1">
+        <Button disabled={amount.lt(1)} onClick={() => discard(1)}>
+          Discard 1
+        </Button>
+        <Button disabled={amount.lt(10)} onClick={() => discard(10)}>
+          Discard 10
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <SplitScreenView
+      panel={
+        <ShopSellDetails
+          details={{
+            item: selectedName,
+          }}
+          properties={{
+            sfl: new Decimal(0),
+          }}
+          actionView={Action()}
+        />
+      }
+      content={
+        <>
+          {DISCARD.map((name: DiscardName) => (
+            <Box
+              isSelected={selectedName === name}
+              key={name}
+              onClick={() => setSelectedName(name)}
+              image={ITEM_DETAILS[name].image}
+              count={inventory[name] || new Decimal(0)}
+            />
+          ))}
+        </>
+      }
+    />
+  );
+};


### PR DESCRIPTION
# Description

Periodically players request that something be discardable.  An easy example that comes up periodically is the desire to discards seeds -- especially since the introducing of the daily chest -- so that Kuebiko is more easily withdrawable.

This change introduces the Discard tab to the Garbage Collector.  The initial discardable items are seeds, but it's trivial to add any other items to the discardable list.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with local game using purchase and sell of sunflower, potato, and pumpkin seeds.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

![image](https://user-images.githubusercontent.com/36871683/235272306-60af3c13-8c55-4e7a-aa70-be375da99835.png)
