### PR TITLE
[FEAT] Add required island check to seed purchases and building purchases

### DIFF
--- a/src/features/game/events/landExpansion/constructBuilding.test.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.test.ts
@@ -513,4 +513,61 @@ describe("Construct building", () => {
     expect(newState.inventory.Egg).toEqual(initialEggs.minus(eggsRequired));
     expect(newState.coins).toEqual(initialCoins - building.coins);
   });
+
+  it("requires desert island to build the crop machine", () => {
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+          buildings: {},
+          coins: 8000,
+          inventory: {
+            Wood: new Decimal(1250),
+            Iron: new Decimal(125),
+            Crimstone: new Decimal(50),
+          },
+          bumpkin: { ...INITIAL_BUMPKIN, experience: LEVEL_EXPERIENCE[64] },
+        },
+        action: {
+          type: "building.constructed",
+          id: "123",
+          name: "Crop Machine",
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+        },
+        createdAt: dateNow,
+      })
+    ).toThrow("You do not have the required island expansion");
+
+    expect(() =>
+      constructBuilding({
+        state: {
+          ...GAME_STATE,
+          buildings: {},
+          coins: 8000,
+          inventory: {
+            Wood: new Decimal(1250),
+            Iron: new Decimal(125),
+            Crimstone: new Decimal(50),
+          },
+          bumpkin: { ...INITIAL_BUMPKIN, experience: LEVEL_EXPERIENCE[64] },
+          island: {
+            type: "desert",
+          },
+        },
+        action: {
+          type: "building.constructed",
+          id: "123",
+          name: "Crop Machine",
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+        },
+        createdAt: dateNow,
+      })
+    ).not.toThrow();
+  });
 });

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -4,6 +4,7 @@ import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
 import { GameState, PlacedItem } from "../../types/game";
 import { getBumpkinLevel } from "features/game/lib/level";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 
 export enum CONSTRUCT_BUILDING_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -57,6 +58,15 @@ export function constructBuilding({
 
   if (coins < buildingToConstruct.coins) {
     throw new Error(CONSTRUCT_BUILDING_ERRORS.NOT_ENOUGH_COINS);
+  }
+
+  const requiredIsland = buildingToConstruct.requiredIsland;
+
+  if (
+    requiredIsland &&
+    !hasRequiredIslandExpansion(stateCopy.island.type, requiredIsland)
+  ) {
+    throw new Error("You do not have the required island expansion");
   }
 
   let missingIngredients: string[] = [];

--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -372,6 +372,9 @@ describe("seedBought", () => {
             },
           ],
         },
+        island: {
+          type: "spring",
+        },
       },
       action: {
         item: "Lily Seed",
@@ -382,5 +385,110 @@ describe("seedBought", () => {
 
     expect(state.coins).toEqual(100);
     expect(state.inventory["Lily Seed"]).toEqual(new Decimal(1));
+  });
+
+  it("requires spring island to buy a flower seed", () => {
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          coins: Infinity,
+        },
+        action: {
+          type: "seed.bought",
+          item: "Lily Seed",
+          amount: 1,
+        },
+      })
+    ).toThrow("You do not have the required island expansion");
+
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          coins: Infinity,
+          island: {
+            type: "spring",
+          },
+        },
+        action: {
+          type: "seed.bought",
+          item: "Lily Seed",
+          amount: 1,
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it("requires desert island to buy a greenhouse crop seed", () => {
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          coins: Infinity,
+        },
+        action: {
+          type: "seed.bought",
+          item: "Rice Seed",
+          amount: 1,
+        },
+      })
+    ).toThrow("You do not have the required island expansion");
+
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          coins: Infinity,
+          island: {
+            type: "desert",
+          },
+        },
+        action: {
+          type: "seed.bought",
+          item: "Rice Seed",
+          amount: 1,
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it("requires desert island to buy a greenhouse fruit seed", () => {
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          coins: Infinity,
+        },
+        action: {
+          type: "seed.bought",
+          item: "Grape Seed",
+          amount: 1,
+        },
+      })
+    ).toThrow("You do not have the required island expansion");
+
+    expect(() =>
+      seedBought({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+          island: {
+            type: "desert",
+          },
+          coins: Infinity,
+        },
+        action: {
+          type: "seed.bought",
+          item: "Grape Seed",
+          amount: 1,
+        },
+      })
+    ).not.toThrow();
   });
 });

--- a/src/features/game/events/landExpansion/seedBought.ts
+++ b/src/features/game/events/landExpansion/seedBought.ts
@@ -9,6 +9,7 @@ import { getBumpkinLevel } from "features/game/lib/level";
 import { Seed, SeedName, SEEDS } from "features/game/types/seeds";
 import { isWearableActive } from "features/game/lib/wearables";
 import { FLOWER_SEEDS } from "features/game/types/flowers";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 
 export type SeedBoughtAction = {
   type: "seed.bought";
@@ -83,6 +84,15 @@ export function seedBought({ state, action }: Options) {
 
   if (stateCopy.stock[item]?.lt(amount)) {
     throw new Error("Not enough stock");
+  }
+
+  const requiredIsland = seed.requiredIsland;
+
+  if (
+    requiredIsland &&
+    !hasRequiredIslandExpansion(stateCopy.island.type, requiredIsland)
+  ) {
+    throw new Error("You do not have the required island expansion");
   }
 
   const price = getBuyPrice(item, seed, stateCopy.inventory, stateCopy);


### PR DESCRIPTION
# Description

This PR updates `building.constructed` and `seed.bought` to allow for an optional field, `requiredIsland`. The implementation matches the implementation of tool.crafted.

The change is a result of these two PRs:

https://github.com/sunflower-land/sunflower-land/pull/3777
https://github.com/sunflower-land/sunflower-land/pull/3778

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
