### PR TITLE
[FIX] Hide wearables that were already selected for withdraw

### DIFF
--- a/src/features/goblins/bank/components/WithdrawWearables.tsx
+++ b/src/features/goblins/bank/components/WithdrawWearables.tsx
@@ -79,8 +79,8 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
   };
 
   const withdrawableItems = [...new Set([...getKeys(wardrobe)])]
-    .sort((a, b) => ITEM_IDS[a] - ITEM_IDS[b])
-    .filter((item) => !isCurrentObsession(item));
+    .filter((item) => wardrobe[item] && !isCurrentObsession(item))
+    .sort((a, b) => ITEM_IDS[a] - ITEM_IDS[b]);
 
   const selectedItems = getKeys(selected)
     .filter((item) => !!selected[item])


### PR DESCRIPTION
# Description

Follow up on my yesterday fix. Forgot to hide wearable if all instances were already selected for withdrawal.
Placed sort() after filter() for better performance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
