### PR TITLE
[FIX] Availbility Dates for Wearables in Stella's

### DIFF
--- a/src/features/game/types/stylist.ts
+++ b/src/features/game/types/stylist.ts
@@ -287,7 +287,7 @@ export const LIMITED_WEARABLES: (game: GameState) => ShopWearables = (
       ingredients: {
         "Mermaid Scale": new Decimal(250),
       },
-      from: new Date("2023-01-1"),
+      from: new Date("2024-01-1"),
       to: new Date("2024-02-01"),
     },
     "Tiki Pants": {
@@ -295,7 +295,7 @@ export const LIMITED_WEARABLES: (game: GameState) => ShopWearables = (
       ingredients: {
         "Mermaid Scale": new Decimal(250),
       },
-      from: new Date("2023-01-1"),
+      from: new Date("2024-01-1"),
       to: new Date("2024-02-01"),
     },
   }),


### PR DESCRIPTION
# Description
- Edited the typo in the availability dates for Stella

Fixes #issue
- Reel Fishing Vest and Tiki Pants being available in Stella before their supposed availability dates 

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/24718ad3-2b5f-4fa7-a4d7-6270f611c36d)
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/02e17bb1-3814-44af-b381-cf8f7f9c936b)


After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/30087fba-4be1-4e80-8b80-63dd81d936f3)
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/6aed4463-f3b1-4ad8-8ccd-9a50676154c8)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Went into LocalHost to make sure that the items are locked 

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
