### PR TITLE
Update crop levels to be time-based

### DIFF
--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -1,5 +1,5 @@
 import { GameState, PlantedCrop } from "../../types/game";
-import { Crop, CROPS } from "../../types/crops";
+import { Crop, CropName, CROPS } from "../../types/crops";
 import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
 import {
@@ -16,6 +16,25 @@ type Options = {
   state: GameState;
   action: LandExpansionHarvestAction;
   createdAt?: number;
+};
+
+export const isBasicCrop = (cropName: CropName) => {
+  const cropDetails = CROPS()[cropName];
+  return cropDetails.harvestSeconds <= CROPS()["Pumpkin"].harvestSeconds;
+};
+
+export const isMediumCrop = (cropName: CropName) => {
+  return !(isBasicCrop(cropName) || isAdvancedCrop(cropName));
+};
+
+export const isAdvancedCrop = (cropName: CropName) => {
+  const cropDetails = CROPS()[cropName];
+  return cropDetails.harvestSeconds >= CROPS()["Eggplant"].harvestSeconds;
+};
+
+export const isOvernightCrop = (cropName: CropName) => {
+  const cropDetails = CROPS()[cropName];
+  return cropDetails.harvestSeconds >= CROPS()["Radish"].harvestSeconds;
 };
 
 export const isReadyToHarvest = (

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -10,6 +10,7 @@ import {
 import cloneDeep from "lodash.clonedeep";
 import { isReadyToHarvest } from "./harvest";
 import { CROPS } from "features/game/types/crops";
+import { isBasicCrop, isMediumCrop, isAdvancedCrop } from "./harvest";
 
 export enum MOVE_CROP_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -44,19 +45,9 @@ export function isLocked(
   const cropName = crop.name;
   const cropDetails = CROPS()[cropName];
 
-  const isBasicCrop =
-    cropName === "Sunflower" || cropName === "Potato" || cropName === "Pumpkin";
-
-  const isMediumLevelCrop =
-    cropName === "Carrot" ||
-    cropName === "Cabbage" ||
-    cropName === "Beetroot" ||
-    cropName === "Cauliflower" ||
-    cropName === "Parsnip";
-
   if (isReadyToHarvest(createdAt, crop, cropDetails)) return false;
 
-  if (isBasicCrop && collectibles["Basic Scarecrow"]?.[0]) {
+  if (isBasicCrop(cropName) && collectibles["Basic Scarecrow"]?.[0]) {
     const basicScarecrowCoordinates =
       collectibles["Basic Scarecrow"]?.[0].coordinates;
     const scarecrowDimensions = COLLECTIBLES_DIMENSIONS["Basic Scarecrow"];
@@ -80,7 +71,7 @@ export function isLocked(
     }
   }
 
-  if (isMediumLevelCrop && collectibles["Scary Mike"]?.[0]) {
+  if (isMediumCrop(cropName) && collectibles["Scary Mike"]?.[0]) {
     const basicScarecrowCoordinates =
       collectibles["Scary Mike"]?.[0].coordinates;
     const scarecrowDimensions = COLLECTIBLES_DIMENSIONS["Scary Mike"];
@@ -128,14 +119,10 @@ export function isLocked(
     }
   }
 
-  const isAdvancedLevelCrop =
-    cropName === "Eggplant" ||
-    cropName === "Corn" ||
-    cropName === "Radish" ||
-    cropName === "Wheat" ||
-    cropName === "Kale";
-
-  if (isAdvancedLevelCrop && collectibles["Laurie the Chuckle Crow"]?.[0]) {
+  if (
+    isAdvancedCrop(cropName) &&
+    collectibles["Laurie the Chuckle Crow"]?.[0]
+  ) {
     const ScarecrowCoordinates =
       collectibles["Laurie the Chuckle Crow"]?.[0].coordinates;
     const scarecrowDimensions =

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -21,6 +21,12 @@ import { setPrecision } from "lib/utils/formatNumber";
 import { SEEDS } from "features/game/types/seeds";
 import { BuildingName } from "features/game/types/buildings";
 import { isWithinAOE } from "features/game/expansion/placeable/lib/collisionDetection";
+import {
+  isBasicCrop,
+  isMediumCrop,
+  isAdvancedCrop,
+  isOvernightCrop,
+} from "./harvest";
 
 export type LandExpansionPlantAction = {
   type: "seed.planted";
@@ -139,11 +145,8 @@ export const getCropTime = (
     seconds = seconds * 0.75;
   }
 
-  const isBasicCrop =
-    crop === "Sunflower" || crop === "Potato" || crop === "Pumpkin";
-
   // If within Basic Scarecrow AOE: 20% reduction
-  if (collectibles["Basic Scarecrow"]?.[0] && isBasicCrop) {
+  if (collectibles["Basic Scarecrow"]?.[0] && isBasicCrop(crop)) {
     if (!plot) return seconds;
 
     const basicScarecrowCoordinates =
@@ -278,14 +281,7 @@ export function getCropYieldAmount({
     amount *= 1.1;
   }
 
-  const isMediumLevelCrop =
-    crop === "Carrot" ||
-    crop === "Cabbage" ||
-    crop === "Beetroot" ||
-    crop === "Cauliflower" ||
-    crop === "Parsnip";
-
-  if (collectibles["Scary Mike"]?.[0] && isMediumLevelCrop && plot) {
+  if (collectibles["Scary Mike"]?.[0] && isMediumCrop(crop) && plot) {
     const scarecrowCoordinates = collectibles["Scary Mike"]?.[0].coordinates;
     const scarecrowDimensions = COLLECTIBLES_DIMENSIONS["Scary Mike"];
 
@@ -328,27 +324,17 @@ export function getCropYieldAmount({
     }
   }
 
-  const isOvernightCrop =
-    crop === "Radish" || crop === "Wheat" || crop === "Kale";
-
   if (
-    isOvernightCrop &&
+    isOvernightCrop(crop) &&
     collectibles["Hoot"] &&
     isCollectibleBuilt("Hoot", collectibles)
   ) {
     amount = amount + 0.5;
   }
 
-  const isAdvancedLevelCrop =
-    crop === "Eggplant" ||
-    crop === "Corn" ||
-    crop === "Radish" ||
-    crop === "Wheat" ||
-    crop === "Kale";
-
   if (
     collectibles["Laurie the Chuckle Crow"]?.[0] &&
-    isAdvancedLevelCrop &&
+    isAdvancedCrop(crop) &&
     plot
   ) {
     const scarecrowCoordinates =


### PR DESCRIPTION
# Description

Crop levels (basic, medium, advanced, overnight) are now calculated by crop duration rather than hardcoded lists of crop names.  In addition to better expressing the concept, support for future crop additions (like corn) requires no further code changes.