### PR TITLE
[FEAT] Enable withdrawals for Halloween Wearables

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1080,7 +1080,7 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Goth Hair": () => false, // Not Launched
   "Pale Potion": () => false, // Not Launched
   "Stretched Jeans": () => false, // Not Launched
-  "Skull Shirt": () => false, // Not Launched
+  "Skull Shirt": () => true, // Halloween is over
   "Victorian Hat": () => false, // Not Launched
   "Boater Hat": () => false, // Not Launched
   "Antique Dress": () => false, // Not Launched
@@ -1093,7 +1093,7 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Parsnip Horns": () => false,
   "Potato Suit": () => false,
   "Whale Hat": () => canWithdrawTimebasedItem(new Date("2023-08-09")), // AUCTION
-  "Pumpkin Shirt": () => false,
+  "Pumpkin Shirt": () => true, // Halloween is over
   Halo: () => false,
   Kama: () => canWithdrawTimebasedItem(new Date("2023-11-02")), // AUCTION
   "Grey Merch Hoodie": () => false,
@@ -1138,5 +1138,5 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Tiki Armor": () => canWithdrawTimebasedItem(new Date("2023-12-02")),
   "Tiki Mask": () => canWithdrawTimebasedItem(new Date("2024-01-02")),
   "Tiki Pants": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  "Banana Amulet": () => canWithdrawTimebasedItem(new Date("01-13-2024")),
+  "Banana Amulet": () => canWithdrawTimebasedItem(new Date("2024-01-13")),
 };

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1138,5 +1138,5 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Tiki Armor": () => canWithdrawTimebasedItem(new Date("2023-12-02")),
   "Tiki Mask": () => canWithdrawTimebasedItem(new Date("2024-01-02")),
   "Tiki Pants": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  "Banana Amulet": () => canWithdrawTimebasedItem(new Date("2024-01-13")),
+  "Banana Amulet": () => canWithdrawTimebasedItem(new Date("01-13-2024")),
 };


### PR DESCRIPTION
# Description
Now that Halloween is over these wearables should be released for trading 
- Enable withdrawals for Pumpkin Shirt and Skull Shirt

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
