### PR TITLE
[FIX] Add Removal Restriction for Greenhouse Building

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -412,6 +412,7 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Knight Chicken": (game) => areAnyOilReservesDrilled(game),
   "Battle Fish": (game) => areAnyOilReservesDrilled(game),
   "Turbo Sprout": (game) => areAnyGreenhouseCropGrowing(game),
+  Greenhouse: (game) => areAnyGreenhouseCropGrowing(game),
   Vinny: (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
   "Grape Granny": (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
   "Rice Panda": (game) => greenhouseCropIsGrowing({ crop: "Rice", game }),

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -47,7 +47,10 @@ function greenhouseCropIsGrowing({
   const cropPlanted = Object.values(game.greenhouse.pots ?? {}).some(
     (pots) => pots.plant && pots.plant.name === crop
   );
-  return [cropPlanted, `${crop} is growing`];
+  return [
+    cropPlanted,
+    translate("restrictionReason.?cropGrowing", { crop: crop }),
+  ];
 }
 
 function areAnyGreenhouseCropGrowing(game: GameState): Restriction {
@@ -55,7 +58,7 @@ function areAnyGreenhouseCropGrowing(game: GameState): Restriction {
     (plot) => !!plot.plant
   );
 
-  return [cropsPlanted, "Crops are growing"];
+  return [cropsPlanted, translate("restrictionReason.cropsGrowing")];
 }
 
 function beanIsPlanted(game: GameState): Restriction {
@@ -301,7 +304,7 @@ function areAnyOilReservesDrilled(game: GameState): Restriction {
     (oilReserve) => !canDrillOilReserve(oilReserve, now)
   );
 
-  return [oilReservesDrilled, "Oil reserves are drilled"];
+  return [oilReservesDrilled, translate("restrictionReason.oilReserveDrilled")];
 }
 
 export const REMOVAL_RESTRICTIONS: Partial<

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4756,6 +4756,7 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.isGrowing": "{{item}} is growing",
   "restrictionReason.beanPlanted": "Magic Bean is planted",
   "restrictionReason.cropsGrowing": "Crops are growing",
+  "restrictionReason.?cropGrowing": "{{crop}} is growing",
   "restrictionReason.basicCropsGrowing": "Basic crops are growing",
   "restrictionReason.mediumCropsGrowing": "Medium crops are growing",
   "restrictionReason.advancedCropsGrowing": "Advanced crops are growing",
@@ -4776,6 +4777,7 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.festiveSeason": "Locked during festive season",
   "restrictionReason.noRestriction": "No restriction",
   "restrictionReason.genieLampRubbed": "Genie Lamp rubbed",
+  "restrictionReason.oilReserveDrilled": "Oil reserves are drilled",
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4942,6 +4942,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.beanPlanted"],
   "restrictionReason.cropsGrowing":
     ENGLISH_TERMS["restrictionReason.cropsGrowing"],
+  "restrictionReason.?cropGrowing":
+    ENGLISH_TERMS["restrictionReason.?cropGrowing"],
   "restrictionReason.basicCropsGrowing":
     ENGLISH_TERMS["restrictionReason.basicCropsGrowing"],
   "restrictionReason.mediumCropsGrowing":
@@ -4976,6 +4978,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.noRestriction"],
   "restrictionReason.genieLampRubbed":
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
+  "restrictionReason.oilReserveDrilled":
+    ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4811,6 +4811,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.beanPlanted"],
   "restrictionReason.cropsGrowing":
     ENGLISH_TERMS["restrictionReason.cropsGrowing"],
+  "restrictionReason.?cropGrowing":
+    ENGLISH_TERMS["restrictionReason.?cropGrowing"],
   "restrictionReason.basicCropsGrowing":
     ENGLISH_TERMS["restrictionReason.basicCropsGrowing"],
   "restrictionReason.mediumCropsGrowing":
@@ -4845,6 +4847,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.noRestriction"],
   "restrictionReason.genieLampRubbed":
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
+  "restrictionReason.oilReserveDrilled":
+    ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4781,6 +4781,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.beanPlanted"],
   "restrictionReason.cropsGrowing":
     ENGLISH_TERMS["restrictionReason.cropsGrowing"],
+  "restrictionReason.?cropGrowing":
+    ENGLISH_TERMS["restrictionReason.?cropGrowing"],
   "restrictionReason.basicCropsGrowing":
     ENGLISH_TERMS["restrictionReason.basicCropsGrowing"],
   "restrictionReason.mediumCropsGrowing":
@@ -4815,6 +4817,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.noRestriction"],
   "restrictionReason.genieLampRubbed":
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
+  "restrictionReason.oilReserveDrilled":
+    ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3255,6 +3255,7 @@ export type RestrictionReason =
   | "restrictionReason.isGrowing"
   | "restrictionReason.beanPlanted"
   | "restrictionReason.cropsGrowing"
+  | "restrictionReason.?cropGrowing"
   | "restrictionReason.basicCropsGrowing"
   | "restrictionReason.mediumCropsGrowing"
   | "restrictionReason.advancedCropsGrowing"
@@ -3274,7 +3275,8 @@ export type RestrictionReason =
   | "restrictionReason.pawShaken"
   | "restrictionReason.festiveSeason"
   | "restrictionReason.noRestriction"
-  | "restrictionReason.genieLampRubbed";
+  | "restrictionReason.genieLampRubbed"
+  | "restrictionReason.oilReserveDrilled";
 
 export type Leaderboard =
   | "leaderboard.leaderboard"


### PR DESCRIPTION
# Description

Adds Removal Restriction when Greenhouse Crops are growing
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/838d28ee-2556-4d21-b12f-40d819777c19)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
