### PR TITLE
[FEAT] Adjust the scrollbar of the trading board

### DIFF
--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -111,13 +111,13 @@ export const BuyPanel: React.FC<{
     }
 
     return (
-      <div className="p-2">
+      <div className="flex flex-col pl-2 pt-2">
         {hasPurchasesRemaining && (
           <Label type="default" icon={SUNNYSIDE.icons.basket} className="ml-2">
             {t("trading.select.resources")}
           </Label>
         )}
-        <div className="flex flex-wrap mt-2">
+        <div className="flex flex-wrap flex-1 pr-2 overflow-y-auto scrollable mt-2">
           {getKeys(TRADE_LIMITS).map((name) => (
             <div
               key={name}
@@ -349,7 +349,7 @@ export const BuyPanel: React.FC<{
     }
 
     return (
-      <div>
+      <div className="flex flex-col w-full pl-2 pt-1">
         <div className="flex items-center">
           <img
             src={SUNNYSIDE.icons.arrow_left}
@@ -369,7 +369,7 @@ export const BuyPanel: React.FC<{
             {selected.current}
           </Label>
         </div>
-        <div className="mt-1">
+        <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">
           {listings.map((listing, index) => {
             // only one resource listing
             const listingItem = listing.items[
@@ -425,7 +425,7 @@ export const BuyPanel: React.FC<{
 
   return (
     <>
-      <div className="max-h-[400px] min-h-[150px] overflow-y-auto pr-1 divide-brown-600 scrollable">
+      <div className="flex flex-col max-h-[400px] divide-brown-600">
         <div className="pl-2 pt-2 space-y-1 sm:space-y-0 sm:flex items-center justify-between ml-1.5">
           <VIPAccess
             isVIP={isVIP}
@@ -448,10 +448,10 @@ export const BuyPanel: React.FC<{
             </Label>
           )}
         </div>
-        <div className="flex items-start justify-between mb-2">
+        <div className="flex flex-col min-h-[150px] items-start justify-between">
           {isSearching && <p className="loading mt-1">{t("searching")}</p>}
           {!isSearching && (
-            <div className="relative w-full">
+            <div className="flex overflow-y-auto relative w-full">
               {view === "search" && searchView()}
               {view === "list" && listView(listings)}
             </div>


### PR DESCRIPTION
# Description

Adjust the scrollbar to only affect the list of items, excluding the navigation button and tab information.

| Before | After|
| ------------ | ------------- |
| ![Before list view](https://github.com/sunflower-land/sunflower-land/assets/142336449/0c4a8e4b-e177-4574-9b3c-d29a3d672205) | ![After list view](https://github.com/sunflower-land/sunflower-land/assets/142336449/087a5934-04df-4245-b160-56963ab2164f) |

| Before | After|
| ------------ | ------------- |
| ![Before search view](https://github.com/sunflower-land/sunflower-land/assets/142336449/4a8351b4-62d0-4b6f-b917-3195d9184e4c) | ![After search view](https://github.com/sunflower-land/sunflower-land/assets/142336449/9b5434e0-fba1-4e79-b1c9-bfa4ebf9d94e) |

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Open the trading board and scroll down.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
