### PR TITLE
[FIX] LiveProgressBar percentage attribute

### DIFF
--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -218,7 +218,7 @@ export const LiveProgressBar: React.FC<LiveProgressBarProps> = ({
   const [secondsLeft, setSecondsLeft] = useState((endAt - Date.now()) / 1000);
 
   const totalSeconds = (endAt - startAt) / 1000;
-  const percentage = secondsLeft / totalSeconds;
+  const percentage = (100 * (totalSeconds - secondsLeft)) / totalSeconds;
 
   const active = endAt >= startAt;
 


### PR DESCRIPTION
The percentage attribute was being calculated incorrectly resulting in composters showing an "always empty" progress bar.