### PR TITLE
[FIX] Pixel scale and alignments for seasonal SFTs

### DIFF
--- a/src/features/island/collectibles/components/Maximus.tsx
+++ b/src/features/island/collectibles/components/Maximus.tsx
@@ -5,17 +5,15 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const Maximus: React.FC = () => {
   return (
-    <>
-      <img
-        src={image}
-        style={{
-          width: `${PIXEL_SCALE * 21}px`,
-          bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 5.5}px`,
-        }}
-        className="absolute"
-        alt="Maximus"
-      />
-    </>
+    <img
+      src={image}
+      style={{
+        width: `${PIXEL_SCALE * 21}px`,
+        bottom: `${PIXEL_SCALE * 1}px`,
+        left: `${PIXEL_SCALE * 5}px`,
+      }}
+      className="absolute pointer-events-none"
+      alt="Maximus"
+    />
   );
 };

--- a/src/features/island/collectibles/components/MushroomHouse.tsx
+++ b/src/features/island/collectibles/components/MushroomHouse.tsx
@@ -5,15 +5,21 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const MushroomHouse: React.FC = () => {
   return (
-    <>
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        width: `${PIXEL_SCALE * 37}px`,
+        bottom: `${PIXEL_SCALE * 0}px`,
+        left: `${PIXEL_SCALE * -3}px`,
+      }}
+    >
       <img
         src={mushroomHouse}
         style={{
           width: `${PIXEL_SCALE * 37}px`,
         }}
-        className="absolute"
         alt="Mushroom House"
       />
-    </>
+    </div>
   );
 };

--- a/src/features/island/collectibles/components/Obie.tsx
+++ b/src/features/island/collectibles/components/Obie.tsx
@@ -1,19 +1,29 @@
 import React from "react";
 
-import gif from "assets/sfts/obie.gif";
+import obie from "assets/sfts/obie.gif";
+import shadow from "assets/npcs/shadow.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const Obie: React.FC = () => {
   return (
     <>
       <img
-        src={gif}
+        src={shadow}
+        className="absolute pointer-events-none"
+        style={{
+          width: `${PIXEL_SCALE * 15}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 0}px`,
+        }}
+      />
+      <img
+        src={obie}
+        className="absolute pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 0.5}px`,
+          left: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute"
         alt="Obie"
       />
     </>

--- a/src/features/island/collectibles/components/PurpleTrail.tsx
+++ b/src/features/island/collectibles/components/PurpleTrail.tsx
@@ -5,17 +5,15 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const PurpleTrail: React.FC = () => {
   return (
-    <>
-      <img
-        src={image}
-        style={{
-          width: `${PIXEL_SCALE * 15}px`,
-          bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 0.5}px`,
-        }}
-        className="absolute"
-        alt="Purple Trail"
-      />
-    </>
+    <img
+      src={image}
+      style={{
+        width: `${PIXEL_SCALE * 15}px`,
+        bottom: `${PIXEL_SCALE * 2}px`,
+        left: `${PIXEL_SCALE * 0}px`,
+      }}
+      className="absolute pointer-events-none"
+      alt="Purple Trail"
+    />
   );
 };


### PR DESCRIPTION
# Description

fixes for some collectibles (more to come):

- make sure collectibles
  - have correct pixel size and pixel placement
  - not obstructing click events that are outside their respective grids (adding pointer-events-none)

Before|After
---|---
<img width="324" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/782b9f76-350e-4dbe-93b4-7c03594e2778">|<img width="333" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/a4fc479e-c9fa-4cf9-a6d3-7ecd0d366a55">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- place Obie, Mushroom House, Maximus and Purple Trail on the farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
