### PR TITLE
[CHORE] Dynamically Calculate Seed/Tool stock with Warehouse/Toolshed

### DIFF
--- a/src/features/game/lib/constants.test.ts
+++ b/src/features/game/lib/constants.test.ts
@@ -20,6 +20,9 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state).Pickaxe).toEqual(new Decimal(60));
     expect(INITIAL_STOCK(state)["Stone Pickaxe"]).toEqual(new Decimal(20));
     expect(INITIAL_STOCK(state)["Iron Pickaxe"]).toEqual(new Decimal(5));
+    expect(INITIAL_STOCK(state)["Gold Pickaxe"]).toEqual(new Decimal(5));
+    expect(INITIAL_STOCK(state)["Oil Drill"]).toEqual(new Decimal(5));
+    expect(INITIAL_STOCK(state).Rod).toEqual(new Decimal(50));
   });
 
   it("increases stock of tools if Toolshed is placed and ready", () => {
@@ -41,6 +44,9 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state).Pickaxe).toEqual(new Decimal(90));
     expect(INITIAL_STOCK(state)["Stone Pickaxe"]).toEqual(new Decimal(30));
     expect(INITIAL_STOCK(state)["Iron Pickaxe"]).toEqual(new Decimal(8));
+    expect(INITIAL_STOCK(state)["Gold Pickaxe"]).toEqual(new Decimal(8));
+    expect(INITIAL_STOCK(state)["Oil Drill"]).toEqual(new Decimal(8));
+    expect(INITIAL_STOCK(state).Rod).toEqual(new Decimal(75));
   });
 
   it("does not increase stock of seeds if Warehouse is placed but NOT ready", () => {
@@ -63,6 +69,7 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state)["Pumpkin Seed"]).toEqual(new Decimal(150));
     expect(INITIAL_STOCK(state)["Carrot Seed"]).toEqual(new Decimal(100));
     expect(INITIAL_STOCK(state)["Cabbage Seed"]).toEqual(new Decimal(90));
+    expect(INITIAL_STOCK(state)["Soybean Seed"]).toEqual(new Decimal(90));
     expect(INITIAL_STOCK(state)["Beetroot Seed"]).toEqual(new Decimal(80));
     expect(INITIAL_STOCK(state)["Cauliflower Seed"]).toEqual(new Decimal(80));
     expect(INITIAL_STOCK(state)["Parsnip Seed"]).toEqual(new Decimal(60));
@@ -71,10 +78,19 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state)["Radish Seed"]).toEqual(new Decimal(40));
     expect(INITIAL_STOCK(state)["Wheat Seed"]).toEqual(new Decimal(40));
     expect(INITIAL_STOCK(state)["Kale Seed"]).toEqual(new Decimal(30));
-    expect(INITIAL_STOCK(state)["Apple Seed"]).toEqual(new Decimal(10));
-    expect(INITIAL_STOCK(state)["Orange Seed"]).toEqual(new Decimal(10));
+
     expect(INITIAL_STOCK(state)["Blueberry Seed"]).toEqual(new Decimal(10));
+    expect(INITIAL_STOCK(state)["Orange Seed"]).toEqual(new Decimal(10));
+    expect(INITIAL_STOCK(state)["Apple Seed"]).toEqual(new Decimal(10));
     expect(INITIAL_STOCK(state)["Banana Plant"]).toEqual(new Decimal(10));
+
+    expect(INITIAL_STOCK(state)["Grape Seed"]).toEqual(new Decimal(10));
+    expect(INITIAL_STOCK(state)["Olive Seed"]).toEqual(new Decimal(10));
+    expect(INITIAL_STOCK(state)["Rice Seed"]).toEqual(new Decimal(10));
+
+    expect(INITIAL_STOCK(state)["Sunpetal Seed"]).toEqual(new Decimal(16));
+    expect(INITIAL_STOCK(state)["Bloom Seed"]).toEqual(new Decimal(8));
+    expect(INITIAL_STOCK(state)["Lily Seed"]).toEqual(new Decimal(4));
   });
 
   it("increases stock of seeds if Warehouse is placed and ready", () => {
@@ -97,6 +113,7 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state)["Pumpkin Seed"]).toEqual(new Decimal(180));
     expect(INITIAL_STOCK(state)["Carrot Seed"]).toEqual(new Decimal(120));
     expect(INITIAL_STOCK(state)["Cabbage Seed"]).toEqual(new Decimal(108));
+    expect(INITIAL_STOCK(state)["Soybean Seed"]).toEqual(new Decimal(108));
     expect(INITIAL_STOCK(state)["Beetroot Seed"]).toEqual(new Decimal(96));
     expect(INITIAL_STOCK(state)["Cauliflower Seed"]).toEqual(new Decimal(96));
     expect(INITIAL_STOCK(state)["Parsnip Seed"]).toEqual(new Decimal(72));
@@ -105,10 +122,19 @@ describe("INITIAL_STOCK", () => {
     expect(INITIAL_STOCK(state)["Radish Seed"]).toEqual(new Decimal(48));
     expect(INITIAL_STOCK(state)["Wheat Seed"]).toEqual(new Decimal(48));
     expect(INITIAL_STOCK(state)["Kale Seed"]).toEqual(new Decimal(36));
-    expect(INITIAL_STOCK(state)["Apple Seed"]).toEqual(new Decimal(12));
-    expect(INITIAL_STOCK(state)["Orange Seed"]).toEqual(new Decimal(12));
+
     expect(INITIAL_STOCK(state)["Blueberry Seed"]).toEqual(new Decimal(12));
+    expect(INITIAL_STOCK(state)["Orange Seed"]).toEqual(new Decimal(12));
+    expect(INITIAL_STOCK(state)["Apple Seed"]).toEqual(new Decimal(12));
     expect(INITIAL_STOCK(state)["Banana Plant"]).toEqual(new Decimal(12));
+
+    expect(INITIAL_STOCK(state)["Grape Seed"]).toEqual(new Decimal(12));
+    expect(INITIAL_STOCK(state)["Olive Seed"]).toEqual(new Decimal(12));
+    expect(INITIAL_STOCK(state)["Rice Seed"]).toEqual(new Decimal(12));
+
+    expect(INITIAL_STOCK(state)["Sunpetal Seed"]).toEqual(new Decimal(20));
+    expect(INITIAL_STOCK(state)["Bloom Seed"]).toEqual(new Decimal(10));
+    expect(INITIAL_STOCK(state)["Lily Seed"]).toEqual(new Decimal(5));
   });
 });
 
@@ -133,6 +159,7 @@ describe("INVENTORY_LIMIT", () => {
     expect(INVENTORY_LIMIT(state)["Pumpkin Seed"]).toEqual(new Decimal(400));
     expect(INVENTORY_LIMIT(state)["Carrot Seed"]).toEqual(new Decimal(250));
     expect(INVENTORY_LIMIT(state)["Cabbage Seed"]).toEqual(new Decimal(240));
+    expect(INVENTORY_LIMIT(state)["Soybean Seed"]).toEqual(new Decimal(240));
     expect(INVENTORY_LIMIT(state)["Beetroot Seed"]).toEqual(new Decimal(220));
     expect(INVENTORY_LIMIT(state)["Cauliflower Seed"]).toEqual(
       new Decimal(200)
@@ -143,10 +170,19 @@ describe("INVENTORY_LIMIT", () => {
     expect(INVENTORY_LIMIT(state)["Radish Seed"]).toEqual(new Decimal(100));
     expect(INVENTORY_LIMIT(state)["Wheat Seed"]).toEqual(new Decimal(100));
     expect(INVENTORY_LIMIT(state)["Kale Seed"]).toEqual(new Decimal(80));
-    expect(INVENTORY_LIMIT(state)["Apple Seed"]).toEqual(new Decimal(25));
-    expect(INVENTORY_LIMIT(state)["Orange Seed"]).toEqual(new Decimal(33));
+
     expect(INVENTORY_LIMIT(state)["Blueberry Seed"]).toEqual(new Decimal(40));
+    expect(INVENTORY_LIMIT(state)["Orange Seed"]).toEqual(new Decimal(33));
+    expect(INVENTORY_LIMIT(state)["Apple Seed"]).toEqual(new Decimal(25));
     expect(INVENTORY_LIMIT(state)["Banana Plant"]).toEqual(new Decimal(25));
+
+    expect(INVENTORY_LIMIT(state)["Grape Seed"]).toEqual(new Decimal(50));
+    expect(INVENTORY_LIMIT(state)["Olive Seed"]).toEqual(new Decimal(50));
+    expect(INVENTORY_LIMIT(state)["Rice Seed"]).toEqual(new Decimal(50));
+
+    expect(INVENTORY_LIMIT(state)["Sunpetal Seed"]).toEqual(new Decimal(40));
+    expect(INVENTORY_LIMIT(state)["Bloom Seed"]).toEqual(new Decimal(20));
+    expect(INVENTORY_LIMIT(state)["Lily Seed"]).toEqual(new Decimal(10));
   });
 
   it("increases inventory limit of seeds if Warehouse is placed and ready", () => {
@@ -169,6 +205,7 @@ describe("INVENTORY_LIMIT", () => {
     expect(INVENTORY_LIMIT(state)["Pumpkin Seed"]).toEqual(new Decimal(480));
     expect(INVENTORY_LIMIT(state)["Carrot Seed"]).toEqual(new Decimal(300));
     expect(INVENTORY_LIMIT(state)["Cabbage Seed"]).toEqual(new Decimal(288));
+    expect(INVENTORY_LIMIT(state)["Soybean Seed"]).toEqual(new Decimal(288));
     expect(INVENTORY_LIMIT(state)["Beetroot Seed"]).toEqual(new Decimal(264));
     expect(INVENTORY_LIMIT(state)["Cauliflower Seed"]).toEqual(
       new Decimal(240)
@@ -179,9 +216,18 @@ describe("INVENTORY_LIMIT", () => {
     expect(INVENTORY_LIMIT(state)["Radish Seed"]).toEqual(new Decimal(120));
     expect(INVENTORY_LIMIT(state)["Wheat Seed"]).toEqual(new Decimal(120));
     expect(INVENTORY_LIMIT(state)["Kale Seed"]).toEqual(new Decimal(96));
-    expect(INVENTORY_LIMIT(state)["Apple Seed"]).toEqual(new Decimal(30));
+
+    expect(INVENTORY_LIMIT(state)["Blueberry Seed"]).toEqual(new Decimal(48));
     expect(INVENTORY_LIMIT(state)["Orange Seed"]).toEqual(new Decimal(40));
-    expect(INVENTORY_LIMIT(state)["Blueberry Seed"]).toEqual(new Decimal(50));
+    expect(INVENTORY_LIMIT(state)["Apple Seed"]).toEqual(new Decimal(30));
     expect(INVENTORY_LIMIT(state)["Banana Plant"]).toEqual(new Decimal(30));
+
+    expect(INVENTORY_LIMIT(state)["Grape Seed"]).toEqual(new Decimal(60));
+    expect(INVENTORY_LIMIT(state)["Olive Seed"]).toEqual(new Decimal(60));
+    expect(INVENTORY_LIMIT(state)["Rice Seed"]).toEqual(new Decimal(60));
+
+    expect(INVENTORY_LIMIT(state)["Sunpetal Seed"]).toEqual(new Decimal(48));
+    expect(INVENTORY_LIMIT(state)["Bloom Seed"]).toEqual(new Decimal(24));
+    expect(INVENTORY_LIMIT(state)["Lily Seed"]).toEqual(new Decimal(12));
   });
 });

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -48,7 +48,7 @@ export function isBuildingReady(building: PlacedItem[]) {
   return building.some((b) => b.readyAt <= Date.now());
 }
 export const INITIAL_STOCK = (state?: GameState): Inventory => {
-  let tools = {
+  const tools = {
     Axe: new Decimal(200),
     Pickaxe: new Decimal(60),
     "Stone Pickaxe": new Decimal(20),
@@ -59,22 +59,15 @@ export const INITIAL_STOCK = (state?: GameState): Inventory => {
   };
 
   // increase in 50% tool stock if you have a toolshed
-  if (
-    state?.buildings["Toolshed"] &&
-    isBuildingReady(state.buildings["Toolshed"])
-  ) {
-    tools = {
-      Axe: new Decimal(300),
-      Pickaxe: new Decimal(90),
-      "Stone Pickaxe": new Decimal(30),
-      "Iron Pickaxe": new Decimal(8),
-      "Gold Pickaxe": new Decimal(8),
-      "Oil Drill": new Decimal(8),
-      Rod: new Decimal(75),
-    };
+  if (state?.buildings.Toolshed && isBuildingReady(state.buildings.Toolshed)) {
+    for (const tool in tools) {
+      tools[tool as keyof typeof tools] = new Decimal(
+        Math.ceil(tools[tool as keyof typeof tools].toNumber() * 1.5)
+      );
+    }
   }
 
-  let seeds = {
+  const seeds = {
     "Sunflower Seed": new Decimal(400),
     "Potato Seed": new Decimal(200),
     "Pumpkin Seed": new Decimal(150),
@@ -94,9 +87,9 @@ export const INITIAL_STOCK = (state?: GameState): Inventory => {
     "Olive Seed": new Decimal(10),
     "Rice Seed": new Decimal(10),
 
-    "Apple Seed": new Decimal(10),
-    "Orange Seed": new Decimal(10),
     "Blueberry Seed": new Decimal(10),
+    "Orange Seed": new Decimal(10),
+    "Apple Seed": new Decimal(10),
     "Banana Plant": new Decimal(10),
 
     "Sunpetal Seed": new Decimal(16),
@@ -105,37 +98,15 @@ export const INITIAL_STOCK = (state?: GameState): Inventory => {
   };
 
   if (
-    state?.buildings["Warehouse"] &&
-    isBuildingReady(state.buildings["Warehouse"])
+    state?.buildings.Warehouse &&
+    isBuildingReady(state.buildings.Warehouse)
   ) {
-    seeds = {
-      "Sunflower Seed": new Decimal(480),
-      "Potato Seed": new Decimal(240),
-      "Pumpkin Seed": new Decimal(180),
-      "Carrot Seed": new Decimal(120),
-      "Cabbage Seed": new Decimal(108),
-      "Soybean Seed": new Decimal(108),
-      "Beetroot Seed": new Decimal(96),
-      "Cauliflower Seed": new Decimal(96),
-      "Parsnip Seed": new Decimal(72),
-      "Eggplant Seed": new Decimal(60),
-      "Corn Seed": new Decimal(60),
-      "Radish Seed": new Decimal(48),
-      "Wheat Seed": new Decimal(48),
-      "Kale Seed": new Decimal(36),
-      "Apple Seed": new Decimal(12),
-      "Orange Seed": new Decimal(12),
-      "Blueberry Seed": new Decimal(12),
-      "Banana Plant": new Decimal(12),
-
-      "Grape Seed": new Decimal(12),
-      "Olive Seed": new Decimal(12),
-      "Rice Seed": new Decimal(12),
-
-      "Sunpetal Seed": new Decimal(20),
-      "Bloom Seed": new Decimal(10),
-      "Lily Seed": new Decimal(5),
-    };
+    // Multiply each seed quantity by 1.2 and round up
+    for (const seed in seeds) {
+      seeds[seed as keyof typeof seeds] = new Decimal(
+        Math.ceil(seeds[seed as keyof typeof seeds].toNumber() * 1.2)
+      );
+    }
   }
 
   return {
@@ -156,7 +127,7 @@ export const INITIAL_STOCK = (state?: GameState): Inventory => {
 };
 
 export const INVENTORY_LIMIT = (state?: GameState): Inventory => {
-  let seeds = {
+  const seeds: Record<string, Decimal> = {
     "Sunflower Seed": new Decimal(1000),
     "Potato Seed": new Decimal(500),
     "Pumpkin Seed": new Decimal(400),
@@ -172,9 +143,9 @@ export const INVENTORY_LIMIT = (state?: GameState): Inventory => {
     "Wheat Seed": new Decimal(100),
     "Kale Seed": new Decimal(80),
 
-    "Apple Seed": new Decimal(25),
-    "Orange Seed": new Decimal(33),
     "Blueberry Seed": new Decimal(40),
+    "Orange Seed": new Decimal(33),
+    "Apple Seed": new Decimal(25),
     "Banana Plant": new Decimal(25),
 
     "Rice Seed": new Decimal(50),
@@ -187,38 +158,15 @@ export const INVENTORY_LIMIT = (state?: GameState): Inventory => {
   };
 
   if (
-    state?.buildings["Warehouse"] &&
-    isBuildingReady(state.buildings["Warehouse"])
+    state?.buildings.Warehouse &&
+    isBuildingReady(state.buildings.Warehouse)
   ) {
-    seeds = {
-      "Sunflower Seed": new Decimal(1200),
-      "Potato Seed": new Decimal(600),
-      "Pumpkin Seed": new Decimal(480),
-      "Carrot Seed": new Decimal(300),
-      "Cabbage Seed": new Decimal(288),
-      "Soybean Seed": new Decimal(288),
-      "Beetroot Seed": new Decimal(264),
-      "Cauliflower Seed": new Decimal(240),
-      "Parsnip Seed": new Decimal(180),
-      "Eggplant Seed": new Decimal(144),
-      "Corn Seed": new Decimal(144),
-      "Radish Seed": new Decimal(120),
-      "Wheat Seed": new Decimal(120),
-      "Kale Seed": new Decimal(96),
-
-      "Apple Seed": new Decimal(30),
-      "Orange Seed": new Decimal(40),
-      "Blueberry Seed": new Decimal(50),
-      "Banana Plant": new Decimal(30),
-
-      "Rice Seed": new Decimal(75),
-      "Grape Seed": new Decimal(75),
-      "Olive Seed": new Decimal(75),
-
-      "Sunpetal Seed": new Decimal(48),
-      "Bloom Seed": new Decimal(24),
-      "Lily Seed": new Decimal(12),
-    };
+    // Multiply each seed quantity by 1.2
+    for (const seed in seeds) {
+      seeds[seed as keyof typeof seeds] = new Decimal(
+        Math.ceil(seeds[seed as keyof typeof seeds].toNumber() * 1.2)
+      );
+    }
   }
 
   return seeds;


### PR DESCRIPTION
# Description

Current Values are hardcoded when toolshed and warehouse are placed, this PR makes it such that it's dynamic.

This caused the **inventory limit** of the following seeds to be reduced with warehouse:
- Blueberry Seeds: 50 => 48
- Grape Seeds: 75 => 60
- Olive Seeds: 75 => 60
- Rice Seeds: 75 => 60

I left the tests hard coded just to make sure that that the numbers are correct in the test

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
