### PR TITLE
[FIX] Goblin Retreat Gold Pass

### DIFF
--- a/src/features/game/lib/transforms.test.ts
+++ b/src/features/game/lib/transforms.test.ts
@@ -59,6 +59,34 @@ describe("transform", () => {
     });
   });
 
+  it("takes off chain Gold Pass balance but lowest of everything else", () => {
+    const state = getAvailableGameState({
+      onChain: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(5),
+          Axe: new Decimal(100),
+          Stone: new Decimal(20),
+        },
+      },
+      offChain: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(10),
+          Axe: new Decimal(90),
+          Gold: new Decimal(0.5),
+          "Gold Pass": new Decimal(1),
+        },
+      },
+    });
+
+    expect(state.inventory).toEqual({
+      Sunflower: new Decimal(5),
+      Axe: new Decimal(90),
+      "Gold Pass": new Decimal(1),
+    });
+  });
+
   it("filters out placed items", () => {
     const lowest = getAvailableGameState({
       onChain: {

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -147,7 +147,14 @@ export function getAvailableGameState({
     const firstAmount = onChain.inventory[name] || new Decimal(0);
     const secondAmount = availableItems[name] || new Decimal(0);
 
-    const amount = firstAmount.lt(secondAmount) ? firstAmount : secondAmount;
+    let amount: Decimal;
+
+    // Gold Pass was airdropped to all farms created prior to the pass release. This is a large number of farms. We will prefer the off chain balance in this case.
+    if (name === "Gold Pass") {
+      amount = secondAmount;
+    } else {
+      amount = firstAmount.lt(secondAmount) ? firstAmount : secondAmount;
+    }
 
     if (amount.eq(0)) {
       return inv;


### PR DESCRIPTION
# Description

Do not require the Gold Pass to be on chain when visiting Goblin Retreat. (Many players were airdropped this off chain when it was released.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
