### PR TITLE
[FIX] Change Bucket O' Worms description

### DIFF
--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -109,7 +109,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: SUNNYSIDE.icons.fish,
     },
     "Bucket O' Worms": {
-      shortDescription: "+1 Worm",
+      shortDescription: "+1 Bait",
       labelType: "success",
       boostTypeIcon: powerup,
     },


### PR DESCRIPTION
# Description

Some players were confused as to whether Bucket O' Worms affects all Bait or just Earthworm because the description says "+1 Worm", to make it clearer I've changed the description to "+1 Bait"

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/a0ddf57d-fd7a-419f-8e26-8ddc50b022d0)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/6378c117-3996-480c-a2d3-7cc214d2c1b8)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
