### PR TITLE
[FIX] SFL/XP toast not showing up when initial value is 0

### DIFF
--- a/src/features/game/toast/ToastPanel.tsx
+++ b/src/features/game/toast/ToastPanel.tsx
@@ -65,21 +65,17 @@ export const ToastPanel: React.FC = () => {
     // balance is set and changed
     if (
       !!newBalance.current &&
-      !(oldBalance.current ?? new Decimal(0)).equals(
-        newBalance.current ?? new Decimal(0)
-      )
+      oldBalance.current?.equals(newBalance.current) !== true
     ) {
-      setBalance(newBalance.current ?? new Decimal(0));
+      setBalance(newBalance.current);
     }
 
     // experience is set and changed
     if (
       !!newExperience.current &&
-      !(oldExperience.current ?? new Decimal(0)).equals(
-        newExperience.current ?? new Decimal(0)
-      )
+      oldExperience.current?.equals(newExperience.current) !== true
     ) {
-      setExperience(newExperience.current ?? new Decimal(0));
+      setExperience(newExperience.current);
     }
   });
 


### PR DESCRIPTION
# Description

- SFL and XP toasts are not showing if the initial SFL and XP is 0 respectively.  This is due to a bug in the code where it is not initializing the current toast values when they are 0 respectively.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- load game with 0 SFL and collect SFL for the first time
- load game with 0 XP and collect XP for the first time

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
