### PR TITLE
[FIX] Hide modal when clicking outside of VIP gift modal

### DIFF
--- a/src/features/game/expansion/components/SeasonTeaser.tsx
+++ b/src/features/game/expansion/components/SeasonTeaser.tsx
@@ -1,11 +1,9 @@
-import { useActor } from "@xstate/react";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 
 import island from "assets/land/vip_island.png";
 import vipGift from "assets/decorations/vip_gift.png";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
-import { Context } from "features/game/GameProvider";
 
 import { MapPlacement } from "./MapPlacement";
 import { Modal } from "components/ui/Modal";
@@ -17,12 +15,10 @@ interface Props {
 
 export const SeasonTeaser: React.FC<Props> = ({ offset }) => {
   const [showModal, setShowModal] = useState(false);
-  const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
 
   return (
     <>
-      <Modal show={showModal}>
+      <Modal show={showModal} onHide={() => setShowModal(false)}>
         <VIPGift onClose={() => setShowModal(false)} />
       </Modal>
       <MapPlacement x={0} y={-6 - offset} width={6}>


### PR DESCRIPTION
# Description

- add onHide effect to VIP Gift modal

![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/c2d3a8b0-8c86-44ef-9b4d-4c180beeaba6)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- click outside of VIP gift modal on main island

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
