### PR TITLE
[FIX] getBumpkinLevelRequiredForNode()

### DIFF
--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -103,14 +103,12 @@ export function getBumpkinLevelRequiredForNode(
   index: number,
   nodeType: string
 ): BumpkinLevel {
-  return 1;
-
   const key = nodeType as keyof Nodes;
 
   let count = LAND_3_NODES[key];
   for (let expansions = 4; expansions <= 23; ++expansions) {
     if (count > index)
-      return EXPANSION_REQUIREMENTS[expansions as Land]
+      return EXPANSION_REQUIREMENTS[(expansions - 1) as Land]
         .bumpkinLevel as BumpkinLevel;
     count += EXPANSION_NODES[expansions as Land][key];
   }


### PR DESCRIPTION
# Description

The root issue for the original bumpkin level requirements for nodes was a missing `-1` in the `getBumpkinLevelRequiredForNode` function.

As such the fix was a one-line change from `expansions` to `(expansions - 1)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Nonetheless, exhaustive testing was done with the test infrastructure in #3179.

Supporting changes
- Add `getLandLimit` function for convenient mapping from bumpkin level to expansion count allowed.
- Add `INITIAL_BUMPKIN_LEVEL` constant for local farm testing.
- Replace the hardcoded experience and inventory node counts in `INITIAL_BUMPKIN` and `OFFLINE_FARM` with values auto-populated based on `INITIAL_BUMPKIN_LEVEL`.
- Automatically place all available stone, iron, and gold nodes in `INITIAL_RESOURCES` based on `INITIAL_BUMPKIN_LEVEL`.
- Apply the fix to `getBumpkinLevelRequiredForNode`.

New nodes are unlocked at the following progress points:
- 3 expansions, unlocked by bumpkin level 1
- 9 expansions, unlocked by bumpkin level 11
- 12 expansions, unlocked by bumpkin level 17
- 15 expansions, unlocked by bumpkin level 26
- 18 expansions, unlocked by bumpkin level 37
- 21 expansions, unlocked by bumpkin level 50

Testing sequence for each of the 6 progress points:
1. Set `INITIAL_BUMPKIN_LEVEL` (and save to trigger farm reload)
2. Verify the correct number of stone, iron, and gold nodes are placed and enabled
3. Change `experience` in `INITIAL_BUMPKIN` to reflect `INITIAL_BUMPKIN_LEVEL - 1` (and save to trigger farm reload)
4. Verify the correct number of stone, iron, and gold nodes are placed but that the most recent expansion nodes are disabled with tooltip indicating the same level as `INITIAL_BUMPKIN_LEVEL`
- Note that steps 3 and 4 are skipped for the bumpkin level 1 case (as there is no such thing as bumpkin level 0).