### PR TITLE
[FIX] Crop Machine Input Lag

### DIFF
--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -287,7 +287,8 @@ describe("supplyCropMachine", () => {
     expect(newState.buildings["Crop Machine"]?.[0].queue).toStrictEqual([
       {
         crop: "Sunflower",
-        amount: 5,
+        // For performance reasons getCropYield is not called in the supplyCropMachine function
+        amount: 0,
         growTimeRemaining: sunflowerTime,
         totalGrowTime: sunflowerTime,
         seeds: 5,
@@ -339,14 +340,16 @@ describe("supplyCropMachine", () => {
     expect(result.buildings["Crop Machine"]?.[0].queue).toStrictEqual([
       {
         crop: "Sunflower",
-        amount: 5,
+        // For performance reasons getCropYield is not called in the supplyCropMachine function
+        amount: 0,
         growTimeRemaining: sunflowerTime, // 5 plots,
         totalGrowTime: sunflowerTime,
         seeds: 5,
       },
       {
         crop: "Potato",
-        amount: 5,
+        // For performance reasons getCropYield is not called in the supplyCropMachine function
+        amount: 0,
         growTimeRemaining: potatoTime,
         totalGrowTime: potatoTime,
         seeds: 5,
@@ -872,7 +875,8 @@ describe("supplyCropMachine", () => {
     expect(newState.buildings["Crop Machine"]?.[0].queue).toStrictEqual([
       {
         crop: "Sunflower",
-        amount: 5.5,
+        // For performance reasons getCropYield is not called in the supplyCropMachine function
+        amount: 0,
         totalGrowTime: sunflowerTime,
         growTimeRemaining: sunflowerTime,
         seeds: 5,

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -331,7 +331,9 @@ export function supplyCropMachine({
   if (seedsAdded.amount > 0) {
     queue.push({
       seeds: seedsAdded.amount,
-      amount: getPackYieldAmount(seedsAdded.amount, crop, stateCopy),
+      // getPackYieldAmount is computationally expensive, let the backend provide this
+      amount: 0,
+      // amount: getPackYieldAmount(seedsAdded.amount, crop, stateCopy),
       crop,
       growTimeRemaining: calculateCropTime(seedsAdded),
       totalGrowTime: calculateCropTime(seedsAdded),

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -331,7 +331,7 @@ export function supplyCropMachine({
   if (seedsAdded.amount > 0) {
     queue.push({
       seeds: seedsAdded.amount,
-      // getPackYieldAmount is computationally expensive, let the backend provide this
+      // getPackYieldAmount is computationally expensive - let the backend provide this
       amount: 0,
       // amount: getPackYieldAmount(seedsAdded.amount, crop, stateCopy),
       crop,


### PR DESCRIPTION
# Description

Crop machine was performing an expensive operation, to calculate crop yield when clicking add seeds button. This is necessary to get the total crop yield, but can be performed by the backend. It doesn't need to block the button click.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
