### PR TITLE
[CHORE] Use new reward interface for chest rewards

### DIFF
--- a/src/features/game/components/Revealed.tsx
+++ b/src/features/game/components/Revealed.tsx
@@ -7,7 +7,7 @@ import { Context } from "../GameProvider";
 import { getKeys } from "../types/craftables";
 import { Label } from "components/ui/Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { ClaimReward } from "../expansion/components/Airdrop";
+import { ClaimReward } from "../expansion/components/ClaimReward";
 
 export const Revealed: React.FC<{
   onAcknowledged?: () => void;

--- a/src/features/game/expansion/components/Airdrop.tsx
+++ b/src/features/game/expansion/components/Airdrop.tsx
@@ -1,111 +1,15 @@
 import { useActor } from "@xstate/react";
-import { Button } from "components/ui/Button";
 import React, { useContext, useState } from "react";
 import { Modal } from "react-bootstrap";
 
-import token from "src/assets/icons/token_2.png";
-import powerup from "assets/icons/level_up.png";
 import { Context } from "features/game/GameProvider";
-import { getKeys } from "features/game/types/craftables";
-import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { getImageUrl } from "features/goblins/tailor/TabContent";
-import { ITEM_IDS } from "features/game/types/bumpkin";
 import { Airdrop as IAirdrop } from "features/game/types/game";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
-import { Label } from "components/ui/Label";
-import { Box } from "components/ui/Box";
-import { CONSUMABLES, ConsumableName } from "features/game/types/consumables";
+import { ClaimReward } from "./ClaimReward";
 
-interface ClaimRewardProps {
-  reward: IAirdrop;
-  onClaim?: () => void;
-  onClose?: () => void;
-}
-
-export const ClaimReward: React.FC<ClaimRewardProps> = ({
-  reward: airdrop,
-  onClaim,
-  onClose,
-}) => {
-  const itemNames = getKeys(airdrop.items);
-
-  return (
-    <>
-      <div className="p-1">
-        <Label
-          className="ml-2 mb-2 mt-1"
-          type="warning"
-          icon={SUNNYSIDE.decorations.treasure_chest}
-        >
-          Reward Discovered
-        </Label>
-        {airdrop.message && (
-          <p className="text-xs mb-2 ml-1">{airdrop.message}</p>
-        )}
-        <div className="flex flex-col">
-          {!!airdrop.sfl && (
-            <div className="flex items-center">
-              <Box image={token} />
-              <div>
-                <Label type="warning">{airdrop.sfl} SFL</Label>
-                <p className="text-xs">Spend it wisely.</p>
-              </div>
-            </div>
-          )}
-
-          {itemNames.length > 0 &&
-            itemNames.map((name) => (
-              <div className="flex items-center" key={name}>
-                <Box image={ITEM_DETAILS[name].image} />
-                <div>
-                  <div className="flex items-center">
-                    <Label type="default" className="mr-2">
-                      {`${airdrop.items[name] ?? 1} x ${name}`}
-                    </Label>
-                    {name in CONSUMABLES && (
-                      <Label
-                        type="success"
-                        icon={powerup}
-                        className="mr-2"
-                      >{`+${
-                        CONSUMABLES[name as ConsumableName].experience
-                      } EXP`}</Label>
-                    )}
-                  </div>
-                  <p className="text-xs">{ITEM_DETAILS[name].description}</p>
-                </div>
-              </div>
-            ))}
-
-          {getKeys(airdrop.wearables ?? {}).length > 0 &&
-            getKeys(airdrop.wearables).map((name) => (
-              <div className="flex items-center mb-2" key={name}>
-                <Box image={getImageUrl(ITEM_IDS[name])} />
-                <div>
-                  <Label type="default">{`${
-                    airdrop.wearables[name] ?? 1
-                  } x ${name}`}</Label>
-                  <p className="text-xs">A wearable for your Bumpkin</p>
-                </div>
-              </div>
-            ))}
-        </div>
-      </div>
-
-      <div className="flex items-center mt-1">
-        {onClose && <Button onClick={onClose}>Close</Button>}
-        {onClaim && (
-          <Button onClick={onClaim} className="ml-1">
-            Claim
-          </Button>
-        )}
-      </div>
-    </>
-  );
-};
 export const AirdropModal: React.FC<{
   airdrop: IAirdrop;
   onClose?: () => void;

--- a/src/features/game/expansion/components/ClaimReward.tsx
+++ b/src/features/game/expansion/components/ClaimReward.tsx
@@ -1,0 +1,110 @@
+import { Button } from "components/ui/Button";
+import React from "react";
+
+import token from "src/assets/icons/token_2.png";
+import powerup from "assets/icons/level_up.png";
+import { getKeys } from "features/game/types/craftables";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { getImageUrl } from "features/goblins/tailor/TabContent";
+import { ITEM_IDS } from "features/game/types/bumpkin";
+import { Airdrop as IAirdrop } from "features/game/types/game";
+import { Label } from "components/ui/Label";
+import { Box } from "components/ui/Box";
+import { CONSUMABLES, ConsumableName } from "features/game/types/consumables";
+import { setPrecision } from "lib/utils/formatNumber";
+import Decimal from "decimal.js-light";
+
+interface ClaimRewardProps {
+  reward: IAirdrop;
+  onClaim?: () => void;
+  onClose?: () => void;
+}
+
+export const ClaimReward: React.FC<ClaimRewardProps> = ({
+  reward: airdrop,
+  onClaim,
+  onClose,
+}) => {
+  const itemNames = getKeys(airdrop.items);
+
+  return (
+    <>
+      <div className="p-1">
+        <Label
+          className="ml-2 mb-2 mt-1"
+          type="warning"
+          icon={SUNNYSIDE.decorations.treasure_chest}
+        >
+          Reward Discovered
+        </Label>
+        {airdrop.message && (
+          <p className="text-xs mb-2 ml-1">{airdrop.message}</p>
+        )}
+        <div className="flex flex-col">
+          {!!airdrop.sfl && (
+            <div className="flex items-center">
+              <Box image={token} />
+              <div>
+                <Label type="warning">
+                  {setPrecision(new Decimal(airdrop.sfl)).toString()} SFL
+                </Label>
+                <p className="text-xs">Spend it wisely.</p>
+              </div>
+            </div>
+          )}
+
+          {itemNames.length > 0 &&
+            itemNames.map((name) => (
+              <div className="flex items-center" key={name}>
+                <Box image={ITEM_DETAILS[name].image} />
+                <div>
+                  <div className="flex items-center">
+                    <Label type="default" className="mr-2">
+                      {`${setPrecision(
+                        new Decimal(airdrop.items[name] ?? 1)
+                      ).toString()} x ${name}`}
+                    </Label>
+                    {name in CONSUMABLES && (
+                      <Label
+                        type="success"
+                        icon={powerup}
+                        className="mr-2"
+                      >{`+${setPrecision(
+                        new Decimal(
+                          CONSUMABLES[name as ConsumableName].experience
+                        )
+                      ).toString()} EXP`}</Label>
+                    )}
+                  </div>
+                  <p className="text-xs">{ITEM_DETAILS[name].description}</p>
+                </div>
+              </div>
+            ))}
+
+          {getKeys(airdrop.wearables ?? {}).length > 0 &&
+            getKeys(airdrop.wearables).map((name) => (
+              <div className="flex items-center mb-2" key={name}>
+                <Box image={getImageUrl(ITEM_IDS[name])} />
+                <div>
+                  <Label type="default">{`${setPrecision(
+                    new Decimal(airdrop.wearables[name] ?? 1)
+                  ).toString()} x ${name}`}</Label>
+                  <p className="text-xs">A wearable for your Bumpkin</p>
+                </div>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      <div className="flex items-center mt-1">
+        {onClose && <Button onClick={onClose}>Close</Button>}
+        {onClaim && (
+          <Button onClick={onClaim} className="ml-1">
+            Claim
+          </Button>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/features/game/expansion/components/DiscordBoat.tsx
+++ b/src/features/game/expansion/components/DiscordBoat.tsx
@@ -13,7 +13,7 @@ import { Button } from "components/ui/Button";
 import { useActor, useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { redirectOAuth } from "features/auth/actions/oauth";
-import { ClaimReward } from "./Airdrop";
+import { ClaimReward } from "./ClaimReward";
 import { BONUSES } from "features/game/types/bonuses";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { MachineState } from "features/game/lib/gameMachine";

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -4,14 +4,12 @@ import { Modal } from "react-bootstrap";
 
 import { InventoryItemName, Reward } from "features/game/types/game";
 
-import { Button } from "components/ui/Button";
-import { ITEM_DETAILS } from "features/game/types/images";
 import { Context } from "features/game/GameProvider";
 
-import token from "assets/icons/token_2.png";
 import { StopTheGoblins } from "features/island/common/chest-reward/StopTheGoblins";
 import { ChestCaptcha } from "features/island/common/chest-reward/ChestCaptcha";
 import { Loading } from "features/auth/components";
+import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 
 interface Props {
   collectedItem?: InventoryItemName;
@@ -68,56 +66,38 @@ export const ChestReward: React.FC<Props> = ({
     <Modal centered show={true}>
       <Panel>
         {loading && <Loading />}
-        <div
-          hidden={loading} // render and hide captchas so images have time to load
-          className="flex flex-col items-center justify-between"
-        >
-          {opened ? (
-            <>
-              <span className="text-center my-2">
-                Woohoo! Here is your reward
-              </span>
-              {items &&
-                items.map((item) => {
-                  const name = `${item.amount} ${item.name}${
-                    item.name === "Gold" ? "" : "s"
-                  }`;
-
-                  return (
-                    <div key={item.name} className="flex items-center my-2">
-                      <img
-                        className="w-5 img-highlight mr-2"
-                        src={ITEM_DETAILS[item.name].image}
-                      />
-                      <span className="text-center">{name}</span>
-                    </div>
-                  );
-                })}
-              {sfl && (
-                <div key="sfl" className="flex items-center my-2">
-                  <img className="w-5 img-highlight mr-2" src={token} />
-                  <span className="text-center">{`${sfl} SFL`}</span>
-                </div>
-              )}
-              <Button onClick={() => close(true)} className="w-full mt-1">
-                Close
-              </Button>
-            </>
-          ) : (
-            <>
-              {challenge.current === "goblins" && (
-                <StopTheGoblins
-                  onFail={fail}
-                  onOpen={open}
-                  collectedItem={collectedItem}
-                />
-              )}
-              {challenge.current === "chest" && (
-                <ChestCaptcha onFail={fail} onOpen={open} />
-              )}
-            </>
-          )}
-        </div>
+        {opened ? (
+          <ClaimReward
+            reward={{
+              id: "chest-reward",
+              createdAt: Date.now(),
+              items:
+                items?.reduce((acc, { name, amount }) => {
+                  return { ...acc, [name]: amount };
+                }, {} as Record<InventoryItemName, number>) ?? {},
+              wearables: {},
+              sfl: sfl ? sfl.toNumber() : 0,
+              message: "Woohoo! Here is your reward",
+            }}
+            onClose={() => close(true)}
+          />
+        ) : (
+          <div
+            hidden={loading} // render and hide captchas so images have time to load
+            className="flex flex-col items-center justify-between"
+          >
+            {challenge.current === "goblins" && (
+              <StopTheGoblins
+                onFail={fail}
+                onOpen={open}
+                collectedItem={collectedItem}
+              />
+            )}
+            {challenge.current === "chest" && (
+              <ChestCaptcha onFail={fail} onOpen={open} />
+            )}
+          </div>
+        )}
       </Panel>
     </Modal>
   );

--- a/src/features/portal/examples/cropBoom/components/CropBoomFinish.tsx
+++ b/src/features/portal/examples/cropBoom/components/CropBoomFinish.tsx
@@ -1,4 +1,4 @@
-import { ClaimReward } from "features/game/expansion/components/Airdrop";
+import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 import React, { useContext } from "react";
 import { PortalContext } from "../lib/PortalProvider";
 import { useActor } from "@xstate/react";

--- a/src/features/world/ui/ParsnipGiveaway.tsx
+++ b/src/features/world/ui/ParsnipGiveaway.tsx
@@ -4,7 +4,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
 import { Context } from "features/game/GameProvider";
-import { ClaimReward } from "features/game/expansion/components/Airdrop";
+import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 import { BONUSES } from "features/game/types/bonuses";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { useContext, useState } from "react";

--- a/src/features/world/ui/npcs/Santa.tsx
+++ b/src/features/world/ui/npcs/Santa.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
-import { ClaimReward } from "features/game/expansion/components/Airdrop";
+import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 import candy from "public/world/candy_icon.png";
 import gift from "assets/icons/gift.png";
 import {


### PR DESCRIPTION
# Description

- use new claim reward screen for chest rewards

Before|After
---|---
<img width="770" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/90e4b168-1a67-4022-8e32-69b50859ae99">|<img width="770" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/77314a5a-8491-423f-ad4e-0174c3d79e4f">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open chest rewards from trees or crops

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
