### PR TITLE
[FIX] Prevent selected collectible from appearing under others

### DIFF
--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -286,6 +286,7 @@ export const MoveableComponent: React.FC<MovableProps> = ({
         className={classNames("h-full relative", {
           "cursor-grabbing": isDragging,
           "cursor-pointer": !isDragging,
+          "z-10": isSelected,
         })}
       >
         {isSelected && (


### PR DESCRIPTION
Requested by @Polysemouse 

# Before

<img width="196" alt="before" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/d09aa0b3-76dd-4f08-be76-5af7552ca2e9">

# After

<img width="252" alt="after" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/cf068a4f-e6ff-4a55-bf25-7256f22a4de6">
