### PR TITLE
[FEAT] Default server

### DIFF
--- a/src/features/island/hud/components/settings-menu/PlazaSettingsModal.tsx
+++ b/src/features/island/hud/components/settings-menu/PlazaSettingsModal.tsx
@@ -73,6 +73,14 @@ export const PlazaSettings: React.FC<Props> = ({ isOpen, onClose }) => {
               <Button onClick={() => setStep("MUTED_PLAYERS")}>
                 {t("plazaSettings.title.mutedPlayers")}
               </Button>
+              <Button
+                onClick={() => {
+                  PubSub.publish("CHANGE_SERVER");
+                  onClose();
+                }}
+              >
+                {t("plazaSettings.changeServer")}
+              </Button>
             </div>
             {/* <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3879,6 +3879,7 @@ const plazaSettings: Record<PlazaSettings, string> = {
   "plazaSettings.keybinds.description":
     "Need to know what keybinds are available? Check them out here.",
   "plazaSettings.noMutedPlayers": "You have no muted players.",
+  "plazaSettings.changeServer": "Change server",
 };
 
 const portal: Record<Portal, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4035,6 +4035,7 @@ const plazaSettings: Record<PlazaSettings, string> = {
   "plazaSettings.keybinds.description":
     "Besoin de savoir quels raccourcis sont disponibles ? Consultez-les ici.",
   "plazaSettings.noMutedPlayers": "Vous n'avez aucun joueur muet.",
+  "plazaSettings.changeServer": ENGLISH_TERMS["plazaSettings.changeServer"],
 };
 
 const portal: Record<Portal, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3925,6 +3925,7 @@ const plazaSettings: Record<PlazaSettings, string> = {
   "plazaSettings.keybinds.description":
     "Precisa saber quais atalhos de teclado estão disponíveis? Confira-os aqui.",
   "plazaSettings.noMutedPlayers": "Você não tem jogadores silenciados.",
+  "plazaSettings.changeServer": ENGLISH_TERMS["plazaSettings.changeServer"],
 };
 
 const portal: Record<Portal, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2608,6 +2608,7 @@ export type Pickserver =
   | "pickserver.built";
 
 export type PlazaSettings =
+  | "plazaSettings.changeServer"
   | "plazaSettings.title.main"
   | "plazaSettings.title.mutedPlayers"
   | "plazaSettings.title.keybinds"


### PR DESCRIPTION
# Description

When players go to the plaza, default to the last server they were in.

By default, new players will go into `sunflower_oasis`. If that is full, they will need to pick a server.

Player can go Settings > Plaza Settings to change to another server (this will become their new default).

<img width="584" alt="Screenshot 2024-03-16 at 1 01 19 pm" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/614449e7-844e-4a6c-bb64-bd4ac3a70e5a">
