### PR TITLE
[FIX] Crop Machine - Reset Oil when Opening and Closing Add Oil

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -503,7 +503,11 @@ export const CropMachineModal: React.FC<Props> = ({
                 stopped={paused || idle}
                 queue={queue}
                 unallocatedOilTime={unallocatedOilTime}
-                onAddOil={() => setOverlayScreen("addOil")}
+                onAddOil={() => {
+                  // Reset Oil Before showing Overlay to Prevent accidental adding
+                  setTotalOil(0);
+                  setOverlayScreen("addOil");
+                }}
               />
             )}
           </div>


### PR DESCRIPTION
# Description

Reset Oil when Opening and Closing Add Oil

<img width="400" alt="resetoil" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/2c2b8651-5c2d-44e0-9275-beaa311b95e6">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes