### PR TITLE
[CHORE] Keep toast visible for longer

### DIFF
--- a/src/features/game/toast/ToastProvider.tsx
+++ b/src/features/game/toast/ToastProvider.tsx
@@ -49,7 +49,7 @@ export const ToastContext = createContext<{
  * The toast timeout in milliseconds.
  * Toasts will be hidden or removed after the timeout if there are no state updates.
  */
-const TOAST_TIMEOUT_MS = 2000;
+const TOAST_TIMEOUT_MS = 8000;
 
 /**
  * The toast provder for setting the toast list for the toast panel.

--- a/src/features/game/toast/ToastProvider.tsx
+++ b/src/features/game/toast/ToastProvider.tsx
@@ -49,7 +49,7 @@ export const ToastContext = createContext<{
  * The toast timeout in milliseconds.
  * Toasts will be hidden or removed after the timeout if there are no state updates.
  */
-const TOAST_TIMEOUT_MS = 8000;
+const TOAST_TIMEOUT_MS = 5000;
 
 /**
  * The toast provder for setting the toast list for the toast panel.


### PR DESCRIPTION
# Description

With coalescing toasts it makes sense to increase timer so values wont reset when you open reward chest in the middle of harvesting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
