### PR TITLE
[FEAT] Remove bumpkin param from getCropTime()

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1562,9 +1562,11 @@ describe("getCropTime", () => {
   it("applies a 5% speed boost with Cultivator skill", () => {
     const time = getCropTime({
       crop: "Carrot",
-      game: TEST_FARM,
+      game: {
+        ...TEST_FARM,
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Cultivator: 1 } },
+      },
       buds: {},
-      bumpkin: { ...INITIAL_BUMPKIN, skills: { Cultivator: 1 } },
       plot,
       inventory: {},
     });
@@ -1584,10 +1586,6 @@ describe("getCropTime", () => {
           equipped: { ...INITIAL_BUMPKIN.equipped, necklace: "Carrot Amulet" },
         },
       },
-      bumpkin: {
-        ...INITIAL_BUMPKIN,
-        equipped: { ...INITIAL_BUMPKIN.equipped, necklace: "Carrot Amulet" },
-      },
     });
 
     expect(time).toEqual(60 * 60 * 0.8);
@@ -1601,7 +1599,6 @@ describe("getCropTime", () => {
       buds: {},
       game: {
         ...TEST_FARM,
-
         collectibles: {
           "Lunar Calendar": [
             {
@@ -1613,7 +1610,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       plot,
     });
 
@@ -1639,8 +1635,6 @@ describe("getCropTime", () => {
         },
       },
       inventory: {},
-
-      bumpkin: { ...INITIAL_BUMPKIN },
       plot,
     });
 
@@ -1665,7 +1659,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot,
     });
@@ -1747,7 +1740,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot,
     });
@@ -1775,7 +1767,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       plot: { ...plot, x: 0, y: -2 },
     });
 
@@ -1801,7 +1792,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       plot: { ...plot, x: 0, y: -2 },
       buds: {},
     });
@@ -1828,7 +1818,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot: { ...plot, x: 0, y: -2 },
     });
@@ -1855,7 +1844,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot: { ...plot, x: 0, y: -2 },
     });
@@ -1882,7 +1870,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot: { ...plot, x: 2, y: -2 },
     });
@@ -1909,7 +1896,6 @@ describe("getCropTime", () => {
           ],
         },
       },
-      bumpkin: { ...INITIAL_BUMPKIN },
       buds: {},
       plot: { ...plot, x: 0, y: -3 },
     });
@@ -2427,8 +2413,6 @@ describe("getCropYield", () => {
 
       const time = getPlantedAt({
         buds: {},
-        buildings: {},
-        bumpkin: INITIAL_BUMPKIN,
         crop: "Sunflower",
         inventory: {},
         game: {
@@ -2462,8 +2446,6 @@ describe("getCropYield", () => {
 
       const time = getPlantedAt({
         buds: {},
-        buildings: {},
-        bumpkin: INITIAL_BUMPKIN,
         crop: "Sunflower",
         inventory: {},
         game: {

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -3,7 +3,6 @@ import Decimal from "decimal.js-light";
 
 import { CropName, CROPS } from "../../types/crops";
 import {
-  Buildings,
   Bumpkin,
   CropPlot,
   GameState,
@@ -118,7 +117,6 @@ export const getCropTime = ({
   crop,
   inventory,
   game,
-  bumpkin,
   buds,
   plot,
   fertiliser,
@@ -126,13 +124,14 @@ export const getCropTime = ({
   crop: CropName;
   inventory: Inventory;
   game: GameState;
-  bumpkin: Bumpkin;
   buds: NonNullable<GameState["buds"]>;
   plot?: CropPlot;
   fertiliser?: CropCompostName;
 }) => {
-  const { skills } = bumpkin;
   let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
+  if (game.bumpkin === undefined) return seconds;
+
+  const { skills } = game.bumpkin;
 
   // Legacy Seed Specialist skill: 10% reduction
   if (inventory["Seed Specialist"]?.gte(1)) {
@@ -239,8 +238,6 @@ type GetPlantedAtArgs = {
   crop: CropName;
   inventory: Inventory;
   game: GameState;
-  buildings: Buildings;
-  bumpkin: Bumpkin;
   createdAt: number;
   plot: CropPlot;
   buds: NonNullable<GameState["buds"]>;
@@ -254,8 +251,6 @@ export function getPlantedAt({
   crop,
   inventory,
   game,
-  buildings,
-  bumpkin,
   buds,
   createdAt,
   plot,
@@ -268,7 +263,6 @@ export function getPlantedAt({
     crop,
     inventory,
     game: game,
-    bumpkin,
     buds,
     plot,
     fertiliser,
@@ -532,13 +526,7 @@ export function plant({
   createdAt = Date.now(),
 }: Options): GameState {
   const stateCopy = cloneDeep(state);
-  const {
-    crops: plots,
-    bumpkin,
-    collectibles,
-    inventory,
-    buildings,
-  } = stateCopy;
+  const { crops: plots, bumpkin, inventory } = stateCopy;
   const buds = stateCopy.buds ?? {};
 
   if (bumpkin === undefined) {
@@ -587,8 +575,6 @@ export function plant({
         crop: cropName,
         inventory,
         game: stateCopy,
-        buildings,
-        bumpkin,
         createdAt,
         plot,
         buds,

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -147,7 +147,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       crop: yields as CropName,
       inventory,
       game: state,
-      bumpkin: state.bumpkin as Bumpkin,
       buds: state.buds ?? {},
     });
   };

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -49,7 +49,7 @@ interface Prop {
 export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const divRef = useRef<HTMLDivElement>(null);
 
-  const { inventory, bumpkin, collectibles, buildings, buds } = gameState;
+  const { inventory, buds } = gameState;
   const basketMap = getBasketItems(inventory);
 
   const basketIsEmpty = Object.values(basketMap).length === 0;
@@ -91,7 +91,6 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
       crop,
       inventory,
       game: gameState,
-      bumpkin: bumpkin as Bumpkin,
       buds: buds ?? {},
     });
   };

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -385,7 +385,6 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
           inventory={inventory}
           // TODO
           game={gameService.state?.context?.state ?? TEST_FARM}
-          bumpkin={bumpkin}
           buds={buds}
           plot={plot}
           plantedAt={crop?.plantedAt}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -51,7 +51,6 @@ const FertilePlotComponent: React.FC<Props> = ({
   cropName,
   inventory,
   game,
-  bumpkin,
   buds,
   plot,
   plantedAt,
@@ -69,13 +68,12 @@ const FertilePlotComponent: React.FC<Props> = ({
   const readyAt = plantedAt ? plantedAt + harvestSeconds * 1000 : 0;
 
   let startAt = plantedAt ?? 0;
-  if (cropName && bumpkin) {
+  if (cropName && game.bumpkin) {
     const fertiliserName = fertiliser?.name ?? undefined;
     harvestSeconds = getCropTime({
       crop: cropName,
       inventory,
       game,
-      bumpkin,
       buds: buds ?? {},
       plot,
       fertiliser: fertiliserName,


### PR DESCRIPTION
# Description

With the introduction of farmhands, passing a separate bumpkin parameter is no longer useful and introduces a pitfall when testing for boosts with farmhand support.

This change removes the at best redundant parameter.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
