### PR TITLE
[FIX] Flower Request Texts

### DIFF
--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -3224,7 +3224,7 @@ export const ITEM_DETAILS: Items = {
   },
   "Blue Lotus": {
     image: blueLotus,
-    description: translate("description.blue.lotu"),
+    description: translate("description.blue.lotus"),
   },
   "Earn Alliance Banner": {
     image: earnAllianceBanner,

--- a/src/features/world/ui/PageFound.tsx
+++ b/src/features/world/ui/PageFound.tsx
@@ -63,8 +63,7 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
               />
             </div>
             <span className="text-sm">
-              {t("pageFounds.knowHowToGrow")}
-              {springBlossom.weeklyFlower}
+              {t("pageFounds.knowHowToGrow")} {springBlossom.weeklyFlower}
               {"!"}
             </span>
           </div>

--- a/src/features/world/ui/SpecialEventModalContent.tsx
+++ b/src/features/world/ui/SpecialEventModalContent.tsx
@@ -257,7 +257,7 @@ export const SpecialEventModalContent: React.FC<{
               {secondsToString(Math.floor((event.endAt - Date.now()) / 1000), {
                 length: "medium",
                 removeTrailingZeros: true,
-              })}
+              })}{" "}
               {t("remaining")}
             </Label>
           </div>

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3599,7 +3599,7 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.finley.badFlower":
     "This flower isn't quite right. Perhaps another one would be more suitable?",
   "npcDialogues.finley.goodFlower":
-    "This Yellow Carnation is beautiful! Thank you for bringing it to me.",
+    "This Daffodil is beautiful! Thank you for bringing it to me.",
 
   "npcDialogues.corale.reward":
     "Your deliveries are much appreciated. Here's a little something to show my gratitude.",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -970,8 +970,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.chef.apron.boost": "+20% Cake Profit",
   "bumpkinItemBuff.fruit.picker.apron.boost": "+0.1 Fruit",
-  "bumpkinItemBuff.angel.wings.boost": "Instant Crops",
-  "bumpkinItemBuff.devil.wings.boost": "Instant Crops",
+  "bumpkinItemBuff.angel.wings.boost": "30% Chance of Instant Crops",
+  "bumpkinItemBuff.devil.wings.boost": "30% Chance of Instant Crops",
   "bumpkinItemBuff.eggplant.onesie.boost": "+0.1 Eggplant",
   "bumpkinItemBuff.golden.spatula.boost": "+10% XP",
   "bumpkinItemBuff.mushroom.hat.boost": "+0.1 Mushrooms",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3621,7 +3621,7 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.raven.badFlower":
     "This flower isn't quite right. Perhaps another search is in order?",
   "npcDialogues.raven.goodFlower":
-    "This Purple Carnation is perfect! Thank you for bringing it to me.",
+    "This Purple flower is perfect! Thank you for bringing it to me.",
 
   "npcDialogues.miranda.reward":
     "Thank you for your efforts. Here's a small token of appreciation for your deliveries.",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3582,13 +3582,13 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.finn.reward":
     "Your contributions are invaluable. Here's a little something to express my gratitude.",
   "npcDialogues.finn.flowerIntro":
-    "I'm yearning for a beautiful Daffodil in Red, Yellow, Purple, White, or Blue. Can you find one?",
+    "I'm yearning for a beautiful Cosmos in White, or Blue. Can you find one?",
   "npcDialogues.finn.averageFlower":
     "Not exactly what I was hoping for, but it's quite pleasing. Thank you.",
   "npcDialogues.finn.badFlower":
     "This flower doesn't quite meet my expectations. Perhaps another try?",
   "npcDialogues.finn.goodFlower":
-    "This Daffodil is stunning! Thank you for bringing it to me.",
+    "This Cosmos is stunning! Thank you for bringing it to me.",
 
   "npcDialogues.finley.reward":
     "Thank you for your efforts. Here's a small token of appreciation for your deliveries.",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1633,7 +1633,7 @@ const decorationDescriptions: Record<DecorationDescriptions, string> = {
   "description.yellow.lotus": "A yellow lotus.",
   "description.purple.lotus": "A purple lotus.",
   "description.white.lotus": "A white lotus.",
-  "description.blue.lotu": "A blue lotus.",
+  "description.blue.lotus": "A blue lotus.",
 
   // Banners
   "description.goblin.war.banner":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3635,13 +3635,13 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.finn.reward":
     "Suas contribuições são inestimáveis. Aqui está algo para expressar minha gratidão.",
   "npcDialogues.finn.flowerIntro":
-    "Estou desejando um belo Narciso em Vermelho, Amarelo, Roxo, Branco ou Azul. Você consegue encontrar um?",
+    "Estou desejando um belo Cosmos em Branco ou Azul. Você consegue encontrar um?",
   "npcDialogues.finn.averageFlower":
     "Não é exatamente o que eu esperava, mas é bastante agradável. Obrigado.",
   "npcDialogues.finn.badFlower":
     "Esta flor não atende exatamente às minhas expectativas. Talvez outra tentativa?",
   "npcDialogues.finn.goodFlower":
-    "Este Narciso é deslumbrante! Obrigado por trazê-lo para mim.",
+    "Este Cosmos é deslumbrante! Obrigado por trazê-lo para mim.",
 
   "npcDialogues.finley.reward":
     "Obrigado por seus esforços. Aqui está um pequeno gesto de apreço por suas entregas.",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1699,7 +1699,7 @@ const decorationDescriptions: Record<DecorationDescriptions, string> = {
   "description.yellow.lotus": "Um lótus amarelo.",
   "description.purple.lotus": "Um lótus roxo.",
   "description.white.lotus": "Um lótus branco.",
-  "description.blue.lotu": "Um lótus azul.",
+  "description.blue.lotus": "Um lótus azul.",
 
   // Banners
   "description.goblin.war.banner":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -986,8 +986,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.chef.apron.boost": "+20% Lucro com Bolos",
   "bumpkinItemBuff.fruit.picker.apron.boost": "+0.1 Fruta",
-  "bumpkinItemBuff.angel.wings.boost": "Chance de colheita Instantânea",
-  "bumpkinItemBuff.devil.wings.boost": "Chance de colheita Instantânea",
+  "bumpkinItemBuff.angel.wings.boost": "30% de Chance de colheita Instantânea",
+  "bumpkinItemBuff.devil.wings.boost": "30% de Chance de colheita Instantânea",
   "bumpkinItemBuff.eggplant.onesie.boost": "+0.1 Berinjela",
   "bumpkinItemBuff.golden.spatula.boost": "+10% XP",
   "bumpkinItemBuff.mushroom.hat.boost": "+0.1 Cogumelos",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3674,7 +3674,7 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.raven.badFlower":
     "Esta flor não está exatamente certa. Talvez outra busca seja necessária?",
   "npcDialogues.raven.goodFlower":
-    "Este Cravo Roxo está perfeito! Obrigado por trazê-lo para mim.",
+    "Este Flor Roxo está perfeito! Obrigado por trazê-lo para mim.",
 
   "npcDialogues.miranda.reward":
     "Obrigado por seus esforços. Aqui está um pequeno gesto de apreço por suas entregas.",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3652,7 +3652,7 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.finley.badFlower":
     "Esta flor não está certa. Talvez outra opção seria mais adequada?",
   "npcDialogues.finley.goodFlower":
-    "Este Cravo Amarelo é lindo! Obrigado por trazê-lo para mim.",
+    "Esse Narciso é lindo! Obrigado por trazê-lo para mim.",
 
   "npcDialogues.corale.reward":
     "Suas entregas são muito apreciadas. Aqui está um pequeno gesto de apreço por seus esforços.",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1177,7 +1177,7 @@ export type DecorationDescriptions =
   | "description.yellow.lotus"
   | "description.purple.lotus"
   | "description.white.lotus"
-  | "description.blue.lotu"
+  | "description.blue.lotus"
 
   //Banners
   | "description.goblin.war.banner"


### PR DESCRIPTION
# Description

Some NPCs are asking different flowers from what they really prefer in the code. Updated the code with the following:
- Updated Finley's Text from asking `Yellow Carnation` to `Daffodil`
- Updated Finn's Flower Request from `Daffoldil` to `Cosmos`
- Update Raven's Good Flower Text
- Fix Typo in Blue Lotus Translation term