### PR TITLE
[FIX] Fully expanded farms fail to load

### DIFF
--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -300,7 +300,7 @@ export const UpcomingExpansion: React.FC = () => {
         />
       )}
 
-      {!state.expansionConstruction && (
+      {!state.expansionConstruction && state.expansionRequirements && (
         <ExpandIcon
           canExpand={canExpand}
           inventory={state.inventory}


### PR DESCRIPTION
```
index.cbedd7e0.js:37  TypeError: Cannot read properties of undefined (reading 'bumpkinLevel')
    at ExpandIcon (index.cbedd7e0.js:1240:150955)
    at Ch$1 (index.cbedd7e0.js:35:57842)
    at ck (index.cbedd7e0.js:39:9756)
    at bk (index.cbedd7e0.js:39:1047)
    at ak (index.cbedd7e0.js:39:970)
    at Tj (index.cbedd7e0.js:39:809)
    at Lj (index.cbedd7e0.js:37:12010)
    at index.cbedd7e0.js:35:41883
    at Bt.unstable_runWithPriority (index.cbedd7e0.js:24:4130)
    at gg (index.cbedd7e0.js:35:41630)
```