### PR TITLE
[FIX] Pixel scale and alignments for mutant crops

### DIFF
--- a/src/features/island/collectibles/components/GiantCabbage.tsx
+++ b/src/features/island/collectibles/components/GiantCabbage.tsx
@@ -11,8 +11,9 @@ export const GiantCabbage: React.FC = () => {
         style={{
           width: `${PIXEL_SCALE * 27}px`,
           bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 3}px`,
         }}
-        className="absolute left-1/2 -translate-x-1/2"
+        className="absolute pointer-events-none"
         alt="Giant Cabbage"
       />
     </>

--- a/src/features/island/collectibles/components/GiantPotato.tsx
+++ b/src/features/island/collectibles/components/GiantPotato.tsx
@@ -6,15 +6,20 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 export const GiantPotato: React.FC = () => {
   return (
     <div
-      className="absolute flex justify-center items-end"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 17}px`,
-        height: `${PIXEL_SCALE * 24}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
-        left: "-1px",
+        left: `${PIXEL_SCALE * 0}px`,
       }}
     >
-      <img src={giantPotato} className="w-full h-full" alt="Giant Potato" />
+      <img
+        src={giantPotato}
+        style={{
+          width: `${PIXEL_SCALE * 17}px`,
+        }}
+        alt="Giant Potato"
+      />
     </div>
   );
 };

--- a/src/features/island/collectibles/components/GiantPumpkin.tsx
+++ b/src/features/island/collectibles/components/GiantPumpkin.tsx
@@ -11,8 +11,9 @@ export const GiantPumpkin: React.FC = () => {
         style={{
           width: `${PIXEL_SCALE * 26}px`,
           bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 3}px`,
         }}
-        className="absolute left-1/2 -translate-x-1/2"
+        className="absolute pointer-events-none"
         alt="Giant Pumpkin"
       />
     </>

--- a/src/features/island/collectibles/components/LabGrownCarrot.tsx
+++ b/src/features/island/collectibles/components/LabGrownCarrot.tsx
@@ -1,30 +1,33 @@
 import React from "react";
 
 import labGrownCarrot from "assets/sfts/lab_grown_carrot.gif";
-import shadow from "assets/npcs/shadow.png";
+import shadow from "assets/npcs/shadow14px.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const LabGrownCarrot: React.FC = () => {
   return (
     <div
-      className="absolute flex justify-center items-end w-full"
+      className="absolute w-full h-full pointer-events-none"
       style={{
-        height: `${PIXEL_SCALE * 22}px`,
+        width: `${PIXEL_SCALE * 22}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
       }}
     >
       <img
         src={shadow}
         style={{
-          width: `${PIXEL_SCALE * 13}px`,
+          width: `${PIXEL_SCALE * 14}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
-        className="absolute bottom-0 pointer-events-none"
+        className="absolute"
       />
       <img
         src={labGrownCarrot}
         style={{
           width: `${PIXEL_SCALE * 12}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
+          left: `${PIXEL_SCALE * 2}px`,
         }}
         className="absolute"
         alt="Lab Grown Carrot"

--- a/src/features/island/collectibles/components/LabGrownPumpkin.tsx
+++ b/src/features/island/collectibles/components/LabGrownPumpkin.tsx
@@ -1,30 +1,33 @@
 import React from "react";
 
 import labGrownPumpkin from "assets/sfts/lab_grown_pumpkin.gif";
-import shadow from "assets/npcs/shadow.png";
+import shadow from "assets/npcs/shadow14px.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const LabGrownPumpkin: React.FC = () => {
   return (
     <div
-      className="absolute flex justify-center items-end w-full"
+      className="absolute w-full h-full pointer-events-none"
       style={{
-        height: `${PIXEL_SCALE * 20}px`,
+        width: `${PIXEL_SCALE * 22}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
       }}
     >
       <img
         src={shadow}
         style={{
-          width: `${PIXEL_SCALE * 13}px`,
+          width: `${PIXEL_SCALE * 14}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
-        className="absolute bottom-0 pointer-events-none"
+        className="absolute"
       />
       <img
         src={labGrownPumpkin}
         style={{
           width: `${PIXEL_SCALE * 12}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
+          left: `${PIXEL_SCALE * 2}px`,
         }}
         className="absolute"
         alt="Lab Grown Pumpkin"

--- a/src/features/island/collectibles/components/LabGrownRadish.tsx
+++ b/src/features/island/collectibles/components/LabGrownRadish.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
 import labGrownRadish from "assets/sfts/lab_grown_radish.gif";
-import shadow from "assets/npcs/shadow.png";
+import shadow from "assets/npcs/shadow14px.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const LabGrownRadish: React.FC = () => {
   return (
     <div
-      className="absolute flex justify-center items-end w-full"
+      className="absolute w-full h-full pointer-events-none"
       style={{
-        height: `${PIXEL_SCALE * 21}px`,
+        width: `${PIXEL_SCALE * 22}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
       }}
     >
@@ -17,14 +17,17 @@ export const LabGrownRadish: React.FC = () => {
         src={shadow}
         style={{
           width: `${PIXEL_SCALE * 14}px`,
+          bottom: `${PIXEL_SCALE * 0}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
-        className="absolute bottom-0 pointer-events-none"
+        className="absolute"
       />
       <img
         src={labGrownRadish}
         style={{
           width: `${PIXEL_SCALE * 14}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
         className="absolute"
         alt="Lab Grown Radish"

--- a/src/features/island/collectibles/components/PotentPotato.tsx
+++ b/src/features/island/collectibles/components/PotentPotato.tsx
@@ -5,16 +5,21 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const PotentPotato: React.FC = () => {
   return (
-    <>
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        width: `${PIXEL_SCALE * 22}px`,
+        bottom: `${PIXEL_SCALE * -2}px`,
+        right: `${PIXEL_SCALE * -3}px`,
+      }}
+    >
       <img
         src={potatoMutant}
         style={{
           width: `${PIXEL_SCALE * 22}px`,
-          bottom: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute left-1/2 -translate-x-1/2"
         alt="Potent Potato"
       />
-    </>
+    </div>
   );
 };

--- a/src/features/island/collectibles/components/RadicalRadish.tsx
+++ b/src/features/island/collectibles/components/RadicalRadish.tsx
@@ -5,16 +5,21 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const RadicalRadish: React.FC = () => {
   return (
-    <>
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        width: `${PIXEL_SCALE * 22}px`,
+        bottom: `${PIXEL_SCALE * -2}px`,
+        right: `${PIXEL_SCALE * -3}px`,
+      }}
+    >
       <img
         src={radishMutant}
         style={{
           width: `${PIXEL_SCALE * 22}px`,
-          bottom: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute left-1/2 -translate-x-1/2"
         alt="Radical Radish"
       />
-    </>
+    </div>
   );
 };

--- a/src/features/island/collectibles/components/StellarSunflower.tsx
+++ b/src/features/island/collectibles/components/StellarSunflower.tsx
@@ -5,16 +5,21 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 
 export const StellarSunflower: React.FC = () => {
   return (
-    <>
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        width: `${PIXEL_SCALE * 22}px`,
+        bottom: `${PIXEL_SCALE * -2}px`,
+        right: `${PIXEL_SCALE * -3}px`,
+      }}
+    >
       <img
         src={sunflowerMutant}
         style={{
           width: `${PIXEL_SCALE * 22}px`,
-          bottom: `${PIXEL_SCALE * 0}px`,
         }}
-        className="absolute left-1/2 -translate-x-1/2"
         alt="Stellar Sunflower"
       />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
# Description

fixes for some collectibles (more to come):

- make sure collectibles
  - have correct pixel size and pixel placement
  - not obstructing click events that are outside their respective grids (adding pointer-events-none)

Before|After
---|---
<img width="376" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/7e4c70ee-0818-4782-a415-a4229891085a">|<img width="382" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/75675254-efba-488e-9023-e1856148e829">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- place mutant crops and all placeable items purchasable in GARTH's shop

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
