### PR TITLE
[FEAT] Seed selection UI

### DIFF
--- a/src/features/island/plots/components/SeedSelection.tsx
+++ b/src/features/island/plots/components/SeedSelection.tsx
@@ -25,18 +25,14 @@ export const SeedSelection: React.FC<Props> = ({ onPlant, inventory }) => {
     <>
       <div className="p-2">
         {!seed && (
-          <Label
-            className="mt-2 mb-1"
-            icon={SUNNYSIDE.icons.seeds}
-            type="danger"
-          >
+          <Label className="mb-1" icon={SUNNYSIDE.icons.seeds} type="danger">
             Seed not selected
           </Label>
         )}
 
         {seed && (
           <Label
-            className="mt-2 mb-1"
+            className="mb-1"
             icon={ITEM_DETAILS[SEEDS()[seed].yield].image}
             type="default"
           >

--- a/src/features/island/plots/components/SeedSelection.tsx
+++ b/src/features/island/plots/components/SeedSelection.tsx
@@ -1,0 +1,70 @@
+import { SUNNYSIDE } from "assets/sunnyside";
+import { Box } from "components/ui/Box";
+import { Button } from "components/ui/Button";
+import { Label } from "components/ui/Label";
+import { getKeys } from "features/game/types/craftables";
+import { FRUIT_SEEDS } from "features/game/types/fruits";
+import { Inventory } from "features/game/types/game";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { SEEDS, SeedName } from "features/game/types/seeds";
+import React, { useState } from "react";
+
+interface Props {
+  onPlant: (seed: SeedName) => void;
+  inventory: Inventory;
+}
+export const SeedSelection: React.FC<Props> = ({ onPlant, inventory }) => {
+  const [seed, setSeed] = useState<SeedName>();
+
+  const availableSeeds = getKeys(inventory).filter(
+    (name) =>
+      name in SEEDS() && !(name in FRUIT_SEEDS()) && inventory[name]?.gte(1)
+  );
+
+  return (
+    <>
+      <div className="p-2">
+        {!seed && (
+          <Label
+            className="mt-2 mb-1"
+            icon={SUNNYSIDE.icons.seeds}
+            type="danger"
+          >
+            Seed not selected
+          </Label>
+        )}
+
+        {seed && (
+          <Label
+            className="mt-2 mb-1"
+            icon={ITEM_DETAILS[SEEDS()[seed].yield].image}
+            type="default"
+          >
+            {seed}
+          </Label>
+        )}
+
+        <p className="text-xs">What seed would you like to select and plant?</p>
+        <div className="flex flex-wrap my-1">
+          {availableSeeds.map((name) => (
+            <Box
+              key={name}
+              image={ITEM_DETAILS[name].image}
+              count={inventory[name]}
+              onClick={() => setSeed(name as SeedName)}
+              isSelected={seed === name}
+            />
+          ))}
+        </div>
+      </div>
+      <Button
+        disabled={!seed}
+        onClick={() => {
+          onPlant(seed as SeedName);
+        }}
+      >
+        Plant
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
# Description

While play testing, new users often got stuck and confused when they clicked on a plot and nothing happens. This PR adds 2 new UIs to help guide the player.

1. Missing seeds UI
2. Seed not selected UI

<img width="553" alt="Screenshot 2023-11-15 at 5 49 57 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/060132ca-6526-4249-8bc8-12cd22f8b5ab">
<img width="538" alt="Screenshot 2023-11-15 at 5 50 27 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/26db1e8e-4c6d-473c-998c-fd8c255156f3">
