### PR TITLE
[FIX] Rename Settings Menu to Advanced

### DIFF
--- a/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/sub-settings/SubSettings.tsx
@@ -54,7 +54,7 @@ export const SubSettings: React.FC<Props> = ({ isOpen, onClose }) => {
     }
 
     return (
-      <CloseButtonPanel title="Settings" onClose={onClose}>
+      <CloseButtonPanel title="Advanced" onClose={onClose}>
         <Button className="col p-1" onClick={onToggleAnimations}>
           {showAnimations ? "Disable Animations" : "Enable Animations"}
         </Button>


### PR DESCRIPTION
# Description

Since the `Settings` Button got renamed to `Advanced` the Menu should be updated to say `Advanced` as well

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/86e2de8d-e226-474b-8bb7-e0e31ea8b18c)
After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/784b2038-5a9a-4f5f-8d12-5d9060e1aae4)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run LocalHost to make sure the text change happens

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
