### PR TITLE
[FIX] Farmhand-equipped Chef Apron

### DIFF
--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -2,18 +2,13 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { COOKABLE_CAKES } from "features/game/types/consumables";
 import { getKeys } from "features/game/types/craftables";
-import {
-  Bumpkin,
-  GameState,
-  Inventory,
-  NPCData,
-  Order,
-} from "features/game/types/game";
+import { GameState, Inventory, NPCData, Order } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
 import { hasFeatureAccess } from "lib/flags";
 import { NPCName } from "lib/npcs";
 import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 import cloneDeep from "lodash.clonedeep";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export type DeliverOrderAction = {
   type: "order.delivered";
@@ -148,19 +143,17 @@ const clone = (state: GameState): GameState => {
   return cloneDeep(state);
 };
 
-export function getOrderSellPrice(bumpkin: Bumpkin, order: Order) {
-  const { skills } = bumpkin;
-
+export function getOrderSellPrice(game: GameState, order: Order) {
   let mul = 1;
 
-  if (skills["Michelin Stars"]) {
+  if (game.bumpkin?.skills["Michelin Stars"]) {
     mul += 0.05;
   }
 
   const items = getKeys(order.items);
   if (
     items.some((name) => name in COOKABLE_CAKES) &&
-    bumpkin.equipped.coat == "Chef Apron"
+    isWearableActive({ name: "Chef Apron", game })
   ) {
     mul += 0.2;
   }
@@ -222,7 +215,7 @@ export function deliverOrder({
   });
 
   if (order.reward.sfl) {
-    const sfl = getOrderSellPrice(bumpkin, order);
+    const sfl = getOrderSellPrice(game, order);
     game.balance = game.balance.add(sfl);
 
     bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sfl);

--- a/src/features/game/events/landExpansion/fulfillGrubOrder.ts
+++ b/src/features/game/events/landExpansion/fulfillGrubOrder.ts
@@ -56,7 +56,7 @@ export function fulfillGrubOrder({
   if (unfulFilledOrders.findIndex((order) => order.id === action.id) >= 4) {
     throw new Error("Order is locked");
   }
-  const sfl = getOrderSellPrice(bumpkin, order);
+  const sfl = getOrderSellPrice(game, order);
 
   bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sfl);
 

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -26,12 +26,10 @@ describe("boosts", () => {
     });
 
     it("does not apply chef apron boost if not equipped on the bumpkin", () => {
-      const bumpkin = INITIAL_BUMPKIN;
       const amount = getSellPrice({
         item: CAKES()["Beetroot Cake"] as SellableItem,
         game: {
           ...TEST_FARM,
-          bumpkin,
         },
       });
       expect(amount).toEqual(new Decimal(marketRate(560)));

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -54,7 +54,6 @@ export const getSellPrice = ({
   let price = item.sellPrice;
 
   const inventory = game.inventory;
-  const bumpkin = game.bumpkin as Bumpkin;
 
   if (!price) {
     return new Decimal(0);
@@ -66,11 +65,7 @@ export const getSellPrice = ({
   }
 
   // apply Chef Apron 20% boost when selling cakes
-  if (
-    item.name in cakes &&
-    bumpkin.equipped.coat &&
-    bumpkin.equipped.coat === "Chef Apron"
-  ) {
+  if (item.name in cakes && isWearableActive({ name: "Chef Apron", game })) {
     price = price.mul(1.2);
   }
 
@@ -199,15 +194,14 @@ export const getFoodExpBoost = (
   return boostedExp.toDecimalPlaces(4).toNumber();
 };
 
-export const getOrderSellPrice = (bumpkin: Bumpkin, order: GrubShopOrder) => {
-  const { skills, equipped } = bumpkin;
+export const getOrderSellPrice = (game: GameState, order: GrubShopOrder) => {
   let mul = 1;
 
-  if (skills["Michelin Stars"]) {
+  if (game.bumpkin?.skills["Michelin Stars"]) {
     mul += 0.05;
   }
 
-  if (order.name in CAKES() && equipped.coat === "Chef Apron") {
+  if (order.name in CAKES() && isWearableActive({ name: "Chef Apron", game })) {
     mul += 0.2;
   }
 

--- a/src/features/helios/components/grubShop/components/GrubShopModal.tsx
+++ b/src/features/helios/components/grubShop/components/GrubShopModal.tsx
@@ -10,7 +10,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
-import { Bumpkin, GrubShop } from "features/game/types/game";
+import { GrubShop } from "features/game/types/game";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Label } from "components/ui/Label";
 import { acknowledgeTutorial, hasShownTutorial } from "lib/tutorial";
@@ -232,10 +232,7 @@ export const GrubShopModal: React.FC<Props> = ({ onClose }) => {
                     <div className="flex justify-center space-x-1 items-center sm:justify-center">
                       <img src={token} className="h-4 sm:h-5" />
                       <span className="text-xs text-center">
-                        {`${getOrderSellPrice(
-                          state.bumpkin as Bumpkin,
-                          selected
-                        )}`}
+                        {`${getOrderSellPrice(state, selected)}`}
                       </span>
                     </div>
                   </div>

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -23,7 +23,7 @@ import {
 } from "features/game/events/landExpansion/deliver";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getKeys } from "features/game/types/craftables";
-import { Bumpkin, Order } from "features/game/types/game";
+import { Order } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { NPC } from "features/island/bumpkin/components/NPC";
 
@@ -69,7 +69,6 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
   const delivery = useSelector(gameService, _delivery);
   const inventory = useSelector(gameService, _inventory);
   const balance = useSelector(gameService, _balance);
-  const bumpkin = useSelector(gameService, _bumpkin);
 
   const [showSkipDialog, setShowSkipDialog] = useState(false);
   const [isRevealing, setIsRevealing] = useState(false);
@@ -96,8 +95,6 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
         ).includes(o.from)
     );
   }
-
-  const skippedAt = delivery.skippedAt ?? 0;
 
   useEffect(() => {
     acknowledgeOrders(delivery);
@@ -140,11 +137,7 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
   const nextOrder = delivery.orders.find((order) => order.readyAt > Date.now());
   const skippedOrder = delivery.orders.find((order) => order.id === "skipping");
 
-  const canFulfill = hasRequirements(previewOrder as Order);
-
   const slots = getDeliverySlots(inventory);
-  let emptySlots = slots - orders.length - (nextOrder ? 1 : 0);
-  emptySlots = Math.max(0, emptySlots);
 
   const progress = Math.min(
     delivery.milestone.goal,
@@ -294,10 +287,7 @@ export const DeliveryOrders: React.FC<Props> = ({ selectedId, onSelect }) => {
                         <div className="flex items-center mt-1">
                           <img src={sfl} className="h-5 mr-1" />
                           <span className="text-xs">
-                            {getOrderSellPrice(
-                              bumpkin as Bumpkin,
-                              order
-                            ).toFixed(2)}
+                            {getOrderSellPrice(gameState, order).toFixed(2)}
                           </span>
                         </div>
                       )}

--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -8,7 +8,7 @@ import { getKeys } from "features/game/types/craftables";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import Decimal from "decimal.js-light";
 import { defaultDialogue, npcDialogues } from "./dialogues";
-import { Bumpkin, GameState, Inventory, Order } from "features/game/types/game";
+import { GameState, Inventory, Order } from "features/game/types/game";
 import { OuterPanel } from "components/ui/Panel";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import sfl from "assets/icons/token_2.png";
@@ -30,7 +30,7 @@ import { gameAnalytics } from "lib/gameAnalytics";
 interface OrderCardsProps {
   orders: Order[];
   balance: Decimal;
-  bumpkin: Bumpkin;
+  game: GameState;
   inventory: Inventory;
   selectedOrderId?: string;
   onSelectOrder: (id: string) => void;
@@ -41,7 +41,7 @@ const OrderCards: React.FC<OrderCardsProps> = ({
   orders,
   inventory,
   balance,
-  bumpkin,
+  game,
   selectedOrderId,
   onSelectOrder,
   hasRequirementsCheck,
@@ -109,7 +109,7 @@ const OrderCards: React.FC<OrderCardsProps> = ({
                   <div className="flex items-center mt-1">
                     <img src={sfl} className="h-5 mr-1" />
                     <span className="text-xs">
-                      {getOrderSellPrice(bumpkin, order).toFixed(2)}
+                      {getOrderSellPrice(game, order).toFixed(2)}
                     </span>
                   </div>
                 )}
@@ -197,10 +197,8 @@ interface Props {
 
 const _delivery = (state: MachineState) => state.context.state.delivery;
 const _inventory = (state: MachineState) => state.context.state.inventory;
-const _island = (state: MachineState) => state.context.state.island;
 const _balance = (state: MachineState) => state.context.state.balance;
-const _bumpkin = (state: MachineState) =>
-  state.context.state.bumpkin as Bumpkin;
+const _game = (state: MachineState) => state.context.state as GameState;
 
 export const DeliveryPanelContent: React.FC<Props> = ({
   npc,
@@ -212,8 +210,7 @@ export const DeliveryPanelContent: React.FC<Props> = ({
   const delivery = useSelector(gameService, _delivery);
   const inventory = useSelector(gameService, _inventory);
   const balance = useSelector(gameService, _balance);
-  const bumpkin = useSelector(gameService, _bumpkin);
-  const island = useSelector(gameService, _island);
+  const game = useSelector(gameService, _game);
 
   let orders = delivery.orders.filter(
     (order) =>
@@ -356,7 +353,7 @@ export const DeliveryPanelContent: React.FC<Props> = ({
               orders={orders}
               inventory={inventory}
               balance={balance}
-              bumpkin={bumpkin}
+              game={game}
               selectedOrderId={selectedOrderId}
               onSelectOrder={(id: string) => setSelectedOrderId(id)}
               hasRequirementsCheck={hasRequirements}


### PR DESCRIPTION
# Description

The boost for Chef Apron was only being applied for the "primary bumpkin", not for farmhands.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
