### PR TITLE
[FEAT] Add Confirmation Screen for Composter Boost

### DIFF
--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -35,6 +35,7 @@ import { getKeys } from "features/game/types/craftables";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { OuterPanel } from "components/ui/Panel";
+import { translate } from "lib/i18n/translate";
 
 const WORM_OUTPUT: Record<ComposterName, string> = {
   "Compost Bin": "2-4",
@@ -164,6 +165,18 @@ export const ComposterModal: React.FC<Props> = ({
     onBoost();
   };
 
+  const [isConfirmBoostModalOpen, showConfirmBoostModal] = useState(false);
+  const openConfirmationModal = () => {
+    showConfirmBoostModal(true);
+  };
+  const closeConfirmationModal = () => {
+    showConfirmBoostModal(false);
+  };
+  const applyBoost = () => {
+    accelerate();
+    showConfirmBoostModal(false);
+  }; // We could do without this const but I added it for better security
+
   const Content = () => {
     if (isReady) {
       return (
@@ -252,10 +265,55 @@ export const ComposterModal: React.FC<Props> = ({
                 disabled={
                   !state.inventory.Egg?.gte(composterInfo.eggBoostRequirements)
                 }
-                onClick={accelerate}
+                onClick={openConfirmationModal}
               >
                 Add Eggs
               </Button>
+              <Modal
+                centered
+                show={isConfirmBoostModalOpen}
+                onHide={closeConfirmationModal}
+              >
+                <CloseButtonPanel className="sm:w-full m-auto">
+                  <div className="flex flex-col p-2">
+                    {/*Text is this format to help with Translations later on*/}
+                    <span className="text-sm text-left">
+                      Are you sure you want to add the following amount of eggs
+                      to reduce compost production time?
+                    </span>
+                    <>
+                      <br />
+                    </>
+                    <span className="text-sm text-left">
+                      Eggs Needed: {composterInfo.eggBoostRequirements}
+                    </span>
+                    <span className="text-sm text-left">
+                      Compost Time Reduction:{" "}
+                      {`${secondsToString(
+                        composterInfo.eggBoostMilliseconds / 1000,
+                        {
+                          length: "short",
+                        }
+                      )}`}
+                    </span>
+                  </div>
+                  <div className="flex justify-content-around mt-2 space-x-1">
+                    <Button
+                      disabled={
+                        !state.inventory.Egg?.gte(
+                          composterInfo.eggBoostRequirements
+                        )
+                      }
+                      onClick={applyBoost}
+                    >
+                      Add Eggs
+                    </Button>
+                    <Button onClick={closeConfirmationModal}>
+                      {translate("cancel")}
+                    </Button>
+                  </div>
+                </CloseButtonPanel>
+              </Modal>
             </OuterPanel>
           )}
           {boost && (


### PR DESCRIPTION
# Description

Add Confirmation Screen for the Compost Production Boost
(I forgot to update the screenshots but it should say "Compost Time Reduction" instead of "Reduction Time")

Compost Bin
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/0db1cf50-0c2c-4fac-9860-122d10ce8978)

Turbo Composter
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/83c66286-115e-452f-99de-07effbe958dc)

Premium Composter
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/82bb6650-109b-4af2-9b22-6dda09e077de)

Reduction time should update accordingly once #3239 is merged

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
