### PR TITLE
[FIX] Change Label Icon of Radiant Ray from Iron Ore to Iron

### DIFF
--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -60,8 +60,6 @@ import goblinLantern from "assets/decorations/lanterns/goblin_lantern.png";
 import poppy from "assets/sfts/poppy.png";
 import kernaldo from "assets/sfts/kernaldo.png";
 
-import ironStone from "assets/resources/iron_small.png";
-
 // AoE items
 import basicScarecrow from "assets/sfts/aoe/basic_scarecrow.png";
 import emeraldTurtle from "assets/sfts/aoe/emerald_turtle.webp";
@@ -2777,7 +2775,7 @@ export const ITEM_DETAILS: Items = {
       labelType: "success",
       shortDescription: "+0.1 Iron",
       boostTypeIcon: powerup,
-      boostedItemIcon: ironStone,
+      boostedItemIcon: iron,
     },
     itemType: "collectible",
   },


### PR DESCRIPTION
# Description

Icon for the Gilded Swordfish shows the Gold Ingot, so to standardise, the Radiant Ray should also show the Iron Ingot as well
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/3f4e191f-f626-48dd-baee-0e058090ccb9)

Current
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/bd29fefc-73ca-4fd2-ac19-1d663f1a9140)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/bcd3ae59-90be-4701-9059-0c3e1613f4d9)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
