### PR TITLE
[FEAT] Keep selected bait and chum in localStorage for next fishing

### DIFF
--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useActor, useSelector } from "@xstate/react";
 
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -129,6 +129,25 @@ const BaitSelection: React.FC<{
       context: { state },
     },
   ] = useActor(gameService);
+
+  useEffect(() => {
+    const lastSelectedBait = localStorage.getItem("lastSelectedBait");
+    if (lastSelectedBait) {
+      setBait(lastSelectedBait as FishingBait);
+    }
+    const lastSelectedChum = localStorage.getItem("lastSelectedChum");
+
+    const hasRequirements =
+      lastSelectedChum &&
+      state.inventory[lastSelectedChum as InventoryItemName]?.gte(
+        CHUM_AMOUNTS[lastSelectedChum as Chum] ?? 0
+      );
+
+    if (hasRequirements) {
+      setChum(lastSelectedChum as Chum);
+    }
+  }, []);
+
   const [showChum, setShowChum] = useState(false);
   const [chum, setChum] = useState<Chum | undefined>();
   const [bait, setBait] = useState<FishingBait>("Earthworm");
@@ -143,6 +162,7 @@ const BaitSelection: React.FC<{
         initial={chum}
         onList={(selected) => {
           setChum(selected);
+          localStorage.setItem("lastSelectedChum", selected);
           setShowChum(false);
         }}
       />
@@ -205,7 +225,10 @@ const BaitSelection: React.FC<{
               image={ITEM_DETAILS[name].image}
               isSelected={bait === name}
               count={state.inventory[name]}
-              onClick={() => setBait(name)}
+              onClick={() => {
+                setBait(name);
+                localStorage.setItem("lastSelectedBait", name);
+              }}
               key={name}
             />
           ))}


### PR DESCRIPTION
# Description

To make fishing more friendly for users i propose to keep selected bait and chum for next fishing. 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
