### PR TITLE
[FEAT] Corn boost when placed inside Laurie the Chuckle Crow AOE

### DIFF
--- a/src/features/game/events/landExpansion/moveCrop.test.ts
+++ b/src/features/game/events/landExpansion/moveCrop.test.ts
@@ -243,5 +243,43 @@ describe("moveCrop", () => {
         },
       })
     ).toThrow(MOVE_CROP_ERRORS.AOE_LOCKED);
+
+    expect(() =>
+      moveCrop({
+        state: {
+          ...TEST_FARM,
+          bumpkin: INITIAL_BUMPKIN,
+          collectibles: {
+            "Laurie the Chuckle Crow": [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                createdAt: Date.now(),
+                readyAt: 0,
+              },
+            ],
+          },
+          crops: {
+            1: {
+              height: 1,
+              width: 1,
+              x: 0,
+              y: -2,
+              createdAt: Date.now(),
+              crop: {
+                name: "Corn",
+                amount: 1,
+                plantedAt: Date.now(),
+              },
+            },
+          },
+        },
+        action: {
+          type: "crop.moved",
+          id: "1",
+          coordinates: { x: 2, y: 2 },
+        },
+      })
+    ).toThrow(MOVE_CROP_ERRORS.AOE_LOCKED);
   });
 });

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -130,6 +130,7 @@ export function isLocked(
 
   const isAdvancedLevelCrop =
     cropName === "Eggplant" ||
+    cropName === "Corn" ||
     cropName === "Radish" ||
     cropName === "Wheat" ||
     cropName === "Kale";

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1093,6 +1093,51 @@ describe("plant", () => {
     expect((plots as Record<number, CropPlot>)[0].crop?.amount).toEqual(1.2);
   });
 
+  it("yields +0.2 if Laurie the Chuckle Crow is placed, plot is within AoE and planting Corn", () => {
+    const state: GameState = plant({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Corn Seed": new Decimal(1),
+          "Laurie the Chuckle Crow": new Decimal(1),
+          "Water Well": new Decimal(1),
+        },
+        crops: {
+          0: {
+            createdAt: Date.now(),
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+          },
+        },
+        collectibles: {
+          "Laurie the Chuckle Crow": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 0, y: 0 },
+              // ready at < now
+              readyAt: dateNow - 12 * 60 * 1000,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "0",
+        item: "Corn Seed",
+      },
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+
+    expect((plots as Record<number, CropPlot>)[0].crop?.amount).toEqual(1.2);
+  });
+
   it("does not give boost if Laurie the Chuckle Crow is placed, plot is within AoE and planting Cauliflower", () => {
     const state: GameState = plant({
       state: {

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -341,6 +341,7 @@ export function getCropYieldAmount({
 
   const isAdvancedLevelCrop =
     crop === "Eggplant" ||
+    crop === "Corn" ||
     crop === "Radish" ||
     crop === "Wheat" ||
     crop === "Kale";

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -124,7 +124,7 @@ export const HELIOS_BLACKSMITH_ITEMS: (
       Wheat: new Decimal(20),
     },
     sfl: new Decimal(45),
-    boost: "+0.2 yield on Eggplants, Radishes, Wheat and Kale",
+    boost: "+0.2 yield on Eggplants, Corn, Radishes, Wheat and Kale",
   },
   "Immortal Pear": {
     description: "A long-lived pear that makes fruit trees last longer.",

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -82,6 +82,7 @@ function areAnyAdvancedCropsPlanted(game: GameState): Restriction {
   const cropsPlanted = Object.values(game.crops ?? {}).some(
     (plot) =>
       plot.crop?.name === "Eggplant" ||
+      plot.crop?.name === "Corn" ||
       plot.crop?.name === "Radish" ||
       plot.crop?.name === "Wheat" ||
       plot.crop?.name === "Kale"


### PR DESCRIPTION
# Description

Corn boost when placed inside Laurie the Chuckle Crow AOE

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<img width="682" alt="Screenshot 2023-08-04 at 6 50 43 PM" src="https://github.com/sunflower-land/sunflower-land/assets/31792031/98d85171-8c1f-499f-9f26-3e9a1e637483">

