### PR TITLE
[FIX] Add Pirate Cake to getFoodExpBoost()

### DIFF
--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -124,7 +124,7 @@ export const getFoodExpBoost = (
   }
 
   if (
-    food.name in COOKABLE_CAKES &&
+    (food.name in COOKABLE_CAKES || food.name === "Pirate Cake") &&
     isCollectibleBuilt("Grain Grinder", collectibles)
   ) {
     boostedExp = boostedExp.mul(1.2);


### PR DESCRIPTION
# Description

The description of Grain Grinder refers to cakes, whether they are cookable or not.

This change updates the front-end to expand the Grain Grinder boost to include Pirate Cake.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
