### PR TITLE
[FIX] Locking for fruits is too restrictive

### DIFF
--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -9,6 +9,8 @@ import {
 import { FRUIT, FruitName, FRUIT_SEEDS } from "features/game/types/fruits";
 import { Collectibles, GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
+import { getTimeLeft } from "lib/utils/time";
+import { FruitPatch } from "features/game/types/game";
 
 export type HarvestFruitAction = {
   type: "fruit.harvested";
@@ -27,6 +29,25 @@ type FruitYield = {
   buds: NonNullable<GameState["buds"]>;
   wearables: Equipped;
 };
+
+export function isFruitGrowing(patch: FruitPatch) {
+  const fruit = patch.fruit;
+  if (!fruit) return false;
+
+  const { name, amount, harvestsLeft, harvestedAt, plantedAt } = fruit;
+  if (!harvestsLeft) return false;
+
+  const { seed } = FRUIT()[name];
+  const { plantSeconds } = FRUIT_SEEDS()[seed];
+
+  if (harvestedAt) {
+    const replenishingTimeLeft = getTimeLeft(harvestedAt, plantSeconds);
+    if (replenishingTimeLeft > 0) return true;
+  }
+
+  const growingTimeLeft = getTimeLeft(plantedAt, plantSeconds);
+  return growingTimeLeft > 0;
+}
 
 export function getFruitYield({
   collectibles,

--- a/src/features/game/events/landExpansion/moveCollectible.test.ts
+++ b/src/features/game/events/landExpansion/moveCollectible.test.ts
@@ -1,3 +1,4 @@
+import "lib/__mocks__/configMock";
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";

--- a/src/features/game/events/landExpansion/removeBud.test.ts
+++ b/src/features/game/events/landExpansion/removeBud.test.ts
@@ -1,3 +1,4 @@
+import "lib/__mocks__/configMock";
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -7,6 +7,7 @@ import { canMine } from "features/game/events/landExpansion/stoneMine";
 import { CommodityName } from "features/game/types/resources";
 import { areUnsupportedChickensBrewing } from "features/game/events/landExpansion/removeBuilding";
 import { Bud, StemTrait, TypeTrait } from "./buds";
+import { isFruitGrowing } from "features/game/events/landExpansion/fruitHarvested";
 
 type RESTRICTION_REASON =
   | "No restriction"
@@ -48,15 +49,15 @@ function beanIsPlanted(game: GameState): Restriction {
 
 function areFruitsGrowing(game: GameState, fruit: FruitName): Restriction {
   const fruitGrowing = Object.values(game.fruitPatches ?? {}).some(
-    (patch) => patch.fruit?.name === fruit
+    (patch) => isFruitGrowing(patch) && patch.fruit?.name === fruit
   );
 
   return [fruitGrowing, `${fruit} is growing`];
 }
 
 function areAnyFruitsGrowing(game: GameState): Restriction {
-  const fruitGrowing = Object.values(game.fruitPatches ?? {}).some(
-    (patch) => !!patch.fruit?.name
+  const fruitGrowing = Object.values(game.fruitPatches ?? {}).some((patch) =>
+    isFruitGrowing(patch)
   );
 
   return [fruitGrowing, `Fruits are growing`];


### PR DESCRIPTION
# Description

The `areFruitsGrowing` and `areAnyFruitsGrowing` functions were incorrect for fruits patches that are ready to be harvested.  As a result, any fruit boost was remaining farm-locked until all patches were razed down to empty soil.

This change updates those functions so that boost items -- importantly buds -- don't get locked on farms for 3+ days.
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
