### PR TITLE
[FIX] Hide modals when clicking outside

### DIFF
--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -113,6 +113,7 @@ interface Props {
 
 export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
   const [interactable, setInteractable] = useState<InteractableName>();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     interactableModalManager.listen((interactable, open) => {
@@ -121,7 +122,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
   }, []);
 
   const closeModal = () => {
-    setInteractable(undefined);
+    !isLoading && setInteractable(undefined);
   };
 
   const { t } = useAppTranslation();
@@ -232,6 +233,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           type="Treasure Key"
           onClose={closeModal}
           location={"plaza"}
+          setIsLoading={setIsLoading}
         />
       </Modal>
       <Modal show={interactable === "rare_chest"} onHide={closeModal}>
@@ -239,6 +241,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           type="Rare Key"
           onClose={closeModal}
           location={"plaza"}
+          setIsLoading={setIsLoading}
         />
       </Modal>
       <Modal show={interactable === "luxury_chest"} onHide={closeModal}>
@@ -246,6 +249,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           type="Luxury Key"
           onClose={closeModal}
           location={"plaza"}
+          setIsLoading={setIsLoading}
         />
       </Modal>
       <Modal show={interactable === "plaza_orange_book"} onHide={closeModal}>
@@ -322,7 +326,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
         />
       </Modal>
       <Modal show={interactable === "clubhouse_reward"} onHide={closeModal}>
-        <BudBox onClose={closeModal} />
+        <BudBox onClose={closeModal} setIsLoading={setIsLoading} />
       </Modal>
       <Modal show={interactable === "raffle"} onHide={closeModal}>
         <Raffle onClose={closeModal} />

--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -227,21 +227,21 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           ]}
         />
       </Modal>
-      <Modal show={interactable === "basic_chest"}>
+      <Modal show={interactable === "basic_chest"} onHide={closeModal}>
         <BasicTreasureChest
           type="Treasure Key"
           onClose={closeModal}
           location={"plaza"}
         />
       </Modal>
-      <Modal show={interactable === "rare_chest"}>
+      <Modal show={interactable === "rare_chest"} onHide={closeModal}>
         <BasicTreasureChest
           type="Rare Key"
           onClose={closeModal}
           location={"plaza"}
         />
       </Modal>
-      <Modal show={interactable === "luxury_chest"}>
+      <Modal show={interactable === "luxury_chest"} onHide={closeModal}>
         <BasicTreasureChest
           type="Luxury Key"
           onClose={closeModal}
@@ -321,7 +321,7 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           ]}
         />
       </Modal>
-      <Modal show={interactable === "clubhouse_reward"}>
+      <Modal show={interactable === "clubhouse_reward"} onHide={closeModal}>
         <BudBox onClose={closeModal} />
       </Modal>
       <Modal show={interactable === "raffle"} onHide={closeModal}>

--- a/src/features/world/ui/chests/BasicTreasureChest.tsx
+++ b/src/features/world/ui/chests/BasicTreasureChest.tsx
@@ -17,12 +17,14 @@ interface Props {
   onClose: () => void;
   location: "plaza";
   type: "Treasure Key" | "Rare Key" | "Luxury Key";
+  setIsLoading?: (isLoading: boolean) => void;
 }
 
 export const BasicTreasureChest: React.FC<Props> = ({
   onClose,
   location,
   type,
+  setIsLoading,
 }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
@@ -36,6 +38,7 @@ export const BasicTreasureChest: React.FC<Props> = ({
   const hasKey = !!gameState.context.state.inventory[type]?.gte(1);
 
   const open = async () => {
+    setIsLoading && setIsLoading(true);
     setIsPicking(true);
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -50,6 +53,7 @@ export const BasicTreasureChest: React.FC<Props> = ({
     });
     setIsRevealing(true);
     setIsPicking(false);
+    setIsLoading && setIsLoading(false);
   };
 
   if (isPicking || (gameState.matches("revealing") && isRevealing)) {

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -21,6 +21,7 @@ import { getDayOfYear, secondsToString } from "lib/utils/time";
 
 interface Props {
   onClose: () => void;
+  setIsLoading?: (isLoading: boolean) => void;
 }
 
 const BUD_ORDER: TypeTrait[] = [
@@ -59,7 +60,7 @@ const ICONS: Record<TypeTrait, string> = {
   Beach: budIcon,
 };
 
-export const BudBox: React.FC<Props> = ({ onClose }) => {
+export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const { t } = useAppTranslation();
@@ -70,6 +71,7 @@ export const BudBox: React.FC<Props> = ({ onClose }) => {
   const [isRevealing, setIsRevealing] = useState(false);
 
   const open = async () => {
+    setIsLoading && setIsLoading(true);
     setIsPicking(true);
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -82,6 +84,7 @@ export const BudBox: React.FC<Props> = ({ onClose }) => {
     });
     setIsRevealing(true);
     setIsPicking(false);
+    setIsLoading && setIsLoading(false);
   };
 
   if (isPicking || (gameState.matches("revealing") && isRevealing)) {


### PR DESCRIPTION
# Description

Allow hiding the clubhouse reward, treasure chest, rare chest, and luxury chest modals by clicking outside.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open the modals and close them by clicking outside.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
