### PR TITLE
[FIX] Hide Last Season Items

### DIFF
--- a/src/features/game/events/landExpansion/buyDecoration.test.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.test.ts
@@ -66,9 +66,9 @@ describe("buyDecoration", () => {
         },
         action: {
           type: "decoration.bought",
-          name: "Candles",
+          name: "Spooky Tree",
         },
-        createdAt: new Date("2023-07-31").getTime(),
+        createdAt: new Date("2023-08-02").getTime(),
       })
     ).toThrow("Too early");
   });
@@ -82,9 +82,9 @@ describe("buyDecoration", () => {
         },
         action: {
           type: "decoration.bought",
-          name: "Candles",
+          name: "Haunted Stump",
         },
-        createdAt: new Date("2023-11-02").getTime(),
+        createdAt: new Date("2023-09-10").getTime(),
       })
     ).toThrow("Too late");
   });

--- a/src/features/game/events/landExpansion/buyDecoration.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.ts
@@ -34,11 +34,11 @@ type Options = {
   createdAt?: number;
 };
 
-const DECORATIONS = (state: GameState) => {
+const DECORATIONS = (state: GameState, date: Date) => {
   return {
     ...BASIC_DECORATIONS(),
     ...LANDSCAPING_DECORATIONS(),
-    ...SEASONAL_DECORATIONS(state),
+    ...SEASONAL_DECORATIONS(state, date),
     ...POTION_HOUSE_DECORATIONS(),
   };
 };
@@ -49,7 +49,7 @@ export function buyDecoration({
 }: Options) {
   const stateCopy = cloneDeep(state);
   const { name } = action;
-  const desiredItem = DECORATIONS(stateCopy)[name];
+  const desiredItem = DECORATIONS(stateCopy, new Date(createdAt))[name];
 
   if (!desiredItem) {
     throw new Error("This item is not a decoration");

--- a/src/features/game/events/landExpansion/craftCollectible.test.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.test.ts
@@ -89,9 +89,9 @@ describe("craftCollectible", () => {
         },
         action: {
           type: "collectible.crafted",
-          name: "Poppy",
+          name: "Kernaldo",
         },
-        createdAt: new Date("2023-07-31").getTime(),
+        createdAt: new Date("2023-08-10").getTime(),
       })
     ).toThrow("Too early");
   });

--- a/src/features/game/events/landExpansion/craftCollectible.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.ts
@@ -48,7 +48,7 @@ export function craftCollectible({
 
   const item = isPotionHouseItem(action.name)
     ? POTION_HOUSE_ITEMS[action.name]
-    : HELIOS_BLACKSMITH_ITEMS(state)[action.name];
+    : HELIOS_BLACKSMITH_ITEMS(state, new Date(createdAt))[action.name];
 
   if (!item) {
     throw new Error("Item does not exist");

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -98,8 +98,12 @@ export type CraftableCollectible = {
 };
 
 export const HELIOS_BLACKSMITH_ITEMS: (
-  game?: GameState
-) => Record<HeliosBlacksmithItem, CraftableCollectible> = (state) => ({
+  game?: GameState,
+  date?: Date
+) => Partial<Record<HeliosBlacksmithItem, CraftableCollectible>> = (
+  state,
+  date = new Date()
+) => ({
   Bale: {
     description:
       "A poultry's favorite neighbor, providing a cozy retreat for chickens",
@@ -120,7 +124,6 @@ export const HELIOS_BLACKSMITH_ITEMS: (
     boost: "20% faster Sunflowers, Potatoes and Pumpkins",
     sfl: new Decimal(0),
   },
-
   "Scary Mike": {
     description:
       "The veggie whisperer and champion of frightfully good harvests!",
@@ -164,70 +167,74 @@ export const HELIOS_BLACKSMITH_ITEMS: (
     },
     boost: "+20% SFL on Treasure Bounty",
   },
-  Poppy: {
-    description: "The mystical corn kernel.",
-    ingredients: {
-      Gold: new Decimal(5),
-      "Crow Feather": new Decimal(250),
+  ...(getCurrentSeason(date) === "Witches' Eve" && {
+    Poppy: {
+      description: "The mystical corn kernel.",
+      ingredients: {
+        Gold: new Decimal(5),
+        "Crow Feather": new Decimal(250),
+      },
+      boost: "+0.1 Corn",
+      from: new Date("2023-08-01"),
+      to: new Date("2023-09-01"),
     },
-    boost: "+0.1 Corn",
-    from: new Date("2023-08-01"),
-    to: new Date("2023-09-01"),
-  },
-  Kernaldo: {
-    description: "The magical corn whisperer.",
-    ingredients: {
-      "Crow Feather": new Decimal(500),
+    Kernaldo: {
+      description: "The magical corn whisperer.",
+      ingredients: {
+        "Crow Feather": new Decimal(500),
+      },
+      sfl: SFLDiscount(state, new Decimal(50)),
+      boost: "+25% Corn Speed",
+      from: new Date("2023-09-01"),
+      to: new Date("2023-10-01"),
     },
-    sfl: SFLDiscount(state, new Decimal(50)),
-    boost: "+25% Corn Speed",
-    from: new Date("2023-09-01"),
-    to: new Date("2023-10-01"),
-  },
-  "Grain Grinder": {
-    description:
-      "Grind your grain and experience a delectable surge in Cake XP.",
-    ingredients: {
-      "Crow Feather": new Decimal(750),
+    "Grain Grinder": {
+      description:
+        "Grind your grain and experience a delectable surge in Cake XP.",
+      ingredients: {
+        "Crow Feather": new Decimal(750),
+      },
+      sfl: SFLDiscount(state, new Decimal(100)),
+      boost: "+20% Cake XP",
+      from: new Date("2023-10-01"),
+      to: new Date("2023-11-01"),
     },
-    sfl: SFLDiscount(state, new Decimal(100)),
-    boost: "+20% Cake XP",
-    from: new Date("2023-10-01"),
-    to: new Date("2023-11-01"),
-  },
-  Nana: {
-    description:
-      "This rare beauty is a surefire way to boost your banana harvests.",
-    ingredients: {
-      "Mermaid Scale": new Decimal(350),
+  }),
+  ...(getCurrentSeason(date) === "Catch the Kraken" && {
+    Nana: {
+      description:
+        "This rare beauty is a surefire way to boost your banana harvests.",
+      ingredients: {
+        "Mermaid Scale": new Decimal(350),
+      },
+      sfl: SFLDiscount(state, new Decimal(50)),
+      boost: "+10% Banana Speed",
+      from: new Date("2023-11-01"),
+      to: new Date("2023-12-01"),
     },
-    sfl: SFLDiscount(state, new Decimal(50)),
-    boost: "+10% Banana Speed",
-    from: new Date("2023-11-01"),
-    to: new Date("2023-12-01"),
-  },
-  "Soil Krabby": {
-    description:
-      "Speedy sifting with a smile! Enjoy a 10% composter speed boost with this crustaceous champ.",
-    ingredients: {
-      "Mermaid Scale": new Decimal(650),
+    "Soil Krabby": {
+      description:
+        "Speedy sifting with a smile! Enjoy a 10% composter speed boost with this crustaceous champ.",
+      ingredients: {
+        "Mermaid Scale": new Decimal(650),
+      },
+      sfl: SFLDiscount(state, new Decimal(65)),
+      boost: "+10% Composter Speed",
+      from: new Date("2023-12-01"),
+      to: new Date("2024-01-01"),
     },
-    sfl: SFLDiscount(state, new Decimal(65)),
-    boost: "+10% Composter Speed",
-    from: new Date("2023-12-01"),
-    to: new Date("2024-01-01"),
-  },
-  "Skill Shrimpy": {
-    description:
-      "Shrimpy's here to help! He'll ensure you get that extra XP from fish.",
-    ingredients: {
-      "Mermaid Scale": new Decimal(865),
+    "Skill Shrimpy": {
+      description:
+        "Shrimpy's here to help! He'll ensure you get that extra XP from fish.",
+      ingredients: {
+        "Mermaid Scale": new Decimal(865),
+      },
+      sfl: SFLDiscount(state, new Decimal(115)),
+      boost: "+20% Fish XP",
+      from: new Date("2024-01-01"),
+      to: new Date("2024-02-01"),
     },
-    sfl: SFLDiscount(state, new Decimal(115)),
-    boost: "+20% Fish XP",
-    from: new Date("2024-01-01"),
-    to: new Date("2024-02-01"),
-  },
+  }),
 });
 
 export type GoblinBlacksmithCraftable = CraftableCollectible & {

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -157,7 +157,7 @@ export const HELIOS_BLACKSMITH_ITEMS: (
       Blueberry: new Decimal(10),
       Orange: new Decimal(10),
     },
-    boost: "+1 harvest",
+    boost: "+1 Harvest",
   },
   "Treasure Map": {
     description: "X marks the spot!",

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -4,6 +4,7 @@ import { Dimensions } from "./buildings";
 import { GameState, Inventory } from "./game";
 import { SFLDiscount } from "../lib/SFLDiscount";
 import { BoostTreasure, DecorationTreasure } from "./treasure";
+import { getCurrentSeason } from "./seasons";
 
 export type AchievementDecorationName =
   | "Chef Bear"
@@ -624,129 +625,138 @@ export const LANDSCAPING_DECORATIONS: () => Record<
 });
 
 export const SEASONAL_DECORATIONS: (
-  state?: GameState
-) => Partial<Record<SeasonalDecorationName, Decoration>> = (state) => ({
-  Candles: {
-    name: "Candles",
-    sfl: SFLDiscount(state, new Decimal(5)),
-    from: new Date("2023-08-01"),
-    to: new Date("2023-11-01"),
-    description:
-      "Enchant your farm with flickering spectral flames during Witches' Eve.",
-    ingredients: {
-      "Crow Feather": new Decimal(5),
+  state?: GameState,
+  date?: Date
+) => Partial<Record<SeasonalDecorationName, Decoration>> = (
+  state,
+  date = new Date()
+) => ({
+  ...(getCurrentSeason(date) === "Witches' Eve" && {
+    Candles: {
+      name: "Candles",
+      sfl: SFLDiscount(state, new Decimal(5)),
+      from: new Date("2023-08-01"),
+      to: new Date("2023-11-01"),
+      description:
+        "Enchant your farm with flickering spectral flames during Witches' Eve.",
+      ingredients: {
+        "Crow Feather": new Decimal(5),
+      },
     },
-  },
-  "Haunted Stump": {
-    name: "Haunted Stump",
-    sfl: new Decimal(0),
-    from: new Date("2023-08-01"),
-    to: new Date("2023-09-01"),
-    description: "Summon spirits and add eerie charm to your farm.",
-    ingredients: {
-      "Crow Feather": new Decimal(100),
+    "Haunted Stump": {
+      name: "Haunted Stump",
+      sfl: new Decimal(0),
+      from: new Date("2023-08-01"),
+      to: new Date("2023-09-01"),
+      description: "Summon spirits and add eerie charm to your farm.",
+      ingredients: {
+        "Crow Feather": new Decimal(100),
+      },
     },
-  },
-  "Spooky Tree": {
-    name: "Spooky Tree",
-    sfl: SFLDiscount(state, new Decimal(50)),
-    from: new Date("2023-09-01"),
-    to: new Date("2023-10-01"),
-    description: "A hauntingly fun addition to your farm's decor!",
-    ingredients: {
-      "Crow Feather": new Decimal(500),
+    "Spooky Tree": {
+      name: "Spooky Tree",
+      sfl: SFLDiscount(state, new Decimal(50)),
+      from: new Date("2023-09-01"),
+      to: new Date("2023-10-01"),
+      description: "A hauntingly fun addition to your farm's decor!",
+      ingredients: {
+        "Crow Feather": new Decimal(500),
+      },
     },
-  },
-  Observer: {
-    name: "Observer",
-    sfl: SFLDiscount(state, new Decimal(50)),
-    from: new Date("2023-10-01"),
-    to: new Date("2023-11-01"),
-    description:
-      "A perpetually roving eyeball, always vigilant and ever-watchful!",
-    ingredients: {
-      "Crow Feather": new Decimal(500),
+    Observer: {
+      name: "Observer",
+      sfl: SFLDiscount(state, new Decimal(50)),
+      from: new Date("2023-10-01"),
+      to: new Date("2023-11-01"),
+      description:
+        "A perpetually roving eyeball, always vigilant and ever-watchful!",
+      ingredients: {
+        "Crow Feather": new Decimal(500),
+      },
     },
-  },
-  "Crow Rock": {
-    name: "Crow Rock",
-    sfl: new Decimal(0),
-    from: new Date("2023-10-01"),
-    to: new Date("2023-11-01"),
-    description: "A crow perched atop a mysterious rock.",
-    ingredients: {
-      "Crow Feather": new Decimal(250),
+    "Crow Rock": {
+      name: "Crow Rock",
+      sfl: new Decimal(0),
+      from: new Date("2023-10-01"),
+      to: new Date("2023-11-01"),
+      description: "A crow perched atop a mysterious rock.",
+      ingredients: {
+        "Crow Feather": new Decimal(250),
+      },
     },
-  },
-  "Mini Corn Maze": {
-    name: "Mini Corn Maze",
-    sfl: SFLDiscount(state, new Decimal(5)),
-    from: new Date("2023-10-01"),
-    to: new Date("2023-11-01"),
-    description:
-      "A memento of the beloved maze from the 2023 Witches' Eve season.",
-    ingredients: {
-      "Crow Feather": new Decimal(50),
+    "Mini Corn Maze": {
+      name: "Mini Corn Maze",
+      sfl: SFLDiscount(state, new Decimal(5)),
+      from: new Date("2023-10-01"),
+      to: new Date("2023-11-01"),
+      description:
+        "A memento of the beloved maze from the 2023 Witches' Eve season.",
+      ingredients: {
+        "Crow Feather": new Decimal(50),
+      },
     },
-  },
-  "Lifeguard Ring": {
-    name: "Lifeguard Ring",
-    sfl: SFLDiscount(state, new Decimal(10)),
-    from: new Date("2024-01-01"),
-    to: new Date("2024-02-01"),
-    description: "Stay afloat with style, your seaside savior!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(50),
+  }),
+  ...(getCurrentSeason(date) === "Catch the Kraken" && {
+    "Lifeguard Ring": {
+      name: "Lifeguard Ring",
+      sfl: SFLDiscount(state, new Decimal(10)),
+      from: new Date("2024-01-01"),
+      to: new Date("2024-02-01"),
+      description: "Stay afloat with style, your seaside savior!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(50),
+      },
     },
-  },
-  Surfboard: {
-    name: "Surfboard",
-    from: new Date("2023-12-01"),
-    to: new Date("2024-01-01"),
-    description: "Ride the waves of wonder, beach bliss on board!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(100),
+    Surfboard: {
+      name: "Surfboard",
+      from: new Date("2023-12-01"),
+      to: new Date("2024-01-01"),
+      description: "Ride the waves of wonder, beach bliss on board!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(100),
+      },
     },
-  },
-  "Hideaway Herman": {
-    name: "Hideaway Herman",
-    sfl: SFLDiscount(state, new Decimal(15)),
-    from: new Date("2024-01-01"),
-    to: new Date("2024-02-01"),
-    description: "Herman's here to hide, but always peeks for a party!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(350),
+    "Hideaway Herman": {
+      name: "Hideaway Herman",
+      sfl: SFLDiscount(state, new Decimal(15)),
+      from: new Date("2024-01-01"),
+      to: new Date("2024-02-01"),
+      description: "Herman's here to hide, but always peeks for a party!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(350),
+      },
     },
-  },
-  "Shifty Sheldon": {
-    name: "Shifty Sheldon",
-    sfl: SFLDiscount(state, new Decimal(50)),
-    from: new Date("2023-12-01"),
-    to: new Date("2024-01-01"),
-    description: "Sheldon's sly, always scuttling to the next sandy surprise!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(500),
+    "Shifty Sheldon": {
+      name: "Shifty Sheldon",
+      sfl: SFLDiscount(state, new Decimal(50)),
+      from: new Date("2023-12-01"),
+      to: new Date("2024-01-01"),
+      description:
+        "Sheldon's sly, always scuttling to the next sandy surprise!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(500),
+      },
     },
-  },
-  "Tiki Torch": {
-    name: "Tiki Torch",
-    from: new Date("2023-11-01"),
-    to: new Date("2023-12-01"),
-    description: "Light the night, tropical vibes burning bright!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(5),
+    "Tiki Torch": {
+      name: "Tiki Torch",
+      from: new Date("2023-11-01"),
+      to: new Date("2023-12-01"),
+      description: "Light the night, tropical vibes burning bright!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(5),
+      },
     },
-  },
-  "Beach Umbrella": {
-    name: "Beach Umbrella",
-    sfl: SFLDiscount(state, new Decimal(20)),
-    from: new Date("2023-11-01"),
-    to: new Date("2023-12-01"),
-    description: "Shade, shelter, and seaside chic in one sunny setup!",
-    ingredients: {
-      "Mermaid Scale": new Decimal(250),
+    "Beach Umbrella": {
+      name: "Beach Umbrella",
+      sfl: SFLDiscount(state, new Decimal(20)),
+      from: new Date("2023-11-01"),
+      to: new Date("2023-12-01"),
+      description: "Shade, shelter, and seaside chic in one sunny setup!",
+      ingredients: {
+        "Mermaid Scale": new Decimal(250),
+      },
     },
-  },
+  }),
 });
 
 export const POTION_HOUSE_DECORATIONS: () => Record<

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -548,11 +548,7 @@ import { FRUIT, FRUIT_SEEDS } from "./fruits";
 import { CONSUMABLES } from "./consumables";
 //Golden Crop Event
 import goldenCrop from "assets/events/golden_crop/golden_crop.gif";
-import {
-  GOBLIN_PIRATE_ITEMS,
-  HELIOS_BLACKSMITH_ITEMS,
-  POTION_HOUSE_ITEMS,
-} from "./collectibles";
+import { GOBLIN_PIRATE_ITEMS, POTION_HOUSE_ITEMS } from "./collectibles";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
@@ -1927,7 +1923,7 @@ export const ITEM_DETAILS: Items = {
 
   "Immortal Pear": {
     image: immortalPear,
-    description: HELIOS_BLACKSMITH_ITEMS()["Immortal Pear"].description,
+    description: "A long-lived pear that makes fruit trees last longer.",
   },
   "Lady Bug": {
     image: ladybug,
@@ -2184,11 +2180,12 @@ export const ITEM_DETAILS: Items = {
     description: GOBLIN_PIRATE_ITEMS["Tin Turtle"].description,
   },
   "Basic Scarecrow": {
-    description: HELIOS_BLACKSMITH_ITEMS()["Basic Scarecrow"].description,
+    description: "Choosy defender of your farm's VIP (Very Important Plants)",
     image: basicScarecrow,
   },
   Bale: {
-    description: HELIOS_BLACKSMITH_ITEMS()["Bale"].description,
+    description:
+      "A poultry's favorite neighbor, providing a cozy retreat for chickens",
     image: bale,
   },
   "Sir Goldensnout": {
@@ -2202,12 +2199,13 @@ export const ITEM_DETAILS: Items = {
     },
   },
   "Scary Mike": {
-    description: HELIOS_BLACKSMITH_ITEMS()["Scary Mike"].description,
+    description:
+      "The veggie whisperer and champion of frightfully good harvests!",
     image: scaryMike,
   },
   "Laurie the Chuckle Crow": {
     description:
-      HELIOS_BLACKSMITH_ITEMS()["Laurie the Chuckle Crow"].description,
+      "With her disconcerting chuckle, she shooes peckers away from your crops!",
     image: laurie,
   },
   "Freya Fox": {

--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -37,7 +37,7 @@ export const HeliosBlacksmithItems: React.FC = () => {
   ] = useActor(gameService);
   const inventory = state.inventory;
 
-  const selectedItem = HELIOS_BLACKSMITH_ITEMS(state)[selectedName];
+  const selectedItem = HELIOS_BLACKSMITH_ITEMS(state)[selectedName]!;
   const isAlreadyCrafted = inventory[selectedName]?.greaterThanOrEqualTo(1);
 
   const lessIngredients = () =>
@@ -87,7 +87,7 @@ export const HeliosBlacksmithItems: React.FC = () => {
           {getKeys(HELIOS_BLACKSMITH_ITEMS(state)).map(
             (name: HeliosBlacksmithItem) => {
               const isTimeLimited = isNotReady(
-                HELIOS_BLACKSMITH_ITEMS(state)[name]
+                HELIOS_BLACKSMITH_ITEMS(state)[name] as CraftableCollectible
               );
 
               return (

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -88,10 +88,11 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
           disabled={!canCompleteObsession()}
           onClick={() => gameService.send("bertObsession.completed")}
         >
-          Claim {reward} feathers
+          Claim {reward} {getSeasonalTicket()}
         </Button>
         <span className="text-xs">
-          You cannot withdraw this item for 3 days after claiming feathers.
+          You cannot withdraw this item for 3 days after claiming{" "}
+          {getSeasonalTicket()}.
         </span>
       </>
     );

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -50,7 +50,7 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
   );
 
   const obsessionName = game.bertObsession?.name;
-  const reward = game.bertObsession?.reward;
+  const reward = game.bertObsession?.reward ?? 0;
 
   const image = isObsessionCollectible
     ? ITEM_DETAILS[obsessionName as InventoryItemName].image
@@ -88,7 +88,7 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
           disabled={!canCompleteObsession()}
           onClick={() => gameService.send("bertObsession.completed")}
         >
-          Claim {reward} {getSeasonalTicket()}
+          {`Claim ${reward} ${getSeasonalTicket()}${reward > 0 ? "s" : ""}`}
         </Button>
         <span className="text-xs">
           You cannot withdraw this item for 3 days after claiming{" "}


### PR DESCRIPTION
# Description

Hide last season's items from Frankie, Blacksmith and Stylist. Update tests.

<img width="497" alt="Screenshot 2023-11-02 at 10 06 13 am" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/2eebb9cf-ccb5-402f-ac9d-546c1e881d7e">
<img width="505" alt="Screenshot 2023-11-02 at 10 06 30 am" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/721bac64-ef7e-4434-ad77-b91e05bff19b">
<img width="496" alt="Screenshot 2023-11-02 at 10 06 54 am" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/e5847fc6-739e-4c66-803e-edd0e79a9aed">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, visit the stores and check all old season items are not there.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
