### PR TITLE
[FEAT] Sort all Boost Collectibles to their own category in Chest tab

### DIFF
--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -430,10 +430,60 @@ export type Purchasable = CraftableCollectible & {
 export const COLLECTIBLE_BUFF_LABELS: Partial<
   Record<InventoryItemName, BuffLabel>
 > = {
-  "Sir Goldensnout": {
-    shortDescription: "+0.5 Crops (AOE)",
+  // Crop Boosts
+  "Basic Scarecrow": {
+    shortDescription:
+      "-20% Basic Crop Growth Time: Sunflower, Potato and Pumpkin (AOE 3x3)",
     labelType: "success",
     boostTypeIcon: powerup,
+  },
+  "Scary Mike": {
+    shortDescription:
+      "+0.2 Medium Crop: Carrot, Cabbage, Beetroot, Cauliflower and Parsnip (AOE 3x3)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Laurie the Chuckle Crow": {
+    shortDescription:
+      "+0.2 Advanced Crop: Eggplant, Corn, Radish, Wheat, Kale (AOE 3x3)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Nancy: {
+    shortDescription: "-15% Crop Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Scarecrow: {
+    shortDescription: "-15% Crop Growth Time; +20% Crop Yield",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Kuebiko: {
+    shortDescription: "-15% Crop Growth Time; +20% Crop Yield; Free Seeds",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Gnome: {
+    shortDescription: "+10 Yield to Medium/Advanced Crops (AOE plot below)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Sir Goldensnout": {
+    shortDescription: "+0.5 Crop (AOE 4x4)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Lunar Calendar": {
+    shortDescription: "-10% Crop Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Victoria Sisters": {
+    shortDescription: "+20% Pumpkin",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
   },
   "Freya Fox": {
     shortDescription: "+0.5 Pumpkin",
@@ -441,27 +491,380 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     boostTypeIcon: powerup,
     boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
   },
+  "Easter Bunny": {
+    shortDescription: "+20% Carrot",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+  },
+  "Pablo The Bunny": {
+    shortDescription: "+0.1 Carrot",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+  },
+  "Cabbage Boy": {
+    shortDescription: "+0.25 Cabbage (+0.5 with Cabbage Girl)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+  },
+  "Cabbage Girl": {
+    shortDescription: "-50% Cabbage Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+  },
+  Karkinos: {
+    shortDescription: "+0.1 Cabbage (Inactive with Cabbage Boy)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+  },
+  "Golden Cauliflower": {
+    shortDescription: "+100% Cauliflower",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Cauliflower.crop,
+  },
+  "Mysterious Parsnip": {
+    shortDescription: "-50% Parsnip Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Parsnip.crop,
+  },
+  "Purple Trail": {
+    shortDescription: "+0.2 Eggplant",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+  },
+  Obie: {
+    shortDescription: "-25% Eggplant Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+  },
+  Maximus: {
+    shortDescription: "+1 Eggplant",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+  },
   Poppy: {
     shortDescription: "+0.1 Corn",
     labelType: "success",
     boostTypeIcon: powerup,
     boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
   },
-  "Grain Grinder": {
-    shortDescription: "+20% Cake XP",
-    boostTypeIcon: powerup,
-    labelType: "success",
-  },
   Kernaldo: {
-    shortDescription: "+25% Corn Growth Speed",
+    shortDescription: "-25% Corn Growth Time",
     labelType: "success",
-    boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    boostTypeIcon: powerup,
     boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
   },
+  "Queen Cornelia": {
+    shortDescription: "+1 Corn (AOE 3x4)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
+  },
+  Foliant: {
+    shortDescription: "+0.2 Kale",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Kale.crop,
+  },
+  Hoot: {
+    shortDescription: "+0.5 Wheat, Radish, Kale",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+
+  // Fruit Boosts
+  "Immortal Pear": {
+    shortDescription: "+1 Max Fruit Harvest per seed",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Black Bearry": {
+    shortDescription: "+1 Blueberry",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Squirrel Monkey": {
+    shortDescription: "-50% Orange Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Lady Bug": {
+    shortDescription: "+0.25 Apple",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Banana Chicken": {
+    shortDescription: "+0.1 Banana",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Nana: {
+    shortDescription: "-10% Banana Growth Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+
+  // Mutant Crops
+  "Carrot Sword": {
+    shortDescription: "4x Chance of Mutant Crop",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Stellar Sunflower": {
+    shortDescription: "3% Chance of +10 Sunflower",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Sunflower.crop,
+  },
+  "Potent Potato": {
+    shortDescription: "3% Chance of +10 Potato",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Potato.crop,
+  },
+  "Radical Radish": {
+    shortDescription: "3% Chance of +10 Radish",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Radish.crop,
+  },
+  "Lab Grown Pumpkin": {
+    shortDescription: "+0.3 Pumpkin",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
+  },
+  "Lab Grown Carrot": {
+    shortDescription: "+0.2 Carrot",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+  },
+  "Lab Grown Radish": {
+    shortDescription: "+0.4 Radish",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Radish.crop,
+  },
+
+  // Animals
+  "Fat Chicken": {
+    shortDescription: "-0.1 Wheat to Feed Chickens",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Rich Chicken": {
+    shortDescription: "+0.1 Egg",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.egg,
+  },
+  "Speed Chicken": {
+    shortDescription: "-10% Egg Production Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Ayam Cemani": {
+    shortDescription: "+0.2 Egg",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.egg,
+  },
+  "El Pollo Veloz": {
+    shortDescription: "-4h Egg Production Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Rooster: {
+    shortDescription: "2x Chance of Mutant Chicken",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Undead Rooster": {
+    shortDescription: "+0.1 Egg",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.egg,
+  },
+  "Chicken Coop": {
+    shortDescription: "+1 Egg Yield; +5 Chicken Limit per Hen House",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Gold Egg": {
+    shortDescription: "Feed Chickens without Wheat",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Bale: {
+    shortDescription: "+0.2 Egg (AOE 4x4)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.egg,
+  },
+
+  // Resources
+  "Woody the Beaver": {
+    shortDescription: "+20% Wood",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wood,
+  },
+  "Apprentice Beaver": {
+    shortDescription: "+20% Wood; -50% Tree Recovery Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wood,
+  },
+  "Foreman Beaver": {
+    shortDescription:
+      "+20% Wood; -50% Tree Recovery Time; Chop Trees without Axes",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wood,
+  },
+  "Wood Nymph Wendy": {
+    shortDescription: "+0.2 Wood",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wood,
+  },
+  "Tiki Totem": {
+    shortDescription: "+0.1 Wood",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wood,
+  },
+  "Tunnel Mole": {
+    shortDescription: "+0.25 Stone",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.stone,
+  },
+  "Rocky the Mole": {
+    shortDescription: "+0.25 Iron",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  Nugget: {
+    shortDescription: "+0.25 Gold",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Rock Golem": {
+    shortDescription: "10% Chance of +2 Stone",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.stone,
+  },
+  "Iron Idol": {
+    shortDescription: "+1 Iron",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Tin Turtle": {
+    shortDescription: "+0.1 Stone (AOE 3x3)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.stone,
+  },
+  "Emerald Turtle": {
+    shortDescription: "+0.5 Stone, Iron, Gold (AOE 3x3)",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Mushroom House": {
+    shortDescription: "+0.2 Wild Mushroom",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.resource.wild_mushroom,
+  },
+
+  // Fish
   "Skill Shrimpy": {
     shortDescription: "+20% Fish XP",
     labelType: "success",
     boostTypeIcon: powerup,
     boostedItemIcon: SUNNYSIDE.icons.fish,
+  },
+  Walrus: {
+    shortDescription: "+1 Fish",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.icons.fish,
+  },
+  Alba: {
+    shortDescription: "10% Chance of +1 Fish",
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: SUNNYSIDE.icons.fish,
+  },
+
+  // Other
+  "Soil Krabby": {
+    shortDescription: " -10% Composter Compost Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Knowledge Crab": {
+    shortDescription: "Double Sprout Mix Effect",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Maneki Neko": {
+    shortDescription: "1 Free Food per Day",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Treasure Map": {
+    shortDescription: "+20% SFL Bounty Sales",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Heart of Davy Jones": {
+    shortDescription: "+20 Daily Digging Limit",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Genie Lamp": {
+    shortDescription: "Grants 3 Wishes",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Grain Grinder": {
+    shortDescription: "+20% Cake XP",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Christmas Tree": {
+    shortDescription: "Free Gift at Christmas",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Festive Tree": {
+    shortDescription: "Free Gift at Christmas",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+
+  // Marine Marvels with Boosts
+  "Radiant Ray": {
+    shortDescription: "+0.1 Iron",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Gilded Swordfish": {
+    shortDescription: "+0.1 Gold",
+    labelType: "success",
+    boostTypeIcon: powerup,
   },
 };

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -31,6 +31,7 @@ import { RESOURCES } from "features/game/types/resources";
 import { BUILDINGS } from "features/game/types/buildings";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibles";
 
 const imageDomain = CONFIG.NETWORK === "mainnet" ? "buds" : "testnet-buds";
 
@@ -184,14 +185,14 @@ export const Chest: React.FC<Props> = ({
   // Sort collectibles by type
   const resources = getKeys(collectibles).filter((name) => name in RESOURCES);
   const buildings = getKeys(collectibles).filter((name) => name in BUILDINGS());
-  const equipment = getKeys(collectibles).filter(
-    (name) => !!ITEM_DETAILS[name].buff
+  const boosts = getKeys(collectibles).filter(
+    (name) => name in COLLECTIBLE_BUFF_LABELS
   );
-  const other = getKeys(collectibles).filter(
+  const decorations = getKeys(collectibles).filter(
     (name) =>
       !resources.includes(name) &&
       !buildings.includes(name) &&
-      !equipment.includes(name)
+      !boosts.includes(name)
   );
 
   return (
@@ -303,13 +304,13 @@ export const Chest: React.FC<Props> = ({
             </div>
           )}
 
-          {equipment.length > 0 && (
-            <div className="flex flex-col pl-2 mb-2 w-full" key="Equipment">
+          {boosts.length > 0 && (
+            <div className="flex flex-col pl-2 mb-2 w-full" key="Boosts">
               <Label type="default" className="my-1" icon={lightning}>
-                Equipment
+                Boosts
               </Label>
               <div className="flex mb-2 flex-wrap -ml-1.5">
-                {equipment.map((item) => (
+                {boosts.map((item) => (
                   <Box
                     count={chestMap[item]}
                     isSelected={selectedChestItem === item}
@@ -323,13 +324,13 @@ export const Chest: React.FC<Props> = ({
             </div>
           )}
 
-          {other.length > 0 && (
-            <div className="flex flex-col pl-2 mb-2 w-full" key="Other">
+          {decorations.length > 0 && (
+            <div className="flex flex-col pl-2 mb-2 w-full" key="Decorations">
               <Label type="default" className="my-1">
-                Other
+                Decorations
               </Label>
               <div className="flex mb-2 flex-wrap -ml-1.5">
-                {other.map((item) => (
+                {decorations.map((item) => (
                   <Box
                     count={chestMap[item]}
                     isSelected={selectedChestItem === item}


### PR DESCRIPTION
# Description

Separate the boost collectibles to their own category in the Chest Tab

Current
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/5878b3a1-baaa-4c01-83c9-141989c3b44b)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/fa307a32-ad44-446e-b13b-e2c8538e2ea6)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I couldn't get my LocalHost to work yet but will post screenshots once I manage to get it working

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
