### PR TITLE
[FIX] Bring back the disabled Collect button while composting

### DIFF
--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -2,7 +2,7 @@ import { Bumpkin } from "../types/game";
 import { BumpkinLevel } from "features/game/lib/level";
 import { getLandLimit } from "../expansion/lib/expansionRequirements";
 
-export const INITIAL_BUMPKIN_LEVEL = 38;
+export const INITIAL_BUMPKIN_LEVEL = 1;
 
 // Special case level 1 for testing expansions.
 export const INITIAL_EXPANSIONS =

--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -2,10 +2,11 @@ import { Bumpkin } from "../types/game";
 import { BumpkinLevel } from "features/game/lib/level";
 import { getLandLimit } from "../expansion/lib/expansionRequirements";
 
-export const INITIAL_BUMPKIN_LEVEL = 1;
+export const INITIAL_BUMPKIN_LEVEL = 38;
 
 // Special case level 1 for testing expansions.
 export const INITIAL_EXPANSIONS =
+  // @ts-expect-error: This comparison appears to be unintentional
   INITIAL_BUMPKIN_LEVEL === 1
     ? 3
     : getLandLimit(INITIAL_BUMPKIN_LEVEL as BumpkinLevel);

--- a/src/features/game/lib/landDataDynamic.ts
+++ b/src/features/game/lib/landDataDynamic.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { Bumpkin, GameState } from "../types/game";
 import { LEVEL_EXPERIENCE } from "./level";
 import { BumpkinLevel } from "features/game/lib/level";
@@ -6,6 +7,7 @@ import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_RESOURCES } from "./landDataStatic";
 import { INITIAL_BUMPKIN } from "./bumpkinData";
 import { STATIC_OFFLINE_FARM } from "./landDataStatic";
+import { getBuildingBumpkinLevelRequired } from "../expansion/lib/buildingRequirements";
 
 function getInitialNodes(name: string) {
   let count = getEnabledNodeCount(INITIAL_BUMPKIN_LEVEL as BumpkinLevel, name);
@@ -41,6 +43,101 @@ function getInitialNodes(name: string) {
   );
 }
 
+function getBuildings() {
+  const buildings = {
+    ...STATIC_OFFLINE_FARM["buildings"],
+  };
+
+  // Add and pre-fill built composters 1 level after unlock.
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Compost Bin")
+  ) {
+    buildings["Compost Bin"] = [
+      {
+        coordinates: { x: 2, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        requires: {
+          Sunflower: 5,
+        },
+        producing: {
+          items: { "Fruitful Blend": 10, "Red Wiggler": 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 8 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Turbo Composter")
+  ) {
+    buildings["Turbo Composter"] = [
+      {
+        coordinates: { x: 0, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        requires: { Apple: 1 },
+        producing: {
+          items: { "Fruitful Blend": 10, "Red Wiggler": 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 8 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Premium Composter")
+  ) {
+    buildings["Premium Composter"] = [
+      {
+        coordinates: { x: -2, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        producing: {
+          items: { "Rapid Root": 10, Grub: 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 12 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+
+  return buildings;
+}
+
+function getInventory() {
+  const inventory = {
+    ...STATIC_OFFLINE_FARM["inventory"],
+  };
+
+  // Add composters to inventory as soon as they unlock.
+  if (INITIAL_BUMPKIN_LEVEL >= getBuildingBumpkinLevelRequired("Compost Bin")) {
+    inventory["Compost Bin"] = new Decimal(1);
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >= getBuildingBumpkinLevelRequired("Turbo Composter")
+  ) {
+    inventory["Turbo Composter"] = new Decimal(1);
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    getBuildingBumpkinLevelRequired("Premium Composter")
+  ) {
+    inventory["Premium Composter"] = new Decimal(1);
+  }
+
+  return inventory;
+}
+
 const DYNAMIC_INITIAL_RESOURCES: Pick<
   GameState,
   "crops" | "trees" | "stones" | "iron" | "gold" | "fruitPatches"
@@ -59,5 +156,7 @@ const DYNAMIC_INITIAL_BUMPKIN: Bumpkin = {
 export const DYNAMIC_OFFLINE_FARM: GameState = {
   ...STATIC_OFFLINE_FARM,
   ...DYNAMIC_INITIAL_RESOURCES,
+  buildings: getBuildings(),
   bumpkin: DYNAMIC_INITIAL_BUMPKIN,
+  inventory: getInventory(),
 };

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -230,7 +230,7 @@ export const ComposterModal: React.FC<Props> = ({
             </div>
           </div>
           <Button
-            className="text-xxs sm:text-sm mt-1 whitespace-nowrap"
+            className="text-xxs sm:text-sm mb-2 whitespace-nowrap"
             onClick={onCollect}
             disabled={true}
           >

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -229,35 +229,38 @@ export const ComposterModal: React.FC<Props> = ({
               </div>
             </div>
           </div>
-          {!boost && (
-            <OuterPanel className="p-1">
-              <div className="flex justify-between mb-1">
-                <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-                  {`${secondsToString(
-                    composterInfo.eggBoostMilliseconds / 1000,
-                    {
-                      length: "short",
-                    }
-                  )} Boost`}
-                </Label>
-                <RequirementLabel
-                  type="item"
-                  item="Egg"
-                  requirement={new Decimal(composterInfo.eggBoostRequirements)}
-                  balance={state.inventory.Egg ?? new Decimal(0)}
-                />
-              </div>
-              <p className="text-xs mb-2">Add eggs to speed up production.</p>
-              <Button
-                disabled={
-                  !state.inventory.Egg?.gte(composterInfo.eggBoostRequirements)
-                }
-                onClick={accelerate}
-              >
-                Add Eggs
-              </Button>
-            </OuterPanel>
-          )}
+          <Button
+            className="text-xxs sm:text-sm mt-1 whitespace-nowrap"
+            onClick={onCollect}
+            disabled={true}
+          >
+            Collect
+          </Button>
+          <OuterPanel className="p-1">
+            <div className="flex justify-between mb-1">
+              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                {`${secondsToString(composterInfo.eggBoostMilliseconds / 1000, {
+                  length: "short",
+                })} Boost`}
+              </Label>
+              <RequirementLabel
+                type="item"
+                item="Egg"
+                requirement={new Decimal(composterInfo.eggBoostRequirements)}
+                balance={state.inventory.Egg ?? new Decimal(0)}
+              />
+            </div>
+            <p className="text-xs mb-2">Add eggs to speed up production.</p>
+            <Button
+              disabled={
+                !boost &&
+                !state.inventory.Egg?.gte(composterInfo.eggBoostRequirements)
+              }
+              onClick={accelerate}
+            >
+              Add Eggs
+            </Button>
+          </OuterPanel>
           {boost && (
             <OuterPanel className="p-1">
               <div className="flex justify-between">


### PR DESCRIPTION
# Description

At least a few of us are accidentally hitting the "Add Eggs" button on our composters.  I believe this is due to the removal of the "Collect" button such that the UI is both "not stable" and confusing.

This change brings back the collect button (disabled while still composting) to help avoid the confusion and accidental clicks.

![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/c9ee6f42-9696-4e12-81f2-8b2ee7fd61ca)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The current branch includes some test infrastructure for local/offline validation of this and related changed.

Intent is to separate some of this infrastructure into a separate PR.
