### PR TITLE
[CHORE] Temporarily Hide Unavailable Islands

### DIFF
--- a/src/features/game/expansion/components/travel/IslandList.tsx
+++ b/src/features/game/expansion/components/travel/IslandList.tsx
@@ -15,6 +15,8 @@ import { AuthMachineState } from "features/auth/lib/authMachine";
 import lockIcon from "assets/skills/lock.png";
 import levelUpIcon from "assets/icons/level_up.png";
 import goblin from "assets/buildings/goblin_sign.png";
+//import sunflorea from "assets/land/islands/sunflorea.png";
+//import snowman from "assets/npcs/snowman.png";
 import dawnBreakerBanner from "assets/decorations/banners/dawn_breaker_banner.png";
 import land from "assets/land/islands/island.webp";
 import { SUNNYSIDE } from "assets/sunnyside";

--- a/src/features/game/expansion/components/travel/IslandList.tsx
+++ b/src/features/game/expansion/components/travel/IslandList.tsx
@@ -15,8 +15,6 @@ import { AuthMachineState } from "features/auth/lib/authMachine";
 import lockIcon from "assets/skills/lock.png";
 import levelUpIcon from "assets/icons/level_up.png";
 import goblin from "assets/buildings/goblin_sign.png";
-import sunflorea from "assets/land/islands/sunflorea.png";
-import snowman from "assets/npcs/snowman.png";
 import dawnBreakerBanner from "assets/decorations/banners/dawn_breaker_banner.png";
 import land from "assets/land/islands/island.webp";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -225,27 +223,27 @@ export const IslandList: React.FC<IslandListProps> = ({
       image: SUNNYSIDE.icons.treasure,
       path: `/land/${farmId}/treasure-island`,
     },
-    {
-      name: "Stone Haven",
-      levelRequired: 20 as BumpkinLevel,
-      image: SUNNYSIDE.resource.boulder,
-      path: `/treasure/${farmId}`,
-      comingSoon: true,
-    },
-    {
-      name: "Sunflorea",
-      levelRequired: 30 as BumpkinLevel,
-      image: sunflorea,
-      path: `/treasure/${farmId}`,
-      comingSoon: true,
-    },
-    {
-      name: "Snow Kingdom",
-      levelRequired: 50 as BumpkinLevel,
-      image: snowman,
-      path: `/snow/${farmId}`,
-      comingSoon: true,
-    },
+    //{
+    //  name: "Stone Haven",
+    //  levelRequired: 20 as BumpkinLevel,
+    //  image: SUNNYSIDE.resource.boulder,
+    //  path: `/treasure/${farmId}`,
+    //  comingSoon: true,
+    //},
+    //{
+    //  name: "Sunflorea",
+    //  levelRequired: 30 as BumpkinLevel,
+    //  image: sunflorea,
+    //  path: `/treasure/${farmId}`,
+    //  comingSoon: true,
+    //},
+    //{
+    //  name: "Snow Kingdom",
+    //  levelRequired: 50 as BumpkinLevel,
+    //  image: snowman,
+    //  path: `/snow/${farmId}`,
+    //  comingSoon: true,
+    //},
   ];
 
   // NOTE: If you're visiting without a session then just show the form by default as there is no option to return to a farm


### PR DESCRIPTION
# Description

This PR is an extension to @brian-man's PR #2915 

- As these islands has been listed as 'coming soon' since the start of land expansion, I thought it will be good to hide them until their islands have started development.
- This also prevents confusion to new players asking when these islands will be released when we don't have concrete info about them yet

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/615d08dd-4672-4686-bb9b-57a02e963d56)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/7f7cefb6-0274-409d-9e6b-9018962902b9)

I have left the code there as comments in the code so that when we want to reenable them we can just remove the comment tag
Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran Local Host

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
