### PR TITLE
[FEAT] Bud Boosts

### DIFF
--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -1,3 +1,5 @@
+import "lib/__mocks__/configMock";
+
 import Decimal from "decimal.js-light";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { FRUIT_SEEDS } from "features/game/types/fruits";
@@ -458,5 +460,49 @@ describe("fruitHarvested", () => {
     });
 
     expect(state.bumpkin?.activity?.["Apple Harvested"]).toEqual(1);
+  });
+
+  it("applies a buds boost", () => {
+    const { fruitPatches } = GAME_STATE;
+    const fruitPatch = (fruitPatches as Record<number, CropPlot>)[0];
+    const initialHarvest = 2;
+
+    const state = harvestFruit({
+      state: {
+        ...GAME_STATE,
+        buds: {
+          1: {
+            aura: "No Aura",
+            colour: "Green",
+            ears: "No Ears",
+            stem: "Hibiscus",
+            type: "Beach",
+            coordinates: { x: 0, y: 0 },
+          },
+        },
+        fruitPatches: {
+          0: {
+            ...fruitPatch,
+            fruit: {
+              name: "Blueberry",
+              plantedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+              amount: 1,
+              harvestsLeft: initialHarvest,
+              harvestedAt: 2,
+            },
+          },
+        },
+      },
+      action: {
+        type: "fruit.harvested",
+
+        index: "0",
+      },
+      createdAt: dateNow,
+    });
+
+    const { fruitPatches: fruitPatchesAfterHarvest } = state;
+    const fruit = fruitPatchesAfterHarvest?.[0].fruit;
+    expect(fruit?.amount).toEqual(1.2);
   });
 });

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -1,3 +1,5 @@
+import "lib/__mocks__/configMock";
+
 import Decimal from "decimal.js-light";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { FruitSeedName, FRUIT_SEEDS } from "features/game/types/fruits";
@@ -489,6 +491,47 @@ describe("fruitPlanted", () => {
       },
     });
     expect(state.bumpkin?.activity?.["Apple Seed Planted"]).toEqual(amount);
+  });
+
+  it("applies a bud boost", () => {
+    const seedAmount = new Decimal(5);
+
+    const patchIndex = "1";
+
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Blueberry Seed": seedAmount,
+          "Black Bearry": new Decimal(1),
+        },
+        buds: {
+          1: {
+            aura: "No Aura",
+            stem: "Hibiscus",
+            colour: "Brown",
+            ears: "No Ears",
+            type: "Beach",
+            coordinates: { x: 0, y: 0 },
+          },
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+
+        seed: "Blueberry Seed",
+      },
+      harvestsLeft: () => 3,
+    });
+
+    const fruitPatches = state.fruitPatches;
+
+    expect(
+      (fruitPatches as Record<number, FruitPatch>)[patchIndex].fruit?.amount
+    ).toEqual(1.2);
   });
 });
 

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -114,7 +114,12 @@ export function plantFruit({
   patch.fruit = {
     name: fruitName,
     plantedAt: getPlantedAt(action.seed, stateCopy.collectibles, createdAt),
-    amount: getFruitYield(fruitName, stateCopy.collectibles),
+    amount: getFruitYield({
+      name: fruitName,
+      collectibles: stateCopy.collectibles,
+      buds: stateCopy.buds ?? {},
+      wearables: bumpkin.equipped,
+    }),
     harvestedAt: 0,
     // Value will be overridden by BE
     harvestsLeft: harvestCount,

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1447,6 +1447,104 @@ describe("plant", () => {
 
     expect((plots as Record<number, CropPlot>)[0].crop?.amount).toEqual(1.1);
   });
+
+  it("applies a bud yield boost", () => {
+    const state: GameState = plant({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Parsnip Seed": new Decimal(1),
+          "Water Well": new Decimal(1),
+        },
+        crops: {
+          0: {
+            createdAt: Date.now(),
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+          },
+        },
+        buds: {
+          1: {
+            aura: "No Aura",
+            colour: "Green",
+            type: "Castle",
+            ears: "Ears",
+            stem: "Egg Head",
+            coordinates: {
+              x: 0,
+              y: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "0",
+        item: "Parsnip Seed",
+      },
+      createdAt: dateNow,
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+
+    expect((plots as Record<number, CropPlot>)[0].crop?.amount).toEqual(1.3);
+  });
+
+  it("applies a bud speed boost", () => {
+    const state: GameState = plant({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Parsnip Seed": new Decimal(1),
+          "Water Well": new Decimal(1),
+        },
+        crops: {
+          0: {
+            createdAt: Date.now(),
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+          },
+        },
+        buds: {
+          1: {
+            aura: "No Aura",
+            colour: "Green",
+            type: "Saphiro",
+            ears: "Ears",
+            stem: "Egg Head",
+            coordinates: {
+              x: 0,
+              y: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "0",
+        item: "Parsnip Seed",
+      },
+      createdAt: dateNow,
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+
+    expect((plots as Record<number, CropPlot>)[0].crop?.plantedAt).toEqual(
+      dateNow - 0.1 * CROPS().Parsnip.harvestSeconds * 1000
+    );
+  });
 });
 
 describe("getCropTime", () => {
@@ -1558,6 +1656,7 @@ describe("getCropTime", () => {
         },
       },
       collectibles: {},
+      buds: {},
       plot,
     });
 
@@ -1576,6 +1675,7 @@ describe("getCropTime", () => {
         },
       },
       collectibles: {},
+      buds: {},
       plot,
     });
 
@@ -1621,6 +1721,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 0, y: -2 }
     );
 
@@ -1644,6 +1745,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 0, y: -2 }
     );
 
@@ -1667,6 +1769,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 0, y: -2 }
     );
 
@@ -1690,6 +1793,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 0, y: -2 }
     );
 
@@ -1713,6 +1817,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 2, y: -2 }
     );
 
@@ -1736,6 +1841,7 @@ describe("getCropTime", () => {
         ],
       },
       { ...INITIAL_BUMPKIN },
+      {},
       { ...plot, x: 0, y: -3 }
     );
 
@@ -1917,6 +2023,7 @@ describe("getCropYield", () => {
         ],
       },
       inventory: {},
+      buds: {},
       plot: { createdAt: 0, height: 1, width: 1, x: 2, y: 3 },
     });
 
@@ -1938,6 +2045,7 @@ describe("getCropYield", () => {
         ],
       },
       inventory: {},
+      buds: {},
       plot: { createdAt: 0, height: 1, width: 1, x: 5, y: 6 },
     });
 

--- a/src/features/game/lib/getBudSpeedBoosts.test.ts
+++ b/src/features/game/lib/getBudSpeedBoosts.test.ts
@@ -1,0 +1,136 @@
+import "lib/__mocks__/configMock";
+
+import { Bud } from "../types/buds";
+import { getBudSpeedBoosts } from "./getBudSpeedBoosts";
+
+const NON_BOOSTED_TRAITS: Omit<Bud, "type"> = {
+  aura: "No Aura",
+  colour: "Blue",
+  ears: "No Ears",
+  stem: "Seashell",
+  coordinates: {
+    x: 0,
+    y: 0,
+  },
+};
+
+describe("getBudSpeedBoosts", () => {
+  it("returns 1 if no buds", () => {
+    expect(getBudSpeedBoosts({}, "Sunflower")).toEqual(1);
+  });
+
+  it("returns 0.9 if Saphiro type", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.9);
+  });
+
+  it("returns 0.895 if Saphiro type and Basic Aura", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Basic",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.895);
+  });
+  8;
+
+  it("returns 0.88 if Saphiro type and Green Aura", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Green",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.88);
+  });
+  it("returns 0.8 if Saphiro type and Rare Aura", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Rare",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.8);
+  });
+
+  it("returns 0.5 if Saphiro type and Mythical Aura", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Mythical",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.5);
+  });
+
+  it("returns the best boost if multiple buds", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "No Aura",
+          },
+          2: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Mythical",
+          },
+          3: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Rare",
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(0.5);
+  });
+
+  it("filters out buds that are not placed", () => {
+    expect(
+      getBudSpeedBoosts(
+        {
+          1: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Saphiro",
+            aura: "Mythical",
+            coordinates: undefined,
+          },
+        },
+        "Sunflower"
+      )
+    ).toEqual(1);
+  });
+});

--- a/src/features/game/lib/getBudSpeedBoosts.ts
+++ b/src/features/game/lib/getBudSpeedBoosts.ts
@@ -1,0 +1,28 @@
+import { Bud } from "../types/buds";
+import { GameState } from "../types/game";
+import { Resource, getAuraBoost, isCrop } from "./getBudYieldBoosts";
+
+const getTypeBoost = (bud: Bud, resource: Resource): number => {
+  if (isCrop(resource) && bud.type === "Saphiro") {
+    return 0.1;
+  }
+
+  return 0;
+};
+
+const getBudSpeedBoost = (bud: Bud, resource: Resource): number => {
+  return 1 - getAuraBoost(bud) * getTypeBoost(bud, resource);
+};
+
+export const getBudSpeedBoosts = (
+  buds: NonNullable<GameState["buds"]>,
+  resource: Resource
+): number => {
+  const boosts = Object.values(buds)
+    // Bud must be placed to give a boost
+    .filter((buds) => !!buds.coordinates)
+    .map((bud) => getBudSpeedBoost(bud, resource));
+
+  // Get the strongest boost from all the buds on the farm
+  return Number(Math.min(...boosts, 1).toFixed(4));
+};

--- a/src/features/game/lib/getBudYieldBoosts.test.ts
+++ b/src/features/game/lib/getBudYieldBoosts.test.ts
@@ -1,0 +1,731 @@
+import "lib/__mocks__/configMock";
+
+import { Bud } from "../types/buds";
+import { getBudYieldBoosts } from "./getBudYieldBoosts";
+
+const NON_BOOSTED_TRAITS: Omit<Bud, "type"> = {
+  aura: "No Aura",
+  colour: "Blue",
+  ears: "No Ears",
+  stem: "Seashell",
+  coordinates: {
+    x: 0,
+    y: 0,
+  },
+};
+
+describe("getBudYieldBoosts", () => {
+  it("returns zero if no buds", () => {
+    expect(getBudYieldBoosts({}, "Stone")).toEqual(0);
+  });
+
+  it("returns 0 for a Basic Aura without a trait active", () => {
+    expect(
+      getBudYieldBoosts(
+        { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza", aura: "Basic" } },
+        "Stone"
+      )
+    ).toEqual(0);
+  });
+
+  it("returns the boost from the most powerful bud", () => {
+    expect(
+      getBudYieldBoosts(
+        {
+          1: { ...NON_BOOSTED_TRAITS, type: "Plaza" },
+          2: { ...NON_BOOSTED_TRAITS, type: "Cave", aura: "Basic" },
+          3: { ...NON_BOOSTED_TRAITS, type: "Cave" },
+        },
+        "Stone"
+      )
+    ).toEqual(0.21);
+  });
+
+  it("filters out buds that are not placed", () => {
+    expect(
+      getBudYieldBoosts(
+        {
+          1: { ...NON_BOOSTED_TRAITS, type: "Plaza", coordinates: undefined },
+          2: {
+            ...NON_BOOSTED_TRAITS,
+            type: "Cave",
+            aura: "Basic",
+            coordinates: undefined,
+          },
+          3: { ...NON_BOOSTED_TRAITS, type: "Cave", coordinates: undefined },
+        },
+        "Stone"
+      )
+    ).toEqual(0);
+  });
+
+  describe("Minerals", () => {
+    it("returns 0.2 Stone boost for a Cave type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave" } },
+          "Stone"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.2 Iron boost for a Cave type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave" } },
+          "Iron"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.2 Gold boost for a Cave type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave" } },
+          "Gold"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0 Stone boost for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Stone"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.2 Stone boost for a Diamond Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Diamond Gem" } },
+          "Stone"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Stone boost for a Cave type with Diamond Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Diamond Gem" } },
+          "Stone"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.2 Gold boost for a Gold Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Gold Gem" } },
+          "Gold"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Gold boost for a Cave type with Gold Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Gold Gem" } },
+          "Gold"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.2 Iron boost for a Miner Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Miner Hat" } },
+          "Iron"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Iron boost for a Cave type with Miner Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Miner Hat" } },
+          "Iron"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.2 Stone boost for a Ruby Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Ruby Gem" } },
+          "Stone"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Stone boost for a Cave type with Ruby Gem stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Ruby Gem" } },
+          "Stone"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.21 Stone boost for a Ruby Gem stem and Basic Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Ruby Gem",
+              aura: "Basic",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.21);
+    });
+
+    it("returns 0.42 Stone boost for a Cave type with Ruby Gem stem and Basic Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Ruby Gem",
+              aura: "Basic",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.42);
+    });
+
+    it("returns 0.24 Stone boost for a Ruby Gem stem and Green Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Ruby Gem",
+              aura: "Green",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.24);
+    });
+
+    it("returns 0.48 Stone boost for a Cave type with Ruby Gem stem and Green Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Ruby Gem",
+              aura: "Green",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.48);
+    });
+
+    it("returns 0.4 Stone boost for a Ruby Gem stem and Rare Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Ruby Gem",
+              aura: "Rare",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.8 Stone boost for a Cave type with Ruby Gem stem and Rare Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Ruby Gem",
+              aura: "Rare",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(0.8);
+    });
+
+    it("returns 1 Stone boost for a Ruby Gem stem and Mythical Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Ruby Gem",
+              aura: "Mythical",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(1);
+    });
+
+    it("returns 2 Stone boost for a Cave type with Ruby Gem stem and Mythical Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Ruby Gem",
+              aura: "Mythical",
+            },
+          },
+          "Stone"
+        )
+      ).toEqual(2);
+    });
+  });
+
+  describe("Crops", () => {
+    it("returns 0 Crop boost for a Cave type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave" } },
+          "Sunflower"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.5 Crop boost for a 3 Leaf Clover stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "3 Leaf Clover" },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.5);
+    });
+
+    it("returns 0.8 Sunflower Boost for a Plaza type with a 3 Leaf Clover stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "3 Leaf Clover" },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.8);
+    });
+
+    it("returns 0.3 Carrot Boost for a a Carrot Head stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Carrot Head" },
+          },
+          "Carrot"
+        )
+      ).toEqual(0.3);
+    });
+
+    it("returns 0.5 Sunflower Boost for a Sunflower Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Sunflower Hat" },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.5);
+    });
+
+    it("returns 0.8 Sunflower Boost for a Plaza type with a Sunflower Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Sunflower Hat" },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.8);
+    });
+
+    it("returns 0.21 Sunflower Boost for a Basic Leaf stem and Basic Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Basic Leaf",
+              aura: "Basic",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.21);
+    });
+
+    it("returns 0.6 Sunflower Boost for a Plaza type with Basic Leaf stem and Green Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Basic Leaf",
+              aura: "Green",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.6);
+    });
+
+    it("returns 0.4 Sunflower Boost for a Basic Leaf stem and Rare Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Basic Leaf",
+              aura: "Rare",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 1 Sunflower Boost for a Plaza type with Basic Leaf stem and Rare Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Basic Leaf",
+              aura: "Rare",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(1);
+    });
+
+    it("returns 1 Sunflower Boost for a Basic Leaf stem and Mythical Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Cave",
+              stem: "Basic Leaf",
+              aura: "Mythical",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(1);
+    });
+
+    it("returns 2.5 Sunflower Boost for a Plaza type with Basic Leaf stem and Mythical Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "Basic Leaf",
+              aura: "Mythical",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(2.5);
+    });
+
+    it("returns 4 Sunflower Boost for a Plaza type with 3 Leaf Clover stem and Mythical Aura", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: {
+              ...NON_BOOSTED_TRAITS,
+              type: "Plaza",
+              stem: "3 Leaf Clover",
+              aura: "Mythical",
+            },
+          },
+          "Sunflower"
+        )
+      ).toEqual(4);
+    });
+  });
+
+  describe("Basic Crops", () => {
+    it("returns 0.3 Sunflower Boost for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Sunflower"
+        )
+      ).toEqual(0.3);
+    });
+
+    it("returns 0 Eggplant Boost for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Eggplant"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.2 Sunflower Boost for a Basic Leaf stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Basic Leaf" } },
+          "Sunflower"
+        )
+      ).toEqual(0.2);
+    });
+  });
+
+  describe("Medium Crops", () => {
+    it("returns 0 Sunflower Boost for a Castle type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Castle" } },
+          "Sunflower"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.3 Cauliflower Boost for a Castle type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Castle" } },
+          "Cauliflower"
+        )
+      ).toEqual(0.3);
+    });
+  });
+
+  describe("Advanced Crops", () => {
+    it("returns 0 Sunflower Boost for a Snow type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Snow" } },
+          "Sunflower"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.3 Eggplant Boost for a Snow type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Snow" } },
+          "Eggplant"
+        )
+      ).toEqual(0.3);
+    });
+  });
+
+  describe("Wood", () => {
+    it("returns 0.2 Wood Boost for a Woodlands type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Woodlands" } },
+          "Wood"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0 Wood Boost for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Wood"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.1 Wood Boost for a Acorn Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Acorn Hat" } },
+          "Wood"
+        )
+      ).toEqual(0.1);
+    });
+
+    it("returns 0.3 Wood Boost for a Woodlands type with Acorn Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Woodlands", stem: "Acorn Hat" },
+          },
+          "Wood"
+        )
+      ).toEqual(0.3);
+    });
+
+    it("returns 0.2 Wood Boost for a Tree Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Tree Hat" } },
+          "Wood"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Wood Boost for a Woodlands type with Tree Hat stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Woodlands", stem: "Tree Hat" },
+          },
+          "Wood"
+        )
+      ).toEqual(0.4);
+    });
+  });
+
+  describe("Animals", () => {
+    it("returns 0.2 Animal produce for a Retreat type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Retreat" } },
+          "Egg"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0 Animal produce for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Egg"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.2 Eggs for a Egg Head stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Egg Head" } },
+          "Egg"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Eggs for a Retreat type with Egg Head stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Retreat", stem: "Egg Head" } },
+          "Egg"
+        )
+      ).toEqual(0.4);
+    });
+  });
+
+  describe("Fruit", () => {
+    it("returns 0.2 Fruit produce for a Beach type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Beach" } },
+          "Apple"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0 Fruit produce for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Apple"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.2 Fruit produce for a Banana stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Banana" } },
+          "Apple"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Fruit produce for a Beach type with a Banana stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Beach", stem: "Banana" } },
+          "Apple"
+        )
+      ).toEqual(0.4);
+    });
+
+    it("returns 0.2 Fruit produce for a Apple Head stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Apple Head" } },
+          "Apple"
+        )
+      ).toEqual(0.2);
+    });
+
+    it("returns 0.4 Fruit produce for a Beach type with a Apple Head stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Beach", stem: "Apple Head" } },
+          "Apple"
+        )
+      ).toEqual(0.4);
+    });
+  });
+
+  describe("Mushrooms", () => {
+    it("returns 0 Mushroom produce for a Plaza type", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Plaza" } },
+          "Wild Mushroom"
+        )
+      ).toEqual(0);
+    });
+
+    it("returns 0.3 Wild Mushroom produce for a Mushroom stem", () => {
+      expect(
+        getBudYieldBoosts(
+          { 1: { ...NON_BOOSTED_TRAITS, type: "Cave", stem: "Mushroom" } },
+          "Wild Mushroom"
+        )
+      ).toEqual(0.3);
+    });
+
+    it("returns 0.2 Magic Mushroom produce for a Magic Mushroom stem", () => {
+      expect(
+        getBudYieldBoosts(
+          {
+            1: { ...NON_BOOSTED_TRAITS, type: "Plaza", stem: "Magic Mushroom" },
+          },
+          "Magic Mushroom"
+        )
+      ).toEqual(0.2);
+    });
+  });
+});

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -1,0 +1,154 @@
+import {
+  isAdvancedCrop,
+  isBasicCrop,
+  isMediumCrop,
+} from "../events/landExpansion/harvest";
+import { Bud, StemTrait, TypeTrait } from "../types/buds";
+import { CROPS, CropName } from "../types/crops";
+import { FRUIT, FruitName } from "../types/fruits";
+import { GameState } from "../types/game";
+import { CommodityName, MushroomName } from "../types/resources";
+
+export type Resource = CommodityName | CropName | FruitName | MushroomName;
+
+export const isCrop = (resource: Resource): resource is CropName => {
+  return resource in CROPS();
+};
+
+const isMineral = (resource: Resource): boolean => {
+  return resource === "Stone" || resource === "Iron" || resource === "Gold";
+};
+
+const isFruit = (resource: Resource): boolean => {
+  return resource in FRUIT();
+};
+
+const getTypeBoost = (bud: Bud, resource: Resource): number => {
+  const hasType = (type: TypeTrait) => bud.type === type;
+
+  if (isMineral(resource) && hasType("Cave")) {
+    return 0.2;
+  }
+
+  if (isCrop(resource) && isBasicCrop(resource) && hasType("Plaza")) {
+    return 0.3;
+  }
+
+  if (isCrop(resource) && isMediumCrop(resource) && hasType("Castle")) {
+    return 0.3;
+  }
+
+  if (isCrop(resource) && isAdvancedCrop(resource) && hasType("Snow")) {
+    return 0.3;
+  }
+
+  if (resource === "Wood" && hasType("Woodlands")) {
+    return 0.2;
+  }
+
+  if (resource === "Egg" && hasType("Retreat")) {
+    return 0.2;
+  }
+
+  if (isFruit(resource) && hasType("Beach")) {
+    return 0.2;
+  }
+
+  return 0;
+};
+
+const getStemBoost = (bud: Bud, resource: Resource): number => {
+  const hasStem = (stem: StemTrait) => bud.stem === stem;
+
+  if (isCrop(resource) && hasStem("3 Leaf Clover")) {
+    return 0.5;
+  }
+
+  if (isCrop(resource) && isBasicCrop(resource) && hasStem("Basic Leaf")) {
+    return 0.2;
+  }
+
+  if (resource === "Carrot" && hasStem("Carrot Head")) {
+    return 0.3;
+  }
+
+  if (resource === "Sunflower" && hasStem("Sunflower Hat")) {
+    return 0.5;
+  }
+
+  if (isMineral(resource) && hasStem("Diamond Gem")) {
+    return 0.2;
+  }
+
+  if (resource === "Stone" && hasStem("Ruby Gem")) {
+    return 0.2;
+  }
+
+  if (resource === "Iron" && hasStem("Miner Hat")) {
+    return 0.2;
+  }
+
+  if (resource === "Gold" && hasStem("Gold Gem")) {
+    return 0.2;
+  }
+
+  if (resource === "Wild Mushroom" && hasStem("Mushroom")) {
+    return 0.3;
+  }
+
+  if (resource === "Magic Mushroom" && hasStem("Magic Mushroom")) {
+    return 0.2;
+  }
+
+  if (resource === "Wood" && hasStem("Acorn Hat")) {
+    return 0.1;
+  }
+
+  if (resource === "Wood" && hasStem("Tree Hat")) {
+    return 0.2;
+  }
+
+  if (isFruit(resource) && hasStem("Banana")) {
+    return 0.2;
+  }
+
+  if (isFruit(resource) && hasStem("Apple Head")) {
+    return 0.2;
+  }
+
+  if (resource === "Egg" && hasStem("Egg Head")) {
+    return 0.2;
+  }
+
+  return 0;
+};
+
+export const getAuraBoost = (bud: Bud): number => {
+  if (bud.aura === "Basic") return 1.05;
+  if (bud.aura === "Green") return 1.2;
+  if (bud.aura === "Rare") return 2;
+  if (bud.aura === "Mythical") return 5;
+
+  return 1;
+};
+
+const getBudBoost = (bud: Bud, resource: Resource): number => {
+  const typeBoost = getTypeBoost(bud, resource);
+  const stemBoost = getStemBoost(bud, resource);
+  const auraBoost = getAuraBoost(bud);
+
+  return Number((auraBoost * (typeBoost + stemBoost)).toFixed(4));
+};
+
+export const getBudYieldBoosts = (
+  buds: NonNullable<GameState["buds"]>,
+  resource: Resource
+): number => {
+  const boosts = Object.values(buds)
+    // Bud must be placed to give a boost
+    .filter((bud) => !!bud.coordinates)
+    .map((bud) => getBudBoost(bud, resource));
+
+  // Get the highest boost from all the buds on the farm
+  return Math.max(0, ...boosts);
+};

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -129,7 +129,8 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       yields as CropName,
       inventory,
       collectibles,
-      state.bumpkin as Bumpkin
+      state.bumpkin as Bumpkin,
+      state.buds ?? {}
     );
   };
 

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -38,7 +38,7 @@ interface Prop {
 export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const divRef = useRef<HTMLDivElement>(null);
 
-  const { inventory, bumpkin, collectibles } = gameState;
+  const { inventory, bumpkin, collectibles, buds } = gameState;
   const basketMap = getBasketItems(inventory);
 
   const basketIsEmpty = Object.values(basketMap).length === 0;
@@ -74,7 +74,13 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     }
 
     const crop = SEEDS()[seedName].yield as CropName;
-    return getCropTime(crop, inventory, collectibles, bumpkin as Bumpkin);
+    return getCropTime(
+      crop,
+      inventory,
+      collectibles,
+      bumpkin as Bumpkin,
+      buds ?? {}
+    );
   };
 
   const harvestCounts = getFruitHarvests(gameState);


### PR DESCRIPTION
# Description

Adds the bud boosts to the front-end.

Many actions  `chop`, `ironMine`, `stoneMine`, `mineGold` use placeholder values for boosts, so these do not call the bud boost method. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
