### PR TITLE
[FIX] Level Up unlocks

### DIFF
--- a/src/features/island/bumpkin/components/LevelUp.tsx
+++ b/src/features/island/bumpkin/components/LevelUp.tsx
@@ -22,6 +22,10 @@ import { BUILDINGS } from "features/game/types/buildings";
 import { ITEM_DETAILS } from "features/game/types/images";
 import worldIcon from "assets/icons/world_small.png";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import {
+  EXPANSION_REQUIREMENTS,
+  Land,
+} from "features/game/expansion/lib/expansionRequirements";
 
 const BONUS_UNLOCKS: Record<number, { text: string; icon: string }[]> = {
   2: [
@@ -72,7 +76,11 @@ function generateUnlockLabels(): Record<
 
     const buildings = getKeys(BUILDINGS())
       .filter((name) =>
-        BUILDINGS()[name].find((b) => b.unlocksAtLevel === level)
+        BUILDINGS()[name].find(
+          (b) =>
+            EXPANSION_REQUIREMENTS[b.unlocksAtLevel as Land]?.bumpkinLevel ===
+            level
+        )
       )
       .map((name) => ({ text: name, icon: ITEM_DETAILS[name].image }));
 


### PR DESCRIPTION
# Description

With Node Rebalancing, the meaning of `unlocksAtLevel` was changed but the Level Up UI wasn't updated to match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
