### PR TITLE
[FEAT] Show auction countdown on main island and plaza

### DIFF
--- a/src/features/helios/Helios.tsx
+++ b/src/features/helios/Helios.tsx
@@ -18,7 +18,6 @@ import { randomInt } from "lib/utils/random";
 import { Hud } from "features/island/hud/Hud";
 import { GarbageCollector } from "./components/garbageCollector/GarbageCollector";
 import { HeliosAuction } from "./components/heliosAuction/HeliosAuction";
-import { AuctionCountdown } from "features/retreat/components/auctioneer/AuctionCountdown";
 import { HayseedHank } from "./components/hayseedHank/HayseedHankPlaza";
 
 const spawn = [
@@ -83,7 +82,6 @@ export const Helios: React.FC = () => {
         {gameState.context.state.hayseedHank && <HayseedHank />}
       </div>
       <Hud isFarming={false} />
-      <AuctionCountdown />
     </>
   );
 };

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -23,6 +23,7 @@ import { createPortal } from "react-dom";
 import { HalveningCountdown } from "./components/HalveningCountdown";
 import { TravelButton } from "./components/deliveries/TravelButton";
 import { CodexButton } from "./components/codex/CodexButton";
+import { AuctionCountdown } from "features/retreat/components/auctioneer/AuctionCountdown";
 
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.
@@ -155,6 +156,16 @@ const HudComponent: React.FC<{
           >
             <CodexButton />
             <TravelButton />
+          </div>
+
+          <div
+            className="fixed z-50 flex flex-col justify-between"
+            style={{
+              bottom: `${PIXEL_SCALE * 3}px`,
+              left: `${PIXEL_SCALE * 28}px`,
+            }}
+          >
+            <AuctionCountdown />
           </div>
 
           <HalveningCountdown />

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -18,6 +18,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Settings } from "./components/Settings";
 import { Leaderboard } from "features/game/expansion/components/leaderboard/Leaderboard";
 import { TravelButton } from "./components/deliveries/TravelButton";
+import { AuctionCountdown } from "features/retreat/components/auctioneer/AuctionCountdown";
 
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.
@@ -100,6 +101,16 @@ const HudComponent: React.FC = () => {
             <Leaderboard farmId={farmId} />
             <TravelButton />
           </div>
+          <div
+            className="fixed z-50 flex flex-col justify-between"
+            style={{
+              bottom: `${PIXEL_SCALE * 3}px`,
+              left: `${PIXEL_SCALE * 28}px`,
+            }}
+          >
+            <AuctionCountdown />
+          </div>
+
           <BumpkinProfile isFullUser={isFullUser} />
 
           <div

--- a/src/features/retreat/components/auctioneer/AuctionCountdown.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionCountdown.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useState } from "react";
-import { loadAuctions } from "./actions/loadAuctions";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { useActor } from "@xstate/react";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
@@ -7,26 +6,39 @@ import { TimerDisplay } from "./AuctionDetails";
 import { InnerPanel } from "components/ui/Panel";
 import { Label } from "components/ui/Label";
 import { Auction } from "features/game/lib/auctionMachine";
-import { createPortal } from "react-dom";
 import { Context } from "features/game/GameProvider";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { loadAuctions } from "./actions/loadAuctions";
 
-const Countdown: React.FC<{ auction: Auction }> = ({ auction }) => {
+const Countdown: React.FC<{ auction: Auction; onComplete: () => void }> = ({
+  auction,
+  onComplete,
+}) => {
   const start = useCountdown(auction?.startAt);
   const end = useCountdown(auction?.endAt);
 
+  useEffect(() => {
+    if (auction.endAt < Date.now()) {
+      onComplete();
+    }
+  }, [end]);
+
   if (auction.endAt < Date.now()) {
-    return (
-      <div className="h-7 flex justify-center">
-        <Label type="danger">Auction has finished</Label>
-      </div>
-    );
+    return null;
   }
 
   if (auction.startAt < Date.now()) {
     return (
       <div>
         <div className="h-6 flex justify-center">
-          <Label type="info">Auction is live!</Label>
+          <Label type="info" icon={SUNNYSIDE.icons.stopwatch} className="ml-1">
+            Auction is live!
+          </Label>
+          <img
+            src={SUNNYSIDE.icons.close}
+            className="h-5 cursor-pointer ml-2"
+            onClick={onComplete}
+          />
         </div>
         <TimerDisplay time={end} />
       </div>
@@ -35,7 +47,16 @@ const Countdown: React.FC<{ auction: Auction }> = ({ auction }) => {
 
   return (
     <div>
-      <p className="text-xxs">Next Auction</p>
+      <div className="flex">
+        <Label type="default" className="ml-1" icon={SUNNYSIDE.icons.stopwatch}>
+          Plaza Auction
+        </Label>
+        <img
+          src={SUNNYSIDE.icons.close}
+          className="h-5 cursor-pointer ml-2"
+          onClick={onComplete}
+        />
+      </div>
       <TimerDisplay time={start} />
     </div>
   );
@@ -47,7 +68,7 @@ export const AuctionCountdown: React.FC = () => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
-  const [auction, setAuction] = useState<Auction>();
+  const [auction, setAuction] = useState<Auction | undefined>();
 
   useEffect(() => {
     const load = async () => {
@@ -56,7 +77,10 @@ export const AuctionCountdown: React.FC = () => {
         transactionId: gameState.context.transactionId as string,
       });
 
-      const upcoming = auctions.filter((auction) => auction.endAt > Date.now());
+      // Show countdown 1 hour from Auction
+      const upcoming = auctions.filter(
+        (auction) => auction.startAt > Date.now() - 60 * 60 * 1000
+      );
 
       if (upcoming.length > 0) {
         setAuction(upcoming[0]);
@@ -70,13 +94,9 @@ export const AuctionCountdown: React.FC = () => {
     return null;
   }
 
-  return createPortal(
-    <InnerPanel
-      className="fixed bottom-2 left-1/2 -translate-x-1/2 flex justify-center"
-      id="test-auction"
-    >
-      <Countdown auction={auction} />
-    </InnerPanel>,
-    document.body
+  return (
+    <InnerPanel className="flex justify-center" id="test-auction">
+      <Countdown auction={auction} onComplete={() => setAuction(undefined)} />
+    </InnerPanel>
   );
 };


### PR DESCRIPTION
# Description

This PR adds the Auction Countdown from Helios to the main HUD + the plaza HUD.

**Includes**

- Styling changes
- Show Auctions 1 hour in advance
- Close Button to remove panel

<img width="358" alt="Screenshot 2023-11-09 at 11 00 10 am" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/a0cc3b4e-731e-419c-9bcf-18d20bf8fc70">
<img width="332" alt="Screenshot 2023-11-09 at 11 00 16 am" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/afcc3fff-2cff-4d41-ab0d-aec63845419c">
