### PR TITLE
[FEAT] Add sound fx back to buildings

### DIFF
--- a/src/features/island/buildings/components/building/bakery/Bakery.tsx
+++ b/src/features/island/buildings/components/building/bakery/Bakery.tsx
@@ -15,6 +15,7 @@ import { BakeryModal } from "./BakeryModal";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { setImageWidth } from "lib/images";
+import { bakeryAudio } from "lib/utils/sfx";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
 
@@ -58,6 +59,7 @@ export const Bakery: React.FC<Props> = ({
     if (isBuilt) {
       // Add future on click actions here
       if (idle || crafting) {
+        bakeryAudio.play();
         setShowModal(true);
         return;
       }

--- a/src/features/island/buildings/components/building/deli/Deli.tsx
+++ b/src/features/island/buildings/components/building/deli/Deli.tsx
@@ -14,6 +14,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { DeliModal } from "./DeliModal";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { setImageWidth } from "lib/images";
+import { bakeryAudio } from "lib/utils/sfx";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
 
@@ -56,6 +57,7 @@ export const Deli: React.FC<Props> = ({
 
     if (isBuilt) {
       if (idle || crafting) {
+        bakeryAudio.play();
         setShowModal(true);
         return;
       }

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -18,6 +18,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { CONVERSATIONS } from "features/game/types/conversations";
+import { bakeryAudio } from "lib/utils/sfx";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
 
@@ -68,6 +69,7 @@ export const FirePit: React.FC<Props> = ({
     if (isBuilt) {
       // Add future on click actions here
       if (idle || crafting) {
+        bakeryAudio.play();
         setShowModal(true);
         return;
       }

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -7,6 +7,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { HenHouseModal } from "./components/HenHouseModal";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { BuildingProps } from "../Building";
+import { barnAudio } from "lib/utils/sfx";
 
 export const ChickenHouse: React.FC<BuildingProps> = ({
   isBuilt,
@@ -22,6 +23,7 @@ export const ChickenHouse: React.FC<BuildingProps> = ({
 
     if (isBuilt) {
       // Add future on click actions here
+      barnAudio.play();
       setIsOpen(true);
       return;
     }

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -14,6 +14,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { KitchenModal } from "./KitchenModal";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { setImageWidth } from "lib/images";
+import { bakeryAudio } from "lib/utils/sfx";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
 
@@ -57,6 +58,7 @@ export const Kitchen: React.FC<Props> = ({
     if (isBuilt) {
       // Add future on click actions here
       if (idle || crafting) {
+        bakeryAudio.play();
         setShowModal(true);
         return;
       }

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -18,6 +18,7 @@ import { NPC_WEARABLES } from "lib/npcs";
 import { getKeys } from "features/game/types/craftables";
 import { CROPS } from "features/game/types/crops";
 import { Bumpkin } from "features/game/types/game";
+import { shopAudio } from "lib/utils/sfx";
 
 const hasSoldCropsBefore = (bumpkin?: Bumpkin) => {
   if (!bumpkin) return false;
@@ -46,6 +47,7 @@ export const Market: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
     }
     if (isBuilt) {
       // Add future on click actions here
+      shopAudio.play();
       setIsOpen(true);
       return;
     }

--- a/src/features/island/buildings/components/building/smoothieShack/SmoothieShack.tsx
+++ b/src/features/island/buildings/components/building/smoothieShack/SmoothieShack.tsx
@@ -14,6 +14,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { setImageWidth } from "lib/images";
 import { SmoothieShackModal } from "./SmoothieShackModal";
+import { bakeryAudio } from "lib/utils/sfx";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
 
@@ -56,6 +57,7 @@ export const SmoothieShack: React.FC<Props> = ({
 
     if (isBuilt) {
       if (idle || crafting) {
+        bakeryAudio.play();
         setShowModal(true);
         return;
       }

--- a/src/features/island/buildings/components/building/workBench/WorkBench.tsx
+++ b/src/features/island/buildings/components/building/workBench/WorkBench.tsx
@@ -16,6 +16,7 @@ import { Modal } from "react-bootstrap";
 import { Panel } from "components/ui/Panel";
 import { Conversation } from "features/farming/mail/components/Conversation";
 import { NPC_WEARABLES } from "lib/npcs";
+import { shopAudio } from "lib/utils/sfx";
 
 export const WorkBench: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
   const { gameService } = useContext(Context);
@@ -35,6 +36,7 @@ export const WorkBench: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
 
     if (isBuilt) {
       // Add future on click actions here
+      shopAudio.play();
       setIsOpen(true);
       return;
     }


### PR DESCRIPTION
# Description

- add sound while opening building modals, just like how it was before island migration

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open modal for all buildings

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
