### PR TITLE
[FEAT] Speed up composter

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -198,6 +198,10 @@ import {
   BurnCollectibleAction,
 } from "./landExpansion/burnCollectible";
 import { claimBonus, ClaimBonusAction } from "./landExpansion/claimBonus";
+import {
+  accelerateComposter,
+  AccelerateComposterAction,
+} from "./landExpansion/accelerateComposter";
 
 export type PlayingEvent =
   | TradeAction
@@ -265,7 +269,8 @@ export type PlayingEvent =
   | TradeTentacleAction
   | RevealLandAction
   | BurnCollectibleAction
-  | ClaimBonusAction;
+  | ClaimBonusAction
+  | AccelerateComposterAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -387,6 +392,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "land.revealed": revealLand,
   "collectible.burned": burnCollectible,
   "bonus.claimed": claimBonus,
+  "compost.accelerated": accelerateComposter,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/accelerateComposter.test.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.test.ts
@@ -196,7 +196,7 @@ describe("accelerateComposter", () => {
     const state = accelerateComposter({
       state: {
         ...GAME_STATE,
-        inventory: { Egg: new Decimal(20) },
+        inventory: { Egg: new Decimal(25) },
         buildings: {
           "Turbo Composter": [
             {
@@ -233,7 +233,7 @@ describe("accelerateComposter", () => {
     const state = accelerateComposter({
       state: {
         ...GAME_STATE,
-        inventory: { Egg: new Decimal(23) },
+        inventory: { Egg: new Decimal(33) },
         buildings: {
           "Premium Composter": [
             {

--- a/src/features/game/events/landExpansion/accelerateComposter.test.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.test.ts
@@ -1,6 +1,8 @@
 import { GameState } from "features/game/types/game";
 import { accelerateComposter } from "./accelerateComposter";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+import Decimal from "decimal.js-light";
+import { composterDetails } from "features/game/types/composters";
 
 const GAME_STATE: GameState = { ...TEST_FARM, bumpkin: INITIAL_BUMPKIN };
 
@@ -75,7 +77,189 @@ describe("accelerateComposter", () => {
       })
     ).toThrow("Composter already done");
   });
-  it("accelerates Compost Bin", () => {});
-  it("accelerates Turbo Composter", () => {});
-  it("accelerates Premium Composter", () => {});
+
+  it("requires player has eggs", () => {
+    expect(() =>
+      accelerateComposter({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            Egg: new Decimal(9),
+          },
+          buildings: {
+            "Compost Bin": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: 10000000,
+                id: "123",
+                readyAt: 10000000,
+                producing: {
+                  items: {},
+                  readyAt: Date.now() + 50000,
+                  startedAt: Date.now() - 500000,
+                },
+              },
+            ],
+          },
+        },
+        action: {
+          type: "compost.accelerated",
+          building: "Compost Bin",
+        },
+        createdAt: Date.now(),
+      })
+    ).toThrow("Missing Eggs");
+  });
+
+  it("does not double boost compost", () => {
+    const readyAt =
+      Date.now() + composterDetails["Compost Bin"].timeToFinishMilliseconds;
+
+    const state = accelerateComposter({
+      state: {
+        ...GAME_STATE,
+        inventory: { Egg: new Decimal(23) },
+        buildings: {
+          "Compost Bin": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 10000000,
+              id: "123",
+              readyAt: 10000000,
+              producing: {
+                items: {},
+                readyAt,
+                startedAt: Date.now() - 500000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.accelerated",
+        building: "Compost Bin",
+      },
+      createdAt: Date.now(),
+    });
+
+    expect(() =>
+      accelerateComposter({
+        state,
+        action: {
+          type: "compost.accelerated",
+          building: "Compost Bin",
+        },
+        createdAt: Date.now(),
+      })
+    ).toThrow("Already boosted");
+  });
+
+  it("accelerates Compost Bin", () => {
+    const readyAt =
+      Date.now() + composterDetails["Compost Bin"].timeToFinishMilliseconds;
+    const state = accelerateComposter({
+      state: {
+        ...GAME_STATE,
+        inventory: { Egg: new Decimal(13) },
+        buildings: {
+          "Compost Bin": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 10000000,
+              id: "123",
+              readyAt: 10000000,
+              producing: {
+                items: {},
+                readyAt,
+                startedAt: Date.now() - 500000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.accelerated",
+        building: "Compost Bin",
+      },
+      createdAt: Date.now(),
+    });
+
+    expect(state.inventory.Egg).toEqual(new Decimal(3));
+    expect(state.buildings["Compost Bin"]?.[0].producing?.readyAt).toEqual(
+      readyAt - 1 * 60 * 60 * 1000
+    );
+  });
+
+  it("accelerates Turbo Composter", () => {
+    const readyAt =
+      Date.now() + composterDetails["Turbo Composter"].timeToFinishMilliseconds;
+    const state = accelerateComposter({
+      state: {
+        ...GAME_STATE,
+        inventory: { Egg: new Decimal(20) },
+        buildings: {
+          "Turbo Composter": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 10000000,
+              id: "123",
+              readyAt: 10000000,
+              producing: {
+                items: {},
+                readyAt,
+                startedAt: Date.now() - 500000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.accelerated",
+        building: "Turbo Composter",
+      },
+      createdAt: Date.now(),
+    });
+
+    expect(state.inventory.Egg).toEqual(new Decimal(5));
+    expect(state.buildings["Turbo Composter"]?.[0].producing?.readyAt).toEqual(
+      readyAt - 2 * 60 * 60 * 1000
+    );
+  });
+  it("accelerates Premium Composter", () => {
+    const readyAt =
+      Date.now() +
+      composterDetails["Premium Composter"].timeToFinishMilliseconds;
+
+    const state = accelerateComposter({
+      state: {
+        ...GAME_STATE,
+        inventory: { Egg: new Decimal(23) },
+        buildings: {
+          "Premium Composter": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 10000000,
+              id: "123",
+              readyAt: 10000000,
+              producing: {
+                items: {},
+                readyAt,
+                startedAt: Date.now() - 500000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.accelerated",
+        building: "Premium Composter",
+      },
+      createdAt: Date.now(),
+    });
+
+    expect(state.inventory.Egg).toEqual(new Decimal(3));
+    expect(
+      state.buildings["Premium Composter"]?.[0].producing?.readyAt
+    ).toEqual(readyAt - 3 * 60 * 60 * 1000);
+  });
 });

--- a/src/features/game/events/landExpansion/accelerateComposter.test.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.test.ts
@@ -1,0 +1,81 @@
+import { GameState } from "features/game/types/game";
+import { accelerateComposter } from "./accelerateComposter";
+import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+
+const GAME_STATE: GameState = { ...TEST_FARM, bumpkin: INITIAL_BUMPKIN };
+
+describe("accelerateComposter", () => {
+  it("requires building exists", () => {
+    expect(() =>
+      accelerateComposter({
+        state: {
+          ...GAME_STATE,
+          buildings: {},
+        },
+        action: {
+          type: "compost.accelerated",
+          building: "Compost Bin",
+        },
+        createdAt: Date.now(),
+      })
+    ).toThrow("Composter does not exist");
+  });
+
+  it("requires compost is producing", () => {
+    expect(() =>
+      accelerateComposter({
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Compost Bin": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: 10000000,
+                id: "123",
+                readyAt: 10000000,
+              },
+            ],
+          },
+        },
+        action: {
+          type: "compost.accelerated",
+          building: "Compost Bin",
+        },
+        createdAt: Date.now(),
+      })
+    ).toThrow("Composter is not producing");
+  });
+
+  it("requires compost is not complete", () => {
+    expect(() =>
+      accelerateComposter({
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Compost Bin": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: 10000000,
+                id: "123",
+                readyAt: 10000000,
+                producing: {
+                  items: {},
+                  readyAt: Date.now() - 500,
+                  startedAt: Date.now() - 500000,
+                },
+              },
+            ],
+          },
+        },
+        action: {
+          type: "compost.accelerated",
+          building: "Compost Bin",
+        },
+        createdAt: Date.now(),
+      })
+    ).toThrow("Composter already done");
+  });
+  it("accelerates Compost Bin", () => {});
+  it("accelerates Turbo Composter", () => {});
+  it("accelerates Premium Composter", () => {});
+});

--- a/src/features/game/events/landExpansion/accelerateComposter.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.ts
@@ -1,0 +1,54 @@
+import Decimal from "decimal.js-light";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import {
+  ComposterName,
+  composterDetails,
+} from "features/game/types/composters";
+import { getKeys } from "features/game/types/craftables";
+import {
+  CompostBuilding,
+  GameState,
+  InventoryItemName,
+} from "features/game/types/game";
+import cloneDeep from "lodash.clonedeep";
+
+export type AccelerateComposterAction = {
+  type: "compost.accelerated";
+  building: ComposterName;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: AccelerateComposterAction;
+  createdAt?: number;
+};
+
+export function accelerateComposter({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  const stateCopy = cloneDeep<GameState>(state);
+
+  const buildings = stateCopy.buildings[action.building] as CompostBuilding[];
+  if (!buildings) {
+    throw new Error("Composter does not exist");
+  }
+
+  const composter = buildings[0];
+  const producing = composter.producing;
+
+  if (!producing) {
+    throw new Error("Composter is not producing");
+  }
+
+  if (createdAt > producing.readyAt) {
+    throw new Error("Composter already done");
+  }
+
+  // Subtract eggs
+
+  // Subtract time
+
+  return stateCopy;
+}

--- a/src/features/game/events/landExpansion/accelerateComposter.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.ts
@@ -1,15 +1,8 @@
-import Decimal from "decimal.js-light";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import {
   ComposterName,
   composterDetails,
 } from "features/game/types/composters";
-import { getKeys } from "features/game/types/craftables";
-import {
-  CompostBuilding,
-  GameState,
-  InventoryItemName,
-} from "features/game/types/game";
+import { CompostBuilding, GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
 
 export type AccelerateComposterAction = {
@@ -46,9 +39,24 @@ export function accelerateComposter({
     throw new Error("Composter already done");
   }
 
+  if (composter.boost) {
+    throw new Error("Already boosted");
+  }
+
+  const details = composterDetails[action.building];
+  if (!stateCopy.inventory.Egg?.gte(details.eggBoostRequirements)) {
+    throw new Error("Missing Eggs");
+  }
+
   // Subtract eggs
+  stateCopy.inventory.Egg = stateCopy.inventory.Egg.sub(
+    details.eggBoostRequirements
+  );
 
   // Subtract time
+  producing.readyAt -= details.eggBoostMilliseconds;
+
+  composter.boost = { Egg: details.eggBoostRequirements };
 
   return stateCopy;
 }

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -233,7 +233,7 @@ export const OFFLINE_FARM: GameState = {
     "Stone Rock": new Decimal(getKeys(INITIAL_RESOURCES.stones).length),
     Axe: new Decimal(10),
     "Block Buck": new Decimal(1),
-    Potato: new Decimal(1),
+    Egg: new Decimal(12),
   },
   wardrobe: {},
 
@@ -273,7 +273,7 @@ export const OFFLINE_FARM: GameState = {
         createdAt: 0,
       },
     ],
-    "Compost Bin": [
+    Workbench: [
       {
         id: "123",
         readyAt: 0,
@@ -282,11 +282,23 @@ export const OFFLINE_FARM: GameState = {
           y: 8,
         },
         createdAt: 0,
+      },
+    ],
+
+    "Compost Bin": [
+      {
+        id: "123",
+        readyAt: 0,
+        coordinates: {
+          x: 2,
+          y: 8,
+        },
+        createdAt: 0,
         producing: {
           items: {
             Earthworm: 1,
           },
-          readyAt: Date.now() + 50000,
+          readyAt: Date.now() + 5000000,
           startedAt: Date.now() - 50000,
         },
         requires: {

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -193,7 +193,7 @@ export const INITIAL_EXPANSIONS = 3;
 
 const INITIAL_BUMPKIN: Bumpkin = {
   id: 1,
-  experience: 0,
+  experience: 1000,
   tokenUri: "bla",
   equipped: {
     body: "Beige Farmer Potion",
@@ -233,6 +233,7 @@ export const OFFLINE_FARM: GameState = {
     "Stone Rock": new Decimal(getKeys(INITIAL_RESOURCES.stones).length),
     Axe: new Decimal(10),
     "Block Buck": new Decimal(1),
+    Potato: new Decimal(1),
   },
   wardrobe: {},
 
@@ -272,7 +273,7 @@ export const OFFLINE_FARM: GameState = {
         createdAt: 0,
       },
     ],
-    Workbench: [
+    "Compost Bin": [
       {
         id: "123",
         readyAt: 0,
@@ -281,6 +282,16 @@ export const OFFLINE_FARM: GameState = {
           y: 8,
         },
         createdAt: 0,
+        producing: {
+          items: {
+            Earthworm: 1,
+          },
+          readyAt: Date.now() + 50000,
+          startedAt: Date.now() - 50000,
+        },
+        requires: {
+          Potato: 1,
+        },
       },
     ],
 

--- a/src/features/game/types/composters.ts
+++ b/src/features/game/types/composters.ts
@@ -59,6 +59,8 @@ export type ComposterDetails = {
   produce: CompostName;
   produceAmount: number;
   worm: Worm;
+  eggBoostRequirements: number;
+  eggBoostMilliseconds: number;
 };
 
 export const composterDetails: Record<ComposterName, ComposterDetails> = {
@@ -67,17 +69,23 @@ export const composterDetails: Record<ComposterName, ComposterDetails> = {
     produce: "Sprout Mix",
     produceAmount: 10,
     timeToFinishMilliseconds: 6 * 60 * 60 * 1000,
+    eggBoostRequirements: 10,
+    eggBoostMilliseconds: 1 * 60 * 60 * 1000,
   },
   "Turbo Composter": {
     produce: "Fruitful Blend",
     produceAmount: 3,
     worm: "Grub",
     timeToFinishMilliseconds: 8 * 60 * 60 * 1000,
+    eggBoostRequirements: 15,
+    eggBoostMilliseconds: 2 * 60 * 60 * 1000,
   },
   "Premium Composter": {
     produce: "Rapid Root",
     produceAmount: 10,
     worm: "Red Wiggler",
     timeToFinishMilliseconds: 12 * 60 * 60 * 1000,
+    eggBoostRequirements: 20,
+    eggBoostMilliseconds: 3 * 60 * 60 * 1000,
   },
 };

--- a/src/features/game/types/composters.ts
+++ b/src/features/game/types/composters.ts
@@ -77,7 +77,7 @@ export const composterDetails: Record<ComposterName, ComposterDetails> = {
     produceAmount: 3,
     worm: "Grub",
     timeToFinishMilliseconds: 8 * 60 * 60 * 1000,
-    eggBoostRequirements: 15,
+    eggBoostRequirements: 20,
     eggBoostMilliseconds: 2 * 60 * 60 * 1000,
   },
   "Premium Composter": {
@@ -85,7 +85,7 @@ export const composterDetails: Record<ComposterName, ComposterDetails> = {
     produceAmount: 10,
     worm: "Red Wiggler",
     timeToFinishMilliseconds: 12 * 60 * 60 * 1000,
-    eggBoostRequirements: 20,
+    eggBoostRequirements: 30,
     eggBoostMilliseconds: 3 * 60 * 60 * 1000,
   },
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -437,6 +437,7 @@ export type Collectibles = Partial<PlacedTypes<CollectibleName>>;
 export type CompostBuilding = PlacedItem & {
   producing?: BuildingProduce;
   requires?: Partial<Record<InventoryItemName, number>>;
+  boost?: Partial<Record<InventoryItemName, number>>;
 };
 
 type CustomBuildings = {

--- a/src/features/island/buildings/components/building/composters/Composter.tsx
+++ b/src/features/island/buildings/components/building/composters/Composter.tsx
@@ -12,6 +12,7 @@ import { ComposterName } from "features/game/types/composters";
 import { CompostBuilding } from "features/game/types/game";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
+import { ITEM_DETAILS } from "features/game/types/images";
 
 const getComposter = (type: BuildingName) => (state: MachineState) =>
   state.context.state.buildings[type]?.[0] as CompostBuilding;
@@ -27,7 +28,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
   const { gameService, showTimers } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
 
-  const [_, setRender] = useState<number>(0);
+  const [renderKey, setRender] = useState<number>(0);
 
   const composter = useSelector(gameService, getComposter(name), compare);
 
@@ -109,6 +110,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
               }}
             >
               <LiveProgressBar
+                key={renderKey}
                 startAt={composter?.producing?.startedAt}
                 endAt={composter?.producing?.readyAt}
                 formatLength="short"
@@ -120,6 +122,19 @@ export const Composter: React.FC<Props> = ({ name }) => {
               />
             </div>
           )}
+          {composter.boost && (
+            <>
+              <img
+                src={ITEM_DETAILS.Egg.image}
+                className="absolute z-10"
+                style={{
+                  width: `${PIXEL_SCALE * 10}px`,
+                  bottom: `${PIXEL_SCALE * 22}px`,
+                  right: `${PIXEL_SCALE * -4}px`,
+                }}
+              />
+            </>
+          )}
         </div>
       </BuildingImageWrapper>
 
@@ -130,6 +145,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
         startComposter={startComposter}
         readyAt={composter?.producing?.readyAt}
         onCollect={handleCollect}
+        onBoost={() => setRender((r) => r + 1)}
       />
       {ready && (
         <div

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -35,6 +35,7 @@ import { getKeys } from "features/game/types/craftables";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { OuterPanel } from "components/ui/Panel";
+import { hasFeatureAccess } from "lib/flags";
 
 const WORM_OUTPUT: Record<ComposterName, string> = {
   "Compost Bin": "2-4",
@@ -202,6 +203,8 @@ export const ComposterModal: React.FC<Props> = ({
       );
     }
 
+    const canBoost = hasFeatureAccess(state, "COMPOST_BOOST");
+
     if (composting) {
       return (
         <>
@@ -229,7 +232,7 @@ export const ComposterModal: React.FC<Props> = ({
               </div>
             </div>
           </div>
-          {!boost && (
+          {canBoost && !boost && (
             <OuterPanel className="p-1">
               <div className="flex justify-between mb-1">
                 <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
@@ -260,7 +263,7 @@ export const ComposterModal: React.FC<Props> = ({
               </Button>
             </OuterPanel>
           )}
-          {boost && (
+          {canBoost && boost && (
             <OuterPanel className="p-1">
               <div className="flex justify-between">
                 <Label

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -113,6 +113,7 @@ interface Props {
   composterName: ComposterName;
   onCollect: () => void;
   readyAt?: number;
+  onBoost: () => void;
 }
 
 export const ComposterModal: React.FC<Props> = ({
@@ -122,6 +123,7 @@ export const ComposterModal: React.FC<Props> = ({
   startComposter,
   readyAt,
   onCollect,
+  onBoost,
 }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
@@ -137,6 +139,8 @@ export const ComposterModal: React.FC<Props> = ({
 
   const produces = state.buildings[composterName]?.[0].producing?.items ?? {};
   const requires = state.buildings[composterName]?.[0].requires ?? {};
+  const boost = state.buildings[composterName]?.[0].boost;
+
   const hasRequirements = getKeys(requires).every((name) => {
     const amount = requires[name] || new Decimal(0);
 
@@ -152,6 +156,13 @@ export const ComposterModal: React.FC<Props> = ({
       setTab(1);
     }
   }, [showModal]);
+
+  const accelerate = () => {
+    gameService.send("compost.accelerated", {
+      building: composterName,
+    });
+    onBoost();
+  };
 
   const Content = () => {
     if (isReady) {
@@ -218,23 +229,58 @@ export const ComposterModal: React.FC<Props> = ({
               </div>
             </div>
           </div>
-          <OuterPanel className="p-1">
-            <div className="flex justify-between mb-1">
-              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-                +1 Hour Boost
-              </Label>
-              <RequirementLabel
-                type="item"
-                item="Egg"
-                requirement={new Decimal(10)}
-                balance={new Decimal(5)}
-              />
-            </div>
-            <p className="text-xs mb-2">
-              Add egg shells to speed up production.
-            </p>
-            <Button>Add Eggs</Button>
-          </OuterPanel>
+          {!boost && (
+            <OuterPanel className="p-1">
+              <div className="flex justify-between mb-1">
+                <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                  {`${secondsToString(
+                    composterInfo.eggBoostMilliseconds / 1000,
+                    {
+                      length: "short",
+                    }
+                  )} Boost`}
+                </Label>
+                <RequirementLabel
+                  type="item"
+                  item="Egg"
+                  requirement={new Decimal(composterInfo.eggBoostRequirements)}
+                  balance={state.inventory.Egg ?? new Decimal(0)}
+                />
+              </div>
+              <p className="text-xs mb-2">
+                Add egg shells to speed up production.
+              </p>
+              <Button
+                disabled={
+                  !state.inventory.Egg?.gte(composterInfo.eggBoostRequirements)
+                }
+                onClick={accelerate}
+              >
+                Add Eggs
+              </Button>
+            </OuterPanel>
+          )}
+          {boost && (
+            <OuterPanel className="p-1">
+              <div className="flex justify-between">
+                <Label
+                  type="info"
+                  icon={SUNNYSIDE.icons.stopwatch}
+                  secondaryIcon={SUNNYSIDE.icons.confirm}
+                >
+                  {`${secondsToString(
+                    composterInfo.eggBoostMilliseconds / 1000,
+                    {
+                      length: "short",
+                    }
+                  )} Boosted`}
+                </Label>
+                <Label type="default" icon={ITEM_DETAILS.Egg.image}>
+                  {composterInfo.eggBoostRequirements} Eggs
+                </Label>
+              </div>
+            </OuterPanel>
+          )}
         </>
       );
     }

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -34,6 +34,7 @@ import { GameState, Inventory } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { SquareIcon } from "components/ui/SquareIcon";
+import { OuterPanel } from "components/ui/Panel";
 
 const WORM_OUTPUT: Record<ComposterName, string> = {
   "Compost Bin": "2-4",
@@ -217,6 +218,23 @@ export const ComposterModal: React.FC<Props> = ({
               </div>
             </div>
           </div>
+          <OuterPanel className="p-1">
+            <div className="flex justify-between mb-1">
+              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                +1 Hour Boost
+              </Label>
+              <RequirementLabel
+                type="item"
+                item="Egg"
+                requirement={new Decimal(10)}
+                balance={new Decimal(5)}
+              />
+            </div>
+            <p className="text-xs mb-2">
+              Add egg shells to speed up production.
+            </p>
+            <Button>Add Eggs</Button>
+          </OuterPanel>
         </>
       );
     }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -23,7 +23,8 @@ type FeatureName =
   | "BEACH"
   | "HALLOWEEN"
   | "BANANA"
-  | "LOCALISATION";
+  | "LOCALISATION"
+  | "COMPOST_BOOST";
 
 // Used for testing production features
 export const ADMIN_IDS = [1, 2, 3, 39488, 1011, 45, 130170, 29, 7841, 51];
@@ -32,6 +33,7 @@ type FeatureFlag = (game: GameState) => boolean;
 
 const featureFlags: Record<FeatureName, FeatureFlag> = {
   JEST_TEST: defaultFeatureFlag,
+  COMPOST_BOOST: defaultFeatureFlag,
   PUMPKIN_PLAZA: defaultFeatureFlag,
   NEW_DELIVERIES: testnetFeatureFlag,
   NEW_FARM_FLOW: () => true,


### PR DESCRIPTION
# Description

This PR enables the ability to speed up a composter using Egg Shells. Players are currently looking for alternate methods to attain bait to meet their fishing needs - this update provides utility for eggs and bonus bait ❤️ 


<img width="519" alt="Screenshot 2023-11-28 at 5 05 12 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/fcfdcb24-974c-4a43-b851-50dcaaf3f159">
<img width="138" alt="Screenshot 2023-11-28 at 5 00 13 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/36f384ef-ecdf-49bb-9c8a-ee99925485f6">
<img width="537" alt="Screenshot 2023-11-28 at 5 00 17 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/7fee89d9-88e8-4436-9d84-a4da2e86f252">


## How to test?

Run locally, and put some eggs in the Composter!
