### PR TITLE
[FIX] Buds announcement correct timestamp

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -712,12 +712,11 @@ export function startGame(authContext: AuthContext) {
                   return false;
                 }
                 const readAt = getBudsRead();
-                console.log({ readAt });
                 if (!readAt) {
                   return true;
                 }
 
-                return readAt.getTime() < Date.now() - 7 * 24 * 60 * 1000;
+                return readAt.getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000;
               },
             },
             {

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -223,7 +223,7 @@ export class PlazaScene extends BaseScene {
       key: "portal_anim",
       frames: this.anims.generateFrameNumbers("portal", {
         start: 0,
-        end: 12,
+        end: 11,
       }),
       repeat: -1,
       frameRate: 10,
@@ -236,7 +236,7 @@ export class PlazaScene extends BaseScene {
       key: "fat_chicken_animation",
       frames: this.anims.generateFrameNumbers("fat_chicken", {
         start: 0,
-        end: 9,
+        end: 8,
       }),
       repeat: -1,
       frameRate: 10,

--- a/src/features/world/ui/CommunityTools.tsx
+++ b/src/features/world/ui/CommunityTools.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { COMMUNITY_TEST_ISLAND } from "../scenes/CommunityScene";
 
 export const CommunityTools: React.FC = () => {
-  const [url, setURL] = useState<string>();
+  const [url, setURL] = useState<string>("");
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
# Description

Buds announcement was showing too frequently due to typo in timestamp.
Also fixed amount of frames for assets in plaza and react form bug.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
