### PR TITLE
[FIX] Withdraw requirements for Angel/Devil Wings

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -791,7 +791,11 @@ const canWithdrawBoostedWearable = (
     );
   }
 
-  if (wearable === "Green Amulet") {
+  if (
+    wearable === "Green Amulet" ||
+    wearable === "Angel Wings" ||
+    wearable === "Devil Wings"
+  ) {
     return getKeys(state.crops).every((id) => !state.crops[id].crop);
   }
 
@@ -880,8 +884,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Reindeer Suit": () => true,
   "Shark Onesie": () => true,
   "Christmas Background": () => true,
-  "Devil Wings": () => true,
-  "Angel Wings": () => true,
+  "Devil Wings": (state) => canWithdrawBoostedWearable("Devil Wings", state),
+  "Angel Wings": (state) => canWithdrawBoostedWearable("Angel Wings", state),
   "Fire Hair": () => true,
   "Luscious Hair": () => true,
   "Ancient War Hammer": () => true,


### PR DESCRIPTION
# Description

Angel Wings and Devil Wings really should follow the same withdraw rules as Green Amulet.

This change updates Angel and Devil Wings to match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
