### PR TITLE
[CHORE] Move the "Already have Farm NFT" text to a button

### DIFF
--- a/src/features/auth/components/NoAccount.tsx
+++ b/src/features/auth/components/NoAccount.tsx
@@ -12,7 +12,6 @@ import { Label } from "components/ui/Label";
 import { isAddress } from "web3-utils";
 import { useActor } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { removeJWT } from "../actions/social";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const NoAccount: React.FC = () => {
@@ -102,28 +101,11 @@ export const NoAccount: React.FC = () => {
           )}
         </div>
         <p className="text-sm mb-2">{`${t("noaccount.welcomeMessage")}`}</p>
-        {isAddress(authState.context.user.token?.address ?? "") && (
-          <div className="mb-2">
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-white text-xs cursor-pointer"
-              onClick={() => setShowClaimAccount(true)}
-            >
-              {t("noaccount.alreadyHaveNFTFarm")}
-            </a>
-          </div>
-        )}
+        {isAddress(authState.context.user.token?.address ?? "")}
       </div>
       <div className="flex">
-        <Button
-          className="mr-1"
-          onClick={() => {
-            removeJWT();
-            authService.send("BACK");
-          }}
-        >
-          {t("back")}
+        <Button className="mr-1" onClick={() => setShowClaimAccount(true)}>
+          {t("noaccount.alreadyHaveNFTFarm")}
         </Button>
         <Button onClick={() => authService.send("CREATE_FARM")}>
           {t("noaccount.createFarm")}


### PR DESCRIPTION
# Description

Players have accidentally created a new farm when transferring their farms to a new wallet because they didn't see the Already have Farm NFT text. 
Upgrade the text to a full button

![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/91d05de1-fad8-48c2-952a-16debd8f80f0)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
