### PR TITLE
[FEAT] Add animations enable/disable to SubSettings

### DIFF
--- a/src/features/farming/hud/lib/animations.ts
+++ b/src/features/farming/hud/lib/animations.ts
@@ -1,0 +1,14 @@
+/**
+ * Cache show timers setting in local storage so we can remember next time we open the HUD.
+ */
+const LOCAL_STORAGE_KEY = "settings.showAnimations";
+
+export function cacheShowAnimationsSetting(show: boolean) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(show));
+}
+
+export function getShowAnimationsSetting(): boolean {
+  const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return cached ? JSON.parse(cached) : true;
+}

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -14,6 +14,10 @@ import {
 import { startGame, MachineInterpreter } from "./lib/gameMachine";
 import { InventoryItemName } from "./types/game";
 import {
+  cacheShowAnimationsSetting,
+  getShowAnimationsSetting,
+} from "features/farming/hud/lib/animations";
+import {
   cacheShowTimersSetting,
   getShowTimersSetting,
 } from "features/farming/hud/lib/timers";
@@ -22,6 +26,8 @@ interface GameContext {
   shortcutItem: (item: InventoryItemName) => void;
   selectedItem?: InventoryItemName;
   gameService: MachineInterpreter;
+  showAnimations: boolean;
+  toggleAnimations: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
 }
@@ -39,6 +45,9 @@ export const GameProvider: React.FC = ({ children }) => {
   const [shortcuts, setShortcuts] = useState<InventoryItemName[]>(
     getShortcuts()
   );
+  const [showAnimations, setShowAnimations] = useState<boolean>(
+    getShowAnimationsSetting()
+  );
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
@@ -55,6 +64,13 @@ export const GameProvider: React.FC = ({ children }) => {
     setShortcuts(items);
   }, []);
 
+  const toggleAnimations = () => {
+    const newValue = !showAnimations;
+
+    setShowAnimations(newValue);
+    cacheShowAnimationsSetting(newValue);
+  };
+
   const toggleTimers = () => {
     const newValue = !showTimers;
 
@@ -70,6 +86,8 @@ export const GameProvider: React.FC = ({ children }) => {
         shortcutItem,
         selectedItem,
         gameService,
+        showAnimations,
+        toggleAnimations,
         showTimers,
         toggleTimers,
       }}

--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -60,7 +60,7 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
         <Button className="col p-1" onClick={onToggleAnimations}>
           {showAnimations ? "Disable Animations" : "Enable Animations"}
         </Button>
-        <Button className="col p-1" onClick={onLogout}>
+        <Button className="col p-1 mt-2" onClick={onLogout}>
           Logout
         </Button>
         {isFullUser && (

--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
   const { authService } = useContext(Auth.Context);
-  const { gameService } = useContext(Context);
+  const { gameService, showAnimations, toggleAnimations } = useContext(Context);
   const [gameState] = useActor(gameService);
 
   const { farmAddress } = gameState.context;
@@ -35,6 +35,10 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
   const onLogout = () => {
     onClose();
     authService.send("LOGOUT"); // hack used to avoid redundancy
+  };
+
+  const onToggleAnimations = () => {
+    toggleAnimations();
   };
 
   const refreshSession = () => {
@@ -53,6 +57,9 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
 
     return (
       <CloseButtonPanel title="Settings" onClose={onClose}>
+        <Button className="col p-1" onClick={onToggleAnimations}>
+          {showAnimations ? "Disable Animations" : "Enable Animations"}
+        </Button>
         <Button className="col p-1" onClick={onLogout}>
           Logout
         </Button>

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -59,8 +59,13 @@ interface Props {
 }
 export const Plot: React.FC<Props> = ({ id }) => {
   const { scale } = useContext(ZoomContext);
-  const { gameService, selectedItem, showTimers, shortcutItem } =
-    useContext(Context);
+  const {
+    gameService,
+    selectedItem,
+    showAnimations,
+    showTimers,
+    shortcutItem,
+  } = useContext(Context);
   const [procAnimation, setProcAnimation] = useState<JSX.Element>();
   const [touchCount, setTouchCount] = useState(0);
   const [showMissingSeeds, setShowMissingSeeds] = useState(false);
@@ -113,7 +118,7 @@ export const Plot: React.FC<Props> = ({ id }) => {
     harvestAudio.play();
 
     // firework animation
-    if (crop.amount && crop.amount >= 10) {
+    if (showAnimations && crop.amount && crop.amount >= 10) {
       setProcAnimation(
         <Spritesheet
           className="absolute pointer-events-none"


### PR DESCRIPTION
# Description

Adds setting to disable/enable animations to the secondary settings menu.

Initial implementation only impacts the firework animation.

# Testing

On local, set all 3 initial Sunflower plantings to 11 yield and confirmed that the enabled and disabled animation values worked as expected.

![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/bfa25f26-584d-4e22-a46c-f5f9f0652d27)
