### PR TITLE
[FEAT] Change Short Form Format for Time Units

### DIFF
--- a/src/features/world/ui/SpecialEventModalContent.tsx
+++ b/src/features/world/ui/SpecialEventModalContent.tsx
@@ -313,7 +313,7 @@ export const SpecialEventModalContent: React.FC<{
 
                     <div className="flex flex-col justify-center items-center">
                       <span className="text-xs capitalize text-center mb-1">
-                        {t("day")} {index + 1}
+                        {t("time.day.full")} {index + 1}
                       </span>
                       <div className="flex justify-start ml-2 h-8 items-center w-6 mb-5">
                         {getKeys(task.requirements.items).map((name) => (
@@ -366,7 +366,7 @@ export const SpecialEventModalContent: React.FC<{
             <OuterPanel className="relative flex flex-col space-y-0.5 my-2">
               <div className="flex justify-between items-center">
                 <Label type="default" className="capitalize">
-                  {t("day")} {selectedIndex + 1}
+                  {t("time.day.full")} {selectedIndex + 1}
                 </Label>
                 {selected.completedAt && (
                   <Label type="success" icon={SUNNYSIDE.icons.confirm}>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -433,16 +433,23 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Plural Forms
+  // Singular
   sec: "秒",
-  min: "分",
-  hr: "时",
+  min: "分中",
+  hr: "小时",
   day: "天",
 
+  // Plural
   secs: "秒",
-  mins: "分",
-  hrs: "时",
+  mins: "分中",
+  hrs: "小时",
   days: "天",
+
+  // Short
+  "sec.short": "秒",
+  "min.short": "分中",
+  "hour.short": "小时",
+  "day.short": "天",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -433,23 +433,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Singular
-  sec: "秒",
-  min: "分中",
-  hr: "小时",
-  day: "天",
+  // Full Singular
+  "time.second.full": "秒",
+  "time.minute.full": "分钟",
+  "time.hour.full": "小时",
+  "time.day.full": "天",
 
-  // Plural
-  secs: "秒",
-  mins: "分中",
-  hrs: "小时",
-  days: "天",
+  // Full Plural
+  "time.seconds.full": "秒",
+  "time.minutes.full": "分钟",
+  "time.hours.full": "小时",
+  "time.days.full": "天",
+
+  // Medium Singular
+  "time.sec.med": "秒",
+  "time.min.med": "分钟",
+  "time.hr.med": "小时",
+  "time.day.med": "天",
+
+  // Medium Plural
+  "time.secs.med": "秒",
+  "time.mins.med": "分钟",
+  "time.hrs.med": "小时",
+  "time.days.med": "天",
 
   // Short
-  "sec.short": "秒",
-  "min.short": "分中",
-  "hour.short": "小时",
-  "day.short": "天",
+  "time.second.short": "秒",
+  "time.minute.short": "分钟",
+  "time.hour.short": "小时",
+  "time.day.short": "天",
+
+  // Relative Time
+  "time.seconds.ago": "{{time}} {{secondORseconds}} 前",
+  "time.minutes.ago": "{{time}} {{minuteORminutes}} 前",
+  "time.hours.ago": "{{time}} {{hourORhours}} 前",
+  "time.days.ago": "{{time}} {{dayORdays}} 前",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -432,16 +432,23 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // time
+  // Singular
   sec: "sec",
   min: "min",
   hr: "hr",
   day: "day",
 
+  // Plural
   secs: "secs",
   mins: "mins",
   hrs: "hrs",
   days: "days",
+
+  // Short Form
+  "sec.short": "s",
+  "min.short": "m",
+  "hour.short": "h",
+  "day.short": "d",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -432,23 +432,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Singular
-  sec: "sec",
-  min: "min",
-  hr: "hr",
-  day: "day",
+  // Full Singular
+  "time.second.full": "second",
+  "time.minute.full": "minute",
+  "time.hour.full": "hour",
+  "time.day.full": "day",
 
-  // Plural
-  secs: "secs",
-  mins: "mins",
-  hrs: "hrs",
-  days: "days",
+  // Full Plural
+  "time.seconds.full": "seconds",
+  "time.minutes.full": "minutes",
+  "time.hours.full": "hours",
+  "time.days.full": "days",
 
-  // Short Form
-  "sec.short": "s",
-  "min.short": "m",
-  "hour.short": "h",
-  "day.short": "d",
+  // Medium Singular
+  "time.sec.med": "sec",
+  "time.min.med": "min",
+  "time.hr.med": "hr",
+  "time.day.med": "day",
+
+  // Medium Plural
+  "time.secs.med": "secs",
+  "time.mins.med": "mins",
+  "time.hrs.med": "hrs",
+  "time.days.med": "days",
+
+  // Short
+  "time.second.short": "s",
+  "time.minute.short": "m",
+  "time.hour.short": "h",
+  "time.day.short": "d",
+
+  // Relative Time
+  "time.seconds.ago": "{{time}} {{secondORseconds}} ago",
+  "time.minutes.ago": "{{time}} {{minuteORminutes}} ago ",
+  "time.hours.ago": "{{time}} {{hourORhours}} ago ",
+  "time.days.ago": "{{time}} {{dayORdays}} ago",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -433,23 +433,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Singular
-  sec: "sec",
-  min: "min",
-  hr: "hr",
-  day: "Jour",
+  // Full Singular
+  "time.second.full": "",
+  "time.minute.full": "",
+  "time.hour.full": "",
+  "time.day.full": "",
 
-  // Plural
-  secs: "secondes",
-  mins: "minutes",
-  hrs: "hrs",
-  days: "Jours",
+  // Full Plural
+  "time.seconds.full": "",
+  "time.minutes.full": "",
+  "time.hours.full": "",
+  "time.days.full": "",
+
+  // Medium Singular
+  "time.sec.med": "",
+  "time.min.med": "",
+  "time.hr.med": "",
+  "time.day.med": "",
+
+  // Medium Plural
+  "time.secs.med": "",
+  "time.mins.med": "",
+  "time.hrs.med": "",
+  "time.days.med": "",
 
   // Short
-  "sec.short": "s",
-  "min.short": "m",
-  "hour.short": "h",
-  "day.short": "j",
+  "time.second.short": "",
+  "time.minute.short": "",
+  "time.hour.short": "",
+  "time.day.short": "",
+
+  // Relative Time
+  "time.seconds.ago": "",
+  "time.minutes.ago": "",
+  "time.hours.ago": "",
+  "time.days.ago": "",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -433,16 +433,23 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Time
+  // Singular
   sec: "sec",
   min: "min",
   hr: "hr",
   day: "Jour",
 
+  // Plural
   secs: "secondes",
   mins: "minutes",
   hrs: "hrs",
   days: "Jours",
+
+  // Short
+  "sec.short": "s",
+  "min.short": "m",
+  "hour.short": "h",
+  "day.short": "j",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -434,40 +434,40 @@ const generalTerms: Record<GeneralTerms, string> = {
 
 const timeUnits: Record<TimeUnits, string> = {
   // Full Singular
-  "time.second.full": "",
-  "time.minute.full": "",
-  "time.hour.full": "",
-  "time.day.full": "",
+  "time.second.full": "seconde",
+  "time.minute.full": "minute",
+  "time.hour.full": "heure",
+  "time.day.full": "jour",
 
   // Full Plural
-  "time.seconds.full": "",
-  "time.minutes.full": "",
-  "time.hours.full": "",
-  "time.days.full": "",
+  "time.seconds.full": "secondes",
+  "time.minutes.full": "minutes",
+  "time.hours.full": "heures",
+  "time.days.full": "jours",
 
   // Medium Singular
-  "time.sec.med": "",
-  "time.min.med": "",
-  "time.hr.med": "",
-  "time.day.med": "",
+  "time.sec.med": "sec",
+  "time.min.med": "min",
+  "time.hr.med": "hr",
+  "time.day.med": "jr",
 
   // Medium Plural
-  "time.secs.med": "",
-  "time.mins.med": "",
-  "time.hrs.med": "",
-  "time.days.med": "",
+  "time.secs.med": "secs",
+  "time.mins.med": "mins",
+  "time.hrs.med": "hrs",
+  "time.days.med": "jrs",
 
   // Short
-  "time.second.short": "",
-  "time.minute.short": "",
-  "time.hour.short": "",
-  "time.day.short": "",
+  "time.second.short": "s",
+  "time.minute.short": "min",
+  "time.hour.short": "h",
+  "time.day.short": "j",
 
   // Relative Time
-  "time.seconds.ago": "",
-  "time.minutes.ago": "",
-  "time.hours.ago": "",
-  "time.days.ago": "",
+  "time.seconds.ago": ENGLISH_TERMS["time.seconds.ago"],
+  "time.minutes.ago": ENGLISH_TERMS["time.minutes.ago"],
+  "time.hours.ago": ENGLISH_TERMS["time.hours.ago"],
+  "time.days.ago": ENGLISH_TERMS["time.days.ago"],
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -434,40 +434,40 @@ const generalTerms: Record<GeneralTerms, string> = {
 
 const timeUnits: Record<TimeUnits, string> = {
   // Full Singular
-  "time.second.full": "",
-  "time.minute.full": "",
-  "time.hour.full": "",
-  "time.day.full": "",
+  "time.second.full": "segundo",
+  "time.minute.full": "minuto",
+  "time.hour.full": "hora",
+  "time.day.full": "dia",
 
   // Full Plural
-  "time.seconds.full": "",
-  "time.minutes.full": "",
-  "time.hours.full": "",
-  "time.days.full": "",
+  "time.seconds.full": "segundos",
+  "time.minutes.full": "minutos",
+  "time.hours.full": "horas",
+  "time.days.full": "dias",
 
   // Medium Singular
-  "time.sec.med": "",
-  "time.min.med": "",
-  "time.hr.med": "",
-  "time.day.med": "",
+  "time.sec.med": "seg",
+  "time.min.med": "min",
+  "time.hr.med": "hr",
+  "time.day.med": "dia",
 
   // Medium Plural
-  "time.secs.med": "",
-  "time.mins.med": "",
-  "time.hrs.med": "",
-  "time.days.med": "",
+  "time.secs.med": "segs",
+  "time.mins.med": "mins",
+  "time.hrs.med": "hrs",
+  "time.days.med": "dias",
 
   // Short
-  "time.second.short": "",
-  "time.minute.short": "",
-  "time.hour.short": "",
-  "time.day.short": "",
+  "time.second.short": "s",
+  "time.minute.short": "m",
+  "time.hour.short": "h",
+  "time.day.short": "d",
 
   // Relative Time
-  "time.seconds.ago": "",
-  "time.minutes.ago": "",
-  "time.hours.ago": "",
-  "time.days.ago": "",
+  "time.seconds.ago": ENGLISH_TERMS["time.seconds.ago"],
+  "time.minutes.ago": ENGLISH_TERMS["time.minutes.ago"],
+  "time.hours.ago": ENGLISH_TERMS["time.hours.ago"],
+  "time.days.ago": ENGLISH_TERMS["time.days.ago"],
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -433,16 +433,23 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Time
+  // Singular
   sec: ENGLISH_TERMS["sec"],
   min: ENGLISH_TERMS["min"],
   hr: ENGLISH_TERMS["hr"],
   day: "dia",
 
+  // Plural
   secs: "segundos",
   mins: "mins",
   hrs: ENGLISH_TERMS["hrs"],
   days: ENGLISH_TERMS["days"],
+
+  // Short
+  "sec.short": "s",
+  "min.short": "m",
+  "hour.short": "h",
+  "day.short": "d",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -433,23 +433,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Singular
-  sec: ENGLISH_TERMS["sec"],
-  min: ENGLISH_TERMS["min"],
-  hr: ENGLISH_TERMS["hr"],
-  day: "dia",
+  // Full Singular
+  "time.second.full": "",
+  "time.minute.full": "",
+  "time.hour.full": "",
+  "time.day.full": "",
 
-  // Plural
-  secs: "segundos",
-  mins: "mins",
-  hrs: ENGLISH_TERMS["hrs"],
-  days: ENGLISH_TERMS["days"],
+  // Full Plural
+  "time.seconds.full": "",
+  "time.minutes.full": "",
+  "time.hours.full": "",
+  "time.days.full": "",
+
+  // Medium Singular
+  "time.sec.med": "",
+  "time.min.med": "",
+  "time.hr.med": "",
+  "time.day.med": "",
+
+  // Medium Plural
+  "time.secs.med": "",
+  "time.mins.med": "",
+  "time.hrs.med": "",
+  "time.days.med": "",
 
   // Short
-  "sec.short": "s",
-  "min.short": "m",
-  "hour.short": "h",
-  "day.short": "d",
+  "time.second.short": "",
+  "time.minute.short": "",
+  "time.hour.short": "",
+  "time.day.short": "",
+
+  // Relative Time
+  "time.seconds.ago": "",
+  "time.minutes.ago": "",
+  "time.hours.ago": "",
+  "time.days.ago": "",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -434,40 +434,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 
 const timeUnits: Record<TimeUnits, string> = {
   // Full Singular
-  "time.second.full": "",
-  "time.minute.full": "",
-  "time.hour.full": "",
-  "time.day.full": "",
+  "time.second.full": "saniye",
+  "time.minute.full": "dakika",
+  "time.hour.full": "saat",
+  "time.day.full": "gün",
 
   // Full Plural
-  "time.seconds.full": "",
-  "time.minutes.full": "",
-  "time.hours.full": "",
-  "time.days.full": "",
+  "time.seconds.full": "saniye",
+  "time.minutes.full": "dakika",
+  "time.hours.full": "saat",
+  "time.days.full": "gün",
 
   // Medium Singular
-  "time.sec.med": "",
-  "time.min.med": "",
-  "time.hr.med": "",
-  "time.day.med": "",
+  "time.sec.med": "sn",
+  "time.min.med": "dk",
+  "time.hr.med": "sa",
+  "time.day.med": "gnn",
 
   // Medium Plural
-  "time.secs.med": "",
-  "time.mins.med": "",
-  "time.hrs.med": "",
-  "time.days.med": "",
+  "time.secs.med": "sn",
+  "time.mins.med": "dk",
+  "time.hrs.med": "sa",
+  "time.days.med": "gn",
 
   // Short
-  "time.second.short": "",
-  "time.minute.short": "",
-  "time.hour.short": "",
-  "time.day.short": "",
+  "time.second.short": "sn",
+  "time.minute.short": "d",
+  "time.hour.short": "sa",
+  "time.day.short": "g",
 
   // Relative Time
-  "time.seconds.ago": "",
-  "time.minutes.ago": "",
-  "time.hours.ago": "",
-  "time.days.ago": "",
+  // Example: 5(time) minutes (singular or plural form) ago
+  "time.seconds.ago": "{{time}} saniye önce",
+  "time.minutes.ago": "{{time}} dakika önce ",
+  "time.hours.ago": "{{time}} saat önce ",
+  "time.days.ago": "{{time}} gün önce",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -433,23 +433,41 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Singular
-  sec: "saniye",
-  min: "dakika",
-  hr: "saat",
-  day: "gün",
+  // Full Singular
+  "time.second.full": "",
+  "time.minute.full": "",
+  "time.hour.full": "",
+  "time.day.full": "",
 
-  // Plural
-  secs: "saniye",
-  mins: "dakika",
-  hrs: "saat",
-  days: "gün",
+  // Full Plural
+  "time.seconds.full": "",
+  "time.minutes.full": "",
+  "time.hours.full": "",
+  "time.days.full": "",
+
+  // Medium Singular
+  "time.sec.med": "",
+  "time.min.med": "",
+  "time.hr.med": "",
+  "time.day.med": "",
+
+  // Medium Plural
+  "time.secs.med": "",
+  "time.mins.med": "",
+  "time.hrs.med": "",
+  "time.days.med": "",
 
   // Short
-  "sec.short": "sn",
-  "min.short": "d",
-  "hour.short": "sa",
-  "day.short": "g",
+  "time.second.short": "",
+  "time.minute.short": "",
+  "time.hour.short": "",
+  "time.day.short": "",
+
+  // Relative Time
+  "time.seconds.ago": "",
+  "time.minutes.ago": "",
+  "time.hours.ago": "",
+  "time.days.ago": "",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -433,16 +433,23 @@ const generalTerms: Record<GeneralTerms, string> = {
 };
 
 const timeUnits: Record<TimeUnits, string> = {
-  // Time
+  // Singular
   sec: "saniye",
   min: "dakika",
   hr: "saat",
   day: "gün",
 
+  // Plural
   secs: "saniye",
   mins: "dakika",
   hrs: "saat",
   days: "gün",
+
+  // Short
+  "sec.short": "sn",
+  "min.short": "d",
+  "hour.short": "sa",
+  "day.short": "g",
 };
 
 const achievementTerms: Record<AchievementsTerms, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -261,7 +261,13 @@ export type TimeUnits =
   | "secs"
   | "mins"
   | "hrs"
-  | "days";
+  | "days"
+
+  // Short
+  | "sec.short"
+  | "min.short"
+  | "hour.short"
+  | "day.short";
 
 export type AchievementsTerms =
   | "breadWinner.description"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -251,23 +251,41 @@ export type GeneralTerms =
   | "vipAccess";
 
 export type TimeUnits =
-  // Singular
-  | "sec"
-  | "min"
-  | "hr"
-  | "day"
+  // Full Singular
+  | "time.second.full"
+  | "time.minute.full"
+  | "time.hour.full"
+  | "time.day.full"
 
-  //Plural
-  | "secs"
-  | "mins"
-  | "hrs"
-  | "days"
+  // Full Plural
+  | "time.seconds.full"
+  | "time.minutes.full"
+  | "time.hours.full"
+  | "time.days.full"
+
+  // Medium Singular
+  | "time.sec.med"
+  | "time.min.med"
+  | "time.hr.med"
+  | "time.day.med"
+
+  // Medium Plural
+  | "time.secs.med"
+  | "time.mins.med"
+  | "time.hrs.med"
+  | "time.days.med"
 
   // Short
-  | "sec.short"
-  | "min.short"
-  | "hour.short"
-  | "day.short";
+  | "time.second.short"
+  | "time.minute.short"
+  | "time.hour.short"
+  | "time.day.short"
+
+  // Relative time
+  | "time.seconds.ago"
+  | "time.minutes.ago"
+  | "time.hours.ago"
+  | "time.days.ago";
 
 export type AchievementsTerms =
   | "breadWinner.description"

--- a/src/lib/utils/time.test.ts
+++ b/src/lib/utils/time.test.ts
@@ -602,28 +602,28 @@ describe("time", () => {
       const now = new Date();
       const pastTimestamp = now.getTime() - 5000; // 5 seconds ago
       const result = getRelativeTime(pastTimestamp);
-      expect(result).toMatch(/^5 seconds ago$/);
+      expect(result).toMatch("5 seconds ago");
     });
 
     it("returns a string indicating the number of minutes ago for timestamps within the past hour", () => {
       const now = new Date();
       const pastTimestamp = now.getTime() - 300000; // 5 minutes ago
       const result = getRelativeTime(pastTimestamp);
-      expect(result).toMatch(/^5 minutes ago$/);
+      expect(result).toMatch("5 minutes ago");
     });
 
     it("returns a string indicating the number of hours ago for timestamps within the past day", () => {
       const now = new Date();
       const pastTimestamp = now.getTime() - 7200000; // 2 hours ago
       const result = getRelativeTime(pastTimestamp);
-      expect(result).toMatch(/^2 hours ago$/);
+      expect(result).toMatch("2 hours ago");
     });
 
     it("returns a string indicating the number of days ago for timestamps older than a day", () => {
       const now = new Date();
       const pastTimestamp = now.getTime() - 604800000; // 7 days ago
       const result = getRelativeTime(pastTimestamp);
-      expect(result).toMatch(/^7 days ago$/);
+      expect(result).toMatch("7 days ago");
     });
   });
 

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -11,6 +11,7 @@ type TimeDuration = {
   value: number;
   unit: TimeUnit;
   pluralisedUnit: TimeUnit;
+  unitShort: TimeUnit;
 };
 
 /**
@@ -42,9 +43,10 @@ const timeUnitToString = (
   const value = duration.value;
   const unit = duration.unit;
   const pluralisedUnit = duration.pluralisedUnit;
+  const unitShort = duration.unitShort;
 
   if (options.isShortFormat) {
-    return `${value}${unit.substring(0, 1)}`;
+    return `${value}${unitShort}`;
   }
 
   const pluralizedUnit = value === 1 ? unit : pluralisedUnit;
@@ -64,21 +66,25 @@ export const secondsToString = (
     value: roundingFunction(seconds % ONE_MIN),
     unit: translate("sec"),
     pluralisedUnit: translate("secs"),
+    unitShort: translate("sec.short"),
   };
   const minutesValue = {
     value: roundingFunction((seconds / ONE_MIN) % ONE_MIN),
     unit: translate("min"),
     pluralisedUnit: translate("mins"),
+    unitShort: translate("min.short"),
   };
   const hoursValue = {
     value: roundingFunction((seconds / ONE_HR) % 24),
     unit: translate("hr"),
     pluralisedUnit: translate("hrs"),
+    unitShort: translate("hour.short"),
   };
   const daysValue = {
     value: roundingFunction(seconds / ONE_DAY),
     unit: translate("day"),
     pluralisedUnit: translate("days"),
+    unitShort: translate("day.short"),
   };
 
   // all time units that constitutes the full string

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -64,27 +64,27 @@ export const secondsToString = (
   // time durations
   const secondsValue = {
     value: roundingFunction(seconds % ONE_MIN),
-    unit: translate("sec"),
-    pluralisedUnit: translate("secs"),
-    unitShort: translate("sec.short"),
+    unit: translate("time.sec.med"),
+    pluralisedUnit: translate("time.secs.med"),
+    unitShort: translate("time.second.short"),
   };
   const minutesValue = {
     value: roundingFunction((seconds / ONE_MIN) % ONE_MIN),
-    unit: translate("min"),
-    pluralisedUnit: translate("mins"),
-    unitShort: translate("min.short"),
+    unit: translate("time.min.med"),
+    pluralisedUnit: translate("time.mins.med"),
+    unitShort: translate("time.minute.short"),
   };
   const hoursValue = {
     value: roundingFunction((seconds / ONE_HR) % 24),
-    unit: translate("hr"),
-    pluralisedUnit: translate("hrs"),
-    unitShort: translate("hour.short"),
+    unit: translate("time.hr.med"),
+    pluralisedUnit: translate("time.hrs.med"),
+    unitShort: translate("time.hour.short"),
   };
   const daysValue = {
     value: roundingFunction(seconds / ONE_DAY),
-    unit: translate("day"),
-    pluralisedUnit: translate("days"),
-    unitShort: translate("day.short"),
+    unit: translate("time.day.med"),
+    pluralisedUnit: translate("time.days.med"),
+    unitShort: translate("time.day.short"),
   };
 
   // all time units that constitutes the full string
@@ -182,16 +182,40 @@ export function getRelativeTime(timestamp: number): string {
   if (secondsAgo === 0) {
     return "now";
   } else if (secondsAgo < 60) {
-    return `${secondsAgo} seconds ago`;
+    return translate("time.seconds.ago", {
+      time: secondsAgo,
+      secondORseconds:
+        secondsAgo !== 1
+          ? translate("time.second.full")
+          : translate("time.seconds.full"),
+    });
   } else if (secondsAgo < 3600) {
     const minutesAgo = Math.floor(secondsAgo / 60);
-    return `${minutesAgo} minute${minutesAgo !== 1 ? "s" : ""} ago`;
+    return translate("time.minutes.ago", {
+      time: minutesAgo,
+      minuteORminutes:
+        minutesAgo !== 1
+          ? translate("time.minute.full")
+          : translate("time.minutes.full"),
+    });
   } else if (secondsAgo < 86400) {
     const hoursAgo = Math.floor(secondsAgo / 3600);
-    return `${hoursAgo} hour${hoursAgo !== 1 ? "s" : ""} ago`;
+    return translate("time.hours.ago", {
+      time: hoursAgo,
+      hourORhours:
+        hoursAgo !== 1
+          ? translate("time.hour.full")
+          : translate("time.hours.full"),
+    });
   } else {
     const daysAgo = Math.floor(secondsAgo / 86400);
-    return `${daysAgo} day${daysAgo !== 1 ? "s" : ""} ago`;
+    return translate("time.days.ago", {
+      time: daysAgo,
+      dayORdays:
+        daysAgo !== 1
+          ? translate("time.day.full")
+          : translate("time.days.full"),
+    });
   }
 }
 
@@ -266,16 +290,28 @@ export function getTimeUntil(timestamp: Date, now = new Date()) {
   const days = Math.floor(hours / 24);
 
   if (days > 0) {
-    return `${days} ${days === 1 ? "day" : "days"}`;
+    return `${days} ${
+      days === 1 ? translate("time.day.full") : translate("time.days.full")
+    }`;
   }
 
   if (hours > 0) {
-    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+    return `${hours} ${
+      hours === 1 ? translate("time.hour.full") : translate("time.hours.full")
+    }`;
   }
 
   if (minutes > 0) {
-    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+    return `${minutes} ${
+      minutes === 1
+        ? translate("time.minute.full")
+        : translate("time.minutes.full")
+    }`;
   }
 
-  return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  return `${seconds} ${
+    seconds === 1
+      ? translate("time.second.full")
+      : translate("time.seconds.full")
+  }`;
 }

--- a/src/lib/utils/time.ts
+++ b/src/lib/utils/time.ts
@@ -186,8 +186,8 @@ export function getRelativeTime(timestamp: number): string {
       time: secondsAgo,
       secondORseconds:
         secondsAgo !== 1
-          ? translate("time.second.full")
-          : translate("time.seconds.full"),
+          ? translate("time.seconds.full")
+          : translate("time.second.full"),
     });
   } else if (secondsAgo < 3600) {
     const minutesAgo = Math.floor(secondsAgo / 60);
@@ -195,8 +195,8 @@ export function getRelativeTime(timestamp: number): string {
       time: minutesAgo,
       minuteORminutes:
         minutesAgo !== 1
-          ? translate("time.minute.full")
-          : translate("time.minutes.full"),
+          ? translate("time.minutes.full")
+          : translate("time.minute.full"),
     });
   } else if (secondsAgo < 86400) {
     const hoursAgo = Math.floor(secondsAgo / 3600);
@@ -204,8 +204,8 @@ export function getRelativeTime(timestamp: number): string {
       time: hoursAgo,
       hourORhours:
         hoursAgo !== 1
-          ? translate("time.hour.full")
-          : translate("time.hours.full"),
+          ? translate("time.hours.full")
+          : translate("time.hour.full"),
     });
   } else {
     const daysAgo = Math.floor(secondsAgo / 86400);
@@ -213,8 +213,8 @@ export function getRelativeTime(timestamp: number): string {
       time: daysAgo,
       dayORdays:
         daysAgo !== 1
-          ? translate("time.day.full")
-          : translate("time.days.full"),
+          ? translate("time.days.full")
+          : translate("time.day.full"),
     });
   }
 }


### PR DESCRIPTION
# Description

Currently the code is set to use the first letter to determine the short form for time units. However, this may not work for some languages such as Chinese and Turkish, where they may have other short forms that may not necessarily use only the first character

This PR adds a `unitShort` const and hard codes a string for the short form

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
