### PR TITLE
[FEAT] Season Changeover

### DIFF
--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -9,6 +9,7 @@ import { analytics } from "lib/analytics";
 import cloneDeep from "lodash.clonedeep";
 import { startChore } from "./startChore";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 
 export type CompleteChoreAction = {
   type: "chore.completed";
@@ -46,6 +47,12 @@ function completeDawnBreakerChore({
 
   if (game.bumpkin.id !== hayseedHank.progress?.bumpkinId) {
     throw new Error("Not the same Bumpkin");
+  }
+
+  const { tasksAreFrozen } = getSeasonChangeover();
+
+  if (tasksAreFrozen) {
+    throw new Error("Chores are frozen");
   }
 
   const activity = hayseedHank.chore.activity;

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -12,6 +12,7 @@ import {
 import { getSeasonalTicket } from "features/game/types/seasons";
 import { hasFeatureAccess } from "lib/flags";
 import { NPCName } from "lib/npcs";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 import cloneDeep from "lodash.clonedeep";
 
 export type DeliverOrderAction = {
@@ -181,6 +182,11 @@ export function deliverOrder({ state, action }: Options): GameState {
 
   if (order.readyAt > Date.now()) {
     throw new Error("Order has not started");
+  }
+
+  const { tasksAreFrozen } = getSeasonChangeover();
+  if (tasksAreFrozen) {
+    throw new Error("Tasks are frozen");
   }
 
   getKeys(order.items).forEach((name) => {

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -46,7 +46,27 @@ export const SEASON_TICKET_NAME: Record<SeasonName, SeasonalTicket> = {
   "Catch the Kraken": "Mermaid Scale",
 };
 
-export function getCurrentSeason(): SeasonName {
+export function getCurrentSeason(now = new Date()): SeasonName {
+  const seasons = Object.keys(SEASONS) as SeasonName[];
+
+  const currentSeason = seasons.find((season) => {
+    const { startDate, endDate } = SEASONS[season];
+
+    return now >= startDate && now <= endDate;
+  });
+
+  if (!currentSeason) {
+    throw new Error("No Season found");
+  }
+
+  return currentSeason;
+}
+
+/**
+ * Preseason is the period where time sensitive features pause (deliveries, chores etc.)
+ * This ensures a smooth transition and testing period.
+ */
+export function isPreSeason(): SeasonName {
   const now = new Date();
 
   const seasons = Object.keys(SEASONS) as SeasonName[];

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -62,28 +62,6 @@ export function getCurrentSeason(now = new Date()): SeasonName {
   return currentSeason;
 }
 
-/**
- * Preseason is the period where time sensitive features pause (deliveries, chores etc.)
- * This ensures a smooth transition and testing period.
- */
-export function isPreSeason(): SeasonName {
-  const now = new Date();
-
-  const seasons = Object.keys(SEASONS) as SeasonName[];
-
-  const currentSeason = seasons.find((season) => {
-    const { startDate, endDate } = SEASONS[season];
-
-    return now >= startDate && now <= endDate;
-  });
-
-  if (!currentSeason) {
-    throw new Error("No Season found");
-  }
-
-  return currentSeason;
-}
-
 export function getSeasonalTicket(): SeasonalTicket {
   const currentSeason = getCurrentSeason();
 

--- a/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
+++ b/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
@@ -6,6 +6,10 @@ import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import { DailyChore } from "./DailyChore";
 import { acknowledgeChores } from "../lib/chores";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { secondsToString } from "lib/utils/time";
+import { Label } from "components/ui/Label";
 
 interface Props {
   isReadOnly?: boolean;
@@ -28,8 +32,37 @@ export const ChoreV2: React.FC<Props> = ({ isReadOnly = false }) => {
     );
   }
 
+  const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
+    getSeasonChangeover();
   return (
     <>
+      {
+        // Give 24 hours heads up before tasks close
+        tasksAreClosing && (
+          <div className="flex flex-col items-center mb-2">
+            <p className="text-xs text-center">
+              A new season approaches, chores will temporarily close.
+            </p>
+            <Label type="info" icon={SUNNYSIDE.icons.timer} className="mt-1">
+              {secondsToString((tasksCloseAt - Date.now()) / 1000, {
+                length: "full",
+              })}
+            </Label>
+          </div>
+        )
+      }
+      {tasksAreFrozen && (
+        <div className="flex flex-col items-center mb-2">
+          <p className="text-xs text-center">
+            New Seasonal Chores opening soon.
+          </p>
+          <Label type="info" icon={SUNNYSIDE.icons.stopwatch} className="mt-1">
+            {secondsToString((tasksStartAt - Date.now()) / 1000, {
+              length: "full",
+            })}
+          </Label>
+        </div>
+      )}
       {getKeys(chores.chores).map((choreId, index) => {
         const chore = chores.chores[choreId];
 

--- a/src/features/helios/components/hayseedHank/components/DailyChore.tsx
+++ b/src/features/helios/components/hayseedHank/components/DailyChore.tsx
@@ -12,6 +12,7 @@ import { ResizableBar } from "components/ui/ProgressBar";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { OuterPanel } from "components/ui/Panel";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 
 const isDateOnSameDayAsToday = (date: Date) => {
   const today = new Date();
@@ -69,6 +70,8 @@ export const DailyChore: React.FC<Props> = ({ id, chore, isReadOnly }) => {
 
   const isTaskComplete = progress >= chore.requirement;
 
+  const { tasksAreFrozen } = getSeasonChangeover();
+
   return (
     <OuterPanel className="p-2 mb-2">
       <div className="flex justify-between">
@@ -112,13 +115,14 @@ export const DailyChore: React.FC<Props> = ({ id, chore, isReadOnly }) => {
                 <Button
                   className="text-sm w-24 h-8 mr-2"
                   onClick={() => skip(id)}
+                  disabled={tasksAreFrozen}
                 >
                   Skip
                 </Button>
               )}
 
               <Button
-                disabled={!isTaskComplete}
+                disabled={!isTaskComplete || tasksAreFrozen}
                 className="text-sm w-24 h-8"
                 onClick={() => complete(id)}
               >

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -41,6 +41,7 @@ import { ResizableBar } from "components/ui/ProgressBar";
 import { Revealing } from "features/game/components/Revealing";
 import { Revealed } from "features/game/components/Revealed";
 import { Label } from "components/ui/Label";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 
 // Bumpkins
 export const BEACH_BUMPKINS: NPCName[] = [
@@ -167,6 +168,9 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
     return <Revealed onAcknowledged={() => setIsRevealing(false)} />;
   }
 
+  const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
+    getSeasonChangeover();
+
   return (
     <div className="flex md:flex-row flex-col-reverse md:mr-1">
       <div
@@ -215,6 +219,38 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
             }}
           />
         </div>
+        {
+          // Give 24 hours heads up before tasks close
+          tasksAreClosing && (
+            <div className="flex flex-col items-center">
+              <p className="text-xs text-center">
+                A new season approaches, deliveries will temporarily close.
+              </p>
+              <Label type="info" icon={SUNNYSIDE.icons.timer} className="mt-1">
+                {secondsToString((tasksCloseAt - Date.now()) / 1000, {
+                  length: "full",
+                })}
+              </Label>
+            </div>
+          )
+        }
+        {tasksAreFrozen && (
+          <div className="flex flex-col items-center">
+            <p className="text-xs text-center">
+              New Seasonal Deliveries opening soon.
+            </p>
+            <Label
+              type="info"
+              icon={SUNNYSIDE.icons.stopwatch}
+              className="mt-1"
+            >
+              {secondsToString((tasksStartAt - Date.now()) / 1000, {
+                length: "full",
+              })}
+            </Label>
+          </div>
+        )}
+
         <div className="flex flex-row w-full flex-wrap max-h-80 scrollable overflow-y-auto">
           {orders.map((order) => (
             <div className="w-1/2 sm:w-1/3 p-1" key={order.id}>
@@ -533,11 +569,18 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
               )}
             </div>
           )}
-          {!hasFeatureAccess(gameState, "NEW_DELIVERIES") && (
-            <Button disabled={!canFulfill} onClick={deliver}>
-              Deliver
-            </Button>
+          {tasksAreFrozen && (
+            <Label
+              type="danger"
+              className="mb-1"
+              icon={SUNNYSIDE.icons.stopwatch}
+            >
+              Deliveries closed
+            </Label>
           )}
+          <Button disabled={!canFulfill || tasksAreFrozen} onClick={deliver}>
+            Deliver
+          </Button>
         </OuterPanel>
       )}
     </div>

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -24,6 +24,7 @@ import { getSeasonalTicket } from "features/game/types/seasons";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { hasFeatureAccess } from "lib/flags";
 import { DELIVERY_LEVELS } from "features/island/delivery/lib/delivery";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 
 interface OrderCardsProps {
   orders: Order[];
@@ -273,6 +274,25 @@ export const DeliveryPanelContent: React.FC<Props> = ({
       onClose();
     }
   };
+
+  const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
+    getSeasonChangeover();
+
+  if (tasksAreFrozen) {
+    return (
+      <SpeakingText
+        onClose={onClose}
+        message={[
+          {
+            text: intro,
+          },
+          {
+            text: `I am waiting for the new season to start. Come back to me then!`,
+          },
+        ]}
+      />
+    );
+  }
 
   const canFulfillAnOrder = orders.some(hasRequirements);
 

--- a/src/lib/utils/getSeasonWeek.test.ts
+++ b/src/lib/utils/getSeasonWeek.test.ts
@@ -1,0 +1,66 @@
+import { getSeasonChangeover } from "./getSeasonWeek";
+
+describe("seasonChangeover", () => {
+  it("provides changeover period for Witches Eve", () => {
+    const changeover = getSeasonChangeover(new Date("2023-10-25").getTime());
+
+    expect(changeover).toEqual({
+      tasksCloseAt: new Date("2023-10-31").getTime(),
+      tasksStartAt: new Date("2023-08-01T03:00:00Z").getTime(),
+      tasksAreClosing: false,
+      tasksAreFrozen: false,
+    });
+  });
+
+  it("sets warning mode when tasks are about to freeze", () => {
+    const changeover = getSeasonChangeover(
+      new Date("2023-10-30T02:00:00Z").getTime()
+    );
+
+    expect(changeover).toEqual({
+      tasksCloseAt: new Date("2023-10-31").getTime(),
+      tasksStartAt: new Date("2023-08-01T03:00:00Z").getTime(),
+      tasksAreClosing: true,
+      tasksAreFrozen: false,
+    });
+  });
+
+  it("freezes tasks", () => {
+    const changeover = getSeasonChangeover(
+      new Date("2023-10-31T02:00:00Z").getTime()
+    );
+
+    expect(changeover).toEqual({
+      tasksCloseAt: new Date("2023-10-31").getTime(),
+      tasksStartAt: new Date("2023-11-01T03:00:00Z").getTime(),
+      tasksAreClosing: false,
+      tasksAreFrozen: true,
+    });
+  });
+
+  it("freezes tasks during testing period", () => {
+    const changeover = getSeasonChangeover(
+      new Date("2023-11-01T02:00:00Z").getTime()
+    );
+
+    expect(changeover).toEqual({
+      tasksCloseAt: new Date("2024-01-31").getTime(),
+      tasksStartAt: new Date("2023-11-01T03:00:00Z").getTime(),
+      tasksAreClosing: false,
+      tasksAreFrozen: true,
+    });
+  });
+
+  it("starts tasks once season is in flight", () => {
+    const changeover = getSeasonChangeover(
+      new Date("2023-11-01T03:01:00Z").getTime()
+    );
+
+    expect(changeover).toEqual({
+      tasksCloseAt: new Date("2024-01-31").getTime(),
+      tasksStartAt: new Date("2023-11-01T03:00:00Z").getTime(),
+      tasksAreClosing: false,
+      tasksAreFrozen: false,
+    });
+  });
+});

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -7,7 +7,7 @@ import { SEASONS, getCurrentSeason } from "features/game/types/seasons";
  */
 export function getSeasonWeek(): SeasonWeek {
   const now = Date.now();
-  const { startDate, endDate } = SEASONS["Witches' Eve"];
+  const { startDate, endDate } = SEASONS[getCurrentSeason()];
   const endTime = endDate.getTime();
   const startTime = startDate.getTime();
 

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -1,5 +1,5 @@
 import { SeasonWeek } from "features/game/types/game";
-import { SEASONS } from "features/game/types/seasons";
+import { SEASONS, getCurrentSeason } from "features/game/types/seasons";
 
 /**
  * Helper function to get the week number of the season
@@ -20,4 +20,52 @@ export function getSeasonWeek(): SeasonWeek {
   }
 
   return Math.min(Math.max(totalWeeks + 1, 1), 13) as SeasonWeek; // Return the week number, minimum is 1, maximum is 12
+}
+
+/**
+ * Preseason is the period where time sensitive features pause
+ * This ensures a smooth transition and testing period.
+ */
+export function getSeasonTasksEndAt(): number {
+  const currentSeason = getCurrentSeason();
+
+  return SEASONS[currentSeason].endDate.getTime() - 24 * 60 * 60 * 1000;
+}
+
+/**
+ * When seasonal activities can commence (3 hrs after start)
+ */
+export function getSeasonTasksStartAt(): number {
+  let season = getCurrentSeason();
+
+  const tasksHaveEnded = getSeasonTasksEndAt() > Date.now();
+
+  // Return next season
+  if (tasksHaveEnded) {
+    season = getCurrentSeason(new Date(Date.now() + 36 * 60 * 60 * 1000));
+  }
+
+  return SEASONS[season].startDate.getTime() + 3 * 60 * 60 * 1000;
+}
+
+export function getSeasonChangeover() {
+  const season = getCurrentSeason();
+  const incomingSeason = getCurrentSeason(
+    new Date(Date.now() + 24 * 60 * 60 * 1000)
+  );
+
+  const tasksCloseAt = SEASONS[season].endDate.getTime() - 24 * 60 * 60 * 1000;
+  const tasksStartAt =
+    SEASONS[incomingSeason].startDate.getTime() + 3 * 60 * 60 * 1000;
+
+  return {
+    season,
+    incomingSeason,
+    tasksCloseAt,
+    tasksStartAt,
+    tasksAreClosing:
+      Date.now() < tasksCloseAt &&
+      Date.now() >= tasksCloseAt - 24 * 60 * 60 * 1000,
+    tasksAreFrozen: Date.now() >= tasksCloseAt && Date.now() <= tasksStartAt,
+  };
 }

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -23,8 +23,7 @@ export function getSeasonWeek(): SeasonWeek {
 }
 
 /**
- * Preseason is the period where time sensitive features pause
- * This ensures a smooth transition and testing period.
+ *
  */
 export function getSeasonTasksEndAt(): number {
   const currentSeason = getCurrentSeason();
@@ -48,24 +47,23 @@ export function getSeasonTasksStartAt(): number {
   return SEASONS[season].startDate.getTime() + 3 * 60 * 60 * 1000;
 }
 
-export function getSeasonChangeover() {
-  const season = getCurrentSeason();
-  const incomingSeason = getCurrentSeason(
-    new Date(Date.now() + 24 * 60 * 60 * 1000)
-  );
+/**
+ * Helps implement a preseason where tasks are 'frozen'
+ * This ensures a smooth transition and testing period.
+ */
+export function getSeasonChangeover(now = Date.now()) {
+  const season = getCurrentSeason(new Date(now));
+  const incomingSeason = getCurrentSeason(new Date(now + 24 * 60 * 60 * 1000));
 
   const tasksCloseAt = SEASONS[season].endDate.getTime() - 24 * 60 * 60 * 1000;
   const tasksStartAt =
     SEASONS[incomingSeason].startDate.getTime() + 3 * 60 * 60 * 1000;
 
   return {
-    season,
-    incomingSeason,
     tasksCloseAt,
     tasksStartAt,
     tasksAreClosing:
-      Date.now() < tasksCloseAt &&
-      Date.now() >= tasksCloseAt - 24 * 60 * 60 * 1000,
-    tasksAreFrozen: Date.now() >= tasksCloseAt && Date.now() <= tasksStartAt,
+      now < tasksCloseAt && now >= tasksCloseAt - 24 * 60 * 60 * 1000,
+    tasksAreFrozen: now <= tasksStartAt,
   };
 }

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -23,31 +23,6 @@ export function getSeasonWeek(): SeasonWeek {
 }
 
 /**
- *
- */
-export function getSeasonTasksEndAt(): number {
-  const currentSeason = getCurrentSeason();
-
-  return SEASONS[currentSeason].endDate.getTime() - 24 * 60 * 60 * 1000;
-}
-
-/**
- * When seasonal activities can commence (3 hrs after start)
- */
-export function getSeasonTasksStartAt(): number {
-  let season = getCurrentSeason();
-
-  const tasksHaveEnded = getSeasonTasksEndAt() > Date.now();
-
-  // Return next season
-  if (tasksHaveEnded) {
-    season = getCurrentSeason(new Date(Date.now() + 36 * 60 * 60 * 1000));
-  }
-
-  return SEASONS[season].startDate.getTime() + 3 * 60 * 60 * 1000;
-}
-
-/**
  * Helps implement a preseason where tasks are 'frozen'
  * This ensures a smooth transition and testing period.
  */


### PR DESCRIPTION
# Description

This PR implements a changeover mechanic, whereby we can smoothly transition between seasons.

The goal is to avoid any time specific edge cases that give players advantages. A 3 hour buffer will be in place that will give the core team extra time to test the season mechanics before the public gain access.

The last 24 hours of each season, tasks will be 'frozen'. This means players can see and prepare for them, but they cannot complete them until the season starts.

Since this impacts grinding players, **everyone will be airdropped 50 Crow Feathers** to ensure this does not disrupt any items they were planning on minting.

<img width="521" alt="Screenshot 2023-10-30 at 2 49 22 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/5f36c23c-8b00-4d27-9ef1-74b099d89481">


## How to test?

Run the codebase locally and test a few different cases by manually changing your clock.

1. Right now a warning message shows 
2. Tomorrow, chores and deliveries are frozen
3. 1am UTC Nov 1st chores and deliveries are still frozen
4. 3am UTC Nov 1st chores and deliveries can be completed.

## Excludes

1. API - PR coming shortly
2. Flag to allow core team to test in first 3 hours of season.