### PR TITLE
[FIX] Enable withdraw copies of equipped wearable

### DIFF
--- a/src/features/goblins/bank/components/WithdrawWearables.tsx
+++ b/src/features/goblins/bank/components/WithdrawWearables.tsx
@@ -31,7 +31,6 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
 
   useEffect(() => {
     setWardrobe(availableWardrobe(goblinState.context.state));
-    setSelected({});
   }, []);
 
   const withdraw = () => {
@@ -65,10 +64,6 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
     }));
   };
 
-  // TODO - Filter out currently equipped items!
-  const bumpkin = goblinState.context.state.bumpkin!;
-  const { equipped } = bumpkin;
-
   const isCurrentObsession = (itemName: BumpkinItem) => {
     const obsessionCompletedAt =
       goblinState.context.state.npcs?.bert?.questCompletedAt;
@@ -85,10 +80,7 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
 
   const withdrawableItems = [...new Set([...getKeys(wardrobe)])]
     .sort((a, b) => ITEM_IDS[a] - ITEM_IDS[b])
-    .filter(
-      (item) =>
-        !Object.values(equipped).includes(item) && !isCurrentObsession(item)
-    );
+    .filter((item) => !isCurrentObsession(item));
 
   const selectedItems = getKeys(selected)
     .filter((item) => !!selected[item])
@@ -124,24 +116,22 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
         </div>
         <h2 className="mb-3">Select items to withdraw</h2>
         <div className="flex flex-wrap h-fit -ml-1.5">
-          {withdrawableItems
-            .filter((name) => !!wardrobe[name])
-            .map((itemName) => {
-              // The wardrobe amount that is not placed
-              const wardrobeCount = wardrobe[itemName];
+          {withdrawableItems.map((itemName) => {
+            // The wardrobe amount that is not placed
+            const wardrobeCount = wardrobe[itemName];
 
-              return (
-                <Box
-                  count={new Decimal(wardrobeCount ?? 0)}
-                  key={itemName}
-                  onClick={() => onAdd(itemName)}
-                  disabled={
-                    !BUMPKIN_WITHDRAWABLES[itemName](goblinState.context.state)
-                  }
-                  image={getImageUrl(ITEM_IDS[itemName])}
-                />
-              );
-            })}
+            return (
+              <Box
+                count={new Decimal(wardrobeCount ?? 0)}
+                key={itemName}
+                onClick={() => onAdd(itemName)}
+                disabled={
+                  !BUMPKIN_WITHDRAWABLES[itemName](goblinState.context.state)
+                }
+                image={getImageUrl(ITEM_IDS[itemName])}
+              />
+            );
+          })}
           {/* Pad with empty boxes */}
           {withdrawableItems.length < 4 &&
             new Array(4 - withdrawableItems.length)


### PR DESCRIPTION
# Description

It was not possible to withdraw extra copies of equipped wearable.

For example here you can see 5 copies of space background:
![image](https://github.com/sunflower-land/sunflower-land/assets/9656961/feeeeaab-d64f-4adf-888b-ab7416752a7f)
But when I equip space background I cant withdraw 4 unused copies of it:
![image](https://github.com/sunflower-land/sunflower-land/assets/9656961/d8a09049-0f87-4de9-b7de-940b07ffaed2)

`availableWardrobe(goblinState.context.state)` function already checks for equipped wearables, so additional check inside component are not needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
