### PR TITLE
[FIX] Scarecrow heads blocking clicks

### DIFF
--- a/src/features/island/collectibles/components/BasicScarecrow.tsx
+++ b/src/features/island/collectibles/components/BasicScarecrow.tsx
@@ -5,7 +5,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 export const BasicScarecrow: React.FC = () => {
   return (
     <div
-      className="absolute"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 22}px`,
         bottom: `${PIXEL_SCALE * 0}px`,

--- a/src/features/island/collectibles/components/LaurieTheChuckelCrow.tsx
+++ b/src/features/island/collectibles/components/LaurieTheChuckelCrow.tsx
@@ -5,7 +5,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 export const LaurieTheChuckleCrow: React.FC = () => {
   return (
     <div
-      className="absolute"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 25}px`,
         bottom: `${PIXEL_SCALE * 0}px`,

--- a/src/features/island/collectibles/components/ScaryMike.tsx
+++ b/src/features/island/collectibles/components/ScaryMike.tsx
@@ -5,7 +5,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 export const ScaryMike: React.FC = () => {
   return (
     <div
-      className="absolute"
+      className="absolute pointer-events-none"
       style={{
         width: `${PIXEL_SCALE * 22}px`,
         bottom: `${PIXEL_SCALE * 0}px`,


### PR DESCRIPTION
# Description

- fix issue where scarecrow heads are blocking clicks.  Eg. If a mushroom/crop plot is near the scarecrow head, it is almost impossible to collect the said resource
  - in the future, new collectibles should be set to pointer-events-none if it is not clickable.  This can prevent the UI blocking issue.  If the collectible is interactable, a parent div with the desired dimensions should be added, and the child should be set to pointer-events-none

![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/08cdc1e7-e708-457c-99be-d1858e880750)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- put the 3 scarecrows on the island and with resources behind the heads, then click the head area

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
