### PR TITLE
[FEAT] add chores to readOnly view

### DIFF
--- a/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
+++ b/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
@@ -6,7 +6,10 @@ import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import { DailyChore } from "./DailyChore";
 
-export const ChoreV2: React.FC = () => {
+interface Props {
+  isReadOnly?: boolean;
+}
+export const ChoreV2: React.FC<Props> = ({ isReadOnly = false }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -31,6 +34,7 @@ export const ChoreV2: React.FC = () => {
             chore={chore}
             id={choreId}
             key={chore.createdAt + index}
+            isReadOnly={isReadOnly}
           />
         );
       })}

--- a/src/features/helios/components/hayseedHank/components/DailyChore.tsx
+++ b/src/features/helios/components/hayseedHank/components/DailyChore.tsx
@@ -26,8 +26,9 @@ const isDateOnSameDayAsToday = (date: Date) => {
 interface Props {
   id: ChoreV2Name;
   chore: ChoreV2;
+  isReadOnly?: boolean;
 }
-export const DailyChore: React.FC<Props> = ({ id, chore }) => {
+export const DailyChore: React.FC<Props> = ({ id, chore, isReadOnly }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -93,31 +94,32 @@ export const DailyChore: React.FC<Props> = ({ id, chore }) => {
             new Decimal(progress)
           )}/${chore.requirement}`}</span>
         </div>
-        {chore.completedAt ? (
-          <div className="flex">
-            <span className="text-xs mr-1">Completed</span>
-            <img src={SUNNYSIDE.icons.confirm} className="h-4" />
-          </div>
-        ) : (
-          <div className="flex mt-1">
-            {!isDateOnSameDayAsToday(new Date(chore.createdAt)) && (
-              <Button
-                className="text-sm w-24 h-8 mr-2"
-                onClick={() => skip(id)}
-              >
-                Skip
-              </Button>
-            )}
+        {!isReadOnly &&
+          (chore.completedAt ? (
+            <div className="flex">
+              <span className="text-xs mr-1">Completed</span>
+              <img src={SUNNYSIDE.icons.confirm} className="h-4" />
+            </div>
+          ) : (
+            <div className="flex mt-1">
+              {!isDateOnSameDayAsToday(new Date(chore.createdAt)) && (
+                <Button
+                  className="text-sm w-24 h-8 mr-2"
+                  onClick={() => skip(id)}
+                >
+                  Skip
+                </Button>
+              )}
 
-            <Button
-              disabled={!isTaskComplete}
-              className="text-sm w-24 h-8"
-              onClick={() => complete(id)}
-            >
-              Complete
-            </Button>
-          </div>
-        )}
+              <Button
+                disabled={!isTaskComplete}
+                className="text-sm w-24 h-8"
+                onClick={() => complete(id)}
+              >
+                Complete
+              </Button>
+            </div>
+          ))}
       </div>
     </OuterPanel>
   );

--- a/src/features/island/delivery/components/DeliveryHelp.tsx
+++ b/src/features/island/delivery/components/DeliveryHelp.tsx
@@ -7,7 +7,7 @@ export const DeliveryHelp: React.FC = () => {
   return (
     <div className="flex flex-col space-y-2 pt-3">
       <div className="flex">
-        <div className="w-12 flex">
+        <div className="w-12 flex justify-center">
           <img src={ITEM_DETAILS["Pumpkin Soup"].image} className="h-7" />
         </div>
         <p className="text-sm flex-1 justify-center">
@@ -20,7 +20,15 @@ export const DeliveryHelp: React.FC = () => {
           <img src={ITEM_DETAILS["Hammer"].image} className="h-7" />
         </div>
         <p className="text-sm flex-1">
-          Expand your land to unlock more slots + quicker orders
+          Expand your land to unlock more slots + quicker delivery orders
+        </p>
+      </div>
+      <div className="flex">
+        <div className="w-12 flex justify-center">
+          <img src={ITEM_DETAILS["Axe"].image} className="h-7" />
+        </div>
+        <p className="text-sm flex-1">
+          Complete your chores and find Hank at the Plaza to claim your rewards.
         </p>
       </div>
       <div className="flex">
@@ -33,6 +41,7 @@ export const DeliveryHelp: React.FC = () => {
           <span className="italic text-xs ml-1">(Coming soon)</span>
         </p>
       </div>
+
       <a
         href="https://docs.sunflower-land.com/player-guides/deliveries"
         target="_blank"

--- a/src/features/island/hud/components/deliveries/DeliveryModal.tsx
+++ b/src/features/island/hud/components/deliveries/DeliveryModal.tsx
@@ -39,7 +39,11 @@ export const DeliveryModal: React.FC<Props> = ({ isOpen, onClose }) => {
               onSelect={setSelectedOrderId}
             />
           )}
-          {tab === 1 && <ChoreV2 isReadOnly />}
+          {tab === 1 && (
+            <div className="pt-1">
+              <ChoreV2 isReadOnly />
+            </div>
+          )}
           {tab === 2 && <DeliveryHelp />}
         </CloseButtonPanel>
       </Modal>

--- a/src/features/island/hud/components/deliveries/DeliveryModal.tsx
+++ b/src/features/island/hud/components/deliveries/DeliveryModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from "react-bootstrap";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { DeliveryHelp } from "features/island/delivery/components/DeliveryHelp";
 import { DeliveryOrders } from "features/island/delivery/components/Orders";
+import { ChoreV2 } from "features/helios/components/hayseedHank/components/ChoreV2";
 
 interface Props {
   isOpen: boolean;
@@ -26,6 +27,7 @@ export const DeliveryModal: React.FC<Props> = ({ isOpen, onClose }) => {
           onClose={onClose}
           tabs={[
             { icon: SUNNYSIDE.icons.expression_chat, name: "Deliveries" },
+            { icon: SUNNYSIDE.icons.expression_chat, name: "Chores" },
             { icon: SUNNYSIDE.icons.expression_confused, name: "Help" },
           ]}
           currentTab={tab}
@@ -37,7 +39,8 @@ export const DeliveryModal: React.FC<Props> = ({ isOpen, onClose }) => {
               onSelect={setSelectedOrderId}
             />
           )}
-          {tab === 1 && <DeliveryHelp />}
+          {tab === 1 && <ChoreV2 isReadOnly />}
+          {tab === 2 && <DeliveryHelp />}
         </CloseButtonPanel>
       </Modal>
     </>


### PR DESCRIPTION
# Description

This PR adds chores to the main Land view with the deliveries, so you can see current chores and progress. Players still need to go to the Plaza to complete/claim chores.

<img width="304" alt="Screenshot 2023-08-23 at 2 34 17 pm" src="https://github.com/sunflower-land/sunflower-land/assets/25412194/f488df89-aea5-498c-b252-1cde99436dc4">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
