### PR TITLE
[FIX] Grey overlay when clicking Auctioneer NPC

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
@@ -86,7 +86,7 @@ export const AuctioneerModal: React.FC<Props> = ({
     <Modal show={isOpen} onHide={closeModal}>
       <CloseButtonPanel
         onClose={onClose}
-        tabs={[{ icon: SUNNYSIDE.icons.stopwatch, name: "Auctions & Drops" }]}
+        tabs={[{ icon: SUNNYSIDE.icons.stopwatch, name: t("auction.title") }]}
         bumpkinParts={NPC_WEARABLES["hammerin harry"]}
         secondaryAction={
           <a

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -16,7 +16,7 @@ export const AuctionHouseModal: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const {
-    context: { state, farmId, linkedWallet },
+    context: { state, linkedWallet },
   } = gameState;
 
   return (

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -66,11 +66,13 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
     setNpc(undefined);
   };
 
+  const isSeparateModal = npc === "Chun Long" || npc === "hammerin harry";
+
   return (
     <>
       <Modal
         // dialogClassName="npc-dialog"
-        show={!!npc}
+        show={!!npc && !isSeparateModal}
         onHide={closeModal}
       >
         {npc === "flopsy" && (

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -607,7 +607,7 @@ const addSFL: Record<AddSFL, string> = {
 };
 
 const auction: Record<Auction, string> = {
-  "auction.title": "Auctions & Drops",
+  "auction.title": ENGLISH_TERMS["auction.title"],
   "auction.bid.message": "Vous avez placé votre enchère.",
   "auction.reveal": "Révéler les gagnants",
   "auction.live": "L'enchère est en cours!",


### PR DESCRIPTION
# Description

- localize auctioneer modal title
- fix grey overlay for auctioneer modal when clicking NPC

Before|After
---|---
<img width="409" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/56d3eb23-3b9e-4a34-a3cd-b47943b03aa1">|<img width="397" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/d3984188-dd19-49d4-960c-6c0093e550bd">
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click Auctioneer NPC when player walks close enough to the NPC

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
