### PR TITLE
[FIX] Rename Removable restriction reason text for Fishing Boosts

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -36,6 +36,7 @@ type RESTRICTION_REASON =
   | "Magic Bean is planted"
   | "Bananas are growing"
   | "In use"
+  | "Recently fished"
   | "Recently used"
   | "Locked during festive season";
 
@@ -207,7 +208,7 @@ function areAnyComposting(game: GameState): Restriction {
 }
 
 function hasFishedToday(game: GameState): Restriction {
-  return [getDailyFishingCount(game) !== 0, "In use"];
+  return [getDailyFishingCount(game) !== 0, "Recently fished"];
 }
 
 function isFertiliserApplied(


### PR DESCRIPTION
# Description

Renamed the Removable Condition from "In use" to "Recently fished" to more accurately describe the removal restriction reason for fish related boosts
Affected boosts: Walrus, Alba, Sea Buds
Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/77d5993c-30e6-4e5d-9104-4b527910775b)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/6bd6d74d-b03d-4406-af07-21de9f6d745c)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
