### PR TITLE
[FIX] Bypass cache on error when fetching bumpkins

### DIFF
--- a/src/features/bumpkins/actions/buildNPCSheets.ts
+++ b/src/features/bumpkins/actions/buildNPCSheets.ts
@@ -88,6 +88,7 @@ export async function buildNPCSheets(request: Request): Promise<Response> {
       },
     };
   } catch {
+    // Since these are not real NFTs, prepend fake ID and version
     const validName = `0_v1_${tokenUri}`;
     const sheets = await buildNPCSheetsRequest(validName);
     return {


### PR DESCRIPTION
# Description

This change adds a second attempt to fetch a bumpkin URL if there is an error. This is a safety precaution in case incorrect CORS headers get cached on the infrastructure layer.

Under normal circumstances this should never really happen, but unfortunately we have a bunch of assets already incorrectly cached.

Below is a screenshot of this in action:

1. First we request the images and get a CORS error
2. We attempt to fetch the image by putting a query string on the asset
3. This is successful so this is the image we use in bumpkins. Note that this second request is served from the disk cache.

<img width="1326" alt="screenshot" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/ec473cce-0532-4876-b50e-0bd5aad730e5">

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
