### PR TITLE
[FEAT] Add island requirement for Flower and Greenhouse seeds

### DIFF
--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -66,12 +66,14 @@ export const GREENHOUSE_SEEDS: () => Record<
     description: "A staple food for many.",
     bumpkinLevel: 40,
     plantSeconds: 32 * 60 * 60,
+    requiredIsland: "desert",
   },
   "Olive Seed": {
     price: 320,
     description: "Zesty with a rich history.",
     bumpkinLevel: 40,
     plantSeconds: 44 * 60 * 60,
+    requiredIsland: "desert",
   },
 });
 

--- a/src/features/game/types/flowers.ts
+++ b/src/features/game/types/flowers.ts
@@ -80,6 +80,7 @@ export const FLOWER_SEEDS: () => Record<FlowerSeedName, FlowerSeed> = () => ({
     plantSeconds: 1 * 24 * 60 * 60,
     description: translate("description.sunpetal.seed"),
     disabled: false,
+    requiredIsland: "spring",
   },
   "Bloom Seed": {
     price: 32,
@@ -87,6 +88,7 @@ export const FLOWER_SEEDS: () => Record<FlowerSeedName, FlowerSeed> = () => ({
     plantSeconds: 2 * 24 * 60 * 60,
     description: translate("description.bloom.seed"),
     disabled: false,
+    requiredIsland: "spring",
   },
   "Lily Seed": {
     price: 48,
@@ -94,6 +96,7 @@ export const FLOWER_SEEDS: () => Record<FlowerSeedName, FlowerSeed> = () => ({
     plantSeconds: 5 * 24 * 60 * 60,
     description: translate("description.lily.seed"),
     disabled: false,
+    requiredIsland: "spring",
   },
 });
 

--- a/src/features/game/types/fruits.ts
+++ b/src/features/game/types/fruits.ts
@@ -122,6 +122,7 @@ export const GREENHOUSE_FRUIT_SEEDS: () => Record<
     plantSeconds: 12 * 60 * 60,
     bumpkinLevel: 14,
     yield: "Grape",
+    requiredIsland: "desert",
   },
 });
 

--- a/src/features/game/types/fruits.ts
+++ b/src/features/game/types/fruits.ts
@@ -120,7 +120,7 @@ export const GREENHOUSE_FRUIT_SEEDS: () => Record<
     price: 160,
     description: "A bunch of grapes",
     plantSeconds: 12 * 60 * 60,
-    bumpkinLevel: 14,
+    bumpkinLevel: 40,
     yield: "Grape",
     requiredIsland: "desert",
   },

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -15,6 +15,7 @@ import {
   GreenHouseFruitSeedName,
 } from "./fruits";
 import { FLOWER_SEEDS, FlowerSeedName } from "./flowers";
+import { IslandType } from "./game";
 
 export type SeedName =
   | CropSeedName
@@ -35,6 +36,7 @@ export type Seed = {
     | GreenHouseCropName
     | GreenHouseFruitName;
   disabled?: boolean;
+  requiredIsland?: IslandType;
 };
 
 export const SEEDS: () => Record<SeedName, Seed> = () => ({

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -21,7 +21,7 @@ import { INVENTORY_LIMIT } from "features/game/lib/constants";
 import { makeBulkBuyAmount } from "./lib/makeBulkBuyAmount";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { SEEDS, SeedName } from "features/game/types/seeds";
-import { Bumpkin } from "features/game/types/game";
+import { Bumpkin, IslandType } from "features/game/types/game";
 import {
   FRUIT,
   FRUIT_SEEDS,
@@ -44,6 +44,8 @@ import {
   SEED_TO_PLANT,
   getGreenhouseCropTime,
 } from "features/game/events/landExpansion/plantGreenhouse";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+import { capitalize } from "lib/utils/capitalize";
 
 interface Props {
   onClose: () => void;
@@ -100,8 +102,24 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
   };
 
   const Action = () => {
-    // return nothing if requirement not met
+    if (
+      !hasRequiredIslandExpansion(state.island.type, selected.requiredIsland)
+    ) {
+      return (
+        <Label type="danger">
+          {t("islandupgrade.requiredIsland", {
+            islandType:
+              selected.requiredIsland === "spring"
+                ? "Petal Paradise"
+                : t("islandupgrade.otherIsland", {
+                    island: capitalize(selected.requiredIsland as IslandType),
+                  }),
+          })}
+        </Label>
+      );
+    }
     if (isSeedLocked(selectedName)) {
+      // return nothing if requirement not met
       return <></>;
     }
 

--- a/src/features/island/buildings/components/building/workBench/components/Tools.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/Tools.tsx
@@ -82,7 +82,12 @@ export const Tools: React.FC<Props> = ({ onClose }) => {
       return (
         <Label type="danger">
           {t("islandupgrade.requiredIsland", {
-            islandType: capitalize(selected.requiredIsland as IslandType),
+            islandType:
+              selected.requiredIsland === "spring"
+                ? "Petal Paradise"
+                : t("islandupgrade.otherIsland", {
+                    island: capitalize(selected.requiredIsland as IslandType),
+                  }),
           })}
         </Label>
       );

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -111,10 +111,15 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
       return (
         <Label type="danger">
           {t("islandupgrade.requiredIsland", {
-            islandType: capitalize(
-              buildingBlueprints[nextBlueprintIndex]
-                .requiredIsland as IslandType
-            ),
+            islandType:
+              buildingBlueprints[nextBlueprintIndex].requiredIsland === "spring"
+                ? "Petal Paradise"
+                : t("islandupgrade.otherIsland", {
+                    island: capitalize(
+                      buildingBlueprints[nextBlueprintIndex]
+                        .requiredIsland as IslandType
+                    ),
+                  }),
           })}
         </Label>
       );

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -2682,6 +2682,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
   "islandupgrade.desertResourcesDescription":
     ENGLISH_TERMS["islandupgrade.desertResourcesDescription"],
   "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
+  "islandupgrade.otherIsland": ENGLISH_TERMS["islandupgrade.otherIsland"],
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2978,7 +2978,8 @@ const islandupgrade: Record<Islandupgrade, string> = {
     "This area of Sunflower Land is known for its exotic resources. Expand your land to discover fruit, flowers, bee hives & rare minerals!",
   "islandupgrade.desertResourcesDescription":
     "The harsh desert environment requires new technology to survive. Expand your land to discover new buildings and what's inside!",
-  "islandupgrade.requiredIsland": "Unlocks on {{islandType}} Island",
+  "islandupgrade.requiredIsland": "Unlocks at {{islandType}}",
+  "islandupgrade.otherIsland": "{{island}} Island",
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -3103,6 +3103,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
   "islandupgrade.desertResourcesDescription":
     ENGLISH_TERMS["islandupgrade.desertResourcesDescription"],
   "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
+  "islandupgrade.otherIsland": ENGLISH_TERMS["islandupgrade.otherIsland"],
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2886,6 +2886,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
   "islandupgrade.desertResourcesDescription":
     ENGLISH_TERMS["islandupgrade.desertResourcesDescription"],
   "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
+  "islandupgrade.otherIsland": ENGLISH_TERMS["islandupgrade.otherIsland"],
 };
 
 const interactableModals: Record<InteractableModals, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2977,6 +2977,7 @@ const islandupgrade: Record<Islandupgrade, string> = {
   "islandupgrade.desertResourcesDescription":
     ENGLISH_TERMS["islandupgrade.desertResourcesDescription"],
   "islandupgrade.requiredIsland": ENGLISH_TERMS["islandupgrade.requiredIsland"],
+  "islandupgrade.otherIsland": ENGLISH_TERMS["islandupgrade.otherIsland"],
 };
 
 const landscapeTerms: Record<LandscapeTerms, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2046,7 +2046,8 @@ export type Islandupgrade =
   | "islandupgrade.notReadyExpandMore"
   | "islandupgrade.exoticResourcesDescription"
   | "islandupgrade.desertResourcesDescription"
-  | "islandupgrade.requiredIsland";
+  | "islandupgrade.requiredIsland"
+  | "islandupgrade.otherIsland";
 
 export type InteractableModals =
   | "interactableModals.returnhome.message"


### PR DESCRIPTION
# Description

Since flower beds unlock in Spring Island, flower seeds should unlock in spring island as well
Likewise, Greenhouse unlock in Desert island, so Greenhouse Seeds unlock in desert island
Updated the unlock level for Grape seed from 14 > 40 to match unlock level of desert island (backend updates needed to change this)

Flower Seeds
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/7100ff55-5d02-43f2-955c-f3edffe4e6ef)

Greenhouse Seeds
- Grape Seed Level updated from 14 > 40

![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/75f811e4-92b7-4215-9d85-bf1ff9a9cddb)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
