### PR TITLE
[CHORE] Fix typo in API Docs

### DIFF
--- a/docs/OFFCHAIN_API.md
+++ b/docs/OFFCHAIN_API.md
@@ -63,7 +63,7 @@ Query current offchain state for one farm.
 ### URL:
 
 ```
-GET https://api.sunflower-land.com/community/farm/{id}
+GET https://api.sunflower-land.com/community/farms/{id}
 ```
 
 ### Response Body:


### PR DESCRIPTION
[skip ci]

# Description

Fix Query URL typo error at docs\OFFCHAIN_API.md under ["Get a Farm"](https://github.com/sunflower-land/sunflower-land/blob/main/docs/OFFCHAIN_API.md#url-1) from
```
GET https://api.sunflower-land.com/community/farm/{id}
```
to
```
GET https://api.sunflower-land.com/community/farms/{id}
```
Typo error introduced with commit https://github.com/sunflower-land/sunflower-land/commit/3ee61c8cb49826dcf22feba2c9fa754697d7fe65.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No test was performed.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
