### PR TITLE
[FIX] Update boost descriptions for fishing wearables

### DIFF
--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -97,13 +97,13 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
     },
     "Sunflower Rod": {
-      shortDescription: "Chance +1 Fish",
+      shortDescription: "10% Chance +1 Fish",
       labelType: "vibrant",
       boostTypeIcon: lightning,
       boostedItemIcon: SUNNYSIDE.icons.fish,
     },
     Trident: {
-      shortDescription: "Chance +1 Fish",
+      shortDescription: "20% Chance +1 Fish",
       labelType: "vibrant",
       boostTypeIcon: lightning,
       boostedItemIcon: SUNNYSIDE.icons.fish,
@@ -120,7 +120,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: SUNNYSIDE.icons.fish,
     },
     "Angler Waders": {
-      shortDescription: "+10 Fish Limit",
+      shortDescription: "+10 Fishing Limit",
       labelType: "success",
       boostTypeIcon: powerup,
       boostedItemIcon: SUNNYSIDE.icons.fish,


### PR DESCRIPTION
# Description

The in-game boost descriptions for Sunflower Rod and Trident were missing specifics that are already present in the docs.

The in-game boost description for Angler Waders was phrased in a way that is easily misinterpreted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
