### PR TITLE
[FIX] Force Reload when user Changes Language

### DIFF
--- a/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
@@ -166,11 +166,11 @@ export const LanguageSwitcher: React.FC = () => {
             </span>
           </div>
           <div className="flex justify-content-around mt-2 space-x-1">
-            <Button onClick={() => handleChangeLanguage(selected)}>
-              {t("gameOptions.generalSettings.changeLanguage")}
-            </Button>
             <Button onClick={() => setConfirmModal(false)}>
               {t("cancel")}
+            </Button>
+            <Button onClick={() => handleChangeLanguage(selected)}>
+              {t("confirm")}
             </Button>
           </div>
         </Panel>

--- a/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Button } from "components/ui/Button";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { Panel } from "components/ui/Panel";
 
 import i18n from "lib/i18n";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -15,15 +16,18 @@ import franceFlag from "assets/sfts/flags/france_flag.gif";
 import turkeyFlag from "assets/sfts/flags/turkey_flag.gif";
 import chinaFlag from "assets/sfts/flags/china_flag.gif";
 import { changeFont } from "lib/utils/fonts";
+import { LanguageCode } from "lib/i18n/dictionaries/dictionary";
 
 export const LanguageSwitcher: React.FC = () => {
   const { t } = useAppTranslation();
 
   const initialLanguage = localStorage.getItem("language") || "en";
   const [language, setLanguage] = useState(initialLanguage);
+  const [selected, setSelected] = useState<LanguageCode>("en");
+  const [isConfirmModalOpen, setConfirmModal] = useState(false);
   const [showContributeLanguage, setShowContributeLanguage] = useState(false);
 
-  const handleChangeLanguage = (languageCode: string) => {
+  const handleChangeLanguage = (languageCode: LanguageCode) => {
     localStorage.setItem("language", languageCode);
     i18n.changeLanguage(languageCode);
     setLanguage(languageCode);
@@ -42,7 +46,10 @@ export const LanguageSwitcher: React.FC = () => {
     <>
       <div className="p-1 space-y-2">
         <Button
-          onClick={() => handleChangeLanguage("en")}
+          onClick={() => {
+            setSelected("en");
+            setConfirmModal(true);
+          }}
           disabled={language === "en"}
         >
           <img
@@ -58,7 +65,10 @@ export const LanguageSwitcher: React.FC = () => {
           {"English"}
         </Button>
         <Button
-          onClick={() => handleChangeLanguage("fr")}
+          onClick={() => {
+            setSelected("fr");
+            setConfirmModal(true);
+          }}
           disabled={language === "fr"}
         >
           <img
@@ -69,7 +79,10 @@ export const LanguageSwitcher: React.FC = () => {
           {"Français"}
         </Button>
         <Button
-          onClick={() => handleChangeLanguage("pt")}
+          onClick={() => {
+            setSelected("pt");
+            setConfirmModal(true);
+          }}
           disabled={language === "pt"}
         >
           <img
@@ -85,7 +98,10 @@ export const LanguageSwitcher: React.FC = () => {
           {"Português"}
         </Button>
         <Button
-          onClick={() => handleChangeLanguage("tk")}
+          onClick={() => {
+            setSelected("tk");
+            setConfirmModal(true);
+          }}
           disabled={language === "tk"}
         >
           <img
@@ -96,7 +112,10 @@ export const LanguageSwitcher: React.FC = () => {
           {"Türkçe"}
         </Button>
         <Button
-          onClick={() => handleChangeLanguage("zh-CN")}
+          onClick={() => {
+            setSelected("zh-CN");
+            setConfirmModal(true);
+          }}
           disabled={language === "zh-CN"}
         >
           <img
@@ -113,32 +132,49 @@ export const LanguageSwitcher: React.FC = () => {
             className="underline text-xs cursor-pointer"
             onClick={() => setShowContributeLanguage(true)}
           >
-            {t("statements.translation.want2contribute")}
+            {t("changeLanguage.contribute")}
           </a>
-          <Modal
-            show={showContributeLanguage}
-            onHide={() => setShowContributeLanguage(false)}
-          >
-            <CloseButtonPanel className="sm:w-4/5 m-auto">
-              <div className="flex flex-col p-2">
-                <span className="text-sm text-center">
-                  <p>{t("statements.translation.contribution")}</p>
-                  <p>
-                    <a
-                      className="underline hover:text-white"
-                      href="https://discord.gg/sunflowerland"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      {t("statements.translation.joinDiscord")}
-                    </a>
-                  </p>
-                </span>
-              </div>
-            </CloseButtonPanel>
-          </Modal>
         </span>
       </div>
+      <Modal
+        show={showContributeLanguage}
+        onHide={() => setShowContributeLanguage(false)}
+      >
+        <Panel className="sm:w-4/5 m-auto">
+          <div className="flex flex-col p-2">
+            <span className="text-sm text-center">
+              <p>{t("changeLanguage.contribute.message")}</p>
+              <p>
+                <a
+                  className="underline hover:text-white"
+                  href="https://discord.gg/sunflowerland"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {t("statements.translation.joinDiscord")}
+                </a>
+              </p>
+            </span>
+          </div>
+        </Panel>
+      </Modal>
+      <Modal show={isConfirmModalOpen} onHide={() => setConfirmModal(false)}>
+        <Panel className="sm:w-4/5 m-auto">
+          <div className="flex flex-col p-2">
+            <span className="text-sm text-center">
+              {t("changeLanguage.confirm")}
+            </span>
+          </div>
+          <div className="flex justify-content-around mt-2 space-x-1">
+            <Button onClick={() => handleChangeLanguage(selected)}>
+              {t("gameOptions.generalSettings.changeLanguage")}
+            </Button>
+            <Button onClick={() => setConfirmModal(false)}>
+              {t("cancel")}
+            </Button>
+          </div>
+        </Panel>
+      </Modal>
     </>
   );
 };

--- a/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
@@ -27,6 +27,7 @@ export const LanguageSwitcher: React.FC = () => {
     localStorage.setItem("language", languageCode);
     i18n.changeLanguage(languageCode);
     setLanguage(languageCode);
+    location.reload();
 
     if (languageCode === "zh-CN") {
       changeFont("Sans Serif");

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -177,6 +177,7 @@ import {
   RemoveCropMachine,
   Username,
   EasterEggKeys,
+  ChangeLanguage,
 } from "./types";
 
 const generalTerms: Record<GeneralTerms, string> = {
@@ -1036,6 +1037,13 @@ const buyFarmHand: Record<BuyFarmHand, string> = {
   "buyFarmHand.notEnoughSpace": "空间不足——升阶您的岛屿",
   "buyFarmHand.buyBumpkin": "购买乡包佬",
   "buyFarmHand.newFarmhandGreeting": "我是您的新雇农。我已经等不及要开干了！",
+};
+
+const changeLanguage: Record<ChangeLanguage, string> = {
+  "changeLanguage.confirm": "此操作将刷新您的浏览器。您确定要更改语言吗？",
+  "changeLanguage.contribute": ENGLISH_TERMS["changeLanguage.contribute"],
+  "changeLanguage.contribute.message":
+    ENGLISH_TERMS["changeLanguage.contribute.message"],
 };
 
 const chat: Record<Chat, string> = {
@@ -4119,11 +4127,7 @@ const statements: Record<Statements, string> = {
   "statements.startgame": ENGLISH_TERMS["statements.startgame"],
   "statements.session.expired": ENGLISH_TERMS["statements.session.expired"],
   "statements.price.change": ENGLISH_TERMS["statements.price.change"],
-  "statements.translation.contribution":
-    ENGLISH_TERMS["statements.translation.contribution"],
   "statements.translation.joinDiscord": "加入 Discord",
-  "statements.translation.want2contribute":
-    ENGLISH_TERMS["statements.translation.want2contribute"],
 };
 
 const stopGoblin: Record<StopGoblin, string> = {
@@ -4547,6 +4551,7 @@ export const CHINESE_SIMPLIFIED_TERMS: Record<TranslationKeys, string> = {
   ...bumpkinSkillsDescription,
   ...bumpkinTrade,
   ...buyFarmHand,
+  ...changeLanguage,
   ...chat,
   ...chickenWinner,
   ...choresStart,

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -176,6 +176,7 @@ import {
   RemoveCropMachine,
   Username,
   EasterEggKeys,
+  ChangeLanguage,
 } from "./types";
 
 const generalTerms: Record<GeneralTerms, string> = {
@@ -1106,6 +1107,14 @@ const buyFarmHand: Record<BuyFarmHand, string> = {
   "buyFarmHand.buyBumpkin": "Buy Bumpkin",
   "buyFarmHand.newFarmhandGreeting":
     "I am your new farmhand. I can't wait to get to work!",
+};
+
+const changeLanguage: Record<ChangeLanguage, string> = {
+  "changeLanguage.confirm":
+    "This action will refresh the browser. Are you sure you want to change your language?",
+  "changeLanguage.contribute": "Want to contribute your Language?",
+  "changeLanguage.contribute.message":
+    "If you are interested in contributing translations for your preferred language, please contact one of the Moderators in the Sunflower Land Discord Server:",
 };
 
 const chat: Record<Chat, string> = {
@@ -4705,9 +4714,6 @@ const statements: Record<Statements, string> = {
 
   "statements.session.expired":
     "It looks like your session has expired. Please refresh the page to continue playing.",
-  "statements.translation.want2contribute": "Want to contribute your Language?",
-  "statements.translation.contribution":
-    "If you are interested in contributing translations for your preferred language, please contact one of the Moderators in the Sunflower Land Discord Server:",
   "statements.translation.joinDiscord": "Join Discord",
 };
 
@@ -5194,6 +5200,7 @@ export const ENGLISH_TERMS: Record<TranslationKeys, string> = {
   ...bumpkinSkillsDescription,
   ...bumpkinTrade,
   ...buyFarmHand,
+  ...changeLanguage,
   ...chat,
   ...chickenWinner,
   ...choresStart,

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -177,6 +177,7 @@ import {
   RemoveCropMachine,
   Username,
   EasterEggKeys,
+  ChangeLanguage,
 } from "./types";
 
 const generalTerms: Record<GeneralTerms, string> = {
@@ -1139,6 +1140,13 @@ const buyFarmHand: Record<BuyFarmHand, string> = {
   "buyFarmHand.buyBumpkin": "Acheter un Bumpkin",
   "buyFarmHand.newFarmhandGreeting":
     "Je suis votre nouveau fermier. J'ai hâte de commencer à travailler!",
+};
+
+const changeLanguage: Record<ChangeLanguage, string> = {
+  "changeLanguage.confirm": ENGLISH_TERMS["changeLanguage.confirm"],
+  "changeLanguage.contribute": ENGLISH_TERMS["changeLanguage.contribute"],
+  "changeLanguage.contribute.message":
+    ENGLISH_TERMS["changeLanguage.contribute.message"],
 };
 
 const chat: Record<Chat, string> = {
@@ -4803,10 +4811,6 @@ const statements: Record<Statements, string> = {
 
   "statements.session.expired":
     "Il semble que votre session ait expiré. Veuillez actualiser la page pour continuer à jouer.",
-  "statements.translation.want2contribute":
-    ENGLISH_TERMS["statements.translation.want2contribute"],
-  "statements.translation.contribution":
-    ENGLISH_TERMS["statements.translation.contribution"],
   "statements.translation.joinDiscord":
     ENGLISH_TERMS["statements.translation.joinDiscord"],
 };
@@ -5330,6 +5334,7 @@ export const FRENCH_TERMS: Record<TranslationKeys, string> = {
   ...bumpkinSkillsDescription,
   ...bumpkinTrade,
   ...buyFarmHand,
+  ...changeLanguage,
   ...chat,
   ...chickenWinner,
   ...choresStart,

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -177,6 +177,7 @@ import {
   RemoveCropMachine,
   Username,
   EasterEggKeys,
+  ChangeLanguage,
 } from "./types";
 
 const generalTerms: Record<GeneralTerms, string> = {
@@ -1129,6 +1130,13 @@ const buyFarmHand: Record<BuyFarmHand, string> = {
 const claimAchievement: Record<ClaimAchievement, string> = {
   "claimAchievement.alreadyHave": "Você já possui esta conquista",
   "claimAchievement.requirementsNotMet": "Você não atende aos requisitos",
+};
+
+const changeLanguage: Record<ChangeLanguage, string> = {
+  "changeLanguage.confirm": ENGLISH_TERMS["changeLanguage.confirm"],
+  "changeLanguage.contribute": ENGLISH_TERMS["changeLanguage.contribute"],
+  "changeLanguage.contribute.message":
+    ENGLISH_TERMS["changeLanguage.contribute.message"],
 };
 
 const chat: Record<Chat, string> = {
@@ -4648,10 +4656,6 @@ const statements: Record<Statements, string> = {
 
   "statements.session.expired":
     "Parece que sua sessão expirou. Atualize a página para continuar jogando.",
-  "statements.translation.want2contribute":
-    ENGLISH_TERMS["statements.translation.want2contribute"],
-  "statements.translation.contribution":
-    ENGLISH_TERMS["statements.translation.contribution"],
   "statements.translation.joinDiscord":
     ENGLISH_TERMS["statements.translation.joinDiscord"],
 };
@@ -5201,6 +5205,7 @@ export const PORTUGUESE_TERMS: Record<TranslationKeys, string> = {
   ...bumpkinTrade,
   ...buyFarmHand,
   ...claimAchievement,
+  ...changeLanguage,
   ...chat,
   ...chickenWinner,
   ...choresStart,

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -177,6 +177,7 @@ import {
   RemoveCropMachine,
   Username,
   EasterEggKeys,
+  ChangeLanguage,
 } from "./types";
 
 const generalTerms: Record<GeneralTerms, string> = {
@@ -1109,6 +1110,13 @@ const buyFarmHand: Record<BuyFarmHand, string> = {
   "buyFarmHand.buyBumpkin": "Bumpkin satın al",
   "buyFarmHand.newFarmhandGreeting":
     "Ben senin yeni çiftçinim. İşe gitmek için sabırsızlanıyorum!",
+};
+
+const changeLanguage: Record<ChangeLanguage, string> = {
+  "changeLanguage.confirm": ENGLISH_TERMS["changeLanguage.confirm"],
+  "changeLanguage.contribute": ENGLISH_TERMS["changeLanguage.contribute"],
+  "changeLanguage.contribute.message":
+    ENGLISH_TERMS["changeLanguage.contribute.message"],
 };
 
 const chat: Record<Chat, string> = {
@@ -4641,10 +4649,6 @@ const statements: Record<Statements, string> = {
 
   "statements.session.expired":
     "Oturumunuzun süresi dolmuş gibi görünüyor. Oynamaya devam etmek için lütfen sayfayı yenileyin.",
-  "statements.translation.want2contribute":
-    ENGLISH_TERMS["statements.translation.want2contribute"],
-  "statements.translation.contribution":
-    ENGLISH_TERMS["statements.translation.contribution"],
   "statements.translation.joinDiscord":
     ENGLISH_TERMS["statements.translation.joinDiscord"],
 };
@@ -5175,6 +5179,7 @@ export const TURKISH_TERMS: Record<TranslationKeys, string> = {
   ...bumpkinSkillsDescription,
   ...bumpkinTrade,
   ...buyFarmHand,
+  ...changeLanguage,
   ...chat,
   ...chickenWinner,
   ...choresStart,

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3152,8 +3152,6 @@ export type Statements =
   | "statements.startgame"
   | "statements.session.expired"
   | "statements.price.change"
-  | "statements.translation.want2contribute"
-  | "statements.translation.contribution"
   | "statements.translation.joinDiscord";
 
 export type StopGoblin =
@@ -3514,6 +3512,11 @@ export type EasterEggKeys =
   | "easterEgg.kingdomBook5"
   | "easterEgg.knight";
 
+export type ChangeLanguage =
+  | "changeLanguage.confirm"
+  | "changeLanguage.contribute"
+  | "changeLanguage.contribute.message";
+
 export type TranslationKeys =
   | AchievementsTerms
   | Auction
@@ -3534,11 +3537,12 @@ export type TranslationKeys =
   | BumpkinSkillsDescription
   | BumpkinTrade
   | BuyFarmHand
-  | ClaimAchievement
+  | ChangeLanguage
   | Chat
   | ChickenWinner
   | ChoresStart
   | ChumDetails
+  | ClaimAchievement
   | Community
   | CompostDescription
   | ComposterDescription


### PR DESCRIPTION
# Description

When user change language but doesn't reload, some texts in game wouldn't switch over to the new language properly until reload. To fix this, I've added a command to force reload when user changes language so that the language gets applied properly across the whole website

I've also added a confirmation message letting users know about the browser refresh:
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/e5cd4dd2-d628-43a0-9484-c3b618af92c8)
Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
