### PR TITLE
[FIX] Milestone 'Claim reward' button is disabled on mainnet

### DIFF
--- a/src/features/island/hud/components/codex/components/Milestone.tsx
+++ b/src/features/island/hud/components/codex/components/Milestone.tsx
@@ -14,7 +14,6 @@ import { Collapse } from "components/ui/Collapse";
 import { Button } from "components/ui/Button";
 import { Milestone as MilestoneDetail } from "features/game/types/milestones";
 import { getKeys } from "features/game/types/craftables";
-import { CONFIG } from "lib/config";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
 
 export const MilestonePanel: React.FC<{
@@ -101,10 +100,7 @@ export const MilestonePanel: React.FC<{
             </div>
           </div>
         </div>
-        <Button
-          onClick={onClaim}
-          disabled={CONFIG.NETWORK === "mainnet" || percentageComplete < 100}
-        >
+        <Button onClick={onClaim} disabled={percentageComplete < 100}>
           <div className="flex items-center">
             <img src={chest} className="mr-1" />
             <span>Claim reward</span>


### PR DESCRIPTION
# Description

Fishing milestone rewards were disabled on mainnet as extra protection during beta period, but enablement was overlooked on feature launch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
