### PR TITLE
[FEAT] Dynamic Leaderboard

### DIFF
--- a/src/features/game/expansion/components/leaderboard/Leaderboard.tsx
+++ b/src/features/game/expansion/components/leaderboard/Leaderboard.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { TicketTable } from "./TicketTable";
-
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-
-import crowFeather from "assets/icons/crow_feather.webp";
 import { getRelativeTime } from "lib/utils/time";
 import { Leaderboards } from "./actions/cache";
 import { LeaderboardButton } from "./LeaderboardButton";
@@ -11,6 +8,11 @@ import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { Modal } from "react-bootstrap";
 import { fetchLeaderboardData } from "./actions/leaderboard";
 import { MazeTable } from "./MazeTable";
+import {
+  getCurrentSeason,
+  getSeasonalTicket,
+} from "features/game/types/seasons";
+import { ITEM_DETAILS } from "features/game/types/images";
 
 interface Props {
   farmId: number;
@@ -46,6 +48,8 @@ export const Leaderboard: React.FC<Props> = ({ farmId }) => {
     setShowLeaderboard(false);
   };
 
+  const seasonTicket = getSeasonalTicket();
+
   return (
     <>
       <LeaderboardButton
@@ -57,8 +61,13 @@ export const Leaderboard: React.FC<Props> = ({ farmId }) => {
           <CloseButtonPanel
             onClose={handleClose}
             tabs={[
-              { icon: crowFeather, name: "Feathers" },
-              { icon: CROP_LIFECYCLE.Corn.crop, name: "Maze" },
+              {
+                icon: ITEM_DETAILS[seasonTicket].image,
+                name: `${seasonTicket}s`,
+              },
+              ...(getCurrentSeason() === "Witches' Eve"
+                ? [{ icon: CROP_LIFECYCLE.Corn.crop, name: "Maze" }]
+                : []),
             ]}
             currentTab={leaderboardTab}
             setCurrentTab={setLeaderboardTab}
@@ -66,7 +75,7 @@ export const Leaderboard: React.FC<Props> = ({ farmId }) => {
             {leaderboardTab === 0 && (
               <div>
                 <div className="p-1 mb-1 space-y-1">
-                  <p className="text-sm">Tickets Leaderboard</p>
+                  <p className="text-sm">{`${seasonTicket} Leaderboard`}</p>
                   <p className="text-[12px]">
                     Last updated: {getRelativeTime(data.lastUpdated)}
                   </p>
@@ -91,7 +100,7 @@ export const Leaderboard: React.FC<Props> = ({ farmId }) => {
                 )}
               </div>
             )}
-            {leaderboardTab === 1 && (
+            {getCurrentSeason() === "Witches' Eve" && leaderboardTab === 1 && (
               <div>
                 <div className="p-1 mb-1 space-y-1 text-sm">
                   <p>Maze Run Leaderboard</p>


### PR DESCRIPTION
# Description

Allow leaderboard to dynamically switch over when new season starts.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

By manually returning the "Catch the Kracken" season from `getCurrentSeason`

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
