### PR TITLE
[FIX] Disable WE-incompatible buyDecoration tests

### DIFF
--- a/src/features/game/events/landExpansion/buyDecoration.test.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.test.ts
@@ -269,81 +269,81 @@ describe("buyDecoration", () => {
     });
   });
 
-  it("throws an error if max limit reached", () => {
-    expect(() =>
-      buyDecoration({
-        state: {
-          ...GAME_STATE,
-          balance: new Decimal(100),
-          inventory: {
-            Gold: new Decimal(150),
-            "Basic Land": new Decimal(10),
-            Eggplant: new Decimal(30),
-            "Wild Mushroom": new Decimal(10),
-            "Giant Dawn Mushroom": new Decimal(5),
-          },
-          buildings: {},
-          collectibles: {},
-        },
-        action: {
-          type: "decoration.bought",
-          name: "Giant Dawn Mushroom",
-          coordinates: { x: 0, y: 5 },
-          id: "123",
-        },
-      })
-    ).toThrow("Max limit reached");
-  });
+  // it("throws an error if max limit reached", () => {
+  //   expect(() =>
+  //     buyDecoration({
+  //       state: {
+  //         ...GAME_STATE,
+  //         balance: new Decimal(100),
+  //         inventory: {
+  //           Gold: new Decimal(150),
+  //           "Basic Land": new Decimal(10),
+  //           Eggplant: new Decimal(30),
+  //           "Wild Mushroom": new Decimal(10),
+  //           "Giant Dawn Mushroom": new Decimal(5),
+  //         },
+  //         buildings: {},
+  //         collectibles: {},
+  //       },
+  //       action: {
+  //         type: "decoration.bought",
+  //         name: "Giant Dawn Mushroom",
+  //         coordinates: { x: 0, y: 5 },
+  //         id: "123",
+  //       },
+  //     })
+  //   ).toThrow("Max limit reached");
+  // });
 
-  it("throws an error if player tries to place a limited decoration without a seasonal banner", () => {
-    expect(() =>
-      buyDecoration({
-        state: {
-          ...GAME_STATE,
-          balance: new Decimal(100),
-          inventory: {
-            Gold: new Decimal(150),
-            "Basic Land": new Decimal(10),
-            "Wild Mushroom": new Decimal(50),
-          },
-          buildings: {},
-          collectibles: {},
-        },
-        action: {
-          type: "decoration.bought",
-          name: "Clementine",
-          coordinates: { x: 0, y: 5 },
-          id: "123",
-        },
-      })
-    ).toThrow("This item is not a decoration");
-  });
+  // it("throws an error if player tries to place a limited decoration without a seasonal banner", () => {
+  //   expect(() =>
+  //     buyDecoration({
+  //       state: {
+  //         ...GAME_STATE,
+  //         balance: new Decimal(100),
+  //         inventory: {
+  //           Gold: new Decimal(150),
+  //           "Basic Land": new Decimal(10),
+  //           "Wild Mushroom": new Decimal(50),
+  //         },
+  //         buildings: {},
+  //         collectibles: {},
+  //       },
+  //       action: {
+  //         type: "decoration.bought",
+  //         name: "Clementine",
+  //         coordinates: { x: 0, y: 5 },
+  //         id: "123",
+  //       },
+  //     })
+  //   ).toThrow("This item is not a decoration");
+  // });
 
-  it("places a limited decoration when the player has a seasonal banner", () => {
-    const state = buyDecoration({
-      state: {
-        ...GAME_STATE,
-        balance: new Decimal(100),
-        inventory: {
-          Gold: new Decimal(150),
-          "Basic Land": new Decimal(10),
-          "Wild Mushroom": new Decimal(50),
-          "Dawn Breaker Banner": new Decimal(1),
-        },
-        buildings: {},
-        collectibles: {},
-      },
-      action: {
-        type: "decoration.bought",
-        name: "Clementine",
-        coordinates: { x: 0, y: 5 },
-        id: "123",
-      },
-    });
+  // it("places a limited decoration when the player has a seasonal banner", () => {
+  //   const state = buyDecoration({
+  //     state: {
+  //       ...GAME_STATE,
+  //       balance: new Decimal(100),
+  //       inventory: {
+  //         Gold: new Decimal(150),
+  //         "Basic Land": new Decimal(10),
+  //         "Wild Mushroom": new Decimal(50),
+  //         "Dawn Breaker Banner": new Decimal(1),
+  //       },
+  //       buildings: {},
+  //       collectibles: {},
+  //     },
+  //     action: {
+  //       type: "decoration.bought",
+  //       name: "Clementine",
+  //       coordinates: { x: 0, y: 5 },
+  //       id: "123",
+  //     },
+  //   });
 
-    expect(state.collectibles["Clementine"]?.[0]?.coordinates).toEqual({
-      x: 0,
-      y: 5,
-    });
-  });
+  //   expect(state.collectibles["Clementine"]?.[0]?.coordinates).toEqual({
+  //     x: 0,
+  //     y: 5,
+  //   });
+  // });
 });


### PR DESCRIPTION
# Description

Three tests for `buyDecoration` involved decorations with limit or a banner requirement, and were implemented during Dawn Breaker.  With that season expiring, the tests broke.

Witches' End decorations have no limits or banner requirements.

This change disables the tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
