### PR TITLE
[FIX] NoBumpkin Deposit Bug & Modal Update

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -503,7 +503,7 @@ export const Land: React.FC = () => {
             {!landscaping && <UpcomingExpansion />}
 
             {/* No Bumpkin */}
-            <Modal show={!bumpkin} backdrop="static" keyboard={false} centered>
+            <Modal show={!bumpkin} keyboard={false} centered>
               <Panel>
                 <NoBumpkin />
               </Panel>

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -755,6 +755,9 @@ export function startGame(authContext: AuthContext) {
         },
         gameRules: {
           on: {
+            DEPOSIT: {
+              target: "depositing",
+            },
             ACKNOWLEDGE: {
               target: "notifying",
             },


### PR DESCRIPTION
# Description

My recent PR showing the modal on login if player doesn't have a Bumpkin might've broke the game a bit, if a player clear their cache or is a very old player, the localStorage doesn't contain the `gameRulesLastRead` value, which is "locking" the deposit function due to game machine.

First Commit include a fix for this in the game machine, I'm also planning to make the deposit modal a bit better and more understandable for players in the next hours.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

including tests later..

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
