### PR TITLE
[FIX] Oil Tank Text

### DIFF
--- a/src/features/greenhouse/GreenhouseOil.tsx
+++ b/src/features/greenhouse/GreenhouseOil.tsx
@@ -121,8 +121,11 @@ export const GreenhouseOil: React.FC = () => {
       >
         <div
           style={{
-            left: `${16 * PIXEL_SCALE}px`,
             top: `${-6 * PIXEL_SCALE}px`,
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+            whiteSpace: "nowrap",
           }}
           className="absolute z-10"
         >

--- a/src/features/greenhouse/GreenhouseOil.tsx
+++ b/src/features/greenhouse/GreenhouseOil.tsx
@@ -65,7 +65,7 @@ export const GreenhouseOil: React.FC = () => {
         <CloseButtonPanel onClose={() => setShowModal(false)}>
           <div className="p-1">
             <Label type="default" className="mb-2" icon={barrel}>
-              {`${totalOil} oil in machine`}
+              {t("greenhouse.oilInMachine", { oil: totalOil })}
             </Label>
             <p className="text-xs mb-2">{t("greenhouse.oilDescription")}</p>
             <div className="flex items-center flex-wrap">
@@ -75,18 +75,20 @@ export const GreenhouseOil: React.FC = () => {
                     src={ITEM_DETAILS[SEED_TO_PLANT[seed]].image}
                     className="h-5 mr-1"
                   />
-                  <p className="text-xs mr-0.5">{`${OIL_USAGE[seed]} Oil`}</p>
+                  <p className="text-xs mr-0.5">
+                    {t("greenhouse.numberOil", { oil: OIL_USAGE[seed] })}
+                  </p>
                 </OuterPanel>
               ))}
             </div>
 
             <div className="flex justify-between items-center mb-2 mt-4 pl-1">
               <Label type="default" icon={SUNNYSIDE.icons.basket}>
-                {`Insert Oil: ${availableOil} ${t("available")}`}
+                {t("greenhouse.insertOil", { oil: availableOil })}
               </Label>
               {totalOil >= 100 && (
                 <Label type="success" icon={SUNNYSIDE.icons.confirm}>
-                  {`Max reached`}
+                  {t("max.reached")}
                 </Label>
               )}
             </div>
@@ -130,7 +132,7 @@ export const GreenhouseOil: React.FC = () => {
           className="absolute z-10"
         >
           <Label type={barrelOil <= 0 ? "danger" : "default"} icon={oilIcon}>
-            {t("greenhouse.oilInTank", { barrelOil: barrelOil })}
+            {t("greenhouse.oilInMachine", { oil: barrelOil })}
           </Label>
         </div>
         <img

--- a/src/features/greenhouse/GreenhouseOil.tsx
+++ b/src/features/greenhouse/GreenhouseOil.tsx
@@ -126,10 +126,9 @@ export const GreenhouseOil: React.FC = () => {
           }}
           className="absolute z-10"
         >
-          <Label
-            type={barrelOil <= 0 ? "danger" : "default"}
-            icon={oilIcon}
-          >{`${barrelOil} Oil`}</Label>
+          <Label type={barrelOil <= 0 ? "danger" : "default"} icon={oilIcon}>
+            {t("greenhouse.oilInTank", { barrelOil: barrelOil })}
+          </Label>
         </div>
         <img
           src={oilBarrels}

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4830,6 +4830,7 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": "The greenhouse needs oil to grow plants.",
   "greenhouse.oilRequired": "Oil required",
+  "greenhouse.oilInTank": "{{oil}} Oil in Tank",
 };
 
 export const ENGLISH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -320,6 +320,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "make.wish": "Make a Wish",
   "making.wish": "Making a wish",
   max: "Max",
+  "max.reached": "Max reached",
   message: "Message",
   messages: "Messages",
   minimum: "Minimum",
@@ -4830,7 +4831,9 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": "The greenhouse needs oil to grow plants.",
   "greenhouse.oilRequired": "Oil required",
-  "greenhouse.oilInTank": "{{oil}} Oil in Tank",
+  "greenhouse.oilInMachine": "{{oil}} Oil in machine",
+  "greenhouse.insertOil": "Insert Oil: {{oil}} available",
+  "greenhouse.numberOil": "{{oil}} Oil",
 };
 
 export const ENGLISH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5034,6 +5034,7 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
+  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
 };
 
 export const FRENCH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -493,6 +493,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "p2p.trading": ENGLISH_TERMS["p2p.trading"],
   vipAccess: ENGLISH_TERMS["vipAccess"],
   vip: ENGLISH_TERMS["vip"],
+  "max.reached": ENGLISH_TERMS["max.reached"],
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -5034,7 +5035,9 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
-  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
+  "greenhouse.oilInMachine": ENGLISH_TERMS["greenhouse.oilInMachine"],
+  "greenhouse.insertOil": ENGLISH_TERMS["greenhouse.insertOil"],
+  "greenhouse.numberOil": ENGLISH_TERMS["greenhouse.numberOil"],
 };
 
 export const FRENCH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -493,6 +493,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "p2p.trading": ENGLISH_TERMS["p2p.trading"],
   vipAccess: ENGLISH_TERMS["vipAccess"],
   vip: ENGLISH_TERMS["vip"],
+  "max.reached": ENGLISH_TERMS["max.reached"],
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -4904,7 +4905,9 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
-  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
+  "greenhouse.oilInMachine": ENGLISH_TERMS["greenhouse.oilInMachine"],
+  "greenhouse.insertOil": ENGLISH_TERMS["greenhouse.insertOil"],
+  "greenhouse.numberOil": ENGLISH_TERMS["greenhouse.numberOil"],
 };
 
 export const PORTUGUESE_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4904,6 +4904,7 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
+  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
 };
 
 export const PORTUGUESE_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4873,6 +4873,7 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
+  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
 };
 
 export const TURKISH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -493,6 +493,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "p2p.trading": ENGLISH_TERMS["p2p.trading"],
   vipAccess: ENGLISH_TERMS["vipAccess"],
   vip: ENGLISH_TERMS["vip"],
+  "max.reached": ENGLISH_TERMS["max.reached"],
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -4873,7 +4874,9 @@ const gameOptions: Record<GameOptions, string> = {
 const greenhouse: Record<GreenhouseKeys, string> = {
   "greenhouse.oilDescription": ENGLISH_TERMS["greenhouse.oilDescription"],
   "greenhouse.oilRequired": ENGLISH_TERMS["greenhouse.oilRequired"],
-  "greenhouse.oilInTank": ENGLISH_TERMS["greenhouse.oilInTank"],
+  "greenhouse.oilInMachine": ENGLISH_TERMS["greenhouse.oilInMachine"],
+  "greenhouse.insertOil": ENGLISH_TERMS["greenhouse.insertOil"],
+  "greenhouse.numberOil": ENGLISH_TERMS["greenhouse.numberOil"],
 };
 
 export const TURKISH_TERMS: Record<TranslationKeys, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -147,6 +147,7 @@ export type GeneralTerms =
   | "message"
   | "messages"
   | "max"
+  | "max.reached"
   | "minimum"
   | "mint"
   | "minting"
@@ -3315,7 +3316,9 @@ export type GameOptions =
 export type GreenhouseKeys =
   | "greenhouse.oilRequired"
   | "greenhouse.oilDescription"
-  | "greenhouse.oilInTank";
+  | "greenhouse.oilInMachine"
+  | "greenhouse.insertOil"
+  | "greenhouse.numberOil";
 
 export type TranslationKeys =
   | AchievementsTerms

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3314,7 +3314,9 @@ export type GameOptions =
 
 export type GreenhouseKeys =
   | "greenhouse.oilRequired"
-  | "greenhouse.oilDescription";
+  | "greenhouse.oilDescription"
+  | "greenhouse.oilInTank";
+
 export type TranslationKeys =
   | AchievementsTerms
   | Auction


### PR DESCRIPTION
# Description

Players may confuse the Oil amount in the greenhouse as the oil in their inventory. This PR makes it clear that the Oil amount in the greenhouse refers to the Oil in Tank, not in inventory.

Change the text in the Oil tank to differentiate between the Oil in Inventory and the Oil in Tank
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f9a53be8-1d56-46ad-ae42-3a4b811934a6)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
