### PR TITLE
[FEAT] Add back button to block bucks modal

### DIFF
--- a/src/features/game/components/modal/components/BlockBucksModal.tsx
+++ b/src/features/game/components/modal/components/BlockBucksModal.tsx
@@ -121,10 +121,10 @@ export const BlockBucksModal: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
-  const [showPoko, setShowPoko] = useState<PokoConfig | undefined>(undefined);
+  const [showPoko, setShowPoko] = useState<PokoConfig>();
   const [loading, setLoading] = useState(false);
 
-  const [price, setPrice] = useState<Price | undefined>(undefined);
+  const [price, setPrice] = useState<Price>();
 
   const onMaticBuy = async (amount: number) => {
     gameService.send("BUY_BLOCK_BUCKS", {
@@ -295,6 +295,7 @@ export const BlockBucksModal: React.FC<Props> = ({
 
   return (
     <CloseButtonPanel
+      onBack={closeable && price ? () => setPrice(undefined) : undefined}
       onClose={closeable ? onClose : undefined}
       title="Buy Block Bucks"
       bumpkinParts={{


### PR DESCRIPTION
# Description

- Add back button to block bucks modal so players can select the amount again without closing the modal

<img width="400" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/fd1c09af-ec89-4a3f-9360-81d3893404c5">

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- select amount of block bucks to buy then press back buton
- back button should not show if credit card is processing (the close button is hidden too)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
