### PR TITLE
[FEAT] Update Spring Blossom Withdrawal Dates

### DIFF
--- a/src/features/game/types/withdrawables.test.ts
+++ b/src/features/game/types/withdrawables.test.ts
@@ -66,7 +66,7 @@ describe("withdrawables", () => {
       const timers = jest.useFakeTimers();
       timers.setSystemTime(new Date("Thu August 7 2023 10:01:00 GMT+1000"));
 
-      const enabled = BUMPKIN_WITHDRAWABLES["Ancient Rod"]();
+      const enabled = BUMPKIN_WITHDRAWABLES["Crimstone Amulet"]();
       expect(enabled).toBeFalsy();
     });
 
@@ -74,7 +74,7 @@ describe("withdrawables", () => {
       const timers = jest.useFakeTimers();
       timers.setSystemTime(new Date("Thu July 7 2023 10:01:00 GMT+1000"));
 
-      const enabled = WITHDRAWABLES["Walrus"]();
+      const enabled = WITHDRAWABLES["Queen Bee"]();
       expect(enabled).toBeFalsy();
     });
 

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -116,7 +116,7 @@ const fruits: Record<FruitName, () => boolean> = {
   Apple: () => true,
   Blueberry: () => true,
   Orange: () => true,
-  Banana: () => canWithdrawTimebasedItem(new Date("2024-02-01")),
+  Banana: () => true,
 };
 
 const flowers: Record<FlowerName, () => boolean> = {
@@ -218,9 +218,9 @@ const heliosBlacksmith: Record<HeliosBlacksmithItem, () => boolean> = {
   "Grain Grinder": () => true,
   Kernaldo: () => true,
   Poppy: () => true,
-  Nana: () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Soil Krabby": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
-  "Skill Shrimpy": () => canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
+  Nana: () => true,
+  "Soil Krabby": () => true,
+  "Skill Shrimpy": () => true,
 };
 
 const commodities: Record<CommodityName, () => boolean> = {
@@ -526,12 +526,12 @@ const seasonalDecorations: Record<SeasonalDecorationName, () => boolean> = {
   Observer: () => true,
   "Crow Rock": () => true,
   "Mini Corn Maze": () => true,
-  "Beach Umbrella": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Hideaway Herman": () => canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
-  "Lifeguard Ring": () => canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
-  "Shifty Sheldon": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
-  "Tiki Torch": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  Surfboard: () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
+  "Beach Umbrella": () => true,
+  "Hideaway Herman": () => true,
+  "Lifeguard Ring": () => true,
+  "Shifty Sheldon": () => true,
+  "Tiki Torch": () => true,
+  Surfboard: () => true,
 };
 
 const mutantCrop: Record<MutantCropName, () => boolean> = {
@@ -632,13 +632,13 @@ const soldOut: Record<SoldOutCollectibleName, () => boolean> = {
   "Queen Cornelia": () => true,
   "White Crow": () => true,
 
-  Walrus: () => canWithdrawTimebasedItem(new Date("2024-01-30")), // Last Auction 2024/01/28 5pm UTC
-  Alba: () => canWithdrawTimebasedItem(new Date("2024-01-21")), // Last Auction 2024/01/19 3pm UTC
-  "Knowledge Crab": () => canWithdrawTimebasedItem(new Date("2024-01-09")), // Last Auction 2024/01/07 3pm UTC
-  Anchor: () => canWithdrawTimebasedItem(new Date("2024-01-18")), // Last Auction 2024/01/16 3pm UTC
-  "Rubber Ducky": () => canWithdrawTimebasedItem(new Date("2024-01-12")), // Last Auction 2024/01/10 5pm UTC
-  "Kraken Head": () => canWithdrawTimebasedItem(new Date("2024-01-24")), // Last Auction 2024/01/22 5pm UTC
-  "Blossom Royale": () => canWithdrawTimebasedItem(new Date("2024-04-25")), // Last Auction 2024/01/24 5pm UTC
+  Walrus: () => true,
+  Alba: () => true,
+  "Knowledge Crab": () => true,
+  Anchor: () => true,
+  "Rubber Ducky": () => true,
+  "Kraken Head": () => true,
+  "Blossom Royale": () => canWithdrawTimebasedItem(new Date("2024-04-25")), // Last Auction 2024/04/24 5pm UTC
   "Humming Bird": () => canWithdrawTimebasedItem(new Date("2024-04-22")), // Last Auction 2024/04/21 5pm UTC
   "Hungry Caterpillar": () => canWithdrawTimebasedItem(new Date("2024-03-31")), // Last Auction 2024/03/30 5pm UTC
   "Queen Bee": () => canWithdrawTimebasedItem(new Date("2024-03-19")), // Last Auction 2024/03/18 5pm UTC
@@ -733,7 +733,7 @@ const eventDecoration: Record<EventDecorationName, () => boolean> = {
   "Sapo Travessuras": () => true,
   "Time Warp Totem": () => false,
 
-  "Bumpkin Nutcracker": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
+  "Bumpkin Nutcracker": () => true,
   "Festive Tree": () => false,
   "Grinx's Hammer": () => true,
   "White Festive Fox": () => true,
@@ -1127,46 +1127,41 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Feather Hat": () => true,
   "Valoria Wreath": () => true,
   "Earn Alliance Sombrero": () => true,
-  "Fresh Catch Vest": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Fish Pro Vest": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
-  "Reel Fishing Vest": () => canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
-  "Clown Shirt": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
+  "Fresh Catch Vest": () => true,
+  "Fish Pro Vest": () => true,
+  "Reel Fishing Vest": () => true,
+  "Clown Shirt": () => true,
   "Luminous Anglerfish Topper": () => false,
-  "Abyssal Angler Hat": () => canWithdrawTimebasedItem(new Date("2024-01-06")), // Last Auction 2024/01/04 5pm UTC
+  "Abyssal Angler Hat": () => true,
   Harpoon: () => false,
-  "Ancient Rod": (state) =>
-    canWithdrawBoostedWearable("Ancient Rod", state) &&
-    canWithdrawTimebasedItem(new Date("2024-01-27")), // Last Auction 2024/01/25 3pm UTC
+  "Ancient Rod": (state) => canWithdrawBoostedWearable("Ancient Rod", state),
   "Fishing Hat": () => false,
   Trident: () => false,
   "Bucket O' Worms": () => false,
   "Coconut Mask": () => false,
   "Crab Trap": () => false,
-  "Seaside Tank Top": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
+  "Seaside Tank Top": () => true,
   "Fish Trap": () => false,
-  "Fishing Pants": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
+  "Fishing Pants": () => true,
   "Angler Waders": () => false,
-  "Fishing Spear": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
-  "Flip Flops": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  Wellies: () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  "Saw Fish": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  "Skinning Knife": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
+  "Fishing Spear": () => true,
+  "Flip Flops": () => true,
+  Wellies: () => true,
+  "Saw Fish": () => true,
+  "Skinning Knife": () => true,
   "Sunflower Rod": () => false,
-  "Tackle Box": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
-  "Infernal Rod": () => canWithdrawTimebasedItem(new Date("2024-02-02")),
+  "Tackle Box": () => true,
+  "Infernal Rod": () => true,
   "Mermaid Potion": () => false,
   "Squirrel Monkey Potion": () => false,
-  "Koi Fish Hat": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Normal Fish Hat": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Stockeye Salmon Onesie": () =>
-    canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
-  "Tiki Armor": () => canWithdrawTimebasedItem(new Date("2023-12-02")), // Available until 2023/12/01
-  "Tiki Mask": () => canWithdrawTimebasedItem(new Date("2024-01-02")), // Available until 2024/01/01
-  "Tiki Pants": () => canWithdrawTimebasedItem(new Date("2024-02-02")), // Available until 2024/02/01
+  "Koi Fish Hat": () => true,
+  "Normal Fish Hat": () => true,
+  "Stockeye Salmon Onesie": () => true,
+  "Tiki Armor": () => true,
+  "Tiki Mask": () => true,
+  "Tiki Pants": () => true,
   "Banana Amulet": (state) =>
-    canWithdrawBoostedWearable("Banana Amulet", state) &&
-    canWithdrawTimebasedItem(new Date("2024-01-15")), // Last Auction 2024/01/13 3pm UTC
-
+    canWithdrawBoostedWearable("Banana Amulet", state),
   "Banana Onesie": () => true,
   "Basic Dumbo": () => false,
   "Companion Cap": () => false,
@@ -1176,20 +1171,18 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Pickaxe Shark": () => false,
   "Seedling Hat": () => false,
   "Stormy Dumbo": () => false,
-  "Ugly Christmas Sweater": () =>
-    canWithdrawTimebasedItem(new Date("2023-12-21")), // Available until 2024/01/01
-
-  "Candy Cane": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
-  "Elf Hat": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
+  "Ugly Christmas Sweater": () => true,
+  "Candy Cane": () => true,
+  "Elf Hat": () => true,
   "Elf Potion": () => false,
   "Elf Shoes": () => false,
-  "Elf Suit": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
-  "Santa Beard": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
-  "Santa Suit": () => canWithdrawTimebasedItem(new Date("2023-12-27")),
+  "Elf Suit": () => true,
+  "Santa Beard": () => true,
+  "Santa Suit": () => true,
 
   "Butterfly Wings": () => false,
   "Cozy Hoodie": () => false,
-  "New Years Tiara": () => canWithdrawTimebasedItem(new Date("2024-01-03")),
+  "New Years Tiara": () => true,
   "Northern Lights Background": () => false,
   "Short Shorts": () => false,
   "Winter Jacket": () => false,
@@ -1205,16 +1198,16 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Crimstone Pants": () => false,
   "Crimstone Armor": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
   "Gardening Overalls": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Crimstone Hammer": () => canWithdrawTimebasedItem(new Date("2024-03-10")), // Last Auction 2024/03/09 5pm UTC
+  "Crimstone Hammer": () => canWithdrawTimebasedItem(new Date("2024-04-13")), // Last Auction 2024/04/12 3pm UTC
   "Crimstone Amulet": () => canWithdrawTimebasedItem(new Date("2024-04-19")), // Last Auction 2024/04/18 5pm UTC
   "Full Bloom Shirt": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Blue Blossom Shirt": () => canWithdrawTimebasedItem(new Date("2024-04-16")), // Last Auction 2024/04/15 5pm UTC
+  "Blue Blossom Shirt": () => canWithdrawTimebasedItem(new Date("2024-03-07")), // Last Auction 2024/03/06 3pm UTC
   "Fairy Sandals": () => false,
   "Daisy Tee": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
   "Propeller Hat": () => canWithdrawTimebasedItem(new Date("2024-04-04")), // Last Auction 2024/04/03 5pm UTC,
   "Honeycomb Shield": () => canWithdrawTimebasedItem(new Date("2024-04-10")), // Last Auction 2024/04/09 5pm UTC
-  "Hornet Mask": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Flower Crown": () => canWithdrawTimebasedItem(new Date("2024-04-13")), // Last Auction 2024/04/12 5pm UTC
+  "Hornet Mask": () => canWithdrawTimebasedItem(new Date("2024-04-16")), // Last Auction 2024/04/15 3pm UTC
+  "Flower Crown": () => canWithdrawTimebasedItem(new Date("2024-03-10")), // Last Auction 2024/03/10 3pm UTC
   "Blue Monarch Dress": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
   "Green Monarch Dress": () => false,
   "Orange Monarch Dress": () =>

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -233,7 +233,7 @@ const commodities: Record<CommodityName, () => boolean> = {
   Stone: () => true,
   Iron: () => true,
   Gold: () => true,
-  Crimstone: () => true,
+  Crimstone: () => canWithdrawTimebasedItem(new Date("2024-05-01")),
   Diamond: () => false,
 
   Sunstone: () => false,


### PR DESCRIPTION
# Description

1. Updated Withdrawal dates for the following Spring Blossom Auction Items (DD/MM):
- Flower Crown: 13/04 > 10/03
- Hornet Mask: 01/05 > 16/04
- Blue Blossom Shirt: 16/04 > 07/03
- Crimstone Hammer: 10/03 > 13/04

2. Added Time based withdrawal date for Crimstone
3. Cleaned up code for items already released to the market

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
