### PR TITLE
[FEAT] Block bucks back button (duplicate)

### DIFF
--- a/src/features/game/components/modal/components/BlockBucksModal.tsx
+++ b/src/features/game/components/modal/components/BlockBucksModal.tsx
@@ -121,10 +121,10 @@ export const BlockBucksModal: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
-  const [showPoko, setShowPoko] = useState<PokoConfig | undefined>(undefined);
+  const [showPoko, setShowPoko] = useState<PokoConfig>();
   const [loading, setLoading] = useState(false);
 
-  const [price, setPrice] = useState<Price | undefined>(undefined);
+  const [price, setPrice] = useState<Price>();
 
   const onMaticBuy = async (amount: number) => {
     gameService.send("BUY_BLOCK_BUCKS", {
@@ -295,6 +295,7 @@ export const BlockBucksModal: React.FC<Props> = ({
 
   return (
     <CloseButtonPanel
+      onBack={closeable && price ? () => setPrice(undefined) : undefined}
       onClose={closeable ? onClose : undefined}
       title="Buy Block Bucks"
       bumpkinParts={{

--- a/src/features/island/collectibles/components/Maximus.tsx
+++ b/src/features/island/collectibles/components/Maximus.tsx
@@ -5,17 +5,15 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const Maximus: React.FC = () => {
   return (
-    <>
-      <img
-        src={image}
-        style={{
-          width: `${PIXEL_SCALE * 21}px`,
-          bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 5.5}px`,
-        }}
-        className="absolute"
-        alt="Maximus"
-      />
-    </>
+    <img
+      src={image}
+      style={{
+        width: `${PIXEL_SCALE * 21}px`,
+        bottom: `${PIXEL_SCALE * 1}px`,
+        left: `${PIXEL_SCALE * 5}px`,
+      }}
+      className="absolute pointer-events-none"
+      alt="Maximus"
+    />
   );
 };

--- a/src/features/island/collectibles/components/MushroomHouse.tsx
+++ b/src/features/island/collectibles/components/MushroomHouse.tsx
@@ -5,15 +5,21 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const MushroomHouse: React.FC = () => {
   return (
-    <>
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        width: `${PIXEL_SCALE * 37}px`,
+        bottom: `${PIXEL_SCALE * 0}px`,
+        left: `${PIXEL_SCALE * -3}px`,
+      }}
+    >
       <img
         src={mushroomHouse}
         style={{
           width: `${PIXEL_SCALE * 37}px`,
         }}
-        className="absolute"
         alt="Mushroom House"
       />
-    </>
+    </div>
   );
 };

--- a/src/features/island/collectibles/components/Obie.tsx
+++ b/src/features/island/collectibles/components/Obie.tsx
@@ -1,19 +1,29 @@
 import React from "react";
 
-import gif from "assets/sfts/obie.gif";
+import obie from "assets/sfts/obie.gif";
+import shadow from "assets/npcs/shadow.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const Obie: React.FC = () => {
   return (
     <>
       <img
-        src={gif}
+        src={shadow}
+        className="absolute pointer-events-none"
+        style={{
+          width: `${PIXEL_SCALE * 15}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 0}px`,
+        }}
+      />
+      <img
+        src={obie}
+        className="absolute pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 0.5}px`,
+          left: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute"
         alt="Obie"
       />
     </>

--- a/src/features/island/collectibles/components/PurpleTrail.tsx
+++ b/src/features/island/collectibles/components/PurpleTrail.tsx
@@ -5,17 +5,15 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const PurpleTrail: React.FC = () => {
   return (
-    <>
-      <img
-        src={image}
-        style={{
-          width: `${PIXEL_SCALE * 15}px`,
-          bottom: `${PIXEL_SCALE * 2}px`,
-          left: `${PIXEL_SCALE * 0.5}px`,
-        }}
-        className="absolute"
-        alt="Purple Trail"
-      />
-    </>
+    <img
+      src={image}
+      style={{
+        width: `${PIXEL_SCALE * 15}px`,
+        bottom: `${PIXEL_SCALE * 2}px`,
+        left: `${PIXEL_SCALE * 0}px`,
+      }}
+      className="absolute pointer-events-none"
+      alt="Purple Trail"
+    />
   );
 };


### PR DESCRIPTION
# Description

- Add back button to block bucks modal so players can select the amount again without closing the modal

<img width="400" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/fd1c09af-ec89-4a3f-9360-81d3893404c5">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- select amount of block bucks to buy then press back buton
- back button should not show if credit card is processing (the close button is hidden too)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
