### PR TITLE
[FIX] Oil Tank Overlay in Crop Machine Modal not closing onHide

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -220,9 +220,12 @@ export const CropMachineModal: React.FC<Props> = ({
   ];
 
   const readyPacks = queue.filter((pack) => isCropPackReady(pack));
-
+  const onHide = () => {
+    setOverlayScreen(undefined);
+    onClose();
+  };
   return (
-    <Modal show={show} onHide={onClose}>
+    <Modal show={show} onHide={onHide}>
       <CloseButtonPanel
         tabs={[{ icon: SUNNYSIDE.icons.seedling, name: "Crop Machine" }]}
         currentTab={tab}

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -143,14 +143,14 @@ export const CropMachineModal: React.FC<Props> = ({
 
   const getMachineStatusLabel = () => {
     if (running) {
-      return <Label type="default">{`Crop machine is running`}</Label>;
+      return <Label type="default">{t("cropMachine.running")}</Label>;
     }
 
     if (paused) {
-      return <Label type="warning">{`Crop machine has stopped`}</Label>;
+      return <Label type="warning">{t("cropMachine.stopped")}</Label>;
     }
 
-    return <Label type="default">{`Crop machine is idle`}</Label>;
+    return <Label type="default">{t("cropMachine.idle")}</Label>;
   };
 
   const getQueueItemCountLabelType = (
@@ -227,7 +227,7 @@ export const CropMachineModal: React.FC<Props> = ({
   return (
     <Modal show={show} onHide={onHide}>
       <CloseButtonPanel
-        tabs={[{ icon: SUNNYSIDE.icons.seedling, name: "Crop Machine" }]}
+        tabs={[{ icon: SUNNYSIDE.icons.seedling, name: t("cropMachine.name") }]}
         currentTab={tab}
         setCurrentTab={setTab}
         onClose={onClose}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1283,6 +1283,10 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.totalCrops": "{{cropName}} 总产出： {{total}}",
   "cropMachine.totalRuntime": "总运行时长： {{time}}",
   "cropMachine.totalSeeds": "总播下种子： {{total}}",
+  "cropMachine.running": ENGLISH_TERMS["cropMachine.running"],
+  "cropMachine.stopped": ENGLISH_TERMS["cropMachine.stopped"],
+  "cropMachine.idle": ENGLISH_TERMS["cropMachine.idle"],
+  "cropMachine.name": ENGLISH_TERMS["cropMachine.name"],
 };
 
 const decorationDescriptions: Record<DecorationDescriptions, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1386,6 +1386,10 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.maxRuntime": "Max runtime: {{time}}",
   "cropMachine.oilToAdd": "Oil to add: {{amount}}",
   "cropMachine.totalRuntime": "Total runtime: {{time}}",
+  "cropMachine.running": "Crop Machine is running",
+  "cropMachine.stopped": "Crop Machine has stopped",
+  "cropMachine.idle": "Crop Machine is idle",
+  "cropMachine.name": "Crop Machine",
 };
 
 const decorationDescriptions: Record<DecorationDescriptions, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1433,6 +1433,10 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.totalCrops": ENGLISH_TERMS["cropMachine.totalCrops"],
   "cropMachine.totalRuntime": ENGLISH_TERMS["cropMachine.totalRuntime"],
   "cropMachine.totalSeeds": ENGLISH_TERMS["cropMachine.totalSeeds"],
+  "cropMachine.running": ENGLISH_TERMS["cropMachine.running"],
+  "cropMachine.stopped": ENGLISH_TERMS["cropMachine.stopped"],
+  "cropMachine.idle": ENGLISH_TERMS["cropMachine.idle"],
+  "cropMachine.name": ENGLISH_TERMS["cropMachine.name"],
 };
 
 const decorationDescriptions: Record<DecorationDescriptions, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1404,6 +1404,10 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.totalCrops": ENGLISH_TERMS["cropMachine.totalCrops"],
   "cropMachine.totalRuntime": ENGLISH_TERMS["cropMachine.totalRuntime"],
   "cropMachine.totalSeeds": ENGLISH_TERMS["cropMachine.totalSeeds"],
+  "cropMachine.running": ENGLISH_TERMS["cropMachine.running"],
+  "cropMachine.stopped": ENGLISH_TERMS["cropMachine.stopped"],
+  "cropMachine.idle": ENGLISH_TERMS["cropMachine.idle"],
+  "cropMachine.name": ENGLISH_TERMS["cropMachine.name"],
 };
 
 const deliveryitem: Record<DeliveryItem, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1392,6 +1392,10 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.totalCrops": ENGLISH_TERMS["cropMachine.totalCrops"],
   "cropMachine.totalRuntime": ENGLISH_TERMS["cropMachine.totalRuntime"],
   "cropMachine.totalSeeds": ENGLISH_TERMS["cropMachine.totalSeeds"],
+  "cropMachine.running": ENGLISH_TERMS["cropMachine.running"],
+  "cropMachine.stopped": ENGLISH_TERMS["cropMachine.stopped"],
+  "cropMachine.idle": ENGLISH_TERMS["cropMachine.idle"],
+  "cropMachine.name": ENGLISH_TERMS["cropMachine.name"],
 };
 
 const decorationDescriptions: Record<DecorationDescriptions, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -976,7 +976,11 @@ export type CropMachine =
   | "cropMachine.harvestAllCrops"
   | "cropMachine.maxRuntime"
   | "cropMachine.oilToAdd"
-  | "cropMachine.totalRuntime";
+  | "cropMachine.totalRuntime"
+  | "cropMachine.running"
+  | "cropMachine.stopped"
+  | "cropMachine.idle"
+  | "cropMachine.name";
 
 export type DeliveryItem =
   | "deliveryitem.inventory"


### PR DESCRIPTION
# Description


Fixes #issue
This PR fixes a minor issue where if user opens Oil Tank overlay in Crop Machine and hides the Crop Machine Modal, when opening the Crop Machine Modal again, it opens with the Oil Tank overlay. 
Added `setOverlayScreen(undefined);` to the onHide function

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


1. Open Crop Machine
2. Open Oil Tank Overlay
3. Without closing Oil tank overlay, hide Crop Machine Modal by clicking away
4. Open Crop Machine again
5. Oil tank overlay should be hidden

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
