### PR TITLE
[CHORE] Hide new delivery message bubble for small screens

### DIFF
--- a/src/features/island/hud/components/codex/CodexButton.tsx
+++ b/src/features/island/hud/components/codex/CodexButton.tsx
@@ -65,68 +65,79 @@ export const CodexButton: React.FC = () => {
         />
 
         {hasDeliveries && (
-          <div
-            className="absolute "
-            style={{
-              width: `${PIXEL_SCALE * 68}px`,
-              left: `${PIXEL_SCALE * 13}px`,
-              top: `${PIXEL_SCALE * 5}px`,
-            }}
-          >
+          <>
             <div
-              className={"absolute uppercase"}
+              className="absolute hidden sm:block"
               style={{
-                fontFamily: "Teeny",
-                color: "black",
-                textShadow: "none",
-                top: `${PIXEL_SCALE * -8}px`,
-                left: `${PIXEL_SCALE * 6}px`,
-
-                borderImage: `url(${speechBubble})`,
-                borderStyle: "solid",
-                borderTopWidth: `${PIXEL_SCALE * 2}px`,
-                borderRightWidth: `${PIXEL_SCALE * 2}px`,
-                borderBottomWidth: `${PIXEL_SCALE * 4}px`,
-                borderLeftWidth: `${PIXEL_SCALE * 5}px`,
-
-                borderImageSlice: "2 2 4 5 fill",
-                imageRendering: "pixelated",
-                borderImageRepeat: "stretch",
-                fontSize: "8px",
+                width: `${PIXEL_SCALE * 68}px`,
+                left: `${PIXEL_SCALE * 13}px`,
+                top: `${PIXEL_SCALE * 5}px`,
               }}
             >
               <div
+                className={"absolute uppercase"}
                 style={{
-                  height: "12px",
-                  minWidth: "50px",
-                  paddingRight: "14px",
+                  fontFamily: "Teeny",
+                  color: "black",
+                  textShadow: "none",
+                  top: `${PIXEL_SCALE * -8}px`,
+                  left: `${PIXEL_SCALE * 6}px`,
+
+                  borderImage: `url(${speechBubble})`,
+                  borderStyle: "solid",
+                  borderTopWidth: `${PIXEL_SCALE * 2}px`,
+                  borderRightWidth: `${PIXEL_SCALE * 2}px`,
+                  borderBottomWidth: `${PIXEL_SCALE * 4}px`,
+                  borderLeftWidth: `${PIXEL_SCALE * 5}px`,
+
+                  borderImageSlice: "2 2 4 5 fill",
+                  imageRendering: "pixelated",
+                  borderImageRepeat: "stretch",
+                  fontSize: "8px",
                 }}
               >
-                <span
-                  className="whitespace-nowrap"
+                <div
                   style={{
-                    fontSize: "10px",
-                    position: "relative",
-                    bottom: "4px",
-                    left: "4px",
-                    wordSpacing: "-4px",
-                    color: "#262b45",
+                    height: "12px",
+                    minWidth: "50px",
+                    paddingRight: "14px",
                   }}
                 >
-                  {t("deliveries.new")}
-                </span>
-                <img
-                  src={coins}
-                  className="absolute animate-pulsate"
-                  style={{
-                    width: "30px",
-                    top: "-12px",
-                    right: "-22px",
-                  }}
-                />
+                  <span
+                    className="whitespace-nowrap"
+                    style={{
+                      fontSize: "10px",
+                      position: "relative",
+                      bottom: "4px",
+                      left: "4px",
+                      wordSpacing: "-4px",
+                      color: "#262b45",
+                    }}
+                  >
+                    {t("deliveries.new")}
+                  </span>
+                  <img
+                    src={coins}
+                    className="absolute animate-pulsate"
+                    style={{
+                      width: "30px",
+                      top: "-12px",
+                      right: "-22px",
+                    }}
+                  />
+                </div>
               </div>
             </div>
-          </div>
+            <img
+              src={coins}
+              className="absolute animate-pulsate sm:hidden"
+              style={{
+                width: "30px",
+                top: "-2px",
+                right: "-10px",
+              }}
+            />
+          </>
         )}
       </div>
 


### PR DESCRIPTION
# Description

Hide the "NEW DELIVERY" chat bubble for smaller screens to avoid UI blocking issues

Before|After (large screens - no visual changes)|After (small screens)
---|---|---
<img width="182" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/72d064d6-d608-46ab-bb96-369730ad2722">|<img width="182" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/72d064d6-d608-46ab-bb96-369730ad2722">|<img width="125" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/514e30b5-6390-48a6-b155-0167b8c40382">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Launch game with new deliveries

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
