### PR TITLE
[FIX] Auction Leaderboard formatting issues

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctionLeaderboardTable.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionLeaderboardTable.tsx
@@ -33,18 +33,21 @@ export const AuctionLeaderboardTable: React.FC<{
           <thead>
             <tr>
               <th
-                style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 w-[20%]"
+                style={{ border: "1px solid #b96f50", textAlign: "left" }}
+                className="p-1.5 w-1/5"
               >
                 <p>{t("rank")}</p>
               </th>
               <th
-                style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 w-1/5"
+                style={{ border: "1px solid #b96f50", textAlign: "left" }}
+                className="p-1.5"
               >
                 <p>{t("farm")}</p>
               </th>
-              <th style={{ border: "1px solid #b96f50" }} className="p-1.5">
+              <th
+                style={{ border: "1px solid #b96f50", textAlign: "left" }}
+                className="p-1.5 w-2/5"
+              >
                 <p>{t("bid")}</p>
               </th>
             </tr>
@@ -63,19 +66,19 @@ export const AuctionLeaderboardTable: React.FC<{
             >
               <td
                 style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 w-[20%] relative"
+                className="p-1.5 w-1/5 relative"
               >
                 {toOrdinalSuffix(result.rank)}
               </td>
               <td
                 style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 w-1/5"
+                className="p-1.5 flex flex-wrap"
               >
                 {result.farmId}
               </td>
               <td
                 style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 flex flex-wrap"
+                className="p-1.5 w-2/5"
               >
                 {result.sfl > 0 && (
                   <div className="flex w-16">


### PR DESCRIPTION
# Description

In the auction leaderboard, the farm ID column is too narrow to fit the 16 digit farm IDs, meanwhile the bid column on the right doesn't need to be that long since it shows a small number.

Updated the Bid column to be 2/5 of the width of the table and the farm ID column to adjust to the remaining size of the bid and rank column
Also aligned the text to the left for consistency

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/40caa838-9b62-45b9-a8ef-d8a65f357ae9)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/af68adb4-0688-40b4-b92e-73f844f624ae)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
