### PR TITLE
[FIX] Close button on grubnuk modal

### DIFF
--- a/src/features/game/expansion/components/Promoting.tsx
+++ b/src/features/game/expansion/components/Promoting.tsx
@@ -2,7 +2,6 @@ import { useSelector } from "@xstate/react";
 import { Modal } from "react-bootstrap";
 
 import { Button } from "components/ui/Button";
-import { Panel } from "components/ui/Panel";
 import { acknowledgeSeasonPass } from "features/announcements/announcementsStorage";
 import { Context } from "features/game/GameProvider";
 import React, { useContext, useState } from "react";
@@ -15,6 +14,7 @@ import { Label } from "components/ui/Label";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { secondsToString } from "lib/utils/time";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 
 const isPromoting = (state: MachineState) => state.matches("promoting");
 
@@ -216,10 +216,10 @@ export const PromotingModal: React.FC<Props> = ({
     );
   };
   return (
-    <Modal centered show={isOpen}>
-      <Panel bumpkinParts={NPC_WEARABLES.grubnuk}>
+    <Modal centered show={isOpen} onHide={onClose}>
+      <CloseButtonPanel bumpkinParts={NPC_WEARABLES.grubnuk} onClose={onClose}>
         <Content />
-      </Panel>
+      </CloseButtonPanel>
     </Modal>
   );
 };


### PR DESCRIPTION
# Description

Add close button to Grubnuk modal. Enable closing on backdrop click. 

<img width="628" alt="Screenshot 2023-06-06 at 9 05 41" src="https://github.com/sunflower-land/sunflower-land/assets/19366687/9508f3e9-63ce-4c88-a0eb-b3820fc3a0a0">

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
