### PR TITLE
[FIX] Completely Allocate Crop Machine when Oil equals Grow Time perfectly

### DIFF
--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -1338,6 +1338,51 @@ describe("supplyCropMachine", () => {
 
     expect(machine.unallocatedOilTime).toBe(getOilTimeInMillis(1));
   });
+
+  it("completely allocates when the oil time perfectly matches the grow time", () => {
+    const now = Date.now();
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        "Pumpkin Seed": new Decimal(20),
+        Oil: new Decimal(1),
+      },
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            id: "0",
+            unallocatedOilTime: 0,
+          },
+        ],
+      },
+    };
+
+    const newState = supplyCropMachine({
+      state,
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Pumpkin Seed", amount: 20 },
+      },
+      createdAt: now,
+    });
+
+    const finalState = supplyCropMachine({
+      state: newState,
+      action: {
+        type: "cropMachine.supplied",
+        oil: 1,
+      },
+      createdAt: now,
+    });
+
+    expect(
+      finalState.buildings["Crop Machine"]?.[0]?.queue?.[0].readyAt
+    ).toBeDefined();
+  });
 });
 
 describe("calculateCropTime", () => {

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -127,14 +127,14 @@ export function updateCropMachine({
 
   queue.forEach((pack, index) => {
     // Skip packs that are already grown or if there's no oil left
-    if (pack.growTimeRemaining === 0 || !cropMachine.unallocatedOilTime) {
+    if (!!pack.readyAt || !cropMachine.unallocatedOilTime) {
       return;
     }
 
     const previousQueueItemReadyAt = queue[index - 1]?.readyAt ?? now;
 
     // Allocate oil to the pack and update its state
-    if (cropMachine.unallocatedOilTime > pack.growTimeRemaining) {
+    if (cropMachine.unallocatedOilTime >= pack.growTimeRemaining) {
       completelyAllocatePack(
         pack,
         cropMachine,


### PR DESCRIPTION
# Description

Updates the crop machine logic to fully allocate a pack when the amount of oil in the machine perfectly matches the grow time of the crops.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
