### PR TITLE
[FEAT] Disable 'Seed not selected' with selected Shovel

### DIFF
--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -5,6 +5,8 @@
 import Decimal from "decimal.js-light";
 import { GameState, Inventory } from "./game";
 
+export type UnlimitedUseToolName = "Shovel";
+
 export type WorkbenchToolName =
   | "Axe"
   | "Pickaxe"
@@ -21,6 +23,17 @@ export interface Tool {
   sfl: Decimal;
   disabled?: boolean;
 }
+
+export const UNLIMITED_USE_TOOLS: (
+  gameState?: GameState
+) => Record<UnlimitedUseToolName, Tool> = () => ({
+  Shovel: {
+    name: "Shovel",
+    description: "Used to harvest crops",
+    ingredients: {},
+    sfl: new Decimal(0),
+  },
+});
 
 export const WORKBENCH_TOOLS: (
   gameState?: GameState

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -31,7 +31,11 @@ import { getFoodExpBoost } from "features/game/expansion/lib/boosts";
 import Decimal from "decimal.js-light";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SELLABLE_TREASURE } from "features/game/types/treasure";
-import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
+import {
+  TREASURE_TOOLS,
+  WORKBENCH_TOOLS,
+  UNLIMITED_USE_TOOLS,
+} from "features/game/types/tools";
 import { getFruitTime } from "features/game/events/landExpansion/fruitPlanted";
 import {
   BAIT,
@@ -110,6 +114,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const fruits = getItems(FRUIT());
   const workbenchTools = getItems(WORKBENCH_TOOLS());
   const treasureTools = getItems(TREASURE_TOOLS);
+  const unlimitedUseTools = getItems(UNLIMITED_USE_TOOLS());
   const exotic = getItems(BEANS());
   const resources = getItems(COMMODITIES);
   const foods = getItems(COOKABLES);
@@ -125,7 +130,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const fish = getItems(FISH);
 
   const allSeeds = [...seeds, ...fruitSeeds];
-  const allTools = [...workbenchTools, ...treasureTools];
+  const allTools = [...unlimitedUseTools, ...workbenchTools, ...treasureTools];
 
   const itemsSection = (title: string, items: InventoryItemName[]) => {
     if (!items.length) {

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -141,6 +141,7 @@ export const Plot: React.FC<Props> = ({ id }) => {
   };
 
   const onClick = (seed: SeedName = selectedItem as SeedName) => {
+    if (selectedItem === "Shovel") return;
     const now = Date.now();
 
     if (!inventory.Shovel) {


### PR DESCRIPTION
# Description

When harvesting only (meaning no planting wanted) of crops, the new "Seed not selected" prompt is pure annoyance.

While the feature has value for new players, it's unfortunate that it breaks the workflow for experienced players.

This change does the following:
1. When in inventory, add Shovel to the Tools section of the Basket.
2. When Shovel is the selected item (as indicated via the first entry in the shortcuts MRU list), clicking an empty crop plot is a non-action as it was previously.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
