### PR TITLE
[FEAT] Community Toast

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -33,6 +33,7 @@ import { MarcusHomeScene } from "./scenes/MarcusHomeScene";
 import { WorldIntroduction } from "./ui/WorldIntroduction";
 import { CommunityScene } from "./scenes/CommunityScene";
 import { CommunityModals } from "./ui/CommunityModalManager";
+import { CommunityToasts } from "./ui/CommunityToastManager";
 import { SceneId } from "./mmoMachine";
 import { CornScene } from "./scenes/CornScene";
 import { useNavigate } from "react-router-dom";
@@ -204,6 +205,7 @@ export const PhaserComponent: React.FC<Props> = ({
         }}
       />
       <CommunityModals />
+      <CommunityToasts />
       <InteractableModals id={authState.context.user.farmId as number} />
       <Modal
         show={mmoState === "loading" || mmoState === "initialising"}

--- a/src/features/world/scenes/CommunityScene.ts
+++ b/src/features/world/scenes/CommunityScene.ts
@@ -5,6 +5,7 @@ import { createErrorLogger } from "lib/errorLogger";
 import { BaseScene } from "./BaseScene";
 import { COMMUNITY_ISLANDS } from "../ui/community/CommunityIslands";
 import { communityModalManager } from "../ui/CommunityModalManager";
+import { communityToastManager } from "../ui/CommunityToastManager";
 import { Room } from "colyseus.js";
 import { PlazaRoomState } from "../types/Room";
 import { MachineInterpreter } from "features/game/lib/gameMachine";
@@ -54,6 +55,7 @@ export abstract class CommunityScene extends Phaser.Scene {
       // Expose API/SDK for usage
       (window as any).BaseScene = BaseScene;
       (window as any).openModal = communityModalManager.open;
+      (window as any).toast = communityToastManager.toast;
 
       const sceneName = this.registry.get("initialScene");
       let island = COMMUNITY_ISLANDS.find((island) => island.id === sceneName);

--- a/src/features/world/scenes/CommunityScene.ts
+++ b/src/features/world/scenes/CommunityScene.ts
@@ -55,7 +55,7 @@ export abstract class CommunityScene extends Phaser.Scene {
       // Expose API/SDK for usage
       (window as any).BaseScene = BaseScene;
       (window as any).openModal = communityModalManager.open;
-      (window as any).toast = communityToastManager.toast;
+      (window as any).createToast = communityToastManager.toast;
 
       const sceneName = this.registry.get("initialScene");
       let island = COMMUNITY_ISLANDS.find((island) => island.id === sceneName);

--- a/src/features/world/ui/CommunityToastManager.tsx
+++ b/src/features/world/ui/CommunityToastManager.tsx
@@ -81,7 +81,7 @@ export const CommunityToasts: React.FC = () => {
           <InnerPanel
             className="flex flex-col items-start fixed z-[99999] pointer-events-none"
             style={{
-              top: `${PIXEL_SCALE * 54}px`,
+              top: `${PIXEL_SCALE * 85}px`,
               left: `${PIXEL_SCALE * 3}px`,
             }}
           >

--- a/src/features/world/ui/CommunityToastManager.tsx
+++ b/src/features/world/ui/CommunityToastManager.tsx
@@ -44,7 +44,11 @@ export const CommunityToasts: React.FC = () => {
 
   useEffect(() => {
     communityToastManager.listen((toast, isShown) => {
-      console.log("OPENED", { toast });
+      if (!toast.text) {
+        return console.warn("Toast text is empty");
+      }
+
+      console.log("TOAST", { toast, isShown });
 
       const newToast: CommunityToast = {
         ...toast,

--- a/src/features/world/ui/CommunityToastManager.tsx
+++ b/src/features/world/ui/CommunityToastManager.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from "react";
+import { InnerPanel } from "components/ui/Panel";
+import { createPortal } from "react-dom";
+import { ITEM_DETAILS } from "../../game/types/images";
+import { InventoryItemName } from "../../game/types/game";
+
+const PIXEL_SCALE = 2.625;
+type ToastItem = InventoryItemName;
+
+const getToastIcon = (item: ToastItem) => {
+  return ITEM_DETAILS[item]?.image;
+};
+
+type CommunityToast = {
+  item?: InventoryItemName;
+  text: string;
+  id: string;
+};
+
+class CommunityToastManager {
+  private listener?: (toast: CommunityToast, isShown: boolean) => void;
+  private id = 0;
+
+  constructor() {
+    this.id = Date.now();
+  }
+
+  public toast = (toast: CommunityToast) => {
+    if (this.listener) {
+      this.listener(toast, true);
+    }
+  };
+
+  public listen(cb: (toast: CommunityToast, isShown: boolean) => void) {
+    this.listener = cb;
+  }
+}
+
+export const communityToastManager = new CommunityToastManager();
+
+export const CommunityToasts: React.FC = () => {
+  const [toasts, setToasts] = useState<CommunityToast[]>([]);
+
+  useEffect(() => {
+    communityToastManager.listen((toast, isShown) => {
+      console.log("OPENED", { toast });
+
+      const newToast: CommunityToast = {
+        ...toast,
+        id: Date.now().toString(),
+      };
+
+      setToasts((prevToasts) => [...prevToasts, newToast]);
+
+      // Automatically remove the toast after 5 seconds
+      setTimeout(() => {
+        hideToast(newToast);
+      }, 5000);
+    });
+  }, []);
+
+  const hideToast = (toast: CommunityToast) => {
+    setToasts((prevToasts) => prevToasts.filter((t) => t !== toast));
+  };
+
+  return (
+    <>
+      {toasts.length > 0 &&
+        createPortal(
+          <InnerPanel
+            className="flex flex-col items-start fixed z-[99999] pointer-events-none"
+            style={{
+              top: `${PIXEL_SCALE * 54}px`,
+              left: `${PIXEL_SCALE * 3}px`,
+            }}
+          >
+            {toasts.map((toast) => (
+              <div key={toast.id} className="flex items-center justify-center">
+                {toast.item && (
+                  <img className="h-6" src={getToastIcon(toast.item)} />
+                )}
+                <span className="text-sm mx-1 mb-0.5">{`${toast.text}`}</span>
+              </div>
+            ))}
+          </InnerPanel>,
+          document.body
+        )}
+    </>
+  );
+};

--- a/src/features/world/ui/CommunityToastManager.tsx
+++ b/src/features/world/ui/CommunityToastManager.tsx
@@ -5,6 +5,7 @@ import { ITEM_DETAILS } from "../../game/types/images";
 import { InventoryItemName } from "../../game/types/game";
 
 const PIXEL_SCALE = 2.625;
+const MAX_TOAST = 6;
 type ToastItem = InventoryItemName;
 
 const getToastIcon = (item: ToastItem) => {
@@ -50,7 +51,13 @@ export const CommunityToasts: React.FC = () => {
         id: Date.now().toString(),
       };
 
-      setToasts((prevToasts) => [...prevToasts, newToast]);
+      setToasts((prevToasts) => {
+        if (prevToasts.length >= MAX_TOAST) {
+          prevToasts.shift();
+        }
+
+        return [...prevToasts, newToast];
+      });
 
       // Automatically remove the toast after 5 seconds
       setTimeout(() => {


### PR DESCRIPTION
# Description

This PR add a way for people to use Toats in their Scene.js (for Community Islands).

Like the modals, we use `window.createToast();`. Here's an example:

```ts
window.createToast({
    text: "Test Toast hello world lol",
    item: "Sunflower", // This is optional
 });
```
![toasts_demo](https://github.com/sunflower-land/sunflower-land/assets/63975424/b2140c1c-6f77-45ae-a1d2-fdfd8742c2a8)

Here's the configuration used for the above gif:
```ts
window.openModal({
    npc: {
        name: "Pedro",
        clothing: Pedro,
    },
    jsx: "test modal for toasts",
    buttons: [
        { id: "1", text: "test1" },
        { id: "2", text: "test2" },
    ],
    onButtonClick: (id: string) => {
        if (id === "1") {
            window.createToast({
                text: "Test Toast 1",
            });
        } else if (id === "2") {
            window.createToast({
                text: "Test Toast 2",
                item: "Eggplant",
            });
        }
    },
});
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

local tests & yarn test
<img width="878" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/63975424/3bd8e09d-c911-4c52-a596-04196debb595">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
