### PR TITLE
[FIX] Dimension heights

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -4,7 +4,7 @@ import { BumpkinLevel } from "features/game/lib/level";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
 import { makeMegaStoreAvailableDates } from "./constants";
-
+import { COLLECTIBLES_DIMENSIONS, getKeys } from "../types/craftables";
 export const INITIAL_RESOURCES: Pick<
   GameState,
   | "crops"
@@ -406,6 +406,10 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Enchanted Rose": new Decimal(1),
     "Flower Cart": new Decimal(1),
     Capybara: new Decimal(1),
+    ...getKeys(COLLECTIBLES_DIMENSIONS).reduce((acc, collectible) => {
+      acc[collectible] = new Decimal(1);
+      return acc;
+    }, {} as Record<string, Decimal>),
   },
   wardrobe: {
     "Elf Suit": 1,
@@ -491,7 +495,19 @@ export const STATIC_OFFLINE_FARM: GameState = {
       },
     ],
   },
-  collectibles: {},
+  collectibles: {
+    "Chef Bear": [
+      {
+        coordinates: {
+          x: 4,
+          y: 5,
+        },
+        createdAt: 0,
+        readyAt: 0,
+        id: "123",
+      },
+    ],
+  },
   pumpkinPlaza: {},
   treasureIsland: {
     holes: {},

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -4,7 +4,6 @@ import { BumpkinLevel } from "features/game/lib/level";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
 import { makeMegaStoreAvailableDates } from "./constants";
-import { COLLECTIBLES_DIMENSIONS, getKeys } from "../types/craftables";
 export const INITIAL_RESOURCES: Pick<
   GameState,
   | "crops"
@@ -406,10 +405,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Enchanted Rose": new Decimal(1),
     "Flower Cart": new Decimal(1),
     Capybara: new Decimal(1),
-    ...getKeys(COLLECTIBLES_DIMENSIONS).reduce((acc, collectible) => {
-      acc[collectible] = new Decimal(1);
-      return acc;
-    }, {} as Record<string, Decimal>),
   },
   wardrobe: {
     "Elf Suit": 1,
@@ -495,19 +490,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
       },
     ],
   },
-  collectibles: {
-    "Dinosaur Bone": [
-      {
-        coordinates: {
-          x: 4,
-          y: 5,
-        },
-        createdAt: 0,
-        readyAt: 0,
-        id: "123",
-      },
-    ],
-  },
+  collectibles: {},
   pumpkinPlaza: {},
   treasureIsland: {
     holes: {},

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -496,7 +496,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     ],
   },
   collectibles: {
-    "Chef Bear": [
+    "Dinosaur Bone": [
       {
         coordinates: {
           x: 4,

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1100,9 +1100,9 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Immortal Pear": { width: 2, height: 2 },
 
   // Market Items
-  Scarecrow: { width: 2, height: 2 },
-  Nancy: { width: 1, height: 2 },
-  Kuebiko: { width: 2, height: 2 },
+  Scarecrow: { width: 2, height: 1 },
+  Nancy: { width: 1, height: 1 },
+  Kuebiko: { width: 2, height: 1 },
   "Golden Cauliflower": { width: 2, height: 2 },
   "Mysterious Parsnip": { width: 1, height: 1 },
   "Carrot Sword": { width: 1, height: 1 },

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1213,11 +1213,11 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   // AoE items
   "Emerald Turtle": { height: 1, width: 1 },
   "Tin Turtle": { height: 1, width: 1 },
-  "Basic Scarecrow": { width: 1, height: 2 },
+  "Basic Scarecrow": { width: 1, height: 1 },
   Bale: { width: 2, height: 2 },
   "Sir Goldensnout": { width: 2, height: 2 },
-  "Scary Mike": { width: 1, height: 2 },
-  "Laurie the Chuckle Crow": { width: 1, height: 2 },
+  "Scary Mike": { width: 1, height: 1 },
+  "Laurie the Chuckle Crow": { width: 1, height: 1 },
   "Queen Cornelia": { width: 1, height: 2 },
 
   // Potion House Items
@@ -1228,13 +1228,13 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "White Crow": { width: 1, height: 1 },
 
   // Marine Marvel Trophies
-  "Twilight Anglerfish": { width: 2, height: 2 },
-  "Starlight Tuna": { width: 2, height: 2 },
-  "Radiant Ray": { width: 2, height: 2 },
-  "Phantom Barracuda": { width: 2, height: 2 },
-  "Gilded Swordfish": { width: 2, height: 2 },
+  "Twilight Anglerfish": { width: 2, height: 1 },
+  "Starlight Tuna": { width: 2, height: 1 },
+  "Radiant Ray": { width: 2, height: 1 },
+  "Phantom Barracuda": { width: 2, height: 1 },
+  "Gilded Swordfish": { width: 2, height: 1 },
   "Kraken Tentacle": { width: 1, height: 1 },
-  "Crimson Carp": { width: 2, height: 2 },
+  "Crimson Carp": { width: 2, height: 1 },
 
   // Catch the Kraken SFTs
   Walrus: { width: 2, height: 2 },

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -177,7 +177,7 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
   },
   "Angel Bear": {
     height: 1,
-    width: 1,
+    width: 2,
   },
   "Badass Bear": {
     height: 1,

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -224,19 +224,19 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 1,
   },
   "T-Rex Skull": {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Sunflower Coin": {
-    height: 2,
+    height: 1,
     width: 2,
   },
   Foliant: {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Skeleton King Staff": {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Lifeguard Bear": {
@@ -260,11 +260,11 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 1,
   },
   Galleon: {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Dinosaur Bone": {
-    height: 2,
+    height: 1,
     width: 2,
   },
   "Human Bear": {

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -168,7 +168,7 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
     width: 1,
   },
   "Chef Bear": {
-    height: 2,
+    height: 1,
     width: 1,
   },
   "Construction Bear": {
@@ -177,14 +177,14 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
   },
   "Angel Bear": {
     height: 1,
-    width: 2,
+    width: 1,
   },
   "Badass Bear": {
     height: 1,
     width: 1,
   },
   "Bear Trap": {
-    height: 2,
+    height: 1,
     width: 1,
   },
   "Brilliant Bear": {
@@ -205,7 +205,7 @@ export const DECORATION_DIMENSIONS: Record<DecorationName, Dimensions> = {
   },
   "Rich Bear": {
     height: 1,
-    width: 2,
+    width: 1,
   },
   "Rainbow Artist Bear": {
     width: 1,


### PR DESCRIPTION
# Description

This PR changes the height of some items which unnecessarily had extra height (bears, scarecrows, trophy cabinets).

This gives players more space for items and aesthetically helps with designing the land and home.

One caveat is that mushrooms may be partially hidden behind items - it is up to users to place & organise their items 