### PR TITLE
[FIX] Round coins to 2 decimal places for reward discovered

### DIFF
--- a/src/features/game/expansion/components/ClaimReward.tsx
+++ b/src/features/game/expansion/components/ClaimReward.tsx
@@ -81,12 +81,13 @@ export const ClaimReward: React.FC<ClaimRewardProps> = ({
               </div>
             </div>
           )}
-          {airdrop.coins !== undefined && airdrop.coins > 0 && (
+          {!!airdrop.coins && (
             <div className="flex items-center">
               <Box image={coins} />
               <div>
                 <Label type="warning">
-                  {airdrop.coins} {airdrop.coins === 1 ? "Coin" : "Coins"}
+                  {setPrecision(new Decimal(airdrop.coins), 2).toString()}{" "}
+                  {airdrop.coins === 1 ? "Coin" : "Coins"}
                 </Label>
                 <p className="text-xs">{t("reward.spendWisely")}</p>
               </div>


### PR DESCRIPTION
# Description

- round down coin rewards for reward discovered to 2 decimal places

Before|After
---|---
<img width="416" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/69b30fcf-b166-42ca-93e5-2d67cae2d842">|<img width="415" alt="image" src="https://github.com/sunflower-land/sunflower-land/assets/107602352/b506ca37-3a97-4a07-b0de-515be8f58f39">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- collect rewards with coins

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
