### PR TITLE
[FIX] Use community island server names

### DIFF
--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -125,9 +125,13 @@ export abstract class BaseScene extends Phaser.Scene {
   zoom = window.innerWidth < 500 ? 3 : 4;
 
   constructor(options: BaseSceneOptions) {
+    if (!options.name) {
+      throw new Error("Missing name in config");
+    }
+
     const defaultedOptions: Required<BaseSceneOptions> = {
       ...options,
-      name: options.name ?? "community_island",
+      name: options.name,
       audio: options.audio ?? { fx: { walk_key: "wood_footstep" } },
       controls: options.controls ?? { enabled: true },
       mmo: options.mmo ?? { enabled: true },
@@ -316,7 +320,7 @@ export abstract class BaseScene extends Phaser.Scene {
         return;
       }
 
-      if (message.sceneId !== this.scene.key) {
+      if (message.sceneId !== this.options.name) {
         return;
       }
 

--- a/src/features/world/scenes/CommunityScene.ts
+++ b/src/features/world/scenes/CommunityScene.ts
@@ -67,7 +67,10 @@ export abstract class CommunityScene extends Phaser.Scene {
       }
 
       this.load.sceneFile("ExternalScene", `${island?.url}/Scene.js`);
-      this.load.tilemapTiledJSON("community_island", `${island?.url}/map.json`);
+      this.load.tilemapTiledJSON(
+        island?.id as string,
+        `${island?.url}/map.json`
+      );
 
       // Load Sound Effects
       this.load.audio("dirt_footstep", SOUNDS.footsteps.dirt);
@@ -106,7 +109,7 @@ export abstract class CommunityScene extends Phaser.Scene {
       this.load.bitmapFont("pixelmix", "world/7px.png", "world/7px.xml");
 
       this.load.once("complete", () => {
-        this.scene.start("community_island");
+        this.scene.start(island?.id);
       });
     } catch (error) {
       errorLogger(error);


### PR DESCRIPTION
# Description

Community Islands must now specify a unique name in their config setup.

See: https://github.com/sunflower-land/community-island-example/commit/63e72e988e6f2b15a4c2cca9548288b8a064e1a2