### PR TITLE
[FIX] getDeliverableItems() now allows Apple

### DIFF
--- a/src/features/goblins/storageHouse/lib/storageItems.test.ts
+++ b/src/features/goblins/storageHouse/lib/storageItems.test.ts
@@ -17,25 +17,15 @@ describe("getDeliverableItems", () => {
 
   it("includes fruits", () => {
     const filtered = getDeliverableItems({
-      Orange: new Decimal(2),
-      Blueberry: new Decimal(3),
-      Kuebiko: new Decimal(1),
-    });
-
-    expect(filtered).toEqual({
-      Orange: new Decimal(2),
-      Blueberry: new Decimal(3),
-    });
-  });
-
-  it("filter out apples", () => {
-    const filtered = getDeliverableItems({
       Apple: new Decimal(5),
+      Orange: new Decimal(2),
       Blueberry: new Decimal(3),
       Kuebiko: new Decimal(1),
     });
 
     expect(filtered).toEqual({
+      Apple: new Decimal(5),
+      Orange: new Decimal(2),
       Blueberry: new Decimal(3),
     });
   });

--- a/src/features/goblins/storageHouse/lib/storageItems.ts
+++ b/src/features/goblins/storageHouse/lib/storageItems.ts
@@ -12,7 +12,7 @@ export function getDeliverableItems(inventory: Inventory) {
     (acc, itemName) => {
       const isDeliverable =
         itemName in CROPS() ||
-        (itemName in FRUIT() && itemName !== "Apple") ||
+        itemName in FRUIT() ||
         (itemName in COMMODITIES && itemName !== "Chicken");
 
       if (isDeliverable && !isNeverWithdrawable(itemName)) {


### PR DESCRIPTION
Apples are marked as withdrawable but `getDeliverableItems()` was preventing them from showing in the Goblin Retreat UI.