### PR TITLE
[FIX] Bud box not opening in certain timezones

### DIFF
--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -238,7 +238,7 @@ function getOrdinalSuffix(day: number): string {
  * @returns Day of the calendar year eg: 182
  */
 export function getDayOfYear(date: Date): number {
-  const startOfYear = new Date(date.getFullYear(), 0, 0);
+  const startOfYear = new Date(Date.UTC(date.getUTCFullYear(), 0, 0));
   const diff = date.getTime() - startOfYear.getTime();
   const oneDay = 1000 * 60 * 60 * 24;
   return Math.floor(diff / oneDay);


### PR DESCRIPTION
# Description

Fixes a bug opening the Bud Box in certain timezones

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```sh
 TZ='Australia/Sydney' node -e 'console.log(new Date(Date.UTC(new Date().getUTCFullYear(), 0, 0)).getTime())'
 
 TZ='Etc/UTC' node -e 'console.log(new Date(Date.UTC(new Date().getUTCFullYear(), 0, 0)).getTime())'
```

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
