### PR TITLE
[FIX] Page collection layout icons get squished for smaller screens

### DIFF
--- a/src/features/world/ui/PageFound.tsx
+++ b/src/features/world/ui/PageFound.tsx
@@ -9,6 +9,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { getSeasonWeek } from "lib/utils/getSeasonWeek";
 import React, { useContext } from "react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SquareIcon } from "components/ui/SquareIcon";
 
 interface Props {
   onClose: () => void;
@@ -28,12 +29,13 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
   if (!springBlossom) {
     return (
       <CloseButtonPanel onClose={onClose} title={t("pageFounds.title")}>
-        <div className="flex flex-col items-center w-full">
-          <span>
-            {t("pageFounds.gardeningBookPage")}
-            {","}
-          </span>
-          <img src="world/page.png" style={{ width: PIXEL_SCALE * 16 * 2 }} />
+        <div className="flex flex-col p-2 items-center w-full">
+          <span>{t("pageFounds.gardeningBookPage")}</span>
+          <img
+            className="my-4"
+            src="world/page.png"
+            style={{ width: PIXEL_SCALE * 16 }}
+          />
         </div>
       </CloseButtonPanel>
     );
@@ -42,7 +44,7 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
   if (springBlossom.collectedFlowerPages.length >= 3) {
     return (
       <CloseButtonPanel onClose={onClose} title={t("pageFounds.title")}>
-        <div className="flex flex-col w-full items-center justify-center gap-2">
+        <div className="flex flex-col w-full p-2 items-center justify-center gap-3">
           <span className="text-sm w-full">
             {t("pageFounds.lastPageFound")}
           </span>
@@ -54,12 +56,10 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
                 width: `${PIXEL_SCALE * 12}px`,
               }}
             >
-              <img
-                src={ITEM_DETAILS[springBlossom.weeklyFlower].image}
-                style={{
-                  width: `${PIXEL_SCALE * 9}px`,
-                }}
+              <SquareIcon
+                icon={ITEM_DETAILS[springBlossom.weeklyFlower].image}
                 className="mr-2"
+                width={9}
               />
             </div>
             <span className="text-sm">
@@ -75,18 +75,20 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
                 width: `${PIXEL_SCALE * 12}px`,
               }}
             >
-              <img
-                src={SUNNYSIDE.icons.search}
-                style={{
-                  width: `${PIXEL_SCALE * 12}px`,
-                }}
+              <SquareIcon
+                icon={SUNNYSIDE.icons.search}
+                width={9}
                 className="mr-2"
               />
             </div>
             <span className="text-sm">{t("pageFounds.checkCodex")}</span>
           </div>
 
-          <img src="world/page.png" style={{ width: PIXEL_SCALE * 16 * 2 }} />
+          <img
+            className="my-4"
+            src="world/page.png"
+            style={{ width: PIXEL_SCALE * 16 }}
+          />
 
           <Label type="success">{t("pageFounds.all")}</Label>
         </div>
@@ -96,16 +98,21 @@ export const PageFound: React.FC<Props> = ({ onClose }) => {
 
   return (
     <CloseButtonPanel onClose={onClose} title={t("pageFounds.title")}>
-      <div className="flex flex-col w-full items-center">
+      <div className="flex flex-col w-full p-2 items-center">
         <span className="text-sm">
           {t("pageFounds.pageContainsInfo")} {springBlossom.weeklyFlower}
           {"!"}
         </span>
-        <img src="world/page.png" style={{ width: PIXEL_SCALE * 16 * 2 }} />
 
-        <Label type="info" className="mt-2">
-          {t("pageFounds")} {springBlossom.collectedFlowerPages.length}
-          {"/3"}
+        <img
+          className="my-4"
+          src="world/page.png"
+          style={{ width: PIXEL_SCALE * 16 }}
+        />
+
+        <Label type="info">
+          {t("pageFounds")} {2}
+          {" / 3"}
         </Label>
       </div>
     </CloseButtonPanel>


### PR DESCRIPTION
# Description

- improve page collection modal layout
- fix issue where icons get squished for smaller screens for the modal

Before|After
---|---
<img width="279" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/16437928-7348-4e46-b7d1-37afea8dc70e">|<img width="278" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/e9b90b0b-b3f8-407a-b346-c31a5bf2c0bf">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- collect pages for discovering new flower species

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
