### PR TITLE
[FIX] Rapid Root UI Bug

### DIFF
--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -189,6 +189,7 @@ const FertilePlotComponent: React.FC<Props> = ({
           }}
         >
           <LiveProgressBar
+            key={`${startAt}-${readyAt}`}
             startAt={startAt}
             endAt={readyAt}
             formatLength="short"


### PR DESCRIPTION
# Description

The Live Progress Bar sets the seconds left on component render. When a change happens to readyAt or plantAt, we should re-render the bar to get the correct time.

Updating the key is a way to enforce this to re-render