### PR TITLE
[FIX] Remove extra decimal places due to rounding errors for coin requirements

### DIFF
--- a/src/components/ui/RequirementsLabel.tsx
+++ b/src/components/ui/RequirementsLabel.tsx
@@ -168,7 +168,7 @@ export const RequirementLabel: React.FC<Props> = (props) => {
     switch (props.type) {
       case "coins":
       case "sellForCoins":
-        return `${props.requirement}`;
+        return `${setPrecision(new Decimal(props.requirement))}`;
       case "sfl":
         return `${props.requirement.toNumber()}`;
       case "sellForSfl": {


### PR DESCRIPTION
# Description

- Fix rounding errors leading to a lot of decimal places for sell for coin requirements

Before|After
---|---
<img width="286" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/2c5077fd-1ba4-472c-aa81-c282bfaf8d1e">|<img width="284" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/7dce8aa3-98c8-43c0-9e41-1e350e8e4c8c">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open crop shop with legacy skill that boosts crop sell value

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
