### PR TITLE
[FIX] Bert's Obsession for mislabelled wearables

### DIFF
--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -43,14 +43,17 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
   const currentObsession = game.bertObsession;
   const obsessionCompletedAt = game.npcs?.bert?.questCompletedAt;
 
-  const isObsessionCollectible = game.bertObsession?.type === "collectible";
-
   const obsessionDialogue = useRandomItem(
     obsessionDialogues(currentObsession?.name as string)
   );
 
   const obsessionName = game.bertObsession?.name;
   const reward = game.bertObsession?.reward ?? 0;
+
+  let isObsessionCollectible = game.bertObsession?.type === "collectible";
+  if (ITEM_DETAILS[obsessionName as InventoryItemName] === undefined) {
+    isObsessionCollectible = false;
+  }
 
   const image = isObsessionCollectible
     ? ITEM_DETAILS[obsessionName as InventoryItemName].image


### PR DESCRIPTION
# Description

Bert's Obsession crashes players this week because a wearable is mislabelled as a collectible.
```
"bertObsession": {
    "type": "collectible",
    "name": "Lion Dance Mask",
    ...
}
```

This change makes the front-end more resilient to this kind of back-end issue.

Long-term all lookups of properties for collectibles and wearables should use a common function that double-checks to ensure the type is correct before accessing data structures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
