### PR TITLE
[FIX] Fix overlapping aura

### DIFF
--- a/src/features/island/collectibles/components/Bud.tsx
+++ b/src/features/island/collectibles/components/Bud.tsx
@@ -17,7 +17,7 @@ type Props = {
 export const Bud: React.FC<Props> = ({ id, type }) => {
   return (
     <div
-      className="absolute"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 32}px`,
         height: `${PIXEL_SCALE * 32}px`,


### PR DESCRIPTION
# Description

A bud's aura was preventing players from interacting with resources.