### PR TITLE
[FEAT] Add Confirmation Modal on Logout

### DIFF
--- a/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
+++ b/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
@@ -30,6 +30,8 @@ import { shortAddress } from "lib/utils/shortAddress";
 import walletIcon from "assets/icons/wallet.png";
 import { removeJWT } from "features/auth/actions/social";
 import { WalletContext } from "features/wallet/WalletProvider";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { translate } from "lib/i18n/translate";
 
 enum MENU_LEVELS {
   ROOT = "root",
@@ -134,6 +136,14 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
     onClose();
   };
 
+  const [isConfirmLogoutModalOpen, showConfirmLogoutModal] = useState(false);
+  const openConfirmLogoutModal = () => {
+    showConfirmLogoutModal(true);
+  };
+  const closeConfirmLogoutModal = () => {
+    showConfirmLogoutModal(false);
+  };
+
   return (
     <>
       <Modal show={show} centered onHide={onHide}>
@@ -233,7 +243,26 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
                   </Button>
                 </li>
                 <li className="p-1">
-                  <Button onClick={onLogout}>Logout</Button>
+                  <Button onClick={openConfirmLogoutModal}>Logout</Button>
+                  <Modal
+                    centered
+                    show={isConfirmLogoutModalOpen}
+                    onHide={closeConfirmLogoutModal}
+                  >
+                    <CloseButtonPanel className="sm:w-4/5 m-auto">
+                      <div className="flex flex-col p-2">
+                        <span className="text-sm text-center">
+                          Are you sure you want to Logout?
+                        </span>
+                      </div>
+                      <div className="flex justify-content-around mt-2 space-x-1">
+                        <Button onClick={onLogout}>Logout</Button>
+                        <Button onClick={closeConfirmLogoutModal}>
+                          {translate("cancel")}
+                        </Button>
+                      </div>
+                    </CloseButtonPanel>
+                  </Modal>
                 </li>
               </>
             )}


### PR DESCRIPTION
# Description

Due to muscle memory of where the Settings (now renamed Advanced) menu used to be, I've accidentally clicked on Logout a few times and I have to re-login to access the game again.
This PR adds a confirmation Modal before the user decides whether they truly want to logout or not

![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/1610e4db-a6d4-453f-93b8-fcdf30da9ddd)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Went to local host and tested on a testnet account, testing that each button and onHide works

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
