### PR TITLE
[CHORE] Change Order of Categories in Basket

### DIFF
--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -186,20 +186,20 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
       content={
         <>
           {itemsSection("Seeds", allSeeds)}
-          {itemsSection("Tools", allTools)}
-          {itemsSection("Crops", crops)}
-          {itemsSection("Fruits", fruits)}
-          {itemsSection("Resources", resources)}
-          {itemsSection("Exotic", exotic)}
-          {itemsSection("Bounty", [...bounty, ...exotics])}
-          {itemsSection("Foods", consumables)}
           {itemsSection("Fertilisers", [
             ...cropCompost,
             ...fruitCompost,
             ...fertilisers,
           ])}
+          {itemsSection("Crops", crops)}
+          {itemsSection("Fruits", fruits)}
+          {itemsSection("Tools", allTools)}
+          {itemsSection("Resources", resources)}
           {itemsSection("Bait", bait)}
           {itemsSection("Fish", fish)}
+          {itemsSection("Foods", consumables)}
+          {itemsSection("Exotic", exotic)}
+          {itemsSection("Bounty", [...bounty, ...exotics])}
           {itemsSection("Coupons", coupons)}
           {itemsSection("Easter Eggs", easterEggs)}
         </>


### PR DESCRIPTION
# Description

_I deleted the previous PR #3008 cuz it had some weird thing with the merge of branches_

- Move Fertiliser Category up below seeds to eliminate the need to scroll down to select the fertilisers
- Reorganised Categories to be a bit more thematic with one another (Seeds, Crops, Fertilisers & Fruits; Tools & Resources; Bait & Fish; Consumables & Others)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
