### PR TITLE
[FEAT] Sunflower Express setting

### DIFF
--- a/src/features/farming/hud/lib/express.ts
+++ b/src/features/farming/hud/lib/express.ts
@@ -1,0 +1,14 @@
+/**
+ * Cache show timers setting in local storage so we can remember next time we open the HUD.
+ */
+const LOCAL_STORAGE_KEY = "settings.express";
+
+export function cacheExpressSetting(show: boolean) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(show));
+}
+
+export function getExpressSetting(): boolean {
+  const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return cached ? JSON.parse(cached) : false;
+}

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -18,6 +18,10 @@ import {
   getShowAnimationsSetting,
 } from "features/farming/hud/lib/animations";
 import {
+  cacheExpressSetting,
+  getExpressSetting,
+} from "features/farming/hud/lib/express";
+import {
   cacheShowTimersSetting,
   getShowTimersSetting,
 } from "features/farming/hud/lib/timers";
@@ -28,6 +32,8 @@ interface GameContext {
   gameService: MachineInterpreter;
   showAnimations: boolean;
   toggleAnimations: () => void;
+  express: boolean;
+  toggleExpress: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
 }
@@ -48,6 +54,7 @@ export const GameProvider: React.FC = ({ children }) => {
   const [showAnimations, setShowAnimations] = useState<boolean>(
     getShowAnimationsSetting()
   );
+  const [express, setExpress] = useState<boolean>(getExpressSetting());
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
@@ -71,6 +78,13 @@ export const GameProvider: React.FC = ({ children }) => {
     cacheShowAnimationsSetting(newValue);
   };
 
+  const toggleExpress = () => {
+    const newValue = !express;
+
+    setExpress(newValue);
+    cacheExpressSetting(newValue);
+  };
+
   const toggleTimers = () => {
     const newValue = !showTimers;
 
@@ -88,6 +102,8 @@ export const GameProvider: React.FC = ({ children }) => {
         gameService,
         showAnimations,
         toggleAnimations,
+        express,
+        toggleExpress,
         showTimers,
         toggleTimers,
       }}

--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -20,7 +20,13 @@ interface Props {
 
 export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
   const { authService } = useContext(Auth.Context);
-  const { gameService, showAnimations, toggleAnimations } = useContext(Context);
+  const {
+    gameService,
+    showAnimations,
+    toggleAnimations,
+    express,
+    toggleExpress,
+  } = useContext(Context);
   const [gameState] = useActor(gameService);
 
   const { farmAddress } = gameState.context;
@@ -43,6 +49,10 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
     toggleAnimations();
   };
 
+  const onToggleExpress = () => {
+    toggleExpress();
+  };
+
   const refreshSession = () => {
     onClose();
     gameService.send("RESET");
@@ -61,6 +71,9 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
       <CloseButtonPanel title="Settings" onClose={onClose}>
         <Button className="col p-1" onClick={onToggleAnimations}>
           {showAnimations ? "Disable Animations" : "Enable Animations"}
+        </Button>
+        <Button className="col p-1" onClick={onToggleExpress}>
+          {express ? "Disable Sunflower Express" : "Enable Sunflower Express"}
         </Button>
         <Button className="col p-1 mt-2" onClick={onLogout}>
           Logout

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -24,6 +24,7 @@ import { playerModalManager } from "../ui/PlayerModals";
 import { hasFeatureAccess } from "lib/flags";
 import { GameState } from "features/game/types/game";
 import { Room } from "colyseus.js";
+import { getExpressSetting } from "features/farming/hud/lib/express";
 
 import defaultTilesetConfig from "assets/map/tileset.json";
 
@@ -931,7 +932,8 @@ export abstract class BaseScene extends Phaser.Scene {
           this.currentPlayer as BumpkinContainer
         );
 
-        if (distance > 50) {
+        const express = getExpressSetting();
+        if (distance > (express ? 5000 : 50)) {
           container.speak("You are too far away");
           return;
         }


### PR DESCRIPTION
# Description

More experienced players want to interact with NPCs (especially for chores and deliveries) without having to spend precious time or risk RSI (repetitive strain injury).

This change adds a new "Sunflower Express" setting to expand the interactive range for NPCs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

With Testnet farm in the ChristmasScene.

Setting UI
![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/8ae6fdd2-6021-4fb3-98f2-172d6e5a910f)

Disabled
![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/291747f8-0ef9-46d9-a81b-dbb275d20836)

Enabled
![image](https://github.com/sunflower-land/sunflower-land/assets/36871683/6e7752f1-cd10-438e-81fb-68ad5dbc493e)
