### PR TITLE
[FIX] Account for SFL discount when checking lantern crafting conditions

### DIFF
--- a/src/features/dawnBreaker/components/PlayerBumpkin.tsx
+++ b/src/features/dawnBreaker/components/PlayerBumpkin.tsx
@@ -79,10 +79,13 @@ export const PlayerBumpkin: React.FC<Props> = ({
     return balance.lt(amount);
   });
 
-  const hasSflRequirement = balance.gte(
-    (availableLantern?.sfl ?? new Decimal(0)).mul(multiplier)
+  const lessFunds = balance.lt(
+    SFLDiscount(
+      gameService.state?.context.state,
+      (availableLantern?.sfl ?? new Decimal(0)).mul(multiplier)
+    )
   );
-  const disableCraft = hasMissingIngredients || !hasSflRequirement;
+  const disableCraft = hasMissingIngredients || lessFunds;
 
   return (
     <>


### PR DESCRIPTION
# Description

- fix button disabled when players have enough SFL to craft lantern due to the 25% discount

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- have just barely enough SFL to craft lantern while owning Dawn Breaker Banner in the inventory
  - eg. if the lantern costs 1SFL to craft, the actual cost will be 0.75SFL with the discount.  Then test it when the player has 0.76SFL in the balance.  

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
