### PR TITLE
[FIX] Bakers Dozen achievement (#3473)

### DIFF
--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -3,8 +3,8 @@ import { marketRate } from "../lib/halvening";
 import { getBumpkinLevel } from "../lib/level";
 import { GameState, Inventory } from "./game";
 import { CookEvent, CraftedEvent, HarvestEvent } from "./bumpkinActivity";
-import { COOKABLES } from "./consumables";
-import { CAKES, getKeys, TOOLS } from "./craftables";
+import { COOKABLES, COOKABLE_CAKES } from "./consumables";
+import { getKeys, TOOLS } from "./craftables";
 import { CROPS } from "./crops";
 import { FRUIT } from "./fruits";
 import { getSeasonalTicket } from "./seasons";
@@ -254,7 +254,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Bakers Dozen": {
     description: translate("bakersDozen.description"),
     progress: (gameState: GameState) => {
-      const cakeEvents = getKeys(CAKES()).map(
+      const cakeEvents = getKeys(COOKABLE_CAKES).map(
         (name) => `${name} Cooked` as CookEvent
       );
 


### PR DESCRIPTION
# Description

When counting the number of baked cakes, the `Bakers Dozen` achievement does not count the following cakes: `Eggplant Cake`, `Orange Cake` and `Honey Cake`.
Fixes #3473 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


