### PR TITLE
[FIX] Close Festive Tree Modal when clicking outside the Modal

### DIFF
--- a/src/features/island/collectibles/components/FestiveTree.tsx
+++ b/src/features/island/collectibles/components/FestiveTree.tsx
@@ -56,7 +56,11 @@ export const FestiveTree: React.FC<Props> = ({ id }) => {
 
   return (
     <>
-      <Modal centered show={showGiftedModal}>
+      <Modal
+        centered
+        show={showGiftedModal}
+        onHide={() => setShowGiftedModal(false)}
+      >
         <CloseButtonPanel
           bumpkinParts={NPC_WEARABLES.santa}
           onClose={() => setShowGiftedModal(false)}
@@ -71,7 +75,11 @@ export const FestiveTree: React.FC<Props> = ({ id }) => {
         </CloseButtonPanel>
       </Modal>
 
-      <Modal centered show={showWrongTimeModal}>
+      <Modal
+        centered
+        show={showWrongTimeModal}
+        onHide={() => setShowWrongTimeModal(false)}
+      >
         <CloseButtonPanel
           bumpkinParts={NPC_WEARABLES.santa}
           onClose={() => setShowWrongTimeModal(false)}


### PR DESCRIPTION
# Description

Add onHide condition for the Festive Tree

Fixes #issue
Modal not closing when clicking outside the modal

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran program locally and changed the time to before 19th and clicked outside the modal and it closes it.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
