### PR TITLE
[FEAT] Delivery cycles

### DIFF
--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -25,7 +25,7 @@ type Options = {
 };
 
 export const BETA_DELIVERY_END_DATE = new Date("08-14-2023");
-export const DELIVERY_END_DATE = new Date("08-08-2023");
+export const DELIVERY_END_DATE = new Date("08-16-2023");
 export function canGenerateDeliveries({
   game,
   now,

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -24,8 +24,8 @@ type Options = {
   action: DeliverOrderAction;
 };
 
-export const BETA_DELIVERY_END_DATE = new Date("08-14-2023");
-export const DELIVERY_END_DATE = new Date("08-16-2023");
+export const BETA_DELIVERY_END_DATE = new Date("2023-08-14");
+export const DELIVERY_END_DATE = new Date("2023-08-16");
 export function canGenerateDeliveries({
   game,
   now,

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -24,7 +24,7 @@ type Options = {
   action: DeliverOrderAction;
 };
 
-export const BETA_DELIVERY_END_DATE = new Date("2023-08-14");
+export const BETA_DELIVERY_END_DATE = new Date("2023-08-15");
 export const DELIVERY_END_DATE = new Date("2023-08-16");
 export function canGenerateDeliveries({
   game,

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -565,6 +565,7 @@ export const OFFLINE_FARM: GameState = {
       {
         id: "123",
         createdAt: Date.now(),
+        completedAt: Date.now(),
         readyAt: 1690855045072,
         from: "pumpkin' pete",
         items: {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -509,6 +509,7 @@ export type Order = {
   };
   createdAt: number;
   readyAt: number;
+  completedAt?: number;
 };
 
 type QuestNPCName =

--- a/src/features/helios/components/hayseedHank/HayseedHankV2.tsx
+++ b/src/features/helios/components/hayseedHank/HayseedHankV2.tsx
@@ -8,7 +8,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { secondsToString } from "lib/utils/time";
 
 // UTC
-function secondsTillReset() {
+export function secondsTillReset() {
   const currentTime = Date.now();
 
   // Calculate the time until the next day in milliseconds

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -270,20 +270,20 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
               </OuterPanel>
             </div>
           )}
-          {(!!inventory["Beta Pass"] &&
+          {((!!inventory["Beta Pass"] &&
             Date.now() >
               BETA_DELIVERY_END_DATE.getTime() - 24 * 60 * 60 * 1000) ||
-            (Date.now() > DELIVERY_END_DATE.getTime() - 24 * 60 * 60 * 1000 && (
-              <div className="flex items-center mb-1 mt-2">
-                <div className="w-6">
-                  <img src={SUNNYSIDE.icons.timer} className="h-4 mx-auto" />
-                </div>
-                <span className="text-xs">{`New deliveries available in ${secondsToString(
-                  secondsTillReset(),
-                  { length: "medium" }
-                )}.`}</span>
+            Date.now() > DELIVERY_END_DATE.getTime() - 24 * 60 * 60 * 1000) && (
+            <div className="flex items-center mb-1 mt-2">
+              <div className="w-6">
+                <img src={SUNNYSIDE.icons.timer} className="h-4 mx-auto" />
               </div>
-            ))}
+              <span className="text-xs">{`New deliveries available in ${secondsToString(
+                secondsTillReset(),
+                { length: "medium" }
+              )}.`}</span>
+            </div>
+          )}
         </div>
       </div>
       {previewOrder && (

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -271,8 +271,9 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
             </div>
           )}
           {(!!inventory["Beta Pass"] &&
-            Date.now() > BETA_DELIVERY_END_DATE.getTime()) ||
-            (Date.now() > DELIVERY_END_DATE.getTime() && (
+            Date.now() >
+              BETA_DELIVERY_END_DATE.getTime() - 24 * 60 * 60 * 1000) ||
+            (Date.now() > DELIVERY_END_DATE.getTime() - 24 * 60 * 60 * 1000 && (
               <div className="flex items-center mb-1 mt-2">
                 <div className="w-6">
                   <img src={SUNNYSIDE.icons.timer} className="h-4 mx-auto" />

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -244,7 +244,8 @@ export const DeliveryPanelContent: React.FC<Props> = ({
     const state = gameService.send("order.delivered", { id: selectedOrderId });
 
     const remainingOrders = state.context.state.delivery.orders.filter(
-      (order) => order.from === npc && Date.now() >= order.readyAt
+      (order) =>
+        order.from === npc && Date.now() >= order.readyAt && !order.completedAt
     );
 
     if (!remainingOrders.length) {

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -196,7 +196,8 @@ export const DeliveryPanelContent: React.FC<Props> = ({
   const bumpkin = useSelector(gameService, _bumpkin);
 
   const orders = delivery.orders.filter(
-    (order) => order.from === npc && Date.now() >= order.readyAt
+    (order) =>
+      order.from === npc && Date.now() >= order.readyAt && !order.completedAt
   );
 
   const dialogue = npcDialogues[npc] || defaultDialogue;

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -198,6 +198,7 @@ export const DeliveryPanelContent: React.FC<Props> = ({
   const orders = delivery.orders.filter(
     (order) => order.from === npc && Date.now() >= order.readyAt
   );
+
   const dialogue = npcDialogues[npc] || defaultDialogue;
   const intro = useRandomItem(dialogue.intro);
   const positive = useRandomItem(dialogue.positiveDelivery);


### PR DESCRIPTION
# Description

Based on player feedback, we are adjusting the deliveries to cycle based on the UTC date (similar to chores). Players will have the entire day (UTC) to complete the delivery. Once complete, it will stay in a 'complete' state until the next day.

This PR will introduce the following improvements:

- Deliveries reset for all players at same time (consistent)
- Players no longer get duplicate NPCs (e.g. multiple Tywins)

These changes aim to simplify the system & make it more predictable for players. This will lead to more stability and consistency in the feature. This will be useful in launching new NPCs + Content for players.

<img width="283" alt="Screenshot 2023-08-09 at 3 33 48 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/c3614df5-0bf2-4386-9d5e-42fd6d524a37">
<img width="289" alt="Screenshot 2023-08-09 at 3 33 53 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/04929bd8-f575-40c4-a130-588fb539518b">
<img width="802" alt="Screenshot 2023-08-09 at 3 46 53 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/d3124309-c33e-4a26-af7e-2a9ec1f6cc81">

## Rollout

Dates to be decided, currently placeholder dates.