### PR TITLE
[CHORE] Add farm id to the modal of the selected player in Pumpkin Plaza

### DIFF
--- a/src/features/world/ui/PlayerModals.tsx
+++ b/src/features/world/ui/PlayerModals.tsx
@@ -88,6 +88,12 @@ export const PlayerModals: React.FC = () => {
                   {/* Progress bar */}
                   <BumpkinLevel experience={player?.experience} />
                 </div>
+
+                {player?.id && (
+                  <div className="flex-auto self-start text-right text-xs mr-3 f-10">
+                    #{player?.id}
+                  </div>
+                )}
               </div>
             </>
           )}


### PR DESCRIPTION
# Description

Add farm id to the modal of the selected player in Pumpkin Plaza

# Changes

Before:
<img width="704" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/5870502/1c5217df-3585-4b0b-ab58-6fa5c3f78df8">


After:
<img width="704" alt="modal" src="https://github.com/sunflower-land/sunflower-land/assets/5870502/10dbd774-fd90-4c3f-b4c6-3b70174bf5cf">



# How Has This Been Tested?

Localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
