### PR TITLE
[FIX] Kernaldo boost descriptions

### DIFF
--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -322,5 +322,5 @@ export const COLLECTIBLE_BUFF: Partial<Record<InventoryItemName, string>> = {
   "Freya Fox": "+0.5 Pumpkin",
   Poppy: "+0.1 Corn",
   "Grain Grinder": "+20% Cake XP",
-  Kernaldo: "+20% Corn Growth Speed",
+  Kernaldo: "+25% Corn Growth Speed",
 };

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -2324,7 +2324,7 @@ export const ITEM_DETAILS: Items = {
   },
   Kernaldo: {
     image: kernaldo,
-    description: "The magical corn whisperer. +20% Corn Growth Speed.",
+    description: "The magical corn whisperer. +25% Corn Growth Speed.",
   },
   Candles: {
     image: candles,


### PR DESCRIPTION
# Description

The docs and metadata indicate 25% as the boost for Kernaldo.

This change corrects a few places that were different.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
