### PR TITLE
[CHORE] Hide Install App button if PWA is installed

### DIFF
--- a/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
+++ b/src/features/island/hud/components/settings-menu/SettingsMenu.tsx
@@ -39,6 +39,7 @@ import { usePWAInstall } from "features/pwa/PWAInstallProvider";
 import { isMobile, isIOS, getUA } from "mobile-device-detect";
 import { fixInstallPromptTextStyles } from "features/pwa/lib/fixInstallPromptStyles";
 import { InstallAppModal } from "./InstallAppModal";
+import { useIsPWA } from "lib/utils/hooks/useIsPWA";
 
 enum MENU_LEVELS {
   ROOT = "root",
@@ -77,6 +78,8 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
   const isMetamaskMobile = /MetaMaskMobile/.test(getUA);
 
   const pwaInstall = usePWAInstall();
+  const isPWA = useIsPWA();
+  const isMobilePWA = isMobile && isPWA;
 
   const handleHowToPlay = () => {
     setShowHowToPlay(true);
@@ -223,11 +226,13 @@ export const SettingsMenu: React.FC<Props> = ({ show, onClose, isFarming }) => {
                     </li>
                   </>
                 )}
-                <li className="p-1">
-                  <Button onClick={handleInstallApp}>
-                    <span>{t("install.app")}</span>
-                  </Button>
-                </li>
+                {!isMobilePWA && (
+                  <li className="p-1">
+                    <Button onClick={handleInstallApp}>
+                      <span>{t("install.app")}</span>
+                    </Button>
+                  </li>
+                )}
                 <li className="p-1">
                   <Button onClick={changeLanguage}>
                     <span>{t("change.Language")}</span>


### PR DESCRIPTION
# Description

Hides `Install App` Button when PWA is installed

PWA Not Installed
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/941e6b5a-1204-432b-ae3b-8209b1124a81)

PWA Installed
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/a3212754-c570-4ab3-b335-f99c28d9e2b5)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
