### PR TITLE
[FIX] UI Land requirements for buildings

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -227,7 +227,7 @@ export const CraftingRequirements: React.FC<Props> = ({
   };
 
   return (
-    <div className="flex flex-col justify-center">
+    <div className="flex flex-col h-full justify-between">
       <div className="flex flex-col justify-center px-1 py-0">
         {getStock()}
         {getItemDetail({ hideDescription })}

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -313,27 +313,30 @@ const getIslandElements = ({
     })
   );
 
-  mapPlacements.push(
-    ...getKeys(mushrooms).flatMap((id) => {
-      const { x, y } = mushrooms[id]!;
+  {
+    mushrooms &&
+      mapPlacements.push(
+        ...getKeys(mushrooms).flatMap((id) => {
+          const { x, y } = mushrooms[id]!;
 
-      return (
-        <MapPlacement
-          key={`mushroom-${id}`}
-          x={x}
-          y={y}
-          height={MUSHROOM_DIMENSIONS.height}
-          width={MUSHROOM_DIMENSIONS.width}
-        >
-          <Mushroom
-            key={`mushroom-${id}`}
-            id={id}
-            isFirstRender={isFirstRender}
-          />
-        </MapPlacement>
+          return (
+            <MapPlacement
+              key={`mushroom-${id}`}
+              x={x}
+              y={y}
+              height={MUSHROOM_DIMENSIONS.height}
+              width={MUSHROOM_DIMENSIONS.width}
+            >
+              <Mushroom
+                key={`mushroom-${id}`}
+                id={id}
+                isFirstRender={isFirstRender}
+              />
+            </MapPlacement>
+          );
+        })
       );
-    })
-  );
+  }
 
   return mapPlacements;
 };
@@ -362,7 +365,6 @@ export const Land: React.FC = () => {
     mushrooms,
   } = useSelector(gameService, selectGameState);
   const autosaving = useSelector(gameService, isAutosaving);
-  const editing = useSelector(gameService, isEditing);
   const visiting = useSelector(gameService, isVisiting);
 
   const grid = getGameGrid({ crops, collectibles });
@@ -439,7 +441,7 @@ export const Land: React.FC = () => {
             isRustyShovelSelected: shortcuts[0] === "Rusty Shovel",
             showTimers: showTimers,
             grid,
-            mushrooms: mushrooms.mushrooms,
+            mushrooms: mushrooms?.mushrooms,
             isFirstRender,
           }).sort((a, b) => b.props.y - a.props.y)}
         </div>
@@ -475,7 +477,7 @@ export const Land: React.FC = () => {
           <LandscapingHud isFarming />
         </>
       ) : (
-        <Hud isFarming />
+        <Hud isFarming={!visiting} />
       )}
     </>
   );

--- a/src/features/island/buildings/components/building/workBench/WorkBench.tsx
+++ b/src/features/island/buildings/components/building/workBench/WorkBench.tsx
@@ -92,7 +92,7 @@ export const WorkBench: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
             <Conversation conversationId={conversationId} />
           </Panel>
         ) : (
-          <WorkbenchModal isOpen={isOpen} onClose={handleClose} />
+          <WorkbenchModal onClose={handleClose} />
         )}
       </Modal>
     </>

--- a/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/WorkbenchModal.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useContext, useState } from "react";
+import React, { SyntheticEvent, useState } from "react";
 
 import { ITEM_DETAILS } from "features/game/types/images";
 
@@ -11,25 +11,13 @@ import { NPC_WEARABLES } from "lib/npcs";
 import { Tools } from "./Tools";
 import { Equipment } from "features/island/hud/components/equipment/Equipment";
 import { Buildings } from "features/island/hud/components/buildings/Buildings";
-import { Context } from "features/game/GameProvider";
-import { useSelector } from "@xstate/react";
-import { MachineState } from "features/game/lib/gameMachine";
 
 interface Props {
-  isOpen: boolean;
   onClose: (e?: SyntheticEvent) => void;
 }
 
-const inventory = (state: MachineState) => state.context.state.inventory;
-
-export const WorkbenchModal: React.FC<Props> = ({ isOpen, onClose }) => {
+export const WorkbenchModal: React.FC<Props> = ({ onClose }) => {
   const [tab, setTab] = useState(0);
-
-  const { gameService } = useContext(Context);
-
-  const gameInventory = useSelector(gameService, inventory, (prev, next) => {
-    return !!prev["Beta Pass"]?.eq(next["Beta Pass"] ?? 0);
-  });
 
   const bumpkinParts: Partial<Equipped> = NPC_WEARABLES.blacksmith;
 

--- a/src/features/island/buildings/components/ui/DetailView.tsx
+++ b/src/features/island/buildings/components/ui/DetailView.tsx
@@ -67,13 +67,11 @@ export const DetailView: React.FC<Props> = ({
   );
 
   const landCount = inventory["Basic Land"] ?? new Decimal(0);
-  // Holds how many desired placed buildings (e.g. water wells)
+  // Holds how many buildings of type placed (e.g. water wells)
   const buildingsPlaced = new Decimal(
     state.buildings[buildingName]?.length || 0
   );
-  // Total number of this building in players inventory.
   const buildingsInInventory = inventory[buildingName] || new Decimal(0);
-  // true, if any of these buildings are unplaced
   const hasUnplacedBuildings = buildingsInInventory
     .minus(1)
     .greaterThanOrEqualTo(buildingsPlaced);
@@ -95,15 +93,6 @@ export const DetailView: React.FC<Props> = ({
 
   const buildingToConstruct = buildingBluePrints[buildingNumber];
 
-  /**
-   * @function showBuildButton This function will return true if the player has not completed all the buildings
-   *                            for the unlocked level. E.g. if the player has unlocked 2 levels of the building then
-   *                            he would need to construct 2 buildings on the farm to reach to the next level. If he
-   *                            has not constructed 2 buildings then we need to show him the build button, if yes then
-   *                            we need to show him the 'Level X required' label.
-   * @param unlockedLevel The level of the building which the player has already unlocked.
-   * @returns Boolean
-   */
   const showBuildButton = (): boolean => {
     return buildingsPlaced.lessThan(allowedBuildings) || hasUnplacedBuildings;
   };


### PR DESCRIPTION
# Description

Reported in the help channel [here](https://discord.com/channels/880987707214544966/925873771137613884/1105625911161782334).

The buildings tab inside of the Workbench was showing next unlock land requirements even when the player had less than the buildings allowed. e.g. Have enough land for two water wells but has only crafted one.. the panel would show that the building was locked due land requirements.

This PR fixes that issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing with the Water Wells is good. You can have one Water Well in your inventory and have 6 lands. You should be able to craft one more Water Well before seeing the `Unlock more lands` feedback.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
