### PR TITLE
[FIX] Deposit Modal not working in chest tab

### DIFF
--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -39,6 +39,7 @@ import { getImageUrl } from "lib/utils/getImageURLS";
 import { MachineState } from "features/game/lib/gameMachine";
 import { Context as GameContext } from "features/game/GameProvider";
 import { getBumpkinLevel } from "features/game/lib/level";
+import { GameWallet } from "features/wallet/Wallet";
 
 const imageDomain = CONFIG.NETWORK === "mainnet" ? "buds" : "testnet-buds";
 
@@ -100,10 +101,47 @@ export const Deposit: React.FC<Props> = ({
   onDeposit,
   onLoaded,
   farmAddress,
+  canDeposit = true,
+}) => {
+  const [showIntro, setShowIntro] = useState(true);
+  const { t } = useAppTranslation();
+  if (showIntro) {
+    return (
+      <>
+        <div className="p-2">
+          <Label icon={SUNNYSIDE.resource.pirate_bounty} type="default">
+            {t("deposit")}
+          </Label>
+          <p className="my-2 text-sm">{t("question.depositSFLItems")}</p>
+        </div>
+        <Button onClick={() => setShowIntro(false)}>{t("continue")}</Button>
+      </>
+    );
+  }
+
+  return (
+    <GameWallet action="deposit">
+      <DepositOptions
+        onClose={onClose}
+        onDeposit={onDeposit}
+        onLoaded={onLoaded}
+        farmAddress={farmAddress}
+        canDeposit={canDeposit}
+      />
+    </GameWallet>
+  );
+};
+
+const DepositOptions: React.FC<Props> = ({
+  onClose,
+  onDeposit,
+  onLoaded,
+  farmAddress,
 }) => {
   const { t } = useAppTranslation();
 
-  const [showIntro, setShowIntro] = useState(true);
+  const [hasWeb3, setHasWeb3] = useState(false);
+
   const [status, setStatus] = useState<Status>("loading");
   // These are the balances of the user's personal wallet
   const [sflBalance, setSflBalance] = useState<Decimal>(new Decimal(0));
@@ -313,19 +351,6 @@ export const Deposit: React.FC<Props> = ({
   //     </div>
   //   );
   // }
-  if (showIntro) {
-    return (
-      <>
-        <div className="p-2">
-          <Label icon={SUNNYSIDE.resource.pirate_bounty} type="default">
-            {t("deposit")}
-          </Label>
-          <p className="my-2 text-sm">{t("question.depositSFLItems")}</p>
-        </div>
-        <Button onClick={() => setShowIntro(false)}>{t("continue")}</Button>
-      </>
-    );
-  }
 
   return (
     <>


### PR DESCRIPTION
# Description

Deposit Modal wasn't working if user clicks on the deposit text at the bottom of the Chest Tab, this was due to an error that I made in #3604 cuz I didn't realise the option to deposit is in the Chest Tab and thought it was a good idea to combine `Deposit` and `DepositOptions` constants together. I've reverted that change in this PR to fix the issue

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Made sure user can connect wallet from Chest Tab
- Made sure it doesn't affect functionality in Blockchain Settings

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
