### PR TITLE
[FEAT] VIP Access UI updates

### DIFF
--- a/src/features/game/components/VipAccess.tsx
+++ b/src/features/game/components/VipAccess.tsx
@@ -39,7 +39,7 @@ export const VIPAccess: React.FC<VIPAccessProps> = ({ onUpgrade, isVIP }) => {
     <Label
       type="warning"
       icon={vipIcon}
-      secondaryIcon={lock}
+      secondaryIcon={SUNNYSIDE.ui.add_button}
       onClick={onUpgrade}
       className="whitespace-nowrap"
     >

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -416,7 +416,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Workbench: new Decimal(1),
     "Basic Land": new Decimal(3),
     Gold: new Decimal(13),
-    "Gold Pass": new Decimal(1),
+    // "Gold Pass": new Decimal(1),
     "Crop Plot": new Decimal(OFFLINE_FARM_CROPS),
     "Water Well": new Decimal(4),
     Tree: new Decimal(3),

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -4,7 +4,7 @@ import dawnBreakerBanner from "assets/decorations/banners/dawn_breaker_banner.pn
 import witchesEveBanner from "assets/decorations/banners/witches_eve_banner.webp";
 import catchTheKrakenBanner from "assets/decorations/banners/catch_the_kraken_banner.webp";
 import springBlossomBanner from "assets/decorations/banners/spring_banner.gif";
-import clashOfFactionsBanner from "assets/decorations/banners/dawn_breaker_banner.png";
+import clashOfFactionsBanner from "assets/decorations/banners/clash_of_factions_banner.webp";
 
 export type SeasonName =
   | "Solar Flare"

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4133,9 +4133,11 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.place.land": "You must place it on your land",
   "season.megastore.discount": "Megastore SFL discount",
   "season.supporter.gift": "Supporter Gift",
-  "season.free.season.passes": "Free Season Passes",
+  "season.free.season.passes": "Free Season Banners",
   "season.free.season.passes.description": "Receive banners for every Season",
-  "season.vip.access": "VIP Access",
+  "season.vip.access": "Season VIP Access",
+  "season.vip.description":
+    "Unlock perks, discounts, bonus tickets, airdrops and more!",
   "season.mystery.gift": "Mystery Gift",
   "season.xp.boost": "10% XP boost",
   "season.lifetime.farmer": "Lifetime Farmer",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4302,6 +4302,7 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.mystery.gift": ENGLISH_TERMS["season.mystery.gift"],
   "season.supporter.gift": ENGLISH_TERMS["season.supporter.gift"],
   "season.vip.access": ENGLISH_TERMS["season.vip.access"],
+  "season.vip.description": ENGLISH_TERMS["season.vip.description"],
   "season.xp.boost": ENGLISH_TERMS["season.xp.boost"],
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4157,6 +4157,7 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.mystery.gift": ENGLISH_TERMS["season.mystery.gift"],
   "season.supporter.gift": ENGLISH_TERMS["season.supporter.gift"],
   "season.vip.access": ENGLISH_TERMS["season.vip.access"],
+  "season.vip.description": ENGLISH_TERMS["season.vip.description"],
   "season.xp.boost": ENGLISH_TERMS["season.xp.boost"],
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4144,6 +4144,7 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.mystery.gift": ENGLISH_TERMS["season.mystery.gift"],
   "season.supporter.gift": ENGLISH_TERMS["season.supporter.gift"],
   "season.vip.access": ENGLISH_TERMS["season.vip.access"],
+  "season.vip.description": ENGLISH_TERMS["season.vip.description"],
   "season.xp.boost": ENGLISH_TERMS["season.xp.boost"],
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2794,6 +2794,7 @@ export type SeasonTerms =
   | "season.supporter.gift"
   | "season.free.season.passes"
   | "season.vip.access"
+  | "season.vip.description"
   | "season.mystery.gift"
   | "season.xp.boost"
   | "season.free.season.passes.description"


### PR DESCRIPTION
# Description

Small, non blocking UI updates for VIP UI components.

<img width="539" alt="Screenshot 2024-04-30 at 11 01 30 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/d99e67b7-bee9-4c01-a7b6-89b0abfad189">
<img width="518" alt="Screenshot 2024-05-01 at 10 53 55 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/b2962463-6fa6-4e15-b71a-8f979bf6b2ba">


- “VIP Access Required” label does not look clickable - Put a plus button on the end of it.
- VIP Items - Banner - Show time left before next deal - “X hours left”
- Was unsure what the “Support Gift” was with the Lifetime banner. Since we don’t mention “Support Gift” with the normal banner I would suggest we just omit it so players don’t think they get something extra. I was looking for a collectible and/or wearable after purchase
- "VIP Access" → "Season VIP Access" = a bit clearer it is not permanent VIP access