### PR TITLE
[FIX] canWithdrawBoostedWearable() is too restrictive

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -16,6 +16,7 @@ import {
 import { isFruitGrowing } from "features/game/events/landExpansion/fruitHarvested";
 import { CompostName, isComposting } from "./composters";
 import { getDailyFishingCount } from "./fishing";
+import { GoblinState } from "features/game/lib/goblinMachine";
 
 type RESTRICTION_REASON =
   | "No restriction"
@@ -45,7 +46,7 @@ type CanRemoveArgs = {
   game: GameState;
 };
 
-function cropIsGrowing({ item, game }: CanRemoveArgs): Restriction {
+export function cropIsGrowing({ item, game }: CanRemoveArgs): Restriction {
   const cropGrowing = Object.values(game.crops ?? {}).some(
     (plot) => isCropGrowing(plot) && plot.crop?.name === item
   );
@@ -58,7 +59,10 @@ function beanIsPlanted(game: GameState): Restriction {
   return [!!beanPlanted, "Magic Bean is planted"];
 }
 
-function areFruitsGrowing(game: GameState, fruit: FruitName): Restriction {
+export function areFruitsGrowing(
+  game: GoblinState,
+  fruit: FruitName
+): Restriction {
   const fruitGrowing = Object.values(game.fruitPatches ?? {}).some(
     (patch) => isFruitGrowing(patch) && patch.fruit?.name === fruit
   );
@@ -66,7 +70,7 @@ function areFruitsGrowing(game: GameState, fruit: FruitName): Restriction {
   return [fruitGrowing, `${fruit} is growing`];
 }
 
-function areAnyFruitsGrowing(game: GameState): Restriction {
+export function areAnyFruitsGrowing(game: GoblinState): Restriction {
   const fruitGrowing = Object.values(game.fruitPatches ?? {}).some((patch) =>
     isFruitGrowing(patch)
   );
@@ -74,7 +78,7 @@ function areAnyFruitsGrowing(game: GameState): Restriction {
   return [fruitGrowing, `Fruits are growing`];
 }
 
-function areAnyCropsGrowing(game: GameState): Restriction {
+export function areAnyCropsGrowing(game: GoblinState): Restriction {
   const cropsGrowing = Object.values(game.crops ?? {}).some((plot) =>
     isCropGrowing(plot)
   );
@@ -164,7 +168,7 @@ function areAnyMineralsMined(game: GameState): Restriction {
   return areGoldsMined;
 }
 
-function areAnyChickensFed(game: GameState): Restriction {
+export function areAnyChickensFed(game: GoblinState): Restriction {
   const chickensAreFed = Object.values(game.chickens).some(
     (chicken) =>
       chicken.fedAt && Date.now() - chicken.fedAt < CHICKEN_TIME_TO_EGG

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -1,7 +1,13 @@
-import { getKeys } from "./craftables";
 import { BumpkinItem } from "./bumpkin";
 import { GoblinState } from "../lib/goblinMachine";
 import { getDailyFishingCount } from "./fishing";
+import {
+  areAnyChickensFed,
+  areAnyCropsGrowing,
+  areAnyFruitsGrowing,
+  areFruitsGrowing,
+  cropIsGrowing,
+} from "./removeables";
 
 export const canWithdrawBoostedWearable = (
   wearable: BumpkinItem,
@@ -15,59 +21,43 @@ export const canWithdrawBoostedWearable = (
     wearable === "Devil Wings" ||
     wearable === "Infernal Pitchfork"
   ) {
-    return getKeys(state.crops).every((id) => !state.crops[id].crop);
+    return !areAnyCropsGrowing(state)[0];
   }
 
   if (wearable === "Sunflower Amulet") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Sunflower"
-    );
+    return !cropIsGrowing({ item: "Sunflower", game: state })[0];
   }
 
   if (wearable === "Carrot Amulet") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Carrot"
-    );
+    return !cropIsGrowing({ item: "Carrot", game: state })[0];
   }
 
   if (wearable === "Beetroot Amulet") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Beetroot"
-    );
+    return !cropIsGrowing({ item: "Beetroot", game: state })[0];
   }
 
   if (wearable === "Parsnip") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Parsnip"
-    );
+    return !cropIsGrowing({ item: "Parsnip", game: state })[0];
   }
 
   if (wearable === "Eggplant Onesie") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Eggplant"
-    );
+    return !cropIsGrowing({ item: "Eggplant", game: state })[0];
   }
 
   if (wearable === "Corn Onesie") {
-    return getKeys(state.crops).every(
-      (id) => state.crops[id].crop?.name !== "Corn"
-    );
+    return !cropIsGrowing({ item: "Corn", game: state })[0];
   }
 
   if (wearable === "Fruit Picker Apron") {
-    return getKeys(state.fruitPatches).every(
-      (id) => state.fruitPatches[id].fruit === undefined
-    );
+    return !areAnyFruitsGrowing(state)[0];
   }
 
   if (wearable === "Banana Amulet") {
-    return getKeys(state.fruitPatches).every(
-      (id) => state.fruitPatches[id].fruit?.name !== "Banana"
-    );
+    return !areFruitsGrowing(state, "Banana")[0];
   }
 
   if (wearable === "Cattlegrim") {
-    return getKeys(state.chickens).every((id) => !state.chickens[id].fedAt);
+    return !areAnyChickensFed(state)[0];
   }
 
   if (wearable === "Luna's Hat") {

--- a/src/features/game/types/withdrawables.test.ts
+++ b/src/features/game/types/withdrawables.test.ts
@@ -1,8 +1,12 @@
+import "lib/__mocks__/configMock";
+
 import { TEST_FARM } from "../lib/constants";
 import { GoblinState } from "../lib/goblinMachine";
 import { BUMPKIN_WITHDRAWABLES, WITHDRAWABLES } from "./withdrawables";
 
 describe("withdrawables", () => {
+  const dateNow = Date.now();
+
   describe("prevents", () => {
     beforeEach(() => {
       jest.useRealTimers();
@@ -86,7 +90,7 @@ describe("withdrawables", () => {
               name: "Apple",
               harvestsLeft: 2,
               amount: 1.35,
-              harvestedAt: 1680624817609,
+              harvestedAt: dateNow,
               plantedAt: 0,
             },
             height: 2,
@@ -111,7 +115,7 @@ describe("withdrawables", () => {
               name: "Eggplant",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -135,7 +139,7 @@ describe("withdrawables", () => {
               name: "Parsnip",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -159,7 +163,7 @@ describe("withdrawables", () => {
               name: "Sunflower",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -183,7 +187,7 @@ describe("withdrawables", () => {
               name: "Carrot",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -207,7 +211,7 @@ describe("withdrawables", () => {
               name: "Beetroot",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -231,7 +235,7 @@ describe("withdrawables", () => {
               name: "Beetroot",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
             height: 1,
           },
@@ -297,7 +301,7 @@ describe("withdrawables", () => {
               name: "Beetroot",
               amount: 1,
               id: "1",
-              plantedAt: 1680606097421,
+              plantedAt: dateNow,
             },
           },
         },


### PR DESCRIPTION
# Description

Wearable withdraw restrictions are "older" and thus too restrictive.  More specifically, they needed to be updated to allow for removal when affected nodes (plots, chickens, etc.) are ready for harvesting/collection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
