### PR TITLE
[FIX] Trade Notifications

### DIFF
--- a/src/features/game/components/Notifications.tsx
+++ b/src/features/game/components/Notifications.tsx
@@ -1,23 +1,23 @@
 import React, { useContext } from "react";
 import { useActor } from "@xstate/react";
 
-import { Context } from "features/game/GameProvider";
 import { OnChainEvent } from "../actions/onChainEvents";
 import { Button } from "components/ui/Button";
 import { PIXEL_SCALE } from "../lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { Context } from "../GoblinProvider";
 
 const CONTENT_HEIGHT = 400;
 
 export const Notifications: React.FC = () => {
-  const { gameService } = useContext(Context);
-  const [state] = useActor(gameService);
+  const { goblinService } = useContext(Context);
+  const [goblinState] = useActor(goblinService);
 
   function onAcknowledge() {
-    gameService.send("ACKNOWLEDGE");
+    goblinService.send("REFRESH");
   }
 
-  const notifications = state.context.notifications as OnChainEvent[];
+  const notifications = goblinState.context.notifications as OnChainEvent[];
 
   return (
     <>

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -21,7 +21,6 @@ import logo from "assets/brand/logo_v2.png";
 import winterLogo from "assets/brand/winter_logo.png";
 import sparkle from "assets/fx/sparkle2.gif";
 
-import { Notifications } from "../components/Notifications";
 import { Hoarding } from "../components/Hoarding";
 import { NoBumpkin } from "features/island/bumpkin/NoBumpkin";
 import { Swarming } from "../components/Swarming";
@@ -68,7 +67,6 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   purchasing: true,
   buyingBlockBucks: true,
   refreshing: true,
-  deposited: true,
   hoarding: true,
   landscaping: false,
   noBumpkinFound: true,
@@ -112,7 +110,6 @@ const isTraded = (state: MachineState) => state.matches("traded");
 const isSniped = (state: MachineState) => state.matches("sniped");
 const isRefreshing = (state: MachineState) => state.matches("refreshing");
 const isBuyingSFL = (state: MachineState) => state.matches("buyingSFL");
-const isDeposited = (state: MachineState) => state.matches("deposited");
 const isError = (state: MachineState) => state.matches("error");
 const isSynced = (state: MachineState) => state.matches("synced");
 const isSyncing = (state: MachineState) => state.matches("syncing");
@@ -234,7 +231,6 @@ export const GameWrapper: React.FC = ({ children }) => {
   const sniped = useSelector(gameService, isSniped);
   const refreshing = useSelector(gameService, isRefreshing);
   const buyingSFL = useSelector(gameService, isBuyingSFL);
-  const deposited = useSelector(gameService, isDeposited);
   const error = useSelector(gameService, isError);
   const synced = useSelector(gameService, isSynced);
   const syncing = useSelector(gameService, isSyncing);
@@ -369,7 +365,6 @@ export const GameWrapper: React.FC = ({ children }) => {
           {loading && <Loading />}
           {refreshing && <Refreshing />}
           {buyingSFL && <AddingSFL />}
-          {deposited && <Notifications />}
           {error && <ErrorMessage errorCode={errorCode as ErrorCode} />}
           {synced && <Success />}
           {syncing && <Syncing />}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -370,7 +370,6 @@ export type BlockchainState = {
     | "loading"
     | "loadLandToVisit"
     | "landToVisitNotFound"
-    | "deposited"
     | "visiting"
     | "gameRules"
     | "portalling"
@@ -665,11 +664,6 @@ export function startGame(authContext: AuthContext) {
         notifying: {
           always: [
             {
-              target: "deposited",
-              cond: (context: Context) =>
-                !!context.notifications && context.notifications?.length > 0,
-            },
-            {
               target: "transacting",
               cond: (context: Context) =>
                 !!context.transaction &&
@@ -787,13 +781,6 @@ export function startGame(authContext: AuthContext) {
           },
         },
 
-        deposited: {
-          on: {
-            ACKNOWLEDGE: {
-              target: "refreshing",
-            },
-          },
-        },
         gameRules: {
           on: {
             ACKNOWLEDGE: {

--- a/src/features/retreat/Game.tsx
+++ b/src/features/retreat/Game.tsx
@@ -41,6 +41,7 @@ import { GameBoard } from "components/GameBoard";
 import { Auctioneer } from "./components/auctioneer/Auctioneer";
 import { PersonhoodContent } from "./components/personhood/PersonhoodContent";
 import { GoldPassModal } from "features/game/expansion/components/GoldPass";
+import { Notifications } from "features/game/components/Notifications";
 
 const spawn = [
   [35, 15],
@@ -65,6 +66,7 @@ const SHOW_MODAL: Partial<Record<StateValues, boolean>> = {
   error: true,
   depositing: true,
   refreshing: true,
+  tradeNotification: true,
 };
 
 export const Game = () => {
@@ -116,6 +118,8 @@ export const Game = () => {
           {goblinState.matches("minting") && <Minting />}
           {goblinState.matches("minted") && <Minted />}
           {goblinState.matches("depositing") && <Loading text="Depositing" />}
+          {goblinState.matches("tradeNotification") && <Notifications />}
+
           {goblinState.matches("refreshing") && <Refreshing />}
         </Panel>
       </Modal>


### PR DESCRIPTION
# Description

Since a wallet is no longer connected, goblin trade notifications cannot be shown on the main island.

Instead, when accessing Goblin Retreat, display any notifications and let the player refresh.

<img width="707" alt="Screenshot 2024-01-10 at 8 49 40 am" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/986d8d9b-cf72-427a-a719-a4a4623a4f51">

## How to test?

Purchase a trade from a farm. Access the farm and see the notification