### PR TITLE
Enforce bumpkin level requirement for buildings

### DIFF
--- a/src/features/game/expansion/lib/buildingRequirements.ts
+++ b/src/features/game/expansion/lib/buildingRequirements.ts
@@ -1,0 +1,26 @@
+import { BuildingName, BUILDINGS } from "features/game/types/buildings";
+import {
+  EXPANSION_REQUIREMENTS,
+  Land,
+} from "features/game/expansion/lib/expansionRequirements";
+import { BumpkinLevel } from "features/game/lib/level";
+
+export function getBuildingBumpkinLevelRequired(
+  name: BuildingName,
+  index?: number
+): number {
+  let requiredExpansionLevel = 1;
+  const blueprint = BUILDINGS()[name];
+  if (blueprint) requiredExpansionLevel = blueprint[index ?? 0].unlocksAtLevel;
+  return (
+    EXPANSION_REQUIREMENTS[requiredExpansionLevel as Land]?.bumpkinLevel ?? 1
+  );
+}
+
+export function isBuildingEnabled(
+  bumpkinLevel: BumpkinLevel,
+  name: BuildingName,
+  index?: number
+): boolean {
+  return bumpkinLevel >= getBuildingBumpkinLevelRequired(name, index);
+}

--- a/src/features/game/expansion/lib/expansionRequirements.ts
+++ b/src/features/game/expansion/lib/expansionRequirements.ts
@@ -1,0 +1,69 @@
+export type Land =
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23;
+
+export interface Requirements {
+  bumpkinLevel: number;
+}
+
+const LAND_4_REQUIREMENTS: Requirements = { bumpkinLevel: 1 };
+const LAND_5_REQUIREMENTS: Requirements = { bumpkinLevel: 3 };
+const LAND_6_REQUIREMENTS: Requirements = { bumpkinLevel: 4 };
+const LAND_7_REQUIREMENTS: Requirements = { bumpkinLevel: 6 };
+const LAND_8_REQUIREMENTS: Requirements = { bumpkinLevel: 8 };
+const LAND_9_REQUIREMENTS: Requirements = { bumpkinLevel: 11 };
+const LAND_10_REQUIREMENTS: Requirements = { bumpkinLevel: 13 };
+const LAND_11_REQUIREMENTS: Requirements = { bumpkinLevel: 15 };
+const LAND_12_REQUIREMENTS: Requirements = { bumpkinLevel: 17 };
+const LAND_13_REQUIREMENTS: Requirements = { bumpkinLevel: 20 };
+const LAND_14_REQUIREMENTS: Requirements = { bumpkinLevel: 23 };
+const LAND_15_REQUIREMENTS: Requirements = { bumpkinLevel: 26 };
+const LAND_16_REQUIREMENTS: Requirements = { bumpkinLevel: 30 };
+const LAND_17_REQUIREMENTS: Requirements = { bumpkinLevel: 34 };
+const LAND_18_REQUIREMENTS: Requirements = { bumpkinLevel: 37 };
+const LAND_19_REQUIREMENTS: Requirements = { bumpkinLevel: 40 };
+const LAND_20_REQUIREMENTS: Requirements = { bumpkinLevel: 45 };
+const LAND_21_REQUIREMENTS: Requirements = { bumpkinLevel: 50 };
+const LAND_22_REQUIREMENTS: Requirements = { bumpkinLevel: 55 };
+const LAND_23_REQUIREMENTS: Requirements = { bumpkinLevel: 60 };
+
+export const EXPANSION_REQUIREMENTS: Record<Land, Requirements> = {
+  4: LAND_4_REQUIREMENTS,
+  5: LAND_5_REQUIREMENTS,
+  6: LAND_6_REQUIREMENTS,
+  7: LAND_7_REQUIREMENTS,
+  8: LAND_8_REQUIREMENTS,
+  9: LAND_9_REQUIREMENTS,
+  10: LAND_10_REQUIREMENTS,
+  11: LAND_11_REQUIREMENTS,
+  12: LAND_12_REQUIREMENTS,
+  13: LAND_13_REQUIREMENTS,
+  14: LAND_14_REQUIREMENTS,
+  15: LAND_15_REQUIREMENTS,
+  16: LAND_16_REQUIREMENTS,
+  17: LAND_17_REQUIREMENTS,
+  18: LAND_18_REQUIREMENTS,
+  19: LAND_19_REQUIREMENTS,
+  20: LAND_20_REQUIREMENTS,
+  21: LAND_21_REQUIREMENTS,
+  22: LAND_22_REQUIREMENTS,
+  23: LAND_23_REQUIREMENTS,
+};

--- a/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
+++ b/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
@@ -41,6 +41,7 @@ export const BuildingImageWrapper: React.FC<Props> = ({
 
   const getHandleDisabledOnClick = (name: string) =>
     function handleDisabledOnClick() {
+      console.log("handleDisabledOnClick");
       const bumpkinLevelRequired = getBuildingBumpkinLevelRequired(
         name as BuildingName
       );

--- a/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
+++ b/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
@@ -66,7 +66,7 @@ export const BuildingImageWrapper: React.FC<Props> = ({
           "relative w-full h-full",
           nonInteractible ? "" : "cursor-pointer hover:img-highlight"
         )}
-        onClick={nonInteractible ? getHandleDisabledOnClick(name) : onClick}
+        onClick={!enabled ? getHandleDisabledOnClick(name) : onClick}
       >
         {children}
       </div>

--- a/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
+++ b/src/features/island/buildings/components/building/BuildingImageWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useSelector } from "@xstate/react";
 import classNames from "classnames";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -12,7 +12,8 @@ import { BuildingName } from "features/game/types/buildings";
 import { MachineState } from "features/game/lib/gameMachine";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { Context } from "features/game/GameProvider";
-
+import { Modal } from "react-bootstrap";
+import lockIcon from "assets/skills/lock.png";
 /**
  * BuildingImageWrapper props
  * @param nonInteractible if the building is non interactible
@@ -38,6 +39,7 @@ export const BuildingImageWrapper: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
   const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const [warning, setWarning] = useState<JSX.Element>();
 
   const getHandleDisabledOnClick = (name: string) =>
     function handleDisabledOnClick() {
@@ -45,10 +47,12 @@ export const BuildingImageWrapper: React.FC<Props> = ({
       const bumpkinLevelRequired = getBuildingBumpkinLevelRequired(
         name as BuildingName
       );
-      return (
-        <CloseButtonPanel>
-          <div>
-            {name} requires bumpkin level {bumpkinLevelRequired} to use.
+
+      setWarning(
+        <CloseButtonPanel onClose={() => setWarning(undefined)}>
+          <div className="p-2 flex flex-col items-center">
+            <img src={lockIcon} className="w-20 my-2" />
+            <p className="text-sm">{`${name} requires Bumpkin level ${bumpkinLevelRequired} to use.`}</p>
           </div>
         </CloseButtonPanel>
       );
@@ -61,6 +65,9 @@ export const BuildingImageWrapper: React.FC<Props> = ({
 
   return (
     <>
+      <Modal centered show={!!warning}>
+        {warning}
+      </Modal>
       {/* building */}
       <div
         className={classNames(

--- a/src/features/island/buildings/components/building/bakery/Bakery.tsx
+++ b/src/features/island/buildings/components/building/bakery/Bakery.tsx
@@ -73,7 +73,7 @@ export const Bakery: React.FC<Props> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} ready={ready}>
+      <BuildingImageWrapper name="Bakery" onClick={handleClick} ready={ready}>
         <img
           src={bakery}
           className={classNames("absolute bottom-0 pointer-events-none", {

--- a/src/features/island/buildings/components/building/deli/Deli.tsx
+++ b/src/features/island/buildings/components/building/deli/Deli.tsx
@@ -71,7 +71,7 @@ export const Deli: React.FC<Props> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} ready={ready}>
+      <BuildingImageWrapper name="Deli" onClick={handleClick} ready={ready}>
         <img
           src={deli}
           className={classNames("absolute bottom-0 pointer-events-none", {

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -77,7 +77,7 @@ export const FirePit: React.FC<Props> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} ready={ready}>
+      <BuildingImageWrapper name="Fire Pit" onClick={handleClick} ready={ready}>
         <img
           src={firePit}
           className={classNames("absolute bottom-0 pointer-events-none", {

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -35,7 +35,7 @@ export const ChickenHouse: React.FC<BuildingProps> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick}>
+      <BuildingImageWrapper name="Hen House" onClick={handleClick}>
         <img
           src={building}
           className="absolute bottom-0 pointer-events-none"

--- a/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
+++ b/src/features/island/buildings/components/building/kitchen/Kitchen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import classNames from "classnames";
 
 import kitchen from "assets/buildings/kitchen.png";
@@ -72,7 +73,7 @@ export const Kitchen: React.FC<Props> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} ready={ready}>
+      <BuildingImageWrapper name="Kitchen" onClick={handleClick} ready={ready}>
         <img
           src={kitchen}
           className={classNames("absolute pointer-events-none bottom-0", {

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -49,7 +49,7 @@ export const Market: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick}>
+      <BuildingImageWrapper name="Market" onClick={handleClick}>
         <img
           src={market}
           className="absolute bottom-0 pointer-events-none"

--- a/src/features/island/buildings/components/building/smoothieShack/SmoothieShack.tsx
+++ b/src/features/island/buildings/components/building/smoothieShack/SmoothieShack.tsx
@@ -71,7 +71,11 @@ export const SmoothieShack: React.FC<Props> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} ready={ready}>
+      <BuildingImageWrapper
+        name="Smoothie Shack"
+        onClick={handleClick}
+        ready={ready}
+      >
         <img
           src={smoothieShack}
           className={classNames("absolute bottom-0 pointer-events-none", {

--- a/src/features/island/buildings/components/building/tent/Tent.tsx
+++ b/src/features/island/buildings/components/building/tent/Tent.tsx
@@ -59,7 +59,11 @@ export const Tent: React.FC<BuildingProps> = ({
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick} nonInteractible={!bumpkin}>
+      <BuildingImageWrapper
+        name="Tent"
+        onClick={handleClick}
+        nonInteractible={!bumpkin}
+      >
         <img
           src={tent}
           className="absolute"

--- a/src/features/island/buildings/components/building/toolshed/Toolshed.tsx
+++ b/src/features/island/buildings/components/building/toolshed/Toolshed.tsx
@@ -20,7 +20,11 @@ export const Toolshed: React.FC<BuildingProps> = ({ onRemove, isBuilt }) => {
   };
 
   return (
-    <BuildingImageWrapper onClick={handleClick} nonInteractible={!onRemove}>
+    <BuildingImageWrapper
+      name="Toolshed"
+      onClick={handleClick}
+      nonInteractible={!onRemove}
+    >
       <div
         className="absolute pointer-events-none"
         style={{

--- a/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
+++ b/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
@@ -54,7 +54,11 @@ export const TownCenter: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
 
   return (
     <div className="absolute h-full w-full">
-      <BuildingImageWrapper onClick={handleClick} nonInteractible={!onRemove}>
+      <BuildingImageWrapper
+        name="Town Center"
+        onClick={handleClick}
+        nonInteractible={!onRemove}
+      >
         <img
           src={townCenter}
           className="absolute pointer-events-none"

--- a/src/features/island/buildings/components/building/warehouse/Warehouse.tsx
+++ b/src/features/island/buildings/components/building/warehouse/Warehouse.tsx
@@ -20,7 +20,11 @@ export const Warehouse: React.FC<BuildingProps> = ({ onRemove, isBuilt }) => {
   };
 
   return (
-    <BuildingImageWrapper onClick={handleClick} nonInteractible={!onRemove}>
+    <BuildingImageWrapper
+      name="Warehouse"
+      onClick={handleClick}
+      nonInteractible={!onRemove}
+    >
       <div
         className="absolute pointer-events-none"
         style={{

--- a/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
+++ b/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
@@ -20,7 +20,11 @@ export const WaterWell: React.FC<BuildingProps> = ({ onRemove, isBuilt }) => {
   };
 
   return (
-    <BuildingImageWrapper onClick={handleClick} nonInteractible={!onRemove}>
+    <BuildingImageWrapper
+      name="Water Well"
+      onClick={handleClick}
+      nonInteractible={!onRemove}
+    >
       <img
         src={well}
         style={{

--- a/src/features/island/buildings/components/building/workBench/WorkBench.tsx
+++ b/src/features/island/buildings/components/building/workBench/WorkBench.tsx
@@ -49,7 +49,7 @@ export const WorkBench: React.FC<BuildingProps> = ({ isBuilt, onRemove }) => {
 
   return (
     <>
-      <BuildingImageWrapper onClick={handleClick}>
+      <BuildingImageWrapper name="Workbench" onClick={handleClick}>
         <img
           src={workbench}
           className="absolute bottom-0 pointer-events-none"


### PR DESCRIPTION
# Description

After installing a bumpkin, expanding, and placing a building, players could freely remove the bumpkin (and replace it with a lower-level bumpkin) while continuing to use the building.

This change now enforces the bumpkin level requirements for buildings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
