### PR TITLE
[FIX] Reveal Land

### DIFF
--- a/src/features/game/components/modal/ModalProvider.tsx
+++ b/src/features/game/components/modal/ModalProvider.tsx
@@ -14,6 +14,7 @@ type GlobalModal =
   | "STORE_ON_CHAIN"
   | "GOLD_PASS"
   | "FIRST_EXPANSION"
+  | "NEXT_EXPANSION"
   | "THIRD_LEVEL"
   | "BETTY"
   | "BLACKSMITH";
@@ -67,6 +68,18 @@ export const ModalProvider: FC = ({ children }) => {
             },
             {
               text: "Keep an eye out for surprise gifts from the generous goblins as you explore—they're not just expert builders, but crafty secret givers!",
+            },
+          ]}
+          onClose={handleClose}
+          bumpkinParts={NPC_WEARABLES["pumpkin' pete"]}
+        />
+      </Modal>
+
+      <Modal centered show={opened === "NEXT_EXPANSION"}>
+        <SpeakingModal
+          message={[
+            {
+              text: "Congratulations, Bumpkin! Keep up the good work.",
             },
           ]}
           onClose={handleClose}

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -290,9 +290,12 @@ export const UpcomingExpansion: React.FC = () => {
   const onReveal = () => {
     setIsRevealing(true);
     const state = gameService.send("land.revealed");
+    gameService.send("SAVE");
 
     if (state.context.state.inventory["Basic Land"]?.eq(4)) {
       openModal("FIRST_EXPANSION");
+    } else {
+      openModal("NEXT_EXPANSION");
     }
   };
 


### PR DESCRIPTION
# Description

When a new player expands, our local `land.revealed` event adds the natural resources and creates random IDs for them. On Autosave, our backend then creates new IDs for these resources.

If a player quickly interacts with a resource after expanding, an error will be thrown.

**Short Term Fix**

This is not a permanent fix, but will help alleviate most of the problems:

1. Save as soon as they expand
2. Show a pop congratulations modal - by the time they close it the game should be updated.