### PR TITLE
[FIX] Force reel

### DIFF
--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -88,6 +88,15 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
     didRefresh.current = !!fishing.wharf.caught;
   }, []);
 
+  useEffect(() => {
+    if (
+      fishing.wharf.caught &&
+      (spriteRef.current?.getInfo("frame") ?? 0) <= FISHING_FRAMES.casting.endAt
+    ) {
+      onWaitFinish();
+    }
+  }, [fishing.wharf.caught]);
+
   let initialState: FishingState = "idle";
   if (fishing.wharf.caught || fishing.wharf.castedAt) {
     initialState = "waiting";
@@ -146,6 +155,7 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
 
     // TEMP: The reelin state is sometimes not showing automatically and players need to refresh
     // Right no they are losing resources, so comment this
+    // Remove comments in future so players don't refresh minigame
     // if (fishDifficulty && didRefresh.current) {
     //   // Player refreshed during challenge
     //   // onChallengeLost();


### PR DESCRIPTION
# Description

A few cases were discovered of players on old devices where the "Reel" button did not display for them.

This is likely caused by some lag issue that prevent the animation states from transition.

This PR introduces a fix, which will force the "Reel" flow to start if a fish is caught and the player is still in some old animation state.