### PR TITLE
[FEAT] Remove bumpkin param from getCropYieldAmount()

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1677,13 +1677,6 @@ describe("getCropTime", () => {
     const amount = getCropYieldAmount({
       crop: "Eggplant",
       inventory: {},
-      bumpkin: {
-        ...INITIAL_BUMPKIN,
-        equipped: {
-          ...INITIAL_BUMPKIN.equipped,
-          onesie: "Eggplant Onesie",
-        },
-      },
       game: {
         ...TEST_FARM,
         bumpkin: {
@@ -1705,13 +1698,6 @@ describe("getCropTime", () => {
     const amount = getCropYieldAmount({
       crop: "Corn",
       inventory: {},
-      bumpkin: {
-        ...INITIAL_BUMPKIN,
-        equipped: {
-          ...INITIAL_BUMPKIN.equipped,
-          onesie: "Corn Onesie",
-        },
-      },
       game: {
         ...TEST_FARM,
         bumpkin: {
@@ -2088,7 +2074,6 @@ describe("getCropYield", () => {
   it("does not apply sir goldensnout boost outside AOE", () => {
     const amount = getCropYieldAmount({
       crop: "Sunflower",
-      bumpkin: INITIAL_BUMPKIN,
       game: {
         ...TEST_FARM,
         collectibles: {
@@ -2113,7 +2098,6 @@ describe("getCropYield", () => {
   it("applies sir goldensnout boost inside AOE", () => {
     const amount = getCropYieldAmount({
       crop: "Sunflower",
-      bumpkin: INITIAL_BUMPKIN,
       game: {
         ...TEST_FARM,
         collectibles: {

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -288,7 +288,6 @@ export function getCropYieldAmount({
   inventory,
   game,
   buds,
-  bumpkin,
   fertiliser,
 }: {
   crop: CropName;
@@ -296,11 +295,12 @@ export function getCropYieldAmount({
   inventory: Inventory;
   game: GameState;
   buds: NonNullable<GameState["buds"]>;
-  bumpkin: Bumpkin;
   fertiliser?: CropCompostName;
 }): number {
   let amount = 1;
-  const { skills } = bumpkin;
+  if (game.bumpkin === undefined) return amount;
+
+  const { skills } = game.bumpkin;
 
   if (
     crop === "Cauliflower" &&
@@ -599,7 +599,6 @@ export function plant({
         crop: cropName,
         inventory,
         game: stateCopy,
-        bumpkin,
         plot,
         buds,
         fertiliser: plot.fertiliser?.name,


### PR DESCRIPTION
# Description

With the introduction of farmhands, passing a separate bumpkin parameter is no longer useful and introduces a pitfall when testing for boosts with farmhand support.

This change removes the at best redundant parameter.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
