### PR TITLE
[FIX] Update BUILDINGS_DIMENSIONS for House

### DIFF
--- a/src/features/game/types/buildings.ts
+++ b/src/features/game/types/buildings.ts
@@ -415,7 +415,7 @@ export const BUILDINGS_DIMENSIONS: Record<BuildingName, Dimensions> = {
   Market: { height: 2, width: 3 },
   "Fire Pit": { height: 2, width: 3 },
   "Town Center": { height: 3, width: 4 },
-  House: { height: 3, width: 4 },
+  House: { height: 4, width: 4 },
   Workbench: { height: 2, width: 3 },
   Kitchen: { height: 3, width: 4 },
   Bakery: { height: 3, width: 4 },


### PR DESCRIPTION
# Description

The house is rendered 4x4 but the dimensions are 4x3 which causes surprising behavior with mushrooms and item placement.

This change updates the dimensions to 4x4.  Alternatively, the art could be scaled to 4x3 if that's preferred.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
