### PR TITLE
[CHORE] Restrict Removal of Town Center, House and Manor

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -392,6 +392,8 @@ export const STATIC_OFFLINE_FARM: GameState = {
     } as Record<ChoreV2Name, ChoreV2>,
   },
   inventory: {
+    Manor: new Decimal(1),
+    House: new Decimal(1),
     "Apple Seed": new Decimal(10),
     "Desert Gnome": new Decimal(1),
     Blossombeard: new Decimal(1),

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -391,6 +391,7 @@ import basicComposter from "assets/composters/composter_basic.png";
 import advancedComposter from "assets/composters/composter_advanced.png";
 import expertComposter from "assets/composters/composter_expert.png";
 import house from "assets/buildings/house.png";
+import manor from "assets/buildings/manor.png";
 
 // Composter Bait
 import earthworm from "assets/composters/earthworm.png";
@@ -1672,8 +1673,7 @@ export const ITEM_DETAILS: Items = {
     description: translate("description.house"),
   },
   Manor: {
-    // TODO feat/manor
-    image: house,
+    image: manor,
     description: translate("description.house"),
   },
   Kitchen: {

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -85,11 +85,21 @@ function getMoveAction(
 export function getRemoveAction(
   name: InventoryItemName | "Bud"
 ): GameEventName<PlacementEvent> | null {
-  if (name in BUILDINGS_DIMENSIONS) {
+  if (
+    name in BUILDINGS_DIMENSIONS &&
+    name !== "Manor" &&
+    name !== "Town Center" &&
+    name !== "House"
+  ) {
     return "building.removed";
   }
 
-  if (name in RESOURCES) {
+  if (
+    name in RESOURCES ||
+    name === "Manor" ||
+    name === "House" ||
+    name === "Town Center"
+  ) {
     return null;
   }
 


### PR DESCRIPTION
# Description

Proposal to restrict removal of Home buildings to prevent players from an exploit where players can remove their home buildings so that they can put more buildings/resource nodes in early expansions in their respective islands

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/b75857da-b5f1-4387-8ef4-818ecd23cb97)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/6aa7031c-49b8-4e26-b01a-4ed12c22470f)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
