### PR TITLE
[FEAT] Hide Event When Finished

### DIFF
--- a/src/features/world/ui/SpecialEventModalContent.tsx
+++ b/src/features/world/ui/SpecialEventModalContent.tsx
@@ -206,6 +206,26 @@ export const SpecialEventModalContent: React.FC<{
     );
   }
 
+  if (event.endAt < Date.now()) {
+    return (
+      <div>
+        <div className="flex justify-between items-center p-2">
+          <Label
+            type="default"
+            className="capitalize"
+            icon={SUNNYSIDE.icons.player}
+          >
+            {npcName ?? t("special.event.finishedLabel")}
+          </Label>
+        </div>
+
+        <p className="text-sm mb-3 p-2">
+          <Dialogue trail={25} message={t("special.event.finished")} />
+        </p>
+      </div>
+    );
+  }
+
   // isEligible should already be checked by the parent component but just in
   // case it was missed, let's check it here as well
   if (!event.isEligible) {
@@ -224,12 +244,7 @@ export const SpecialEventModalContent: React.FC<{
         )}
 
         <p className="text-sm mb-3 p-2">
-          <Dialogue
-            trail={25}
-            message={
-              "There is no work needing to be done right now, thanks for stopping by though!"
-            }
-          />
+          <Dialogue trail={25} message={t("special.event.ineligible")} />
         </p>
       </div>
     );

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4109,6 +4109,11 @@ const specialEvent: Record<SpecialEvent, string> = {
   "special.event.web3Wallet":
     "A Web3 wallet is required for this event as it contains an Airdrop.",
   "special.event.airdrop": "Airdrop",
+  "special.event.finishedLabel": "Event Finished",
+  "special.event.finished":
+    "This event has finished. Stay tuned for future events!",
+  "special.event.ineligible":
+    "There is no work needing to be done right now, thanks for stopping by though!",
 };
 
 const statements: Record<Statements, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4150,6 +4150,9 @@ const specialEvent: Record<SpecialEvent, string> = {
   "special.event.web3Wallet":
     "Uma carteira Web3 é necessária para este evento, pois contém um Airdrop.",
   "special.event.airdrop": "Airdrop",
+  "special.event.finishedLabel": ENGLISH_TERMS["special.event.finishedLabel"],
+  "special.event.finished": ENGLISH_TERMS["special.event.finished"],
+  "special.event.ineligible": ENGLISH_TERMS["special.event.ineligible"],
 };
 
 const statements: Record<Statements, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2781,7 +2781,10 @@ export type SpecialEvent =
   | "special.event.airdropHandling"
   | "special.event.walletRequired"
   | "special.event.web3Wallet"
-  | "special.event.airdrop";
+  | "special.event.airdrop"
+  | "special.event.finishedLabel"
+  | "special.event.finished"
+  | "special.event.ineligible";
 
 export type Statements =
   | "statements.adventure"


### PR DESCRIPTION
# Description

Hide event if the end Date has passed. Defaults label text for spacing reasons if npcName not supplied.

![event finished](https://github.com/sunflower-land/sunflower-land/assets/41215134/83f5b367-dc21-4f2e-ae59-d335db83c694)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
