### PR TITLE
[CHORE] Use Labels for oil requirements

### DIFF
--- a/src/features/greenhouse/GreenhouseOil.tsx
+++ b/src/features/greenhouse/GreenhouseOil.tsx
@@ -17,7 +17,6 @@ import { Button } from "components/ui/Button";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { Box } from "components/ui/Box";
 import Decimal from "decimal.js-light";
-import { OuterPanel } from "components/ui/Panel";
 import {
   OIL_USAGE,
   SEED_TO_PLANT,
@@ -68,17 +67,16 @@ export const GreenhouseOil: React.FC = () => {
               {t("greenhouse.oilInMachine", { oil: totalOil })}
             </Label>
             <p className="text-xs mb-2">{t("greenhouse.oilDescription")}</p>
-            <div className="flex items-center flex-wrap">
+            <div className="flex items-center flex-wrap gap-1">
               {getKeys(OIL_USAGE).map((seed) => (
-                <OuterPanel key={seed} className="flex items-center mr-1">
-                  <img
-                    src={ITEM_DETAILS[SEED_TO_PLANT[seed]].image}
-                    className="h-5 mr-1"
-                  />
-                  <p className="text-xs mr-0.5">
-                    {t("greenhouse.numberOil", { oil: OIL_USAGE[seed] })}
-                  </p>
-                </OuterPanel>
+                <Label
+                  key={seed}
+                  type="formula"
+                  className="mx-1"
+                  icon={ITEM_DETAILS[SEED_TO_PLANT[seed]].image}
+                >
+                  {t("greenhouse.numberOil", { oil: OIL_USAGE[seed] })}
+                </Label>
               ))}
             </div>
 


### PR DESCRIPTION
# Description

- use Label instead of OuterPanel for oil requrements.  Otherwise the oil reqirements looks like buttons

Before|After
---|---
![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/877cb7a0-d0b0-4fba-be25-e7e920fd44f5)|![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/ba7b7b94-4969-40c2-9592-d4947f760d25)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- add oil in greenhouse

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
