### PR TITLE
[FIX] Add missing wearable boost descriptions

### DIFF
--- a/src/features/game/types/bumpkin.ts
+++ b/src/features/game/types/bumpkin.ts
@@ -549,7 +549,7 @@ export const BUMPKIN_ITEM_BUFF: Partial<Record<BumpkinItem, string>> = {
   "Eggplant Onesie": "+0.1 Eggplant",
   "Golden Spatula": "+10% EXP",
   "Mushroom Hat": "+0.1 Mushrooms",
-  "Parsnip": "+20% Parsnip",
+  Parsnip: "+20% Parsnip",
   "Sunflower Amulet": "+10% Sunflower",
   "Carrot Amulet": "-20% Carrot growth time",
   "Beetroot Amulet": "+20% Beetroot",

--- a/src/features/game/types/bumpkin.ts
+++ b/src/features/game/types/bumpkin.ts
@@ -549,4 +549,9 @@ export const BUMPKIN_ITEM_BUFF: Partial<Record<BumpkinItem, string>> = {
   "Eggplant Onesie": "+0.1 Eggplant",
   "Golden Spatula": "+10% EXP",
   "Mushroom Hat": "+0.1 Mushrooms",
+  "Parsnip": "+20% Parsnip",
+  "Sunflower Amulet": "+10% Sunflower",
+  "Carrot Amulet": "-20% Carrot growth time",
+  "Beetroot Amulet": "+20% Beetroot",
+  "Green Amulet": "Chance for 10x crops",
 };


### PR DESCRIPTION
# Description

The following wearables were missing in-game descriptions for their boosts:
- Parsnip
- Sunflower Amulet
- Carrot Amulet
- Green Amulet
- Beetroot Amulet

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
