### PR TITLE
Enable withdraw for DB TI boost collectibles in front-end

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -535,8 +535,8 @@ const market: Record<MarketItem, boolean> = {
 const boostTreasure: Record<BoostTreasure, boolean> = {
   "Lunar Calendar": true,
   "Tiki Totem": true,
-  "Genie Lamp": false,
-  Foliant: false,
+  "Genie Lamp": true,
+  Foliant: true,
 };
 
 const goblinPirate: Record<GoblinPirateItemName, boolean> = {


### PR DESCRIPTION
# Description

Enables withdraw of Foliant and Genie Lamp in front-end.
