### PR TITLE
[FIX] Click through for travel modal

### DIFF
--- a/src/features/island/hud/components/deliveries/TravelModal.tsx
+++ b/src/features/island/hud/components/deliveries/TravelModal.tsx
@@ -96,13 +96,18 @@ export const TravelModal: React.FC<Props> = ({
     getBumpkinLevel(gameState.context.state.bumpkin?.experience ?? 0) < 3;
 
   return (
-    <>
-      <Modal
-        centered
-        show={isOpen}
-        onHide={onClose}
-        onShow={() => gameService.send("SAVE")}
-        dialogClassName="md:max-w-3xl"
+    <Modal
+      centered
+      show={isOpen}
+      onHide={onClose}
+      onShow={() => gameService.send("SAVE")}
+      dialogClassName="md:max-w-3xl"
+    >
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        onMouseUp={(e) => e.stopPropagation()}
+        onTouchStart={(e) => e.stopPropagation()}
+        onTouchEnd={(e) => e.stopPropagation()}
       >
         {isLocked && (
           <CloseButtonPanel onClose={onClose}>
@@ -194,7 +199,7 @@ export const TravelModal: React.FC<Props> = ({
             </div>
           </CloseButtonPanel>
         )}
-      </Modal>
-    </>
+      </div>
+    </Modal>
   );
 };


### PR DESCRIPTION
# Description

Fix click though that happens with the travel modal in plaza

![click-through](https://github.com/sunflower-land/sunflower-land/assets/17863697/12943592-bff3-41b0-8dc8-a01d03c51a86)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Go to plaza, move bumpkin close to Stella, open the Travel modal. Click somewhere on the travel modal that is over the top of Stella. She should not open.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
