### PR TITLE
[FIX] Beehive showing in Boosts in Chest

### DIFF
--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -187,9 +187,9 @@ export const Chest: React.FC<Props> = ({
   // Sort collectibles by type
   const resources = getKeys(collectibles).filter((name) => name in RESOURCES);
   const buildings = getKeys(collectibles).filter((name) => name in BUILDINGS);
-  const boosts = getKeys(collectibles).filter(
-    (name) => name in COLLECTIBLE_BUFF_LABELS
-  );
+  const boosts = getKeys(collectibles)
+    .filter((name) => name in COLLECTIBLE_BUFF_LABELS)
+    .filter((name) => !resources.includes(name) && !buildings.includes(name));
   const decorations = getKeys(collectibles).filter(
     (name) =>
       !resources.includes(name) &&


### PR DESCRIPTION
# Description

Hides Beehive from boost section of Chest

## Before

![before](https://github.com/sunflower-land/sunflower-land/assets/41215134/e34e37f7-f4e6-4114-9b6c-33148a57c49f)

## After 

![after](https://github.com/sunflower-land/sunflower-land/assets/41215134/31326ffe-cb98-4684-82dc-05d29cbb018d)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes