### PR TITLE
[FEAT] Crop Machine Removal Restriction

### DIFF
--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -113,6 +113,43 @@ describe("removeBuilding", () => {
     ).toThrow(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
   });
 
+  it("does not remove a building that has a removal restriction that is not met", () => {
+    expect(() =>
+      removeBuilding({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            "Rusty Shovel": new Decimal(0),
+          },
+          buildings: {
+            "Crop Machine": [
+              {
+                id: "123",
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                readyAt: 0,
+                queue: [
+                  {
+                    crop: "Sunflower",
+                    amount: 1,
+                    seeds: 1,
+                    totalGrowTime: 60,
+                    growTimeRemaining: 60,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "building.removed",
+          name: "Crop Machine",
+          id: "123",
+        },
+      })
+    ).toThrow("Machine is in use");
+  });
+
   it("removes a building and does not affect buildings of the same type", () => {
     const gameState = removeBuilding({
       state: {

--- a/src/features/game/events/landExpansion/removeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.test.ts
@@ -115,7 +115,7 @@ describe("removeBuilding", () => {
     ).toThrow(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
   });
 
-  it("does not remove a building that has a removal restriction that is not met", () => {
+  it("does not remove a building that has a removal restriction", () => {
     const buildingName: BuildingName = "Crop Machine";
     const id = "123";
     const state: GameState = {

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -7,6 +7,7 @@ import cloneDeep from "lodash.clonedeep";
 import { getSupportedChickens } from "./utils";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { isBuildingEnabled } from "features/game/expansion/lib/buildingRequirements";
+import { hasRemoveRestriction } from "features/game/types/removeables";
 
 export enum REMOVE_BUILDING_ERRORS {
   INVALID_BUILDING = "This building does not exist",
@@ -158,6 +159,16 @@ export function removeBuilding({
 
   if (buildingToRemove.readyAt > createdAt) {
     throw new Error(REMOVE_BUILDING_ERRORS.BUILDING_UNDER_CONSTRUCTION);
+  }
+
+  const [restricted, error] = hasRemoveRestriction(
+    action.name,
+    action.id,
+    stateCopy
+  );
+
+  if (restricted) {
+    throw new Error(error);
   }
 
   // TODO - remove once landscaping is launched

--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -813,6 +813,28 @@ describe("canremove", () => {
 
       expect(restricted).toBe(false);
     });
+
+    it("enables a user to remove a crop machine when there are no seeds or crops in the machine", () => {
+      const [restricted] = hasRemoveRestriction("Crop Machine", "1", {
+        ...TEST_FARM,
+        inventory: {
+          "Crop Machine": new Decimal(1),
+        },
+        buildings: {
+          "Crop Machine": [
+            {
+              id: "123",
+              createdAt: 0,
+              readyAt: 0,
+              queue: [],
+              coordinates: { x: 1, y: 1 },
+            },
+          ],
+        },
+      });
+
+      expect(restricted).toBe(false);
+    });
   });
 
   it("enables a user to remove a peeled potato when not in use", () => {

--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -1460,4 +1460,33 @@ describe("canremove", () => {
 
     expect(restricted).toBe(true);
   });
+
+  it("prevents a user from removing a crop machine when crops are inside the machine", () => {
+    const [restricted] = hasRemoveRestriction("Crop Machine", "123", {
+      ...TEST_FARM,
+      buildings: {
+        "Crop Machine": [
+          {
+            coordinates: { x: 1, y: 1 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+            queue: [
+              {
+                crop: "Sunflower",
+                amount: 20,
+                seeds: 20,
+                growTimeRemaining: 0,
+                totalGrowTime: 1000,
+                startTime: Date.now(),
+                readyAt: Date.now() + 1000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(restricted).toBe(true);
+  });
 });

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -311,7 +311,7 @@ function hasSeedsCropsInMachine(game: GameState): Restriction {
   const machine = game.buildings["Crop Machine"]?.[0];
   return [
     !!machine?.queue?.length,
-    translate("restrictionReason.machineInUse"),
+    translate("restrictionReason.buildingInUse"),
   ];
 }
 

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -307,7 +307,7 @@ function areAnyOilReservesDrilled(game: GameState): Restriction {
   return [oilReservesDrilled, translate("restrictionReason.oilReserveDrilled")];
 }
 
-function hasSeedsInMachine(game: GameState): Restriction {
+function hasSeedsCropsInMachine(game: GameState): Restriction {
   const machine = game.buildings["Crop Machine"]?.[0];
   return [
     !!machine?.queue?.length,
@@ -429,7 +429,7 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Rice Panda": (game) => greenhouseCropIsGrowing({ crop: "Rice", game }),
 
   // Buildings
-  "Crop Machine": (game) => hasSeedsInMachine(game),
+  "Crop Machine": (game) => hasSeedsCropsInMachine(game),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -307,6 +307,14 @@ function areAnyOilReservesDrilled(game: GameState): Restriction {
   return [oilReservesDrilled, translate("restrictionReason.oilReserveDrilled")];
 }
 
+function hasSeedsInMachine(game: GameState): Restriction {
+  const machine = game.buildings["Crop Machine"]?.[0];
+  return [
+    !!machine?.queue?.length,
+    translate("restrictionReason.machineInUse"),
+  ];
+}
+
 export const REMOVAL_RESTRICTIONS: Partial<
   Record<InventoryItemName, RemoveCondition>
 > = {
@@ -419,6 +427,9 @@ export const REMOVAL_RESTRICTIONS: Partial<
   Vinny: (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
   "Grape Granny": (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
   "Rice Panda": (game) => greenhouseCropIsGrowing({ crop: "Rice", game }),
+
+  // Buildings
+  "Crop Machine": (game) => hasSeedsInMachine(game),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<

--- a/src/features/island/collectibles/RemoveCropMachineModal.tsx
+++ b/src/features/island/collectibles/RemoveCropMachineModal.tsx
@@ -32,7 +32,7 @@ export const RemoveCropMachineModal: React.FC<Props> = ({
         </div>
 
         <Button onClick={onRemove} className="mt-2">
-          {t("removeCropMachine.removeSeeds")}
+          {t("removeCropMachine.removeOil")}
         </Button>
       </CloseButtonPanel>
     </Modal>

--- a/src/features/island/collectibles/RemoveCropMachineModal.tsx
+++ b/src/features/island/collectibles/RemoveCropMachineModal.tsx
@@ -32,7 +32,7 @@ export const RemoveCropMachineModal: React.FC<Props> = ({
         </div>
 
         <Button onClick={onRemove} className="mt-2">
-          {t("removeCropMachine.removeOil")}
+          {t("remove")}
         </Button>
       </CloseButtonPanel>
     </Modal>

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -135,7 +135,7 @@ const LandscapingHudComponent: React.FC<{
                 marginBottom: `${PIXEL_SCALE * 25}px`,
                 width: `${PIXEL_SCALE * 22}px`,
                 right: `${PIXEL_SCALE * 3}px`,
-                top: `${PIXEL_SCALE * 38}px`,
+                top: `${PIXEL_SCALE * 31}px`,
               }}
             >
               <div

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3644,8 +3644,7 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeSeeds":
-    ENGLISH_TERMS["removeCropMachine.removeSeeds"],
+  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const removeHungryCaterpillar: Record<RemoveHungryCaterpillar, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3710,6 +3710,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.genieLampRubbed": "神灯已被摩擦",
   "restrictionReason.?cropGrowing": "{{crop}} is growing",
   "restrictionReason.oilReserveDrilled": "Oil reserves are drilled",
+  "restrictionReason.machineInUse":
+    ENGLISH_TERMS["restrictionReason.machineInUse"],
 };
 
 const restock: Record<Restock, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3709,8 +3709,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.genieLampRubbed": "神灯已被摩擦",
   "restrictionReason.?cropGrowing": "{{crop}} is growing",
   "restrictionReason.oilReserveDrilled": "Oil reserves are drilled",
-  "restrictionReason.machineInUse":
-    ENGLISH_TERMS["restrictionReason.machineInUse"],
+  "restrictionReason.buildingInUse":
+    ENGLISH_TERMS["restrictionReason.buildingInUse"],
 };
 
 const restock: Record<Restock, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3644,7 +3644,6 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const removeHungryCaterpillar: Record<RemoveHungryCaterpillar, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4193,7 +4193,6 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": "Remove Crop Machine?",
   "removeCropMachine.description":
     "This action will remove all the oil stored in your crop machine.",
-  "removeCropMachine.removeOil": "Remove oil",
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4889,6 +4889,7 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.noRestriction": "No restriction",
   "restrictionReason.genieLampRubbed": "Genie Lamp rubbed",
   "restrictionReason.oilReserveDrilled": "Oil reserves are drilled",
+  "restrictionReason.machineInUse": "Machine is in use",
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4192,8 +4192,8 @@ const removeHungryCaterpillar: Record<RemoveHungryCaterpillar, string> = {
 const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": "Remove Crop Machine?",
   "removeCropMachine.description":
-    "This action will remove oil and all the seeds stored in your crop machine.",
-  "removeCropMachine.removeSeeds": "Remove seeds",
+    "This action will remove all the oil stored in your crop machine.",
+  "removeCropMachine.removeOil": "Remove oil",
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4889,7 +4889,7 @@ const restrictionReason: Record<RestrictionReason, string> = {
   "restrictionReason.noRestriction": "No restriction",
   "restrictionReason.genieLampRubbed": "Genie Lamp rubbed",
   "restrictionReason.oilReserveDrilled": "Oil reserves are drilled",
-  "restrictionReason.machineInUse": "Machine is in use",
+  "restrictionReason.buildingInUse": "Building is in use",
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4341,8 +4341,7 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeSeeds":
-    ENGLISH_TERMS["removeCropMachine.removeSeeds"],
+  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4341,7 +4341,6 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5085,8 +5085,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
-  "restrictionReason.machineInUse":
-    ENGLISH_TERMS["restrictionReason.machineInUse"],
+  "restrictionReason.buildingInUse":
+    ENGLISH_TERMS["restrictionReason.buildingInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5086,6 +5086,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
+  "restrictionReason.machineInUse":
+    ENGLISH_TERMS["restrictionReason.machineInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4954,8 +4954,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
-  "restrictionReason.machineInUse":
-    ENGLISH_TERMS["restrictionReason.machineInUse"],
+  "restrictionReason.buildingInUse":
+    ENGLISH_TERMS["restrictionReason.buildingInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4190,8 +4190,7 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeSeeds":
-    ENGLISH_TERMS["removeCropMachine.removeSeeds"],
+  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4955,6 +4955,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
+  "restrictionReason.machineInUse":
+    ENGLISH_TERMS["restrictionReason.machineInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4190,7 +4190,6 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4187,7 +4187,6 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4928,6 +4928,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
+  "restrictionReason.machineInUse":
+    ENGLISH_TERMS["restrictionReason.machineInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4187,8 +4187,7 @@ const removeCropMachine: Record<RemoveCropMachine, string> = {
   "removeCropMachine.title": ENGLISH_TERMS["removeCropMachine.title"],
   "removeCropMachine.description":
     ENGLISH_TERMS["removeCropMachine.description"],
-  "removeCropMachine.removeSeeds":
-    ENGLISH_TERMS["removeCropMachine.removeSeeds"],
+  "removeCropMachine.removeOil": ENGLISH_TERMS["removeCropMachine.removeOil"],
 };
 
 const resale: Record<Resale, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4927,8 +4927,8 @@ const restrictionReason: Record<RestrictionReason, string> = {
     ENGLISH_TERMS["restrictionReason.genieLampRubbed"],
   "restrictionReason.oilReserveDrilled":
     ENGLISH_TERMS["restrictionReason.oilReserveDrilled"],
-  "restrictionReason.machineInUse":
-    ENGLISH_TERMS["restrictionReason.machineInUse"],
+  "restrictionReason.buildingInUse":
+    ENGLISH_TERMS["restrictionReason.buildingInUse"],
 };
 
 export const leaderboardTerms: Record<Leaderboard, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2838,8 +2838,7 @@ export type RemoveKuebiko =
 
 export type RemoveCropMachine =
   | "removeCropMachine.title"
-  | "removeCropMachine.description"
-  | "removeCropMachine.removeOil";
+  | "removeCropMachine.description";
 
 export type Resale = "resale.actionText";
 

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3362,7 +3362,8 @@ export type RestrictionReason =
   | "restrictionReason.festiveSeason"
   | "restrictionReason.noRestriction"
   | "restrictionReason.genieLampRubbed"
-  | "restrictionReason.oilReserveDrilled";
+  | "restrictionReason.oilReserveDrilled"
+  | "restrictionReason.machineInUse";
 
 export type Leaderboard =
   | "leaderboard.leaderboard"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2839,7 +2839,7 @@ export type RemoveKuebiko =
 export type RemoveCropMachine =
   | "removeCropMachine.title"
   | "removeCropMachine.description"
-  | "removeCropMachine.removeSeeds";
+  | "removeCropMachine.removeOil";
 
 export type Resale = "resale.actionText";
 

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3363,7 +3363,7 @@ export type RestrictionReason =
   | "restrictionReason.noRestriction"
   | "restrictionReason.genieLampRubbed"
   | "restrictionReason.oilReserveDrilled"
-  | "restrictionReason.machineInUse";
+  | "restrictionReason.buildingInUse";
 
 export type Leaderboard =
   | "leaderboard.leaderboard"


### PR DESCRIPTION
# Description

This PR adds a removal restriction to the crop machine so it cannot be removed if it has any seeds/crops currently in the machine.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally in art mode and against the corresponding BE PR.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
