### PR TITLE
[FEAT] New resource withdrawal

### DIFF
--- a/src/features/goblins/bank/components/Withdraw.tsx
+++ b/src/features/goblins/bank/components/Withdraw.tsx
@@ -28,7 +28,6 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
 
   useEffect(() => {
     const load = async () => {
-      setIsLoading(true);
       const check = await loadBanDetails(
         authState.context.user.farmId?.toString() as string,
         authState.context.user.rawToken as string,

--- a/src/features/goblins/storageHouse/components/DeliverItems.tsx
+++ b/src/features/goblins/storageHouse/components/DeliverItems.tsx
@@ -50,7 +50,7 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
 
   const [jiggerState, setJiggerState] =
     useState<{ url: string; status: JiggerStatus }>();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [selected, setSelected] = useState<Inventory>({});
 
   const inventory: Inventory = useMemo(() => {
@@ -65,7 +65,6 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
 
   useEffect(() => {
     const load = async () => {
-      setIsLoading(true);
       const check = await loadBanDetails(
         authState.context.user.farmId?.toString() as string,
         authState.context.user.rawToken as string,
@@ -193,15 +192,6 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
                 className="flex items-center justify-between gap-2 mt-2"
                 key={itemName}
               >
-                {/* <Box
-                        hideCount
-                        disabled
-                        count={selected[itemName]}
-                        key={itemName}
-                        onClick={() => onSubtract(itemName)}
-                        image={ITEM_DETAILS[itemName].image}
-                        canBeLongPressed
-                      /> */}
                 <div className="flex items-center gap-2">
                   <div
                     className="bg-brown-600"
@@ -222,7 +212,7 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
                     value={parseFloat(selected[itemName]?.toString() || "0")}
                     onChange={(e) => handleAmountChange(e, itemName)}
                     className={classNames(
-                      "p-1 bg-brown-200 text-shadow shadow-inner shadow-black",
+                      "px-2 py-1 bg-brown-200 text-shadow shadow-inner shadow-black",
                       isMobile ? "w-[80px]" : "w-[140px]",
                       {
                         "text-error":

--- a/src/features/goblins/storageHouse/components/DeliverItems.tsx
+++ b/src/features/goblins/storageHouse/components/DeliverItems.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useActor } from "@xstate/react";
@@ -48,6 +49,7 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
   const [authState] = useActor(authService);
 
   const [isMobile] = useIsMobile();
+  const deliveryItemsStartRef = useRef<HTMLDivElement>(null);
 
   const [jiggerState, setJiggerState] =
     useState<{ url: string; status: JiggerStatus }>();
@@ -124,9 +126,10 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
     }
 
     setSelected((prev) => ({
-      ...prev,
       [itemName]: prev[itemName] || amount,
+      ...prev,
     }));
+    deliveryItemsStartRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   const onRemove = (itemName: InventoryItemName) => {
@@ -191,6 +194,7 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
           className="flex flex-col gap-2 min-h-[48px] scrollable overflow-y-auto"
           style={{ maxHeight: 158 }}
         >
+          <div ref={deliveryItemsStartRef} className="-mt-2"></div>
           {getKeys(selected).map((itemName) => (
             <div
               className="flex items-center justify-between gap-2"
@@ -251,19 +255,17 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
         </div>
 
         <div className="w-full my-3 border-t-2 border-white" />
-        <div className="flex items-center my-2">
+        <div className="flex items-center mb-2 text-xs">
           <img src={SUNNYSIDE.icons.player} className="h-8 mr-2" />
           <div>
-            <p className="text-sm">Deliver to your wallet</p>
-            <p className="text-sm">
-              {shortAddress(wallet.myAccount || "XXXX")}
-            </p>
+            <p>Deliver to your wallet</p>
+            <p>{shortAddress(wallet.myAccount || "XXXX")}</p>
           </div>
         </div>
 
-        <span className="text-sm mb-4">
+        <p className="text-xs">
           Once delivered, you will be able to view your items on OpenSea.
-        </span>
+        </p>
       </div>
       <Button onClick={withdraw} disabled={hasWrongInputs()}>
         Deliver

--- a/src/features/goblins/storageHouse/components/DeliverItems.tsx
+++ b/src/features/goblins/storageHouse/components/DeliverItems.tsx
@@ -29,6 +29,7 @@ import { SquareIcon } from "components/ui/SquareIcon";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { useIsMobile } from "lib/utils/hooks/useIsMobile";
+import { getKeys } from "features/game/types/craftables";
 
 interface Props {
   onWithdraw: () => void;
@@ -86,7 +87,8 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
   const hasWrongInputs = (): boolean => {
     const entries = Object.entries(selected) as [InventoryItemName, Decimal][];
     const wrongInputs = entries.filter(
-      ([k, v]) => v?.lte(0) || v?.gt(inventory[k] || new Decimal(0))
+      ([itemName, amount]) =>
+        amount?.lte(0) || amount?.gt(inventory[itemName] || new Decimal(0))
     );
 
     return !entries.length || !!wrongInputs.length;
@@ -172,95 +174,96 @@ export const DeliverItems: React.FC<Props> = ({ onWithdraw }) => {
   return (
     <>
       <div className="p-2 mb-2">
-        <div className="mt-3">
-          <h2 className="mb-1 text-sm">Inventory:</h2>
-          <div className="flex flex-wrap h-fit -ml-1.5 mb-2">
-            {(Object.keys(inventory) as InventoryItemName[]).map((itemName) => (
-              <Box
-                key={itemName}
-                count={inventory[itemName]}
-                onClick={() => onAdd(itemName)}
-                image={ITEM_DETAILS[itemName].image}
-              />
-            ))}
-          </div>
-
-          <div className="mt-2 min-h-[64px]">
-            <h2 className="text-sm">Items to deliver:</h2>
-            {(Object.keys(selected) as InventoryItemName[]).map((itemName) => (
-              <div
-                className="flex items-center justify-between gap-2 mt-2"
-                key={itemName}
-              >
-                <div className="flex items-center gap-2">
-                  <div
-                    className="bg-brown-600"
-                    style={{
-                      width: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
-                      height: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
-                      ...pixelDarkBorderStyle,
-                    }}
-                  >
-                    <SquareIcon
-                      icon={ITEM_DETAILS[itemName as InventoryItemName].image}
-                      width={INNER_CANVAS_WIDTH}
-                    />
-                  </div>
-                  <input
-                    type="number"
-                    name={itemName + "amount"}
-                    value={parseFloat(selected[itemName]?.toString() || "0")}
-                    onChange={(e) => handleAmountChange(e, itemName)}
-                    className={classNames(
-                      "px-2 py-1 bg-brown-200 text-shadow shadow-inner shadow-black",
-                      isMobile ? "w-[80px]" : "w-[140px]",
-                      {
-                        "text-error":
-                          selected[itemName]?.gt(
-                            inventory[itemName] || new Decimal(0)
-                          ) || selected[itemName]?.lte(new Decimal(0)),
-                      }
-                    )}
-                  />
-                  <div className="flex flex-col">
-                    <span
-                      className={isMobile ? "text-xxs" : "text-xs"}
-                    >{`${parseFloat(
-                      selected[itemName]
-                        ?.mul(1 - DELIVERY_FEE / 100)
-                        .toFixed(4, Decimal.ROUND_DOWN) as string
-                    )} ${itemName}`}</span>
-                    <span className="text-xxs">{`${parseFloat(
-                      selected[itemName]
-                        ?.mul(DELIVERY_FEE / 100)
-                        .toFixed(4, Decimal.ROUND_DOWN) as string
-                    )} Goblin fee`}</span>
-                  </div>
-                </div>
-                <img
-                  src={SUNNYSIDE.icons.cancel}
-                  className="h-4 cursor-pointer"
-                  onClick={() => onRemove(itemName)}
-                />
-              </div>
-            ))}
-          </div>
-
-          <div className="w-full my-3 border-t-2 border-white" />
-          <div className="flex items-center my-2">
-            <img src={SUNNYSIDE.icons.player} className="h-8 mr-2" />
-            <div>
-              <p className="text-sm">Deliver to your wallet</p>
-              <p className="text-sm">
-                {shortAddress(wallet.myAccount || "XXXX")}
-              </p>
-            </div>
-          </div>
-
-          <span className="text-sm mb-4">
-            Once delivered, you will be able to view your items on OpenSea.
-          </span>
+        <h2 className="mb-1 text-sm">Inventory:</h2>
+        <div className="flex flex-wrap h-fit -ml-1.5 mb-2">
+          {getKeys(inventory).map((itemName) => (
+            <Box
+              key={itemName}
+              count={inventory[itemName]}
+              onClick={() => onAdd(itemName)}
+              image={ITEM_DETAILS[itemName].image}
+            />
+          ))}
         </div>
+
+        <h2 className="mb-1 text-sm">Items to deliver:</h2>
+        <div
+          className="flex flex-col gap-2 min-h-[48px] scrollable overflow-y-auto"
+          style={{ maxHeight: 158 }}
+        >
+          {getKeys(selected).map((itemName) => (
+            <div
+              className="flex items-center justify-between gap-2"
+              key={itemName}
+            >
+              <div className="flex items-center gap-2">
+                <div
+                  className="bg-brown-600"
+                  style={{
+                    width: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
+                    height: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
+                    ...pixelDarkBorderStyle,
+                  }}
+                >
+                  <SquareIcon
+                    icon={ITEM_DETAILS[itemName as InventoryItemName].image}
+                    width={INNER_CANVAS_WIDTH}
+                  />
+                </div>
+                <input
+                  type="number"
+                  name={itemName + "amount"}
+                  value={parseFloat(selected[itemName]?.toString() || "0")}
+                  onChange={(e) => handleAmountChange(e, itemName)}
+                  className={classNames(
+                    "px-2 py-1 bg-brown-200 text-shadow shadow-inner shadow-black",
+                    isMobile ? "w-[80px]" : "w-[140px]",
+                    {
+                      "text-error":
+                        selected[itemName]?.gt(
+                          inventory[itemName] || new Decimal(0)
+                        ) || selected[itemName]?.lte(new Decimal(0)),
+                    }
+                  )}
+                />
+                <div className="flex flex-col">
+                  <span
+                    className={isMobile ? "text-xxs" : "text-xs"}
+                  >{`${parseFloat(
+                    selected[itemName]
+                      ?.mul(1 - DELIVERY_FEE / 100)
+                      .toFixed(4, Decimal.ROUND_DOWN) as string
+                  )} ${itemName}`}</span>
+                  <span className="text-xxs">{`${parseFloat(
+                    selected[itemName]
+                      ?.mul(DELIVERY_FEE / 100)
+                      .toFixed(4, Decimal.ROUND_DOWN) as string
+                  )} Goblin fee`}</span>
+                </div>
+              </div>
+              <img
+                src={SUNNYSIDE.icons.cancel}
+                className="h-4 mr-2 cursor-pointer"
+                onClick={() => onRemove(itemName)}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="w-full my-3 border-t-2 border-white" />
+        <div className="flex items-center my-2">
+          <img src={SUNNYSIDE.icons.player} className="h-8 mr-2" />
+          <div>
+            <p className="text-sm">Deliver to your wallet</p>
+            <p className="text-sm">
+              {shortAddress(wallet.myAccount || "XXXX")}
+            </p>
+          </div>
+        </div>
+
+        <span className="text-sm mb-4">
+          Once delivered, you will be able to view your items on OpenSea.
+        </span>
       </div>
       <Button onClick={withdraw} disabled={hasWrongInputs()}>
         Deliver

--- a/src/features/goblins/storageHouse/components/Delivery.tsx
+++ b/src/features/goblins/storageHouse/components/Delivery.tsx
@@ -14,32 +14,33 @@ export const Delivery: React.FC<Props> = ({ onWithdraw }) => {
 
   if (isTalking) {
     return (
-      <div className="p-2">
-        <img
-          src={SUNNYSIDE.npcs.goblin_carry}
-          className="h-16 my-2 running relative left-1/4"
-        />
-
-        <div className="flex flex-col space-y-3">
-          <span className="text-sm">Want me to deliver resources?</span>
-          <span className="text-sm">
-            {"It ain't free, I've got a tribe to feed!"}
-          </span>
-          <span className="text-sm">
-            {"I'll take 30% of the resources for the "}
-            <a
-              className="underline"
-              href="https://docs.sunflower-land.com/economy/goblin-community-treasury"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Goblin community treasury
-            </a>
-            .
-          </span>
-          <Button onClick={() => setIsTalking(false)}>Continue</Button>
+      <>
+        <div className="p-2 mb-2">
+          <img
+            src={SUNNYSIDE.npcs.goblin_carry}
+            className="h-16 my-2 running relative left-1/4"
+          />
+          <div className="flex flex-col space-y-3">
+            <span className="text-sm">Want me to deliver resources?</span>
+            <span className="text-sm">
+              {"It ain't free, I've got a tribe to feed!"}
+            </span>
+            <span className="text-sm">
+              {"I'll take 30% of the resources for the "}
+              <a
+                className="underline"
+                href="https://docs.sunflower-land.com/economy/goblin-community-treasury"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Goblin community treasury
+              </a>
+              .
+            </span>
+          </div>
         </div>
-      </div>
+        <Button onClick={() => setIsTalking(false)}>Continue</Button>
+      </>
     );
   }
   return <DeliverItems onWithdraw={onWithdraw} />;


### PR DESCRIPTION
# Description

Longpress for resource withdrawal was not optimal when you tried to withdraw big amounts.

So after discussing it with community we decided to switch to a numeric input.
I reused the same one which is used in AddSFL modal as @spencerdezartsmith suggested.

Mobile view:
![image](https://github.com/sunflower-land/sunflower-land/assets/9656961/f661213a-1500-4a04-9294-f56b28783740)

PC view:

https://github.com/sunflower-land/sunflower-land/assets/9656961/f05a72af-7610-4ff8-8754-91ad25888947




## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual test + yarn test.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
