### PR TITLE
[CHORE] Icon Overrides

### DIFF
--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -11,6 +11,7 @@ import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { Label } from "../Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { ITEM_ICONS } from "features/island/hud/components/inventory/Chest";
 
 /**
  * The props for the details for items.
@@ -73,7 +74,7 @@ export const InventoryItemDetails: React.FC<Props> = ({
   const { t } = useAppTranslation();
   const getItemDetail = () => {
     const item = ITEM_DETAILS[details.item];
-    const icon = item.image;
+    const icon = ITEM_ICONS(game.island.type)[details.item] ?? item.image;
     const title = details.item;
 
     let description = item.description;

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -174,7 +174,10 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
                 isSelected={selectedName === name}
                 key={name}
                 onClick={() => setSelectedName(name)}
-                image={ITEM_ICONS[name] ?? ITEM_DETAILS[name].image}
+                image={
+                  ITEM_ICONS(state.island.type)[name] ??
+                  ITEM_DETAILS[name].image
+                }
                 secondaryImage={secondaryIcon}
                 showOverlay={isLocked}
               />

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -1,7 +1,11 @@
 import React, { useRef } from "react";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { GameState, InventoryItemName } from "features/game/types/game";
+import {
+  GameState,
+  InventoryItemName,
+  IslandType,
+} from "features/game/types/game";
 import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { getChestBuds, getChestItems } from "./utils/inventory";
 import Decimal from "decimal.js-light";
@@ -33,10 +37,13 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { TREE_VARIANTS } from "features/island/resources/Resource";
 
 const imageDomain = CONFIG.NETWORK === "mainnet" ? "buds" : "testnet-buds";
 
-export const ITEM_ICONS: Partial<Record<InventoryItemName, string>> = {
+export const ITEM_ICONS: (
+  island: IslandType
+) => Partial<Record<InventoryItemName, string>> = (island) => ({
   Market: marketIcon,
   "Fire Pit": firePitIcon,
   Workbench: workbenchIcon,
@@ -47,7 +54,8 @@ export const ITEM_ICONS: Partial<Record<InventoryItemName, string>> = {
   "Smoothie Shack": smoothieIcon,
   Toolshed: toolshedIcon,
   Warehouse: warehouseIcon,
-};
+  Tree: TREE_VARIANTS[island],
+});
 
 interface Props {
   state: GameState;
@@ -274,7 +282,10 @@ export const Chest: React.FC<Props> = ({
                     isSelected={selectedChestItem === item}
                     key={item}
                     onClick={() => handleItemClick(item)}
-                    image={ITEM_ICONS[item] ?? ITEM_DETAILS[item].image}
+                    image={
+                      ITEM_ICONS(state.island.type)[item] ??
+                      ITEM_DETAILS[item].image
+                    }
                     parentDivRef={divRef}
                   />
                 ))}
@@ -298,7 +309,10 @@ export const Chest: React.FC<Props> = ({
                     isSelected={selectedChestItem === item}
                     key={item}
                     onClick={() => handleItemClick(item)}
-                    image={ITEM_ICONS[item] ?? ITEM_DETAILS[item].image}
+                    image={
+                      ITEM_ICONS(state.island.type)[item] ??
+                      ITEM_DETAILS[item].image
+                    }
                     parentDivRef={divRef}
                   />
                 ))}
@@ -318,7 +332,10 @@ export const Chest: React.FC<Props> = ({
                     isSelected={selectedChestItem === item}
                     key={item}
                     onClick={() => handleItemClick(item)}
-                    image={ITEM_ICONS[item] ?? ITEM_DETAILS[item].image}
+                    image={
+                      ITEM_ICONS(state.island.type)[item] ??
+                      ITEM_DETAILS[item].image
+                    }
                     parentDivRef={divRef}
                   />
                 ))}
@@ -338,7 +355,10 @@ export const Chest: React.FC<Props> = ({
                     isSelected={selectedChestItem === item}
                     key={item}
                     onClick={() => handleItemClick(item)}
-                    image={ITEM_ICONS[item] ?? ITEM_DETAILS[item].image}
+                    image={
+                      ITEM_ICONS(state.island.type)[item] ??
+                      ITEM_DETAILS[item].image
+                    }
                     parentDivRef={divRef}
                   />
                 ))}

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -32,7 +32,7 @@ import { IslandType } from "features/game/types/game";
 
 import cacti from "assets/resources/tree/cacti.webp";
 
-const TREE_VARIANTS: Record<IslandType, string> = {
+export const TREE_VARIANTS: Record<IslandType, string> = {
   basic: SUNNYSIDE.resource.tree,
   spring: SUNNYSIDE.resource.tree,
   desert: cacti,


### PR DESCRIPTION
# Description

Reported during beta testing, adds ability to override icon

![icon-override](https://github.com/sunflower-land/sunflower-land/assets/41215134/33690107-e751-4e79-8c79-c202acd01392)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
