### PR TITLE
[FIX] Delivery NPCs locked on desert

### DIFF
--- a/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
+++ b/src/features/world/ui/deliveries/DeliveryPanelContent.tsx
@@ -209,7 +209,7 @@ export function getTotalExpansions({
 }) {
   let totalExpansions = game.inventory["Basic Land"] ?? new Decimal(3);
 
-  if (game.island.type === "spring") {
+  if (game.island.type !== "basic") {
     totalExpansions = totalExpansions.add(game.island.previousExpansions ?? 6);
   }
 


### PR DESCRIPTION
# Description

Delivery NPCs should be unlocked for desert (prestige 2) regardless of how many expansions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
