### PR TITLE
[FIX] Cannot load farm if fish not in ITEM_DETAILS

### DIFF
--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -144,7 +144,7 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
           <p>Congrats</p>
           {getKeys(fishing.wharf.caught ?? {}).map((name) => (
             <div className="flex" key={name}>
-              <img src={ITEM_DETAILS[name].image} className="h-6" />
+              <img src={ITEM_DETAILS[name]?.image} className="h-6" />
               <span className="text-sm">{name}</span>
             </div>
           ))}


### PR DESCRIPTION
# Description

My testnet farm won't load.

I suspect it's because the `undefined` here:
```
        "fishing": {
            "wharf": {
                "castedAt": 1697134118506,
                "caught": {
                    "undefined": 1
                },
                "chum": "Potato"
            }
        },
```

But I also saw a similar error message (but not blocking farm load) after catching `Fish B`.

This change attempts to make the code generally more resilient so that farm loading isn't broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
