### PR TITLE
[FIX] Fix the origin x and y when the user releases and then immediat…

### DIFF
--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -241,7 +241,10 @@ export const MoveableComponent: React.FC<MovableProps> = ({
       onStart={(_, data) => {
         const x = Math.round(data.x);
         const y = Math.round(-data.y);
-        origin.current = { x, y };
+
+        if (!origin.current) {
+          origin.current = { x, y };
+        }
       }}
       onDrag={(_, data) => {
         const xDiff = Math.round((origin.current.x + data.x) / GRID_WIDTH_PX);


### PR DESCRIPTION
# Description

Adjust the origin coordinates x and y when the user releases and then immediately drags the component.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A bug that troubles me a lot when moving components, especially on mobile devices. It occurs when the user releases the component somewhere that collides and then tries to move it again.

https://github.com/sunflower-land/sunflower-land/assets/5870502/b9e0ba3b-b31f-49c6-ba69-65a03f4094f5
_After release above the ocean(collision), the bug start to happen show de red square in correct positions._

https://github.com/sunflower-land/sunflower-land/assets/5870502/67f023d8-2186-4b68-840e-13ff76a5bdfa
_After release above a stone, the bug start to happen show de red square in correct positions._



https://github.com/sunflower-land/sunflower-land/assets/5870502/f0ecf1f4-ce56-4c1d-9a6a-6e7d8b4d650c
_After fix_


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
