### PR TITLE
[FIX] Crop Machine Start Time

### DIFF
--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -1604,6 +1604,52 @@ describe("supplyCropMachine", () => {
 
     expect(secondGrowsUntil).toBeGreaterThan(firstGrowsUntil ?? Infinity);
   });
+
+  it("sets startTime greater than Date.now when the queue has finished crops", () => {
+    const now = Date.now();
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        "Pumpkin Seed": new Decimal(40),
+        Oil: new Decimal(1),
+      },
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            id: "0",
+            unallocatedOilTime: MAX_OIL_CAPACITY_IN_MILLIS,
+            queue: [],
+          },
+        ],
+      },
+    };
+
+    const newState = supplyCropMachine({
+      state,
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Pumpkin Seed", amount: 20 },
+      },
+      createdAt: 1,
+    });
+
+    const finalState = supplyCropMachine({
+      state: newState,
+      action: {
+        type: "cropMachine.supplied",
+        seeds: { type: "Pumpkin Seed", amount: 20 },
+      },
+      createdAt: now,
+    });
+
+    expect(
+      finalState.buildings["Crop Machine"]?.[0]?.queue?.[1].startTime
+    ).toBeGreaterThanOrEqual(now);
+  });
 });
 
 describe("calculateCropTime", () => {

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -220,7 +220,8 @@ function setPackStartTime(
   now: number
 ) {
   if (!pack.startTime) {
-    pack.startTime = index === 0 ? now : previousQueueItemReadyAt;
+    pack.startTime =
+      index === 0 ? now : Math.max(previousQueueItemReadyAt, now);
   }
 }
 


### PR DESCRIPTION
# Description

Fixes a bug where `startTime` can be set in the past when allocating oil or seeds to the crop machine.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
