### PR TITLE
[CHORE] Standardize pixel scale for some UI elements

### DIFF
--- a/src/features/game/expansion/components/PirateChest.tsx
+++ b/src/features/game/expansion/components/PirateChest.tsx
@@ -74,10 +74,11 @@ export const PirateChest: React.FC = () => {
         {canOpen && (
           <img
             src={SUNNYSIDE.icons.expression_alerted}
-            className="w-2 absolute animate-float"
+            className="absolute animate-float"
             style={{
               top: `${PIXEL_SCALE * -13}px`,
               left: `${PIXEL_SCALE * 6}px`,
+              width: `${PIXEL_SCALE * 4}px`,
             }}
           />
         )}

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -100,9 +100,9 @@ const HudComponent: React.FC<{
                   src={SUNNYSIDE.icons.drag}
                   className={"absolute"}
                   style={{
-                    top: `${PIXEL_SCALE * 5}px`,
-                    left: `${PIXEL_SCALE * 5}px`,
-                    width: `${PIXEL_SCALE * 12}px`,
+                    top: `${PIXEL_SCALE * 4}px`,
+                    left: `${PIXEL_SCALE * 4}px`,
+                    width: `${PIXEL_SCALE * 14}px`,
                   }}
                 />
               </div>


### PR DESCRIPTION
# Description

- fix pixel scale for some UI elements

Before|After
---|---
![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/dc8745df-6414-4cc1-9d18-726892f4ae2a)|![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/f7822b23-09fd-417d-94e2-7c32c0248cec)
![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/bdc0c4cf-3c56-4f95-8456-cae47b130791)|![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/e7ba7abf-b00e-440e-8fc8-0eca587dd2cf)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check treasure island chest when open-able
- check hud in main lsland

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
