### PR TITLE
[FIX] Lantern crafting SFL cost display

### DIFF
--- a/src/components/ui/RequirementsLabel.tsx
+++ b/src/components/ui/RequirementsLabel.tsx
@@ -12,7 +12,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { setPrecision } from "lib/utils/formatNumber";
 
 /**
- * The props for SFL requirement label.
+ * The props for SFL requirement label. Use this when the item costs SFL.
  * @param type The type is SFL.
  * @param balance The SFL balance of the player.
  * @param requirement The SFL requirement.
@@ -24,7 +24,7 @@ interface SFLProps {
 }
 
 /**
- * The props for sell for SFL requirement label.
+ * The props for sell for SFL requirement label. Use this when selling the item gives players SFL.
  * @param type The type is sell for SFL.
  * @param requirement The SFL requirement.
  */

--- a/src/features/dawnBreaker/components/PlayerBumpkin.tsx
+++ b/src/features/dawnBreaker/components/PlayerBumpkin.tsx
@@ -20,6 +20,7 @@ import { NPC } from "features/island/bumpkin/components/NPC";
 import { Modal } from "react-bootstrap";
 import { Button } from "components/ui/Button";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
+import { setImageWidth } from "lib/images";
 
 interface Props {
   currentWeek: Week;
@@ -116,15 +117,16 @@ export const PlayerBumpkin: React.FC<Props> = ({
                   <img
                     src={ITEM_DETAILS[availableLantern.name].image}
                     alt={availableLantern.name}
-                    className="w-10"
+                    onLoad={(e) => setImageWidth(e.currentTarget)}
                   />
                 </div>
                 <div className="flex flex-1 items-center justify-center flex-col">
                   {availableLantern.sfl && (
                     <RequirementLabel
-                      type="sellForSfl"
+                      type="sfl"
+                      balance={balance}
                       requirement={SFLDiscount(
-                        gameService.state.context.state,
+                        gameService.state?.context.state,
                         availableLantern.sfl.mul(multiplier)
                       )}
                     />


### PR DESCRIPTION
# Description

- fix SFL label not turning red when player does not have enough SFL to craft lanterns
  - for the `RequirementLabel` component, type="sfl" is used when the item costs SFL, while type="sellForSfl" is used when selling the item gives players SFL
- fix dawn breaker island crashing when running locally without setting testnet (ART mode)
- fix pixel scale for lantern

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/235728291-0115bf17-b8dd-45cc-8643-34528a0f285b.png)|![image](https://user-images.githubusercontent.com/107602352/235728333-93e5f9f8-145f-4844-b690-79ef124b520d.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open lantern crafting modal in dawn breaker island with not enough SFL

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
