### PR TITLE
[FEAT] Allow buying 1 block buck when player have less than 5

### DIFF
--- a/src/features/game/components/modal/components/BlockBucksModal.tsx
+++ b/src/features/game/components/modal/components/BlockBucksModal.tsx
@@ -10,18 +10,22 @@ import Decimal from "decimal.js-light";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { analytics } from "lib/analytics";
 
+const bulkAmount = 5;
+
 interface Props {
   onClose: () => void;
 }
+
 export const BlockBucksModal: React.FC<Props> = ({ onClose }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
   const count =
     gameState.context.state.inventory["Block Buck"] ?? new Decimal(0);
-  const canBuyMore = count.eq(0);
+  const canBuyOne = count.lessThan(bulkAmount);
+  const canBuyBulk = count.lessThan(1);
 
-  const onBuy = (amount: 1 | 5) => {
+  const onBuy = (amount: 1 | typeof bulkAmount) => {
     gameService.send("SYNC", { captcha: "", blockBucks: amount });
     onClose();
   };
@@ -42,15 +46,31 @@ export const BlockBucksModal: React.FC<Props> = ({ onClose }) => {
       );
     }
 
-    return (
-      <>
-        {!canBuyMore && (
-          <p className="text-xs text-center mb-4 leading-none">
+    const getWarning = () => {
+      if (!canBuyOne) {
+        return (
+          <p className="text-xs text-center pb-3 px-2 leading-none">
             {`You have ${count} Block Bucks. You must use these before purchasing more.`}
           </p>
-        )}
+        );
+      }
 
-        <div className="flex justify-around mx-3 space-x-5">
+      if (!canBuyBulk) {
+        return (
+          <p className="text-xs text-center pb-3 px-2 leading-none">
+            {`You have ${count} Block Bucks. You can buy and own up to ${bulkAmount} Block Bucks.`}
+          </p>
+        );
+      }
+
+      return <></>;
+    };
+
+    return (
+      <>
+        {getWarning()}
+
+        <div className="flex justify-around px-3 space-x-5 pt-2">
           <OuterPanel className="w-full h-full flex flex-col items-center relative">
             <div className="flex w-full items-center justify-center py-4 px-2">
               <p className="mr-2 mb-1">1 x</p>
@@ -61,7 +81,7 @@ export const BlockBucksModal: React.FC<Props> = ({ onClose }) => {
                 }}
               />
             </div>
-            <Button disabled={!canBuyMore} onClick={() => onBuy(1)}>
+            <Button disabled={!canBuyOne} onClick={() => onBuy(1)}>
               $0.10 USD
             </Button>
           </OuterPanel>
@@ -78,16 +98,16 @@ export const BlockBucksModal: React.FC<Props> = ({ onClose }) => {
                 }}
               />
             </div>
-            <Button disabled={!canBuyMore} onClick={() => onBuy(5)}>
+            <Button disabled={!canBuyBulk} onClick={() => onBuy(bulkAmount)}>
               $0.75 USD
             </Button>
           </OuterPanel>
         </div>
 
-        <p className="text-xs text-center pt-2">
+        <p className="text-xs text-center pt-2 px-2">
           Game progress will be stored on Blockchain.
         </p>
-        <p className="text-xxs italic text-center py-2">
+        <p className="text-xxs italic text-center p-2">
           *Prices exclude Blockchain transaction fees.
         </p>
       </>


### PR DESCRIPTION
# Description

- allow purchasing 1 block buck when players have less than 5

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/235310623-4d8482ea-59d3-4fb8-80ea-9fc9af90d43c.png)|![image](https://user-images.githubusercontent.com/107602352/235310627-943a752d-c5e8-4e17-a2da-29e2cfaaba85.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check warning message nad whether buttons are disabled when players have 0, 1, 2, 3, 4 or 5 block bucks in their inventories

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
