### PR TITLE
[FEAT] Exclude harvested item from StopTheGoblins challenge

### DIFF
--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -180,6 +180,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
 
       {/* Chest reward */}
       <ChestReward
+        collectedItem={"Wood"}
         reward={reward}
         onCollected={onCollectChest}
         onOpen={() =>

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -2,7 +2,7 @@ import { Panel } from "components/ui/Panel";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { Modal } from "react-bootstrap";
 
-import { Reward } from "features/game/types/game";
+import { InventoryItemName, Reward } from "features/game/types/game";
 
 import { Button } from "components/ui/Button";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -14,6 +14,7 @@ import { ChestCaptcha } from "features/island/common/chest-reward/ChestCaptcha";
 import { Loading } from "features/auth/components";
 
 interface Props {
+  collectedItem?: InventoryItemName;
   reward?: Reward;
   onCollected: (success: boolean) => void;
   onOpen: () => void;
@@ -22,6 +23,7 @@ interface Props {
 type Challenge = "goblins" | "chest";
 
 export const ChestReward: React.FC<Props> = ({
+  collectedItem,
   reward,
   onCollected,
   onOpen,
@@ -104,7 +106,11 @@ export const ChestReward: React.FC<Props> = ({
           ) : (
             <>
               {challenge.current === "goblins" && (
-                <StopTheGoblins onFail={fail} onOpen={open} />
+                <StopTheGoblins
+                  onFail={fail}
+                  onOpen={open}
+                  collectedItem={collectedItem}
+                />
               )}
               {challenge.current === "chest" && (
                 <ChestCaptcha onFail={fail} onOpen={open} />

--- a/src/features/island/common/chest-reward/StopTheGoblins.tsx
+++ b/src/features/island/common/chest-reward/StopTheGoblins.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { addNoise } from "lib/images";
 
@@ -60,7 +61,10 @@ const moonSeekers = [
   SUNNYSIDE.npcs.moonseeker5,
 ];
 
-const generateImages = (isMoonSeekerMode: boolean) => {
+const generateImages = (
+  isMoonSeekerMode: boolean,
+  collectedItem?: InventoryItemName
+) => {
   const newImageItem = (src: any, isGoblin: boolean): Item => {
     return {
       src: src,
@@ -76,9 +80,19 @@ const generateImages = (isMoonSeekerMode: boolean) => {
   };
 
   const items: Item[] = [];
-  const resourceImages = isMoonSeekerMode
-    ? [...getKeys(CROPS()), ...getKeys(FRUIT()), ...getKeys(COMMODITIES)]
-    : getKeys(CONSUMABLES);
+  let resourceImages;
+  if (isMoonSeekerMode) {
+    resourceImages = [
+      ...getKeys(CROPS()),
+      ...getKeys(FRUIT()),
+      ...getKeys(COMMODITIES),
+    ];
+    resourceImages = resourceImages.filter(
+      (name: InventoryItemName) => name !== collectedItem
+    );
+  } else {
+    resourceImages = getKeys(CONSUMABLES);
+  }
   const availableResourceImages = resourceImages.map(
     (name) => ITEM_DETAILS[name].image
   );
@@ -103,13 +117,18 @@ const generateImages = (isMoonSeekerMode: boolean) => {
 interface Props {
   onOpen: () => void;
   onFail: () => void;
+  collectedItem?: InventoryItemName;
 }
 
-export const StopTheGoblins: React.FC<Props> = ({ onOpen, onFail }) => {
+export const StopTheGoblins: React.FC<Props> = ({
+  onOpen,
+  onFail,
+  collectedItem,
+}) => {
   const [wrongAttempts, setWrongAttempts] = useState(new Set<number>());
   const [correctAttempts, setCorrectAttempts] = useState(new Set<number>());
   const [isMoonSeekerMode] = useState(randomBoolean());
-  const [items] = useState(generateImages(isMoonSeekerMode));
+  const [items] = useState(generateImages(isMoonSeekerMode, collectedItem));
 
   const attemptsLeft = MAX_ATTEMPTS - wrongAttempts.size;
 

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -360,6 +360,7 @@ export const Plot: React.FC<Props> = ({ id }) => {
         />
       </div>
       <ChestReward
+        collectedItem={crop?.name}
         reward={reward}
         onCollected={onCollectReward}
         onOpen={() =>


### PR DESCRIPTION
# Description

Exclude the harvested item (crop or wood) from the possible images to avoid cognitive dissonance for players.

# Testing

On local, forced `StopTheGoblins` challenge for both moonseeker and non-moonseeker, confirming that the moonseeker flavor excludes Sunflower when Sunflower is being harvested.
