### PR TITLE
[CHORE] Speed up modal close

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -65,6 +65,11 @@
         image-rendering: pixelated;
         border-radius: 13.125px;
         padding: 2.625px;
+        width: 100%;
+
+        @media screen and (min-width: 768px) {
+          width: 75%;
+        }
       }
 
       .inner-panel {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -68,7 +68,7 @@ export const Modal: React.FC<ModalProps> = ({
               enter="ease-out duration-300"
               enterFrom="opacity-0"
               enterTo="opacity-100"
-              leave="ease-in duration-200"
+              leave="ease-out duration-75"
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
               beforeEnter={() => onShow?.()}


### PR DESCRIPTION
# Description

There was a small flash of content that was changing when modals were closing. This PR aims to reduce that by speeding up the modal close and adding a different curve to the transition.

_Before_
![modal-slow](https://github.com/sunflower-land/sunflower-land/assets/17863697/25b92926-0577-49a3-9879-25619e54c98a)

_After_
![modal-fast](https://github.com/sunflower-land/sunflower-land/assets/17863697/9e13ca72-897b-4989-b2e3-d11d97f9da8e)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
