### PR TITLE
[FIX] Correctly set readyAt when Crop Machine has existing crops

### DIFF
--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -180,7 +180,8 @@ function completelyAllocatePack(
     delete pack.growsUntil;
   } else {
     // If the pack was not previously growing, set its readyAt time
-    pack.readyAt = previousQueueItemReadyAt + pack.growTimeRemaining;
+    pack.readyAt =
+      Math.max(previousQueueItemReadyAt, now) + pack.growTimeRemaining;
   }
 
   pack.growTimeRemaining = 0;


### PR DESCRIPTION
# Description

Fixes a bug in the crop machine which made crops grow instantly. It was allocating time based on previous crop, even if it was ready in the past.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
