### PR TITLE
[FIX] Revert tailwind pulse override

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -501,18 +501,6 @@ img {
   animation: pulse 1s infinite;
 }
 
-@keyframes pulse {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.15);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
 .npc-loading {
   animation: subtle-pulse 2s infinite;
 }


### PR DESCRIPTION
# Description

- fix tailwind "pulse" css style override.  Currently the npc loading silhouette is resizing instead of pulsing while loading the bumpkin

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- wait for bumpkin images to load

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
