### PR TITLE
[FIX] Crop Machine incorrectly calculating grows until when supplying partial Oil

### DIFF
--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -1223,7 +1223,7 @@ describe("supplyCropMachine", () => {
                 totalGrowTime: packOneGrowTime,
                 growTimeRemaining: 70 * 60 * 1000, // 70 minutes
                 startTime: packOneStartTime,
-                growsUntil: packOneStartTime + 70 * 60 * 1000,
+                growsUntil: packOneStartTime + 30 * 60 * 1000,
                 seeds: 1000,
               },
             ],
@@ -1489,6 +1489,116 @@ describe("supplyCropMachine", () => {
     expect(
       thirdState.buildings["Crop Machine"]?.[0]?.queue?.[1].readyAt
     ).toBeGreaterThan(now);
+  });
+
+  it("sets the growsUntil to a minimum of growsUntil + oil when partially allocating slot 0 (previously partially allocated)", () => {
+    const now = Date.now();
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        "Pumpkin Seed": new Decimal(1000),
+        Oil: new Decimal(11),
+      },
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            id: "0",
+            unallocatedOilTime: 0,
+            queue: [],
+          },
+        ],
+      },
+    };
+
+    const newState = supplyCropMachine({
+      state,
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Pumpkin Seed", amount: 1000 },
+        oil: 10,
+      },
+      createdAt: now,
+    });
+
+    const finalState = supplyCropMachine({
+      state: newState,
+      action: {
+        type: "cropMachine.supplied",
+        oil: 1,
+      },
+      createdAt: now,
+    });
+
+    const firstGrowsUntil =
+      newState.buildings["Crop Machine"]?.[0]?.queue?.[0].growsUntil;
+    const secondGrowsUntil =
+      finalState.buildings["Crop Machine"]?.[0]?.queue?.[0].growsUntil;
+
+    expect(secondGrowsUntil).toBeGreaterThan(firstGrowsUntil ?? Infinity);
+  });
+
+  it("sets the growsUntil to a minimum of growsUntil + oil when partially allocating slot 1 (previously partially allocated)", () => {
+    const now = Date.now();
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        "Pumpkin Seed": new Decimal(1000),
+        Oil: new Decimal(11),
+      },
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            id: "0",
+            unallocatedOilTime: 0,
+            queue: [
+              {
+                amount: 1,
+                crop: "Sunflower",
+                growTimeRemaining: 0,
+                seeds: 1,
+                totalGrowTime: 1,
+                readyAt: 1,
+                startTime: 1,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const newState = supplyCropMachine({
+      state,
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Pumpkin Seed", amount: 1000 },
+        oil: 10,
+      },
+      createdAt: now,
+    });
+
+    const finalState = supplyCropMachine({
+      state: newState,
+      action: {
+        type: "cropMachine.supplied",
+        oil: 1,
+      },
+      createdAt: now,
+    });
+
+    const firstGrowsUntil =
+      newState.buildings["Crop Machine"]?.[0]?.queue?.[1].growsUntil;
+    const secondGrowsUntil =
+      finalState.buildings["Crop Machine"]?.[0]?.queue?.[1].growsUntil;
+
+    expect(secondGrowsUntil).toBeGreaterThan(firstGrowsUntil ?? Infinity);
   });
 });
 

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -199,16 +199,12 @@ function partiallyAllocatedPack(
 ) {
   setPackStartTime(pack, index, previousQueueItemReadyAt, now);
 
-  if (index === 0) {
-    pack.growsUntil = now + (cropMachine.unallocatedOilTime as number);
-  } else {
-    updateGrowsUntil(
-      pack,
-      previousQueueItemReadyAt,
-      now,
-      cropMachine.unallocatedOilTime as number
-    );
-  }
+  updateGrowsUntil(
+    pack,
+    previousQueueItemReadyAt,
+    now,
+    cropMachine.unallocatedOilTime as number
+  );
 
   pack.growTimeRemaining -= cropMachine.unallocatedOilTime as number;
   cropMachine.unallocatedOilTime = 0;


### PR DESCRIPTION
# Description

When supplying oil to crops in the first slot of the crop machine, it only uses date.now, ignoring if the crop was previously growing. The result is a fast forward of crop growth time.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
