### PR TITLE
[FIX] Update compost limits in front-end

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -113,6 +113,11 @@ export const maxItems: Inventory = {
   "Lab Grown Radish": new Decimal(1),
   "Magic Bean": new Decimal(5),
 
+  // Fertilisers
+  "Sprout Mix": new Decimal(500),
+  "Fruitful Blend": new Decimal(500),
+  "Rapid Root": new Decimal(500),
+
   // Bait
   Earthworm: new Decimal(100),
   Grub: new Decimal(100),


### PR DESCRIPTION
# Description

The back-end limits for compost (in the game contract) are set to 500.

The front-end was not enforcing (any value), causing players to run into unusual "can't collect from composter" issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
