### PR TITLE
[FIX] Carrot Amulet equipped on farmhand

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1577,8 +1577,13 @@ describe("getCropTime", () => {
       crop: "Carrot",
       inventory: {},
       buds: {},
-      game: TEST_FARM,
-
+      game: {
+        ...TEST_FARM,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: { ...INITIAL_BUMPKIN.equipped, necklace: "Carrot Amulet" },
+        },
+      },
       bumpkin: {
         ...INITIAL_BUMPKIN,
         equipped: { ...INITIAL_BUMPKIN.equipped, necklace: "Carrot Amulet" },

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -131,8 +131,7 @@ export const getCropTime = ({
   plot?: CropPlot;
   fertiliser?: CropCompostName;
 }) => {
-  const { skills, equipped } = bumpkin;
-  const { necklace } = equipped;
+  const { skills } = bumpkin;
   let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
 
   // Legacy Seed Specialist skill: 10% reduction
@@ -149,7 +148,7 @@ export const getCropTime = ({
   }
 
   // Bumpkin Wearable Boost
-  if (crop === "Carrot" && necklace === "Carrot Amulet") {
+  if (crop === "Carrot" && isWearableActive({ name: "Carrot Amulet", game })) {
     seconds = seconds * 0.8;
   }
 


### PR DESCRIPTION
# Description

When equipping Carrot Amulet on a farmhand, the front-end is now reflecting the boost while the back-end does apply the boost.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
