### PR TITLE
[CHORE] change aqua potion black

### DIFF
--- a/src/features/game/expansion/components/potions/lib/potions.ts
+++ b/src/features/game/expansion/components/potions/lib/potions.ts
@@ -3,7 +3,7 @@ import { Potion } from "./types";
 import orangeBottle from "assets/decorations/orange_bottle.webp";
 import blueBottle from "assets/decorations/blue_bottle.webp";
 import pinkBottle from "assets/decorations/pink_bottle.webp";
-import aquaBottle from "assets/decorations/aqua_bottle.webp";
+import blackBottle from "assets/decorations/black_bottle.webp";
 import greenBottle from "assets/decorations/green_bottle.webp";
 import mustardBottle from "assets/decorations/mustard_bottle.webp";
 import whiteBottle from "assets/decorations/white_bottle.webp";
@@ -27,7 +27,7 @@ export const POTIONS: Record<PotionName, Potion> = {
   },
   "Flower Power": {
     name: "Flower Power",
-    image: aquaBottle,
+    image: blackBottle,
     description: "Unleash a burst of floral energy upon your plants.",
   },
   "Silver Syrup": {


### PR DESCRIPTION
# Description

change aqua potion to black potion for potion house as the proximity of potion colors are confusing for some players

Before|After
---|---
<img width="281" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/5255651a-c262-4208-9caa-39eda5c32b4b">|<img width="283" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/fcdd5cad-e512-404b-a5bd-c6fb4f47e5dd">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- go to potion house and mix potions

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
