### PR TITLE
[FIX] Bud overlapping with island

### DIFF
--- a/src/features/game/expansion/components/Water.tsx
+++ b/src/features/game/expansion/components/Water.tsx
@@ -35,11 +35,6 @@ export const WaterComponent: React.FC<Props> = ({ expansionCount }) => {
   const offset = Math.ceil((Math.sqrt(expansionCount) * LAND_WIDTH) / 2);
   const { openModal } = useContext(ModalContext);
 
-  const frogCoordinates = {
-    x: expansionCount >= 7 ? -2 : 5,
-    y: expansionCount >= 7 ? -11 : -5,
-  };
-
   return (
     // Container
     <div
@@ -72,8 +67,8 @@ export const WaterComponent: React.FC<Props> = ({ expansionCount }) => {
         />
       </MapPlacement>
 
-      {/* Worm Bud swimming */}
-      <MapPlacement x={-2 - offset} y={1} width={6}>
+      {/* Bear Bud */}
+      <MapPlacement x={-7 - offset} y={1} width={6}>
         <img
           src={snowBudRaft}
           className="cursor-pointer hover:img-highlight"
@@ -85,6 +80,7 @@ export const WaterComponent: React.FC<Props> = ({ expansionCount }) => {
         />
       </MapPlacement>
 
+      {/* Worm Bud */}
       <MapPlacement x={6 + offset} y={-2} width={6}>
         <img
           src={wormBudRaft}


### PR DESCRIPTION
# Description

Fix floating bud too close to the island

Before|After
---|---
![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/18f4fa4f-22db-4634-9b11-ab8e73a2a1dd)|![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/73bb1f9d-9f03-456e-9838-d141adc83824)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visit island when the island owns "Basic Land": new Decimal(18)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
