### PR TITLE
[FEAT] Admin testing

### DIFF
--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -49,7 +49,10 @@ function completeDawnBreakerChore({
     throw new Error("Not the same Bumpkin");
   }
 
-  const { tasksAreFrozen } = getSeasonChangeover(createdAt);
+  const { tasksAreFrozen } = getSeasonChangeover({
+    id: state.id,
+    now: createdAt,
+  });
 
   if (tasksAreFrozen) {
     throw new Error("Chores are frozen");

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -189,7 +189,10 @@ export function deliverOrder({
     throw new Error("Order has not started");
   }
 
-  const { tasksAreFrozen } = getSeasonChangeover(createdAt);
+  const { tasksAreFrozen } = getSeasonChangeover({
+    id: state.id,
+    now: createdAt,
+  });
   if (tasksAreFrozen) {
     throw new Error("Tasks are frozen");
   }

--- a/src/features/game/events/landExpansion/saveMaze.test.ts
+++ b/src/features/game/events/landExpansion/saveMaze.test.ts
@@ -1,3 +1,5 @@
+import "lib/__mocks__/configMock";
+
 import { MAX_FEATHERS_PER_WEEK, saveMaze } from "./saveMaze";
 import { jest } from "@jest/globals";
 import { Inventory, SeasonWeek } from "features/game/types/game";

--- a/src/features/game/events/landExpansion/startMaze.test.ts
+++ b/src/features/game/events/landExpansion/startMaze.test.ts
@@ -1,3 +1,4 @@
+import "lib/__mocks__/configMock";
 import { TEST_FARM } from "features/game/lib/constants";
 import { startMaze } from "./startMaze";
 import { getSeasonWeek } from "lib/utils/getSeasonWeek";

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -182,6 +182,7 @@ export const INITIAL_BUMPKIN: Bumpkin = {
 
 export const TEST_FARM: GameState = {
   balance: new Decimal(0),
+  id: 123,
   inventory: {
     Sunflower: new Decimal(5),
     Potato: new Decimal(12),
@@ -394,6 +395,7 @@ export const TEST_FARM: GameState = {
 
 export const EMPTY: GameState = {
   balance: new Decimal(fromWei("0")),
+  id: 123,
   createdAt: new Date().getTime(),
   inventory: {
     "Chicken Coop": new Decimal(1),

--- a/src/features/game/lib/visitingMachine.ts
+++ b/src/features/game/lib/visitingMachine.ts
@@ -107,7 +107,7 @@ export function startGame({ farmToVisitID }: { farmToVisitID: number }) {
             address: farmAccount.account,
             owner,
             isBlacklisted,
-            state: { id: farmToVisitID, ...onChain },
+            state: { ...onChain, id: farmToVisitID },
           };
         },
       },

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -711,7 +711,7 @@ export type Fishing = {
 };
 
 export interface GameState {
-  id?: number;
+  id: number;
   balance: Decimal;
   airdrops?: Airdrop[];
   farmAddress?: string;

--- a/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
+++ b/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
@@ -33,7 +33,7 @@ export const ChoreV2: React.FC<Props> = ({ isReadOnly = false }) => {
   }
 
   const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
-    getSeasonChangeover();
+    getSeasonChangeover({ id: gameService.state.context.state.id });
   return (
     <>
       {

--- a/src/features/helios/components/hayseedHank/components/DailyChore.tsx
+++ b/src/features/helios/components/hayseedHank/components/DailyChore.tsx
@@ -70,7 +70,9 @@ export const DailyChore: React.FC<Props> = ({ id, chore, isReadOnly }) => {
 
   const isTaskComplete = progress >= chore.requirement;
 
-  const { tasksAreFrozen } = getSeasonChangeover();
+  const { tasksAreFrozen } = getSeasonChangeover({
+    id: gameService.state.context.state.id,
+  });
 
   return (
     <OuterPanel className="p-2 mb-2">

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -176,7 +176,7 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
   }
 
   const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
-    getSeasonChangeover();
+    getSeasonChangeover({ id: gameService.state.context.state.id });
 
   return (
     <div className="flex md:flex-row flex-col-reverse md:mr-1">

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -275,8 +275,9 @@ export const DeliveryPanelContent: React.FC<Props> = ({
     }
   };
 
-  const { tasksAreClosing, tasksStartAt, tasksCloseAt, tasksAreFrozen } =
-    getSeasonChangeover();
+  const { tasksAreFrozen } = getSeasonChangeover({
+    id: gameService.state.context.state.id,
+  });
 
   if (tasksAreFrozen) {
     return (

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -27,6 +27,9 @@ type FeatureName =
   | "XSOLLA"
   | "BANANA";
 
+// Used for testing production features
+export const ADMIN_IDS = [1, 2, 3, 39488, 1011, 45, 130170, 29];
+
 type FeatureFlag = (game: GameState) => boolean;
 
 const featureFlags: Record<FeatureName, FeatureFlag> = {
@@ -36,7 +39,13 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
   CORN_MAZE: testnetFeatureFlag,
   NEW_FARM_FLOW: () => true,
   BUDS_DEPOSIT_FLOW: () => true,
-  FISHING: defaultFeatureFlag,
+  FISHING: (game: GameState) => {
+    if (ADMIN_IDS.includes(game.id ?? 0)) {
+      return true;
+    }
+
+    return Date.now() > SEASONS["Catch the Kraken"].startDate.getTime();
+  },
   XSOLLA: testnetFeatureFlag,
   HALLOWEEN: (game: GameState) => {
     if (Date.now() > new Date("2023-11-01").getTime()) {
@@ -64,7 +73,13 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
 
     return defaultFeatureFlag(game);
   },
-  BANANA: defaultFeatureFlag,
+  BANANA: (game: GameState) => {
+    if (Date.now() > SEASONS["Catch the Kraken"].startDate.getTime()) {
+      return true;
+    }
+
+    return defaultFeatureFlag(game);
+  },
 };
 
 export const hasFeatureAccess = (game: GameState, featureName: FeatureName) => {

--- a/src/lib/utils/getSeasonWeek.test.ts
+++ b/src/lib/utils/getSeasonWeek.test.ts
@@ -1,8 +1,12 @@
+import "lib/__mocks__/configMock";
 import { getSeasonChangeover } from "./getSeasonWeek";
 
 describe("seasonChangeover", () => {
   it("provides changeover period for Witches Eve", () => {
-    const changeover = getSeasonChangeover(new Date("2023-10-25").getTime());
+    const changeover = getSeasonChangeover({
+      id: 123,
+      now: new Date("2023-10-25").getTime(),
+    });
 
     expect(changeover).toEqual({
       tasksCloseAt: new Date("2023-10-31").getTime(),
@@ -13,9 +17,10 @@ describe("seasonChangeover", () => {
   });
 
   it("sets warning mode when tasks are about to freeze", () => {
-    const changeover = getSeasonChangeover(
-      new Date("2023-10-30T02:00:00Z").getTime()
-    );
+    const changeover = getSeasonChangeover({
+      now: new Date("2023-10-30T02:00:00Z").getTime(),
+      id: 123,
+    });
 
     expect(changeover).toEqual({
       tasksCloseAt: new Date("2023-10-31").getTime(),
@@ -26,9 +31,10 @@ describe("seasonChangeover", () => {
   });
 
   it("freezes tasks", () => {
-    const changeover = getSeasonChangeover(
-      new Date("2023-10-31T02:00:00Z").getTime()
-    );
+    const changeover = getSeasonChangeover({
+      id: 123,
+      now: new Date("2023-10-31T02:00:00Z").getTime(),
+    });
 
     expect(changeover).toEqual({
       tasksCloseAt: new Date("2023-10-31").getTime(),
@@ -39,9 +45,10 @@ describe("seasonChangeover", () => {
   });
 
   it("freezes tasks during testing period", () => {
-    const changeover = getSeasonChangeover(
-      new Date("2023-11-01T02:00:00Z").getTime()
-    );
+    const changeover = getSeasonChangeover({
+      id: 123,
+      now: new Date("2023-11-01T02:00:00Z").getTime(),
+    });
 
     expect(changeover).toEqual({
       tasksCloseAt: new Date("2024-01-31").getTime(),
@@ -52,9 +59,10 @@ describe("seasonChangeover", () => {
   });
 
   it("starts tasks once season is in flight", () => {
-    const changeover = getSeasonChangeover(
-      new Date("2023-11-01T03:01:00Z").getTime()
-    );
+    const changeover = getSeasonChangeover({
+      id: 123,
+      now: new Date("2023-11-01T03:01:00Z").getTime(),
+    });
 
     expect(changeover).toEqual({
       tasksCloseAt: new Date("2024-01-31").getTime(),

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -1,5 +1,6 @@
 import { SeasonWeek } from "features/game/types/game";
 import { SEASONS, getCurrentSeason } from "features/game/types/seasons";
+import { ADMIN_IDS } from "lib/flags";
 
 /**
  * Helper function to get the week number of the season
@@ -26,7 +27,13 @@ export function getSeasonWeek(): SeasonWeek {
  * Helps implement a preseason where tasks are 'frozen'
  * This ensures a smooth transition and testing period.
  */
-export function getSeasonChangeover(now = Date.now()) {
+export function getSeasonChangeover({
+  id,
+  now = Date.now(),
+}: {
+  id: number;
+  now?: number;
+}) {
   const season = getCurrentSeason(new Date(now));
   const incomingSeason = getCurrentSeason(new Date(now + 24 * 60 * 60 * 1000));
 
@@ -34,11 +41,13 @@ export function getSeasonChangeover(now = Date.now()) {
   const tasksStartAt =
     SEASONS[incomingSeason].startDate.getTime() + 3 * 60 * 60 * 1000;
 
+  const isAdmin = ADMIN_IDS.includes(id);
+
   return {
     tasksCloseAt,
     tasksStartAt,
     tasksAreClosing:
       now < tasksCloseAt && now >= tasksCloseAt - 24 * 60 * 60 * 1000,
-    tasksAreFrozen: now <= tasksStartAt,
+    tasksAreFrozen: !isAdmin && now <= tasksStartAt,
   };
 }


### PR DESCRIPTION
# Description

This PR enables admin testing of new season mechanics. The purpose is to double check every season mechanic in the first 3 hours.

It also disables fishing for Beta testing (until season launch), so we can reset all progress