### PR TITLE
[FEAT] Adjust scale to 75% on mobile

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -7,9 +7,10 @@ import {
   ExpansionConstruction,
   PlacedItem,
 } from "../types/game";
+import { detectMobile } from "lib/utils/hooks/useIsMobile";
 
 // Our "zoom" factor
-export const PIXEL_SCALE = 2.625;
+export const PIXEL_SCALE = 2.625 * (detectMobile() ? 0.75 : 1);
 
 // How many pixels a raw green square is
 export const SQUARE_WIDTH = 16;

--- a/src/features/world/ui/CommunityToastManager.tsx
+++ b/src/features/world/ui/CommunityToastManager.tsx
@@ -3,8 +3,9 @@ import { InnerPanel } from "components/ui/Panel";
 import { createPortal } from "react-dom";
 import { ITEM_DETAILS } from "../../game/types/images";
 import { InventoryItemName } from "../../game/types/game";
+import { detectMobile } from "lib/utils/hooks/useIsMobile";
 
-const PIXEL_SCALE = 2.625;
+const PIXEL_SCALE = 2.625 * (detectMobile() ? 0.75 : 1);
 const MAX_TOAST = 6;
 type ToastItem = InventoryItemName;
 


### PR DESCRIPTION
# Description

The buttons (and the UI in general) is a bit "too big" on mobile.

This change adjusts the `PIXEL_SCALE` to be 75% of what it is on Desktop.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

_Emulation of Samsung Galaxy Fold_

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/65b118b8-de92-4186-a279-a1fdfe5c67fa)
After
![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/d0dd2cc6-dca6-4ed0-a9ed-0e4760ac3e6e)
