### PR TITLE
[FIX] Make SFL donations text more consistent

### DIFF
--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1947,7 +1947,7 @@ const factions: Record<Factions, string> = {
   "faction.donation.request.message":
     "Greetings, {{faction}}! We are currently accepting donations of resources and SFL to help build up our faction. You will be rewarded faction points in return for your generosity.",
   "faction.donation.label": "{{faction}} Faction Donation",
-  "faction.donation.sfl": "SFL donations min(10)",
+  "faction.donation.sfl": "SFL donations (min 10)",
   "faction.donation.sfl.max.per.day": "{{donatedToday}}/500 max per day",
   "faction.donation.bulk.resources": "Bulk resource donations (min {{min}})",
   "faction.donation.bulk.resources.unlimited.per.day":


### PR DESCRIPTION
# Description

Fix text consistency for SFL donations

Before|After
---|---
<img width="449" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/2afe08ed-60c3-4e3a-8b70-d8348669522d">|<img width="453" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/b8e1f874-c414-42c7-b60a-f2c22a0b4833">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try to donate SFL and resources for factions

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
