### PR TITLE
[FIX] Allow closing the trading board modal

### DIFF
--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -578,6 +578,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
       <Modal
         show={interactable === "trading_board"}
         dialogClassName="md:max-w-3xl"
+        onHide={closeModal}
       >
         <TradingBoard onClose={closeModal} />
       </Modal>


### PR DESCRIPTION
# Description

Allow closing the trading board modal by clicking outside of the board.

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

* Open the trading board and close it by clicking outside of the board.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
