### PR TITLE
[FIX] Remove Weak Bumpkin Warning

### DIFF
--- a/src/features/game/components/bank/components/WithdrawBumpkin.tsx
+++ b/src/features/game/components/bank/components/WithdrawBumpkin.tsx
@@ -14,13 +14,17 @@ import { BASIC_WEARABLES } from "features/game/types/stylist";
 import { isCurrentObsession } from "./WithdrawWearables";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Context } from "features/game/GameProvider";
+import { formatDateTime } from "lib/utils/time";
 
+const WITHDRAWAL_CLOSE_DATE = new Date("2024-05-01T00:00:00Z");
 interface Props {
   onWithdraw: () => void;
 }
 export const WithdrawBumpkin: React.FC<Props> = ({ onWithdraw }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
+
+  const isClosed = new Date() > WITHDRAWAL_CLOSE_DATE;
 
   const bumpkin = gameState.context.state.bumpkin!;
   const { equipped } = bumpkin;
@@ -57,11 +61,43 @@ export const WithdrawBumpkin: React.FC<Props> = ({ onWithdraw }) => {
     );
   };
 
+  if (isClosed) {
+    return (
+      <div className="p-2">
+        <div className="flex flex-col border-2 rounded-md border-black p-2 bg-red-background mb-3 text-xs">
+          <span>{t("withdraw.bumpkin.closed")}</span>
+          <a
+            className="underline text-xxs pb-1 pt-0.5 hover:text-blue-500"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://docs.sunflower-land.com/player-guides/island-upgrade#bumpkin-migration"
+          >
+            {t("read.more")}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="p-2">
-        <div className="flex items-center border-2 rounded-md border-black p-2 bg-green-background mb-3">
-          <span className="text-xs">{t("withdraw.bumpkin.play")}</span>
+        <div className="flex flex-col border-2 rounded-md border-black p-2 bg-red-background mb-3 text-xs">
+          <span>
+            {t("withdraw.bumpkin.closing", {
+              timeRemaining: formatDateTime(
+                WITHDRAWAL_CLOSE_DATE.toISOString()
+              ),
+            })}
+          </span>
+          <a
+            className="underline text-xxs pb-1 pt-0.5 hover:text-blue-500"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://docs.sunflower-land.com/player-guides/island-upgrade#bumpkin-migration"
+          >
+            {t("read.more")}
+          </a>
         </div>
         {getText()}
         <div className="flex justify-center items-center mb-4">

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -79,8 +79,6 @@ import { BudName } from "../types/buds";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { isValidRedirect } from "features/portal/examples/cropBoom/lib/portalUtil";
 import { portal } from "features/world/ui/community/actions/portal";
-import { BUMPKIN_EXPANSIONS_LEVEL } from "../types/expansions";
-import { getBumpkinLevel } from "./level";
 import { listRequest } from "../actions/listTrade";
 import { deleteListingRequest } from "../actions/deleteListing";
 import { fulfillTradeListingRequest } from "../actions/fulfillTradeListing";
@@ -782,21 +780,6 @@ export function startGame(authContext: AuthContext) {
               target: "noBumpkinFound",
               cond: (context: Context, event: any) =>
                 !event.data?.state.bumpkin && !context.state.bumpkin,
-            },
-            {
-              target: "weakBumpkin",
-              cond: (context: Context) => {
-                const requiredLevel =
-                  BUMPKIN_EXPANSIONS_LEVEL[context.state.island.type][
-                    context.state.inventory["Basic Land"]?.toNumber() ?? 3
-                  ];
-
-                const level = getBumpkinLevel(
-                  context.state.bumpkin?.experience ?? 0
-                );
-
-                return requiredLevel > level;
-              },
             },
             {
               target: "introduction",

--- a/src/features/goblins/bank/components/WithdrawBumpkin.tsx
+++ b/src/features/goblins/bank/components/WithdrawBumpkin.tsx
@@ -62,8 +62,8 @@ export const WithdrawBumpkin: React.FC<Props> = ({ onWithdraw }) => {
   return (
     <>
       <div className="p-2">
-        <div className="flex items-center border-2 rounded-md border-black p-2 bg-green-background mb-3">
-          <span className="text-xs">{t("withdraw.bumpkin.play")}</span>
+        <div className="flex items-center border-2 rounded-md border-black p-2 bg-red-background mb-3">
+          <span className="text-xs">{t("withdraw.bumpkin.closing")}</span>
         </div>
         {getText()}
         <div className="flex justify-center items-center mb-4">

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4560,8 +4560,9 @@ const withdraw: Record<Withdraw, string> = {
     "Your Bumpkin is currently wearing the following item(s) that can't be withdrawn. You will need to unequip them before you can withdraw.",
   "withdraw.bumpkin.sure.withdraw":
     "Are you sure you want to withdraw your Bumpkin?",
-  "withdraw.bumpkin.play":
-    "To play the game, you always need a Bumpkin on your farm.",
+  "withdraw.bumpkin.closed": "Bumpkin withdrawal has been permanently disabled",
+  "withdraw.bumpkin.closing":
+    "Bumpkins are moving off chain. Bumpkin withdrawal will be permanently disabled, {{timeRemaining}}",
   "withdraw.buds": "Select Buds to withdraw",
   "withdraw.budRestricted": "Used in today's bud box",
 };

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4750,8 +4750,8 @@ const withdraw: Record<Withdraw, string> = {
     "Votre Bumpkin porte actuellement les objets suivants qui ne peuvent pas être retirés. Vous devrez les déséquiper avant de pouvoir les retirer.",
   "withdraw.bumpkin.sure.withdraw":
     "Êtes-vous sûr de vouloir retirer votre Bumpkin?",
-  "withdraw.bumpkin.play":
-    "Pour jouer au jeu, vous avez toujours besoin d'un Bumpkin sur votre ferme.",
+  "withdraw.bumpkin.closed": ENGLISH_TERMS["withdraw.bumpkin.closed"],
+  "withdraw.bumpkin.closing": ENGLISH_TERMS["withdraw.bumpkin.closing"],
   "withdraw.buds": "Sélectionnez des Buds à retirer",
 };
 

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4587,8 +4587,8 @@ const withdraw: Record<Withdraw, string> = {
     "Seu Bumpkin está atualmente usando o(s) seguinte(s) item(ns) que não podem ser retirados. Você precisará desequipá-los antes de poder retirar.",
   "withdraw.bumpkin.sure.withdraw":
     "Tem certeza de que deseja retirar seu Bumpkin?",
-  "withdraw.bumpkin.play":
-    "Para jogar o jogo, você sempre precisa de um Bumpkin em sua fazenda.",
+  "withdraw.bumpkin.closed": ENGLISH_TERMS["withdraw.bumpkin.closed"],
+  "withdraw.bumpkin.closing": ENGLISH_TERMS["withdraw.bumpkin.closing"],
   "withdraw.buds": "Selecione Buds para retirar",
 };
 

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4578,8 +4578,8 @@ const withdraw: Record<Withdraw, string> = {
     "Bumpkin'iniz şu anda geri alınamayan aşağıdaki öğeleri giyiyor. Geri çekilmeden önce bunları donanımdan çıkarmanız gerekecek.",
   "withdraw.bumpkin.sure.withdraw":
     "Bumpkin'inizi geri çekmek istediğinizden emin misiniz?",
-  "withdraw.bumpkin.play":
-    "Oyunu oynamak için çiftliğinizde her zaman bir Bumpkin'e ihtiyacınız vardır.",
+  "withdraw.bumpkin.closed": ENGLISH_TERMS["withdraw.bumpkin.closed"],
+  "withdraw.bumpkin.closing": ENGLISH_TERMS["withdraw.bumpkin.closing"],
   "withdraw.buds": "Çekilecek Tomurcukları seçin",
   "withdraw.budRestricted": "Bugünkü tomurcuk kutusunda kullanıldı",
 };

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3078,7 +3078,8 @@ export type Withdraw =
   | "withdraw.budRestricted"
   | "withdraw.bumpkin.wearing"
   | "withdraw.bumpkin.sure.withdraw"
-  | "withdraw.bumpkin.play"
+  | "withdraw.bumpkin.closed"
+  | "withdraw.bumpkin.closing"
   | "withdraw.buds";
 
 export type WornDescription =


### PR DESCRIPTION
# Description

This PR removes the weak bumpkin warning that has been reoccuring for returning players. This PR is in combination with a Backend update, that includes an in game announcement that withdrawal of bumpkins is being disabled April 30th.

<img width="445" alt="1" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/960e3f8c-a895-42b7-989c-6f9679dab724">

<img width="430" alt="2" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/43a8d21b-52a3-49f7-875f-22586e148a12">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
