### PR TITLE
[Fix] Fix label box when the text overflows

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -61,7 +61,7 @@ export const Label: React.FC<Props> = ({
             className="inline-flex items-center"
             style={{
               lineHeight: "12px",
-              height: "14px",
+              height: "auto",
               paddingBottom: "2px",
             }}
           >


### PR DESCRIPTION
# Description

Fix label box's height when the text overflows

Before:
<img width="520" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/5870502/9c44ce08-5286-4acf-9a30-b27b17087567">


After:
<img width="520" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/5870502/1ee2d0d1-ae7f-4a60-8a60-c3b7a9221394">


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
