### PR TITLE
[FEAT] Remove Potion House Add/Remove Buttons

### DIFF
--- a/src/features/game/expansion/components/potions/Experiment.tsx
+++ b/src/features/game/expansion/components/potions/Experiment.tsx
@@ -211,7 +211,7 @@ export const Experiment: React.FC<Props> = ({
         {!isFinished && !showStartButton && (
           <div className="flex flex-col justify-end grow">
             <h2 className="mb-1">Potions</h2>
-            <span className="text-xxs italic mb-1">
+            <span className="text-xxs italic">
               (Click on a bottle to add to your guess)
             </span>
             <div className="flex flex-wrap gap-2 mt-3 mb-2">
@@ -230,7 +230,7 @@ export const Experiment: React.FC<Props> = ({
         )}
       </div>
       {showStartButton && (
-        <div className="flex flex-col-reverse space-y-1 sm:flex-row sm:space-y-0 sm:space-x-1 ">
+        <div className="flex flex-col-reverse space-y-reverse space-y-1 sm:flex-row sm:space-y-0 sm:space-x-1 ">
           <Button onClick={onClose}>Close</Button>
           <Button
             onClick={handleStart}

--- a/src/features/game/expansion/components/potions/lib/potionHouseMachine.ts
+++ b/src/features/game/expansion/components/potions/lib/potionHouseMachine.ts
@@ -1,5 +1,4 @@
 import { Interpreter, State, assign, createMachine } from "xstate";
-import { Potion } from "./types";
 import {
   acknowledgePotionHouseIntro,
   getPotionHouseIntroRead,
@@ -18,7 +17,6 @@ type Potions = [
 
 export interface PotionHouseContext {
   guessSpot: number;
-  selectedPotion: Potion;
   currentGuess: Potions;
   isNewGame: boolean;
   isFinished: boolean;
@@ -32,7 +30,6 @@ type PotionHouseEvent =
   | { type: "OPEN_RULES" }
   | { type: "REMOVE_GUESS"; guessSpot: number }
   | { type: "ADD_GUESS"; guessSpot: number; potion: PotionName }
-  | { type: "SELECT_POTION"; potion: Potion }
   | { type: "SELECT_GUESS_SPOT"; guessSpot: number }
   | { type: "MIX_POTION" }
   | { type: "NEXT_ANIMATION"; score: number | null }
@@ -103,7 +100,6 @@ export const potionHouseMachine = createMachine<
   initial: "introduction",
   context: {
     guessSpot: 0,
-    selectedPotion: Object.values(POTIONS)[0],
     currentGuess: [null, null, null, null],
     isFinished: false,
     isNewGame: false,
@@ -279,14 +275,6 @@ export const potionHouseMachine = createMachine<
               ...context,
               currentGuess: newGuess,
               guessSpot,
-            };
-          }),
-        },
-        SELECT_POTION: {
-          actions: assign((context, event) => {
-            return {
-              ...context,
-              selectedPotion: event.potion,
             };
           }),
         },


### PR DESCRIPTION
# Description

This PR makes some changes to the UX of the Potion House.  A player is now able to click on bottles to add and remove them from the game. I have also added a `Close` button next to the `Start New Game` button to stop players from accidentally starting a new game.

<img width="300" alt="Screenshot 2023-09-06 at 8 39 29 pm" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/b51f09bd-dcdd-42dc-9242-4e4f0994ffaa">

<img width="300" alt="Screenshot 2023-09-06 at 8 48 12 pm" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/44ab9d95-eaf4-46d1-8db9-2860935f90f9">

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally. Play Potion House to make sure all is well :)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
