### PR TITLE
[FEAT] Enforce bumpkin level requirements for nodes

### DIFF
--- a/src/features/builder/components/ResourcePlacer.tsx
+++ b/src/features/builder/components/ResourcePlacer.tsx
@@ -31,7 +31,7 @@ export const RESOURCES: Record<
   }
 > = {
   trees: {
-    component: () => <Tree id="0" />,
+    component: () => <Tree id="0" index={0} />,
     icon: SUNNYSIDE.resource.tree,
     dimensions: {
       height: 2,
@@ -39,7 +39,7 @@ export const RESOURCES: Record<
     },
   },
   fruitPatches: {
-    component: () => <FruitPatch id="0" />,
+    component: () => <FruitPatch id="0" index={0} />,
     icon: fruitPatch,
     dimensions: {
       height: 2,
@@ -55,7 +55,7 @@ export const RESOURCES: Record<
     icon: SUNNYSIDE.resource.small_stone,
   },
   iron: {
-    component: () => <Iron id="0" />,
+    component: () => <Iron id="0" index={0} />,
     dimensions: {
       height: 1,
       width: 1,
@@ -63,7 +63,7 @@ export const RESOURCES: Record<
     icon: ironStone,
   },
   gold: {
-    component: () => <Gold id="0" />,
+    component: () => <Gold id="0" index={0} />,
     dimensions: {
       height: 1,
       width: 1,
@@ -71,7 +71,7 @@ export const RESOURCES: Record<
     icon: goldStone,
   },
   plots: {
-    component: () => <Plot id="0" />,
+    component: () => <Plot id="0" index={0} />,
     dimensions: {
       height: 1,
       width: 1,

--- a/src/features/builder/components/ResourcePlacer.tsx
+++ b/src/features/builder/components/ResourcePlacer.tsx
@@ -47,7 +47,7 @@ export const RESOURCES: Record<
     },
   },
   stones: {
-    component: () => <Stone id="0" />,
+    component: () => <Stone id="0" index={0} />,
     dimensions: {
       height: 1,
       width: 1,

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -13,7 +13,12 @@ import {
 } from "../types/craftables";
 import { LandBase } from "./components/LandBase";
 import { UpcomingExpansion } from "./components/UpcomingExpansion";
-import { GameState, ExpansionConstruction, PlacedItem } from "../types/game";
+import {
+  Bumpkin,
+  GameState,
+  ExpansionConstruction,
+  PlacedItem,
+} from "../types/game";
 import { BuildingName, BUILDINGS_DIMENSIONS } from "../types/buildings";
 import { Building } from "features/island/buildings/components/building/Building";
 import { Collectible } from "features/island/collectibles/Collectible";
@@ -43,6 +48,7 @@ const getIslandElements = ({
   buildings,
   collectibles,
   chickens,
+  bumpkin,
   trees,
   stones,
   iron,
@@ -60,6 +66,7 @@ const getIslandElements = ({
   buildings: Partial<Record<BuildingName, PlacedItem[]>>;
   collectibles: Partial<Record<CollectibleName, PlacedItem[]>>;
   chickens: Partial<Record<string, Chicken>>;
+  bumpkin?: Bumpkin;
   trees: GameState["trees"];
   stones: GameState["stones"];
   iron: GameState["iron"];
@@ -167,7 +174,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(trees).map((id) => {
+    ...getKeys(trees).map((id, index) => {
       const { x, y, width, height } = trees[id];
 
       return (
@@ -184,6 +191,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -193,7 +201,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(stones).map((id) => {
+    ...getKeys(stones).map((id, index) => {
       const { x, y, width, height } = stones[id];
 
       return (
@@ -210,6 +218,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -219,7 +228,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(iron).map((id) => {
+    ...getKeys(iron).map((id, index) => {
       const { x, y, width, height } = iron[id];
 
       return (
@@ -236,6 +245,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -245,7 +255,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(gold).map((id) => {
+    ...getKeys(gold).map((id, index) => {
       const { x, y, width, height } = gold[id];
 
       return (
@@ -262,6 +272,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -271,7 +282,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(fruitPatches).map((id) => {
+    ...getKeys(fruitPatches).map((id, index) => {
       const { x, y, width, height } = fruitPatches[id];
 
       return (
@@ -287,6 +298,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -296,7 +308,7 @@ const getIslandElements = ({
   );
 
   mapPlacements.push(
-    ...getKeys(crops).map((id) => {
+    ...getKeys(crops).map((id, index) => {
       const { x, y, width, height } = crops[id];
 
       return (
@@ -312,6 +324,7 @@ const getIslandElements = ({
             createdAt={0}
             readyAt={0}
             id={id}
+            index={index}
             x={x}
             y={y}
           />
@@ -506,6 +519,7 @@ export const Land: React.FC = () => {
               buildings,
               collectibles,
               chickens,
+              bumpkin,
               trees,
               stones,
               iron,

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -102,6 +102,7 @@ const getIslandElements = ({
               <Building
                 name={name}
                 id={building.id}
+                index={itemIndex}
                 readyAt={building.readyAt}
                 createdAt={building.createdAt}
                 craftingItemName={building.crafting?.name}

--- a/src/features/game/expansion/components/resources/gold/components/RecoveredGold.tsx
+++ b/src/features/game/expansion/components/resources/gold/components/RecoveredGold.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -15,20 +16,33 @@ import { miningAudio } from "lib/utils/sfx";
 import gold from "assets/resources/gold_small.png";
 import { ZoomContext } from "components/ZoomProvider";
 
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
+import { getBumpkinLevel } from "features/game/lib/level";
+
 const tool = "Iron Pickaxe";
 
 const STRIKE_SHEET_FRAME_WIDTH = 112;
 const STRIKE_SHEET_FRAME_HEIGHT = 48;
 
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
+  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
 }
 
-const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
+const RecoveredGoldComponent: React.FC<Props> = ({
+  bumpkinLevelRequired,
+  hasTool,
+  touchCount,
+}) => {
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
+  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const strikeGif = useRef<SpriteSheetInstance>();
 
@@ -39,7 +53,12 @@ const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
     };
   }, []);
 
+  const { gameService } = useContext(Context);
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
   useEffect(() => {
+    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -48,12 +67,17 @@ const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
   }, [touchCount]);
 
   const handleHover = () => {
+    if (bumpkinTooLow) {
+      setShowBumpkinLevel(true);
+      return;
+    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
   };
 
   const handleMouseLeave = () => {
+    setShowBumpkinLevel(false);
     setShowEquipTool(false);
   };
 
@@ -74,7 +98,11 @@ const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
         {!showSpritesheet && (
           <img
             src={gold}
-            className="absolute pointer-events-none"
+            className={
+              bumpkinTooLow
+                ? "absolute pointer-events-none opacity-50"
+                : "absolute pointer-events-none"
+            }
             style={{
               width: `${PIXEL_SCALE * 14}px`,
               bottom: `${PIXEL_SCALE * 3}px`,
@@ -120,6 +148,22 @@ const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
           />
         )}
       </div>
+
+      {/* Bumpkin level warning */}
+      {showBumpkinLevel && (
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -14}px`,
+          }}
+        >
+          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
+            <div className="text-xxs mx-1 p-1">
+              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
+            </div>
+          </InnerPanel>
+        </div>
+      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/stone/Stone.tsx
+++ b/src/features/game/expansion/components/resources/stone/Stone.tsx
@@ -15,6 +15,7 @@ import { DepletingStone } from "./components/DepletingStone";
 import { RecoveredStone } from "./components/RecoveredStone";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
+import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Pickaxe";
@@ -31,11 +32,15 @@ const compareResource = (prev: Rock, next: Rock) => {
   return JSON.stringify(prev) === JSON.stringify(next);
 };
 
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
   id: string;
+  index: number;
 }
 
-export const Stone: React.FC<Props> = ({ id }) => {
+export const Stone: React.FC<Props> = ({ id, index }) => {
   const { gameService, shortcutItem } = useContext(Context);
 
   const [touchCount, setTouchCount] = useState(0);
@@ -78,9 +83,17 @@ export const Stone: React.FC<Props> = ({ id }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, STONE_RECOVERY_TIME);
   const mined = !canMine(resource, STONE_RECOVERY_TIME);
 
+  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
+    index,
+    "Stone Rock"
+  );
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
   useUiRefresher({ active: mined });
 
   const strike = () => {
+    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -116,6 +129,7 @@ export const Stone: React.FC<Props> = ({ id }) => {
       {!mined && (
         <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
           <RecoveredStone
+            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             showHelper={false} // FUTURE ENHANCEMENT

--- a/src/features/game/expansion/components/resources/stone/components/RecoveredStone.tsx
+++ b/src/features/game/expansion/components/resources/stone/components/RecoveredStone.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -16,18 +17,27 @@ import stone from "assets/resources/stone_small.png";
 import { ZoomContext } from "components/ZoomProvider";
 import { SUNNYSIDE } from "assets/sunnyside";
 
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
+import { getBumpkinLevel } from "features/game/lib/level";
+
 const tool = "Pickaxe";
 
 const STRIKE_SHEET_FRAME_WIDTH = 112;
 const STRIKE_SHEET_FRAME_HEIGHT = 48;
 
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
+  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
   showHelper: boolean;
 }
 
 const RecoveredStoneComponent: React.FC<Props> = ({
+  bumpkinLevelRequired,
   hasTool,
   touchCount,
   showHelper,
@@ -35,6 +45,7 @@ const RecoveredStoneComponent: React.FC<Props> = ({
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
+  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const strikeGif = useRef<SpriteSheetInstance>();
 
@@ -45,7 +56,12 @@ const RecoveredStoneComponent: React.FC<Props> = ({
     };
   }, []);
 
+  const { gameService } = useContext(Context);
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
   useEffect(() => {
+    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -54,12 +70,17 @@ const RecoveredStoneComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
+    if (bumpkinTooLow) {
+      setShowBumpkinLevel(true);
+      return;
+    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
   };
 
   const handleMouseLeave = () => {
+    setShowBumpkinLevel(false);
     setShowEquipTool(false);
   };
 
@@ -92,7 +113,11 @@ const RecoveredStoneComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={stone}
-            className="absolute pointer-events-none"
+            className={
+              bumpkinTooLow
+                ? "absolute pointer-events-none opacity-50"
+                : "absolute pointer-events-none"
+            }
             style={{
               width: `${PIXEL_SCALE * 14}px`,
               bottom: `${PIXEL_SCALE * 3}px`,
@@ -138,6 +163,22 @@ const RecoveredStoneComponent: React.FC<Props> = ({
           />
         )}
       </div>
+
+      {/* Bumpkin level warning */}
+      {showBumpkinLevel && (
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -14}px`,
+          }}
+        >
+          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
+            <div className="text-xxs mx-1 p-1">
+              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
+            </div>
+          </InnerPanel>
+        </div>
+      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -25,6 +25,8 @@ import { DepletedTree } from "./components/DepletedTree";
 import { DepletingTree } from "./components/DepletingTree";
 import { RecoveredTree } from "./components/RecoveredTree";
 import { gameAnalytics } from "lib/gameAnalytics";
+import { getBumpkinLevel } from "features/game/lib/level";
+import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Axe";
@@ -55,11 +57,15 @@ const compareCollectibles = (prev: Collectibles, next: Collectibles) =>
   isCollectibleBuilt("Foreman Beaver", prev) ===
   isCollectibleBuilt("Foreman Beaver", next);
 
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
   id: string;
+  index: number;
 }
 
-export const Tree: React.FC<Props> = ({ id }) => {
+export const Tree: React.FC<Props> = ({ id, index }) => {
   const { gameService, shortcutItem } = useContext(Context);
 
   const [touchCount, setTouchCount] = useState(0);
@@ -108,9 +114,17 @@ export const Tree: React.FC<Props> = ({ id }) => {
   const timeLeft = getTimeLeft(resource.wood.choppedAt, TREE_RECOVERY_TIME);
   const chopped = !canChop(resource);
 
+  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
+    index,
+    "Stone Rock"
+  );
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
   useUiRefresher({ active: chopped });
 
   const shake = () => {
+    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -165,6 +179,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
       {!chopped && (
         <div ref={divRef} className="absolute w-full h-full" onClick={shake}>
           <RecoveredTree
+            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             showHelper={treesChopped < 3 && treesChopped + 1 === Number(id)}

--- a/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
+++ b/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
+import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -15,18 +16,27 @@ import { chopAudio } from "lib/utils/sfx";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ZoomContext } from "components/ZoomProvider";
 
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
+import { getBumpkinLevel } from "features/game/lib/level";
+
 const tool = "Axe";
 
 const SHAKE_SHEET_FRAME_WIDTH = 448 / 7;
 const SHAKE_SHEET_FRAME_HEIGHT = 48;
 
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
+  bumpkinLevelRequired: number;
   hasTool: boolean;
   showHelper: boolean;
   touchCount: number;
 }
 
 const RecoveredTreeComponent: React.FC<Props> = ({
+  bumpkinLevelRequired,
   hasTool,
   touchCount,
   showHelper,
@@ -34,6 +44,7 @@ const RecoveredTreeComponent: React.FC<Props> = ({
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
+  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const shakeGif = useRef<SpriteSheetInstance>();
 
@@ -44,7 +55,12 @@ const RecoveredTreeComponent: React.FC<Props> = ({
     };
   }, []);
 
+  const { gameService } = useContext(Context);
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
   useEffect(() => {
+    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       chopAudio.play();
@@ -53,12 +69,17 @@ const RecoveredTreeComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
+    if (bumpkinTooLow) {
+      setShowBumpkinLevel(true);
+      return;
+    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
   };
 
   const handleMouseLeave = () => {
+    setShowBumpkinLevel(false);
     setShowEquipTool(false);
   };
 
@@ -91,7 +112,11 @@ const RecoveredTreeComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={SUNNYSIDE.resource.tree}
-            className="absolute pointer-events-none"
+            className={
+              bumpkinTooLow
+                ? "absolute pointer-events-none opacity-50"
+                : "absolute pointer-events-none"
+            }
             style={{
               width: `${PIXEL_SCALE * 26}px`,
               bottom: `${PIXEL_SCALE * 2}px`,
@@ -137,6 +162,22 @@ const RecoveredTreeComponent: React.FC<Props> = ({
           />
         )}
       </div>
+
+      {/* Bumpkin level warning */}
+      {showBumpkinLevel && (
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -14}px`,
+          }}
+        >
+          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
+            <div className="text-xxs mx-1 p-1">
+              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
+            </div>
+          </InnerPanel>
+        </div>
+      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -1,0 +1,133 @@
+import {
+  EXPANSION_REQUIREMENTS,
+  Land,
+} from "features/game/expansion/lib/expansionRequirements";
+import { BumpkinLevel } from "features/game/lib/level";
+
+export interface Nodes {
+  "Crop Plot": number;
+  Tree: number;
+  "Stone Rock": number;
+  "Iron Rock": number;
+  "Gold Rock": number;
+  "Fruit Patch": number;
+}
+
+// These represent the nodes received after the pack is complete.
+// For simplicity (and generosity), only the expansion level at
+// the beginning of the pack is required for the enforcement that
+// uses this data structure.
+const LAND_3_NODES: Nodes = {
+  "Crop Plot": 29,
+  Tree: 8,
+  "Stone Rock": 7,
+  "Iron Rock": 3,
+  "Gold Rock": 2,
+  "Fruit Patch": 0,
+};
+const LAND_9_NODES: Nodes = {
+  "Crop Plot": 4,
+  Tree: 3,
+  "Stone Rock": 2,
+  "Iron Rock": 2,
+  "Gold Rock": 1,
+  "Fruit Patch": 2,
+};
+const LAND_12_NODES: Nodes = {
+  "Crop Plot": 4,
+  Tree: 1,
+  "Stone Rock": 3,
+  "Iron Rock": 1,
+  "Gold Rock": 1,
+  "Fruit Patch": 3,
+};
+const LAND_15_NODES: Nodes = {
+  "Crop Plot": 2,
+  Tree: 2,
+  "Stone Rock": 1,
+  "Iron Rock": 1,
+  "Gold Rock": 1,
+  "Fruit Patch": 3,
+};
+const LAND_18_NODES: Nodes = {
+  "Crop Plot": 4,
+  Tree: 1,
+  "Stone Rock": 1,
+  "Iron Rock": 1,
+  "Gold Rock": 0,
+  "Fruit Patch": 2,
+};
+const LAND_21_NODES: Nodes = {
+  "Crop Plot": 3,
+  Tree: 2,
+  "Stone Rock": 2,
+  "Iron Rock": 2,
+  "Gold Rock": 1,
+  "Fruit Patch": 2,
+};
+
+const NO_ADDITIONAL_NODES: Nodes = {
+  "Crop Plot": 0,
+  Tree: 0,
+  "Stone Rock": 0,
+  "Iron Rock": 0,
+  "Gold Rock": 0,
+  "Fruit Patch": 0,
+};
+
+export const EXPANSION_NODES: Record<Land, Nodes> = {
+  3: LAND_3_NODES,
+  4: NO_ADDITIONAL_NODES,
+  5: NO_ADDITIONAL_NODES,
+  6: NO_ADDITIONAL_NODES,
+  7: NO_ADDITIONAL_NODES,
+  8: NO_ADDITIONAL_NODES,
+  9: LAND_9_NODES,
+  10: NO_ADDITIONAL_NODES,
+  11: NO_ADDITIONAL_NODES,
+  12: LAND_12_NODES,
+  13: NO_ADDITIONAL_NODES,
+  14: NO_ADDITIONAL_NODES,
+  15: LAND_15_NODES,
+  16: NO_ADDITIONAL_NODES,
+  17: NO_ADDITIONAL_NODES,
+  18: LAND_18_NODES,
+  19: NO_ADDITIONAL_NODES,
+  20: NO_ADDITIONAL_NODES,
+  21: LAND_21_NODES,
+  22: NO_ADDITIONAL_NODES,
+  23: NO_ADDITIONAL_NODES,
+};
+
+export function getBumpkinLevelRequiredForNode(
+  index: number,
+  nodeType: string
+): BumpkinLevel {
+  const key = nodeType as keyof Nodes;
+
+  let count = LAND_3_NODES[key];
+  for (let expansions = 4; expansions <= 23; ++expansions) {
+    if (count > index)
+      return EXPANSION_REQUIREMENTS[expansions as Land]
+        .bumpkinLevel as BumpkinLevel;
+    count += EXPANSION_NODES[expansions as Land][key];
+  }
+
+  return 65 as BumpkinLevel;
+}
+
+export function getEnabledNodeCount(
+  bumpkinLevel: BumpkinLevel,
+  nodeType: string
+): number {
+  const key = nodeType as keyof Nodes;
+
+  let count = LAND_3_NODES[key];
+  for (let expansions = 4; expansions <= 23; ++expansions) {
+    if (EXPANSION_REQUIREMENTS[expansions as Land].bumpkinLevel > bumpkinLevel)
+      break;
+    count += EXPANSION_NODES[expansions as Land][key];
+  }
+
+  return count;
+}

--- a/src/features/game/expansion/lib/expansionRequirements.ts
+++ b/src/features/game/expansion/lib/expansionRequirements.ts
@@ -1,4 +1,5 @@
 export type Land =
+  | 3
   | 4
   | 5
   | 6
@@ -24,6 +25,7 @@ export interface Requirements {
   bumpkinLevel: number;
 }
 
+const LAND_3_REQUIREMENTS: Requirements = { bumpkinLevel: 1 };
 const LAND_4_REQUIREMENTS: Requirements = { bumpkinLevel: 1 };
 const LAND_5_REQUIREMENTS: Requirements = { bumpkinLevel: 3 };
 const LAND_6_REQUIREMENTS: Requirements = { bumpkinLevel: 4 };
@@ -46,6 +48,7 @@ const LAND_22_REQUIREMENTS: Requirements = { bumpkinLevel: 55 };
 const LAND_23_REQUIREMENTS: Requirements = { bumpkinLevel: 60 };
 
 export const EXPANSION_REQUIREMENTS: Record<Land, Requirements> = {
+  3: LAND_3_REQUIREMENTS,
   4: LAND_4_REQUIREMENTS,
   5: LAND_5_REQUIREMENTS,
   6: LAND_6_REQUIREMENTS,

--- a/src/features/island/buds/Bud.tsx
+++ b/src/features/island/buds/Bud.tsx
@@ -23,7 +23,7 @@ const BudComponent: React.FC<BudProps> = ({ id, x, y }) => {
 
   if (landscaping)
     return (
-      <MoveableComponent name="Bud" id={String(id)} x={x} y={y}>
+      <MoveableComponent name="Bud" id={String(id)} index={0} x={x} y={y}>
         <_Bud id={String(id)} type={bud.type} />
       </MoveableComponent>
     );

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -15,6 +15,7 @@ import { CookableName } from "features/game/types/consumables";
 interface Prop {
   name: BuildingName;
   id: string;
+  index: number;
   readyAt: number;
   createdAt: number;
   craftingItemName?: CookableName;
@@ -26,6 +27,7 @@ interface Prop {
 
 export interface BuildingProps {
   buildingId: string;
+  buildingIndex: number;
   craftingItemName?: CookableName;
   craftingReadyAt?: number;
   isBuilt?: boolean;
@@ -35,6 +37,7 @@ export interface BuildingProps {
 const InProgressBuilding: React.FC<Prop> = ({
   name,
   id,
+  index,
   readyAt,
   createdAt,
   showTimers,
@@ -54,7 +57,7 @@ const InProgressBuilding: React.FC<Prop> = ({
         onMouseLeave={() => setShowTooltip(false)}
       >
         <div className="w-full h-full pointer-events-none opacity-50">
-          <BuildingPlaced buildingId={id} />
+          <BuildingPlaced buildingId={id} buildingIndex={index} />
         </div>
         {showTimers && (
           <div
@@ -89,6 +92,7 @@ const InProgressBuilding: React.FC<Prop> = ({
 const BuildingComponent: React.FC<Prop> = ({
   name,
   id,
+  index,
   readyAt,
   createdAt,
   craftingItemName,
@@ -110,6 +114,7 @@ const BuildingComponent: React.FC<Prop> = ({
           key={id}
           name={name}
           id={id}
+          index={index}
           readyAt={readyAt}
           createdAt={createdAt}
           showTimers={showTimers}
@@ -119,6 +124,7 @@ const BuildingComponent: React.FC<Prop> = ({
       ) : (
         <BuildingPlaced
           buildingId={id}
+          buildingIndex={index}
           craftingItemName={craftingItemName}
           craftingReadyAt={craftingReadyAt}
           isBuilt
@@ -143,6 +149,7 @@ const MoveableBuilding: React.FC<Prop> = (props) => {
     return (
       <MoveableComponent
         id={props.id}
+        index={props.index}
         name={props.name}
         x={props.x}
         y={props.y}

--- a/src/features/island/buildings/components/building/BuildingComponents.tsx
+++ b/src/features/island/buildings/components/building/BuildingComponents.tsx
@@ -24,6 +24,7 @@ import { Composter } from "./composters/Composter";
 
 export interface BuildingProps {
   buildingId: string;
+  buildingIndex: number;
   craftingItemName?: CookableName;
   craftingReadyAt?: number;
   isBuilt?: boolean;
@@ -35,31 +36,43 @@ export const BUILDING_COMPONENTS: Record<
 > = {
   "Fire Pit": ({
     buildingId,
+    buildingIndex,
     craftingItemName,
     craftingReadyAt,
     isBuilt,
   }: BuildingProps) => (
     <WithCraftingMachine
       buildingId={buildingId}
+      buildingIndex={buildingIndex}
       craftingItemName={craftingItemName}
       craftingReadyAt={craftingReadyAt}
     >
-      <FirePit buildingId={buildingId} isBuilt={isBuilt} />
+      <FirePit
+        buildingId={buildingId}
+        buildingIndex={buildingIndex}
+        isBuilt={isBuilt}
+      />
     </WithCraftingMachine>
   ),
   Workbench: WorkBench,
   Bakery: ({
     buildingId,
+    buildingIndex,
     craftingItemName,
     craftingReadyAt,
     isBuilt,
   }: BuildingProps) => (
     <WithCraftingMachine
       buildingId={buildingId}
+      buildingIndex={buildingIndex}
       craftingItemName={craftingItemName}
       craftingReadyAt={craftingReadyAt}
     >
-      <Bakery buildingId={buildingId} isBuilt={isBuilt} />
+      <Bakery
+        buildingId={buildingId}
+        buildingIndex={buildingIndex}
+        isBuilt={isBuilt}
+      />
     </WithCraftingMachine>
   ),
   Market: Market,
@@ -71,44 +84,62 @@ export const BUILDING_COMPONENTS: Record<
   "Hen House": ChickenHouse,
   Kitchen: ({
     buildingId,
+    buildingIndex,
     craftingItemName,
     craftingReadyAt,
     isBuilt,
   }: BuildingProps) => (
     <WithCraftingMachine
       buildingId={buildingId}
+      buildingIndex={buildingIndex}
       craftingItemName={craftingItemName}
       craftingReadyAt={craftingReadyAt}
     >
-      <Kitchen buildingId={buildingId} isBuilt={isBuilt} />
+      <Kitchen
+        buildingId={buildingId}
+        buildingIndex={buildingIndex}
+        isBuilt={isBuilt}
+      />
     </WithCraftingMachine>
   ),
   Deli: ({
     buildingId,
+    buildingIndex,
     craftingItemName,
     craftingReadyAt,
     isBuilt,
   }: BuildingProps) => (
     <WithCraftingMachine
       buildingId={buildingId}
+      buildingIndex={buildingIndex}
       craftingItemName={craftingItemName}
       craftingReadyAt={craftingReadyAt}
     >
-      <Deli buildingId={buildingId} isBuilt={isBuilt} />
+      <Deli
+        buildingId={buildingId}
+        buildingIndex={buildingIndex}
+        isBuilt={isBuilt}
+      />
     </WithCraftingMachine>
   ),
   "Smoothie Shack": ({
     buildingId,
+    buildingIndex,
     craftingItemName,
     craftingReadyAt,
     isBuilt,
   }: BuildingProps) => (
     <WithCraftingMachine
       buildingId={buildingId}
+      buildingIndex={buildingIndex}
       craftingItemName={craftingItemName}
       craftingReadyAt={craftingReadyAt}
     >
-      <SmoothieShack buildingId={buildingId} isBuilt={isBuilt} />
+      <SmoothieShack
+        buildingId={buildingId}
+        buildingIndex={buildingIndex}
+        isBuilt={isBuilt}
+      />
     </WithCraftingMachine>
   ),
   "Compost Bin": () => <Composter name="Compost Bin" />,

--- a/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
+++ b/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
@@ -6,7 +6,11 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { BuildingProps } from "../Building";
 
-export const WaterWell: React.FC<BuildingProps> = ({ onRemove, isBuilt }) => {
+export const WaterWell: React.FC<BuildingProps> = ({
+  onRemove,
+  isBuilt,
+  buildingIndex,
+}) => {
   const handleClick = () => {
     if (onRemove) {
       onRemove();
@@ -22,6 +26,7 @@ export const WaterWell: React.FC<BuildingProps> = ({ onRemove, isBuilt }) => {
   return (
     <BuildingImageWrapper
       name="Water Well"
+      index={buildingIndex}
       onClick={handleClick}
       nonInteractible={!onRemove}
     >

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -526,7 +526,13 @@ const LockedChicken: React.FC<Props> = (props) => {
 
 const MoveableChicken: React.FC<Props> = (props) => {
   return (
-    <MoveableComponent name="Chicken" x={props.x} y={props.y} id={props.id}>
+    <MoveableComponent
+      name="Chicken"
+      x={props.x}
+      y={props.y}
+      id={props.id}
+      index={0}
+    >
       <PlaceableChicken {...props} />
     </MoveableComponent>
   );

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -102,6 +102,7 @@ export function getRemoveAction(
 export interface MovableProps {
   name: CollectibleName | BuildingName | "Chicken" | "Bud";
   id: string;
+  index: number;
   x: number;
   y: number;
 }
@@ -111,6 +112,7 @@ const getMovingItem = (state: MachineState) => state.context.moving;
 export const MoveableComponent: React.FC<MovableProps> = ({
   name,
   id,
+  index,
   x: coordinatesX,
   y: coordinatesY,
   children,

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -52,6 +52,7 @@ const getFruitTreeStatus = (plantedFruit?: PlantedFruit): FruitTreeStatus => {
 };
 
 interface Props {
+  bumpkinLevelRequired: number;
   plantedFruit?: PlantedFruit;
   plantTree: () => void;
   harvestFruit: () => void;
@@ -62,6 +63,7 @@ interface Props {
 }
 
 export const FruitTree: React.FC<Props> = ({
+  bumpkinLevelRequired,
   plantedFruit,
   plantTree,
   harvestFruit,
@@ -118,7 +120,10 @@ export const FruitTree: React.FC<Props> = ({
   // Ready tree
   return (
     <div className="absolute w-full h-full" onClick={harvestFruit}>
-      <ReplenishedTree fruitName={name} />
+      <ReplenishedTree
+        bumpkinLevelRequired={bumpkinLevelRequired}
+        fruitName={name}
+      />
     </div>
   );
 };

--- a/src/features/island/fruit/ReplenishedTree.tsx
+++ b/src/features/island/fruit/ReplenishedTree.tsx
@@ -1,14 +1,30 @@
-import React from "react";
+import React, { useContext, useState } from "react";
+import { useSelector } from "@xstate/react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { FRUIT, FruitName } from "features/game/types/fruits";
 import { FRUIT_LIFECYCLE } from "./fruits";
 
+import { InnerPanel } from "components/ui/Panel";
+
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
+import { getBumpkinLevel } from "features/game/lib/level";
+
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
 interface Props {
+  bumpkinLevelRequired: number;
   fruitName: FruitName;
 }
 
-export const ReplenishedTree: React.FC<Props> = ({ fruitName }) => {
+export const ReplenishedTree: React.FC<Props> = ({
+  bumpkinLevelRequired,
+  fruitName,
+}) => {
+  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
+
   const lifecycle = FRUIT_LIFECYCLE[fruitName];
 
   const { isBush } = FRUIT()[fruitName];
@@ -18,17 +34,55 @@ export const ReplenishedTree: React.FC<Props> = ({ fruitName }) => {
   const left = isBanana ? 1.2 : isBush ? 4 : 3;
   const width = isBanana ? 31 : isBush ? 24 : 26;
 
+  const { gameService } = useContext(Context);
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
+
+  const handleHover = () => {
+    if (bumpkinTooLow) {
+      setShowBumpkinLevel(true);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    setShowBumpkinLevel(false);
+  };
+
   return (
-    <div className="absolute w-full h-full cursor-pointer hover:img-highlight">
+    <div
+      className="absolute w-full h-full cursor-pointer hover:img-highlight"
+      onMouseEnter={handleHover}
+      onMouseLeave={handleMouseLeave}
+    >
       <img
         src={lifecycle.ready}
-        className="absolute pointer-events-none"
+        className={
+          bumpkinTooLow
+            ? "absolute pointer-events-none opacity-50"
+            : "absolute pointer-events-none"
+        }
         style={{
           bottom: `${PIXEL_SCALE * bottom}px`,
           left: `${PIXEL_SCALE * left}px`,
           width: `${PIXEL_SCALE * width}px`,
         }}
       />
+
+      {/* Bumpkin level warning */}
+      {showBumpkinLevel && (
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -14}px`,
+          }}
+        >
+          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
+            <div className="text-xxs mx-1 p-1">
+              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
+            </div>
+          </InnerPanel>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/island/plots/components/NonFertilePlot.tsx
+++ b/src/features/island/plots/components/NonFertilePlot.tsx
@@ -6,12 +6,27 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Modal } from "react-bootstrap";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { InnerPanel } from "components/ui/Panel";
 
 const NonFertilePlotComponent = () => {
   const [showModal, setShowModal] = useState(false);
+  const [showWaterWell, setShowWaterWell] = useState(false);
+
+  const handleHover = () => {
+    setShowWaterWell(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowWaterWell(false);
+  };
+
   return (
     <>
-      <div className="w-full h-full relative cursor-pointer hover:img-highlight">
+      <div
+        className="w-full h-full relative cursor-pointer hover:img-highlight"
+        onMouseEnter={handleHover}
+        onMouseLeave={handleMouseLeave}
+      >
         <img
           src={SUNNYSIDE.soil.soil_dry}
           alt="soil image"
@@ -23,6 +38,23 @@ const NonFertilePlotComponent = () => {
           onClick={() => setShowModal(true)}
         />
       </div>
+
+      {/* Water Well warning */}
+      {showWaterWell && (
+        <div
+          className="flex justify-center absolute w-full pointer-events-none"
+          style={{
+            top: `${PIXEL_SCALE * -14}px`,
+          }}
+        >
+          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
+            <div className="text-xxs mx-1 p-1">
+              <span>Additional Water Well required.</span>
+            </div>
+          </InnerPanel>
+        </div>
+      )}
+
       <Modal centered show={showModal} onHide={() => setShowModal(false)}>
         <CloseButtonPanel
           title="These crops need water!"

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -26,6 +26,7 @@ import lockIcon from "assets/skills/lock.png";
 export interface ResourceProps {
   name: ResourceName;
   id: string;
+  index: number;
   readyAt: number;
   createdAt: number;
   x: number;


### PR DESCRIPTION
Bumpkin level requirements are now enforced for:
- crop plots
- trees
- stone rocks
- iron rocks
- gold rocks
- fruit patches
 
When bumpkin level requirements are not met, the required bumpkin level is shown to the user.  Additionally, non-interactable nodes have 50% opacity applied.

![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/00f7b066-7167-471b-a3cd-b74d2d15e3e9)

