### PR TITLE
[FIX] Fish Encyclopedia milestone

### DIFF
--- a/src/features/game/types/milestones.ts
+++ b/src/features/game/types/milestones.ts
@@ -1,4 +1,7 @@
-import { getFishByType } from "features/island/hud/components/codex/lib/utils";
+import {
+  getEncyclopediaFish,
+  getFishByType,
+} from "features/island/hud/components/codex/lib/utils";
 import { KNOWN_IDS } from ".";
 import { BumpkinItem } from "./bumpkin";
 import { getKeys } from "./craftables";
@@ -82,9 +85,10 @@ export const FISH_MILESTONES: Record<MilestoneName, Milestone> = {
   "Fish Encyclopedia": {
     task: "Discover all fish",
     percentageComplete: (farmActivity: GameState["farmActivity"]) => {
-      const totalFishRequired = getKeys(FISH).length;
+      const encyclopediaFish = getEncyclopediaFish();
+      const totalFishRequired = encyclopediaFish.length;
 
-      const totalFishCaught = getKeys(FISH).reduce(
+      const totalFishCaught = encyclopediaFish.reduce(
         (total, name) =>
           total + Math.min(farmActivity[`${name} Caught`] ?? 0, 1),
         0

--- a/src/features/island/hud/components/codex/lib/utils.ts
+++ b/src/features/island/hud/components/codex/lib/utils.ts
@@ -42,3 +42,16 @@ export const getFishByType = () => {
 
   return fishByType;
 };
+
+export const getEncyclopediaFish = () => {
+  const encyclopediaFish: (FishName | MarineMarvelName)[] = [];
+  getKeys(FISH).forEach((fishName) => {
+    if (fishName !== "Kraken Tentacle") {
+      const fish = FISH[fishName];
+      if (fish.type !== "marine marvel") {
+        encyclopediaFish.push(fishName);
+      }
+    }
+  });
+  return encyclopediaFish;
+};


### PR DESCRIPTION
# Description

Fish Encyclopedia milestone should exclude marine marvels and Kraken Tentacle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
