### PR TITLE
[FEAT] Enable players to continue playing maze after winning for the week

### DIFF
--- a/src/features/game/events/landExpansion/startMaze.test.ts
+++ b/src/features/game/events/landExpansion/startMaze.test.ts
@@ -237,4 +237,39 @@ describe("startMaze", () => {
       })
     );
   });
+
+  it("allows a player to enter the maze for free if they have already claimed all feathers for the week", () => {
+    const now = Date.now();
+
+    const state = startMaze({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(10),
+        witchesEve: {
+          weeklyLostCrowCount,
+          maze: {
+            [week]: {
+              highestScore: 25,
+              claimedFeathers: 100,
+              attempts: [
+                {
+                  startedAt: 0,
+                  crowsFound: 25,
+                  health: 3,
+                  timeRemaining: 10,
+                  completedAt: 123456,
+                },
+              ],
+            },
+          },
+        },
+      },
+      action: {
+        type: "maze.started",
+      },
+      createdAt: now,
+    });
+
+    expect(state.balance).toEqual(new Decimal(10));
+  });
 });

--- a/src/features/game/events/landExpansion/startMaze.ts
+++ b/src/features/game/events/landExpansion/startMaze.ts
@@ -3,6 +3,7 @@ import { GameState, MazeAttempt } from "features/game/types/game";
 import { SEASONS } from "features/game/types/seasons";
 import { getSeasonWeek } from "lib/utils/getSeasonWeek";
 import cloneDeep from "lodash.clonedeep";
+import { MAX_FEATHERS_PER_WEEK } from "./saveMaze";
 
 export type StartMazeAction = {
   type: "maze.started";
@@ -45,7 +46,7 @@ export function startMaze({ state, action, createdAt = Date.now() }: Options) {
     };
   }
 
-  const { attempts } = currentWeekMazeData;
+  const { attempts, claimedFeathers } = currentWeekMazeData;
   const inProgressAttempt = attempts?.find((attempt) => !attempt.completedAt);
 
   if (inProgressAttempt) {
@@ -63,6 +64,13 @@ export function startMaze({ state, action, createdAt = Date.now() }: Options) {
 
   attempts.push(newAttempt);
 
+  copy.witchesEve.maze[currentWeek] = currentWeekMazeData;
+
+  if (claimedFeathers === MAX_FEATHERS_PER_WEEK) {
+    // Don't charge entry if players have already claimed the max feathers
+    return copy;
+  }
+
   const { balance } = copy;
 
   if (balance.lessThan(MAZE_SFL_FEE)) {
@@ -70,8 +78,6 @@ export function startMaze({ state, action, createdAt = Date.now() }: Options) {
   }
 
   copy.balance = balance.minus(MAZE_SFL_FEE);
-
-  copy.witchesEve.maze[currentWeek] = currentWeekMazeData;
 
   return copy;
 }

--- a/src/features/world/ui/cornMaze/MazeHud.tsx
+++ b/src/features/world/ui/cornMaze/MazeHud.tsx
@@ -336,12 +336,26 @@ export const MazeHud: React.FC = () => {
           }}
         />
       </Modal>
-      {/* Paused: Continue */}
-      {/* Need to find more crows */}
+      {/* Paused: Lower score than last highest score */}
+      {/* If found all crows again, save and leave or need to find more crows or leave and come back later */}
       <Modal show={paused && !hasNewHighScore} centered>
         <PausedLowScoreModalContent
+          score={score}
+          totalLostCrows={weeklyLostCrowCount}
           highestScore={highestScore}
           onContinue={handleResume}
+          onEnd={() => {
+            handleSaveAttempt({
+              crowsFound: score,
+              health,
+              crowIds,
+              timeRemaining: MAZE_TIME_LIMIT_SECONDS - timeElapsed,
+              ...(score === weeklyLostCrowCount && {
+                completedAt: pausedAt,
+              }),
+            });
+            handleReturnToPlaza();
+          }}
         />
       </Modal>
       {/* Welcome Modal */}

--- a/src/features/world/ui/cornMaze/PausedLowScoreModalContent.tsx
+++ b/src/features/world/ui/cornMaze/PausedLowScoreModalContent.tsx
@@ -4,14 +4,92 @@ import { Panel } from "components/ui/Panel";
 import { NPC_WEARABLES } from "lib/npcs";
 
 interface Props {
+  score: number;
   highestScore: number;
+  totalLostCrows: number;
   onContinue: () => void;
+  onEnd: () => void;
 }
 
 export const PausedLowScoreModalContent: React.FC<Props> = ({
+  score,
   highestScore,
+  totalLostCrows,
   onContinue,
+  onEnd,
 }) => {
+  const Content = () => {
+    // Haven't found any crows -> Save progress and leave or keep playing
+    if (score === 0) {
+      return (
+        <>
+          <div className="p-1 space-y-2 mb-2 flex flex-col">
+            <p>{`Oh no! You haven't found any crows! You need to find more than that if you want more feathers from me!`}</p>
+            <p>
+              You can return to the Plaza now and come back later if you like?
+            </p>
+          </div>
+          <div className="flex flex-col-reverse space-y-1 space-y-reverse md:flex-row md:space-y-0 md:space-x-1">
+            <Button onClick={onEnd}>Return to Plaza</Button>
+            <Button onClick={onContinue}>Keep Playing</Button>
+          </div>
+        </>
+      );
+    }
+
+    // Found all crows (will only be in this modal if they have already claimed all feathers for the week) -> Save progress and leave
+    if (score === totalLostCrows) {
+      return (
+        <>
+          <div className="p-1 space-y-2 mb-2 flex flex-col">
+            <p>
+              Nice one! You found all my crows! You have already claimed all the
+              feathers available for this week.
+            </p>
+            <p>Your attempt will be saved though!</p>
+          </div>
+          <div className="flex flex-col-reverse space-y-1 space-y-reverse md:flex-row md:space-y-0 md:space-x-1">
+            <Button onClick={onEnd}>Return to Plaza</Button>
+          </div>
+        </>
+      );
+    }
+
+    if (highestScore === totalLostCrows) {
+      return (
+        <>
+          <div className="p-1 space-y-2 mb-2 flex flex-col">
+            <p>{`You have already claimed all the feathers available for this week so there are no more to earn. You can keep going and try to beat your time though!`}</p>
+            <p>
+              Or you can return to the Plaza now and come back later if you
+              like?
+            </p>
+          </div>
+          <div className="flex flex-col-reverse space-y-1 space-y-reverse md:flex-row md:space-y-0 md:space-x-1">
+            <Button onClick={onEnd}>Return to Plaza</Button>
+            <Button onClick={onContinue}>Keep Playing</Button>
+          </div>
+        </>
+      );
+    }
+
+    // Found some crows but not more than their highest score -> Save progress and leave or keep playing
+    return (
+      <>
+        <div className="p-1 space-y-2 mb-2 flex flex-col">
+          <p>{`Oh no! Last time you found ${highestScore} crows! You need to find more than that if you want more feathers from me!`}</p>
+          <p>
+            You can return to the Plaza now and come back later if you like?
+          </p>
+        </div>
+        <div className="flex flex-col-reverse space-y-1 space-y-reverse md:flex-row md:space-y-0 md:space-x-1">
+          <Button onClick={onEnd}>Return to Plaza</Button>
+          <Button onClick={onContinue}>Keep Playing</Button>
+        </div>
+      </>
+    );
+  };
+
   return (
     <Panel
       bumpkinParts={{
@@ -19,16 +97,7 @@ export const PausedLowScoreModalContent: React.FC<Props> = ({
         body: "Light Brown Worried Farmer Potion",
       }}
     >
-      <div className="p-1 space-y-2 mb-2 flex flex-col">
-        {highestScore === 0 ? (
-          <p>{`Oh no! You haven't found any crows! You need to find more than that if you want more feathers from me!`}</p>
-        ) : (
-          <p>{`Oh no! Last time you found ${highestScore} crows! You need to find more than that if you want more feathers from me!`}</p>
-        )}
-      </div>
-      <div className="flex flex-col-reverse space-y-1 space-y-reverse md:flex-row md:space-y-0 md:space-x-1">
-        <Button onClick={onContinue}>Keep Playing</Button>
-      </div>
+      {Content()}
     </Panel>
   );
 };


### PR DESCRIPTION
# Description

This PR sets up the maze to be able to be played for free (once we start charging entry) after they've claimed the max number for feathers for the week. 

It also set up the modal to allow them to save progress when they haven't earnt a high score or when they find all the crows again (ie. save new time etc)

New modal states: 

- Haven't found any crows -> Save progress and leave or keep playing
- Found all crows but have already claimed all feathers for the week -> Save progress and leave
- Found some crows but not more than their highest score -> Save progress and leave or keep playing

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
