### PR TITLE
[FIX] Add Generic Crop Machine Text

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -255,7 +255,7 @@ export const CropMachineModal: React.FC<Props> = ({
                   <Box image={ITEM_DETAILS[selectedPack.crop].image} />
                   <div className="flex flex-col justify-center space-y-1">
                     <span className="text-xs">
-                      {`??? x `}
+                      {`${t("growing")} `}
                       {selectedPack.crop === "Potato"
                         ? `${selectedPack.crop}es`
                         : `${selectedPack.crop}s`}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -279,6 +279,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   goto: "去",
   "grant.wish": "许下新愿望",
   guide: "指南",
+  growing: ENGLISH_TERMS["growing"],
   honey: "蜂蜜",
   "hungry?": "饿了么？",
   info: "概览",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -301,6 +301,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   goto: "Go to",
   "grant.wish": "Grant New Wish",
   greenhouse: "Greenhouse",
+  growing: "Growing",
   guide: "Guide",
   harvested: "Harvested",
   honey: "Honey",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -319,6 +319,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   goto: "Aller à",
   "grant.wish": "Exaucer un vœu",
   greenhouse: ENGLISH_TERMS["greenhouse"],
+  growing: ENGLISH_TERMS["growing"],
   guide: "Guide",
   harvested: "Récolté",
   "hoarding.check": "Vérification des stocks",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -293,6 +293,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   goto: "Ir para",
   "grant.wish": "Conceder Novo Desejo",
   greenhouse: ENGLISH_TERMS["greenhouse"],
+  growing: ENGLISH_TERMS["growing"],
   guide: "Guia",
   honey: "Mel",
   "hungry?": "Com Fome?",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -300,6 +300,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   goto: "Git",
   "grant.wish": "Yeni Dilek Dile",
   greenhouse: ENGLISH_TERMS["greenhouse"],
+  growing: ENGLISH_TERMS["growing"],
   guide: "Rehber",
   harvested: "Hasat edilmiş",
   honey: "Bal",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -122,6 +122,7 @@ export type GeneralTerms =
   | "goto"
   | "grant.wish"
   | "greenhouse"
+  | "growing"
   | "guide"
   | "harvested"
   | "honey"


### PR DESCRIPTION
Updates the text in the crop machine from `??? x` to `Growing`

<img width="498" alt="growing" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/7cc59fc0-fc99-4709-a259-2943fcb2a066">
