### PR TITLE
[FIX] Prevent Null Listings

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -87,6 +87,7 @@ const ListTrade: React.FC<{
                   border: "2px solid #ead4aa",
                 }}
                 type="number"
+                min={1}
                 value={selected[item]}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   if (VALID_NUMBER.test(e.target.value)) {


### PR DESCRIPTION
# Description

This PR is preventing people from listing null trades by changing minimum resource from 0 to 1.

For example: 0 Wood, 0 Stone, 0 Egg for 1 SFL
![image](https://github.com/sunflower-land/sunflower-land/assets/63975424/64b9f695-1154-4017-8295-b0a8d0e6a1eb)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

local test & yarn test
![Screenshot 2023-08-30 at 00 37 51](https://github.com/sunflower-land/sunflower-land/assets/63975424/cc20eac3-973b-4dd4-b697-8ea58acd7ac6)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
