### PR TITLE
[FEAT] Oil Boosts (Battle Fish and Knight Chicken)

### DIFF
--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { GameState, OilReserve } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
 
@@ -14,7 +15,26 @@ type Options = {
 };
 
 export const BASE_OIL_DROP_AMOUNT = 10;
+export const OIL_BONUS_DROP_AMOUNT = 20;
 export const OIL_RESERVE_RECOVERY_TIME = 20 * 60 * 60;
+
+function getNextOilDropAmount(game: GameState, reserve: OilReserve) {
+  let amount = new Decimal(BASE_OIL_DROP_AMOUNT);
+
+  if ((reserve.drilled + 1) % 3 === 0) {
+    amount = amount.add(OIL_BONUS_DROP_AMOUNT);
+  }
+
+  if (isCollectibleBuilt({ name: "Battle Fish", game })) {
+    amount = amount.add(0.05);
+  }
+
+  if (isCollectibleBuilt({ name: "Knight Chicken", game })) {
+    amount = amount.add(0.1);
+  }
+
+  return amount.toDecimalPlaces(4).toNumber();
+}
 
 export function canDrillOilReserve(
   reserve: OilReserve,
@@ -56,7 +76,7 @@ export function drillOilReserve({
   // Increment drilled count
   oilReserve.drilled += 1;
   // Set next drill drop amount
-  oilReserve.oil.amount = BASE_OIL_DROP_AMOUNT;
+  oilReserve.oil.amount = getNextOilDropAmount(game, oilReserve);
 
   return game;
 }

--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -1281,4 +1281,58 @@ describe("canremove", () => {
 
     expect(restricted).toBe(true);
   });
+
+  it("prevents a user from removing Battle Fish when oil is drilled", () => {
+    const [restricted] = hasRemoveRestriction("Battle Fish", "123", {
+      ...TEST_FARM,
+      oilReserves: {
+        0: {
+          x: 0,
+          y: 3,
+          width: 1,
+          height: 1,
+          oil: {
+            amount: 1,
+            drilledAt: Date.now() - 100,
+          },
+          createdAt: 0,
+          drilled: 1,
+        },
+      },
+      collectibles: {
+        "Battle Fish": [
+          { coordinates: { x: 1, y: 1 }, createdAt: 0, id: "123", readyAt: 0 },
+        ],
+      },
+    });
+
+    expect(restricted).toBe(true);
+  });
+
+  it("prevents a user from removing Knight Chicken when oil is drilled", () => {
+    const [restricted] = hasRemoveRestriction("Knight Chicken", "123", {
+      ...TEST_FARM,
+      oilReserves: {
+        0: {
+          x: 0,
+          y: 3,
+          width: 1,
+          height: 1,
+          oil: {
+            amount: 1,
+            drilledAt: Date.now() - 100,
+          },
+          createdAt: 0,
+          drilled: 1,
+        },
+      },
+      collectibles: {
+        "Knight Chicken": [
+          { coordinates: { x: 1, y: 1 }, createdAt: 0, id: "123", readyAt: 0 },
+        ],
+      },
+    });
+
+    expect(restricted).toBe(true);
+  });
 });

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -19,6 +19,7 @@ import { FLOWERS, FLOWER_SEEDS } from "./flowers";
 import { getCurrentHoneyProduced } from "../expansion/components/resources/beehive/beehiveMachine";
 import { DEFAULT_HONEY_PRODUCTION_TIME } from "../lib/updateBeehives";
 import { translate } from "lib/i18n/translate";
+import { canDrillOilReserve } from "../events/landExpansion/drillOilReserve";
 
 export type Restriction = [boolean, string];
 type RemoveCondition = (gameState: GameState) => Restriction;
@@ -270,6 +271,17 @@ function hasShakenTree(game: GameState): Restriction {
 
   return [hasShakenRecently, translate("restrictionReason.festiveSeason")];
 }
+
+function areAnyOilReservesDrilled(game: GameState): Restriction {
+  const now = Date.now();
+
+  const oilReservesDrilled = Object.values(game.oilReserves).some(
+    (oilReserve) => !canDrillOilReserve(oilReserve, now)
+  );
+
+  return [oilReservesDrilled, "Oil reserves are drilled"];
+}
+
 export const REMOVAL_RESTRICTIONS: Partial<
   Record<InventoryItemName, RemoveCondition>
 > = {
@@ -374,6 +386,9 @@ export const REMOVAL_RESTRICTIONS: Partial<
 
   // Clash of Factions
   Soybliss: (game) => cropIsGrowing({ item: "Soybean", game }),
+
+  "Knight Chicken": (game) => areAnyOilReservesDrilled(game),
+  "Battle Fish": (game) => areAnyOilReservesDrilled(game),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<


### PR DESCRIPTION
# Description

- Adds the Oil Boost of Battle Fish and Knight Chicken
- Adds Remove restriction for Battle Fish and Knight Chicken

## How to Test

1. Acquire Battle Fish and Knight Chicken
2. Place both
3. Assert first oil mine is not boosted

![oil1](https://github.com/sunflower-land/sunflower-land/assets/41215134/8680d43e-e610-4261-be9f-4f967328dc7b)

4. Assert second oil mine is boosted

![oil2](https://github.com/sunflower-land/sunflower-land/assets/41215134/9a3f5750-e54e-4578-8ad4-2a0940219c28)

5. Assert the two collectibles cannot be removed from farm

![oil3](https://github.com/sunflower-land/sunflower-land/assets/41215134/edb6ce78-f442-48e1-a7f0-c75291b6c202)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
