### PR TITLE
[FIX] Gold Pass Required for Goblin Retreat

### DIFF
--- a/src/features/retreat/Game.tsx
+++ b/src/features/retreat/Game.tsx
@@ -1,4 +1,12 @@
-import React, { useContext, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+
 import { GRID_WIDTH_PX } from "features/game/lib/constants";
 import ScrollContainer from "react-indiana-drag-scroll";
 import background from "assets/land/retreat.webp";
@@ -37,6 +45,7 @@ import { RetreatPirate } from "./components/pirate/RetreatPirate";
 import { GameBoard } from "components/GameBoard";
 import { Auctioneer } from "./components/auctioneer/Auctioneer";
 import { PersonhoodContent } from "./components/personhood/PersonhoodContent";
+import { GoldPassModal } from "features/game/expansion/components/GoldPass";
 
 const spawn = [
   [35, 15],
@@ -65,11 +74,15 @@ const SHOW_MODAL: Partial<Record<StateValues, boolean>> = {
 
 export const Game = () => {
   const container = useRef(null);
+  const navigate = useNavigate();
   const { goblinService } = useContext(Context);
   const [goblinState] = useActor(goblinService);
   const [scrollIntoView] = useScrollIntoView();
   const [retreatLoaded, setRetreatLoaded] = useState(false);
   const [sealSpawn] = useState(getRandomSpawn());
+  const [showGoldPassModal, setShowGoldPassModal] = useState<boolean>(false);
+
+  const { bumpkin, inventory } = goblinState.context.state;
 
   useLayoutEffect(() => {
     if (retreatLoaded) {
@@ -77,7 +90,16 @@ export const Game = () => {
     }
   }, [retreatLoaded]);
 
-  const { bumpkin } = goblinState.context.state;
+  useEffect(() => {
+    if (!inventory["Gold Pass"]) {
+      setShowGoldPassModal(true);
+    }
+  }, []);
+
+  const handleGoldPassModalClose = () => {
+    setShowGoldPassModal(false);
+    navigate("/land");
+  };
 
   const hasRequiredLevel =
     bumpkin && getBumpkinLevel(bumpkin.experience) >= RETREAT_LEVEL_REQUIREMENT;
@@ -139,6 +161,17 @@ export const Game = () => {
                 id={Section.RetreatBackground}
                 onLoad={() => setRetreatLoaded(true)}
               />
+
+              {/* No Gold Pass Modal */}
+              <Modal
+                show={showGoldPassModal}
+                centered
+                backdrop="static"
+                keyboard={false}
+              >
+                <GoldPassModal onClose={handleGoldPassModalClose} />
+              </Modal>
+
               <RetreatBank />
               <RetreatStorageHouse />
               <RetreatHotAirBalloon />


### PR DESCRIPTION
# Description

I've noticed that for some players the Gold Pass modal wasn't showing up when trying to access to the Goblin Retreat, mostly when a player is trying to access it from the URL or sfl.tools

This PR fix the issue by displaying the modal with a static backdrop when going to Goblin Retreat without a Gold Pass.

The backdrop is static to prevent the player from interacting with anything in there, which is causing errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
