### PR TITLE
[FIX] calculate time for Cooking Oil Boost

### DIFF
--- a/src/features/island/buildings/components/building/BuildingOilTank.tsx
+++ b/src/features/island/buildings/components/building/BuildingOilTank.tsx
@@ -103,7 +103,7 @@ export const BuildingOilTank = ({
 
   const canIncrementOil = () => {
     const oilBalance = game.inventory.Oil ?? new Decimal(0);
-    if (!canAddOil() || !isCookingBuilding(buildingName) || !oilBalance)
+    if (!canAddOil() || !isCookingBuilding(buildingName) || oilBalance.lt(1))
       return false;
 
     const hasEnoughOil = oilBalance.toNumber() >= totalOilToAdd;

--- a/src/features/island/buildings/lib/craftingMachine.ts
+++ b/src/features/island/buildings/lib/craftingMachine.ts
@@ -3,6 +3,7 @@ import { assign, createMachine, Interpreter, State } from "xstate";
 import { MachineInterpreter as GameServiceMachineInterpreter } from "src/features/game/lib/gameMachine";
 import { GameEventName, PlayingEvent } from "features/game/events";
 import { getCookingTime } from "features/game/expansion/lib/boosts";
+import { getCookingOilBoost } from "features/game/events/landExpansion/cook";
 
 export interface CraftingContext {
   name?: CookableName;
@@ -151,10 +152,13 @@ export const craftingMachine = createMachine<
         });
       },
       assignCraftingDetails: assign((context, event) => {
-        const { cookingSeconds } = COOKABLES[(event as CraftEvent).item];
         const { bumpkin } = context.gameService.state.context.state;
         const reducedSeconds = getCookingTime(
-          cookingSeconds,
+          getCookingOilBoost(
+            (event as CraftEvent).item,
+            context.gameService.state.context.state,
+            context.buildingId
+          ).timeToCook,
           bumpkin,
           context.gameService.state.context.state
         );


### PR DESCRIPTION
# Description

This PR adds a fix for the wrong time being shown when cooking something with oil boost applying. UI only.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
