### PR TITLE
[FIX] Crop Machine output showing Seed name instead of Crop Name

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -252,11 +252,14 @@ export const CropMachineModal: React.FC<Props> = ({
                   </div>
                 )}
                 <div className="flex">
-                  <Box
-                    image={ITEM_DETAILS[`${selectedPack.crop} Seed`].image}
-                  />
+                  <Box image={ITEM_DETAILS[selectedPack.crop].image} />
                   <div className="flex flex-col justify-center space-y-1">
-                    <span className="text-xs">{`${selectedPack.amount} x ${selectedPack.crop} Seeds`}</span>
+                    <span className="text-xs">
+                      {`??? x `}
+                      {selectedPack.crop === "Potato"
+                        ? `${selectedPack.crop}es`
+                        : `${selectedPack.crop}s`}
+                    </span>
                     {show && (
                       <PackGrowthProgressBar
                         paused={paused}


### PR DESCRIPTION
# Description

- Change from showing output to `??? Crop` instead

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/06dbf151-2138-44d3-9817-d46b4714168a)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/a10e3c77-799e-4045-8d10-53ca6407503d)

Added Pluralisation condition for potatoes

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
