### PR TITLE
[CHORE] Add missing boost collectibles to boost category in Chest tab

### DIFF
--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -855,6 +855,16 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     labelType: "success",
     boostTypeIcon: powerup,
   },
+  "Grinx's Hammer": {
+    shortDescription: "Halves expansion costs",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
+  "Time Warp Totem": {
+    shortDescription: "50% Reduction to Crop, Mineral, Cooking and Tree Time",
+    labelType: "success",
+    boostTypeIcon: powerup,
+  },
 
   // Marine Marvels with Boosts
   "Radiant Ray": {


### PR DESCRIPTION
# Description

Continuation to #3327 I missed out the Grinx Hammer and Time Warp Totem when drafting the other PR

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
