### PR TITLE
[FEAT] Add Redirect to Buy Block Bucks when Player doesn't have enough Block Bucks to buy Season Banner

### DIFF
--- a/src/features/game/components/modal/components/BlockBucksModal.tsx
+++ b/src/features/game/components/modal/components/BlockBucksModal.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from "lib/utils/hooks/useIsMobile";
 import classNames from "classnames";
 import { GameWallet } from "features/wallet/Wallet";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { translate } from "lib/i18n/translate";
 
 interface Props {
   show: boolean;
@@ -398,7 +399,7 @@ export const BlockBucksModal: React.FC<Props> = ({
         <CloseButtonPanel
           onBack={closeable && price ? () => setPrice(undefined) : undefined}
           onClose={closeable ? onClose : undefined}
-          title="Buy Block Bucks"
+          title={translate("transaction.buy.BlockBucks")}
           bumpkinParts={{
             body: "Light Brown Farmer Potion",
             hair: "White Long Hair",

--- a/src/features/game/expansion/components/SpecialOffer.tsx
+++ b/src/features/game/expansion/components/SpecialOffer.tsx
@@ -17,6 +17,7 @@ import { SEASONS, getSeasonalBanner } from "features/game/types/seasons";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SUNNYSIDE } from "assets/sunnyside";
 import blockBuck from "assets/icons/block_buck.png";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
 
 const isPromoting = (state: MachineState) => state.matches("specialOffer");
 const _inventory = (state: MachineState) => state.context.state.inventory;
@@ -25,7 +26,6 @@ export const SpecialOffer: React.FC = () => {
   const { gameService } = useContext(Context);
   const specialOffer = useSelector(gameService, isPromoting);
   const inventory = useSelector(gameService, _inventory);
-
   const hasPreviousSeasonBanner = !!inventory[getSeasonalBanner()];
 
   return (
@@ -56,6 +56,8 @@ export const PromotingModal: React.FC<Props> = ({
 }) => {
   const { t } = useAppTranslation();
 
+  const { openModal } = useContext(ModalContext);
+
   const isPreSeason =
     Date.now() < SEASONS["Spring Blossom"].startDate.getTime();
 
@@ -63,6 +65,9 @@ export const PromotingModal: React.FC<Props> = ({
   const inventory = useSelector(gameService, _inventory);
 
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showInsufficientBlockBuck, setShowInsufficientBlockBuck] =
+    useState(false);
+
   const [showPurchased, setShowPurchased] = useState(hasPurchased);
 
   let price = hasDiscount ? "35" : "50";
@@ -74,6 +79,14 @@ export const PromotingModal: React.FC<Props> = ({
   const onCloseConfirmation = () => {
     onClose();
     setShowConfirmation(false);
+  };
+
+  const onCloseInsufficientBlockBucks = () => {
+    setShowInsufficientBlockBuck(false);
+  };
+
+  const buyBlockBucks = () => {
+    openModal("BUY_BLOCK_BUCKS");
   };
 
   const Content = () => {
@@ -100,7 +113,21 @@ export const PromotingModal: React.FC<Props> = ({
         </>
       );
     }
-
+    if (showInsufficientBlockBuck) {
+      return (
+        <>
+          <p className="text-sm my-2">{t("offer.not.enough.BlockBucks")}</p>
+          <div className="flex">
+            <Button className="mr-1" onClick={onCloseInsufficientBlockBucks}>
+              {t("no.thanks")}
+            </Button>
+            <Button onClick={buyBlockBucks}>
+              {t("transaction.buy.BlockBucks")}
+            </Button>
+          </div>
+        </>
+      );
+    }
     if (showPurchased) {
       return (
         <>
@@ -151,7 +178,7 @@ export const PromotingModal: React.FC<Props> = ({
 
     const msLeft = SEASONS["Spring Blossom"].startDate.getTime() - Date.now();
     const secondsLeft = msLeft / 1000;
-    const insuficientBlockBucks = !inventory["Block Buck"]?.gte(price);
+    const insufficientBlockBucks = !inventory["Block Buck"]?.gte(price);
 
     return (
       <>
@@ -240,9 +267,12 @@ export const PromotingModal: React.FC<Props> = ({
             {t("no.thanks")}
           </Button>
           <Button
-            disabled={insuficientBlockBucks}
             onClick={() => {
-              setShowConfirmation(true);
+              if (insufficientBlockBucks) {
+                setShowInsufficientBlockBuck(true);
+              } else {
+                setShowConfirmation(true);
+              }
             }}
           >
             {t("season.buyNow")}

--- a/src/features/game/expansion/components/SpecialOffer.tsx
+++ b/src/features/game/expansion/components/SpecialOffer.tsx
@@ -17,6 +17,7 @@ import { SEASONS, getSeasonalBanner } from "features/game/types/seasons";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SUNNYSIDE } from "assets/sunnyside";
 import blockBuck from "assets/icons/block_buck.png";
+import lockIcon from "assets/skills/lock.png";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 
 const isPromoting = (state: MachineState) => state.matches("specialOffer");
@@ -116,7 +117,12 @@ export const PromotingModal: React.FC<Props> = ({
     if (showInsufficientBlockBuck) {
       return (
         <>
-          <p className="text-sm my-2">{t("offer.not.enough.BlockBucks")}</p>
+          <div className="p-2">
+            <Label icon={lockIcon} type="danger" className="my-2">
+              {t("transaction.buy.BlockBucks")}
+            </Label>
+            <p className="text-sm my-2">{t("offer.not.enough.BlockBucks")}</p>
+          </div>
           <div className="flex">
             <Button className="mr-1" onClick={onCloseInsufficientBlockBucks}>
               {t("no.thanks")}

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3688,6 +3688,7 @@ const offer: Record<Offer, string> = {
   "offer.getStarted": "Get Started Now",
   "offer.NFT.include": "Farm NFT. This will include",
   "offer.free": "free",
+  "offer.not.enough.BlockBucks": "You do not have enough Block Bucks!",
 };
 
 const onboarding: Record<Onboarding, string> = {
@@ -4296,6 +4297,7 @@ const transactionTerms: Record<TransactionTerms, string> = {
     "In order to buy your farm you will need to accept the Sunflower Land terms of service.",
   "transaction.termsOfService.two":
     "This step will take you back to your new sequence wallet to accept the terms of service.",
+  "transaction.buy.BlockBucks": "Buy Block Bucks",
 };
 
 const transfer: Record<Transfer, string> = {

--- a/src/lib/i18n/dictionaries/sampleDictionary.ts
+++ b/src/lib/i18n/dictionaries/sampleDictionary.ts
@@ -2589,6 +2589,7 @@ const offer: Record<Offer, string> = {
   "offer.getStarted": "",
   "offer.NFT.include": "",
   "offer.free": "",
+  "offer.not.enough.BlockBucks": "",
 };
 const onboarding: Record<Onboarding, string> = {
   "onboarding.welcome": "",
@@ -3054,6 +3055,7 @@ const transactionTerms: Record<TransactionTerms, string> = {
   "transaction.withdraw.polygon": "",
   "transaction.termsOfService.one": "",
   "transaction.termsOfService.two": "",
+  "transaction.buy.BlockBucks": "",
 };
 const transfer: Record<Transfer, string> = {
   "transfer.sure.adress": "",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2497,7 +2497,8 @@ export type Offer =
   | "offer.newHere"
   | "offer.getStarted"
   | "offer.NFT.include"
-  | "offer.free";
+  | "offer.free"
+  | "offer.not.enough.BlockBucks";
 
 export type Onboarding =
   | "onboarding.welcome"
@@ -2942,7 +2943,8 @@ export type TransactionTerms =
   | "transaction.displayItems"
   | "transaction.withdraw.polygon"
   | "transaction.termsOfService.one"
-  | "transaction.termsOfService.two";
+  | "transaction.termsOfService.two"
+  | "transaction.buy.BlockBucks";
 
 export type Transfer =
   | "transfer.sure.adress"


### PR DESCRIPTION
# Description

Many players kept asking on Discord why their buy now button was greyed out and turns out they didn't realise they needed to use Block Bucks to buy the banner.

When the player clicks on the Buy Now button to Buy the Banner, if they don't have enough Block Bucks they will be redirected to this Modal, prompting them to buy Block Bucks to continue:
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/756eddd0-ea89-4e7e-a3c7-0c8b0ed61f37)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Ran with less than 65 Block Bucks to test the button out
- Ran with 65 Block Bucks to make sure the if else statement is working

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
