### PR TITLE
[FIX] Add Honey hoarder limit

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -104,6 +104,7 @@ export const maxItems: Inventory = {
   Stone: new Decimal("800"),
   Wood: new Decimal("4000"),
   "Wild Mushroom": new Decimal("100"),
+  Honey: new Decimal("100"),
 
   "War Bond": new Decimal(500),
   "Human War Banner": new Decimal(1),

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -104,7 +104,7 @@ export const maxItems: Inventory = {
   Stone: new Decimal("800"),
   Wood: new Decimal("4000"),
   "Wild Mushroom": new Decimal("100"),
-  Honey: new Decimal("100"),
+  Honey: new Decimal("80"),
 
   "War Bond": new Decimal(500),
   "Human War Banner": new Decimal(1),


### PR DESCRIPTION
# Description

The back-end is enforcing a limit of 100 for honey.

This updates the front-end to match.

Observed AS-001 on Testnet 162 when trying to Save after adding to 99.62 honey in the session.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
