### PR TITLE
[FEAT] Block Maximus when in use

### DIFF
--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -1094,4 +1094,46 @@ describe("canremove", () => {
 
     expect(restricted).toBe(true);
   });
+
+  it("prevents a user from removing Maximus when Eggplant is planted", () => {
+    const [restricted] = hasRemoveRestriction("Maximus", "1", {
+      ...TEST_FARM,
+      crops: {
+        0: {
+          createdAt: Date.now(),
+          x: -2,
+          y: -1,
+          height: 1,
+          width: 1,
+          crop: { name: "Eggplant", plantedAt: Date.now(), amount: 1 },
+        },
+      },
+      inventory: {
+        Maximus: new Decimal(1),
+      },
+    });
+
+    expect(restricted).toBe(true);
+  });
+
+  it("prevents a user from removing Purple Trail when Eggplant is planted", () => {
+    const [restricted] = hasRemoveRestriction("Purple Trail", "1", {
+      ...TEST_FARM,
+      crops: {
+        0: {
+          createdAt: Date.now(),
+          x: -2,
+          y: -1,
+          height: 1,
+          width: 1,
+          crop: { name: "Eggplant", plantedAt: Date.now(), amount: 1 },
+        },
+      },
+      inventory: {
+        Maximus: new Decimal(1),
+      },
+    });
+
+    expect(restricted).toBe(true);
+  });
 });

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -225,6 +225,8 @@ export const REMOVAL_RESTRICTIONS: Partial<
   Poppy: (game) => cropIsPlanted({ game, item: "Corn" }),
   Kernaldo: (game) => cropIsPlanted({ game, item: "Corn" }),
   "Queen Cornelia": (game) => cropIsPlanted({ game, item: "Corn" }),
+  Maximus: (game) => cropIsPlanted({ item: "Eggplant", game }),
+  "Purple Trail": (game) => cropIsPlanted({ item: "Eggplant", game }),
 
   "Squirrel Monkey": (game) => areFruitsGrowing(game, "Orange"),
   "Black Bearry": (game) => areFruitsGrowing(game, "Blueberry"),


### PR DESCRIPTION
# Description

This PR blocks removal for Maximus and Purple Trail when in use

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
