### PR TITLE
[FEAT] Show VIP purchase items in modals

### DIFF
--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -27,6 +27,7 @@ import Decimal from "decimal.js-light";
 import { getSeasonWeek } from "lib/utils/getSeasonWeek";
 import classNames from "classnames";
 import { secondsToString } from "lib/utils/time";
+import { acknowledgeSeasonPass } from "features/announcements/announcementsStorage";
 
 type VIPItem = SeasonalBanner | "Lifetime Farmer Banner";
 
@@ -38,6 +39,7 @@ const _inventory = (state: MachineState) => state.context.state.inventory;
 
 type Props = {
   onClose: () => void;
+  onSkip?: () => void;
 };
 
 const SeasonVIPDiscountTime: React.FC = () => {
@@ -70,7 +72,7 @@ const SeasonVIPDiscountTime: React.FC = () => {
   );
 };
 
-export const VIPItems: React.FC<Props> = ({ onClose }) => {
+export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   const { gameService } = useContext(Context);
   const [selected, setSelected] = useState<VIPItem>();
   const { t } = useTranslation();
@@ -325,6 +327,7 @@ export const VIPItems: React.FC<Props> = ({ onClose }) => {
               {getSeasonalBannerPriceLabel()}
             </div>
           </OuterPanel>
+          {onSkip && <Button onClick={onSkip}>{t("close")}</Button>}
         </div>
       )}
       {selected && (
@@ -359,6 +362,21 @@ export const VIPItems: React.FC<Props> = ({ onClose }) => {
           </Button>
         </div>
       )}
+    </>
+  );
+};
+
+export const VIPOffer: React.FC = () => {
+  const { gameService } = useContext(Context);
+
+  const onClose = () => {
+    acknowledgeSeasonPass();
+    gameService.send("ACKNOWLEDGE");
+  };
+
+  return (
+    <>
+      <VIPItems onClose={onClose} onSkip={onClose} />
     </>
   );
 };

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -37,7 +37,6 @@ import land from "assets/land/islands/island.webp";
 import { IslandNotFound } from "./components/IslandNotFound";
 import { Rules } from "../components/Rules";
 import { Introduction } from "./components/Introduction";
-import { SpecialOffer } from "./components/SpecialOffer";
 import { Purchasing } from "../components/Purchasing";
 import { Transacting } from "../components/Transacting";
 import { Minting } from "../components/Minting";
@@ -67,6 +66,7 @@ import { PersonhoodContent } from "features/retreat/components/personhood/Person
 import { hasFeatureAccess } from "lib/flags";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PriceChange } from "../components/PriceChange";
+import { VIPOffer } from "../components/modal/components/VIPItems";
 
 export const AUTO_SAVE_INTERVAL = 1000 * 30; // autosave every 30 seconds
 const SHOW_MODAL: Record<StateValues, boolean> = {
@@ -96,7 +96,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   buyingSFL: true,
   depositing: true,
   introduction: false,
-  specialOffer: false,
+  specialOffer: true,
   transacting: true,
   minting: true,
   auctionResults: false,
@@ -462,7 +462,7 @@ export const GameWrapper: React.FC = ({ children }) => {
             {minting && <Minting />}
             {promo && <Promo />}
             {airdrop && <AirdropPopup />}
-            {specialOffer && <SpecialOffer />}
+            {specialOffer && <VIPOffer />}
             {withdrawing && <Withdrawing />}
             {withdrawn && <Withdrawn />}
           </Panel>
@@ -471,7 +471,6 @@ export const GameWrapper: React.FC = ({ children }) => {
         {claimingAuction && <ClaimAuction />}
         {refundAuction && <RefundAuction />}
 
-        <SpecialOffer />
         <Introduction />
         <NewMail />
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -56,6 +56,7 @@ import { CollectibleLocation, PurchasableItems } from "../types/collectibles";
 import {
   getGameRulesLastRead,
   getIntroductionRead,
+  getSeasonPassRead,
 } from "features/announcements/announcementsStorage";
 import { depositToFarm } from "lib/blockchain/Deposit";
 import Decimal from "decimal.js-light";
@@ -799,13 +800,13 @@ export function startGame(authContext: AuthContext) {
               target: "swarming",
               cond: () => isSwarming(),
             },
-            // {
-            //   target: "specialOffer",
-            //   cond: (context) =>
-            //     (context.state.bumpkin?.experience ?? 0) > 100 &&
-            //     !context.state.collectibles["Spring Blossom Banner"] &&
-            //     !getSeasonPassRead(),
-            // },
+            {
+              target: "specialOffer",
+              cond: (context) =>
+                (context.state.bumpkin?.experience ?? 0) > 100 &&
+                !context.state.collectibles["Clash of Factions Banner"] &&
+                !getSeasonPassRead(),
+            },
             // EVENTS THAT TARGET NOTIFYING OR LOADING MUST GO ABOVE THIS LINE
 
             // EVENTS THAT TARGET PLAYING MUST GO BELOW THIS LINE

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -432,7 +432,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Banana: new Decimal(12),
     Wood: new Decimal(500),
     Crimstone: new Decimal(20),
-    "Block Buck": new Decimal(20),
+    "Block Buck": new Decimal(200),
     Stone: new Decimal(100),
     Iron: new Decimal(100),
     "Mermaid Scale": new Decimal(1000),


### PR DESCRIPTION
# Description

When starting a session, show a popup modal with the VIP items.

<img width="557" alt="Screenshot 2024-04-30 at 9 46 57 PM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/0462cc2f-50d1-483d-b95e-4df841fedfd8">


