### PR TITLE
[FIX] Bumpkin Modal Height. Format Magic Link Display.

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -161,16 +161,23 @@ export const BumpkinModal: React.FC<Props> = ({
           : []),
       ]}
     >
-      {tab === 0 && (
-        <div className="flex flex-wrap">
-          <div className="w-full sm:w-1/3 z-10 mr-0 sm:mr-2">
-            <div className="w-full rounded-md overflow-hidden mb-1">
-              <DynamicNFT
-                showBackground
-                bumpkinParts={bumpkin?.equipped as BumpkinParts}
-              />
-            </div>
-            {/* {isFullUser && (
+      <div
+        style={{
+          maxHeight: "calc(100vh - 100px)",
+          overflowY: "auto",
+        }}
+        className="scrollable"
+      >
+        {tab === 0 && (
+          <div className="flex flex-wrap">
+            <div className="w-full sm:w-1/3 z-10 mr-0 sm:mr-2">
+              <div className="w-full rounded-md overflow-hidden mb-1">
+                <DynamicNFT
+                  showBackground
+                  bumpkinParts={bumpkin?.equipped as BumpkinParts}
+                />
+              </div>
+              {/* {isFullUser && (
               <div className="ml-1">
                 <a
                   href={getVisitBumpkinUrl()}
@@ -182,83 +189,84 @@ export const BumpkinModal: React.FC<Props> = ({
                 </a>
               </div>
             )} */}
-          </div>
+            </div>
 
-          <div className="flex-1">
-            <div className="mb-3">
-              <div className="flex items-center ml-1 my-2">
-                <img
-                  src={levelIcon}
-                  style={{
-                    width: `${PIXEL_SCALE * 10}px`,
-                    marginRight: `${PIXEL_SCALE * 4}px`,
-                  }}
-                />
-                <div>
-                  <p className="text-base">
-                    {t("lvl")} {level}
-                    {maxLevel ? " (Max)" : ""}
-                  </p>
-                  {/* Progress bar */}
-                  <BumpkinLevel experience={bumpkin.experience} />
+            <div className="flex-1">
+              <div className="mb-3">
+                <div className="flex items-center ml-1 my-2">
+                  <img
+                    src={levelIcon}
+                    style={{
+                      width: `${PIXEL_SCALE * 10}px`,
+                      marginRight: `${PIXEL_SCALE * 4}px`,
+                    }}
+                  />
+                  <div>
+                    <p className="text-base">
+                      {t("lvl")} {level}
+                      {maxLevel ? " (Max)" : ""}
+                    </p>
+                    {/* Progress bar */}
+                    <BumpkinLevel experience={bumpkin.experience} />
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div
-              className="mb-2 cursor-pointer"
-              onClick={() => setView("skills")}
-            >
-              <InnerPanel className="relative mt-1 !px-2 !py-1">
-                <div className="flex items-center mb-1 justify-between">
-                  <div className="flex items-center">
-                    <span className="text-xs">{t("skills")}</span>
-                    {hasAvailableSP && !readonly && (
-                      <img
-                        src={SUNNYSIDE.icons.expression_alerted}
-                        className="h-4 ml-2"
-                      />
-                    )}
+              <div
+                className="mb-2 cursor-pointer"
+                onClick={() => setView("skills")}
+              >
+                <InnerPanel className="relative mt-1 !px-2 !py-1">
+                  <div className="flex items-center mb-1 justify-between">
+                    <div className="flex items-center">
+                      <span className="text-xs">{t("skills")}</span>
+                      {hasAvailableSP && !readonly && (
+                        <img
+                          src={SUNNYSIDE.icons.expression_alerted}
+                          className="h-4 ml-2"
+                        />
+                      )}
+                    </div>
+                    <span className="text-xxs underline">{t("viewAll")}</span>
                   </div>
-                  <span className="text-xxs underline">{t("viewAll")}</span>
-                </div>
-                <SkillBadges
-                  inventory={inventory}
-                  bumpkin={bumpkin as Bumpkin}
-                />
-              </InnerPanel>
-            </div>
+                  <SkillBadges
+                    inventory={inventory}
+                    bumpkin={bumpkin as Bumpkin}
+                  />
+                </InnerPanel>
+              </div>
 
-            <div
-              className="mb-2 cursor-pointer"
-              onClick={() => setView("achievements")}
-            >
-              <InnerPanel className="relative mt-1 !px-2 !py-1">
-                <div className="flex items-center mb-1 justify-between">
-                  <div className="flex items-center">
-                    <span className="text-xs">{t("achievements")}</span>
+              <div
+                className="mb-2 cursor-pointer"
+                onClick={() => setView("achievements")}
+              >
+                <InnerPanel className="relative mt-1 !px-2 !py-1">
+                  <div className="flex items-center mb-1 justify-between">
+                    <div className="flex items-center">
+                      <span className="text-xs">{t("achievements")}</span>
+                    </div>
+                    <span className="text-xxs underline">{t("viewAll")}</span>
                   </div>
-                  <span className="text-xxs underline">{t("viewAll")}</span>
-                </div>
-                <AchievementBadges achievements={bumpkin?.achievements} />
-              </InnerPanel>
+                  <AchievementBadges achievements={bumpkin?.achievements} />
+                </InnerPanel>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-      {tab === 1 && (
-        <BumpkinEquip
-          equipment={bumpkin.equipped}
-          game={gameState}
-          onEquip={(equipment) => {
-            gameService.send("bumpkin.equipped", {
-              equipment,
-            });
-            gameService.send("SAVE");
-          }}
-        />
-      )}
-      {tab === 2 && <Trade />}
+        )}
+        {tab === 1 && (
+          <BumpkinEquip
+            equipment={bumpkin.equipped}
+            game={gameState}
+            onEquip={(equipment) => {
+              gameService.send("bumpkin.equipped", {
+                equipment,
+              });
+              gameService.send("SAVE");
+            }}
+          />
+        )}
+        {tab === 2 && <Trade />}
+      </div>
     </CloseButtonPanel>
   );
 };

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -163,7 +163,7 @@ export const BumpkinModal: React.FC<Props> = ({
     >
       <div
         style={{
-          maxHeight: "calc(100vh - 100px)",
+          maxHeight: "calc(100vh - 200px)",
           overflowY: "auto",
         }}
         className="scrollable"

--- a/src/features/farming/mail/components/PWAInstallMessage.tsx
+++ b/src/features/farming/mail/components/PWAInstallMessage.tsx
@@ -116,6 +116,13 @@ export const PWAInstallMessage: React.FC<Props> = ({
 
   const conversation = message;
 
+  const formatMagicLink = () => {
+    if (!magicLink) return "";
+
+    const url = new URL(magicLink);
+    return `${url.origin}...`;
+  };
+
   return (
     <div
       style={{ maxHeight: CONTENT_HEIGHT }}
@@ -136,17 +143,20 @@ export const PWAInstallMessage: React.FC<Props> = ({
               "install.app.mobile.metamask.description.two"
             )}`}</p>
             <div
-              className={classNames("cursor-pointer text-xs flex", {
-                loading: magicLink === undefined,
-                underline: !!magicLink,
-              })}
+              className={classNames(
+                "cursor-pointer text-xs flex items-center",
+                {
+                  loading: magicLink === undefined,
+                  underline: !!magicLink,
+                }
+              )}
               style={{ marginLeft: 0, height: 25 }}
               onMouseEnter={() => setShowLabel(true)}
               onMouseLeave={() => setShowLabel(false)}
               onClick={copyToClipboard}
             >
               {magicLink ? (
-                <span>{t("magic.link")}</span>
+                <span>{formatMagicLink()}</span>
               ) : (
                 <span>{t("generating.link")}</span>
               )}


### PR DESCRIPTION
# Description

Restrict the height of the Bumpkin Modal and make scrollable. Format the generated magic link to show the origin of the link for clearer UX.

eg.

`https://api.sunflower-land.com...`

<img width="371" alt="Screenshot 2024-03-15 at 8 41 00 AM" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/3b755386-5b58-4e69-8b87-c955e3044bed">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally. Code review should suffice.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
