### PR TITLE
[FIX] Allow tywin to accept old sfl deliveries

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -79,13 +79,43 @@ describe("deliver", () => {
     ).toThrow("Insufficient ingredient: Sunflower");
   });
 
-  // SFL will be a potential requirement for quests
+  // SFL will be a potential requirement for quests (Legacy)
   it("requires player has the sfl", () => {
     expect(() =>
       deliverOrder({
         state: {
           ...TEST_FARM,
           balance: new Decimal(0),
+          delivery: {
+            ...TEST_FARM.delivery,
+            orders: [
+              {
+                id: "123",
+                createdAt: 0,
+                readyAt: Date.now(),
+                from: "tywin",
+                items: {
+                  sfl: 10,
+                },
+                reward: { tickets: 100 },
+              },
+            ],
+          },
+        },
+        action: {
+          id: "123",
+          type: "order.delivered",
+        },
+      })
+    ).toThrow("Insufficient ingredient: sfl");
+  });
+
+  it("requires player has the coins", () => {
+    expect(() =>
+      deliverOrder({
+        state: {
+          ...TEST_FARM,
+          coins: 0,
           delivery: {
             ...TEST_FARM.delivery,
             orders: [
@@ -106,10 +136,39 @@ describe("deliver", () => {
           id: "123",
           type: "order.delivered",
         },
-        // 1693526400000 = Friday, September 1, 2023 12:00:00 AM GMT
-        createdAt: 1693526400000,
       })
     ).toThrow("Insufficient ingredient: coins");
+  });
+
+  it("takes sfl from player is required in delivery", () => {
+    const balance = new Decimal(100);
+    const game = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        balance,
+        delivery: {
+          ...TEST_FARM.delivery,
+          orders: [
+            {
+              id: "123",
+              createdAt: 0,
+              readyAt: Date.now(),
+              from: "tywin",
+              items: {
+                sfl: 50,
+              },
+              reward: { tickets: 100 },
+            },
+          ],
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+    });
+
+    expect(game.balance).toEqual(balance.sub(50));
   });
 
   it("rewards sfl", () => {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -192,6 +192,8 @@ export function deliverOrder({
       if (sfl.lessThan(amount)) {
         throw new Error(`Insufficient ingredient: ${name}`);
       }
+
+      game.balance = sfl.sub(amount);
     } else {
       const count = game.inventory[name] || new Decimal(0);
       const amount = order.items[name] || new Decimal(0);


### PR DESCRIPTION
# Description

This PR fixes a bug where Tywin was unable to accept old SFL deliveries.

<img width="507" alt="Screenshot 2024-04-03 at 4 59 20 PM" src="https://github.com/sunflower-land/sunflower-land-api/assets/17863697/f39a7f51-3a0a-442a-8df1-e7f696aed206">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
