### PR TITLE
[FIX] Show first bumpkin on tent

### DIFF
--- a/src/features/island/buildings/components/building/tent/Tent.tsx
+++ b/src/features/island/buildings/components/building/tent/Tent.tsx
@@ -41,10 +41,8 @@ export const Tent: React.FC<BuildingProps> = ({
   const buildingIndex = buildings["Tent"]?.findIndex(
     (building) => building.id === buildingId
   );
-  const placedIndex =
-    buildingIndex !== undefined ? buildingIndex + 1 : undefined;
 
-  const bumpkin = placedIndex !== undefined && bumpkins[placedIndex];
+  const bumpkin = buildingIndex !== undefined && bumpkins[buildingIndex];
 
   const handleClick = () => {
     if (onRemove) {
@@ -86,7 +84,7 @@ export const Tent: React.FC<BuildingProps> = ({
       </BuildingImageWrapper>
       <Modal centered show={showModal} onHide={() => setShowModal(false)}>
         <TentModal
-          defaultSelectedIndex={placedIndex}
+          defaultSelectedIndex={buildingIndex}
           onClose={() => setShowModal(false)}
         />
       </Modal>


### PR DESCRIPTION
# Description

With the release of Bumpkin Deposits, we should show the first Bumpkin in the Tent.

My Bumpkins:
<img width="894" alt="my bumpkins" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/9616f049-43e3-4ef6-a0e9-e829e96f7858">

Tent Modal shows:
<img width="519" alt="tent modal" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/bcf3bdf8-bdf9-4eab-b313-95487e3b8ae7">

Farm shows:
<img width="379" alt="farm" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/c9387255-4aa7-4bd3-8b4b-2f88a043f2fc">


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
