### PR TITLE
[FEAT] Add Confirmation Screen for Composter Boost

### DIFF
--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -167,6 +167,12 @@ export const ComposterModal: React.FC<Props> = ({
     onBoost();
   };
 
+  const [isConfirmBoostModalOpen, showConfirmBoostModal] = useState(false);
+  const applyBoost = () => {
+    accelerate();
+    showConfirmBoostModal(false);
+  }; // We could do without this const but I added it for better security
+
   const Content = () => {
     if (isReady) {
       return (
@@ -261,7 +267,7 @@ export const ComposterModal: React.FC<Props> = ({
                   />
                 </div>
                 <p className="text-xs mb-2">
-                  {t("guide.compost.add.eggs.speed")}
+                  {t("guide.compost.addEggs.speed")}
                   {"."}
                 </p>
                 <Button
@@ -271,10 +277,45 @@ export const ComposterModal: React.FC<Props> = ({
                       composterInfo.eggBoostRequirements
                     )
                   }
-                  onClick={accelerate}
+                  onClick={() => showConfirmBoostModal(true)}
                 >
-                  {t("guide.compost.add.eggs")}
+                  {t("guide.compost.addEggs")}
                 </Button>
+                <Modal
+                  show={isConfirmBoostModalOpen}
+                  onHide={() => showConfirmBoostModal(false)}
+                >
+                  <CloseButtonPanel className="sm:w-full m-auto">
+                    <div className="flex flex-col p-2">
+                      <span className="text-sm text-left">
+                        {t("guide.compost.addEggs.confirmation", {
+                          noEggs: composterInfo.eggBoostRequirements,
+                          time: secondsToString(
+                            composterInfo.eggBoostMilliseconds / 1000,
+                            {
+                              length: "short",
+                            }
+                          ),
+                        })}
+                      </span>
+                    </div>
+                    <div className="flex justify-content-around mt-2 space-x-1">
+                      <Button
+                        disabled={
+                          !state.inventory.Egg?.gte(
+                            composterInfo.eggBoostRequirements
+                          )
+                        }
+                        onClick={applyBoost}
+                      >
+                        {t("guide.compost.addEggs")}
+                      </Button>
+                      <Button onClick={() => showConfirmBoostModal(false)}>
+                        {t("cancel")}
+                      </Button>
+                    </div>
+                  </CloseButtonPanel>
+                </Modal>
               </OuterPanel>
             </>
           )}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -2329,8 +2329,8 @@ const goldTooth: Record<GoldTooth, string> = {
 };
 
 const guideCompost: Record<GuideCompost, string> = {
-  "guide.compost.add.eggs.speed": "添加鸡蛋以加快生产速度",
-  "guide.compost.add.eggs": "添加鸡蛋",
+  "guide.compost.addEggs.speed": "添加鸡蛋以加快生产速度",
+  "guide.compost.addEggs": "添加鸡蛋",
   "guide.compost.eggs": "鸡蛋",
   "guide.compost.cropGrowthTime": "-50% 庄稼生长时间",
   "guide.compost.fishingBait": "鱼饵",
@@ -2339,6 +2339,8 @@ const guideCompost: Record<GuideCompost, string> = {
     "一个堆肥周期可以生产多个肥料，可用来促进你的作物和水果生长",
   "guide.compost.yieldsWorms": "每个堆肥产出的蚯蚓可以用作钓鱼的饵",
   "guide.compost.useEggs": "厌倦了等待？使用鸡蛋来加速堆肥生产",
+  "guide.compost.addEggs.confirmation":
+    ENGLISH_TERMS["guide.compost.addEggs.confirmation"],
 };
 
 const guideTerms: Record<GuideTerms, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2579,8 +2579,8 @@ const goldTooth: Record<GoldTooth, string> = {
 };
 
 const guideCompost: Record<GuideCompost, string> = {
-  "guide.compost.add.eggs.speed": "Add eggs to speed up production",
-  "guide.compost.add.eggs": "Add Eggs",
+  "guide.compost.addEggs.speed": "Add eggs to speed up production",
+  "guide.compost.addEggs": "Add Eggs",
   "guide.compost.eggs": "Eggs",
   "guide.compost.cropGrowthTime": "-50% Crop Growth Time",
   "guide.compost.fishingBait": "Fishing bait",
@@ -2591,6 +2591,8 @@ const guideCompost: Record<GuideCompost, string> = {
     "Each compost yields worms that can be used as bait for fishing",
   "guide.compost.useEggs":
     "Tired of waiting? Use Eggs to speed up the compost production",
+  "guide.compost.addEggs.confirmation":
+    "Are you sure you want to add {{noEggs}} Eggs to reduce compost production time by {{time}}?",
 };
 
 const guideTerms: Record<GuideTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -2690,9 +2690,9 @@ const goldTooth: Record<GoldTooth, string> = {
 };
 
 const guideCompost: Record<GuideCompost, string> = {
-  "guide.compost.add.eggs.speed":
+  "guide.compost.addEggs.speed":
     "Ajoutez des œufs pour accélérer la production",
-  "guide.compost.add.eggs": "Ajouter des œufs",
+  "guide.compost.addEggs": "Ajouter des œufs",
   "guide.compost.eggs": "Œufs",
   "guide.compost.cropGrowthTime": "-50% Temps de croissance des cultures",
   "guide.compost.fishingBait": "Appât de pêche",
@@ -2704,6 +2704,8 @@ const guideCompost: Record<GuideCompost, string> = {
     "Chaque compost produit des vers qui peuvent être utilisés comme appât pour la pêche",
   "guide.compost.useEggs":
     "Fatigué d'attendre ? Utilisez des œufs pour accélérer la production de compost",
+  "guide.compost.addEggs.confirmation":
+    ENGLISH_TERMS["guide.compost.addEggs.confirmation"],
 };
 
 const guideTerms: Record<GuideTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2598,8 +2598,8 @@ const goldTooth: Record<GoldTooth, string> = {
 };
 
 const guideCompost: Record<GuideCompost, string> = {
-  "guide.compost.add.eggs.speed": "Adicione ovos para acelerar a produção",
-  "guide.compost.add.eggs": "Adicione ovos",
+  "guide.compost.addEggs.speed": "Adicione ovos para acelerar a produção",
+  "guide.compost.addEggs": "Adicione ovos",
   "guide.compost.eggs": "Ovos",
   "guide.compost.cropGrowthTime": "-50% Tempo de crescimento da plantação",
   "guide.compost.fishingBait": "Isca de pesca",
@@ -2611,6 +2611,8 @@ const guideCompost: Record<GuideCompost, string> = {
     "Cada compostagem produz minhocas que podem ser usadas como isca para pesca",
   "guide.compost.useEggs":
     "Cansado de esperar? Use ovos para acelerar a produção de compostagem",
+  "guide.compost.addEggs.confirmation":
+    ENGLISH_TERMS["guide.compost.addEggs.confirmation"],
 };
 
 const guideTerms: Record<GuideTerms, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2574,8 +2574,8 @@ const goldTooth: Record<GoldTooth, string> = {
 };
 
 const guideCompost: Record<GuideCompost, string> = {
-  "guide.compost.add.eggs.speed": "Üretimi hızlandırmak için yumurta ekleyin",
-  "guide.compost.add.eggs": "Yumurta Ekle",
+  "guide.compost.addEggs.speed": "Üretimi hızlandırmak için yumurta ekleyin",
+  "guide.compost.addEggs": "Yumurta Ekle",
   "guide.compost.eggs": "Yumurtalar",
   "guide.compost.cropGrowthTime": "-50% Mahsul Büyüme Süresi",
   "guide.compost.fishingBait": "Balık yemi",
@@ -2587,6 +2587,8 @@ const guideCompost: Record<GuideCompost, string> = {
     "Her kompost, balık tutmak için yem olarak kullanılabilecek solucanlar üretir",
   "guide.compost.useEggs":
     "Beklemekten yoruldunuz mu? Kompost üretimini hızlandırmak için Yumurta kullanın",
+  "guide.compost.addEggs.confirmation":
+    ENGLISH_TERMS["guide.compost.addEggs.confirmation"],
 };
 
 const guideTerms: Record<GuideTerms, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1847,15 +1847,16 @@ export type GOBLIN_MESSAGES =
 export type GoldTooth = "goldTooth.intro.part1" | "goldTooth.intro.part2";
 
 export type GuideCompost =
-  | "guide.compost.add.eggs.speed"
-  | "guide.compost.add.eggs"
+  | "guide.compost.addEggs.speed"
+  | "guide.compost.addEggs"
   | "guide.compost.eggs"
   | "guide.compost.cropGrowthTime"
   | "guide.compost.fishingBait"
   | "guide.compost.placeCrops"
   | "guide.compost.compostCycle"
   | "guide.compost.yieldsWorms"
-  | "guide.compost.useEggs";
+  | "guide.compost.useEggs"
+  | "guide.compost.addEggs.confirmation";
 
 export type GuideTerms =
   | "guide.intro"


### PR DESCRIPTION
# Description

I'm reopening a PR for this from #3242 
Many players have been requesting for a confirmation screen for adding eggs for composters ever since the last PR as there have been many times where they accidentally added eggs to composters
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/84414b46-3ae2-4812-a8d6-b2d602235928)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
