### PR TITLE
[FIX] [QOL] Quantity Input not being able to delete completely / Show price per unit in trade listing screen

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -40,8 +40,8 @@ const ListTrade: React.FC<{
 }> = ({ inventory, onList, onCancel, isSaving, floorPrices }) => {
   const { t } = useAppTranslation();
   const [selected, setSelected] = useState<InventoryItemName>();
-  const [quantity, setQuantity] = useState<number>(1);
-  const [sfl, setSFL] = useState(1);
+  const [quantity, setQuantity] = useState<number>(0);
+  const [sfl, setSFL] = useState(0);
 
   const maxSFL = sfl > MAX_SFL;
 
@@ -145,7 +145,10 @@ const ListTrade: React.FC<{
               ) {
                 e.target.value = e.target.value.replace(/^0/, "");
               }
-              if (VALID_INTEGER.test(e.target.value)) {
+
+              if (e.target.value === "") {
+                setQuantity(0); // Reset to 0 if input is empty
+              } else if (VALID_INTEGER.test(e.target.value)) {
                 const amount = Number(e.target.value.slice(0, INPUT_MAX_CHAR));
                 setQuantity(amount);
               }
@@ -155,7 +158,8 @@ const ListTrade: React.FC<{
               {
                 "text-error":
                   inventory[selected]?.lt(quantity) ||
-                  quantity > (TRADE_LIMITS[selected] ?? 0),
+                  quantity > (TRADE_LIMITS[selected] ?? 0) ||
+                  quantity === 0, // Add condition to change text color to red when quantity is 0
               }
             )}
           />
@@ -221,7 +225,9 @@ const ListTrade: React.FC<{
         }}
       >
         <span className="text-xs"> {t("bumpkinTrade.pricePerUnit")}</span>
-        <p className="text-xs">{`${(sfl / quantity).toFixed(4)} SFL`}</p>
+        <p className="text-xs">
+          {quantity === 0 ? "0.0000 SFL" : `${(sfl / quantity).toFixed(4)} SFL`}
+        </p>
       </div>
       <div
         className="flex justify-between"
@@ -251,8 +257,8 @@ const ListTrade: React.FC<{
           disabled={
             maxSFL ||
             (inventory[selected]?.lt(quantity) ?? false) ||
-            quantity > (TRADE_LIMITS[selected] ?? 0) ||
-            sfl === 0 ||
+            quantity === 0 || // Disable when quantity is 0
+            sfl === 0 || // Disable when sfl is 0
             isSaving
           }
           onClick={() => onList({ [selected]: quantity }, sfl)}

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -97,9 +97,25 @@ const ListTrade: React.FC<{
   return (
     <>
       <div className="flex justify-between items-center">
-        <div className="flex items-center">
-          <Box image={ITEM_DETAILS[selected].image} disabled />
-          <span className="text-sm">{selected}</span>
+        <div className="flex flex-col items-start">
+          <div className="flex items-center">
+            <Box image={ITEM_DETAILS[selected].image} disabled />
+            <span className="text-sm">{selected}</span>
+          </div>
+          <Label
+            type={
+              sfl / quantity < (floorPrices[selected] ?? 0)
+                ? "danger"
+                : sfl / quantity > (floorPrices[selected] ?? 0)
+                ? "success"
+                : "warning"
+            }
+            className="my-1"
+          >
+            {t("bumpkinTrade.floorPrice", {
+              price: floorPrices[selected]?.toFixed(4) || "",
+            })}
+          </Label>
         </div>
         <div className="flex flex-col items-end pr-1">
           <Label
@@ -113,6 +129,7 @@ const ListTrade: React.FC<{
           </span>
         </div>
       </div>
+
       <div className="flex">
         <div className="w-1/2 mr-1">
           <div className="flex items-center">
@@ -225,7 +242,9 @@ const ListTrade: React.FC<{
           padding: "5px 5px 5px 2px",
         }}
       >
-        <span className="text-xs"> {t("bumpkinTrade.pricePerUnit")}</span>
+        <span className="text-xs">
+          {t("bumpkinTrade.pricePerUnit", { resource: selected })}
+        </span>
         <p className="text-xs">
           {quantity === 0 ? "0.0000 SFL" : `${(sfl / quantity).toFixed(4)} SFL`}
         </p>

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -82,8 +82,9 @@ const ListTrade: React.FC<{
                     className="absolute -bottom-2 text-center mt-1 p-1"
                     style={{ width: "calc(100% + 10px)" }}
                   >
-                    {floorPrices[name]?.toFixed(4)}
-                    {t("unit")}
+                    {t("bumpkinTrade.price/unit", {
+                      price: floorPrices[name]?.toFixed(4) || "",
+                    })}
                   </Label>
                 </OuterPanel>
               </div>
@@ -124,7 +125,7 @@ const ListTrade: React.FC<{
             </Label>
             {quantity > (TRADE_LIMITS[selected] ?? 0) && (
               <Label type="danger" className="my-1 ml-2 mr-1">
-                {`Max: ${TRADE_LIMITS[selected] ?? 0}`}
+                {t("bumpkinTrade.max", { max: TRADE_LIMITS[selected] ?? 0 })}
               </Label>
             )}
           </div>
@@ -168,7 +169,7 @@ const ListTrade: React.FC<{
           <div className="flex items-center">
             {sfl > MAX_SFL && (
               <Label type="danger" className="my-1 ml-2 mr-1">
-                {`Max: ${MAX_SFL}`}
+                {t("bumpkinTrade.max", { max: MAX_SFL })}
               </Label>
             )}
             <Label icon={token} type="default" className="my-1 ml-2 mr-1">

--- a/src/features/world/ui/market/SalesPanel.tsx
+++ b/src/features/world/ui/market/SalesPanel.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from "react";
 import { useActor } from "@xstate/react";
 
@@ -220,9 +221,11 @@ export const SalesPanel: React.FC<{
               <span
                 className={classNames("text-xs", { "text-red-500": !canSell })}
               >{`${MARKET_BUNDLES[selected]}`}</span>
-              <span className="text-xs">{`${Number(unitPrice).toFixed(4)}${t(
-                "unit"
-              )}`}</span>
+              <span className="text-xs">
+                {t("bumpkinTrade.price/unit", {
+                  price: Number(unitPrice).toFixed(4),
+                })}
+              </span>
             </div>
           </div>
           <span className="pt-3 text-xs px-1 pb-2">
@@ -327,10 +330,12 @@ export const SalesPanel: React.FC<{
                         style={{ width: "calc(100% + 10px)" }}
                       >
                         <span className={classNames({ pulse: showPulse })}>
-                          {marketPrices?.prices?.currentPrices?.[name]?.toFixed(
-                            4
-                          ) || "0.0000"}
-                          {t("unit")}
+                          {t("bumpkinTrade.price/unit", {
+                            price:
+                              marketPrices?.prices?.currentPrices?.[
+                                name
+                              ]?.toFixed(4) || "0.0000",
+                          })}
                         </span>
                         {priceMovement === "up" && (
                           <img

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -112,8 +112,9 @@ export const BuyPanel: React.FC<{
                   className="absolute -bottom-2 text-center mt-1 p-1"
                   style={{ width: "calc(100% + 10px)" }}
                 >
-                  {floorPrices[name]?.toFixed(4)}
-                  {t("unit")}
+                  {t("bumpkinTrade.price/unit", {
+                    price: floorPrices[name]?.toFixed(4) || "",
+                  })}
                 </Label>
               </OuterPanel>
             </div>

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1071,14 +1071,15 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.quantity": "Quantity",
   "bumpkinTrade.price": "Price",
   "bumpkinTrade.listingPrice": "Listing price",
-  "bumpkinTrade.pricePerUnit": "Price per unit",
+  "bumpkinTrade.pricePerUnit": "Price per {{resource}}",
   "bumpkinTrade.tradingFee": "Trading fee",
   "bumpkinTrade.youWillReceive": "You will receive",
   "bumpkinTrade.cancel": "Cancel",
   "bumpkinTrade.list": "List",
   "bumpkinTrade.maxListings": "Max listings reached",
   "bumpkinTrade.max": "Max: {{max}}",
-  "bumpkinTrade.price/unit": "{{price}}/unit",
+  "bumpkinTrade.floorPrice": "Floor Price: {{price}} SFL",
+  "bumpkinTrade.price/unit": "{{price}} / unit",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -474,7 +474,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   buildings: "Buildings",
   boosts: "Boosts",
   decorations: "Decorations",
-  unit: "/unit",
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1061,11 +1060,6 @@ const bumpkinSkillsDescription: Record<BumpkinSkillsDescription, string> = {
 };
 
 const bumpkinTrade: Record<BumpkinTrade, string> = {
-  "bumpkinTrade.askPrice": "Asking price:",
-  "bumpkinTrade.listingPurchased":
-    "Congratulations, your listing was purchased!",
-  "bumpkinTrade.travelPlaza":
-    "Travel to the plaza so players can trade with you",
   "bumpkinTrade.minLevel": "You must be level 10 to trade",
   "bumpkinTrade.noTradeListed": "You have no trades listed.",
   "bumpkinTrade.sell": "Sell your resources to other players for SFL.",
@@ -1083,6 +1077,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.cancel": "Cancel",
   "bumpkinTrade.list": "List",
   "bumpkinTrade.maxListings": "Max listings reached",
+  "bumpkinTrade.max": "Max: {{max}}",
+  "bumpkinTrade.price/unit": "{{price}}/unit",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1094,14 +1094,15 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.quantity": "Quantité",
   "bumpkinTrade.price": "Prix",
   "bumpkinTrade.listingPrice": "Prix catalogue",
-  "bumpkinTrade.pricePerUnit": "Prix par unité",
+  "bumpkinTrade.pricePerUnit": "Prix par {{resource}}",
   "bumpkinTrade.tradingFee": "Frais de négociation",
   "bumpkinTrade.youWillReceive": "Vous recevrez",
   "bumpkinTrade.cancel": "Annuler",
   "bumpkinTrade.list": "Liste",
   "bumpkinTrade.maxListings": "Nombre maximum d'annonces atteint",
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
-  "bumpkinTrade.price/unit": "{{price}}/unité",
+  "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
+  "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -475,7 +475,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   yes: "Oui",
   "yes.please": "Oui, s'il vous plaît",
   "you.are.here": "Vous êtes ici",
-  unit: ENGLISH_TERMS.unit,
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1083,11 +1082,6 @@ const bumpkinSkillsDescription: Record<BumpkinSkillsDescription, string> = {
 };
 
 const bumpkinTrade: Record<BumpkinTrade, string> = {
-  "bumpkinTrade.askPrice": "Prix demandé",
-  "bumpkinTrade.listingPurchased":
-    "Félicitations, votre annonce a été achetée!",
-  "bumpkinTrade.travelPlaza":
-    "Rendez-vous à la place du marché pour que d'autres joueurs puissent commercer avec vous",
   "bumpkinTrade.minLevel": "Vous devez être niveau 10 pour commercer",
   "bumpkinTrade.noTradeListed": "Vous n'avez aucune annonce en cours.",
   "bumpkinTrade.sell":
@@ -1106,6 +1100,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.cancel": "Annuler",
   "bumpkinTrade.list": "Liste",
   "bumpkinTrade.maxListings": "Nombre maximum d'annonces atteint",
+  "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.price/unit": "{{price}}/unité",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -475,7 +475,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   upcoming: "Próximo",
   wearables: "Vestíveis",
   wish: "Desejo",
-  unit: "/unidade",
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1079,10 +1078,6 @@ const bumpkinSkillsDescription: Record<BumpkinSkillsDescription, string> = {
 };
 
 const bumpkinTrade: Record<BumpkinTrade, string> = {
-  "bumpkinTrade.askPrice": "Preço solicitado",
-  "bumpkinTrade.listingPurchased": "Parabéns, sua oferta foi comprada!",
-  "bumpkinTrade.travelPlaza":
-    "Viaje para a praça para que outros(as) jogadores(as) possam negociar com você",
   "bumpkinTrade.minLevel": "Você deve estar no nível 10 para negociar",
   "bumpkinTrade.noTradeListed": "Você não tem negociações listadas.",
   "bumpkinTrade.sell": "Venda seus recursos para outros jogadores por SFL.",
@@ -1099,6 +1094,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.cancel": ENGLISH_TERMS["bumpkinTrade.cancel"],
   "bumpkinTrade.list": ENGLISH_TERMS["bumpkinTrade.list"],
   "bumpkinTrade.maxListings": ENGLISH_TERMS["bumpkinTrade.maxListings"],
+  "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.price/unit": "{{price}}/unidade",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1095,7 +1095,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": ENGLISH_TERMS["bumpkinTrade.list"],
   "bumpkinTrade.maxListings": ENGLISH_TERMS["bumpkinTrade.maxListings"],
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
-  "bumpkinTrade.price/unit": "{{price}}/unidade",
+  "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
+  "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -475,7 +475,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   "copy.failed": "Kopyalama Başarısız!",
   search: "Ara",
   searching: "Aranıyor",
-  unit: "/birim",
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1063,10 +1062,6 @@ const bumpkinSkillsDescription: Record<BumpkinSkillsDescription, string> = {
 };
 
 const bumpkinTrade: Record<BumpkinTrade, string> = {
-  "bumpkinTrade.askPrice": "Fiyat sorma",
-  "bumpkinTrade.listingPurchased": "Tebrikler, ilanınız satın alındı!",
-  "bumpkinTrade.travelPlaza":
-    "Oyuncuların sizinle ticaret yapabilmesi için plazaya gidin",
   "bumpkinTrade.minLevel": "Ticaret yapmak için 10. seviyede olmanız gerekir",
   "bumpkinTrade.noTradeListed": "Listelenen herhangi bir işleminiz yok.",
   "bumpkinTrade.sell": "Kaynaklarınızı SFL için diğer oyunculara satın.",
@@ -1083,6 +1078,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.cancel": "İptal",
   "bumpkinTrade.list": "Listele",
   "bumpkinTrade.maxListings": "Maksimum listelemeye ulaşıldı",
+  "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.price/unit": "{{price}}/birim",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1072,14 +1072,15 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.quantity": "Miktar",
   "bumpkinTrade.price": "Fiyat",
   "bumpkinTrade.listingPrice": "Listeleme fiyatı",
-  "bumpkinTrade.pricePerUnit": "Ürün başına fiyat",
+  "bumpkinTrade.pricePerUnit": ENGLISH_TERMS["bumpkinTrade.pricePerUnit"],
   "bumpkinTrade.tradingFee": "Takas ücreti",
   "bumpkinTrade.youWillReceive": "Alacağın miktar",
   "bumpkinTrade.cancel": "İptal",
   "bumpkinTrade.list": "Listele",
   "bumpkinTrade.maxListings": "Maksimum listelemeye ulaşıldı",
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
-  "bumpkinTrade.price/unit": "{{price}}/birim",
+  "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
+  "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -763,13 +763,14 @@ export type BumpkinTrade =
   | "bumpkinTrade.listingPrice"
   | "bumpkinTrade.listingPrice"
   | "bumpkinTrade.pricePerUnit"
+  | "bumpkinTrade.price/unit"
   | "bumpkinTrade.tradingFee"
   | "bumpkinTrade.youWillReceive"
   | "bumpkinTrade.cancel"
   | "bumpkinTrade.list"
   | "bumpkinTrade.maxListings"
-  | "bumpkinTrade.price/unit"
-  | "bumpkinTrade.max";
+  | "bumpkinTrade.max"
+  | "bumpkinTrade.floorPrice";
 
 export type GoblinTrade =
   | "goblinTrade.select"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -298,8 +298,7 @@ export type GeneralTerms =
   | "new.species"
   | "buildings"
   | "boosts"
-  | "decorations"
-  | "unit";
+  | "decorations";
 
 export type TimeUnits =
   // Singular
@@ -752,9 +751,6 @@ export type BumpkinSkillsDescription =
   | "description.buckaroo";
 
 export type BumpkinTrade =
-  | "bumpkinTrade.askPrice"
-  | "bumpkinTrade.listingPurchased"
-  | "bumpkinTrade.travelPlaza"
   | "bumpkinTrade.minLevel"
   | "bumpkinTrade.noTradeListed"
   | "bumpkinTrade.sell"
@@ -771,7 +767,9 @@ export type BumpkinTrade =
   | "bumpkinTrade.youWillReceive"
   | "bumpkinTrade.cancel"
   | "bumpkinTrade.list"
-  | "bumpkinTrade.maxListings";
+  | "bumpkinTrade.maxListings"
+  | "bumpkinTrade.price/unit"
+  | "bumpkinTrade.max";
 
 export type GoblinTrade =
   | "goblinTrade.select"


### PR DESCRIPTION
# Description

**Bug Fix**
- Fixed an issue that prevents user from deleting quantity field all the way to 0

**QOL**
- When Quantity = 0, turns the text red
- When Quantity = 0, List button is disabled
- When Quantity = 0, Price Per Unit = 0.0000 SFL
- When user enters this screen, both input fields are set to 0 by default
- Added Floor Price info in list screen
- If price/unit < floor price, label is red (signifying they're below the floor)
- if Price/unit > floor price, label is green (signifying that they're above the floor)

default
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f3f41474-150d-441b-9de3-1da7a6bc2210)

Price/unit<Floor Price
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/a6c4b32b-977e-4cd4-917d-4c9f799ebcbe)

Price/unit>Floor Price
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/2ffac75d-b214-48a2-8d6b-10ecf0cc3f43)

Mobile:
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/119d5254-c97f-4173-b2f5-1bfda21ae4e6)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Going into input tab and delete all the way

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
