### PR TITLE
[CHORE] Add mint timer to mint screen after connecting wallet

### DIFF
--- a/src/features/retreat/components/auctioneer/Winner.tsx
+++ b/src/features/retreat/components/auctioneer/Winner.tsx
@@ -27,12 +27,24 @@ export const Winner: React.FC<Props> = ({ onMint, bid, farmId, results }) => {
     return (
       <GameWallet action="purchase">
         <>
-          <div className="my-2">
-            <Label type="success">{t("congrats")}</Label>
+          <div className="flex flex-col justify-center items-center pt-2">
+            <div className="my-2">
+              <Label type="success">{t("congrats")}</Label>
+            </div>
+            <p className="text-xs mb-2">{t("winner.mintTime")}</p>
+            <TimerDisplay time={countdown} />
+            <a
+              href="https://docs.sunflower-land.com/player-guides/auctions#how-to-mint-an-items"
+              className="mx-auto text-xxs underline text-center pb-2 pt-2"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("read.more")}
+            </a>
+            <Button className="mt-2" onClick={() => onMint(bid.auctionId)}>
+              {t("mint")}
+            </Button>
           </div>
-          <Button className="mt-2" onClick={() => onMint(bid.auctionId)}>
-            {t("mint")}
-          </Button>
         </>
       </GameWallet>
     );


### PR DESCRIPTION
# Description

Currently the mint screen after connecting wallet post auction is a bit empty, This PR adds the countdown timer and the read more info to make the page less empty
Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/9230f356-1e71-4c53-82c9-7a9712943099)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/cf8ad8a9-446f-4f5d-83ee-7c797955671f)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
