### PR TITLE
[FEAT] Persist crow ids for active attempt

### DIFF
--- a/src/features/game/events/landExpansion/saveMaze.ts
+++ b/src/features/game/events/landExpansion/saveMaze.ts
@@ -10,6 +10,7 @@ export type SaveMazeAction = {
   crowsFound: number;
   health: number;
   timeRemaining: number;
+  crowIds?: string[];
   completedAt?: number;
 };
 
@@ -75,6 +76,7 @@ export function saveMaze({ state, action, createdAt = Date.now() }: Options) {
   attempts[attemptIdx].crowsFound = action.crowsFound;
   attempts[attemptIdx].health = action.health;
   attempts[attemptIdx].time = MAZE_TIME_LIMIT_SECONDS - action.timeRemaining;
+  attempts[attemptIdx].crowIds = action.crowIds;
 
   if (!action.completedAt) {
     return copy;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -600,6 +600,7 @@ export type MazeAttempt = {
   crowsFound: number;
   health: number;
   time: number;
+  crowIds?: string[];
 };
 
 export type MazeMetadata = {

--- a/src/features/world/lib/cornmazeMachine.ts
+++ b/src/features/world/lib/cornmazeMachine.ts
@@ -5,7 +5,7 @@ import { MazeAttempt } from "features/game/types/game";
 
 // Define the events for the machine
 type CornMazeEvent =
-  | { type: "COLLECT_CROW" }
+  | { type: "COLLECT_CROW"; id: string }
   | { type: "HIT" }
   | { type: "SHOW_TIPS" }
   | { type: "SCENE_LOADED" }
@@ -19,6 +19,7 @@ type CornMazeEvent =
 interface CornMazeContext {
   score: number;
   health: number;
+  crowIds: string[];
   totalLostCrows: number;
   gameOver: "wonGame" | "lostGame" | undefined;
   sceneLoaded: boolean;
@@ -137,6 +138,7 @@ export const cornMazeMachine = createMachine<
           cond: (context) => !context.gameOver,
           actions: assign({
             score: (context) => context.score + 1,
+            crowIds: (context, event) => [...context.crowIds, event.id],
           }),
         },
         HIT: {

--- a/src/features/world/ui/cornMaze/MazeHud.tsx
+++ b/src/features/world/ui/cornMaze/MazeHud.tsx
@@ -43,6 +43,7 @@ class MazeManager {
 
   public collect(id: string) {
     if (this.listener) {
+      console.log("id in collect", id);
       this.listener.collectCrow(id);
     }
   }
@@ -83,6 +84,7 @@ const _timeElapsed = (state: MachineState) => state.context.timeElapsed;
 const _startedAt = (state: MachineState) => state.context.startedAt;
 const _attemptCompletedAt = (state: MachineState) =>
   state.context.attemptCompletedAt;
+const _crowIds = (state: MachineState) => state.context.crowIds;
 const _pausedAt = (state: MachineState) => state.context.pausedAt;
 const _paused = (state: MachineState) => state.matches("paused");
 const _wonGame = (state: MachineState) => state.matches("wonGame");
@@ -110,6 +112,7 @@ export const MazeHud: React.FC = () => {
     context: {
       score: activeAttempt?.crowsFound ?? 0,
       health: activeAttempt?.health ?? DEFAULT_HEALTH,
+      crowIds: activeAttempt?.crowIds ?? [],
       totalLostCrows: weeklyLostCrowCount,
       gameOver: undefined,
       sceneLoaded: false,
@@ -123,6 +126,7 @@ export const MazeHud: React.FC = () => {
 
   const score = useSelector(cornMazeService, _score);
   const health = useSelector(cornMazeService, _health);
+  const crowIds = useSelector(cornMazeService, _crowIds);
   const timeElapsed = useSelector(cornMazeService, _timeElapsed);
   const startedAt = useSelector(cornMazeService, _startedAt);
   const paused = useSelector(cornMazeService, _paused);
@@ -139,8 +143,8 @@ export const MazeHud: React.FC = () => {
     let timeout: NodeJS.Timeout;
 
     mazeManager.listen({
-      collectCrow: () => {
-        cornMazeService.send("COLLECT_CROW");
+      collectCrow: (id: string) => {
+        cornMazeService.send("COLLECT_CROW", { id });
       },
       hit: () => {
         cornMazeService.send("HIT");
@@ -159,9 +163,9 @@ export const MazeHud: React.FC = () => {
     });
 
     const saveGameState = (event: BeforeUnloadEvent) => {
-      console.log("active attempt in save, ", activeAttempt);
       handleSaveAttempt({
         crowsFound: cornMazeService.state.context.score,
+        crowIds: cornMazeService.state.context.crowIds,
         health: cornMazeService.state.context.health,
         timeRemaining: Math.max(
           MAZE_TIME_LIMIT_SECONDS - cornMazeService.state.context.timeElapsed,
@@ -193,6 +197,7 @@ export const MazeHud: React.FC = () => {
     handleSaveAttempt({
       crowsFound: score,
       health,
+      crowIds,
       timeRemaining: MAZE_TIME_LIMIT_SECONDS - timeElapsed,
       completedAt: attemptCompletedAt,
     });
@@ -303,6 +308,7 @@ export const MazeHud: React.FC = () => {
             handleSaveAttempt({
               crowsFound: score,
               health,
+              crowIds,
               timeRemaining: MAZE_TIME_LIMIT_SECONDS - timeElapsed,
               completedAt: attemptCompletedAt,
             });
@@ -322,6 +328,7 @@ export const MazeHud: React.FC = () => {
             handleSaveAttempt({
               crowsFound: score,
               health,
+              crowIds,
               timeRemaining: MAZE_TIME_LIMIT_SECONDS - timeElapsed,
               completedAt: pausedAt,
             });


### PR DESCRIPTION
# Description

Persist found crows for maze attempts that haven't been completed eg. Page refresh.
Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
