### PR TITLE
[FIX] Disable deposit button if there is nothing to deposit

### DIFF
--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -103,8 +103,8 @@ export const Deposit: React.FC<Props> = ({
         setStatus("loaded");
         // Notify parent that we're done loading
         onLoaded && onLoaded(true);
-      } catch (error: any) {
-        console.error(error.message);
+      } catch (error: unknown) {
+        console.error(error instanceof Error ? error.message : error);
         setStatus("error");
         // Notify parent that we're done loading
         onLoaded && onLoaded(false);
@@ -367,7 +367,12 @@ export const Deposit: React.FC<Props> = ({
           <Button
             onClick={handleDeposit}
             className="w-full"
-            disabled={amountGreaterThanBalance}
+            disabled={
+              (sflDepositAmount <= 0 &&
+                !hasWearablesToDeposit &&
+                !hasItemsToDeposit) ||
+              amountGreaterThanBalance
+            }
           >
             Send to farm
           </Button>


### PR DESCRIPTION
# Description

Before: 
![image](https://github.com/sunflower-land/sunflower-land/assets/9656961/25dbedbd-4fab-40fa-b573-7cf3e53de983)

After: 

https://github.com/sunflower-land/sunflower-land/assets/9656961/49855395-42dd-4684-a70d-e908bb8b87e4


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test + yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
