### PR TITLE
[FIX] Crop boost order

### DIFF
--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -5,7 +5,7 @@ import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { FRUIT, FRUIT_SEEDS } from "features/game/types/fruits";
 import { GameState, FruitPatch } from "features/game/types/game";
 import {
-  getFruitPatchYield,
+  getFruitYield,
   harvestFruit,
   isFruitReadyToHarvest,
 } from "./fruitHarvested";
@@ -580,11 +580,9 @@ describe("fruitHarvested", () => {
 
   describe("getFruitYield", () => {
     it("provides no bonuses", () => {
-      const amount = getFruitPatchYield({
-        buds: {},
+      const amount = getFruitYield({
         game: TEST_FARM,
         name: "Apple",
-        wearables: { ...INITIAL_BUMPKIN.equipped },
       });
     });
   });

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -74,7 +74,7 @@ export function isFruitGrowing(patch: FruitPatch) {
   return growingTimeLeft > 0;
 }
 
-export function getFruitYield({ game, name, fertiliser }: FruitYield) {
+export function getFruitYield({ name, game, fertiliser }: FruitYield) {
   let amount = 1;
 
   if (name === "Apple" && isCollectibleBuilt({ name: "Lady Bug", game })) {

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { getBudYieldBoosts } from "features/game/lib/getBudYieldBoosts";
-import { Equipped } from "features/game/types/bumpkin";
 import {
   BumpkinActivityName,
   trackActivity,
@@ -51,10 +50,8 @@ export const isFruitReadyToHarvest = (
 };
 
 type FruitYield = {
-  name: FruitName;
+  name: FruitName | GreenHouseFruitName;
   game: GameState;
-  buds: NonNullable<GameState["buds"]>;
-  wearables: Equipped;
   fertiliser?: FruitCompostName;
 };
 
@@ -77,29 +74,8 @@ export function isFruitGrowing(patch: FruitPatch) {
   return growingTimeLeft > 0;
 }
 
-export function getFruitYield({
-  game,
-  name,
-}: {
-  game: GameState;
-  name: FruitName | GreenHouseFruitName;
-}) {
-  const { buds } = game;
+export function getFruitYield({ game, name, fertiliser }: FruitYield) {
   let amount = 1;
-
-  amount += getBudYieldBoosts(buds ?? {}, name);
-
-  return amount;
-}
-
-export function getFruitPatchYield({
-  game,
-  buds,
-  name,
-  wearables,
-  fertiliser,
-}: FruitYield) {
-  let amount = getFruitYield({ game, name });
 
   if (name === "Apple" && isCollectibleBuilt({ name: "Lady Bug", game })) {
     amount += 0.25;
@@ -136,6 +112,16 @@ export function getFruitPatchYield({
   ) {
     amount += 0.1;
   }
+
+  // Grape
+  if (name === "Grape" && isCollectibleBuilt({ name: "Vinny", game })) {
+    amount += 0.25;
+  }
+
+  if (name === "Grape" && isCollectibleBuilt({ name: "Grape Granny", game })) {
+    amount += 1;
+  }
+  amount += getBudYieldBoosts(game.buds ?? {}, name);
 
   return amount;
 }
@@ -190,10 +176,8 @@ export function harvestFruit({
     createdAt
   );
 
-  patch.fruit.amount = getFruitPatchYield({
+  patch.fruit.amount = getFruitYield({
     game: stateCopy,
-    buds: stateCopy.buds ?? {},
-    wearables: bumpkin.equipped,
     name,
     fertiliser: patch.fertiliser?.name,
   });

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -13,7 +13,7 @@ import {
 import { Bumpkin, GameState } from "features/game/types/game";
 import { randomInt } from "lib/utils/random";
 import cloneDeep from "lodash.clonedeep";
-import { getFruitPatchYield } from "./fruitHarvested";
+import { getFruitYield } from "./fruitHarvested";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import { isWearableActive } from "features/game/lib/wearables";
 import { translate } from "lib/i18n/translate";
@@ -166,11 +166,9 @@ export function plantFruit({
       stateCopy,
       createdAt
     ),
-    amount: getFruitPatchYield({
+    amount: getFruitYield({
       name: fruitName,
       game: stateCopy,
-      buds: stateCopy.buds ?? {},
-      wearables: bumpkin.equipped,
       fertiliser: patch.fertiliser?.name,
     }),
     harvestedAt: 0,

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -5,7 +5,7 @@ import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { GameState, CropPlot } from "../../types/game";
 import {
   getCropPlotTime,
-  getPlotYieldAmount,
+  getCropYieldAmount,
   getPlantedAt,
   isPlotFertile,
   plant,
@@ -1709,9 +1709,8 @@ describe("getCropTime", () => {
   });
 
   it("applies the eggplant boost when wearing the onesie", () => {
-    const amount = getPlotYieldAmount({
+    const amount = getCropYieldAmount({
       crop: "Eggplant",
-      inventory: {},
       game: {
         ...TEST_FARM,
         bumpkin: {
@@ -1722,7 +1721,6 @@ describe("getCropTime", () => {
           },
         },
       },
-      buds: {},
       plot,
     });
 
@@ -1730,9 +1728,8 @@ describe("getCropTime", () => {
   });
 
   it("applies the corn boost when wearing the corn onesie", () => {
-    const amount = getPlotYieldAmount({
+    const amount = getCropYieldAmount({
       crop: "Corn",
-      inventory: {},
       game: {
         ...TEST_FARM,
         bumpkin: {
@@ -1743,7 +1740,6 @@ describe("getCropTime", () => {
           },
         },
       },
-      buds: {},
       plot,
     });
 
@@ -2174,7 +2170,7 @@ describe("isPlotFertile", () => {
 
 describe("getCropYield", () => {
   it("does not apply sir goldensnout boost outside AOE", () => {
-    const amount = getPlotYieldAmount({
+    const amount = getCropYieldAmount({
       crop: "Sunflower",
       game: {
         ...TEST_FARM,
@@ -2189,8 +2185,6 @@ describe("getCropYield", () => {
           ],
         },
       },
-      inventory: {},
-      buds: {},
       plot: { createdAt: 0, height: 1, width: 1, x: 2, y: 3 },
     });
 
@@ -2198,7 +2192,7 @@ describe("getCropYield", () => {
   });
 
   it("applies sir goldensnout boost inside AOE", () => {
-    const amount = getPlotYieldAmount({
+    const amount = getCropYieldAmount({
       crop: "Sunflower",
       game: {
         ...TEST_FARM,
@@ -2213,8 +2207,6 @@ describe("getCropYield", () => {
           ],
         },
       },
-      inventory: {},
-      buds: {},
       plot: { createdAt: 0, height: 1, width: 1, x: 5, y: 6 },
     });
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -324,10 +324,32 @@ export function getCropYieldAmount({
   const skills = bumpkin.skills ?? {};
 
   if (
-    crop === "Cauliflower" &&
-    isCollectibleBuilt({ name: "Golden Cauliflower", game })
+    isCollectibleBuilt({ name: "Scarecrow", game }) ||
+    isCollectibleBuilt({ name: "Kuebiko", game })
   ) {
-    amount *= 2;
+    amount *= 1.2;
+  }
+
+  if (inventory.Coder?.gte(1)) {
+    amount *= 1.2;
+  }
+
+  //Bumpkin Skill boost Green Thumb Skill
+  if (skills["Green Thumb"]) {
+    amount *= 1.05;
+  }
+
+  //Bumpkin Skill boost Master Farmer Skill
+  if (skills["Master Farmer"]) {
+    amount *= 1.1;
+  }
+
+  //Bumpkin Wearable boost Sunflower Amulet
+  if (
+    crop === "Sunflower" &&
+    isWearableActive({ name: "Sunflower Amulet", game })
+  ) {
+    amount *= 1.1;
   }
 
   if (crop === "Carrot" && isCollectibleBuilt({ name: "Easter Bunny", game })) {
@@ -353,36 +375,26 @@ export function getCropYieldAmount({
   ) {
     amount *= 1.2;
   }
-  //Bumpkin Wearable boost Sunflower Amulet
-  if (
-    crop === "Sunflower" &&
-    isWearableActive({ name: "Sunflower Amulet", game })
-  ) {
-    amount *= 1.1;
-  }
 
   if (
-    isCollectibleBuilt({ name: "Scarecrow", game }) ||
-    isCollectibleBuilt({ name: "Kuebiko", game })
+    crop === "Cauliflower" &&
+    isCollectibleBuilt({ name: "Golden Cauliflower", game })
   ) {
-    amount *= 1.2;
+    amount *= 2;
   }
 
-  if (inventory.Coder?.gte(1)) {
-    amount *= 1.2;
+  // Generic Additive Crop Boosts
+  if (isWearableActive({ name: "Infernal Pitchfork", game })) {
+    amount += 3;
   }
 
-  //Bumpkin Skill boost Green Thumb Skill
-  if (skills["Green Thumb"]) {
-    amount *= 1.05;
+  amount += getBudYieldBoosts(buds ?? {}, crop);
+
+  // Specific Crop Additive Boosts
+  if (isOvernightCrop(crop) && isCollectibleBuilt({ name: "Hoot", game })) {
+    amount = amount + 0.5;
   }
 
-  //Bumpkin Skill boost Master Farmer Skill
-  if (skills["Master Farmer"]) {
-    amount *= 1.1;
-  }
-
-  // Additive boosts below
   if (crop === "Soybean" && isCollectibleBuilt({ name: "Soybliss", game })) {
     amount += 1;
   }
@@ -546,18 +558,6 @@ export function getCropYieldAmount({
 
   if (fertiliser === "Sprout Mix") {
     amount += 0.2;
-  }
-
-  // Generic Crop Boosts
-
-  if (isWearableActive({ name: "Infernal Pitchfork", game })) {
-    amount += 3;
-  }
-
-  amount += getBudYieldBoosts(buds ?? {}, crop);
-
-  if (isOvernightCrop(crop) && isCollectibleBuilt({ name: "Hoot", game })) {
-    amount = amount + 0.5;
   }
 
   // Greenhouse Crops

--- a/src/features/game/events/landExpansion/plantGreenhouse.ts
+++ b/src/features/game/events/landExpansion/plantGreenhouse.ts
@@ -16,7 +16,6 @@ import {
   BumpkinActivityName,
   trackActivity,
 } from "features/game/types/bumpkinActivity";
-import { isWearableActive } from "features/game/lib/wearables";
 import { GREENHOUSE_CROP_TIME_SECONDS } from "./harvestGreenHouse";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { getCropTime, getCropYieldAmount } from "./plant";
@@ -75,38 +74,11 @@ export function getGreenhouseYieldAmount({
   crop: GreenHouseCropName | GreenHouseFruitName;
   game: GameState;
 }): number {
-  let amount = 1;
-
   if (isGreenhouseCrop(crop)) {
-    amount = getCropYieldAmount({ crop, game });
-  } else {
-    amount = getFruitYield({ name: crop, game });
+    return getCropYieldAmount({ crop, game });
   }
 
-  // Rice
-  if (crop === "Rice" && isWearableActive({ name: "Non La Hat", game })) {
-    amount += 1;
-  }
-
-  if (crop === "Rice" && isCollectibleBuilt({ name: "Rice Panda", game })) {
-    amount += 0.25;
-  }
-
-  // Grape
-  if (crop === "Grape" && isCollectibleBuilt({ name: "Vinny", game })) {
-    amount += 0.25;
-  }
-
-  if (crop === "Grape" && isCollectibleBuilt({ name: "Grape Granny", game })) {
-    amount += 1;
-  }
-
-  // Olive
-  if (crop === "Olive" && isWearableActive({ name: "Olive Shield", game })) {
-    amount += 1;
-  }
-
-  return amount;
+  return getFruitYield({ name: crop, game });
 }
 
 type GetPlantedAtArgs = {


### PR DESCRIPTION
# Description

In the Greenhouse release, we accidentally changed the order boosts were applied. This caused crop yields to increase quite dramatically.

This PR puts boosts into the correct order.

1. Multiplicative first
2. Additive second

All crops (plot and greenhouse) are now in the one function to preserve correct order, same for fruits.