### PR TITLE
[FEAT] Input promo code

### DIFF
--- a/src/features/auth/Auth.tsx
+++ b/src/features/auth/Auth.tsx
@@ -19,7 +19,7 @@ import { ConnectedToWallet } from "./components/ConnectedToWallet";
 import { Verifying } from "./components/Verifying";
 import { Welcome } from "./components/Welcome";
 import classNames from "classnames";
-import { SignIn } from "./components/SignIn";
+import { SignIn, SignUp } from "./components/SignIn";
 import { CreateWallet } from "./components/CreateWallet";
 import { Label } from "components/ui/Label";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -74,13 +74,14 @@ export const Auth: React.FC = () => {
             )}
           </div>
         </div>
-        <Panel className="pb-1">
+        <Panel className="pb-1 relative">
           {authState.matches("initialising") && <Loading />}
           {authState.matches("welcome") && <Welcome />}
           {authState.matches("createWallet") && <CreateWallet />}
           {(authState.matches("idle") || authState.matches("signIn")) && (
             <SignIn />
           )}
+          {authState.matches("signUp") && <SignUp />}
           {connecting && <Loading text={t("connecting")} />}
           {authState.matches("connectedToWallet") && <ConnectedToWallet />}
           {authState.matches("signing") && <Signing />}

--- a/src/features/auth/components/SignIn.tsx
+++ b/src/features/auth/components/SignIn.tsx
@@ -323,7 +323,7 @@ export const SignUp = () => {
             }
           />
         </div>
-        <div className="flex">
+        <div className="flex space-x-1">
           <Button
             onClick={() => {
               setShowPromoCode(false);

--- a/src/features/auth/components/SignIn.tsx
+++ b/src/features/auth/components/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { ChangeEvent, useContext, useState } from "react";
 
 import { Button } from "components/ui/Button";
 import { Context } from "../lib/Provider";
@@ -14,7 +14,7 @@ import bitgetIcon from "src/assets/icons/bitget_logo.svg";
 
 import { Label } from "components/ui/Label";
 import { Web3SupportedProviders } from "lib/web3SupportedProviders";
-import { getPromoCode } from "features/game/actions/loadSession";
+import { getPromoCode, savePromoCode } from "features/game/actions/loadSession";
 import { hasFeatureAccess } from "lib/flags";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
@@ -295,5 +295,76 @@ export const SignIn = () => {
         </a>
       </div>
     </div>
+  );
+};
+
+export const SignUp = () => {
+  const [showPromoCode, setShowPromoCode] = useState(false);
+  const [promoCode, setPromoCode] = useState(getPromoCode());
+
+  if (showPromoCode) {
+    return (
+      <>
+        <div className="p-2">
+          <p className="text-xs mb-1">Enter your promo code:</p>
+          <input
+            style={{
+              boxShadow: "#b96e50 0px 1px 1px 1px inset",
+              border: "2px solid #ead4aa",
+            }}
+            type="text"
+            min={1}
+            value={promoCode}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setPromoCode(e.target.value);
+            }}
+            className={
+              "text-shadow mr-2 rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10"
+            }
+          />
+        </div>
+        <div className="flex">
+          <Button
+            onClick={() => {
+              setShowPromoCode(false);
+            }}
+          >
+            Back
+          </Button>
+          <Button
+            disabled={!promoCode}
+            onClick={() => {
+              setShowPromoCode(false);
+              savePromoCode(promoCode as string);
+            }}
+          >
+            Ok
+          </Button>
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      {promoCode && (
+        <div className="absolute top-3 right-5">
+          <Label type="formula" icon={SUNNYSIDE.icons.search}>
+            {`Promo Code: ${getPromoCode()}`}
+          </Label>
+        </div>
+      )}
+      {!promoCode && (
+        <div className="absolute top-3 right-5 flex items-center">
+          <Button onClick={() => setShowPromoCode(true)} className="h-6">
+            <div className="flex">
+              <span className="text-xxs">Add Promo Code</span>
+            </div>
+          </Button>
+          <img src={SUNNYSIDE.icons.expression_confused} className="h-4 ml-1" />
+        </div>
+      )}
+
+      <SignIn />
+    </>
   );
 };

--- a/src/features/auth/components/Welcome.tsx
+++ b/src/features/auth/components/Welcome.tsx
@@ -26,7 +26,7 @@ export const Welcome: React.FC = () => {
       </Button>
       <Button
         className="mb-2 py-2 text-sm relative"
-        onClick={() => authService.send("CONTINUE")}
+        onClick={() => authService.send("SIGNUP")}
       >
         <div className="px-8">
           <img

--- a/src/features/auth/lib/authMachine.ts
+++ b/src/features/auth/lib/authMachine.ts
@@ -20,8 +20,6 @@ import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { web3ConnectStrategyFactory } from "./web3-connect-strategy/web3ConnectStrategy.factory";
 import { Web3SupportedProviders } from "lib/web3SupportedProviders";
 import { loadSession, savePromoCode } from "features/game/actions/loadSession";
-import { hasFeatureAccess } from "lib/flags";
-import { TEST_FARM } from "features/game/lib/constants";
 
 export const ART_MODE = !CONFIG.API_URL;
 
@@ -130,6 +128,7 @@ export type BlockchainEvent =
       type: "CHOOSE_CHARITY";
     }
   | { type: "CONTINUE" }
+  | { type: "SIGNUP" }
   | { type: "BACK" }
   | { type: "CONNECT_TO_DISCORD" }
   | { type: "CONFIRM" }
@@ -149,6 +148,7 @@ export type BlockchainState = {
     | "welcome"
     | "createWallet"
     | "signIn"
+    | "signUp"
     | "initialising"
     | "visiting"
     | "connectingToWallet"
@@ -226,17 +226,10 @@ export const authMachine = createMachine(
             target: "signIn",
             actions: () => onboardingAnalytics.logEvent("connect_wallet"),
           },
-          CONTINUE: [
-            {
-              target: "signIn",
-              cond: () => hasFeatureAccess(TEST_FARM, "NEW_FARM_FLOW"),
-              actions: () => onboardingAnalytics.logEvent("create_account"),
-            },
-            {
-              target: "createWallet",
-              actions: () => onboardingAnalytics.logEvent("create_account"),
-            },
-          ],
+          SIGNUP: {
+            target: "signUp",
+            actions: () => onboardingAnalytics.logEvent("create_account"),
+          },
         },
       },
 
@@ -250,6 +243,17 @@ export const authMachine = createMachine(
       },
       signIn: {
         id: "signIn",
+        on: {
+          CONNECT_TO_WALLET: {
+            target: "connectingToWallet",
+          },
+          BACK: {
+            target: "welcome",
+          },
+        },
+      },
+      signUp: {
+        id: "signUp",
         on: {
           CONNECT_TO_WALLET: {
             target: "connectingToWallet",

--- a/src/features/island/buildings/components/building/workBench/WorkBench.tsx
+++ b/src/features/island/buildings/components/building/workBench/WorkBench.tsx
@@ -15,17 +15,6 @@ import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 
-const host = window.location.host.replace(/^www\./, "");
-const LOCAL_STORAGE_KEY = `workbench-read.${host}-${window.location.pathname}`;
-
-function acknowledgeRead() {
-  localStorage.setItem(LOCAL_STORAGE_KEY, new Date().toString());
-}
-
-function hasRead() {
-  return !!localStorage.getItem(LOCAL_STORAGE_KEY);
-}
-
 const needsHelp = (state: MachineState) => {
   const missingScarecrow =
     !state.context.state.inventory["Basic Scarecrow"] &&

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -45,9 +45,9 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
   const { inventory } = state;
 
   const buildingBlueprints = BUILDINGS()[selectedName];
-  const buildingUnlockLevels = buildingBlueprints.map(
-    ({ unlocksAtLevel }) => unlocksAtLevel
-  );
+  const buildingUnlockLevels = buildingBlueprints
+    .filter((blueprint) => blueprint.unlocksAtLevel !== 99)
+    .map(({ unlocksAtLevel }) => unlocksAtLevel);
   const landCount = inventory["Basic Land"] ?? new Decimal(0);
   const buildingsInInventory = inventory[selectedName] || new Decimal(0);
   // Some buildings have multiple blueprints, so we need to check if the next blueprint is available else fallback to the first one


### PR DESCRIPTION
# Description

This PR adds support for inputting a custom promo code. Ideally this would sit on a specific account create step, but that will be coming in future iterations.

If you have an existing promo code, it will pre-fill.

<img width="785" alt="Screenshot 2023-11-20 at 5 04 16 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/5988f00a-21e8-4c15-bebb-aab069f54fae">
<img width="589" alt="Screenshot 2023-11-20 at 5 04 24 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/d5220fab-b08d-4789-ba02-94bf673347de">


**How to test?**

Clear local storage and add a promo code.

**Future considerations**

This was done in a bit of a rush for this week's expo. Future considerations include:
- Specific create account screen
- Remove inputted code (if incorrect)