### PR TITLE
[FIX] Move beach spawn location

### DIFF
--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -21,7 +21,7 @@ export const SPAWNS: SpawnLocation = {
   },
   beach: {
     default: {
-      x: 468,
+      x: 438,
       y: 652,
     },
   },


### PR DESCRIPTION
# Description

Players have requested repeatedly to move the players spawn location on the beach to avoid "portal bouncing".

This change moves the spawn location 30 to the west.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/2ec43791-33ce-4b42-8700-8e89374d5399)
