### PR TITLE
[FEAT] Add bait to garbage collector

### DIFF
--- a/src/features/game/types/garbage.ts
+++ b/src/features/game/types/garbage.ts
@@ -18,7 +18,10 @@ export type GarbageName =
   | "Red Egg"
   | "Yellow Egg"
   | "Rapid Growth"
-  | "Tent";
+  | "Tent"
+  | "Earthworm"
+  | "Grub"
+  | "Red Wiggler";
 
 export type Garbage = {
   sellPrice: Decimal;
@@ -74,5 +77,15 @@ export const GARBAGE: Record<GarbageName, Garbage> = {
   },
   Tent: {
     sellPrice: new Decimal(1),
+  },
+
+  Earthworm: {
+    sellPrice: marketRate(0.1),
+  },
+  Grub: {
+    sellPrice: marketRate(0.1),
+  },
+  "Red Wiggler": {
+    sellPrice: marketRate(0.1),
   },
 };


### PR DESCRIPTION
# Description

Some players only want to use their composters for fertilizer.  For such players, the hoarder limits for bait is cumbersome (and expensive).

This change adds all three composter bait types to the garbage collector.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
