### PR TITLE
[FEAT] Analytics ID

### DIFF
--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -32,6 +32,7 @@ type Response = {
   promoCode?: string;
   moderation: Moderation;
   sessionId: string;
+  analyticsId: string;
 };
 
 const API_URL = CONFIG.API_URL;
@@ -87,6 +88,7 @@ export async function loadSession(request: Request): Promise<Response> {
     farmId,
     sessionId,
     farmAddress,
+    analyticsId,
   } = await sanitizeHTTPResponse<{
     farm: any;
     startedAt: string;
@@ -100,6 +102,7 @@ export async function loadSession(request: Request): Promise<Response> {
     promoCode?: string;
     sessionId: string;
     farmId: string;
+    analyticsId: string;
     farmAddress?: string;
   }>(response);
 
@@ -117,6 +120,7 @@ export async function loadSession(request: Request): Promise<Response> {
     verified,
     moderation,
     promoCode: promo,
+    analyticsId,
   };
 }
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -522,6 +522,7 @@ export function startGame(authContext: AuthContext) {
                 moderation: response.moderation,
                 promoCode: response.promoCode,
                 farmAddress: response.farmAddress,
+                analyticsId: response.analyticsId,
               };
             },
             onDone: [
@@ -1668,9 +1669,9 @@ export function startGame(authContext: AuthContext) {
     },
     {
       actions: {
-        initialiseAnalytics: (context) => {
+        initialiseAnalytics: (context, event: any) => {
           if (!ART_MODE) {
-            gameAnalytics.initialise(context.farmId);
+            gameAnalytics.initialise(event.data.analyticsId);
             onboardingAnalytics.initialise({
               id: context.farmId,
               wallet: authContext.user.web3?.wallet as string,

--- a/src/lib/gameAnalytics.ts
+++ b/src/lib/gameAnalytics.ts
@@ -22,6 +22,9 @@ class GameAnalyticTracker {
 
   public async initialise(id: number) {
     try {
+      if (!id) {
+        throw new Error("Missing User ID for analytics");
+      }
       // GameAnalytics.setEnabledInfoLog(true);
       // GameAnalytics.setEnabledVerboseLog(true);
 


### PR DESCRIPTION
# Description

Supports a permanent analytics ID to track usage even when users are changing/upgrading farms