### PR TITLE
[FIX] Fisherman clickable area overlaps partially with land

### DIFF
--- a/src/features/island/fisherman/Fisherman.tsx
+++ b/src/features/island/fisherman/Fisherman.tsx
@@ -27,17 +27,17 @@ export const Fisherman: React.FC = () => {
 
   const wharfCoords = () => {
     if (expansionCount < 7) {
-      return { x: -1, y: -3.5 };
+      return { x: -1, y: -3 };
     }
     if (expansionCount >= 7 && expansionCount < 21) {
-      return { x: -8, y: -9.5 };
+      return { x: -8, y: -9 };
     } else {
-      return { x: -14, y: -15.5 };
+      return { x: -14, y: -15 };
     }
   };
 
   const cast = (bait: FishingBait, chum?: InventoryItemName) => {
-    const state = gameService.send("rod.casted", {
+    gameService.send("rod.casted", {
       bait,
       chum,
       location: "wharf",
@@ -47,38 +47,39 @@ export const Fisherman: React.FC = () => {
   };
 
   return (
-    <div className={classNames({ "pointer-events-none": isVisiting })}>
+    <>
+      <div className={classNames({ "pointer-events-none": isVisiting })}>
+        <MapPlacement
+          x={wharfCoords().x}
+          y={wharfCoords().y}
+          width={3}
+          height={3}
+        >
+          <FishermanNPC onClick={() => setShowModal(true)} />
+
+          <img
+            src={bubbles}
+            className="absolute z-0 skew-animation pointer-events-none"
+            style={{
+              width: `${37 * PIXEL_SCALE}px`,
+              right: `${-6 * PIXEL_SCALE}px`,
+              bottom: `${-7 * PIXEL_SCALE}px`,
+            }}
+          />
+          <img
+            src={fishSilhoutte}
+            className="absolute z-0 fish-swimming pointer-events-none"
+            style={{
+              width: `${11 * PIXEL_SCALE}px`,
+              right: `${0 * PIXEL_SCALE}px`,
+              bottom: `${-20 * PIXEL_SCALE}px`,
+            }}
+          />
+        </MapPlacement>
+      </div>
       <Modal show={showModal} onHide={() => setShowModal(false)}>
         <FishermanModal onCast={cast} onClose={() => setShowModal(false)} />
       </Modal>
-
-      <MapPlacement
-        x={wharfCoords().x}
-        y={wharfCoords().y}
-        width={3}
-        height={3}
-      >
-        <FishermanNPC onClick={() => setShowModal(true)} />
-
-        <img
-          src={bubbles}
-          className="absolute z-0 skew-animation cursor-pointer"
-          style={{
-            width: `${37 * PIXEL_SCALE}px`,
-            right: `${-6 * PIXEL_SCALE}px`,
-            bottom: `${-6 * PIXEL_SCALE}px`,
-          }}
-        />
-        <img
-          src={fishSilhoutte}
-          className="absolute z-0 fish-swimming"
-          style={{
-            width: `${11 * PIXEL_SCALE}px`,
-            right: `${0 * PIXEL_SCALE}px`,
-            bottom: `${-20 * PIXEL_SCALE}px`,
-          }}
-        />
-      </MapPlacement>
-    </div>
+    </>
   );
 };

--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -257,8 +257,8 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
               src={SUNNYSIDE.icons.fish_icon}
               style={{
                 width: `${PIXEL_SCALE * 18}px`,
-                right: `${PIXEL_SCALE * 2}px`,
-                top: `${PIXEL_SCALE * 10}px`,
+                right: `${PIXEL_SCALE * 1}px`,
+                top: `${PIXEL_SCALE * 9}px`,
               }}
             />
 
@@ -267,8 +267,8 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
               src={lockIcon}
               style={{
                 width: `${PIXEL_SCALE * 12}px`,
-                right: `${PIXEL_SCALE * 12}px`,
-                top: `${PIXEL_SCALE * 12}px`,
+                right: `${PIXEL_SCALE * 10}px`,
+                top: `${PIXEL_SCALE * 7}px`,
               }}
             />
           </>

--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useSelector } from "@xstate/react";
-import classNames from "classnames";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import reel from "assets/ui/reel.png";
@@ -29,6 +28,7 @@ import { getBumpkinLevel } from "features/game/lib/level";
 import { Label } from "components/ui/Label";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import classNames from "classnames";
 
 type SpriteFrames = { startAt: number; endAt: number };
 
@@ -224,13 +224,143 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
     setShowCaughtModal(false);
   };
 
-  const totalFishCaught = getKeys(FISH).reduce(
-    (total, name) => total + (farmActivity[`${name} Caught`] ?? 0),
-    0
-  );
+  const handleClick = () => {
+    if (!canFish) {
+      setShowLockedModal(true);
+      return;
+    }
+
+    if (showReelLabel) {
+      reelIn();
+      return;
+    }
+
+    if (fishing.wharf.castedAt) {
+      return;
+    }
+
+    onClick();
+  };
 
   return (
     <>
+      <div
+        className={classNames("absolute w-full h-full", {
+          "cursor-pointer hover:img-highlight": !fishing.wharf.castedAt,
+        })}
+        onClick={handleClick}
+      >
+        {!canFish && (
+          <>
+            <img
+              className="absolute pointer-events-none z-50"
+              src={SUNNYSIDE.icons.fish_icon}
+              style={{
+                width: `${PIXEL_SCALE * 18}px`,
+                right: `${PIXEL_SCALE * 2}px`,
+                top: `${PIXEL_SCALE * 10}px`,
+              }}
+            />
+
+            <img
+              className="absolute pointer-events-none z-50"
+              src={lockIcon}
+              style={{
+                width: `${PIXEL_SCALE * 12}px`,
+                right: `${PIXEL_SCALE * 12}px`,
+                top: `${PIXEL_SCALE * 12}px`,
+              }}
+            />
+          </>
+        )}
+
+        {!showReelLabel && showFishFrenzy && canFish && (
+          <img
+            src={lightning}
+            style={{
+              width: `${PIXEL_SCALE * 8}px`,
+              left: `${PIXEL_SCALE * 5}px`,
+              top: `${PIXEL_SCALE * -17}px`,
+
+              imageRendering: "pixelated",
+            }}
+            className="absolute pointer-events-none"
+          />
+        )}
+
+        {showReelLabel && (
+          <React.Fragment>
+            <img
+              src={SUNNYSIDE.icons.expression_alerted}
+              style={{
+                width: `${PIXEL_SCALE * 4}px`,
+                left: `${PIXEL_SCALE * 7}px`,
+                top: `${PIXEL_SCALE * -15}px`,
+
+                imageRendering: "pixelated",
+              }}
+              className="absolute"
+            />
+            <img
+              src={reel}
+              style={{
+                width: `${PIXEL_SCALE * 39}px`,
+                left: `${PIXEL_SCALE * 16}px`,
+                top: `${PIXEL_SCALE * 36}px`,
+
+                imageRendering: "pixelated",
+              }}
+              className="absolute z-10 cursor-pointer"
+            />
+          </React.Fragment>
+        )}
+
+        {canFish && (
+          <Spritesheet
+            className="absolute z-50 pointer-events-none"
+            style={{
+              width: `${PIXEL_SCALE * 58}px`,
+              left: `${PIXEL_SCALE * -10}px`,
+              top: `${PIXEL_SCALE * -14}px`,
+
+              imageRendering: "pixelated",
+            }}
+            getInstance={(spritesheet) => {
+              spriteRef.current = spritesheet;
+            }}
+            image={SUNNYSIDE.npcs.fishing_sheet}
+            widthFrame={58}
+            heightFrame={50}
+            zoomScale={scale}
+            fps={14}
+            steps={56}
+            startAt={FISHING_FRAMES[initialState].startAt}
+            endAt={FISHING_FRAMES[initialState].endAt}
+            direction={`forward`}
+            autoplay
+            loop
+            onEnterFrame={[
+              {
+                frame: FISHING_FRAMES.idle.endAt - 1,
+                callback: onIdleFinish,
+              },
+              {
+                frame: FISHING_FRAMES.casting.endAt - 1,
+                callback: onCastFinish,
+              },
+              {
+                frame: FISHING_FRAMES.waiting.endAt - 1,
+                callback: onWaitFinish,
+              },
+              {
+                frame: FISHING_FRAMES.caught.endAt - 1,
+                callback: onCaughtFinish,
+              },
+            ]}
+          />
+        )}
+      </div>
+
       <Modal show={showLockedModal} onHide={() => setShowLockedModal(false)}>
         <CloseButtonPanel onClose={() => setShowLockedModal(false)}>
           <div className="flex flex-col items-center">
@@ -244,30 +374,6 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
           </div>
         </CloseButtonPanel>
       </Modal>
-      {!canFish && (
-        <>
-          <img
-            className="absolute cursor-pointer group-hover:img-highlight z-50"
-            src={SUNNYSIDE.icons.fish_icon}
-            onClick={() => setShowLockedModal(true)}
-            style={{
-              width: `${PIXEL_SCALE * 18}px`,
-              right: `${PIXEL_SCALE * 2}px`,
-              top: `${PIXEL_SCALE * 16}px`,
-            }}
-          />
-
-          <img
-            className="absolute pointer-events-none group-hover:img-highlight z-50"
-            src={lockIcon}
-            style={{
-              width: `${PIXEL_SCALE * 8}px`,
-              right: `${PIXEL_SCALE * 12}px`,
-              top: `${PIXEL_SCALE * 16}px`,
-            }}
-          />
-        </>
-      )}
 
       <Modal show={showCaughtModal} onHide={close} onExited={claim}>
         <CloseButtonPanel
@@ -292,100 +398,6 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
           />
         </Panel>
       </Modal>
-
-      {!showReelLabel && showFishFrenzy && canFish && (
-        <img
-          src={lightning}
-          style={{
-            width: `${PIXEL_SCALE * 8}px`,
-            left: `${PIXEL_SCALE * 5}px`,
-            top: `${PIXEL_SCALE * -17}px`,
-
-            imageRendering: "pixelated",
-          }}
-          className="absolute"
-        />
-      )}
-
-      {showReelLabel && (
-        <React.Fragment>
-          <img
-            src={SUNNYSIDE.icons.expression_alerted}
-            style={{
-              width: `${PIXEL_SCALE * 4}px`,
-              left: `${PIXEL_SCALE * 7}px`,
-              top: `${PIXEL_SCALE * -15}px`,
-
-              imageRendering: "pixelated",
-            }}
-            className="absolute"
-          />
-          <img
-            src={reel}
-            onClick={reelIn}
-            style={{
-              width: `${PIXEL_SCALE * 39}px`,
-              left: `${PIXEL_SCALE * 16}px`,
-              top: `${PIXEL_SCALE * 36}px`,
-
-              imageRendering: "pixelated",
-            }}
-            className="absolute z-10 cursor-pointer"
-          />
-        </React.Fragment>
-      )}
-      {canFish && (
-        <Spritesheet
-          className={classNames("absolute  z-50", {
-            "hover:img-highlight cursor-pointer": !fishing.wharf.castedAt,
-          })}
-          style={{
-            width: `${PIXEL_SCALE * 58}px`,
-            left: `${PIXEL_SCALE * -10}px`,
-            top: `${PIXEL_SCALE * -14}px`,
-
-            imageRendering: "pixelated",
-          }}
-          onClick={() => {
-            if (fishing.wharf.castedAt) {
-              return;
-            }
-            onClick();
-          }}
-          getInstance={(spritesheet) => {
-            spriteRef.current = spritesheet;
-          }}
-          image={SUNNYSIDE.npcs.fishing_sheet}
-          widthFrame={58}
-          heightFrame={50}
-          zoomScale={scale}
-          fps={14}
-          steps={56}
-          startAt={FISHING_FRAMES[initialState].startAt}
-          endAt={FISHING_FRAMES[initialState].endAt}
-          direction={`forward`}
-          autoplay
-          loop
-          onEnterFrame={[
-            {
-              frame: FISHING_FRAMES.idle.endAt - 1,
-              callback: onIdleFinish,
-            },
-            {
-              frame: FISHING_FRAMES.casting.endAt - 1,
-              callback: onCastFinish,
-            },
-            {
-              frame: FISHING_FRAMES.waiting.endAt - 1,
-              callback: onWaitFinish,
-            },
-            {
-              frame: FISHING_FRAMES.caught.endAt - 1,
-              callback: onCaughtFinish,
-            },
-          ]}
-        />
-      )}
     </>
   );
 };


### PR DESCRIPTION
# Description

- fix issue where fisherman is overlapping with some land area.  E.g. when trying to harvest crops at the bottom of the island, players might misclick the fisherman
- make the whole 3x3 area clickable for the fisherman

<img width="315" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/19a35e95-4db9-4e50-82a3-4a1e93e30062">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try fishing

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes