### PR TITLE
Remove unused FERTILISE_FRUIT_ERRORS.FRUIT_EXISTS

### DIFF
--- a/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
+++ b/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
@@ -8,7 +8,6 @@ import { GameState, PlantedFruit } from "features/game/types/game";
 
 export enum FERTILISE_FRUIT_ERRORS {
   EMPTY_PATCH = "Fruit Patch does not exist!",
-  FRUIT_EXISTS = "There no fruit planted!",
   READY_TO_HARVEST = "Fruit is ready to harvest!",
   FRUIT_ALREADY_FERTILISED = "Fruit is already fertilised!",
   NO_FERTILISER_SELECTED = "No fertiliser selected!",


### PR DESCRIPTION
# Description

I was about to update the text to fix the grammar, but noticed that the value is no longer used.
