### PR TITLE
[FEAT] Add Island Gates

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -152,7 +152,6 @@ export const Box: React.FC<BoxProps> = ({
       <div
         className={classNames("bg-brown-600 cursor-pointer relative", {
           "bg-brown-600 cursor-not-allowed opacity-75": disabled,
-          "opacity-75": locked,
           "cursor-pointer": canClick,
         })}
         {...clickEvents}
@@ -166,7 +165,14 @@ export const Box: React.FC<BoxProps> = ({
           ...pixelDarkBorderStyle,
         }}
       >
-        <div className="absolute flex justify-center items-center w-full h-full">
+        <div
+          className={classNames(
+            "absolute flex justify-center items-center w-full h-full",
+            {
+              "opacity-75": locked,
+            }
+          )}
+        >
           <SquareIcon
             icon={image}
             width={INNER_CANVAS_WIDTH}

--- a/src/features/game/events/landExpansion/craftTool.test.ts
+++ b/src/features/game/events/landExpansion/craftTool.test.ts
@@ -102,36 +102,52 @@ describe("craftTool", () => {
       })
     ).toThrow("Not enough stock");
   });
-});
 
-it("increments Axe Crafted activity by 1 when 1 axe is crafted", () => {
-  const state = craftTool({
-    state: {
-      ...GAME_STATE,
-      coins: 100,
-      inventory: {},
-    },
-    action: {
-      type: "tool.crafted",
-      tool: "Axe",
-    },
+  it("increments Axe Crafted activity by 1 when 1 axe is crafted", () => {
+    const state = craftTool({
+      state: {
+        ...GAME_STATE,
+        coins: 100,
+        inventory: {},
+      },
+      action: {
+        type: "tool.crafted",
+        tool: "Axe",
+      },
+    });
+
+    expect(state.bumpkin?.activity?.["Axe Crafted"]).toBe(1);
   });
 
-  expect(state.bumpkin?.activity?.["Axe Crafted"]).toBe(1);
-});
+  it("increments Coins spent when axe is crafted", () => {
+    const state = craftTool({
+      state: {
+        ...GAME_STATE,
+        coins: 100,
+        inventory: {},
+      },
+      action: {
+        type: "tool.crafted",
+        tool: "Axe",
+      },
+    });
 
-it("increments Coins spent when axe is crafted", () => {
-  const state = craftTool({
-    state: {
-      ...GAME_STATE,
-      coins: 100,
-      inventory: {},
-    },
-    action: {
-      type: "tool.crafted",
-      tool: "Axe",
-    },
+    expect(state.bumpkin?.activity?.["Coins Spent"]).toEqual(20);
   });
 
-  expect(state.bumpkin?.activity?.["Coins Spent"]).toEqual(20);
+  it("does not craft a tool that has a required island expansion that the player has not reached", () => {
+    expect(() =>
+      craftTool({
+        state: {
+          ...GAME_STATE,
+          coins: 100,
+          inventory: { Wood: new Decimal(25), Iron: new Decimal(10) },
+        },
+        action: {
+          type: "tool.crafted",
+          tool: "Oil Drill",
+        },
+      })
+    ).toThrow("You do not have the required island expansion");
+  });
 });

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -16,6 +16,7 @@ import {
   PurchaseableBait,
 } from "features/game/types/fishing";
 import { translate } from "lib/i18n/translate";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 
 type CraftableToolName =
   | WorkbenchToolName
@@ -48,6 +49,15 @@ export function craftTool({ state, action }: Options) {
 
   if (!tool) {
     throw new Error("Tool does not exist");
+  }
+
+  const requiredIsland = tool.requiredIsland;
+
+  if (
+    requiredIsland &&
+    !hasRequiredIslandExpansion(stateCopy.island.type, requiredIsland)
+  ) {
+    throw new Error("You do not have the required island expansion");
   }
 
   if (stateCopy.stock[action.tool]?.lt(1)) {

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -51,12 +51,7 @@ export function craftTool({ state, action }: Options) {
     throw new Error("Tool does not exist");
   }
 
-  const requiredIsland = tool.requiredIsland;
-
-  if (
-    requiredIsland &&
-    !hasRequiredIslandExpansion(stateCopy.island.type, requiredIsland)
-  ) {
+  if (!hasRequiredIslandExpansion(stateCopy.island.type, tool.requiredIsland)) {
     throw new Error("You do not have the required island expansion");
   }
 

--- a/src/features/game/lib/hasRequiredIslandExpansion.ts
+++ b/src/features/game/lib/hasRequiredIslandExpansion.ts
@@ -1,0 +1,15 @@
+import { ISLAND_EXPANSIONS, IslandType } from "../types/game";
+
+export function hasRequiredIslandExpansion(
+  island: IslandType,
+  requiredIslandExpansion: IslandType
+): boolean {
+  const currentIslandIndex = ISLAND_EXPANSIONS.findIndex(
+    (name) => name === island
+  );
+  const requiredIslandIndex = ISLAND_EXPANSIONS.findIndex(
+    (name) => name === requiredIslandExpansion
+  );
+
+  return currentIslandIndex >= requiredIslandIndex;
+}

--- a/src/features/game/lib/hasRequiredIslandExpansion.ts
+++ b/src/features/game/lib/hasRequiredIslandExpansion.ts
@@ -2,8 +2,10 @@ import { ISLAND_EXPANSIONS, IslandType } from "../types/game";
 
 export function hasRequiredIslandExpansion(
   island: IslandType,
-  requiredIslandExpansion: IslandType
+  requiredIslandExpansion?: IslandType
 ): boolean {
+  if (!requiredIslandExpansion) return true;
+
   const currentIslandIndex = ISLAND_EXPANSIONS.findIndex(
     (name) => name === island
   );

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -843,6 +843,10 @@ export type MegaStore = {
 
 export type IslandType = "basic" | "spring" | "desert";
 
+/**
+ * The order of the islands is important as it determines the levels of the islands.
+ * Each new island should be added to the end of the array.
+ */
 export const ISLAND_EXPANSIONS: IslandType[] = ["basic", "spring", "desert"];
 
 export type Home = {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -843,6 +843,8 @@ export type MegaStore = {
 
 export type IslandType = "basic" | "spring" | "desert";
 
+export const ISLAND_EXPANSIONS: IslandType[] = ["basic", "spring", "desert"];
+
 export type Home = {
   collectibles: Collectibles;
 };

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -3,7 +3,7 @@
  */
 
 import Decimal from "decimal.js-light";
-import { Inventory } from "./game";
+import { Inventory, IslandType } from "./game";
 import { translate } from "lib/i18n/translate";
 
 export type WorkbenchToolName =
@@ -23,6 +23,7 @@ export interface Tool {
   ingredients: Inventory;
   price: number;
   disabled?: boolean;
+  requiredIsland?: IslandType;
 }
 
 export const WORKBENCH_TOOLS: Record<WorkbenchToolName, Tool> = {
@@ -85,6 +86,7 @@ export const WORKBENCH_TOOLS: Record<WorkbenchToolName, Tool> = {
       Wood: new Decimal(25),
       Iron: new Decimal(10),
     },
+    requiredIsland: "desert",
   },
 };
 

--- a/src/features/island/buildings/components/building/workBench/components/Tools.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/Tools.tsx
@@ -15,6 +15,12 @@ import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements
 import { makeBulkBuyAmount } from "../../market/lib/makeBulkBuyAmount";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+
+import lockIcon from "assets/skills/lock.png";
+import { Label } from "components/ui/Label";
+import { capitalize } from "lib/utils/capitalize";
+import { IslandType } from "features/game/types/game";
 
 interface Props {
   onClose: (e?: SyntheticEvent) => void;
@@ -69,7 +75,19 @@ export const Tools: React.FC<Props> = ({ onClose }) => {
 
   const bulkToolCraftAmount = makeBulkBuyAmount(stock);
   const { t } = useAppTranslation();
-  const Action = () => {
+  const getAction = () => {
+    if (
+      !hasRequiredIslandExpansion(state.island.type, selected.requiredIsland)
+    ) {
+      return (
+        <Label type="danger">
+          {t("islandupgrade.requiredIsland", {
+            islandType: capitalize(selected.requiredIsland as IslandType),
+          })}
+        </Label>
+      );
+    }
+
     if (stock.equals(0)) {
       return <Restock onClose={onClose}></Restock>;
     }
@@ -110,20 +128,30 @@ export const Tools: React.FC<Props> = ({ onClose }) => {
             coins: selected.price,
             resources: selected.ingredients,
           }}
-          actionView={Action()}
+          actionView={getAction()}
         />
       }
       content={
         <>
-          {getKeys(WORKBENCH_TOOLS).map((toolName) => (
-            <Box
-              isSelected={selectedName === toolName}
-              key={toolName}
-              onClick={() => onToolClick(toolName)}
-              image={ITEM_DETAILS[toolName].image}
-              count={inventory[toolName]}
-            />
-          ))}
+          {getKeys(WORKBENCH_TOOLS).map((toolName) => {
+            const { requiredIsland } = WORKBENCH_TOOLS[toolName];
+            const isLocked = !hasRequiredIslandExpansion(
+              state.island.type,
+              requiredIsland
+            );
+
+            return (
+              <Box
+                isSelected={selectedName === toolName}
+                key={toolName}
+                onClick={() => onToolClick(toolName)}
+                image={ITEM_DETAILS[toolName].image}
+                count={inventory[toolName]}
+                secondaryImage={lockIcon}
+                showOverlay={isLocked}
+              />
+            );
+          })}
         </>
       }
     />

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -95,24 +95,21 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
     onClose();
   };
 
-  const landLocked = () => {
-    return (
-      <div className="flex flex-col w-full justify-center">
-        <div className="flex items-center justify-center ">
-          <Label
-            type="danger"
-            icon={SUNNYSIDE.icons.player}
-          >{`Level ${nextLockedLevel} required`}</Label>
-        </div>
-      </div>
-    );
-  };
-
-  const action = () => {
+  const getAction = () => {
     const hasMaxNumberOfBuildings =
       buildingsInInventory.gte(numOfBuildingAllowed);
     // Hasn't unlocked the first
-    if (nextLockedLevel && hasMaxNumberOfBuildings) return landLocked();
+    if (nextLockedLevel && hasMaxNumberOfBuildings)
+      return (
+        <div className="flex flex-col w-full justify-center">
+          <div className="flex items-center justify-center ">
+            <Label
+              type="danger"
+              icon={SUNNYSIDE.icons.player}
+            >{`Level ${nextLockedLevel} required`}</Label>
+          </div>
+        </div>
+      );
 
     if (isAlreadyCrafted) {
       return <p className="text-xxs text-center mb-1">{t("alr.crafted")}</p>;
@@ -148,7 +145,7 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
               {}
             ),
           }}
-          actionView={action()}
+          actionView={getAction()}
         />
       }
       content={

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2817,6 +2817,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
     "You are not ready. Expand {{remainingExpansions}} more times",
   "islandupgrade.exoticResourcesDescription":
     "This area of Sunflower Land is known for its exotic resources. Expand your land to discover fruit, flowers, bee hives & rare minerals!",
+  "islandupgrade.requiredIsland": "Unlocks on {{islandType}} Island",
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -2953,6 +2953,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
     "You are not ready. Expand {{remainingExpansions}} more times",
   "islandupgrade.exoticResourcesDescription":
     "Cette partie de Sunflower Land est connue pour ses ressources exotiques. Étendez votre île pour découvrir des fruits, des fleurs, des ruches d'abeilles et des minéraux rares!",
+  "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2734,6 +2734,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
     ENGLISH_TERMS["islandupgrade.notReadyExpandMore"],
   "islandupgrade.exoticResourcesDescription":
     "Esta área de Sunflower Land é conhecida por seus recursos exóticos. Expanda sua terra para descobrir frutas, flores, colmeias e minerais raros!",
+  "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
 };
 
 const interactableModals: Record<InteractableModals, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2825,6 +2825,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
     ENGLISH_TERMS["islandupgrade.notReadyExpandMore"],
   "islandupgrade.exoticResourcesDescription":
     "Sunflower Land bu bölgesi egzotik kaynaklarıyla tanınır. Meyveleri, çiçekleri, arı kovanlarını ve nadir mineralleri keşfetmek için topraklarınızı genişletin!",
+  "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1913,7 +1913,8 @@ export type Islandupgrade =
   | "islandupgrade.welcomePetalParadise"
   | "islandupgrade.itemsReturned"
   | "islandupgrade.notReadyExpandMore"
-  | "islandupgrade.exoticResourcesDescription";
+  | "islandupgrade.exoticResourcesDescription"
+  | "islandupgrade.requiredIsland";
 
 export type InteractableModals =
   | "interactableModals.returnhome.message"


### PR DESCRIPTION
# Description

This adds "island gating" to tools. You should not be able to craft an Oil Drill unless you have reached desert island (at least)

<img width="513" alt="Screenshot 2024-05-07 at 12 11 46 PM" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/b45c6d27-ed65-4946-878b-34b9e9425d7c">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
