### PR TITLE
[FIX] Wanderleaf greedy count

### DIFF
--- a/src/features/world/ui/dawn/WanderLeaf.tsx
+++ b/src/features/world/ui/dawn/WanderLeaf.tsx
@@ -25,9 +25,7 @@ export const WanderLeaf: React.FC<Props> = ({ onClose }) => {
           bumpkinParts={NPC_WEARABLES["wanderleaf"]}
           message={[
             {
-              text: `Hey friend, don't be greedy. You are a well-travelled Bumpkin! You now have ${
-                discoveredCount
-              } entries into my prize giveaway`,
+              text: `Hey friend, don't be greedy. You are a well-travelled Bumpkin! You now have ${discoveredCount} entries into my prize giveaway`,
             },
             {
               text: "Come back tomorrow and try find me.",

--- a/src/features/world/ui/dawn/WanderLeaf.tsx
+++ b/src/features/world/ui/dawn/WanderLeaf.tsx
@@ -26,7 +26,7 @@ export const WanderLeaf: React.FC<Props> = ({ onClose }) => {
           message={[
             {
               text: `Hey friend, don't be greedy. You are a well-travelled Bumpkin! You now have ${
-                discoveredCount + 1
+                discoveredCount
               } entries into my prize giveaway`,
             },
             {


### PR DESCRIPTION
# Description

When revisiting Wanderleaf multiple times per day, the "greedy" message was showing the wrong count.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
