### PR TITLE
[FIX] Confirmation Modal appears even though Buy button wasn't clicked

### DIFF
--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -99,6 +99,10 @@ export const HeliosBlacksmithItems: React.FC = () => {
   const closeConfirmationModal = () => {
     showConfirmBuyModal(false);
   };
+  const handleBuy = () => {
+    craft();
+    showConfirmBuyModal(false);
+  };
 
   return (
     <SplitScreenView
@@ -140,7 +144,7 @@ export const HeliosBlacksmithItems: React.FC = () => {
                     <div className="flex justify-content-around mt-2 space-x-1">
                       <Button
                         disabled={lessIngredients() || isNotReady(selectedItem)}
-                        onClick={craft}
+                        onClick={handleBuy}
                       >
                         Craft
                       </Button>

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -112,6 +112,10 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
   const closeConfirmationModal = () => {
     showConfirmBuyModal(false);
   };
+  const handleBuy = () => {
+    buy();
+    showConfirmBuyModal(false);
+  };
 
   const { t } = useAppTranslation();
   const Action = () => {
@@ -163,7 +167,7 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
                   lessFunds() ||
                   lessIngredients()
                 }
-                onClick={buy}
+                onClick={handleBuy}
               >
                 Buy
               </Button>


### PR DESCRIPTION
# Description
This PR is to address an issue from #3207 where if you buy something in either Stella or Blacksmith and attempt to click on another item, even though you didn't click on buy the confirmation modal appears. The issue doesn't appear for frankie as I added it in the initial PR

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
