### PR TITLE
[FIX] Crimstone Reset Timer

### DIFF
--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -718,7 +718,7 @@ describe("revealLand", () => {
       createdAt: now,
     });
 
-    expect(state.crimstones[1].stone.minedAt).toBeLessThan(
+    expect(state.crimstones[1].stone.minedAt).toBeLessThanOrEqual(
       now - CRIMSTONE_RECOVERY_TIME * 1000
     );
   });

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -14,6 +14,7 @@ import cloneDeep from "lodash.clonedeep";
 import { getKeys } from "features/game/types/craftables";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 
 export type RevealLandAction = {
   type: "land.revealed";
@@ -284,7 +285,7 @@ export function revealLand({
         ...game.crimstones[id],
         stone: {
           ...game.crimstones[id].stone,
-          minedAt: createdAt - 48 * 60 * 60 * 1000,
+          minedAt: createdAt - CRIMSTONE_RECOVERY_TIME * 1000,
         },
       },
     };


### PR DESCRIPTION
# Description

Crimstone streak is resetting due to `revealLand` moving `minedAt` into the past. This PR changes the windback to be 24 hours instead of the current 48 hours. 

The result of this change is that the player has th valid 24 hour window to mine the crimstone and continue the streak.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
