### PR TITLE
[FIX] Crop progress with boosts

### DIFF
--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -202,6 +202,7 @@ export const ProgressBar: React.FC<Props> = ({
 interface LiveProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   startAt: number;
   endAt: number;
+  formatLength: TimeFormatLength;
   onComplete: () => void;
 }
 
@@ -212,6 +213,7 @@ interface LiveProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
 export const LiveProgressBar: React.FC<LiveProgressBarProps> = ({
   startAt,
   endAt,
+  formatLength,
   onComplete,
   ...divProps
 }) => {
@@ -238,7 +240,7 @@ export const LiveProgressBar: React.FC<LiveProgressBarProps> = ({
   return (
     <ProgressBar
       seconds={secondsLeft}
-      formatLength="short"
+      formatLength={formatLength}
       percentage={percentage}
       type="progress"
       {...divProps}

--- a/src/features/island/buildings/components/building/composters/Composter.tsx
+++ b/src/features/island/buildings/components/building/composters/Composter.tsx
@@ -100,6 +100,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
             <LiveProgressBar
               startAt={composter?.producing?.startedAt}
               endAt={composter?.producing?.readyAt}
+              formatLength="short"
               className="relative"
               style={{
                 width: `${PIXEL_SCALE * 14}px`,

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -16,7 +16,7 @@ import { NonFertilePlot } from "./components/NonFertilePlot";
 import { FertilePlot } from "./components/FertilePlot";
 import { ChestReward } from "../common/chest-reward/ChestReward";
 import { Context } from "features/game/GameProvider";
-import { useSelector } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
 import { BuildingName } from "features/game/types/buildings";
 import { ZoomContext } from "components/ZoomProvider";
@@ -50,6 +50,17 @@ export const Plot: React.FC<Props> = ({ id }) => {
 
   const crop = crops?.[id]?.crop;
   const fertiliser = crops?.[id]?.fertiliser;
+
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
+  const inventory = state.inventory;
+  const collectibles = state.collectibles;
+  const bumpkin = state.bumpkin;
+  const buds = state.buds;
+  const plot = crops[id];
 
   const isFertile = isPlotFertile({
     plotIndex: id,
@@ -165,6 +176,11 @@ export const Plot: React.FC<Props> = ({ id }) => {
       <div onClick={onClick} className="w-full h-full relative">
         <FertilePlot
           cropName={crop?.name}
+          inventory={inventory}
+          collectibles={collectibles}
+          bumpkin={bumpkin}
+          buds={buds}
+          plot={plot}
           plantedAt={crop?.plantedAt}
           fertiliser={fertiliser}
           procAnimation={procAnimation}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -4,19 +4,32 @@ import { CROPS, CropName } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { GrowthStage, Soil } from "features/island/plots/components/Soil";
-import { Bar, ProgressBar } from "components/ui/ProgressBar";
+import { Bar, LiveProgressBar } from "components/ui/ProgressBar";
 
 import powerup from "assets/icons/level_up.png";
 
 import { TimerPopover } from "../../common/TimerPopover";
-import { getTimeLeft } from "lib/utils/time";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import classNames from "classnames";
-import { CropFertiliser } from "features/game/types/game";
+import {
+  Bumpkin,
+  Collectibles,
+  CropFertiliser,
+  CropPlot,
+  GameState,
+  Inventory,
+} from "features/game/types/game";
 import { SUNNYSIDE } from "assets/sunnyside";
+
+import { getCropTime } from "features/game/events/landExpansion/plant";
 
 interface Props {
   cropName?: CropName;
+  inventory: Inventory;
+  collectibles: Collectibles;
+  bumpkin?: Bumpkin;
+  buds?: NonNullable<GameState["buds"]>;
+  plot: CropPlot;
   plantedAt?: number;
   fertiliser?: CropFertiliser;
   procAnimation?: JSX.Element;
@@ -26,6 +39,11 @@ interface Props {
 
 const FertilePlotComponent: React.FC<Props> = ({
   cropName,
+  inventory,
+  collectibles,
+  bumpkin,
+  buds,
+  plot,
   plantedAt,
   fertiliser,
   procAnimation,
@@ -34,10 +52,29 @@ const FertilePlotComponent: React.FC<Props> = ({
 }) => {
   const [showTimerPopover, setShowTimerPopover] = useState(false);
 
-  const harvestSeconds = cropName ? CROPS()[cropName].harvestSeconds : 0;
-  const timeLeft = plantedAt ? getTimeLeft(plantedAt, harvestSeconds) : 0;
+  const [_, setRender] = useState<number>(0);
+
+  let harvestSeconds = cropName ? CROPS()[cropName].harvestSeconds : 0;
+  const readyAt = plantedAt ? plantedAt + harvestSeconds * 1000 : 0;
+
+  let startAt = plantedAt ?? 0;
+  if (cropName && bumpkin) {
+    const fertiliserName = fertiliser?.name ?? undefined;
+    harvestSeconds = getCropTime({
+      crop: cropName,
+      inventory,
+      collectibles,
+      bumpkin,
+      buds: buds ?? {},
+      plot,
+      fertiliser: fertiliserName,
+    });
+    startAt = readyAt - harvestSeconds * 1000;
+  }
+  const timeLeft = readyAt > 0 ? (readyAt - Date.now()) / 1000 : 0;
   const isGrowing = timeLeft > 0;
 
+  // REVIEW: Is this still needed after changing to LiveProgressBar?
   useUiRefresher({ active: isGrowing });
 
   const growPercentage = 100 - (timeLeft / harvestSeconds) * 100;
@@ -143,7 +180,7 @@ const FertilePlotComponent: React.FC<Props> = ({
       )}
 
       {/* Progres bar for growing crops */}
-      {showTimers && timeLeft > 0 && (
+      {showTimers && isGrowing && (
         <div
           className="absolute pointer-events-none"
           style={{
@@ -151,11 +188,11 @@ const FertilePlotComponent: React.FC<Props> = ({
             width: `${PIXEL_SCALE * 15}px`,
           }}
         >
-          <ProgressBar
-            percentage={growPercentage}
-            seconds={timeLeft}
-            type="progress"
+          <LiveProgressBar
+            startAt={startAt}
+            endAt={readyAt}
             formatLength="short"
+            onComplete={() => setRender((r) => r + 1)}
           />
         </div>
       )}


### PR DESCRIPTION
# Description

The progress bar for crops does not reflect duration boosts, which is especially odd for significant boosts like Cabbage Girl and Mysterious Parsnip.

This change updates the progress bar for crops to use `getCropTime()` for better progress reporting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
