### PR TITLE
[CHORE] Bake in open/close sounds to modals + escape key to close modals

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import React, { Fragment, useRef } from "react";
+import React, { Fragment, useEffect, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
+import { useSound } from "lib/utils/hooks/useSound";
 
 interface ModalProps {
   size?: "lg" | "sm";
@@ -27,6 +28,24 @@ export const Modal: React.FC<ModalProps> = ({
   backdrop = true,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+
+  const openSound = useSound("open");
+  const closeSound = useSound("close");
+
+  // exit modal if Escape key is pressed
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && show) {
+        onHide?.();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [show, onHide]);
 
   return (
     <Transition appear show={!!show} as={Fragment}>
@@ -71,7 +90,13 @@ export const Modal: React.FC<ModalProps> = ({
               leave="ease-out duration-75"
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
-              beforeEnter={() => onShow?.()}
+              beforeEnter={() => {
+                if (backdrop) openSound.play();
+                onShow?.();
+              }}
+              beforeLeave={() => {
+                closeSound.play();
+              }}
               afterLeave={() => onExited?.()}
             >
               <Dialog.Panel

--- a/src/features/game/components/CloseablePanel.tsx
+++ b/src/features/game/components/CloseablePanel.tsx
@@ -53,7 +53,6 @@ export const CloseButtonPanel: React.FC<Props> = ({
   children,
 }) => {
   const tabSound = useSound("tab");
-  const close = useSound("close");
   const button = useSound("button");
 
   const handleTabClick = (index: number) => {
@@ -136,7 +135,6 @@ export const CloseButtonPanel: React.FC<Props> = ({
               src={SUNNYSIDE.icons.close}
               className="flex-none cursor-pointer float-right"
               onClick={() => {
-                close.play();
                 onClose();
               }}
               style={{

--- a/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
+++ b/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
@@ -14,7 +14,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Bar } from "components/ui/ProgressBar";
 import { InnerPanel } from "components/ui/Panel";
 import classNames from "classnames";
-import { chopAudio } from "lib/utils/sfx";
+import { chopAudio, loadAudio } from "lib/utils/sfx";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ZoomContext } from "components/ZoomProvider";
 import { IslandType } from "features/game/types/game";
@@ -56,6 +56,8 @@ const RecoveredTreeComponent: React.FC<Props> = ({
 
   const shakeGif = useRef<SpriteSheetInstance>();
   const { t } = useAppTranslation();
+
+  loadAudio([chopAudio]);
 
   // prevent performing react state update on an unmounted component
   useEffect(() => {

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -58,7 +58,6 @@ const LandscapingHudComponent: React.FC<{
   const [showDecorations, setShowDecorations] = useState(false);
   const [showRemoveConfirmation, setShowRemoveConfirmation] = useState(false);
 
-  const open = useSound("open");
   const button = useSound("button");
 
   const child = gameService.state.children.landscaping as MachineInterpreter;
@@ -170,7 +169,6 @@ const LandscapingHudComponent: React.FC<{
               {location === "farm" && (
                 <div
                   onClick={() => {
-                    open.play();
                     setShowDecorations(true);
                   }}
                   className="w-full z-10 cursor-pointer hover:img-highlight relative"
@@ -315,13 +313,10 @@ const Chest: React.FC<{
 
   const chestItems = getChestItems(gameState.context.state);
 
-  const open = useSound("open");
-
   return (
     <>
       <div
         onClick={() => {
-          open.play();
           setShowChest(true);
         }}
         className="z-50 cursor-pointer hover:img-highlight relative"

--- a/src/features/island/hud/components/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/BumpkinProfile.tsx
@@ -218,7 +218,6 @@ export const BumpkinProfile: React.FC<{
   const [showModal, setShowModal] = useState(false);
 
   const profile = useSound("profile");
-  const close = useSound("close");
 
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
@@ -262,7 +261,6 @@ export const BumpkinProfile: React.FC<{
   };
 
   const handleHideModal = () => {
-    close.play();
     setShowModal(false);
   };
 

--- a/src/features/island/hud/components/Settings.tsx
+++ b/src/features/island/hud/components/Settings.tsx
@@ -35,8 +35,6 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
   const { pathname } = useLocation();
 
   const button = useSound("button");
-  const open = useSound("open");
-  const close = useSound("close");
 
   // The actions included in this more buttons should not be shown if the player is in goblin retreat or visiting another farm
   const showLimitedButtons =
@@ -58,13 +56,11 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
   }, []);
 
   const handleCloseAudioMenu = () => {
-    close.play();
     setOpenAudioMenu(false);
     setShowMoreButtons(false);
   };
 
   const handleCloseSettingsMenu = () => {
-    close.play();
     setOpenSettingsMenu(false);
     setShowMoreButtons(false);
   };
@@ -160,7 +156,6 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
     settingButton(
       index,
       () => {
-        open.play();
         setOpenAudioMenu(true);
       },
       <img
@@ -199,7 +194,6 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
     settingButton(
       index,
       () => {
-        open.play();
         setOpenSettingsMenu(true);
       },
       <img

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -49,7 +49,6 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
   const [showMilestoneReached, setShowMilestoneReached] = useState(false);
   const [milestoneName, setMilestoneName] = useState<MilestoneName>();
 
-  const close = useSound("close");
   const tab = useSound("tab");
 
   const [data, setData] = useState<Leaderboards | null | undefined>(undefined);

--- a/src/features/island/hud/components/codex/CodexButton.tsx
+++ b/src/features/island/hud/components/codex/CodexButton.tsx
@@ -14,7 +14,6 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useSelector } from "@xstate/react";
-import { useSound } from "lib/utils/hooks/useSound";
 
 const _delivery = (state: MachineState) => state.context.state.delivery;
 const _level = (state: MachineState) =>
@@ -22,8 +21,6 @@ const _level = (state: MachineState) =>
 
 export const CodexButton: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-
-  const open = useSound("open");
 
   const { gameService } = useContext(Context);
 
@@ -45,7 +42,6 @@ export const CodexButton: React.FC = () => {
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
-          open.play();
           setIsOpen(true);
         }}
       >

--- a/src/features/island/hud/components/deliveries/TravelButton.tsx
+++ b/src/features/island/hud/components/deliveries/TravelButton.tsx
@@ -4,18 +4,13 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import world from "assets/icons/world.png";
 import { Modal } from "components/ui/Modal";
 import { WorldMap } from "./WorldMap";
-import { useSound } from "lib/utils/hooks/useSound";
 
 export const Travel: React.FC<{ isVisiting?: boolean }> = ({
   isVisiting = false,
 }) => {
   const [showModal, setShowModal] = useState(false);
 
-  const open = useSound("open");
-  const close = useSound("close");
-
   const onClose = () => {
-    close.play();
     setShowModal(false);
   };
 
@@ -32,7 +27,6 @@ export const Travel: React.FC<{ isVisiting?: boolean }> = ({
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
-            open.play();
             setShowModal(true);
           }}
         >

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -40,7 +40,6 @@ export const Inventory: React.FC<Props> = ({
   const { pathname } = useLocation();
 
   const inventory = useSound("inventory");
-  const close = useSound("close");
 
   // The actions included in this more buttons should not be shown if the player is in goblin retreat or visiting another farm
   const limitedInventory =
@@ -136,7 +135,6 @@ export const Inventory: React.FC<Props> = ({
       <InventoryItemsModal
         show={isOpen}
         onHide={() => {
-          close.play();
           setIsOpen(false);
         }}
         state={state}

--- a/src/features/world/lib/AudioController.ts
+++ b/src/features/world/lib/AudioController.ts
@@ -17,7 +17,7 @@ export class WalkAudioController {
   handleWalkSound(isWalking: boolean): void {
     if (isWalking) {
       if (!this.walkSound.isPlaying) {
-        this.walkSound.play({ loop: true, volume: 0.1, rate: 0.62 });
+        this.walkSound.play({ loop: true, volume: 0.07, rate: 0.62 });
       }
     } else {
       if (this.walkSound.isPlaying) {

--- a/src/lib/utils/hooks/useSound.ts
+++ b/src/lib/utils/hooks/useSound.ts
@@ -7,27 +7,27 @@ const HOWLERS = {
   open: new Howl({
     src: [SOUNDS.ui.hud],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   tab: new Howl({
     src: [SOUNDS.ui.tab],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   close: new Howl({
     src: [SOUNDS.ui.close],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   travel: new Howl({
     src: [SOUNDS.ui.travel],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   profile: new Howl({
     src: [SOUNDS.ui.profile],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   inventory: new Howl({
     src: [SOUNDS.ui.inventory],
@@ -37,19 +37,19 @@ const HOWLERS = {
   button: new Howl({
     src: [SOUNDS.ui.button],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   copypaste: new Howl({
     src: [SOUNDS.ui.copypaste],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   romy_rick: new Howl({
     src: [willow_tree],
     preload: false,
     volume: 0.06,
     loop: true,
-    rate: 0.76,
+    rate: 1,
   }),
   desert: new Howl({
     src: [SOUNDS.loops.desert],
@@ -61,22 +61,22 @@ const HOWLERS = {
   sfl: new Howl({
     src: [SOUNDS.ui.sfl],
     preload: false,
-    volume: 0.1,
+    volume: 0.05,
   }),
   mushroom_1: new Howl({
     src: [SOUNDS.resources.mushroom_1],
     preload: false,
-    volume: 0.15,
+    volume: 0.1,
   }),
   mushroom_2: new Howl({
     src: [SOUNDS.resources.mushroom_2],
     preload: false,
-    volume: 0.15,
+    volume: 0.1,
   }),
   mushroom_3: new Howl({
     src: [SOUNDS.resources.mushroom_3],
     preload: false,
-    volume: 0.15,
+    volume: 0.1,
   }),
 };
 

--- a/src/lib/utils/hooks/useSound.ts
+++ b/src/lib/utils/hooks/useSound.ts
@@ -7,27 +7,27 @@ const HOWLERS = {
   open: new Howl({
     src: [SOUNDS.ui.hud],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   tab: new Howl({
     src: [SOUNDS.ui.tab],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   close: new Howl({
     src: [SOUNDS.ui.close],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   travel: new Howl({
     src: [SOUNDS.ui.travel],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   profile: new Howl({
     src: [SOUNDS.ui.profile],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   inventory: new Howl({
     src: [SOUNDS.ui.inventory],
@@ -37,12 +37,12 @@ const HOWLERS = {
   button: new Howl({
     src: [SOUNDS.ui.button],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   copypaste: new Howl({
     src: [SOUNDS.ui.copypaste],
     preload: false,
-    volume: 0.1,
+    volume: 0.2,
   }),
   romy_rick: new Howl({
     src: [willow_tree],
@@ -61,22 +61,22 @@ const HOWLERS = {
   sfl: new Howl({
     src: [SOUNDS.ui.sfl],
     preload: false,
-    volume: 0.05,
+    volume: 0.1,
   }),
   mushroom_1: new Howl({
     src: [SOUNDS.resources.mushroom_1],
     preload: false,
-    volume: 0.1,
+    volume: 0.15,
   }),
   mushroom_2: new Howl({
     src: [SOUNDS.resources.mushroom_2],
     preload: false,
-    volume: 0.1,
+    volume: 0.15,
   }),
   mushroom_3: new Howl({
     src: [SOUNDS.resources.mushroom_3],
     preload: false,
-    volume: 0.1,
+    volume: 0.15,
   }),
 };
 

--- a/src/lib/utils/sfx.ts
+++ b/src/lib/utils/sfx.ts
@@ -32,122 +32,122 @@ export const loadAudio = (sounds: Howl[]) => {
 export const harvestAudio = new Howl({
   src: [SOUNDS.resources.harvest],
   preload: false,
-  volume: 0.2,
+  volume: 0.05,
 });
 
 export const plantAudio = new Howl({
   src: [SOUNDS.resources.plant],
   preload: false,
-  volume: 0.2,
+  volume: 0.05,
 });
 
 export const bakeryAudio = new Howl({
   src: [SOUNDS.buildings.kitchen],
   preload: false,
-  volume: 0.5,
+  volume: 0.25,
 });
 
 export const blacksmithAudio = new Howl({
   src: [SOUNDS.buildings.blacksmith],
   preload: false,
-  volume: 0.2,
+  volume: 0.05,
 });
 
 export const shopAudio = new Howl({
   src: [SOUNDS.buildings.shop],
   preload: false,
-  volume: 0.2,
+  volume: 0.05,
 });
 
 export const bankAudio = new Howl({
   src: [SOUNDS.buildings.bank],
   preload: false,
-  volume: 0.2,
+  volume: 0.05,
 });
 
 export const beggarAudio = new Howl({
   src: [SOUNDS.misc.begger],
   preload: false,
-  volume: 0.3,
+  volume: 0.1,
 });
 
 export const wishingWellAudio = new Howl({
   src: [SOUNDS.buildings.wishing_well],
   preload: false,
-  volume: 0.5,
+  volume: 0.25,
 });
 
 export const miningAudio = new Howl({
   src: [SOUNDS.resources.mining],
   preload: false,
-  volume: 0.5,
+  volume: 0.1,
 });
 
 export const miningFallAudio = new Howl({
   src: [SOUNDS.resources.mining_fall],
   preload: false,
-  volume: 0.5,
+  volume: 0.1,
 });
 
 export const chopAudio = new Howl({
   src: [SOUNDS.resources.chop],
   preload: false,
-  volume: 0.3,
+  volume: 0.1,
 });
 
 export const treeFallAudio = new Howl({
   src: [SOUNDS.resources.tree_fall],
   preload: false,
-  volume: 0.3,
+  volume: 0.1,
 });
 
 export const tailorAudio = new Howl({
   src: [SOUNDS.buildings.tailor],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });
 
 export const barnAudio = new Howl({
   src: [SOUNDS.buildings.barn],
   preload: false,
-  volume: 0.1,
+  volume: 0.05,
 });
 
 export const diaryAudio = new Howl({
   src: [SOUNDS.misc.diary],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });
 
 export const battleAudio = new Howl({
   src: [SOUNDS.misc.battle],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });
 
 export const fountainAudio = new Howl({
   src: [SOUNDS.misc.fountain],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });
 
 export const observatoryAnimationAudio = new Howl({
   src: [SOUNDS.misc.mom_observatory_animation_sounds],
   preload: false,
-  volume: 0.5,
+  volume: 0.15,
   loop: true,
 });
 
 export const burningSound = new Howl({
   src: [SOUNDS.loops.fire],
   preload: false,
-  volume: 0.5,
+  volume: 0.25,
 });
 
 export const warChant = new Howl({
   src: [SOUNDS.misc.war_chant],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });
 
 // Arcade - Greedy Goblin
@@ -155,23 +155,23 @@ export const greedyGoblinAudio = {
   greedyGoblinIntroAudio: new Howl({
     src: [SOUNDS.greedy_goblin.intro],
     preload: false,
-    volume: 0.3,
+    volume: 0.15,
   }),
   greedyGoblinPlayingAudio: new Howl({
     src: [SOUNDS.greedy_goblin.playing],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
     loop: true,
   }),
   greedyGoblinPickAudio: new Howl({
     src: [SOUNDS.greedy_goblin.pick],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   greedyGoblinGameOverAudio: new Howl({
     src: [SOUNDS.misc.game_over],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
 };
 
@@ -180,23 +180,23 @@ export const chickenFightAudio = {
   chickenFightPlayingAudio: new Howl({
     src: [SOUNDS.chicken_fight.playing],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
     loop: true,
   }),
   chickenFightPunchAudio: new Howl({
     src: [SOUNDS.chicken_fight.punch],
     preload: false,
-    volume: 0.3,
+    volume: 0.15,
   }),
   chickenFightHitAudio: new Howl({
     src: [SOUNDS.chicken_fight.hit],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
   chickenFightGameOverAudio: new Howl({
     src: [SOUNDS.misc.game_over],
     preload: false,
-    volume: 0.2,
+    volume: 0.1,
   }),
 };
 
@@ -204,5 +204,5 @@ export const chickenFightAudio = {
 export const mazeOver = new Howl({
   src: [SOUNDS.notifications.maze_over],
   preload: false,
-  volume: 0.2,
+  volume: 0.1,
 });


### PR DESCRIPTION
# Description

- bake in open and close sounds to modals.  No more setting it everywhere
- modal listens to escape key and closes when escape key is pressed
- boosts new sound levels because they are too dim compared to the existing sfx


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- chop trees on desert island

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes