### PR TITLE
Change Testnet release label to commit hash

### DIFF
--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get the current version ref
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo ::set-output name=VERSION::${GITHUB_SHA}
 
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
# Description

The `VITE_RELEASE_VERSION` for Testnet value of `refs/heads/main` is not very helpful.

This change uses the SHA hash of the commit instead.  With this hash, developers and testers can immediately know which front-end code is being used for testnet.
