### PR TITLE
[FEAT] Persist island example

### DIFF
--- a/src/features/community/actions/loadIsland.ts
+++ b/src/features/community/actions/loadIsland.ts
@@ -1,0 +1,54 @@
+import { CONFIG } from "lib/config";
+import { ERRORS } from "lib/errors";
+import { CommunityIsland } from "features/game/types/game";
+
+type Request = {
+  islandId: string;
+  farmId: number;
+};
+
+type Response = {
+  island: CommunityIsland;
+};
+
+const API_URL = CONFIG.API_URL;
+
+export async function loadIsland(
+  request: Request
+): Promise<Response | undefined> {
+  if (!API_URL) return;
+
+  const response = await window.fetch(
+    `${API_URL}/island/${request.islandId}/farm/${request.farmId}`,
+    {
+      method: "GET",
+      //mode: "no-cors",
+      headers: {
+        "content-type": "application/json;charset=UTF-8",
+        accept: "application/json",
+      },
+    }
+  );
+
+  if (response.status === 503) {
+    throw new Error(ERRORS.MAINTENANCE);
+  }
+
+  if (response.status === 429) {
+    throw new Error(ERRORS.TOO_MANY_REQUESTS);
+  }
+
+  if (response.status === 401) {
+    throw new Error(ERRORS.SESSION_EXPIRED);
+  }
+
+  if (response.status >= 400) {
+    throw new Error(ERRORS.SESSION_SERVER_ERROR);
+  }
+
+  const { island } = await response.json();
+
+  return {
+    island,
+  };
+}

--- a/src/features/community/actions/updateIsland.ts
+++ b/src/features/community/actions/updateIsland.ts
@@ -1,0 +1,78 @@
+import { CONFIG } from "lib/config";
+import { ERRORS } from "lib/errors";
+import { Wardrobe } from "features/game/types/game";
+import { InventoryItemName } from "../types/community";
+
+type Request = {
+  token: string;
+  islandId: string;
+  farmId: number;
+  apiKey: string;
+  metadata: string;
+  mintItems?: Partial<Record<InventoryItemName, number>>;
+  mintWearables?: Wardrobe;
+  burnItems?: Partial<Record<InventoryItemName, number>>;
+  burnSFL?: number;
+  transactionId?: string;
+};
+
+type Response = {
+  updatedAt: number;
+};
+
+const API_URL = CONFIG.API_URL;
+
+/**
+ * An example POST request for updating island data
+ * You should never store your ApiKey on the client side
+ * Only exceptions are low-risk/impact situations. Assume your data can be changed at will
+ */
+export async function updateIsland(
+  request: Request
+): Promise<Response | undefined> {
+  if (!API_URL) return;
+
+  const response = await window.fetch(
+    `${API_URL}/island/${request.islandId}/farm/${request.farmId}`,
+    {
+      method: "POST",
+      //mode: "no-cors",
+      headers: {
+        "content-type": "application/json;charset=UTF-8",
+        Authorization: `Bearer ${request.token}`,
+        accept: "application/json",
+        "X-Transaction-ID": request.transactionId ?? "",
+      },
+      body: JSON.stringify({
+        apiKey: request.apiKey,
+        metadata: request.metadata,
+        mintItems: request.mintItems,
+        mintWearables: request.mintWearables,
+        burnItems: request.burnItems,
+        burnSFL: request.burnSFL,
+      }),
+    }
+  );
+
+  if (response.status === 503) {
+    throw new Error(ERRORS.MAINTENANCE);
+  }
+
+  if (response.status === 429) {
+    throw new Error(ERRORS.TOO_MANY_REQUESTS);
+  }
+
+  if (response.status === 401) {
+    throw new Error(ERRORS.SESSION_EXPIRED);
+  }
+
+  if (response.status >= 400) {
+    throw new Error(ERRORS.SESSION_SERVER_ERROR);
+  }
+
+  const { updatedAt } = await response.json();
+
+  return {
+    updatedAt,
+  };
+}

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -78,6 +78,8 @@ export function makeGame(farm: any): GameState {
     expansionConstruction: farm.expansionConstruction,
     expansionRequirements: farm.expansionRequirements,
 
+    islands: farm.islands,
+
     bumpkin: farm.bumpkin,
     buildings: farm.buildings,
     airdrops: farm.airdrops,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -622,6 +622,19 @@ export type ChoresV2 = {
   choresSkipped: number;
 };
 
+export type CommunityIsland = {
+  metadata: string;
+  updatedAt: number;
+  mints?: {
+    items: Partial<Record<InventoryItemName, number>>;
+    wearables: Wardrobe;
+  };
+  burns?: {
+    sfl: number;
+    items: Partial<Record<InventoryItemName, number>>;
+  };
+};
+
 export interface GameState {
   id?: number;
   balance: Decimal;
@@ -633,6 +646,8 @@ export interface GameState {
   tradedAt?: string;
   tradeOffer?: TradeOffer;
   warCollectionOffer?: WarCollectionOffer;
+
+  islands?: Record<string, CommunityIsland>;
 
   chickens: Record<string, Chicken>;
   inventory: Inventory;


### PR DESCRIPTION
# Description

This PR includes support for reading and persisting community island data. This setup is required for the Unicorn Island launching next week which will include:

- Burning Food
- Persisting Quest Data
- Minting a Wearable

# Load Island

Community developers will be able to query island data using the following endpoint `/island/:id/farm/:farmId`.

This returns persisted data for a specific farm. There is not yet support for storing/sharing global island data (e.g. leaderboards, counters)

# Update Island

For basic data persistence, we will allow developers to store data in Sunflower Land APIs if desired.

Each update request will require a custom **API KEY** which will be sent to approved islands. You should always keep this key private if the data you hold is sensitive. If you include the API Key in the front-end, assume players can cheat your island and bypass quests/content you establish.

There are cases when you may want to consider storing the API Key in your client-side code.

1. You want an easy setup island with no backend
2. The data you are storing is not critical (i.e. storing a name)
3. The progress players make on your island is low impact (i.e. small quests with small rewards)

If you do not want data manipulation, we recommend storing your API key server-side and making all requests update through your own server.

When calling update, you will be able to provide the following fields.

1. `metadata` - A loose `string` field which can be used to stored island specific data for a player such as quest progress or any other data storage you wish. On Unicorn Island for example we will store "{ unicornsFed: 5, fedAt: 100210001 }". The data must be less than `1KB` and only string format is supported.
2. `mintItems` - SFL resources & decorations to mint. These items will be pre-approved by the SFL team and an allowance is set per user.  Once the allowance is breached, an error is thrown. This will be great for incentivising players to visit your island. For example, finish your quest and earn a "Pirate Cake"
3. `mintWearables` - Wearables pre-approved by the SFL team, including an allowance per player. For Unicorn Island, we will support minting the Unicorn Horn.
5. `burnItems` - SFL resources pre-approved by SFL team, including an allowance to burn per player. For Unicorn Island, we will use this to burn crops + food while feeding unicorns. This will also be used to monetize your island and burn `Block Bucks`
6. `burnSFL` - SFL pre-approved to burn. This can be useful for charging entry prices to content on your island.

Overall this is an exciting initiative which will allow developers to monetise their islands and collaborate with the SFL team to integrate SFL resources and prizes onto their islands 🚀 