### PR TITLE
[FIX] Hide SFL display if no SFL is needed to craft lantern

### DIFF
--- a/src/components/ui/RequirementsLabel.tsx
+++ b/src/components/ui/RequirementsLabel.tsx
@@ -135,11 +135,7 @@ export const RequirementLabel: React.FC<Props> = (props) => {
 
   const getText = () => {
     switch (props.type) {
-      case "sfl": {
-        return props.requirement.equals(0)
-          ? "Free"
-          : `${props.requirement.toNumber()}`;
-      }
+      case "sfl":
       case "sellForSfl": {
         return `${props.requirement.toNumber()}`;
       }

--- a/src/features/dawnBreaker/components/PlayerBumpkin.tsx
+++ b/src/features/dawnBreaker/components/PlayerBumpkin.tsx
@@ -124,16 +124,6 @@ export const PlayerBumpkin: React.FC<Props> = ({
                   />
                 </div>
                 <div className="flex flex-1 items-center justify-center flex-col">
-                  {availableLantern.sfl && (
-                    <RequirementLabel
-                      type="sfl"
-                      balance={balance}
-                      requirement={SFLDiscount(
-                        gameService.state?.context.state,
-                        availableLantern.sfl.mul(multiplier)
-                      )}
-                    />
-                  )}
                   {availableLantern.ingredients &&
                     getKeys(availableLantern.ingredients).map((name) => (
                       <RequirementLabel
@@ -146,6 +136,16 @@ export const PlayerBumpkin: React.FC<Props> = ({
                         balance={inventory[name] ?? new Decimal(0)}
                       />
                     ))}
+                  {availableLantern.sfl?.gt(0) && (
+                    <RequirementLabel
+                      type="sfl"
+                      balance={balance}
+                      requirement={SFLDiscount(
+                        gameService.state?.context.state,
+                        availableLantern.sfl.mul(multiplier)
+                      )}
+                    />
+                  )}
                 </div>
               </OuterPanel>
             </div>


### PR DESCRIPTION
# Description

- hide SFL requirement for crafting lanterns if no SFL is needed to craft the lantern
- move SFL display to the bottom of the list to be consistent with the other crafting screens

Before|After
---|---
![image](https://user-images.githubusercontent.com/107602352/236747020-afb05dfe-9f58-4269-80f4-030a57075441.png)|![image](https://user-images.githubusercontent.com/107602352/236746718-98c3f689-e5c3-4d68-b279-e4b9af0a822e.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open lantern crafting screen if the `dawnBreaker` `availableLantern` `sfl` cost equals `new Decimal(0)`

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
