### PR TITLE
[FEAT] Weak bumpkin prevention

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -56,6 +56,7 @@ import { CONFIG } from "lib/config";
 import { Home } from "features/home/Home";
 import { hasFeatureAccess } from "lib/flags";
 import { Wallet } from "features/wallet/Wallet";
+import { WeakBumpkin } from "features/island/bumpkin/WeakBumpkin";
 
 export const AUTO_SAVE_INTERVAL = 1000 * 30; // autosave every 30 seconds
 const SHOW_MODAL: Record<StateValues, boolean> = {
@@ -71,6 +72,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   hoarding: true,
   landscaping: false,
   noBumpkinFound: true,
+  weakBumpkin: true,
   swarming: true,
   coolingDown: true,
   gameRules: true,
@@ -124,6 +126,7 @@ const isPurchasing = (state: MachineState) =>
   state.matches({ buyingBlockBucks: "transacting" });
 const isNoBumpkinFound = (state: MachineState) =>
   state.matches("noBumpkinFound");
+const isWeakBumpkin = (state: MachineState) => state.matches("weakBumpkin");
 const isCoolingDown = (state: MachineState) => state.matches("coolingDown");
 const isGameRules = (state: MachineState) => state.matches("gameRules");
 const isDepositing = (state: MachineState) => state.matches("depositing");
@@ -239,6 +242,7 @@ export const GameWrapper: React.FC = ({ children }) => {
   const hoarding = useSelector(gameService, isHoarding);
   const swarming = useSelector(gameService, isSwarming);
   const noBumpkinFound = useSelector(gameService, isNoBumpkinFound);
+  const weakBumpkin = useSelector(gameService, isWeakBumpkin);
   const coolingDown = useSelector(gameService, isCoolingDown);
   const gameRules = useSelector(gameService, isGameRules);
   const depositing = useSelector(gameService, isDepositing);
@@ -386,6 +390,7 @@ export const GameWrapper: React.FC = ({ children }) => {
               <NoBumpkin />
             </Wallet>
           )}
+          {weakBumpkin && <WeakBumpkin />}
 
           {coolingDown && <Cooldown />}
           {gameRules && <Rules />}

--- a/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
@@ -12,7 +12,6 @@ import { MachineState } from "features/game/lib/gameMachine";
 import Decimal from "decimal.js-light";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 import { RecoveredCrimstone } from "./components/RecoveredCrimstone";
 import { DepletingCrimstone } from "./components/DepletingCrimstone";
 import { DepletedCrimstone } from "./components/DepletedCrimstone";
@@ -98,17 +97,9 @@ export const Crimstone: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, CRIMSTONE_RECOVERY_TIME);
   const mined = !canMine(resource, CRIMSTONE_RECOVERY_TIME);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Crimstone Rock"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: mined });
 
   const strike = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -144,7 +135,6 @@ export const Crimstone: React.FC<Props> = ({ id, index }) => {
       {!mined && (
         <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
           <RecoveredCrimstone
-            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             minesLeft={resource.minesLeft}

--- a/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -21,7 +20,6 @@ import crimstone_5 from "assets/resources/crimstone/crimstone_rock_5.webp";
 import { ZoomContext } from "components/ZoomProvider";
 
 import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { getCrimstoneStage } from "../Crimstone";
 
@@ -34,7 +32,6 @@ const _bumpkinLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
   minesLeft: number;
@@ -42,7 +39,6 @@ interface Props {
 }
 
 const RecoveredCrimstoneComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
   hasTool,
   touchCount,
   minesLeft,
@@ -51,7 +47,6 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
-  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const strikeGif = useRef<SpriteSheetInstance>();
 
@@ -64,10 +59,6 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
     };
   }, []);
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   const crimstoneImage = [
     crimstone_1,
     crimstone_2,
@@ -77,7 +68,6 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
   ][getCrimstoneStage(minesLeft, minedAt) - 1];
 
   useEffect(() => {
-    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -86,17 +76,12 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
   };
 
   const handleMouseLeave = () => {
-    setShowBumpkinLevel(false);
     setShowEquipTool(false);
   };
 
@@ -117,11 +102,7 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={crimstoneImage}
-            className={
-              bumpkinTooLow
-                ? "absolute pointer-events-none opacity-50"
-                : "absolute pointer-events-none"
-            }
+            className={"absolute pointer-events-none opacity-50"}
             style={{
               width: `${PIXEL_SCALE * 24}px`,
               bottom: `${PIXEL_SCALE * 1}px`,
@@ -135,11 +116,7 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
           <>
             <img
               src={crimstoneImage}
-              className={
-                bumpkinTooLow
-                  ? "absolute pointer-events-none opacity-50"
-                  : "absolute pointer-events-none"
-              }
+              className={"absolute pointer-events-none"}
               style={{
                 width: `${PIXEL_SCALE * 24}px`,
                 bottom: `${PIXEL_SCALE * 1}px`,
@@ -182,22 +159,6 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
           </>
         )}
       </div>
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/gold/Gold.tsx
+++ b/src/features/game/expansion/components/resources/gold/Gold.tsx
@@ -15,7 +15,6 @@ import { DepletingGold } from "./components/DepletingGold";
 import { RecoveredGold } from "./components/RecoveredGold";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Iron Pickaxe";
@@ -83,17 +82,9 @@ export const Gold: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, GOLD_RECOVERY_TIME);
   const mined = !canMine(resource, GOLD_RECOVERY_TIME);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Gold Rock"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: mined });
 
   const strike = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -128,11 +119,7 @@ export const Gold: React.FC<Props> = ({ id, index }) => {
       {/* Resource ready to collect */}
       {!mined && (
         <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
-          <RecoveredGold
-            bumpkinLevelRequired={bumpkinLevelRequired}
-            hasTool={hasTool}
-            touchCount={touchCount}
-          />
+          <RecoveredGold hasTool={hasTool} touchCount={touchCount} />
         </div>
       )}
 

--- a/src/features/game/expansion/components/resources/gold/components/RecoveredGold.tsx
+++ b/src/features/game/expansion/components/resources/gold/components/RecoveredGold.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -17,7 +16,6 @@ import gold from "assets/resources/gold_small.png";
 import { ZoomContext } from "components/ZoomProvider";
 
 import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
 
 const tool = "Iron Pickaxe";
@@ -29,16 +27,11 @@ const _bumpkinLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
 }
 
-const RecoveredGoldComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
-  hasTool,
-  touchCount,
-}) => {
+const RecoveredGoldComponent: React.FC<Props> = ({ hasTool, touchCount }) => {
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
@@ -55,12 +48,7 @@ const RecoveredGoldComponent: React.FC<Props> = ({
     };
   }, []);
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useEffect(() => {
-    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -69,10 +57,6 @@ const RecoveredGoldComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
@@ -100,11 +84,7 @@ const RecoveredGoldComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={gold}
-            className={
-              bumpkinTooLow
-                ? "absolute pointer-events-none opacity-50"
-                : "absolute pointer-events-none"
-            }
+            className={"absolute pointer-events-none"}
             style={{
               width: `${PIXEL_SCALE * 14}px`,
               bottom: `${PIXEL_SCALE * 3}px`,
@@ -150,22 +130,6 @@ const RecoveredGoldComponent: React.FC<Props> = ({
           />
         )}
       </div>
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/iron/Iron.tsx
+++ b/src/features/game/expansion/components/resources/iron/Iron.tsx
@@ -12,10 +12,8 @@ import { MachineState } from "features/game/lib/gameMachine";
 import Decimal from "decimal.js-light";
 import { DepletedIron } from "./components/DepletedIron";
 import { DepletingIron } from "./components/DepletingIron";
-import { RecoveredIron } from "./components/RecoveredIron";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Stone Pickaxe";
@@ -83,17 +81,9 @@ export const Iron: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, IRON_RECOVERY_TIME);
   const mined = !canMine(resource, IRON_RECOVERY_TIME);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Iron Rock"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: mined });
 
   const strike = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -125,17 +115,6 @@ export const Iron: React.FC<Props> = ({ id, index }) => {
 
   return (
     <div className="relative w-full h-full">
-      {/* Resource ready to collect */}
-      {!mined && (
-        <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
-          <RecoveredIron
-            bumpkinLevelRequired={bumpkinLevelRequired}
-            hasTool={hasTool}
-            touchCount={touchCount}
-          />
-        </div>
-      )}
-
       {/* Depleting resource animation */}
       {collecting && <DepletingIron resourceAmount={collectedAmount} />}
 

--- a/src/features/game/expansion/components/resources/stone/Stone.tsx
+++ b/src/features/game/expansion/components/resources/stone/Stone.tsx
@@ -15,7 +15,6 @@ import { DepletingStone } from "./components/DepletingStone";
 import { RecoveredStone } from "./components/RecoveredStone";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Pickaxe";
@@ -31,9 +30,6 @@ const showHelper = (state: MachineState) =>
 const compareResource = (prev: Rock, next: Rock) => {
   return JSON.stringify(prev) === JSON.stringify(next);
 };
-
-const _bumpkinLevel = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
   id: string;
@@ -87,17 +83,9 @@ export const Stone: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, STONE_RECOVERY_TIME);
   const mined = !canMine(resource, STONE_RECOVERY_TIME);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Stone Rock"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: mined });
 
   const strike = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -133,7 +121,6 @@ export const Stone: React.FC<Props> = ({ id, index }) => {
       {!mined && (
         <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
           <RecoveredStone
-            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             showHelper={false} // FUTURE ENHANCEMENT

--- a/src/features/game/expansion/components/resources/stone/components/RecoveredStone.tsx
+++ b/src/features/game/expansion/components/resources/stone/components/RecoveredStone.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -18,7 +17,6 @@ import { ZoomContext } from "components/ZoomProvider";
 import { SUNNYSIDE } from "assets/sunnyside";
 
 import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
 
 const tool = "Pickaxe";
@@ -30,14 +28,12 @@ const _bumpkinLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
   showHelper: boolean;
 }
 
 const RecoveredStoneComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
   hasTool,
   touchCount,
   showHelper,
@@ -58,12 +54,7 @@ const RecoveredStoneComponent: React.FC<Props> = ({
     };
   }, []);
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useEffect(() => {
-    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -72,10 +63,6 @@ const RecoveredStoneComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
@@ -115,11 +102,7 @@ const RecoveredStoneComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={stone}
-            className={
-              bumpkinTooLow
-                ? "absolute pointer-events-none opacity-50"
-                : "absolute pointer-events-none"
-            }
+            className={"absolute pointer-events-none opacity-50"}
             style={{
               width: `${PIXEL_SCALE * 14}px`,
               bottom: `${PIXEL_SCALE * 3}px`,
@@ -165,22 +148,6 @@ const RecoveredStoneComponent: React.FC<Props> = ({
           />
         )}
       </div>
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/sunstone/Sunstone.tsx
+++ b/src/features/game/expansion/components/resources/sunstone/Sunstone.tsx
@@ -12,7 +12,6 @@ import { MachineState } from "features/game/lib/gameMachine";
 import Decimal from "decimal.js-light";
 import { canMine } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 import { DepletedSunstone } from "./components/DepletedSunstone";
 import { RecoveredSunstone } from "./components/RecoveredSunstone";
 import { DepletingSunstone } from "./components/DepletingSunstone";
@@ -96,17 +95,9 @@ export const Sunstone: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.stone.minedAt, SUNSTONE_RECOVERY_TIME);
   const mined = !canMine(resource, SUNSTONE_RECOVERY_TIME);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Sunstone Rock"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: mined });
 
   const strike = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -142,7 +133,6 @@ export const Sunstone: React.FC<Props> = ({ id, index }) => {
       {!mined && (
         <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
           <RecoveredSunstone
-            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             minesLeft={resource.minesLeft}

--- a/src/features/game/expansion/components/resources/sunstone/components/RecoveredSunstone.tsx
+++ b/src/features/game/expansion/components/resources/sunstone/components/RecoveredSunstone.tsx
@@ -25,11 +25,7 @@ import sunstone_10 from "assets/resources/sunstone/sunstone_rock_10.webp";
 
 import { ZoomContext } from "components/ZoomProvider";
 
-import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
-import { getBumpkinLevel } from "features/game/lib/level";
 import { getSunstoneStage } from "../Sunstone";
-import { ITEM_DETAILS } from "features/game/types/images";
 
 const tool = "Gold Pickaxe";
 
@@ -126,11 +122,7 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
           <>
             <img
               src={sunstoneImage}
-              className={
-                bumpkinTooLow
-                  ? "absolute pointer-events-none opacity-50"
-                  : "absolute pointer-events-none"
-              }
+              className="absolute pointer-events-none"
               style={{
                 width: `${PIXEL_SCALE * 24}px`,
                 bottom: `${PIXEL_SCALE * 1}px`,

--- a/src/features/game/expansion/components/resources/sunstone/components/RecoveredSunstone.tsx
+++ b/src/features/game/expansion/components/resources/sunstone/components/RecoveredSunstone.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -30,24 +29,20 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { getSunstoneStage } from "../Sunstone";
+import { ITEM_DETAILS } from "features/game/types/images";
 
 const tool = "Gold Pickaxe";
 
 const STRIKE_SHEET_FRAME_WIDTH = 48;
 const STRIKE_SHEET_FRAME_HEIGHT = 48;
 
-const _bumpkinLevel = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
-
 interface Props {
-  bumpkinLevelRequired: number;
   hasTool: boolean;
   touchCount: number;
   minesLeft: number;
 }
 
 const RecoveredSunstoneComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
   hasTool,
   touchCount,
   minesLeft,
@@ -68,10 +63,6 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
     };
   }, []);
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   const sunstoneImage = [
     sunstone_1,
     sunstone_2,
@@ -86,7 +77,6 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
   ][getSunstoneStage(minesLeft) - 1];
 
   useEffect(() => {
-    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       miningAudio.play();
@@ -95,10 +85,6 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
@@ -126,11 +112,7 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={sunstoneImage}
-            className={
-              bumpkinTooLow
-                ? "absolute pointer-events-none opacity-50"
-                : "absolute pointer-events-none"
-            }
+            className={"absolute pointer-events-none"}
             style={{
               width: `${PIXEL_SCALE * 24}px`,
               bottom: `${PIXEL_SCALE * 1}px`,
@@ -191,22 +173,6 @@ const RecoveredSunstoneComponent: React.FC<Props> = ({
           </>
         )}
       </div>
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -26,7 +26,6 @@ import { DepletingTree } from "./components/DepletingTree";
 import { RecoveredTree } from "./components/RecoveredTree";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HITS = 3;
 const tool = "Axe";
@@ -113,14 +112,9 @@ export const Tree: React.FC<Props> = ({ id, index }) => {
   const timeLeft = getTimeLeft(resource.wood.choppedAt, TREE_RECOVERY_TIME);
   const chopped = !canChop(resource);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(index, "Tree");
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useUiRefresher({ active: chopped });
 
   const shake = () => {
-    if (bumpkinTooLow) return;
     if (!hasTool) return;
 
     setTouchCount((count) => count + 1);
@@ -176,7 +170,6 @@ export const Tree: React.FC<Props> = ({ id, index }) => {
       {!chopped && (
         <div ref={divRef} className="absolute w-full h-full" onClick={shake}>
           <RecoveredTree
-            bumpkinLevelRequired={bumpkinLevelRequired}
             hasTool={hasTool}
             touchCount={touchCount}
             showHelper={treesChopped < 3 && treesChopped + 1 === Number(id)}

--- a/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
+++ b/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useSelector } from "@xstate/react";
 
 import Spritesheet, {
   SpriteSheetInstance,
@@ -16,27 +15,18 @@ import { chopAudio } from "lib/utils/sfx";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ZoomContext } from "components/ZoomProvider";
 
-import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
-import { getBumpkinLevel } from "features/game/lib/level";
-
 const tool = "Axe";
 
 const SHAKE_SHEET_FRAME_WIDTH = 448 / 7;
 const SHAKE_SHEET_FRAME_HEIGHT = 48;
 
-const _bumpkinLevel = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
-
 interface Props {
-  bumpkinLevelRequired: number;
   hasTool: boolean;
   showHelper: boolean;
   touchCount: number;
 }
 
 const RecoveredTreeComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
   hasTool,
   touchCount,
   showHelper,
@@ -44,7 +34,6 @@ const RecoveredTreeComponent: React.FC<Props> = ({
   const { scale } = useContext(ZoomContext);
   const [showSpritesheet, setShowSpritesheet] = useState(false);
   const [showEquipTool, setShowEquipTool] = useState(false);
-  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const shakeGif = useRef<SpriteSheetInstance>();
 
@@ -55,12 +44,7 @@ const RecoveredTreeComponent: React.FC<Props> = ({
     };
   }, []);
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   useEffect(() => {
-    if (bumpkinTooLow) return;
     if (touchCount > 0) {
       setShowSpritesheet(true);
       chopAudio.play();
@@ -69,17 +53,12 @@ const RecoveredTreeComponent: React.FC<Props> = ({
   }, [touchCount]);
 
   const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     if (!hasTool) {
       setShowEquipTool(true);
     }
   };
 
   const handleMouseLeave = () => {
-    setShowBumpkinLevel(false);
     setShowEquipTool(false);
   };
 
@@ -112,11 +91,7 @@ const RecoveredTreeComponent: React.FC<Props> = ({
         {!showSpritesheet && (
           <img
             src={SUNNYSIDE.resource.tree}
-            className={
-              bumpkinTooLow
-                ? "absolute pointer-events-none opacity-50"
-                : "absolute pointer-events-none"
-            }
+            className={"absolute pointer-events-none"}
             style={{
               width: `${PIXEL_SCALE * 26}px`,
               bottom: `${PIXEL_SCALE * 2}px`,
@@ -162,22 +137,6 @@ const RecoveredTreeComponent: React.FC<Props> = ({
           />
         )}
       </div>
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
 
       {/* No tool warning */}
       {showEquipTool && (

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -18,24 +18,6 @@ export interface Nodes {
   Beehive: number;
 }
 
-export function getBumpkinLevelRequiredForNode(
-  index: number,
-  nodeType: string
-): BumpkinLevel {
-  // Excluded: New Bumpkin Level blocking code - separate PR
-  return 0 as BumpkinLevel;
-
-  const key = nodeType as keyof Nodes;
-
-  for (let expansions = 4; expansions <= 23; ++expansions) {
-    if (TOTAL_EXPANSION_NODES.basic[expansions as Land][key] > index)
-      return EXPANSION_REQUIREMENTS[(expansions - 1) as Land]
-        .bumpkinLevel as BumpkinLevel;
-  }
-
-  return 50 as BumpkinLevel;
-}
-
 export function getEnabledNodeCount(
   bumpkinLevel: BumpkinLevel,
   nodeType: string

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -81,6 +81,8 @@ import { BudName } from "../types/buds";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { isValidRedirect } from "features/portal/examples/cropBoom/lib/portalUtil";
 import { portal } from "features/world/ui/community/actions/portal";
+import { BUMPKIN_EXPANSIONS_LEVEL } from "../types/expansions";
+import { getBumpkinLevel } from "./level";
 
 const getPortal = () => {
   const code = new URLSearchParams(window.location.search).get("portal");
@@ -408,6 +410,7 @@ export type BlockchainState = {
     | "buds"
     | "airdrop"
     | "noBumpkinFound"
+    | "weakBumpkin"
     | "coolingDown"
     | "buyingBlockBucks"
     | "auctionResults"
@@ -694,6 +697,21 @@ export function startGame(authContext: AuthContext) {
                 !event.data?.state.bumpkin && !context.state.bumpkin,
             },
             {
+              target: "weakBumpkin",
+              cond: (context: Context) => {
+                const requiredLevel =
+                  BUMPKIN_EXPANSIONS_LEVEL[context.state.island.type][
+                    context.state.inventory["Basic Land"]?.toNumber() ?? 3
+                  ];
+
+                const level = getBumpkinLevel(
+                  context.state.bumpkin?.experience ?? 0
+                );
+
+                return requiredLevel > level;
+              },
+            },
+            {
               target: "introduction",
               cond: (context) => {
                 return (
@@ -763,6 +781,7 @@ export function startGame(authContext: AuthContext) {
             },
           },
         },
+        weakBumpkin: {},
         specialOffer: {
           on: {
             ACKNOWLEDGE: {

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -301,7 +301,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     spawnedAt: 0,
   },
   farmHands: { bumpkins: {} },
-  bumpkin: { ...INITIAL_BUMPKIN, experience: 1000000 },
+  bumpkin: { ...INITIAL_BUMPKIN, experience: 1 },
   buds: {
     1: {
       aura: "Basic",
@@ -340,7 +340,8 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Market: new Decimal(1),
     Workbench: new Decimal(1),
     "Basic Land": new Decimal(3),
-    "Crop Plot": new Decimal(9),
+    "Gold Pass": new Decimal(1),
+    "Crop Plot": new Decimal(OFFLINE_FARM_CROPS),
     "Water Well": new Decimal(4),
     Tree: new Decimal(3),
     "Stone Rock": new Decimal(2),

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -1877,3 +1877,56 @@ export const EXPANSION_REQUIREMENTS: Record<
     // TODO
   },
 };
+
+/**
+ * Minimum Bumpkin level to work on a land.
+ * Prevents abuse of bumpkin swapping and reuse
+ */
+export const BUMPKIN_EXPANSIONS_LEVEL: Record<
+  IslandType,
+  Record<number, number>
+> = {
+  basic: {
+    3: 1,
+    4: 1,
+    5: 1,
+    6: 1,
+    7: 1,
+    8: 3,
+    9: 3,
+    10: 5,
+    11: 12,
+    12: 17,
+    13: 20,
+    14: 23,
+    15: 25,
+    16: 30,
+    17: 30,
+    18: 30,
+    19: 40,
+    20: 40,
+    21: 45,
+    22: 45,
+    23: 50,
+  },
+  spring: {
+    4: 10,
+    5: 12,
+    6: 13,
+    7: 15,
+    8: 17,
+    9: 20,
+    10: 23,
+    11: 25,
+    12: 25,
+    13: 30,
+    14: 30,
+    15: 35,
+    16: 35,
+    17: 40,
+    18: 40,
+    19: 45,
+    20: 50,
+  },
+  desert: {},
+};

--- a/src/features/island/bumpkin/NoBumpkin.tsx
+++ b/src/features/island/bumpkin/NoBumpkin.tsx
@@ -10,9 +10,13 @@ import { wallet } from "lib/blockchain/wallet";
 import { OuterPanel } from "components/ui/Panel";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
+import { BUMPKIN_EXPANSIONS_LEVEL } from "features/game/types/expansions";
+import { useActor } from "@xstate/react";
+import { Label } from "components/ui/Label";
 
 export const NoBumpkin: React.FC = () => {
   const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
 
   const [selectedBumpkinId, setSelectedBumpkinId] = useState<number>();
 
@@ -20,6 +24,11 @@ export const NoBumpkin: React.FC = () => {
   const [farmBumpkins, setFarmBumpkins] = useState<OnChainBumpkin[]>();
 
   const [isLoading, setIsLoading] = useState(true);
+
+  const requiredLevel =
+    BUMPKIN_EXPANSIONS_LEVEL[gameState.context.state.island.type][
+      gameState.context.state.inventory["Basic Land"]?.toNumber() ?? 3
+    ];
 
   useEffect(() => {
     const load = async () => {
@@ -103,6 +112,10 @@ export const NoBumpkin: React.FC = () => {
             You need a Bumpkin to help you plant, harvest, chop, mine and expand
             your land.
           </p>
+          <Label
+            type="danger"
+            className="mx-auto my-2"
+          >{`Level ${requiredLevel} required`}</Label>
           <p className="text-sm my-2">You can get a Bumpkin from OpenSea:</p>
           <p className="text-xs sm:text-sm text-shadow text-white p-1">
             <a
@@ -159,6 +172,13 @@ export const NoBumpkin: React.FC = () => {
             );
           })}
         </div>
+        <p className="text-sm my-2">
+          This is an advanced island. A strong Bumpkin is required:
+        </p>
+        <Label
+          type="danger"
+          className="mx-auto my-2"
+        >{`Level ${requiredLevel} required`}</Label>
       </div>
       <Button disabled={!selectedBumpkinId} onClick={deposit}>
         Deposit

--- a/src/features/island/bumpkin/WeakBumpkin.tsx
+++ b/src/features/island/bumpkin/WeakBumpkin.tsx
@@ -1,0 +1,51 @@
+import { useActor } from "@xstate/react";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { Label } from "components/ui/Label";
+import { Context } from "features/game/GameProvider";
+import React, { useContext, useState } from "react";
+import lock from "assets/skills/lock.png";
+import { BUMPKIN_EXPANSIONS_LEVEL } from "features/game/types/expansions";
+import { Button } from "components/ui/Button";
+import { IslandList } from "features/game/expansion/components/travel/IslandList";
+
+export const WeakBumpkin: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+
+  const [showList, setShowList] = useState(false);
+
+  const requiredLevel =
+    BUMPKIN_EXPANSIONS_LEVEL[gameState.context.state.island.type][
+      gameState.context.state.inventory["Basic Land"]?.toNumber() ?? 3
+    ];
+
+  if (showList) {
+    return (
+      <IslandList
+        bumpkin={undefined}
+        showVisitList={false}
+        gameState={gameState.context.state}
+        travelAllowed={true}
+        hasBetaAccess={false}
+        onClose={() => setShowList(false)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="p-2">
+        <img src={SUNNYSIDE.icons.sad} className="w-16 mx-auto my-2" />
+        <p className="text-sm mb-2 text-center">
+          Oh no! Your Bumpkin is not strong enough for this island.
+        </p>
+        <Label
+          type="danger"
+          className="mx-auto my-2"
+          icon={lock}
+        >{`Level ${requiredLevel} required`}</Label>
+      </div>
+      <Button onClick={() => setShowList(true)}>Travel</Button>
+    </>
+  );
+};

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -25,7 +25,6 @@ import { ResourceDropAnimator } from "components/animation/ResourceDropAnimator"
 import fruitPatchDirt from "assets/fruit/fruit_patch.png";
 import powerup from "assets/icons/level_up.png";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 
 const HasAxes = (
   inventory: Partial<Record<InventoryItemName, Decimal>>,
@@ -90,13 +89,6 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
 
   const hasAxes = HasAxes(inventory, game, fruit);
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Fruit Patch"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   const plantTree = async () => {
     if (selectedItem === "Fruitful Blend") {
       fertilise();
@@ -129,7 +121,6 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
   };
 
   const harvestFruit = async () => {
-    if (bumpkinTooLow) return;
     if (!fruitPatch) return;
 
     const newState = gameService.send("fruit.harvested", {
@@ -195,7 +186,6 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
 
       {/* Fruit tree stages */}
       <FruitTree
-        bumpkinLevelRequired={bumpkinLevelRequired}
         plantedFruit={fruit}
         plantTree={plantTree}
         harvestFruit={harvestFruit}

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -52,7 +52,6 @@ const getFruitTreeStatus = (plantedFruit?: PlantedFruit): FruitTreeStatus => {
 };
 
 interface Props {
-  bumpkinLevelRequired: number;
   plantedFruit?: PlantedFruit;
   plantTree: () => void;
   harvestFruit: () => void;
@@ -63,7 +62,6 @@ interface Props {
 }
 
 export const FruitTree: React.FC<Props> = ({
-  bumpkinLevelRequired,
   plantedFruit,
   plantTree,
   harvestFruit,
@@ -120,10 +118,7 @@ export const FruitTree: React.FC<Props> = ({
   // Ready tree
   return (
     <div className="absolute w-full h-full" onClick={harvestFruit}>
-      <ReplenishedTree
-        bumpkinLevelRequired={bumpkinLevelRequired}
-        fruitName={name}
-      />
+      <ReplenishedTree fruitName={name} />
     </div>
   );
 };

--- a/src/features/island/fruit/ReplenishedTree.tsx
+++ b/src/features/island/fruit/ReplenishedTree.tsx
@@ -1,30 +1,16 @@
-import React, { useContext, useState } from "react";
-import { useSelector } from "@xstate/react";
+import React, { useContext } from "react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { FRUIT, FruitName } from "features/game/types/fruits";
 import { FRUIT_LIFECYCLE } from "./fruits";
 
-import { InnerPanel } from "components/ui/Panel";
-
-import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
-import { getBumpkinLevel } from "features/game/lib/level";
-
-const _bumpkinLevel = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  bumpkinLevelRequired: number;
   fruitName: FruitName;
 }
 
-export const ReplenishedTree: React.FC<Props> = ({
-  bumpkinLevelRequired,
-  fruitName,
-}) => {
-  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
-
+export const ReplenishedTree: React.FC<Props> = ({ fruitName }) => {
   const lifecycle = FRUIT_LIFECYCLE[fruitName];
 
   const { isBush } = FRUIT()[fruitName];
@@ -35,54 +21,18 @@ export const ReplenishedTree: React.FC<Props> = ({
   const width = isBanana ? 31 : isBush ? 24 : 26;
 
   const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
-  const handleHover = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-    }
-  };
-
-  const handleMouseLeave = () => {
-    setShowBumpkinLevel(false);
-  };
 
   return (
-    <div
-      className="absolute w-full h-full cursor-pointer hover:img-highlight"
-      onMouseEnter={handleHover}
-      onMouseLeave={handleMouseLeave}
-    >
+    <div className="absolute w-full h-full cursor-pointer hover:img-highlight">
       <img
         src={lifecycle.ready}
-        className={
-          bumpkinTooLow
-            ? "absolute pointer-events-none opacity-50"
-            : "absolute pointer-events-none"
-        }
+        className={"absolute pointer-events-none"}
         style={{
           bottom: `${PIXEL_SCALE * bottom}px`,
           left: `${PIXEL_SCALE * left}px`,
           width: `${PIXEL_SCALE * width}px`,
         }}
       />
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -31,7 +31,6 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { SeedName } from "features/game/types/seeds";
 import { SeedSelection } from "./components/SeedSelection";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getBumpkinLevelRequiredForNode } from "features/game/expansion/lib/expansionNodes";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import lockIcon from "assets/skills/lock.png";
 import { getKeys } from "features/game/types/craftables";
@@ -116,13 +115,6 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
   const buds = state.buds;
   const plot = crops[id];
 
-  const bumpkinLevelRequired = getBumpkinLevelRequiredForNode(
-    index,
-    "Crop Plot"
-  );
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   const isFertile = isPlotFertile({
     plotIndex: id,
     crops: crops,
@@ -172,8 +164,6 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
   };
 
   const onClick = (seed: SeedName = selectedItem as SeedName) => {
-    if (bumpkinTooLow) return;
-
     const now = Date.now();
 
     if (!inventory.Shovel) {
@@ -380,7 +370,6 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
         )}
 
         <FertilePlot
-          bumpkinLevelRequired={bumpkinLevelRequired}
           cropName={crop?.name}
           inventory={inventory}
           // TODO

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -1,12 +1,10 @@
-import React, { useContext, useState } from "react";
-import { useSelector } from "@xstate/react";
+import React, { useState } from "react";
 
 import { CROPS, CropName } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { GrowthStage, Soil } from "features/island/plots/components/Soil";
 import { Bar, LiveProgressBar } from "components/ui/ProgressBar";
-import { InnerPanel } from "components/ui/Panel";
 
 import powerup from "assets/icons/level_up.png";
 
@@ -25,14 +23,12 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { getCropTime } from "features/game/events/landExpansion/plant";
 
 import { MachineState } from "features/game/lib/gameMachine";
-import { Context } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
 
 const _bumpkinLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  bumpkinLevelRequired: number;
   cropName?: CropName;
   inventory: Inventory;
   game: GameState;
@@ -47,7 +43,6 @@ interface Props {
 }
 
 const FertilePlotComponent: React.FC<Props> = ({
-  bumpkinLevelRequired,
   cropName,
   inventory,
   game,
@@ -60,7 +55,6 @@ const FertilePlotComponent: React.FC<Props> = ({
   showTimers,
 }) => {
   const [showTimerPopover, setShowTimerPopover] = useState(false);
-  const [showBumpkinLevel, setShowBumpkinLevel] = useState(false);
 
   const [_, setRender] = useState<number>(0);
 
@@ -97,15 +91,7 @@ const FertilePlotComponent: React.FC<Props> = ({
     ? "halfway"
     : "seedling";
 
-  const { gameService } = useContext(Context);
-  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
-  const bumpkinTooLow = bumpkinLevel < bumpkinLevelRequired;
-
   const handleMouseEnter = () => {
-    if (bumpkinTooLow) {
-      setShowBumpkinLevel(true);
-      return;
-    }
     // show details if field is growing
     if (isGrowing) {
       // set state to show details
@@ -114,7 +100,6 @@ const FertilePlotComponent: React.FC<Props> = ({
   };
 
   const handleMouseLeave = () => {
-    setShowBumpkinLevel(false);
     // set state to hide details
     setShowTimerPopover(false);
   };
@@ -132,11 +117,7 @@ const FertilePlotComponent: React.FC<Props> = ({
       >
         {/* Crop base image */}
         <div
-          className={
-            bumpkinTooLow
-              ? "absolute pointer-events-none opacity-50"
-              : "absolute pointer-events-none"
-          }
+          className={"absolute pointer-events-none"}
           style={{
             width: `${PIXEL_SCALE * 16}px`,
           }}
@@ -169,22 +150,6 @@ const FertilePlotComponent: React.FC<Props> = ({
             right: `${PIXEL_SCALE * 0}px`,
           }}
         />
-      )}
-
-      {/* Bumpkin level warning */}
-      {showBumpkinLevel && (
-        <div
-          className="flex justify-center absolute w-full pointer-events-none"
-          style={{
-            top: `${PIXEL_SCALE * -14}px`,
-          }}
-        >
-          <InnerPanel className="absolute whitespace-nowrap w-fit z-50">
-            <div className="text-xxs mx-1 p-1">
-              <span>Bumpkin level {bumpkinLevelRequired} required.</span>
-            </div>
-          </InnerPanel>
-        </div>
       )}
 
       {/* Time popover */}


### PR DESCRIPTION
# Description

Simplify weak bumpkin check and do not let them access powerful lands. This aims to prevent Bumpkin swapping abuse and multi-accounting. This modal will appear after login.

If someone deposits a weak Bumpkin, they will not get access to their island. They can still travel to Goblin Retreat and withdraw.

<img width="558" alt="Screenshot 2024-01-25 at 12 17 41 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/6173c498-f488-4563-9b52-879941b66f71">
