### PR TITLE
[CHORE] Sort crop seeds in seed selection UI

### DIFF
--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -16,7 +16,7 @@ export type Seed = {
   disabled?: boolean;
 };
 
-export const SEEDS: () => Record<SeedName, Seed> = () => ({
+export const CROP_SEEDS: () => Record<CropSeedName, Seed> = () => ({
   "Sunflower Seed": {
     sfl: marketRate(0.01),
     description: "A sunny flower",
@@ -112,5 +112,9 @@ export const SEEDS: () => Record<SeedName, Seed> = () => ({
     plantSeconds: 36 * 60 * 60,
     yield: "Kale",
   },
+});
+
+export const SEEDS: () => Record<SeedName, Seed> = () => ({
+  ...CROP_SEEDS(),
   ...FRUIT_SEEDS(),
 });

--- a/src/features/island/plots/components/SeedSelection.tsx
+++ b/src/features/island/plots/components/SeedSelection.tsx
@@ -3,10 +3,9 @@ import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
 import { getKeys } from "features/game/types/craftables";
-import { FRUIT_SEEDS } from "features/game/types/fruits";
 import { Inventory } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { SEEDS, SeedName } from "features/game/types/seeds";
+import { CROP_SEEDS, SEEDS, SeedName } from "features/game/types/seeds";
 import React, { useState } from "react";
 
 interface Props {
@@ -16,9 +15,8 @@ interface Props {
 export const SeedSelection: React.FC<Props> = ({ onPlant, inventory }) => {
   const [seed, setSeed] = useState<SeedName>();
 
-  const availableSeeds = getKeys(inventory).filter(
-    (name) =>
-      name in SEEDS() && !(name in FRUIT_SEEDS()) && inventory[name]?.gte(1)
+  const availableSeeds = getKeys(CROP_SEEDS()).filter((name) =>
+    inventory[name]?.gte(1)
   );
 
   return (


### PR DESCRIPTION
# Description

- sort seeds based on SEEDS() for seed selection UI
- separate crop related seeds into new CROP_SEEDS() funcrtion

<img width="608" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/9ffc6022-1266-47c1-a63c-df9a33cb7341">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open seed selection UI when not selecting a seed and attemping to plant one

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
