### PR TITLE
[FEAT] Allow Time Warp Totem Placement to be able to be cancelled

### DIFF
--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -35,14 +35,12 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
   const { t } = useAppTranslation();
   const [
     {
-      value,
       context: {
         collisionDetected,
         placeable,
         requirements,
         coordinates,
         maximum,
-        action,
       },
     },
     send,
@@ -175,8 +173,6 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
     );
   };
 
-  const isForcedToPlace = placeable === "Time Warp Totem";
-
   const isWrongLocation =
     location === "home" &&
     ((!COLLECTIBLES_DIMENSIONS[placeable as CollectibleName] &&
@@ -204,17 +200,15 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
             height: `${PIXEL_SCALE * 17}px`,
           }}
         >
-          {!isForcedToPlace && (
-            <Button onClick={handleCancelPlacement}>
-              <img
-                src={SUNNYSIDE.icons.cancel}
-                alt="cancel"
-                style={{
-                  width: `${PIXEL_SCALE * 11}px`,
-                }}
-              />
-            </Button>
-          )}
+          <Button onClick={handleCancelPlacement}>
+            <img
+              src={SUNNYSIDE.icons.cancel}
+              alt="cancel"
+              style={{
+                width: `${PIXEL_SCALE * 11}px`,
+              }}
+            />
+          </Button>
 
           <Button
             disabled={collisionDetected || isWrongLocation}


### PR DESCRIPTION
# Description

Since we're able to obtain more than 1 Time Warp Totem from events and Bumpkin relations, this creates a situation where players who have more than one Time Warp Totem are forced to place both down and as a result of that waste the boost of one of them.

This PR removes the `isForcedToPlace` trait altogether and allows players to cancel the placing down of the Time Warp Totem

Before
https://github.com/sunflower-land/sunflower-land/assets/101262042/493d5dd6-ff3f-4fb4-9f31-a0d28af5dece

After
https://github.com/sunflower-land/sunflower-land/assets/101262042/46adf579-92b2-4c55-b028-21d12b1dd601

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
