### PR TITLE
[FIX] Partial revert of Axe shortcutItem for Foreman Beaver

### DIFF
--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -109,7 +109,8 @@ export const Tree: React.FC<Props> = ({ id }) => {
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
-    shortcutItem(tool);
+    if (!isCollectibleBuilt("Foreman Beaver", collectibles))
+      shortcutItem(tool);
 
     // need to hit enough times to collect resource
     if (touchCount < HITS - 1) return;

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -109,8 +109,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
-    if (!isCollectibleBuilt("Foreman Beaver", collectibles))
-      shortcutItem(tool);
+    if (!isCollectibleBuilt("Foreman Beaver", collectibles)) shortcutItem(tool);
 
     // need to hit enough times to collect resource
     if (touchCount < HITS - 1) return;

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -115,8 +115,10 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
         return displayInformation();
       }
 
-      if (!isCollectibleBuilt("Foreman Beaver", collectibles) ||
-          (fruit?.name === "Blueberry"))
+      if (
+        !isCollectibleBuilt("Foreman Beaver", collectibles) ||
+        fruit?.name === "Blueberry"
+      )
         shortcutItem("Axe");
 
       const newState = gameService.send("fruitTree.removed", {

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -115,7 +115,9 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
         return displayInformation();
       }
 
-      shortcutItem("Axe");
+      if (!isCollectibleBuilt("Foreman Beaver", collectibles) ||
+          (fruit?.name === "Blueberry"))
+        shortcutItem("Axe");
 
       const newState = gameService.send("fruitTree.removed", {
         index: id,


### PR DESCRIPTION
# Description

The auto-shortcutting introduced by !2714 is actually a downgrade for owners of Foreman Beaver.

More specifically, it breaks workflows such as { harvest crop, plant crop, chop tree, repeat }.  I noticed this immediately as soon as the PR merged.

It also breaks two-tapping non-blueberry fruit trees for Foreman Beaver.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
