### PR TITLE
[FEAT] Bee Swarm

### DIFF
--- a/src/features/game/events/landExpansion/harvestBeehive.test.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.test.ts
@@ -30,6 +30,21 @@ describe("harvestBeehive", () => {
     },
   };
 
+  it("throw an error if you don't have a bumpkin", () => {
+    expect(() =>
+      harvestBeehive({
+        state: {
+          ...TEST_FARM,
+          bumpkin: undefined,
+        },
+        action: {
+          type: "beehive.harvested",
+          id: "1234",
+        },
+      })
+    ).toThrow("You do not have a Bumpkin");
+  });
+
   it("does not harvest a beehive that is not placed", () => {
     expect(() =>
       harvestBeehive({
@@ -284,6 +299,56 @@ describe("harvestBeehive", () => {
     expect(state.beehives?.["1234"].swarm).toEqual(false);
   });
 
+  it("adds bumpkin activity for honey harvested from a full hive", () => {
+    const amount = 1;
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: true,
+            honey: {
+              updatedAt: 0,
+              produced: HONEY_PRODUCTION_TIME,
+            },
+          },
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+    expect(state.bumpkin?.activity?.["Honey Harvested"]).toEqual(amount);
+  });
+
+  it("adds bumpkin activity for honey harvested from a partially full hive", () => {
+    const amount = 0.5;
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: false,
+            honey: {
+              updatedAt: 0,
+              produced: HONEY_PRODUCTION_TIME / 2,
+            },
+          },
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+    expect(state.bumpkin?.activity?.["Honey Harvested"]).toEqual(amount);
+  });
+
   it("updates the beehives", () => {
     const beehiveId = "1234";
     const flowerId = "5678";
@@ -320,6 +385,6 @@ describe("harvestBeehive", () => {
       createdAt: now,
     });
 
-    expect(gameState.beehives?.[beehiveId].flowers).toHaveLength(0);
+    expect(gameState.beehives?.[beehiveId].flowers).toHaveLength(1);
   });
 });

--- a/src/features/game/events/landExpansion/harvestBeehive.test.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.test.ts
@@ -10,6 +10,7 @@ describe("harvestBeehive", () => {
   const DEFAULT_BEEHIVE: Beehive = {
     x: 3,
     y: 3,
+    swarm: false,
     height: 1,
     width: 1,
     honey: { updatedAt: 0, produced: 0 },
@@ -51,17 +52,7 @@ describe("harvestBeehive", () => {
         state: {
           ...TEST_FARM,
           beehives: {
-            [beehiveId]: {
-              height: 1,
-              width: 1,
-              honey: {
-                updatedAt: 0,
-                produced: 0,
-              },
-              flowers: [],
-              x: 4,
-              y: 4,
-            },
+            [beehiveId]: { ...DEFAULT_BEEHIVE },
           },
         },
         action: {
@@ -142,6 +133,157 @@ describe("harvestBeehive", () => {
     expect(gameState.inventory.Honey).toEqual(new Decimal(0.5));
   });
 
+  it("does not add a crop boost when there is no swarm", () => {
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            honey: {
+              updatedAt: 0,
+              produced: 1000,
+            },
+          },
+        },
+        crops: {
+          "987": {
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+            createdAt: 0,
+            crop: {
+              name: "Potato",
+              amount: 1,
+              plantedAt: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+
+    expect(state.crops?.["987"].crop?.amount).toEqual(1);
+  });
+
+  it("does not activate a swarm when the hive is not full", () => {
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: true,
+            honey: {
+              updatedAt: 0,
+              produced: 500,
+            },
+          },
+        },
+        crops: {
+          "987": {
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+            createdAt: 0,
+            crop: {
+              name: "Potato",
+              amount: 1,
+              plantedAt: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+
+    expect(state.crops?.["987"].crop?.amount).toEqual(1);
+  });
+
+  it("activates the swarm when the hive is full adding 0.2 crop boost to planted crops", () => {
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: true,
+            honey: {
+              updatedAt: 0,
+              produced: HONEY_PRODUCTION_TIME,
+            },
+          },
+        },
+        crops: {
+          "987": {
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+            createdAt: 0,
+            crop: {
+              name: "Potato",
+              amount: 1,
+              plantedAt: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+
+    expect(state.crops?.["987"].crop?.amount).toEqual(1.2);
+  });
+
+  it("sets the swarm to false after activating the swarm", () => {
+    const state = harvestBeehive({
+      state: {
+        ...TEST_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: true,
+            honey: {
+              updatedAt: 0,
+              produced: HONEY_PRODUCTION_TIME,
+            },
+          },
+        },
+        crops: {
+          "987": {
+            height: 1,
+            width: 1,
+            x: 0,
+            y: -2,
+            createdAt: 0,
+            crop: {
+              name: "Potato",
+              amount: 1,
+              plantedAt: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+    });
+
+    expect(state.beehives?.["1234"].swarm).toEqual(false);
+  });
+
   it("updates the beehives", () => {
     const beehiveId = "1234";
     const flowerId = "5678";
@@ -178,6 +320,6 @@ describe("harvestBeehive", () => {
       createdAt: now,
     });
 
-    expect(gameState.beehives?.[beehiveId].flowers).toHaveLength(1);
+    expect(gameState.beehives?.[beehiveId].flowers).toHaveLength(0);
   });
 });

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -6,6 +6,7 @@ import {
   updateBeehives,
 } from "features/game/lib/updateBeehives";
 import { getKeys } from "features/game/types/craftables";
+import { trackActivity } from "features/game/types/bumpkinActivity";
 
 export enum HARVEST_BEEHIVE_ERRORS {
   BEEHIVE_NOT_PLACED = "This beehive is not placed.",
@@ -55,6 +56,10 @@ export function harvestBeehive({
 }: Options): GameState {
   const stateCopy = cloneDeep(state) as GameState;
 
+  if (!stateCopy.bumpkin) {
+    throw new Error("You do not have a Bumpkin");
+  }
+
   // Update beehives before harvesting to set honey produced
   const freshBeehives = updateBeehives({
     beehives: stateCopy.beehives,
@@ -86,6 +91,12 @@ export function harvestBeehive({
     stateCopy.crops = applySwarmBoostToCrops(stateCopy.crops);
     stateCopy.beehives[action.id].swarm = false;
   }
+
+  stateCopy.bumpkin.activity = trackActivity(
+    `Honey Harvested`,
+    stateCopy.bumpkin?.activity,
+    new Decimal(totalHoneyProduced)
+  );
 
   const updatedBeehives = updateBeehives({
     beehives: stateCopy.beehives,

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -87,8 +87,13 @@ export function harvestBeehive({
     new Decimal(totalHoneyProduced)
   );
 
-  if (isFull && stateCopy.beehives[action.id].swarm) {
-    stateCopy.crops = applySwarmBoostToCrops(stateCopy.crops);
+  // If the beehive is full, check, apply and update swarm
+  if (isFull) {
+    if (stateCopy.beehives[action.id].swarm) {
+      stateCopy.crops = applySwarmBoostToCrops(stateCopy.crops);
+    }
+
+    // Actual value updated on the server
     stateCopy.beehives[action.id].swarm = false;
   }
 

--- a/src/features/game/events/landExpansion/moveBeehive.test.ts
+++ b/src/features/game/events/landExpansion/moveBeehive.test.ts
@@ -33,6 +33,7 @@ describe("moveBeehive", () => {
         ...GAME_STATE,
         beehives: {
           "1234": {
+            swarm: false,
             height: 1,
             width: 1,
             honey: {

--- a/src/features/game/events/landExpansion/placeBeehive.ts
+++ b/src/features/game/events/landExpansion/placeBeehive.ts
@@ -36,6 +36,7 @@ export function placeBeehive({
   const beehive: Beehive = {
     x: action.coordinates.x,
     y: action.coordinates.y,
+    swarm: false,
     height: 1,
     width: 1,
     honey: {

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -25,6 +25,7 @@ const GAME_STATE: GameState = {
       crop: {
         name: "Sunflower",
         plantedAt: 0,
+        amount: 1,
       },
     },
   },
@@ -137,6 +138,7 @@ describe("plant", () => {
               crop: {
                 name: "Sunflower",
                 plantedAt: dateNow,
+                amount: 1,
               },
             },
           },

--- a/src/features/game/events/landExpansion/removeBeehive.test.ts
+++ b/src/features/game/events/landExpansion/removeBeehive.test.ts
@@ -13,6 +13,7 @@ describe("removeBeehive", () => {
   const DEFAULT_BEEHIVE: Beehive = {
     x: 3,
     y: 3,
+    swarm: false,
     height: 1,
     width: 1,
     honey: { updatedAt: 0, produced: 0 },

--- a/src/features/game/events/landExpansion/removeCrop.test.ts
+++ b/src/features/game/events/landExpansion/removeCrop.test.ts
@@ -98,6 +98,7 @@ describe("removeCrop", () => {
               crop: {
                 name: "Sunflower",
                 plantedAt: dateNow - 40 * 1000,
+                amount: 1,
               },
             },
           },
@@ -121,6 +122,7 @@ describe("removeCrop", () => {
               crop: {
                 name: "Sunflower",
                 plantedAt: dateNow - 40 * 1000,
+                amount: 1,
               },
             },
           },
@@ -147,6 +149,7 @@ describe("removeCrop", () => {
               crop: {
                 name: "Sunflower",
                 plantedAt: dateNow - 40 * 1000,
+                amount: 1,
               },
             },
           },
@@ -170,6 +173,7 @@ describe("removeCrop", () => {
               crop: {
                 name: "Sunflower",
                 plantedAt: dateNow - 120 * 1000,
+                amount: 1,
               },
             },
           },
@@ -192,6 +196,7 @@ describe("removeCrop", () => {
             crop: {
               name: "Sunflower",
               plantedAt: dateNow - 40 * 1000,
+              amount: 1,
             },
           },
         },

--- a/src/features/game/expansion/components/resources/beehive/BeeSwarm.tsx
+++ b/src/features/game/expansion/components/resources/beehive/BeeSwarm.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import bee from "assets/icons/bee.webp";
+
+export const BeeSwarm: React.FC = () => (
+  <div
+    id="swarm"
+    className="absolute -top-1 left-1/2 -translate-x-1/2 h-36 w-40 pointer-events-none"
+  >
+    {Array.from({ length: 7 }).map((_, i) => (
+      <img
+        key={`swarm-bee-${i + 1}`}
+        src={bee}
+        alt="Bee"
+        className={`absolute left-1/2 -translate-x-1/2 swarm-bee-${i + 1}`}
+        style={{
+          width: `${PIXEL_SCALE * 7}px`,
+        }}
+      />
+    ))}
+  </div>
+);

--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -245,6 +245,7 @@ describe("isWithinAOE", () => {
         crop: {
           name: "Sunflower",
           plantedAt: 0,
+          amount: 1,
         },
       },
     },

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -3,6 +3,7 @@ import { GameState, Inventory } from "../types/game";
 import { BumpkinLevel } from "features/game/lib/level";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
+import { HONEY_PRODUCTION_TIME } from "./updateBeehives";
 
 export const INITIAL_RESOURCES: Pick<
   GameState,
@@ -468,7 +469,26 @@ export const STATIC_OFFLINE_FARM: GameState = {
   },
   airdrops: [],
   username: "Local Hero",
-  beehives: {},
+  beehives: {
+    "123": {
+      x: 6,
+      y: 2,
+      height: 1,
+      width: 1,
+      swarm: true,
+      honey: {
+        updatedAt: Date.now(),
+        produced: 0,
+      },
+      flowers: [
+        {
+          attachedAt: Date.now(),
+          attachedUntil: Date.now() + HONEY_PRODUCTION_TIME,
+          id: "1",
+        },
+      ],
+    },
+  },
   flowers: {
     "1": {
       createdAt: Date.now(),

--- a/src/features/game/lib/updateBeehives.test.ts
+++ b/src/features/game/lib/updateBeehives.test.ts
@@ -26,6 +26,7 @@ describe("updateBeehives", () => {
     y: 3,
     height: 1,
     width: 1,
+    swarm: false,
     honey: { updatedAt: now, produced: 0 },
     flowers: [],
   };

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -28,7 +28,11 @@ type SellableName =
 type Recipes = Food | CookableName;
 type Edibles = Food | ConsumableName;
 
-export type HarvestEvent = `${CropName | FruitName | FlowerName} Harvested`;
+export type HarvestEvent = `${
+  | CropName
+  | FruitName
+  | FlowerName
+  | "Honey"} Harvested`;
 export type PlantEvent = `${CropName | FruitName} Planted`;
 export type FruitPlantEvent = `${FruitSeedName} Planted`;
 export type PlantFlowerEvent = `${FlowerSeedName} Planted`;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -374,7 +374,7 @@ export type PlantedCrop = {
   id?: string;
   name: CropName;
   plantedAt: number;
-  amount?: number;
+  amount: number;
   reward?: Reward;
 };
 
@@ -789,6 +789,7 @@ export type AttachedFlower = {
 };
 
 export type Beehive = {
+  swarm: boolean;
   honey: {
     updatedAt: number;
     produced: number;

--- a/src/styles.css
+++ b/src/styles.css
@@ -941,3 +941,183 @@ img {
   animation: honey-drop 1s infinite;
   animation-delay: 1.5s;
 }
+
+@keyframes fly-up-right {
+  0% {
+    transform: translate(0, -5px) scale(0) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(0, -15px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+}
+
+@keyframes fly-up-left {
+  0% {
+    transform: translate(0, -5px) scale(0);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(0, -15px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+}
+
+/* Bee Swarm of 5 bees coming out of the hive and flying in different directions and then fading out */
+@keyframes bee-1 {
+  0% {
+    transform: translate(0, -7px) scale(0) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  15% {
+    transform: translate(0, -15px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(5px, 150px) scale(1) scaleX(-1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+/* Bee 2 should fly towards a 60 deg angle */
+@keyframes bee-2 {
+  0% {
+    transform: translate(0, -16px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(40px, 160px) scale(1) scaleX(-1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+@keyframes bee-3 {
+  0% {
+    transform: translate(0, -8px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  10% {
+    transform: translate(0, -20px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(60px, 140px) scale(1) scaleX(-1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+@keyframes bee-4 {
+  0% {
+    transform: translate(-10px, -8px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  10% {
+    transform: translate(-12px, -15px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-40px, 175px) scale(1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+@keyframes bee-5 {
+  0% {
+    transform: translate(-30px, -8px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  10% {
+    transform: translate(-32px, -15px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-70px, 90px) scale(1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+@keyframes bee-6 {
+  0% {
+    transform: translate(-20px, -20px) scale(1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-70px, 80px) scale(1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+@keyframes bee-7 {
+  0% {
+    transform: translate(5px, -8px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  15% {
+    transform: translate(8px, -14px) scale(1) scaleX(-1);
+    transform-origin: center bottom;
+    opacity: 1;
+  }
+  100% {
+    transform: translate(50px, 60px) scale(1) scaleX(-1);
+    transform-origin: center center;
+    opacity: 0;
+  }
+}
+
+.swarm-bee-1 {
+  animation: fly-up-right 4s, bee-1 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-2 {
+  animation: fly-up-right 4s, bee-2 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-3 {
+  animation: fly-up-right 4s, bee-3 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-4 {
+  animation: fly-up-left 4s, bee-4 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-5 {
+  animation: fly-up-left 4s, bee-5 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-6 {
+  animation: fly-up-left 4s, bee-6 4s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}
+.swarm-bee-7 {
+  animation: fly-up-right 3s, bee-7 3s;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.36, 0.03, 0.18, 1.08);
+}


### PR DESCRIPTION
# Description
When harvesting a hive a player has a 1/10 chance of triggering a bee swarm which will boost planted crops by 0.2.

![bee-swarm](https://github.com/sunflower-land/sunflower-land/assets/17863697/f4a555d1-bc12-461c-b248-677ff51b84f3)
_Bumpkin on the modal is not final. Waiting on the beehive wearables_

**NOTE:** Hives can be harvested at any time. To have a chance of triggering a bee swarm the hive has to be full when harvesting.

- Add `swarm` to `Beehive` type
- Add `BeeSwarm` and add logic to show the swarm inside of `Beehive`
- Logic for swarm value generation

- Add missing honey harvest bumpkin activity.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally in Art Mode and against API branch

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
