### PR TITLE
[FIX] Gold Egg has no wheat requirement and need for shortcut

### DIFF
--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -203,16 +203,18 @@ const PlaceableChicken: React.FC<Props> = ({ id }) => {
   };
 
   const feed = async () => {
-    const hasWheat = HasWheat(inventoryWheatCount, collectibles);
+    if (!isCollectibleBuilt("Gold Egg", collectibles)) {
+      const hasWheat = HasWheat(inventoryWheatCount, collectibles);
 
-    if (!hasWheat) {
-      setShowPopover(true);
-      await new Promise((resolve) => setTimeout(resolve, POPOVER_TIME_MS));
-      setShowPopover(false);
-      return;
+      if (!hasWheat) {
+        setShowPopover(true);
+        await new Promise((resolve) => setTimeout(resolve, POPOVER_TIME_MS));
+        setShowPopover(false);
+        return;
+      }
+
+      shortcutItem("Wheat");
     }
-
-    shortcutItem("Wheat");
 
     const {
       context: {


### PR DESCRIPTION
When the Gold Egg is "built" on a farm, both the inventory check for wheat and the auto-shortcutting of wheat should be bypassed.

This is similar to the Foreman Beaver fix when auto-shortcutting axes was implemented.