### PR TITLE
[FIX] Add missing woodlands teleport to map

### DIFF
--- a/src/features/island/hud/components/deliveries/WorldMap.tsx
+++ b/src/features/island/hud/components/deliveries/WorldMap.tsx
@@ -1,7 +1,5 @@
 import React, { useContext, useEffect } from "react";
 
-import * as Auth from "features/auth/lib/Provider";
-
 import worldMap from "assets/map/world_map.png";
 
 import { Context } from "features/game/GameProvider";
@@ -10,8 +8,9 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { useNavigate } from "react-router-dom";
 import { OuterPanel } from "components/ui/Panel";
 
+const showDebugBorders = false;
+
 export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
-  const { authService } = useContext(Auth.Context);
   const { gameService } = useContext(Context);
   const { t } = useAppTranslation();
 
@@ -35,6 +34,7 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         style={{
           width: "27%",
           height: "34%",
+          border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: 0,
           bottom: 0,
@@ -61,11 +61,12 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         style={{
           width: "18%",
           height: "24%",
+          border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "35%",
           bottom: "20%",
         }}
-        className="flex justify-center items-center  cursor-pointer"
+        className="flex justify-center items-center cursor-pointer"
         onClick={() => {
           navigate("/world/plaza");
           onClose();
@@ -86,12 +87,13 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       <div
         style={{
           width: "12%",
-          height: "34%",
+          height: "38%",
+          border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "22%",
-          bottom: "25%",
+          bottom: "27%",
         }}
-        className="flex justify-center items-start md:items-center  cursor-pointer"
+        className="flex justify-center items-center cursor-pointer"
         onClick={() => {
           navigate("/world/beach");
           onClose();
@@ -109,14 +111,46 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         </span>
       </div>
 
+      <div
+        style={{
+          width: "15%",
+          height: "15%",
+          border: showDebugBorders ? "2px solid red" : "",
+          position: "absolute",
+          right: "34%",
+          bottom: "33%",
+        }}
+        className="flex justify-center items-center cursor-pointer"
+        onClick={() => {
+          navigate("/world/woodlands");
+          onClose();
+        }}
+      >
+        <span
+          className="text-xs sm:text-sm"
+          style={
+            {
+              "-webkit-text-stroke": "1px black",
+            } as any
+          }
+        >
+          {t("world.woodlands")}
+        </span>
+      </div>
+
       {/* <div
         style={{
           width: "18%",
           height: "24%",
-          border: "1px solid red",
+          border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "35%",
           bottom: "50%",
+        }}
+        className="flex justify-center items-center cursor-pointer"
+        onClick={() => {
+          navigate("...");
+          onClose();
         }}
         >
         <span
@@ -136,12 +170,12 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         style={{
           width: "35%",
           height: "34%",
-          // border: "1px solid red",
+          border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           right: "0%",
           bottom: "0%",
         }}
-        className="flex justify-center  cursor-pointer"
+        className="flex justify-center items-center cursor-pointer"
         onClick={() => {
           navigate("/world/retreat");
           onClose();

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -25,7 +25,7 @@ export const SPAWNS: () => SpawnLocation = () => ({
     },
 
     woodlands: {
-      x: 867,
+      x: 850,
       y: 142,
     },
     beach: {
@@ -47,7 +47,7 @@ export const SPAWNS: () => SpawnLocation = () => ({
   },
   beach: {
     default: {
-      x: 438,
+      x: 450,
       y: 652,
     },
   },
@@ -78,7 +78,7 @@ export const SPAWNS: () => SpawnLocation = () => ({
   },
   woodlands: {
     default: {
-      x: 10,
+      x: 30,
       y: 290,
     },
   },

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4592,6 +4592,7 @@ const world: Record<World, string> = {
     "No harrasment, swearing or bullying. Thank you for respecting others.",
   "world.plaza": "Plaza",
   "world.beach": "Beach",
+  "world.woodlands": "Woodlands",
   "world.retreat": "Retreat",
   "world.home": "Home",
   "world.kingdom": "Kingdom",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4762,6 +4762,7 @@ const world: Record<World, string> = {
   "world.plaza": ENGLISH_TERMS["world.plaza"],
   "world.beach": ENGLISH_TERMS["world.beach"],
   "world.retreat": ENGLISH_TERMS["world.retreat"],
+  "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
 };

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4617,6 +4617,7 @@ const world: Record<World, string> = {
   "world.plaza": ENGLISH_TERMS["world.plaza"],
   "world.beach": ENGLISH_TERMS["world.beach"],
   "world.retreat": ENGLISH_TERMS["world.retreat"],
+  "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
 };

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4610,6 +4610,7 @@ const world: Record<World, string> = {
   "world.plaza": ENGLISH_TERMS["world.plaza"],
   "world.beach": ENGLISH_TERMS["world.beach"],
   "world.retreat": ENGLISH_TERMS["world.retreat"],
+  "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
 };

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3104,6 +3104,7 @@ export type World =
   | "world.plaza"
   | "world.beach"
   | "world.retreat"
+  | "world.woodlands"
   | "world.home"
   | "world.kingdom";
 


### PR DESCRIPTION
# Description

- add woodlands to map teleport location
- add debug flag in code to turn on map teleport location to troubleshoot div locations
- move spawn points further away from map borders

Before|After
---|---
<img width="578" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/66325bcd-180c-4ff3-870d-9c377c2a97f9">|<img width="580" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/59d298c4-b2cd-4a16-9e73-f48b92f90985">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open world map and clicking different teleport options

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
