### PR TITLE
[POC] Outfits

### DIFF
--- a/src/features/bumpkins/components/BumpkinEquip.tsx
+++ b/src/features/bumpkins/components/BumpkinEquip.tsx
@@ -19,6 +19,8 @@ import { getKeys } from "features/game/types/craftables";
 import { Label } from "components/ui/Label";
 import classNames from "classnames";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
+import { getLocationType } from "features/farming/hud/lib/locationType";
+import { getOutfit } from "features/farming/hud/lib/outfit";
 
 const REQUIRED: BumpkinPart[] = [
   "background",
@@ -78,6 +80,15 @@ export const BumpkinEquip: React.FC = () => {
   const finish = (equipment: Equipped) => {
     gameService.send("bumpkin.equipped", {
       equipment,
+    });
+    gameService.send("SAVE");
+  };
+
+  const loadCached = () => {
+    const locationType = getLocationType();
+    console.log("Loading " + locationType + "...");
+    gameService.send("bumpkin.equipped", {
+      equipment: getOutfit(locationType),
     });
     gameService.send("SAVE");
   };
@@ -148,6 +159,16 @@ export const BumpkinEquip: React.FC = () => {
           </div>
           <Button disabled={!isDirty || warn} onClick={() => finish(equipped)}>
             <div className="flex">Save</div>
+          </Button>
+          <Button
+            disabled={!gameState.context.state.bumpkin}
+            onClick={() => loadCached()}
+          >
+            <div className="flex">
+              Load outfit for
+              <br />
+              {getLocationType()}
+            </div>
           </Button>
           {warn && <Label type="warning">{warning()}</Label>}
         </div>

--- a/src/features/farming/hud/lib/locationType.ts
+++ b/src/features/farming/hud/lib/locationType.ts
@@ -1,0 +1,8 @@
+export type LocationType = "Home" | "Social" | "Visit" | "Other";
+
+export function getLocationType(): LocationType {
+  if (window.location.href.includes("/world/")) return "Social";
+  if (window.location.href.includes("/land/")) return "Home";
+  if (window.location.href.includes("visit")) return "Visit";
+  return "Other";
+}

--- a/src/features/farming/hud/lib/outfit.ts
+++ b/src/features/farming/hud/lib/outfit.ts
@@ -1,0 +1,17 @@
+import { Bumpkin } from "features/game/types/game";
+import { Equipped } from "features/game/types/bumpkin";
+
+const LOCAL_STORAGE_KEY_PREFIX = "bumpkin.outfit.";
+
+export function cacheOutfit(bumpkin: Bumpkin, outfitName: string) {
+  localStorage.setItem(
+    LOCAL_STORAGE_KEY_PREFIX + outfitName,
+    JSON.stringify(bumpkin.equipped)
+  );
+}
+
+export function getOutfit(outfitName: string): Equipped | null {
+  const cached = localStorage.getItem(LOCAL_STORAGE_KEY_PREFIX + outfitName);
+  if (!cached || cached.length == 0) return null;
+  return JSON.parse(cached);
+}

--- a/src/features/game/events/landExpansion/equip.ts
+++ b/src/features/game/events/landExpansion/equip.ts
@@ -2,6 +2,8 @@ import { Equipped } from "features/game/types/bumpkin";
 import { getKeys } from "features/game/types/craftables";
 import { GameState, Wardrobe } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
+import { cacheOutfit } from "features/farming/hud/lib/outfit";
+import { getLocationType } from "features/farming/hud/lib/locationType";
 
 export type EquipBumpkinAction = {
   type: "bumpkin.equipped";
@@ -62,6 +64,11 @@ export function equip({
   });
 
   bumpkin.equipped = action.equipment;
+
+  const locationType = getLocationType();
+  if (locationType !== "Other") cacheOutfit(bumpkin, locationType);
+
+  cacheOutfit(bumpkin, "last");
 
   return game;
 }


### PR DESCRIPTION
# Description

Proof of Concept for Outfits feature

Equipping and saving wearables on local "has issues" so it's difficult to test things properly.

That said, the following works for me when running local:
1. When clicking Save after making a change in the Equip tab of the active bumpkin, the equipped state gets saved to bumpkin.outfit.last in browser local storage.
2. Also when step 1 happens, one of these gets created with the same content:
  - bumpkin.outfit.Home
  - bumpkin.outfit.Social
  - bumpkin.outfit.Visit
  - bumpkin.outfit.Other
3. There is a new button "Load outfit for X" where X is Home/Social/Visit/Other which loads the outfit stored in the corresponding bumpkin.outfit.X value in browser local storage.
4. The bumpkin.outfit.last value not used (yet).

Next:
What I'd like to implement (once I know how) is a setting to allow the Home, Social, Visit and Other values to (all) automatically load when entering associated locations.  (And probably remove the "Load outfit" button entirely.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
