### PR TITLE
[FIX] Shroom Syrup showing as Mashed Potato instead

### DIFF
--- a/src/features/game/types/consumables.ts
+++ b/src/features/game/types/consumables.ts
@@ -219,7 +219,7 @@ export const FIRE_PIT_COOKABLES: Record<FirePitCookableName, Cookable> = {
   },
   "Rapid Roast": {
     name: "Rapid Roast",
-    description: "For Bumpkins in a hurry...",
+    description: translate("description.rapidRoast"),
     experience: 300,
     building: "Fire Pit",
     cookingSeconds: 10,
@@ -396,7 +396,7 @@ export const KITCHEN_COOKABLES: Record<KitchenCookableName, Cookable> = {
   },
   "Beetroot Blaze": {
     name: "Beetroot Blaze",
-    description: "A spicy beetroot-infused magic mushroom dish",
+    description: translate("description.beetrootBlaze"),
     experience: 2000,
     building: "Kitchen",
     cookingSeconds: 30,
@@ -677,7 +677,7 @@ export const DELI_COOKABLES: Record<DeliCookableName, Cookable> = {
   },
   "Shroom Syrup": {
     name: "Shroom Syrup",
-    description: "The essence of bees and enchanted fungi",
+    description: translate("description.fermented.shroomSyrup"),
     experience: 10000,
     building: "Deli",
     cookingSeconds: 10,

--- a/src/features/game/types/consumables.ts
+++ b/src/features/game/types/consumables.ts
@@ -676,7 +676,7 @@ export const DELI_COOKABLES: Record<DeliCookableName, Cookable> = {
     marketRate: 0,
   },
   "Shroom Syrup": {
-    name: "Mashed Potato",
+    name: "Shroom Syrup",
     description: "The essence of bees and enchanted fungi",
     experience: 10000,
     building: "Deli",

--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -29,7 +29,7 @@ export const BakeryModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const cakeRecipes = Object.values(BAKERY_COOKABLES).sort(
-    (a, b) => a.cookingSeconds - b.cookingSeconds // Future proofing for future foods released
+    (a, b) => a.cookingSeconds - b.cookingSeconds // Sorts Foods based on their cooking time
   );
   const [selected, setSelected] = useState<Cookable>(
     cakeRecipes.find((recipe) => recipe.name === itemInProgress) ||

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -29,7 +29,7 @@ export const DeliModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const deliRecipes = Object.values(DELI_COOKABLES).sort(
-    (a, b) => a.cookingSeconds - b.cookingSeconds // Future proofing for future foods released
+    (a, b) => a.cookingSeconds - b.cookingSeconds // Sorts Foods based on their cooking time
   );
   const [selected, setSelected] = useState<Cookable>(
     deliRecipes.find((recipe) => recipe.name === itemInProgress) ||

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -48,7 +48,9 @@ export const FirePitModal: React.FC<Props> = ({
 }) => {
   const [showIntro, setShowIntro] = React.useState(!hasRead());
   const { t } = useAppTranslation();
-  const firePitRecipes = Object.values(FIRE_PIT_COOKABLES);
+  const firePitRecipes = Object.values(FIRE_PIT_COOKABLES).sort(
+    (a, b) => a.cookingSeconds - b.cookingSeconds // Sorts Foods based on their cooking time
+  );
 
   const [selected, setSelected] = useState<Cookable>(
     firePitRecipes.find((recipe) => recipe.name === itemInProgress) ||

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -29,7 +29,7 @@ export const KitchenModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const kitchenRecipes = Object.values(KITCHEN_COOKABLES).sort(
-    (a, b) => a.cookingSeconds - b.cookingSeconds // Future proofing for future foods released
+    (a, b) => a.cookingSeconds - b.cookingSeconds // Sorts Foods based on their cooking time
   );
   const [selected, setSelected] = useState<Cookable>(
     kitchenRecipes.find((recipe) => recipe.name === itemInProgress) ||

--- a/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
+++ b/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
@@ -29,7 +29,7 @@ export const SmoothieShackModal: React.FC<Props> = ({
   craftingService,
 }) => {
   const JuiceRecipes = Object.values(JUICE_COOKABLES).sort(
-    (a, b) => a.cookingSeconds - b.cookingSeconds // Future proofing for future foods released
+    (a, b) => a.cookingSeconds - b.cookingSeconds // Sorts Foods based on their cooking time
   );
   const [selected, setSelected] = useState<Cookable>(
     JuiceRecipes.find((recipe) => recipe.name === itemInProgress) ||


### PR DESCRIPTION
# Description

- Fix Shroom Syrup showing as Mashed Potato in Deli
- Not too sure why the sorting by cooking time for fire pit was removed so I added it back

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/67315ed8-6d24-4097-8b37-52a321d8ddc3)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/470950b2-2e15-4848-aa87-27e9b1cc5a1c)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
