### PR TITLE
[FEAT] Set unit price limits

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -21,7 +21,10 @@ import { getBumpkinLevel } from "features/game/lib/level";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { makeListingType } from "lib/utils/makeTradeListingType";
 import { Label } from "components/ui/Label";
-import { TRADE_LIMITS } from "features/world/ui/trader/BuyPanel";
+import {
+  TRADE_LIMITS,
+  TRADE_MINIMUMS,
+} from "features/world/ui/trader/BuyPanel";
 import { FloorPrices } from "features/game/actions/getListingsFloorPrices";
 import { setPrecision } from "lib/utils/formatNumber";
 import { hasVipAccess } from "features/game/lib/vipAccess";
@@ -110,6 +113,7 @@ const ListTrade: React.FC<{
   }
 
   const unitPrice = sfl / quantity;
+  const tooLittle = !!quantity && quantity < (TRADE_MINIMUMS[selected] ?? 0);
 
   const isTooHigh =
     !!sfl &&
@@ -193,6 +197,11 @@ const ListTrade: React.FC<{
             {quantity > (TRADE_LIMITS[selected] ?? 0) && (
               <Label type="danger" className="my-1 ml-2 mr-1">
                 {t("bumpkinTrade.max", { max: TRADE_LIMITS[selected] ?? 0 })}
+              </Label>
+            )}
+            {tooLittle && (
+              <Label type="danger" className="my-1 ml-2 mr-1">
+                {t("bumpkinTrade.min", { min: TRADE_MINIMUMS[selected] ?? 0 })}
               </Label>
             )}
           </div>
@@ -336,6 +345,7 @@ const ListTrade: React.FC<{
         </Button>
         <Button
           disabled={
+            tooLittle ||
             isTooHigh ||
             isTooLow ||
             maxSFL ||

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -109,30 +109,26 @@ const ListTrade: React.FC<{
     );
   }
 
+  const unitPrice = sfl / quantity;
+
+  const isTooHigh =
+    !!sfl &&
+    !!quantity &&
+    !!floorPrices[selected] &&
+    new Decimal(floorPrices[selected] ?? 0).mul(1.2).lt(unitPrice);
+
+  const isTooLow =
+    !!sfl &&
+    !!quantity &&
+    !!floorPrices[selected] &&
+    new Decimal(floorPrices[selected] ?? 0).mul(0.8).gt(unitPrice);
+
   return (
     <>
-      <div className="flex justify-between items-center">
-        <div className="flex flex-col items-start">
-          <div className="flex items-center">
-            <Box image={ITEM_DETAILS[selected].image} disabled />
-            <span className="text-sm">{selected}</span>
-          </div>
-          <Label
-            type={
-              sfl / quantity < (floorPrices[selected] ?? 0)
-                ? "danger"
-                : sfl / quantity > (floorPrices[selected] ?? 0)
-                ? "success"
-                : "warning"
-            }
-            className="my-1"
-          >
-            {t("bumpkinTrade.floorPrice", {
-              price: floorPrices[selected]
-                ? setPrecision(new Decimal(floorPrices[selected] ?? 0))
-                : "?",
-            })}
-          </Label>
+      <div className="flex justify-between">
+        <div className="flex items-center">
+          <Box image={ITEM_DETAILS[selected].image} disabled />
+          <span className="text-sm">{selected}</span>
         </div>
         <div className="flex flex-col items-end pr-1">
           <Label
@@ -145,6 +141,43 @@ const ListTrade: React.FC<{
             {`${setPrecision(new Decimal(inventory?.[selected] ?? 0), 0)}`}
           </span>
         </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Label
+          type={
+            sfl / quantity < (floorPrices[selected] ?? 0)
+              ? "danger"
+              : sfl / quantity > (floorPrices[selected] ?? 0)
+              ? "success"
+              : "warning"
+          }
+          className="my-1"
+        >
+          {t("bumpkinTrade.floorPrice", {
+            price: floorPrices[selected]
+              ? setPrecision(new Decimal(floorPrices[selected] ?? 0))
+              : "?",
+          })}
+        </Label>
+        {isTooLow && (
+          <Label type="danger" className="my-1 ml-2 mr-1">
+            {t("bumpkinTrade.minimumFloor", {
+              min: setPrecision(new Decimal(floorPrices[selected] ?? 0))
+                .mul(0.8)
+                .toNumber(),
+            })}
+          </Label>
+        )}
+        {isTooHigh && (
+          <Label type="danger" className="my-1 ml-2 mr-1">
+            {t("bumpkinTrade.maximumFloor", {
+              max: setPrecision(new Decimal(floorPrices[selected] ?? 0))
+                .mul(1.2)
+                .toNumber(),
+            })}
+          </Label>
+        )}
       </div>
 
       <div className="flex">
@@ -303,6 +336,8 @@ const ListTrade: React.FC<{
         </Button>
         <Button
           disabled={
+            isTooHigh ||
+            isTooLow ||
             maxSFL ||
             (inventory[selected]?.lt(quantity) ?? false) ||
             quantity === 0 || // Disable when quantity is 0

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -59,6 +59,34 @@ export const TRADE_LIMITS: Partial<Record<InventoryItemName, number>> = {
   Crimstone: 20,
 };
 
+export const TRADE_MINIMUMS: Partial<Record<InventoryItemName, number>> = {
+  Sunflower: 200,
+  Potato: 200,
+  Pumpkin: 100,
+  Carrot: 100,
+  Cabbage: 100,
+  Soybean: 50,
+  Beetroot: 50,
+  Cauliflower: 50,
+  Parsnip: 20,
+  Eggplant: 20,
+  Corn: 20,
+  Radish: 10,
+  Wheat: 10,
+  Kale: 10,
+  Blueberry: 5,
+  Orange: 5,
+  Apple: 5,
+  Banana: 5,
+  Wood: 50,
+  Stone: 30,
+  Iron: 10,
+  Gold: 5,
+  Egg: 10,
+  Honey: 5,
+  Crimstone: 1,
+};
+
 const MAX_NON_VIP_PURCHASES = 3;
 
 function getRemainingFreePurchases(dailyPurchases: {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1146,6 +1146,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": "List",
   "bumpkinTrade.maxListings": "Max listings reached",
   "bumpkinTrade.max": "Max: {{max}}",
+  "bumpkinTrade.min": "Min: {{min}}",
   "bumpkinTrade.minimumFloor": "Min unit price: {{min}}",
   "bumpkinTrade.maximumFloor": "Max unit price: {{max}}",
   "bumpkinTrade.floorPrice": "Floor Price: {{price}} SFL",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1146,6 +1146,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": "List",
   "bumpkinTrade.maxListings": "Max listings reached",
   "bumpkinTrade.max": "Max: {{max}}",
+  "bumpkinTrade.minimumFloor": "Min unit price: {{min}}",
+  "bumpkinTrade.maximumFloor": "Max unit price: {{max}}",
   "bumpkinTrade.floorPrice": "Floor Price: {{price}} SFL",
   "bumpkinTrade.price/unit": "{{price}} / unit",
   "bumpkinTrade.sellConfirmation":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1174,6 +1174,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": "Liste",
   "bumpkinTrade.maxListings": "Nombre maximum d'annonces atteint",
   "bumpkinTrade.max": "Max : {{max}}",
+  "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],
+  "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.floorPrice": "Prix minimum : {{price}} SFL",
   "bumpkinTrade.price/unit": "{{price}} / unité",
   "bumpkinTrade.sellConfirmation":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1174,6 +1174,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": "Liste",
   "bumpkinTrade.maxListings": "Nombre maximum d'annonces atteint",
   "bumpkinTrade.max": "Max : {{max}}",
+  "bumpkinTrade.min": "Min : {{min}}",
   "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],
   "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.floorPrice": "Prix minimum : {{price}} SFL",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1161,6 +1161,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": ENGLISH_TERMS["bumpkinTrade.list"],
   "bumpkinTrade.maxListings": ENGLISH_TERMS["bumpkinTrade.maxListings"],
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.min": ENGLISH_TERMS["bumpkinTrade.min"],
   "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],
   "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1161,6 +1161,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": ENGLISH_TERMS["bumpkinTrade.list"],
   "bumpkinTrade.maxListings": ENGLISH_TERMS["bumpkinTrade.maxListings"],
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],
+  "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
   "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
   "bumpkinTrade.sellConfirmation":

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1145,6 +1145,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.list": "Listele",
   "bumpkinTrade.maxListings": "Maksimum listelemeye ulaşıldı",
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
+  "bumpkinTrade.min": ENGLISH_TERMS["bumpkinTrade.min"],
   "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
   "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
   "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1147,6 +1147,8 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.max": ENGLISH_TERMS["bumpkinTrade.max"],
   "bumpkinTrade.floorPrice": ENGLISH_TERMS["bumpkinTrade.floorPrice"],
   "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
+  "bumpkinTrade.minimumFloor": ENGLISH_TERMS["bumpkinTrade.minimumFloor"],
+  "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
 };

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -823,6 +823,8 @@ export type BumpkinTrade =
   | "bumpkinTrade.list"
   | "bumpkinTrade.maxListings"
   | "bumpkinTrade.max"
+  | "bumpkinTrade.minimumFloor"
+  | "bumpkinTrade.maximumFloor"
   | "bumpkinTrade.floorPrice"
   | "bumpkinTrade.sellConfirmation";
 

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -823,6 +823,7 @@ export type BumpkinTrade =
   | "bumpkinTrade.list"
   | "bumpkinTrade.maxListings"
   | "bumpkinTrade.max"
+  | "bumpkinTrade.min"
   | "bumpkinTrade.minimumFloor"
   | "bumpkinTrade.maximumFloor"
   | "bumpkinTrade.floorPrice"


### PR DESCRIPTION
# Description

We have discovered a handful of bots who are bypassing anti-botting mechanisms through the trading feature. They would often list items for ridiculously large SFL, to transfer SFL into a root account.

This PR sets reasonable limits (+20% -20%) so pricing does not stray too far from the floor prices.

<img width="453" alt="Screenshot 2024-05-28 at 11 32 39 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/a96c2ef2-f28b-4c17-b5fd-ef4cc897a21d">
