### PR TITLE
[FEAT] Emblem Airdrop Countdown

### DIFF
--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -7,16 +7,12 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import confetti from "canvas-confetti";
 import { Context } from "features/game/GameProvider";
-import { CONFIG } from "lib/config";
 import { useSelector } from "@xstate/react";
 import { FACTION_POINT_ICONS } from "features/world/ui/factions/FactionDonationPanel";
 import { MachineState } from "features/game/lib/gameMachine";
+import classNames from "classnames";
 
-const ART_MODE = !CONFIG.API_URL;
-
-export const EMBLEM_AIRDROP_DATE = ART_MODE
-  ? new Date(Date.now() + 5000)
-  : new Date("2024-06-14T00:00:00Z");
+export const EMBLEM_AIRDROP_DATE = new Date("2024-06-14T00:00:00Z");
 
 const _faction = (state: MachineState) => state.context.state.faction;
 
@@ -47,10 +43,10 @@ const Countdown: React.FC<{ time: Date; onComplete: () => void }> = ({
         <Label
           type="info"
           icon={SUNNYSIDE.icons.stopwatch}
-          className="mx-1"
+          className={classNames("ml-1", { "mr-1": !!faction })}
           secondaryIcon={faction && FACTION_POINT_ICONS[faction.name]}
         >
-          {t("emblemCountdown.title")}
+          {t("faction.emblemAirdrop")}
         </Label>
         <img
           src={SUNNYSIDE.icons.close}

--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -13,6 +13,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import classNames from "classnames";
 
 export const EMBLEM_AIRDROP_DATE = new Date("2024-06-14T00:00:00Z");
+const SHOW_COUNTDOWN = new Date("2024-06-01T00:00:00Z");
 
 const _faction = (state: MachineState) => state.context.state.faction;
 
@@ -60,11 +61,15 @@ const Countdown: React.FC<{ time: Date; onComplete: () => void }> = ({
 };
 
 export const EmblemAirdropCountdown: React.FC = () => {
-  const [halvening, setHalvening] = useState<Date | undefined>(
-    EMBLEM_AIRDROP_DATE
-  );
+  const [airdropDate, setAirdropDate] = useState<Date>();
 
-  if (!halvening) {
+  useEffect(() => {
+    if (SHOW_COUNTDOWN.getTime() < Date.now()) {
+      setAirdropDate(EMBLEM_AIRDROP_DATE);
+    }
+  }, []);
+
+  if (!airdropDate) {
     return null;
   }
 
@@ -72,7 +77,7 @@ export const EmblemAirdropCountdown: React.FC = () => {
     <InnerPanel className="flex justify-center" id="emblem-airdrop">
       <Countdown
         time={EMBLEM_AIRDROP_DATE}
-        onComplete={() => setHalvening(undefined)}
+        onComplete={() => setAirdropDate(undefined)}
       />
     </InnerPanel>
   );

--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -1,0 +1,83 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { InnerPanel } from "components/ui/Panel";
+import { Label } from "components/ui/Label";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
+import confetti from "canvas-confetti";
+import { Context } from "features/game/GameProvider";
+import { CONFIG } from "lib/config";
+import { useSelector } from "@xstate/react";
+import { FACTION_POINT_ICONS } from "features/world/ui/factions/FactionDonationPanel";
+import { MachineState } from "features/game/lib/gameMachine";
+
+const ART_MODE = !CONFIG.API_URL;
+
+export const EMBLEM_AIRDROP_DATE = ART_MODE
+  ? new Date(Date.now() + 5000)
+  : new Date("2024-06-14T00:00:00Z");
+
+const _faction = (state: MachineState) => state.context.state.faction;
+
+const Countdown: React.FC<{ time: Date; onComplete: () => void }> = ({
+  time,
+  onComplete,
+}) => {
+  const start = useCountdown(time.getTime());
+  const { t } = useAppTranslation();
+
+  const { showAnimations, gameService } = useContext(Context);
+  const faction = useSelector(gameService, _faction);
+
+  useEffect(() => {
+    if (time.getTime() < Date.now()) {
+      if (showAnimations) confetti();
+      onComplete();
+    }
+  }, [start]);
+
+  if (time.getTime() < Date.now()) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="h-6 flex justify-center">
+        <Label
+          type="info"
+          icon={SUNNYSIDE.icons.stopwatch}
+          className="mx-1"
+          secondaryIcon={faction && FACTION_POINT_ICONS[faction.name]}
+        >
+          {t("emblemCountdown.title")}
+        </Label>
+        <img
+          src={SUNNYSIDE.icons.close}
+          className="h-5 cursor-pointer ml-2"
+          onClick={onComplete}
+        />
+      </div>
+      <TimerDisplay time={start} />
+    </div>
+  );
+};
+
+export const EmblemAirdropCountdown: React.FC = () => {
+  const [halvening, setHalvening] = useState<Date | undefined>(
+    EMBLEM_AIRDROP_DATE
+  );
+
+  if (!halvening) {
+    return null;
+  }
+
+  return (
+    <InnerPanel className="flex justify-center" id="emblem-airdrop">
+      <Countdown
+        time={EMBLEM_AIRDROP_DATE}
+        onComplete={() => setHalvening(undefined)}
+      />
+    </InnerPanel>
+  );
+};

--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -11,9 +11,10 @@ import { useSelector } from "@xstate/react";
 import { FACTION_POINT_ICONS } from "features/world/ui/factions/FactionDonationPanel";
 import { MachineState } from "features/game/lib/gameMachine";
 import classNames from "classnames";
+import { hasFeatureAccess } from "lib/flags";
+import { TEST_FARM } from "features/game/lib/constants";
 
 export const EMBLEM_AIRDROP_DATE = new Date("2024-06-14T00:00:00Z");
-const SHOW_COUNTDOWN = new Date("2024-06-10T00:00:00Z");
 
 const _faction = (state: MachineState) => state.context.state.faction;
 
@@ -66,7 +67,10 @@ export const EmblemAirdropCountdown: React.FC = () => {
   const [airdropDate, setAirdropDate] = useState<Date>();
 
   useEffect(() => {
-    if (SHOW_COUNTDOWN.getTime() < Date.now()) {
+    if (
+      hasFeatureAccess(TEST_FARM, "EMBLEM_COUNTDOWN_TIMER") &&
+      EMBLEM_AIRDROP_DATE.getTime() > Date.now()
+    ) {
       setAirdropDate(EMBLEM_AIRDROP_DATE);
     }
   }, []);

--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -13,7 +13,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import classNames from "classnames";
 
 export const EMBLEM_AIRDROP_DATE = new Date("2024-06-14T00:00:00Z");
-const SHOW_COUNTDOWN = new Date("2024-06-01T00:00:00Z");
+const SHOW_COUNTDOWN = new Date("2024-06-10T00:00:00Z");
 
 const _faction = (state: MachineState) => state.context.state.faction;
 

--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -45,7 +45,9 @@ const Countdown: React.FC<{ time: Date; onComplete: () => void }> = ({
           type="info"
           icon={SUNNYSIDE.icons.stopwatch}
           className={classNames("ml-1", { "mr-1": !!faction })}
-          secondaryIcon={faction && FACTION_POINT_ICONS[faction.name]}
+          secondaryIcon={
+            faction ? FACTION_POINT_ICONS[faction.name] : undefined
+          }
         >
           {t("faction.emblemAirdrop")}
         </Label>

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -23,6 +23,7 @@ import Decimal from "decimal.js-light";
 import { BuyCurrenciesModal } from "./components/BuyCurrenciesModal";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSound } from "lib/utils/hooks/useSound";
+import { EmblemAirdropCountdown } from "./EmblemAirdropCountdown";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _xp = (state: MachineState) =>
@@ -164,6 +165,7 @@ const HudComponent: React.FC<{
         >
           <AuctionCountdown />
           <HalveningCountdown />
+          <EmblemAirdropCountdown />
         </div>
 
         <div

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -21,6 +21,7 @@ import { HudContainer } from "components/ui/HudContainer";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { hasFeatureAccess } from "lib/flags";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { EmblemAirdropCountdown } from "./EmblemAirdropCountdown";
 
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.
@@ -119,6 +120,7 @@ const HudComponent: React.FC = () => {
         }}
       >
         <AuctionCountdown />
+        <EmblemAirdropCountdown />
       </div>
 
       <BumpkinProfile isFullUser={isFullUser} />

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -11,6 +11,10 @@ const clashOfFactionsFeatureFlag = () => {
 
   return Date.now() > new Date("2024-05-01T00:00:00Z").getTime();
 };
+
+const timeBasedFeatureFlag = (date: Date) => () => {
+  return testnetFeatureFlag() || Date.now() > date.getTime();
+};
 /*
  * How to Use:
  * Add the feature name to this list when working on a new feature.
@@ -31,7 +35,8 @@ export type FeatureName =
   | "COOKING_BOOST"
   | "DESERT_RECIPES"
   | "KINGDOM"
-  | "FACTION_HOUSE";
+  | "FACTION_HOUSE"
+  | "EMBLEM_COUNTDOWN_TIMER";
 
 // Used for testing production features
 export const ADMIN_IDS = [1, 2, 3, 39488];
@@ -60,6 +65,9 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
   // Just in case we need to disable the crop machine, leave the flag in temporarily
   CROP_MACHINE: () => true,
   COOKING_BOOST: defaultFeatureFlag,
+  EMBLEM_COUNTDOWN_TIMER: timeBasedFeatureFlag(
+    new Date("2024-06-10T00:00:00Z")
+  ),
 };
 
 export const hasFeatureAccess = (game: GameState, featureName: FeatureName) => {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1903,6 +1903,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": ENGLISH_TERMS["faction.points.title"],
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
+  "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2090,6 +2090,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": "Faction Points",
   "faction.points.pledge.warning":
     "Pledge a faction to receive faction points!",
+  "faction.emblemAirdrop": "Emblem Airdrop",
 
   // Kingdom NPCs
   "faction.restrited.area":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -2167,6 +2167,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": ENGLISH_TERMS["faction.points.title"],
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
+  "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2113,6 +2113,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": ENGLISH_TERMS["faction.points.title"],
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
+  "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2097,6 +2097,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": ENGLISH_TERMS["faction.points.title"],
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
+  "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1513,6 +1513,7 @@ export type Factions =
   | "faction.points.with.number"
   | "faction.points.title"
   | "faction.points.pledge.warning"
+  | "faction.emblemAirdrop"
   // Kingdom
   | "faction.restrited.area"
   | "faction.not.pledged"


### PR DESCRIPTION
# Description

Adds a countdown timer for emblem airdrop ~4 days before airdrop

## Without Faction
![withoutfaction](https://github.com/sunflower-land/sunflower-land/assets/41215134/bf195edb-7be9-47ca-a315-0cfa9a76c3ba)

## With Faction
![withfaction](https://github.com/sunflower-land/sunflower-land/assets/41215134/332eaf1e-8b82-4da6-a90c-34fb422b1cba)


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
