### PR TITLE
[FEAT] Change Language Modal Updates

### DIFF
--- a/src/features/auth/components/Splash.tsx
+++ b/src/features/auth/components/Splash.tsx
@@ -10,7 +10,6 @@ import cossies from "assets/decorations/cossies.png";
 import goblinSwimming from "assets/npcs/goblin_farting.gif";
 import shadow from "assets/npcs/shadow.png";
 
-import { CONFIG } from "lib/config";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Panel } from "components/ui/Panel";
 import { Modal } from "components/ui/Modal";
@@ -20,8 +19,6 @@ import { Button } from "components/ui/Button";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { hasFeatureAccess } from "lib/flags";
 import { GameState } from "features/game/types/game";
-
-const releaseVersion = CONFIG.RELEASE_VERSION as string;
 
 const Languages = () => {
   // Determine the initial language from localStorage or default to 'en'

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // CROPS
 import magicBean from "assets/crops/magic_bean.png";
 import appleSeed from "assets/fruit/apple/apple_seed.png";

--- a/src/features/island/hud/components/settings-menu/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/LanguageChangeModal.tsx
@@ -2,12 +2,18 @@
 /* eslint-disable unused-imports/no-unused-vars */
 /* eslint-disable react/prop-types */
 /* eslint-disable react/react-in-jsx-scope */
+import { useState } from "react";
+
 import { Button } from "components/ui/Button";
 import { Modal } from "components/ui/Modal";
-
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { changeLanguage } from "i18next";
+
+import i18n from "lib/i18n";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+import british_flag from "assets/sfts/flags/british_flag.gif";
+import brazilFlag from "assets/sfts/flags/brazil_flag.gif";
+import portugalFlag from "assets/sfts/flags/portugal_flag.gif";
 
 interface Props {
   isOpen: boolean;
@@ -17,22 +23,63 @@ interface Props {
 export const LanguageSwitcher: React.FC<Props> = ({ isOpen, onClose }) => {
   const { t } = useAppTranslation();
 
+  const initialLanguage = localStorage.getItem("language") || "en";
+  const [language, setLanguage] = useState(initialLanguage);
+
   const handleChangeLanguage = (languageCode: string) => {
-    changeLanguage(languageCode);
+    localStorage.setItem("language", languageCode);
+    i18n.changeLanguage(languageCode);
+    setLanguage(languageCode);
+    onClose();
   };
+
   const Content = () => {
     return (
       <CloseButtonPanel title={t("change.Language")} onClose={onClose}>
         <div className="p-1">
-          <Button onClick={() => handleChangeLanguage("en")}>
+          <Button
+            onClick={() => handleChangeLanguage("en")}
+            disabled={language === "en"}
+          >
+            <img
+              style={{ display: "inline-block", marginRight: "5px" }}
+              src={british_flag}
+              alt="British Flag"
+            />
             {"English"}
           </Button>
-          <Button onClick={() => handleChangeLanguage("pt")}>
+          <Button
+            onClick={() => handleChangeLanguage("pt")}
+            disabled={language === "pt"}
+          >
+            <img
+              style={{ display: "inline-block", marginRight: "5px" }}
+              src={brazilFlag}
+              alt="Brazillian Flag"
+            />
+            <img
+              style={{ display: "inline-block", marginRight: "5px" }}
+              src={portugalFlag}
+              alt="Portuguese Flag"
+            />
             {"Português"}
           </Button>
         </div>
       </CloseButtonPanel>
     );
   };
-  return <Modal show={isOpen}>{Content()}</Modal>;
+
+  // Close Modal on Hide
+  const [view, setView] = useState<"settings">("settings");
+
+  const closeAndResetView = () => {
+    onClose();
+    setView("settings");
+  };
+
+  return (
+    <Modal show={isOpen} onHide={closeAndResetView}>
+      {Content()}
+    </Modal>
+  );
 };


### PR DESCRIPTION
# Description

Previous version #3463 doesn't save the changed language in local storage. 
- Update modal to save the language in localStorage
- Added flag images to the buttons
- Disable language button when it matches the current set language
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/ad91315e-6b6c-4094-a4ee-cf1bee68bfe9)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Went to local and test to see if the language change stays after refresh

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
