### PR TITLE
[FIX] Banana description

### DIFF
--- a/src/features/game/types/fruits.ts
+++ b/src/features/game/types/fruits.ts
@@ -51,7 +51,7 @@ export const FRUIT_SEEDS: () => Record<FruitSeedName, FruitSeed> = () => ({
   },
   "Banana Plant": {
     sfl: marketRate(70),
-    description: "Oh Banana!",
+    description: "Oh banana!",
     plantSeconds: 12 * 60 * 60,
     bumpkinLevel: 16,
     yield: "Banana",
@@ -92,7 +92,7 @@ export const FRUIT: () => Record<FruitName, Fruit> = () => ({
     bumpkinLevel: 15,
   },
   Banana: {
-    description: "Oh Banana!",
+    description: "Oh banana!",
     name: "Banana",
     sellPrice: marketRate(25),
     isBush: true,

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -767,7 +767,7 @@ export const ITEM_DETAILS: Items = {
     image: orange,
   },
   Banana: {
-    description: FRUIT()["Orange"].description,
+    description: FRUIT()["Banana"].description,
     image: banana,
   },
   Honey: {


### PR DESCRIPTION
# Description

The in-game UI (at the Market NPC) was displaying the Orange description for Banana.

This change fixes that issue and standardizes the casing for the Orange and Orange Plant descriptions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
