### PR TITLE
[FIX] Prevent listing 0 items and for 0 SFL

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -29,10 +29,9 @@ const MAX_SFL = 150;
 type Items = Partial<Record<InventoryItemName, number>>;
 const ListTrade: React.FC<{
   inventory: Inventory;
-  balance: Decimal;
   onList: (items: Items, sfl: number) => void;
   onCancel: () => void;
-}> = ({ inventory, balance, onList, onCancel }) => {
+}> = ({ inventory, onList, onCancel }) => {
   const [selected, setSelected] = useState<Items>({});
   const [sfl, setSFL] = useState(1);
   const select = (name: InventoryItemName) => {
@@ -51,6 +50,9 @@ const ListTrade: React.FC<{
   );
 
   const maxSFL = sfl > MAX_SFL;
+  const allListedAmtGreaterThanZero = getKeys(selected).every((name) => {
+    return selected[name] ?? 0 > 0;
+  });
 
   return (
     <div>
@@ -89,6 +91,13 @@ const ListTrade: React.FC<{
                 type="number"
                 value={selected[item]}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  // Strip the leading zero from numbers
+                  if (
+                    /^0+(?!\.)/.test(e.target.value) &&
+                    e.target.value.length > 1
+                  ) {
+                    e.target.value = e.target.value.replace(/^0/, "");
+                  }
                   if (VALID_NUMBER.test(e.target.value)) {
                     const amount = Number(
                       e.target.value.slice(0, INPUT_MAX_CHAR)
@@ -104,7 +113,8 @@ const ListTrade: React.FC<{
                   {
                     "text-error":
                       inventory[item]?.lt(selected[item] ?? 0) ||
-                      (selected[item] ?? 0) > (TRADE_LIMITS[item] ?? 0),
+                      (selected[item] ?? 0) > (TRADE_LIMITS[item] ?? 0) ||
+                      !allListedAmtGreaterThanZero,
                   }
                 )}
               />
@@ -133,6 +143,14 @@ const ListTrade: React.FC<{
               type="number"
               value={sfl}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                // Strip the leading zero from numbers
+                if (
+                  /^0+(?!\.)/.test(e.target.value) &&
+                  e.target.value.length > 1
+                ) {
+                  e.target.value = e.target.value.replace(/^0/, "");
+                }
+
                 if (VALID_NUMBER.test(e.target.value)) {
                   const amount = Number(
                     e.target.value.slice(0, INPUT_MAX_CHAR)
@@ -143,7 +161,7 @@ const ListTrade: React.FC<{
               className={classNames(
                 "text-shadow mr-2 rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10",
                 {
-                  "text-error": maxSFL,
+                  "text-error": maxSFL || sfl === 0,
                 }
               )}
             />
@@ -164,7 +182,9 @@ const ListTrade: React.FC<{
             maxSFL ||
             exceedsMax ||
             getKeys(selected).length === 0 ||
-            !hasResources
+            !hasResources ||
+            !allListedAmtGreaterThanZero ||
+            sfl === 0
           }
           onClick={() => onList(selected, sfl)}
         >
@@ -271,6 +291,8 @@ export const Trade: React.FC = () => {
     gameState.context.state.bumpkin?.experience ?? 0
   );
 
+  console.log({ showListing });
+
   if (level < 10) {
     return (
       <div className="relative">
@@ -286,15 +308,10 @@ export const Trade: React.FC = () => {
     );
   }
 
-  if (gameState.matches("autosaving")) {
-    return <p className="m-1 loading">Saving</p>;
-  }
-
   if (showListing) {
     return (
       <ListTrade
         inventory={gameState.context.state.inventory}
-        balance={gameState.context.state.balance}
         onCancel={() => setShowListing(false)}
         onList={(items, sfl) => {
           gameService.send("trade.listed", { items, sfl });

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -291,8 +291,6 @@ export const Trade: React.FC = () => {
     gameState.context.state.bumpkin?.experience ?? 0
   );
 
-  console.log({ showListing });
-
   if (level < 10) {
     return (
       <div className="relative">

--- a/src/features/world/ui/TradeCompleted.tsx
+++ b/src/features/world/ui/TradeCompleted.tsx
@@ -24,7 +24,6 @@ export const TradeCompleted: React.FC<Props> = ({ mmoService, farmId }) => {
 
   useEffect(() => {
     mmoService?.state?.context?.server?.state?.trades?.onAdd((trade) => {
-      console.log(JSON.stringify(trade));
       if (trade.buyerId && trade.sellerId === farmId) {
         setTrade(trade);
       }


### PR DESCRIPTION
# Description

This PR blocks a trade from being listing for 0 amount of an item and also listing for 0 SFL.

![Screenshot 2023-08-30 at 8 43 11 am](https://github.com/sunflower-land/sunflower-land/assets/17863697/b61b86b1-7504-4d30-8131-8dd9bc5a4b44)
![Screenshot 2023-08-30 at 9 06 05 am](https://github.com/sunflower-land/sunflower-land/assets/17863697/2db90b9c-85c1-4687-a410-027abec2af9e)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
