### PR TITLE
[FIX] Description for Sand Drill

### DIFF
--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -86,7 +86,7 @@ export const TREASURE_TOOLS: Record<TreasureToolName, Tool> = {
   },
   "Sand Drill": {
     name: "Sand Drill",
-    description: "Drill deep for rare treasure",
+    description: "Drill deep for uncommon or rare treasure",
     ingredients: {
       Gold: new Decimal(1),
       Iron: new Decimal(3),


### PR DESCRIPTION
# Description

The description for Sand Drill is deceptive, implying the drill treasure yield is better than it is.

This change updates the in-game description of the item to match the official documented behavior:
<https://docs.sunflower-land.com/player-guides/islands/treasure-island#drilling>
> ensures the treasure you find is uncommon or rare

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)