### PR TITLE
[FEAT] Increase hoarder limits for Earthworm and Grub

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -168,8 +168,8 @@ export const maxItems: Inventory = {
   "Rapid Root": new Decimal(500),
 
   // Bait
-  Earthworm: new Decimal(100),
-  Grub: new Decimal(100),
+  Earthworm: new Decimal(200),
+  Grub: new Decimal(150),
   "Red Wiggler": new Decimal(100),
   "Fishing Lure": new Decimal(100),
 


### PR DESCRIPTION
# Description

Updates front-end to increase hoarder limits for Earthworm and Grub

Values provided by Dcol

## Type of change

- [x] New feature (non-breaking change which adds functionality)
