### PR TITLE
[FIX] Add fishing lure to bait category

### DIFF
--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -75,7 +75,7 @@ export function startComposter({
     items: {
       [composterDetails[action.building].produce]: 10,
       // Set on backend
-      [composterDetails[action.building].bait]: 1,
+      [composterDetails[action.building].worm]: 1,
     },
     startedAt: createdAt,
     readyAt: createdAt + getReadyAt(stateCopy, action.building),

--- a/src/features/game/types/composters.ts
+++ b/src/features/game/types/composters.ts
@@ -1,6 +1,6 @@
 import { InventoryItemName } from "./game";
 
-export type Bait = "Earthworm" | "Grub" | "Red Wiggler";
+export type Worm = "Earthworm" | "Grub" | "Red Wiggler";
 
 export type FruitCompostName = "Fruitful Blend";
 export type CropCompostName = "Sprout Mix" | "Rapid Root";
@@ -12,7 +12,7 @@ export type ComposterName =
   | "Turbo Composter"
   | "Premium Composter";
 
-export const BAIT: Record<Bait, { description: string }> = {
+export const WORM: Record<Worm, { description: string }> = {
   Earthworm: {
     description: "A wriggly worm that attracts small fish.",
   },
@@ -58,12 +58,12 @@ export type ComposterDetails = {
   timeToFinishMilliseconds: number;
   produce: CompostName;
   produceAmount: number;
-  bait: Bait;
+  worm: Worm;
 };
 
 export const composterDetails: Record<ComposterName, ComposterDetails> = {
   "Compost Bin": {
-    bait: "Earthworm",
+    worm: "Earthworm",
     produce: "Sprout Mix",
     produceAmount: 10,
     timeToFinishMilliseconds: 6 * 60 * 60 * 1000,
@@ -71,13 +71,13 @@ export const composterDetails: Record<ComposterName, ComposterDetails> = {
   "Turbo Composter": {
     produce: "Fruitful Blend",
     produceAmount: 3,
-    bait: "Grub",
+    worm: "Grub",
     timeToFinishMilliseconds: 8 * 60 * 60 * 1000,
   },
   "Premium Composter": {
     produce: "Rapid Root",
     produceAmount: 10,
-    bait: "Red Wiggler",
+    worm: "Red Wiggler",
     timeToFinishMilliseconds: 12 * 60 * 60 * 1000,
   },
 };

--- a/src/features/game/types/fishing.ts
+++ b/src/features/game/types/fishing.ts
@@ -1,10 +1,10 @@
 import Decimal from "decimal.js-light";
-import { Bait } from "./composters";
+import { Worm } from "./composters";
 import { Bumpkin, GameState, InventoryItemName } from "./game";
 import { Tool } from "./tools";
 
 export type PurchaseableBait = "Fishing Lure";
-export type FishingBait = Bait | PurchaseableBait;
+export type FishingBait = Worm | PurchaseableBait;
 export type FishType = "basic" | "advanced" | "expert" | "marine marvel";
 
 export type FishName =

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -554,7 +554,7 @@ import { GOBLIN_PIRATE_ITEMS, POTION_HOUSE_ITEMS } from "./collectibles";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
-import { BAIT, CROP_COMPOST, FRUIT_COMPOST } from "./composters";
+import { WORM, CROP_COMPOST, FRUIT_COMPOST } from "./composters";
 import { BuffLabel } from ".";
 import { PURCHASEABLE_BAIT } from "./fishing";
 
@@ -2637,15 +2637,15 @@ export const ITEM_DETAILS: Items = {
   // Bait
   Earthworm: {
     image: earthworm,
-    description: BAIT.Earthworm.description,
+    description: WORM.Earthworm.description,
   },
   Grub: {
     image: grub,
-    description: BAIT.Grub.description,
+    description: WORM.Grub.description,
   },
   "Red Wiggler": {
     image: redWiggler,
-    description: BAIT["Red Wiggler"].description,
+    description: WORM["Red Wiggler"].description,
   },
   "Fishing Lure": {
     image: fishingLure,

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -556,6 +556,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { BAIT, CROP_COMPOST, FRUIT_COMPOST } from "./composters";
 import { BuffLabel } from ".";
+import { PURCHASEABLE_BAIT } from "./fishing";
 
 export interface ItemDetails extends Omit<LimitedItem, "name" | "description"> {
   description: string;
@@ -2648,7 +2649,7 @@ export const ITEM_DETAILS: Items = {
   },
   "Fishing Lure": {
     image: fishingLure,
-    description: "Great for catching rare fish!",
+    description: PURCHASEABLE_BAIT["Fishing Lure"].description,
   },
   // Compost
   "Sprout Mix": {

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -20,7 +20,7 @@ import expertComposting from "assets/composters/composter_expert_closed.png";
 import expertReady from "assets/composters/composter_expert_ready.png";
 
 import {
-  BAIT,
+  WORM,
   ComposterName,
   composterDetails,
 } from "features/game/types/composters";
@@ -208,7 +208,7 @@ export const ComposterModal: React.FC<Props> = ({
                   >
                     <img src={ITEM_DETAILS[name].image} className="h-5" />
                     <Label type="default">
-                      {name in BAIT
+                      {name in WORM
                         ? `? ${name}s`
                         : `${produces[name]} ${name}`}
                     </Label>
@@ -302,13 +302,13 @@ export const ComposterModal: React.FC<Props> = ({
               <div className="flex space-x-1 justify-start">
                 <SquareIcon
                   icon={
-                    ITEM_DETAILS[composterDetails[composterName].bait].image
+                    ITEM_DETAILS[composterDetails[composterName].worm].image
                   }
                   width={14}
                 />
                 <div className="block">
                   <p className="text-xs mb-1">
-                    {`${WORM_OUTPUT[composterName]} ${composterDetails[composterName].bait}s`}
+                    {`${WORM_OUTPUT[composterName]} ${composterDetails[composterName].worm}s`}
                   </p>
                   <Label
                     icon={SUNNYSIDE.tools.fishing_rod}

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -38,7 +38,7 @@ import {
   CROP_COMPOST,
   FRUIT_COMPOST,
 } from "features/game/types/composters";
-import { FISH } from "features/game/types/fishing";
+import { FISH, PURCHASEABLE_BAIT } from "features/game/types/fishing";
 
 interface Prop {
   gameState: GameState;
@@ -122,6 +122,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const cropCompost = getItems(CROP_COMPOST);
   const fruitCompost = getItems(FRUIT_COMPOST);
   const bait = getItems(BAIT);
+  const purchaseableBait = getItems(PURCHASEABLE_BAIT);
   const fish = getItems(FISH);
 
   const allSeeds = [...seeds, ...fruitSeeds];
@@ -202,7 +203,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
           {itemsSection("Exotic", [...exotic, ...exotics])}
           {itemsSection("Tools", allTools)}
           {itemsSection("Resources", resources)}
-          {itemsSection("Bait", bait)}
+          {itemsSection("Bait", [...bait, ...purchaseableBait])}
           {itemsSection("Fish", fish)}
           {itemsSection("Foods", [...foods, ...pirateCake])}
           {itemsSection("Bounty", bounty)}

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -34,7 +34,7 @@ import { SELLABLE_TREASURE } from "features/game/types/treasure";
 import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { getFruitTime } from "features/game/events/landExpansion/fruitPlanted";
 import {
-  BAIT,
+  WORM,
   CROP_COMPOST,
   FRUIT_COMPOST,
 } from "features/game/types/composters";
@@ -121,7 +121,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const exotics = getItems(EXOTIC_CROPS);
   const cropCompost = getItems(CROP_COMPOST);
   const fruitCompost = getItems(FRUIT_COMPOST);
-  const bait = getItems(BAIT);
+  const worm = getItems(WORM);
   const purchaseableBait = getItems(PURCHASEABLE_BAIT);
   const fish = getItems(FISH);
 
@@ -203,7 +203,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
           {itemsSection("Exotic", [...exotic, ...exotics])}
           {itemsSection("Tools", allTools)}
           {itemsSection("Resources", resources)}
-          {itemsSection("Bait", [...bait, ...purchaseableBait])}
+          {itemsSection("Bait", [...worm, ...purchaseableBait])}
           {itemsSection("Fish", fish)}
           {itemsSection("Foods", [...foods, ...pirateCake])}
           {itemsSection("Bounty", bounty)}


### PR DESCRIPTION
# Description
Fishing Lure is currently not showing in the Bait category in the basket, even if the user has bought it. It still shows in the fishing menu, however.

(Secondary Change) Change the relevant constants from 'Bait' to 'Worm' to more accurately reflect the worms

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/cc9d1262-cffe-448f-99df-4c681577170b)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f829d426-dfda-4dc5-b379-3f123f7b1bd9)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
