### PR TITLE
[FIX] Stop displaying Frenzy UI after first cast

### DIFF
--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -308,8 +308,15 @@ export const FishermanModal: React.FC<Props> = ({ onCast, onClose }) => {
 
   const [showIntro, setShowIntro] = React.useState(!hasRead());
 
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
+  const dailyFishingCount = getDailyFishingCount(state);
+
   const [showFishFrenzy, setShowFishFrenzy] = React.useState(
-    weather === "Fish Frenzy"
+    weather === "Fish Frenzy" && dailyFishingCount === 0
   );
 
   const [tab, setTab] = useState(0);


### PR DESCRIPTION
# Description

Disables the `SpeakingText` for `FishermanModal` after player has casted at least once today.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local testing was done.

Staging:
- Set `experience` in `INITIAL_BUMPKIN` for L5+.
- Add `Earthworm` and `Rod` to `OFFLINE_FARM`.
- Set `weather` in `fishing` in `OFFLINE_FARM` TO `Fish Frenzy`.

Testing steps:
1. Open fishing UI.
2. Observe speaking text.
3. Cast.
4. Reel.
5. Pass Kraken challenge. ;)
6. Collect fish.
7. Open fishing UI.
8. Observe absence of speaking text.