### PR TITLE
[FIX] Align height for some SFTs

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1099,7 +1099,7 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Victoria Sisters": { width: 2, height: 2 },
   "Basic Bear": { width: 1, height: 1 },
   "Peeled Potato": { width: 1, height: 1 },
-  "Wood Nymph Wendy": { width: 1, height: 2 },
+  "Wood Nymph Wendy": { width: 1, height: 1 },
   "Cabbage Boy": { width: 1, height: 1 },
   "Cabbage Girl": { width: 1, height: 1 },
 
@@ -1125,8 +1125,8 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
 
   //Easter Event Items
   "Easter Bunny": { width: 2, height: 1 },
-  "Pablo The Bunny": { width: 1, height: 2 },
-  "Easter Bear": { width: 1, height: 2 },
+  "Pablo The Bunny": { width: 1, height: 1 },
+  "Easter Bear": { width: 1, height: 1 },
   "Giant Carrot": { width: 2, height: 2 },
   "Easter Bush": { width: 2, height: 2 },
 

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -90,11 +90,11 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 1,
   },
   "Construction Bear": {
-    height: 2,
+    height: 1,
     width: 1,
   },
   "Angel Bear": {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Badass Bear": {
@@ -110,7 +110,7 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 1,
   },
   "Classy Bear": {
-    height: 2,
+    height: 1,
     width: 1,
   },
   "Farmer Bear": {
@@ -194,7 +194,7 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 2,
   },
   "Human Bear": {
-    height: 2,
+    height: 1,
     width: 1,
   },
   "Tiki Totem": {


### PR DESCRIPTION
# Description

Since we have landscaping and its easy to move SFTs it makes sense to align height of some items.

This allows players to design their farms in more efficient way.

![image](https://github.com/sunflower-land/sunflower-land/assets/9656961/54769790-7fcb-429c-9dee-afcf0490f26a)

PS: I left few bears with original height since those are huge and takes whole area.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
