### PR TITLE
[FEAT] Offline Refresh

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -66,9 +66,10 @@
         border-radius: 13.125px;
         padding: 2.625px;
         width: 100%;
+        max-width: fit-content;
 
         @media screen and (min-width: 768px) {
-          width: 75%;
+          width: 50%;
         }
       }
 
@@ -81,6 +82,9 @@
         image-rendering: pixelated;
         border-radius: 13.125px;
         padding: 2.625px;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
       }
 
       .panel-content {
@@ -93,6 +97,29 @@
         margin-bottom: 12px;
         display: flex;
         flex-direction: column;
+      }
+
+      .refresh-button {
+        border-image-slice: "20%";
+        border-image-repeat: "stretch";
+        background-color: rgb(231 168 115);
+        border-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKAgMAAADwXCcuAAAACVBMVEUAAAAYFCXq1KoZSBjjAAAAAXRSTlMAQObYZgAAABpJREFUCNdjYA1lYJBa5cCQwDABGwbJgdQAAKX2CF37xkC2AAAAAElFTkSuQmCC")
+          20% / 1 / 0 stretch;
+        border-style: solid;
+        border-width: 5.25px;
+        image-rendering: pixelated;
+        border-radius: 13.125px;
+        padding: 2.625px;
+        padding-bottom: 8px;
+        width: 100%;
+        font-family: "Paytone One", sans-serif;
+        overflow: hidden;
+        color: white;
+        font-size: 22px;
+        letter-spacing: -0.4px;
+        word-spacing: 3px;
+        line-height: 20px;
+        text-shadow: 1px 1px #1f1f1f;
       }
     </style>
   </head>
@@ -116,6 +143,9 @@
               </span>
             </div>
           </div>
+          <button class="refresh-button" onclick="window.location.reload(true)">
+            Refresh
+          </button>
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React from "react";
+import React, { useEffect } from "react";
 
 import { initialise } from "lib/utils/init";
 
@@ -13,14 +13,47 @@ import { useServiceWorkerUpdate } from "lib/utils/hooks/useServiceWorkerUpdate";
 
 // Initialise Global Settings
 initialise();
+
+// Android + Metamask browser has issues loading assets when the Service Worker is running
+// The cause is unknown hence we unregister the service worker for these users to prevent
+// rendering issues
+const NoServiceWorker = () => {
+  useEffect(() => {
+    (async () => {
+      if ("serviceWorker" in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        const unregisterPromises = registrations.map((registration) =>
+          registration.unregister()
+        );
+
+        const allCaches = await caches.keys();
+        const cacheDeletionPromises = allCaches.map((cache) =>
+          caches.delete(cache)
+        );
+
+        await Promise.all([...unregisterPromises, ...cacheDeletionPromises]);
+      }
+    })();
+  }, []);
+  return null;
+};
+
+const ServiceWorker = () => {
+  useServiceWorkerUpdate();
+  return null;
+};
+
 /**
  * Top level wrapper for providers
  */
 export const App: React.FC = () => {
-  useServiceWorkerUpdate();
-
   return (
     <>
+      {/Metamask/i.test(navigator.userAgent) ? (
+        <NoServiceWorker />
+      ) : (
+        <ServiceWorker />
+      )}
       <Auth.Provider>
         <WalletProvider>
           <ErrorBoundary>


### PR DESCRIPTION
Authored-By: Spencer Dezart-Smith <17863697+spencerdezartsmith@users.noreply.github.com>
Co-Authored-By: @c-py

# Description

- This PR adds a button to refresh the page if the PWA is serving offline.html.
- This PR attempts to resolve a bug in Metamask Mobile on Android wherwe assets are taking a long time to load. It resolves this issue by un-registering the service worker from the Metamask App, (root cause: unknown).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Chrome Android
Tested on Chrome MacOS
Tested on Firefox Android
Tested on Firefox MacOS
Tested on Metamask Mobile Android

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]