### PR TITLE
[FIX] Formally disable Honey Cake and Pancakes

### DIFF
--- a/src/features/game/types/consumables.ts
+++ b/src/features/game/types/consumables.ts
@@ -235,6 +235,7 @@ export const COOKABLE_CAKES: Record<CakeName, Cookable> = {
       Egg: new Decimal(10),
     },
     marketRate: 550,
+    disabled: true,
   },
 };
 
@@ -363,6 +364,7 @@ export const COOKABLES: Record<CookableName, Cookable> = {
       Honey: new Decimal(10),
     },
     marketRate: 10,
+    disabled: true,
   },
 
   "Club Sandwich": {

--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -30,6 +30,10 @@ export const BakeryModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const cakeRecipes = getKeys(COOKABLES).reduce((acc, name) => {
+    if (COOKABLES[name]?.disabled) {
+      return acc;
+    }
+
     if (COOKABLES[name].building !== "Bakery") {
       return acc;
     }

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -30,6 +30,10 @@ export const KitchenModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const kitchenRecipes = getKeys(COOKABLES).reduce((acc, name) => {
+    if (COOKABLES[name]?.disabled) {
+      return acc;
+    }
+
     if (COOKABLES[name].building !== "Kitchen") {
       return acc;
     }


### PR DESCRIPTION
# Description

As honey is not available in the game yet, this change disables Honey Cake and Pancakes to avoid confusing new players.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
