### PR TITLE
[FEAT] Mute audio when navigating tabs

### DIFF
--- a/src/features/game/components/AudioMenu.tsx
+++ b/src/features/game/components/AudioMenu.tsx
@@ -75,6 +75,22 @@ export const AudioMenu: React.FC<Props> = ({
     cacheAudioSetting(AudioLocalStorageKeys.musicPaused, musicPaused);
   }, [musicPaused]);
 
+  useEffect(() => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        if (!musicPaused) {
+          musicPlayer.current.play();
+          musicPlayer.current.muted = false;
+        }
+        Howler.mute(audioMuted);
+      } else {
+        musicPlayer.current.pause();
+        Howler.mute(true);
+      }
+    });
+  }, []);
+
   return (
     <Modal show={show} centered onHide={onClose}>
       <CloseButtonPanel title="Audio Settings" onClose={onClose}>


### PR DESCRIPTION
# Description

Feedback from OKX. In their dapp browser they want the music to be muted when the player navigates aways from the tab.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost - navigate away from the tab to test

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
