### PR TITLE
[FEAT] Add Confirmation Modal for Blacksmith, Stella and Frankie

### DIFF
--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -138,7 +138,12 @@ export const HeliosBlacksmithItems: React.FC = () => {
                       </span>
                     </div>
                     <div className="flex justify-content-around mt-2 space-x-1">
-                      <Button onClick={craft}>Craft</Button>
+                      <Button
+                        disabled={lessIngredients() || isNotReady(selectedItem)}
+                        onClick={craft}
+                      >
+                        Craft
+                      </Button>
                       <Button onClick={closeConfirmationModal}>
                         {t("cancel")}
                       </Button>

--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -19,6 +19,9 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { Modal } from "react-bootstrap";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 function isNotReady(collectible: CraftableCollectible) {
   return (
@@ -38,6 +41,8 @@ export const HeliosBlacksmithItems: React.FC = () => {
     },
   ] = useActor(gameService);
   const inventory = state.inventory;
+
+  const { t } = useAppTranslation();
 
   const selectedItem = HELIOS_BLACKSMITH_ITEMS(state)[selectedName]!;
   const isAlreadyCrafted = inventory[selectedName]?.greaterThanOrEqualTo(1);
@@ -87,6 +92,14 @@ export const HeliosBlacksmithItems: React.FC = () => {
     shortcutItem(selectedName);
   };
 
+  const [isConfirmBuyModalOpen, showConfirmBuyModal] = useState(false);
+  const openConfirmationModal = () => {
+    showConfirmBuyModal(true);
+  };
+  const closeConfirmationModal = () => {
+    showConfirmBuyModal(false);
+  };
+
   return (
     <SplitScreenView
       panel={
@@ -106,12 +119,33 @@ export const HeliosBlacksmithItems: React.FC = () => {
             isAlreadyCrafted ? (
               <p className="text-xxs text-center mb-1">Already crafted!</p>
             ) : (
-              <Button
-                disabled={lessIngredients() || isNotReady(selectedItem)}
-                onClick={craft}
-              >
-                Craft
-              </Button>
+              <>
+                <Button
+                  disabled={lessIngredients() || isNotReady(selectedItem)}
+                  onClick={openConfirmationModal}
+                >
+                  Craft
+                </Button>
+                <Modal
+                  centered
+                  show={isConfirmBuyModalOpen}
+                  onHide={closeConfirmationModal}
+                >
+                  <CloseButtonPanel className="sm:w-4/5 m-auto">
+                    <div className="flex flex-col p-2">
+                      <span className="text-sm text-center">
+                        Are you sure you want to craft this item?
+                      </span>
+                    </div>
+                    <div className="flex justify-content-around mt-2 space-x-1">
+                      <Button onClick={craft}>Craft</Button>
+                      <Button onClick={closeConfirmationModal}>
+                        {t("cancel")}
+                      </Button>
+                    </div>
+                  </CloseButtonPanel>
+                </Modal>
+              </>
             )
           }
         />

--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -134,7 +134,7 @@ export const HeliosBlacksmithItems: React.FC = () => {
                   <CloseButtonPanel className="sm:w-4/5 m-auto">
                     <div className="flex flex-col p-2">
                       <span className="text-sm text-center">
-                        Are you sure you want to craft this item?
+                        Are you sure you want to craft {`${selectedName}`}?
                       </span>
                     </div>
                     <div className="flex justify-content-around mt-2 space-x-1">

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -154,7 +154,7 @@ export const DecorationItems: React.FC<Props> = ({ items }) => {
                 <CloseButtonPanel className="sm:w-4/5 m-auto">
                   <div className="flex flex-col p-2">
                     <span className="text-sm text-center">
-                      Are you sure you want to buy this item?
+                      Are you sure you want to buy {`${selected.name}`}?
                     </span>
                   </div>
                   <div className="flex justify-content-around mt-2 space-x-1">

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -158,7 +158,17 @@ export const DecorationItems: React.FC<Props> = ({ items }) => {
                     </span>
                   </div>
                   <div className="flex justify-content-around mt-2 space-x-1">
-                    <Button onClick={handleBuy}>Buy</Button>
+                    <Button
+                      disabled={
+                        isNotReady(selected) ||
+                        lessFunds() ||
+                        lessIngredients() ||
+                        limitReached()
+                      }
+                      onClick={handleBuy}
+                    >
+                      Buy
+                    </Button>
                     <Button onClick={closeConfirmationModal}>
                       {t("cancel")}
                     </Button>

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -14,6 +14,9 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { Modal } from "react-bootstrap";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 function isNotReady(collectible: Decoration) {
   return (
@@ -40,6 +43,7 @@ interface Props {
   items: Partial<Record<DecorationName, Decoration>>;
 }
 export const DecorationItems: React.FC<Props> = ({ items }) => {
+  const { t } = useAppTranslation();
   const [selected, setSelected] = useState<Decoration>(
     items[getKeys(items)[0]] as Decoration
   );
@@ -102,6 +106,18 @@ export const DecorationItems: React.FC<Props> = ({ items }) => {
   const limitReached = () =>
     selected.limit ? inventory[selected.name]?.gte(selected.limit) : false;
 
+  const [isConfirmBuyModalOpen, showConfirmBuyModal] = useState(false);
+  const openConfirmModal = () => {
+    showConfirmBuyModal(true);
+  };
+  const handleBuy = () => {
+    buy();
+    showConfirmBuyModal(false);
+  };
+  const closeConfirmationModal = () => {
+    showConfirmBuyModal(false);
+  };
+
   return (
     <SplitScreenView
       panel={
@@ -118,17 +134,38 @@ export const DecorationItems: React.FC<Props> = ({ items }) => {
           }}
           limit={selected.limit}
           actionView={
-            <Button
-              disabled={
-                isNotReady(selected) ||
-                lessFunds() ||
-                lessIngredients() ||
-                limitReached()
-              }
-              onClick={buy}
-            >
-              Buy
-            </Button>
+            <>
+              <Button
+                disabled={
+                  isNotReady(selected) ||
+                  lessFunds() ||
+                  lessIngredients() ||
+                  limitReached()
+                }
+                onClick={openConfirmModal}
+              >
+                Buy
+              </Button>
+              <Modal
+                centered
+                show={isConfirmBuyModalOpen}
+                onHide={closeConfirmationModal}
+              >
+                <CloseButtonPanel className="sm:w-4/5 m-auto">
+                  <div className="flex flex-col p-2">
+                    <span className="text-sm text-center">
+                      Are you sure you want to buy this item?
+                    </span>
+                  </div>
+                  <div className="flex justify-content-around mt-2 space-x-1">
+                    <Button onClick={handleBuy}>Buy</Button>
+                    <Button onClick={closeConfirmationModal}>
+                      {t("cancel")}
+                    </Button>
+                  </div>
+                </CloseButtonPanel>
+              </Modal>
+            </>
           }
         />
       }

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -118,7 +118,7 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
     if (state.wardrobe[selected])
       return (
         <div className="flex justify-center items-center">
-          <span className="text-xs">Already crafted</span>
+          <span className="text-xs">Already bought!</span>
           <img src={SUNNYSIDE.icons.confirm} className="h-4 ml-1" />
         </div>
       );
@@ -143,7 +143,7 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
           }
           onClick={openConfirmationModal}
         >
-          Craft
+          Buy
         </Button>
         <Modal
           centered
@@ -153,11 +153,11 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
           <CloseButtonPanel className="sm:w-4/5 m-auto">
             <div className="flex flex-col p-2">
               <span className="text-sm text-center">
-                Are you sure you want to craft this item?
+                Are you sure you want to buy {`${selected}`}?
               </span>
             </div>
             <div className="flex justify-content-around mt-2 space-x-1">
-              <Button onClick={buy}>Craft</Button>
+              <Button onClick={buy}>Buy</Button>
               <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
             </div>
           </CloseButtonPanel>

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -153,11 +153,11 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
           <CloseButtonPanel className="sm:w-4/5 m-auto">
             <div className="flex flex-col p-2">
               <span className="text-sm text-center">
-                Are you sure you want to buy this item?
+                Are you sure you want to craft this item?
               </span>
             </div>
             <div className="flex justify-content-around mt-2 space-x-1">
-              <Button onClick={buy}>Buy</Button>
+              <Button onClick={buy}>Craft</Button>
               <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
             </div>
           </CloseButtonPanel>

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -23,6 +23,9 @@ import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements
 import { GameState } from "features/game/types/game";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { Modal } from "react-bootstrap";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 function isNotReady(name: BumpkinItem, state: GameState) {
   const wearable = STYLIST_WEARABLES(state)[name] as StylistWearable;
@@ -102,6 +105,15 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
     }
   };
 
+  const [isConfirmBuyModalOpen, showConfirmBuyModal] = useState(false);
+  const openConfirmationModal = () => {
+    showConfirmBuyModal(true);
+  };
+  const closeConfirmationModal = () => {
+    showConfirmBuyModal(false);
+  };
+
+  const { t } = useAppTranslation();
   const Action = () => {
     if (state.wardrobe[selected])
       return (
@@ -124,14 +136,33 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
     }
 
     return (
-      <Button
-        disabled={
-          isNotReady(selected, state) || lessFunds() || lessIngredients()
-        }
-        onClick={buy}
-      >
-        Craft
-      </Button>
+      <>
+        <Button
+          disabled={
+            isNotReady(selected, state) || lessFunds() || lessIngredients()
+          }
+          onClick={openConfirmationModal}
+        >
+          Craft
+        </Button>
+        <Modal
+          centered
+          show={isConfirmBuyModalOpen}
+          onHide={closeConfirmationModal}
+        >
+          <CloseButtonPanel className="sm:w-4/5 m-auto">
+            <div className="flex flex-col p-2">
+              <span className="text-sm text-center">
+                Are you sure you want to buy this item?
+              </span>
+            </div>
+            <div className="flex justify-content-around mt-2 space-x-1">
+              <Button onClick={buy}>Buy</Button>
+              <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
+            </div>
+          </CloseButtonPanel>
+        </Modal>
+      </>
     );
   };
 

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -157,7 +157,16 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
               </span>
             </div>
             <div className="flex justify-content-around mt-2 space-x-1">
-              <Button onClick={buy}>Buy</Button>
+              <Button
+                disabled={
+                  isNotReady(selected, state) ||
+                  lessFunds() ||
+                  lessIngredients()
+                }
+                onClick={buy}
+              >
+                Buy
+              </Button>
               <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
             </div>
           </CloseButtonPanel>


### PR DESCRIPTION
# Description

Players have reported accidentally pressing on buy for a seasonal item when browsing through the respective shops when they are saving their scales for auctions. I added a confirmation modal for all of them so that they can still have a chance to cancel if they do not want to buy it

![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f5a00766-ad76-4310-bcf0-feaced781cc3)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
