### PR TITLE
[FEAT] Add Desert Island Unlock Requirement for Greenhouse and Crop Machine

### DIFF
--- a/src/features/game/types/buildings.ts
+++ b/src/features/game/types/buildings.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { CollectibleName } from "./craftables";
-import { InventoryItemName } from "./game";
+import { InventoryItemName, IslandType } from "./game";
 import { ResourceName } from "./resources";
 
 export type Home = "Tent" | "House" | "Manor";
@@ -34,6 +34,7 @@ export type BuildingBluePrint = {
   ingredients: Ingredient[];
   coins: number;
   constructionSeconds: number;
+  requiredIsland?: IslandType;
 };
 
 export type PlaceableName =
@@ -437,6 +438,7 @@ export const BUILDINGS: Record<BuildingName, BuildingBluePrint[]> = {
           amount: new Decimal(100),
         },
       ],
+      requiredIsland: "desert",
     },
   ],
   "Crop Machine": [
@@ -458,6 +460,7 @@ export const BUILDINGS: Record<BuildingName, BuildingBluePrint[]> = {
           amount: new Decimal(50),
         },
       ],
+      requiredIsland: "desert",
     },
   ],
 };

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -17,6 +17,9 @@ import { ITEM_ICONS } from "../inventory/Chest";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { hasFeatureAccess } from "lib/flags";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+import { IslandType } from "features/game/types/game";
+import { capitalize } from "lib/utils/capitalize";
 
 interface Props {
   onClose: () => void;
@@ -99,6 +102,24 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
   };
 
   const getAction = () => {
+    if (
+      !hasRequiredIslandExpansion(
+        state.island.type,
+        buildingBlueprints[nextBlueprintIndex].requiredIsland
+      )
+    ) {
+      return (
+        <Label type="danger">
+          {t("islandupgrade.requiredIsland", {
+            islandType: capitalize(
+              buildingBlueprints[nextBlueprintIndex]
+                .requiredIsland as IslandType
+            ),
+          })}
+        </Label>
+      );
+    }
+
     const hasMaxNumberOfBuildings =
       buildingsInInventory.gte(numOfBuildingAllowed);
     // Hasn't unlocked the first
@@ -106,10 +127,9 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
       return (
         <div className="flex flex-col w-full justify-center">
           <div className="flex items-center justify-center ">
-            <Label
-              type="danger"
-              icon={SUNNYSIDE.icons.player}
-            >{`Level ${nextLockedLevel} required`}</Label>
+            <Label type="danger" icon={SUNNYSIDE.icons.player}>
+              {t("warning.level.required", { lvl: nextLockedLevel })}
+            </Label>
           </div>
         </div>
       );


### PR DESCRIPTION
# Description

Adds IslandType restriction to Crop Machine and Greenhouse

Crop Machine
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/c972d1f5-d22c-4c9b-ab05-5c8f1f95f95c)
Greenhouse
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/6ede8760-38e3-4cb9-9a21-18749235e27a)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran in local
- Set islandtype to basic to check if restriction applies
- Set islandtype to petal paradise to check if restriction applies
- Set islandtype to desert to check that restriction doesn't apply there

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
