### PR TITLE
[FEAT] Offline testing support for composters

### DIFF
--- a/src/features/game/lib/landDataDynamic.ts
+++ b/src/features/game/lib/landDataDynamic.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js-light";
 import { Bumpkin, GameState } from "../types/game";
 import { LEVEL_EXPERIENCE } from "./level";
 import { BumpkinLevel } from "features/game/lib/level";
@@ -6,6 +7,7 @@ import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_RESOURCES } from "./landDataStatic";
 import { INITIAL_BUMPKIN } from "./bumpkinData";
 import { STATIC_OFFLINE_FARM } from "./landDataStatic";
+import { getBuildingBumpkinLevelRequired } from "../expansion/lib/buildingRequirements";
 
 function getInitialNodes(name: string) {
   let count = getEnabledNodeCount(INITIAL_BUMPKIN_LEVEL as BumpkinLevel, name);
@@ -41,6 +43,101 @@ function getInitialNodes(name: string) {
   );
 }
 
+function getBuildings() {
+  const buildings = {
+    ...STATIC_OFFLINE_FARM["buildings"],
+  };
+
+  // Add and pre-fill built composters 1 level after unlock.
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Compost Bin")
+  ) {
+    buildings["Compost Bin"] = [
+      {
+        coordinates: { x: 2, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        requires: {
+          Sunflower: 5,
+        },
+        producing: {
+          items: { "Fruitful Blend": 10, "Red Wiggler": 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 8 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Turbo Composter")
+  ) {
+    buildings["Turbo Composter"] = [
+      {
+        coordinates: { x: 0, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        requires: { Apple: 1 },
+        producing: {
+          items: { "Fruitful Blend": 10, "Red Wiggler": 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 8 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    1 + getBuildingBumpkinLevelRequired("Premium Composter")
+  ) {
+    buildings["Premium Composter"] = [
+      {
+        coordinates: { x: -2, y: 8 },
+        createdAt: 0,
+        id: "123",
+        readyAt: 0,
+        producing: {
+          items: { "Rapid Root": 10, Grub: 3 },
+
+          readyAt: Date.now() + 30000,
+          startedAt: Date.now() - 50000 - 12 * 60 * 60 * 1000,
+        },
+      },
+    ];
+  }
+
+  return buildings;
+}
+
+function getInventory() {
+  const inventory = {
+    ...STATIC_OFFLINE_FARM["inventory"],
+  };
+
+  // Add composters to inventory as soon as they unlock.
+  if (INITIAL_BUMPKIN_LEVEL >= getBuildingBumpkinLevelRequired("Compost Bin")) {
+    inventory["Compost Bin"] = new Decimal(1);
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >= getBuildingBumpkinLevelRequired("Turbo Composter")
+  ) {
+    inventory["Turbo Composter"] = new Decimal(1);
+  }
+  if (
+    INITIAL_BUMPKIN_LEVEL >=
+    getBuildingBumpkinLevelRequired("Premium Composter")
+  ) {
+    inventory["Premium Composter"] = new Decimal(1);
+  }
+
+  return inventory;
+}
+
 const DYNAMIC_INITIAL_RESOURCES: Pick<
   GameState,
   "crops" | "trees" | "stones" | "iron" | "gold" | "fruitPatches"
@@ -59,5 +156,7 @@ const DYNAMIC_INITIAL_BUMPKIN: Bumpkin = {
 export const DYNAMIC_OFFLINE_FARM: GameState = {
   ...STATIC_OFFLINE_FARM,
   ...DYNAMIC_INITIAL_RESOURCES,
+  buildings: getBuildings(),
   bumpkin: DYNAMIC_INITIAL_BUMPKIN,
+  inventory: getInventory(),
 };


### PR DESCRIPTION
# Description

Improved composter support for offline/local testing and validation.

For each composter type:
- when the `INITIAL_BUMPKIN_LEVEL` is set to the unlock level, the item is added to the inventory
- when the `INITIAL_BUMPKIN_LEVEL` is set to the unlock level + 1, the item is also placed and prepopulated with "ready" set at 30 seconds in the future

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Compost Bin unlocks at expansion 6 or bumpkin level 4.
Turbo Composter unlocks at expansion 10 or bumpkin level 13.
Premium Composter unlocks at expansion 18 or bumpkin level 37.

Local validation of the following important bumpkin levels:
- 1
- 4
- 5
- 13
- 14
- 37
- 38
