### PR TITLE
[FIX] Switch network on crypto com

### DIFF
--- a/src/features/auth/components/Web3Missing.tsx
+++ b/src/features/auth/components/Web3Missing.tsx
@@ -21,7 +21,7 @@ export const Web3Missing: React.FC<{ wallet?: "PHANTOM" | "CRYPTO_COM" }> = ({
 
   const goToCryptoComSetupDocs = () => {
     window.open(
-      "https://help.crypto.com/en/articles/5484125-wallet-extension",
+      "https://chrome.google.com/webstore/detail/cryptocom-wallet-extensio/hifafgmccdpekplomjjkcfgodnhcellj",
       "_blank"
     );
   };

--- a/src/features/auth/components/WrongChain.tsx
+++ b/src/features/auth/components/WrongChain.tsx
@@ -26,7 +26,7 @@ export const WrongChain: React.FC = () => {
   }, []);
 
   const initialiseNetwork = async () => {
-    await wallet.initialiseNetwork();
+    await wallet.initialiseNetwork(wallet.web3Provider);
   };
 
   return (

--- a/src/lib/blockchain/wallet.ts
+++ b/src/lib/blockchain/wallet.ts
@@ -102,7 +102,7 @@ export class Wallet {
       const chainId = await this.web3?.eth.getChainId();
 
       if (!(chainId === CONFIG.POLYGON_CHAIN_ID)) {
-        await this.initialiseNetwork();
+        await this.initialiseNetwork(provider);
       }
 
       await this.initialiseContracts();
@@ -220,8 +220,8 @@ export class Wallet {
     return chainId === CONFIG.POLYGON_CHAIN_ID;
   }
 
-  public async switchNetwork() {
-    await window.ethereum.request({
+  public async switchNetwork(provider: any) {
+    await provider.request({
       method: "wallet_switchEthereumChain",
       params: [
         { chainId: `0x${Number(CONFIG.POLYGON_CHAIN_ID).toString(16)}` },
@@ -229,10 +229,10 @@ export class Wallet {
     });
   }
 
-  public async addNetwork() {
+  public async addNetwork(provider: any) {
     try {
       const defaultChainParam = this.getDefaultChainParam();
-      await window.ethereum.request({
+      await provider.request({
         method: "wallet_addEthereumChain",
         params: [
           {
@@ -245,12 +245,12 @@ export class Wallet {
     }
   }
 
-  public async initialiseNetwork() {
+  public async initialiseNetwork(provider: any) {
     try {
-      await this.switchNetwork();
+      await this.switchNetwork(provider);
     } catch (e: any) {
       if (e.code === 4902) {
-        await this.addNetwork();
+        await this.addNetwork(provider);
       }
       throw e;
     }


### PR DESCRIPTION
# Description

By default we were using `window.ethereum` to switch networks. If you had both MetaMask and CryptoCom wallet, it would always open Metamask.

This fix ensures we use the provider that was selected.

Also updated link to one they provided.