### PR TITLE
[FIX] Add missing Hoot boost

### DIFF
--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -323,6 +323,17 @@ export function getCropYieldAmount({
     }
   }
 
+  const isOvernightCrop =
+    crop === "Radish" || crop === "Wheat" || crop === "Kale";
+
+  if (
+    isOvernightCrop &&
+    collectibles["Hoot"] &&
+    isCollectibleBuilt("Hoot", collectibles)
+  ) {
+    amount = amount + 0.5;
+  }
+
   return Number(setPrecision(new Decimal(amount)));
 }
 


### PR DESCRIPTION
# Description

Adds yield boost for Hoot collectible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
