### PR TITLE
[CHORE] Round down listing floor prices to 4 digits properly

### DIFF
--- a/src/components/ui/ListingCategoryCard.tsx
+++ b/src/components/ui/ListingCategoryCard.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import classNames from "classnames";
+import { OuterPanel } from "./Panel";
+import { setPrecision } from "lib/utils/formatNumber";
+import { Label } from "./Label";
+import Decimal from "decimal.js-light";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { InventoryItemName } from "features/game/types/game";
+import { ITEM_DETAILS } from "features/game/types/images";
+import increase_arrow from "assets/icons/increase_arrow.png";
+import decrease_arrow from "assets/icons/decrease_arrow.png";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { SquareIcon } from "./SquareIcon";
+
+interface Props {
+  itemName: InventoryItemName;
+  pricePerUnit: number | undefined;
+  inventoryAmount?: Decimal;
+  disabled?: boolean;
+  marketBundle?: number;
+  showPulse?: boolean;
+  priceMovement?: "up" | "down" | "same";
+  onClick: () => void;
+}
+
+export const ListingCategoryCard: React.FC<Props> = ({
+  itemName,
+  pricePerUnit,
+  inventoryAmount,
+  disabled,
+  marketBundle,
+  showPulse,
+  priceMovement,
+  onClick,
+}) => {
+  const { t } = useAppTranslation();
+
+  return (
+    <OuterPanel
+      className={classNames(
+        "w-full relative flex flex-col items-center justify-center",
+        {
+          "cursor-not-allowed opacity-75": disabled,
+          "cursor-pointer hover:bg-brown-200": !disabled,
+        }
+      )}
+      onClick={onClick}
+    >
+      {inventoryAmount && (
+        <Label
+          type="default"
+          className="absolute"
+          style={{
+            top: `${PIXEL_SCALE * -5}px`,
+            right: `${PIXEL_SCALE * -3}px`,
+          }}
+        >
+          {`${setPrecision(inventoryAmount, 0)}`}
+        </Label>
+      )}
+      <span className="text-xs mt-1">{itemName}</span>
+      <SquareIcon icon={ITEM_DETAILS[itemName].image} width={20} />
+      {marketBundle && (
+        <span className={"text-xxs md:text-xs mb-1.5"}>
+          {/* \u{d7} is &times; in unicode */}
+          {`\u{d7} ${marketBundle}`}
+        </span>
+      )}
+      <Label
+        type="warning"
+        className="w-full text-center p-1"
+        style={{
+          width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+          marginBottom: `${PIXEL_SCALE * -3}px`,
+        }}
+      >
+        <span
+          className={classNames("text-[12px]", {
+            pulse: showPulse,
+          })}
+        >
+          {t("bumpkinTrade.price/unit", {
+            price: pricePerUnit
+              ? setPrecision(new Decimal(pricePerUnit)).toFixed(4)
+              : "?",
+          })}
+        </span>
+        {priceMovement === "up" && (
+          <img
+            src={increase_arrow}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 10}px`,
+              right: `${PIXEL_SCALE * -2}px`,
+              top: `${PIXEL_SCALE * -10}px`,
+            }}
+          />
+        )}
+        {priceMovement === "down" && (
+          <img
+            src={decrease_arrow}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 10}px`,
+              right: `${PIXEL_SCALE * -2}px`,
+              top: `${PIXEL_SCALE * -10}px`,
+            }}
+          />
+        )}
+      </Label>
+    </OuterPanel>
+  );
+};

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -31,6 +31,7 @@ import { hasVipAccess } from "features/game/lib/vipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { VIPAccess } from "features/game/components/VipAccess";
 import { getDayOfYear } from "lib/utils/time";
+import { ListingCategoryCard } from "components/ui/ListingCategoryCard";
 
 const VALID_INTEGER = new RegExp(/^\d+$/);
 const VALID_FOUR_DECIMAL_NUMBER = new RegExp(/^\d*(\.\d{0,4})?$/);
@@ -82,29 +83,12 @@ const ListTrade: React.FC<{
               key={name}
               className="w-1/3 sm:w-1/4 md:w-1/5 lg:w-1/6 pr-1 pb-1 mb-2"
             >
-              <OuterPanel
-                className="w-full relative flex flex-col items-center justify-center cursor-pointer hover:bg-brown-200"
-                onClick={() => {
-                  setSelected(name);
-                }}
-              >
-                <Label type="default" className="absolute -top-3 -right-2">
-                  {`${setPrecision(new Decimal(inventory?.[name] ?? 0), 0)}`}
-                </Label>
-                <span className="text-xs mb-1">{name}</span>
-                <img src={ITEM_DETAILS[name].image} className="h-10 mb-6" />
-                <Label
-                  type="warning"
-                  className="absolute -bottom-2 text-center mt-1 p-1"
-                  style={{ width: "calc(100% + 10px)" }}
-                >
-                  {t("bumpkinTrade.price/unit", {
-                    price: floorPrices[name]
-                      ? setPrecision(new Decimal(floorPrices[name] ?? 0))
-                      : "?",
-                  })}
-                </Label>
-              </OuterPanel>
+              <ListingCategoryCard
+                itemName={name}
+                inventoryAmount={inventory?.[name] ?? new Decimal(0)}
+                pricePerUnit={floorPrices[name]}
+                onClick={() => setSelected(name)}
+              />
             </div>
           ))}
         </div>

--- a/src/features/world/ui/market/SalesPanel.tsx
+++ b/src/features/world/ui/market/SalesPanel.tsx
@@ -6,7 +6,6 @@ import { Context } from "features/game/GameProvider";
 import { ITEM_DETAILS } from "features/game/types/images";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { OuterPanel } from "components/ui/Panel";
 import { getKeys } from "features/game/types/craftables";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
@@ -18,17 +17,17 @@ import { Button } from "components/ui/Button";
 import classNames from "classnames";
 import { getRelativeTime } from "lib/utils/time";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { setPrecision } from "lib/utils/formatNumber";
 
 import sflIcon from "assets/icons/sfl.webp";
 import lock from "assets/skills/lock.png";
-import increase_arrow from "assets/icons/increase_arrow.png";
-import decrease_arrow from "assets/icons/decrease_arrow.png";
 import { Box } from "components/ui/Box";
 import { MAX_SESSION_SFL } from "features/game/lib/processEvent";
 
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { VIPAccess } from "features/game/components/VipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { ListingCategoryCard } from "components/ui/ListingCategoryCard";
 
 export const MARKET_BUNDLES: Record<TradeableName, number> = {
   Sunflower: 2000,
@@ -223,7 +222,7 @@ export const SalesPanel: React.FC<{
               >{`${MARKET_BUNDLES[selected]}`}</span>
               <span className="text-[12px]">
                 {t("bumpkinTrade.price/unit", {
-                  price: Number(unitPrice).toFixed(4),
+                  price: setPrecision(new Decimal(unitPrice)).toFixed(4),
                 })}
               </span>
             </div>
@@ -291,67 +290,18 @@ export const SalesPanel: React.FC<{
                     key={name}
                     className="w-1/3 sm:w-1/4 md:w-1/5 lg:w-1/6 pr-1 pb-1"
                   >
-                    <OuterPanel
-                      className={classNames(
-                        "w-full relative flex flex-col items-center justify-center",
-                        {
-                          "cursor-not-allowed opacity-75":
-                            !hasVIP || !hasPrices,
-                          "cursor-pointer hover:bg-brown-200":
-                            hasVIP && hasPrices,
-                        }
-                      )}
-                      onClick={
-                        hasPrices && hasVIP
-                          ? () => {
-                              onSell(
-                                name,
-                                marketPrices.prices.currentPrices[name]
-                              );
-                            }
-                          : undefined
-                      }
-                    >
-                      <span className="text-xs mt-1">{name}</span>
-                      <img
-                        src={ITEM_DETAILS[name].image}
-                        className="h-10 my-1"
-                      />
-                      <span className={"text-xxs md:text-xs mb-7"}>
-                        {/* \u{d7} is &times; in unicode */}
-                        {`\u{d7}${MARKET_BUNDLES[name]}`}
-                      </span>
-                      <Label
-                        type="warning"
-                        className="absolute -bottom-2 text-center mt-1 p-1"
-                        style={{ width: "calc(100% + 10px)" }}
-                      >
-                        <span
-                          className={classNames("text-[12px]", {
-                            pulse: showPulse,
-                          })}
-                        >
-                          {t("bumpkinTrade.price/unit", {
-                            price:
-                              marketPrices?.prices?.currentPrices?.[
-                                name
-                              ]?.toFixed(4) || "0.0000",
-                          })}
-                        </span>
-                        {priceMovement === "up" && (
-                          <img
-                            src={increase_arrow}
-                            className="w-6 absolute -right-1 -top-6"
-                          />
-                        )}
-                        {priceMovement === "down" && (
-                          <img
-                            src={decrease_arrow}
-                            className="w-6 absolute -right-1 -top-6"
-                          />
-                        )}
-                      </Label>
-                    </OuterPanel>
+                    <ListingCategoryCard
+                      itemName={name}
+                      pricePerUnit={marketPrices?.prices?.currentPrices?.[name]}
+                      disabled={!hasPrices || !hasVIP}
+                      marketBundle={MARKET_BUNDLES[name]}
+                      showPulse={showPulse}
+                      priceMovement={priceMovement}
+                      onClick={() => {
+                        if (!hasPrices || !hasVIP) return;
+                        onSell(name, marketPrices.prices.currentPrices[name]);
+                      }}
+                    />
                   </div>
                 );
               })}

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -30,6 +30,8 @@ import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { VIPAccess } from "features/game/components/VipAccess";
 import { getDayOfYear } from "lib/utils/time";
+import { setPrecision } from "lib/utils/formatNumber";
+import { ListingCategoryCard } from "components/ui/ListingCategoryCard";
 
 export const TRADE_LIMITS: Partial<Record<InventoryItemName, number>> = {
   Sunflower: 2000,
@@ -157,25 +159,11 @@ export const BuyPanel: React.FC<{
               key={name}
               className="w-1/3 sm:w-1/4 md:w-1/5 lg:w-1/6 pr-1 pb-1"
             >
-              <OuterPanel
-                className="w-full relative flex flex-col items-center justify-center cursor-pointer hover:bg-brown-200"
+              <ListingCategoryCard
+                itemName={name}
+                pricePerUnit={floorPrices[name]}
                 onClick={() => onSearch(name)}
-              >
-                <span className="text-xs mt-1">{name}</span>
-                <img
-                  src={ITEM_DETAILS[name].image}
-                  className="h-10 mt-1 mb-8"
-                />
-                <Label
-                  type="warning"
-                  className={"absolute -bottom-2 text-center mt-1 p-1"}
-                  style={{ width: "calc(100% + 10px)" }}
-                >
-                  {t("bumpkinTrade.price/unit", {
-                    price: floorPrices[name]?.toFixed(4) || "",
-                  })}
-                </Label>
-              </OuterPanel>
+              />
             </div>
           ))}
         </div>
@@ -328,7 +316,7 @@ export const BuyPanel: React.FC<{
         const listingItem = selectedListing.items[
           getKeys(selectedListing.items)[0]
         ] as number;
-        const unitPrice = (selectedListing.sfl / listingItem).toFixed(4);
+        const unitPrice = selectedListing.sfl / listingItem;
 
         return (
           <>
@@ -354,8 +342,12 @@ export const BuyPanel: React.FC<{
                           <img src={token} className="h-6 mr-1" />
                           <p className="text-xs">{`${selectedListing.sfl} SFL`}</p>
                         </div>
-                        <p className="text-xxs ">
-                          {t("bumpkinTrade.price/unit", { price: unitPrice })}
+                        <p className="text-xxs">
+                          {t("bumpkinTrade.price/unit", {
+                            price: setPrecision(new Decimal(unitPrice)).toFixed(
+                              4
+                            ),
+                          })}
                         </p>
                       </div>
                     </div>
@@ -412,7 +404,7 @@ export const BuyPanel: React.FC<{
             const listingItem = listing.items[
               getKeys(listing.items)[0]
             ] as number;
-            const unitPrice = (listing.sfl / listingItem).toFixed(4);
+            const unitPrice = listing.sfl / listingItem;
             return (
               <OuterPanel className="mb-2" key={`data-${index}`}>
                 <div className="flex justify-between">
@@ -431,8 +423,12 @@ export const BuyPanel: React.FC<{
                           <img src={token} className="h-6 mr-1" />
                           <p className="text-xs">{`${listing.sfl} SFL`}</p>
                         </div>
-                        <p className="text-xxs ">
-                          {t("bumpkinTrade.price/unit", { price: unitPrice })}
+                        <p className="text-xxs">
+                          {t("bumpkinTrade.price/unit", {
+                            price: setPrecision(new Decimal(unitPrice)).toFixed(
+                              4
+                            ),
+                          })}
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
# Description

- use new custom component for listing category cards
- properly round unit price down to 4 decimal places and show 4 decimal places
- standardize pixel scales for those components

<img width="393" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/24e20ae5-d117-48cb-a6f7-3054d4867799">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check bumpkin trades tab
- check goblin market
- check bumpkin market buy and sell tabs

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
