### PR TITLE
[FIX] Allow entering "0" after "." for trading inputs

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -176,8 +176,8 @@ const ListTrade: React.FC<{
               if (e.target.value === "") {
                 setQuantityDisplay(""); // Reset to 0 if input is empty
               } else if (VALID_INTEGER.test(e.target.value)) {
-                const amount = Number(e.target.value.slice(0, INPUT_MAX_CHAR));
-                setQuantityDisplay(`${amount}`);
+                const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
+                setQuantityDisplay(amount);
               }
             }}
             className={classNames(
@@ -223,8 +223,8 @@ const ListTrade: React.FC<{
               if (e.target.value === "") {
                 setSflDisplay(""); // Reset to 0 if input is empty
               } else if (VALID_FOUR_DECIMAL_NUMBER.test(e.target.value)) {
-                const amount = Number(e.target.value.slice(0, INPUT_MAX_CHAR));
-                setSflDisplay(`${amount}`);
+                const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
+                setSflDisplay(amount);
               }
             }}
             className={classNames(


### PR DESCRIPTION
# Description

- Fix issue where players cannot enter 0 after decimal point for trading inputs

<img width="365" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/90a3416d-b264-4066-9fa2-aeaf63f2bc1d">

Caused by #3587

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- enter quantity and SFL for trading screen

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
