### PR TITLE
[FEAT Update Get Started Options

### DIFF
--- a/src/features/auth/components/NoAccount.tsx
+++ b/src/features/auth/components/NoAccount.tsx
@@ -100,39 +100,20 @@ export const NoAccount: React.FC = () => {
             </a>
           )}
         </div>
-        <p className="text-sm mb-2">{`${t("noaccount.welcomeMessage")}`}</p>
-        {/* {isAddress(authState.context.user.token?.address ?? "") && (
-          <div className="mb-2">
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-white text-xs cursor-pointer"
-              onClick={() => setShowClaimAccount(true)}
-            >
-              {t("noaccount.alreadyHaveNFTFarm")}
-            </a>
-          </div>
-        )} */}
       </div>
-      {isAddress(authState.context.user.token?.address ?? "") ? (
-        <div className="flex flex-col space-y-2">
-          <span className="px-2 text-sm">{`Would you like to create a new farm?`}</span>
-          <div className="space-y-1 mt-2">
-            <Button
-              onClick={() => authService.send("CREATE_FARM")}
-            >{`Yes create a new farm!`}</Button>
-            <Button
-              onClick={() => setShowClaimAccount(true)}
-            >{`No I have a farm already`}</Button>
-          </div>
-        </div>
-      ) : (
-        <div className="flex mt-1">
+      <div className="flex flex-col space-y-2">
+        <span className="px-2 text-sm">{t("noaccount.welcomeMessage")}</span>
+        <div className="flex space-x-1 mt-2.5">
+          {isAddress(authState.context.user.token?.address ?? "") && (
+            <Button onClick={() => setShowClaimAccount(true)}>
+              {t("noaccount.haveFarm")}
+            </Button>
+          )}
           <Button onClick={() => authService.send("CREATE_FARM")}>
-            {t("start")}
+            {`Yes, let's go!`}
           </Button>
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/features/auth/components/NoAccount.tsx
+++ b/src/features/auth/components/NoAccount.tsx
@@ -101,7 +101,7 @@ export const NoAccount: React.FC = () => {
           )}
         </div>
         <p className="text-sm mb-2">{`${t("noaccount.welcomeMessage")}`}</p>
-        {isAddress(authState.context.user.token?.address ?? "") && (
+        {/* {isAddress(authState.context.user.token?.address ?? "") && (
           <div className="mb-2">
             <a
               target="_blank"
@@ -112,13 +112,27 @@ export const NoAccount: React.FC = () => {
               {t("noaccount.alreadyHaveNFTFarm")}
             </a>
           </div>
-        )}
+        )} */}
       </div>
-      <div className="flex mt-1">
-        <Button onClick={() => authService.send("CREATE_FARM")}>
-          {t("start")}
-        </Button>
-      </div>
+      {isAddress(authState.context.user.token?.address ?? "") ? (
+        <div className="flex flex-col space-y-2">
+          <span className="px-2 text-sm">{`Would you like to create a new farm?`}</span>
+          <div className="space-y-1 mt-2">
+            <Button
+              onClick={() => authService.send("CREATE_FARM")}
+            >{`Yes create a new farm!`}</Button>
+            <Button
+              onClick={() => setShowClaimAccount(true)}
+            >{`No I have a farm already`}</Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex mt-1">
+          <Button onClick={() => authService.send("CREATE_FARM")}>
+            {t("start")}
+          </Button>
+        </div>
+      )}
     </>
   );
 };

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -2841,6 +2841,8 @@ const noaccount: Record<Noaccount, string> = {
   "noaccount.selectNFTID": ENGLISH_TERMS["noaccount.selectNFTID"],
   "noaccount.welcomeMessage": "欢迎来到 Sunflower Land！ 看来你还没有农场。",
   "noaccount.promoCodeLabel": ENGLISH_TERMS["noaccount.promoCodeLabel"],
+  "noaccount.haveFarm": ENGLISH_TERMS["noaccount.haveFarm"],
+  "noaccount.letsGo": ENGLISH_TERMS["noaccount.letsGo"],
 };
 
 const noBumpkin: Record<NoBumpkin, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3183,8 +3183,10 @@ const noaccount: Record<Noaccount, string> = {
   "noaccount.createNewFarm": "Create new farm",
   "noaccount.selectNFTID": "Select your NFT ID:",
   "noaccount.welcomeMessage":
-    "Welcome to Sunflower Land. It looks like you don't have a farm yet.",
+    "Welcome to Sunflower Land. Do you want to create a farm?",
   "noaccount.promoCodeLabel": "Promo Code",
+  "noaccount.haveFarm": "No, I have one",
+  "noaccount.letsGo": "Yes, let's go!",
 };
 
 const noBumpkin: Record<NoBumpkin, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -3317,6 +3317,8 @@ const noaccount: Record<Noaccount, string> = {
   "noaccount.welcomeMessage":
     "Bienvenue dans Sunflower Land. Il semble que vous n'ayez pas encore de ferme.",
   "noaccount.promoCodeLabel": "Code promotionnel",
+  "noaccount.haveFarm": ENGLISH_TERMS["noaccount.haveFarm"],
+  "noaccount.letsGo": ENGLISH_TERMS["noaccount.letsGo"],
 };
 
 const noBumpkin: Record<NoBumpkin, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3197,6 +3197,8 @@ const noaccount: Record<Noaccount, string> = {
   "noaccount.welcomeMessage":
     "Bem-vindo à Sunflower Land. Parece que você ainda não tem uma fazenda.",
   "noaccount.promoCodeLabel": "Código Promocional",
+  "noaccount.haveFarm": ENGLISH_TERMS["noaccount.haveFarm"],
+  "noaccount.letsGo": ENGLISH_TERMS["noaccount.letsGo"],
 };
 
 const noBumpkin: Record<NoBumpkin, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -3179,6 +3179,8 @@ const noaccount: Record<Noaccount, string> = {
   "noaccount.welcomeMessage":
     "Sunflower Land’de hoş geldiniz. Henüz bir çiftliğiniz yok gibi görünüyor.",
   "noaccount.promoCodeLabel": "Promosyon kodu",
+  "noaccount.haveFarm": ENGLISH_TERMS["noaccount.haveFarm"],
+  "noaccount.letsGo": ENGLISH_TERMS["noaccount.letsGo"],
 };
 
 const noBumpkin: Record<NoBumpkin, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2264,7 +2264,9 @@ export type Noaccount =
   | "noaccount.createNewFarm"
   | "noaccount.selectNFTID"
   | "noaccount.welcomeMessage"
-  | "noaccount.promoCodeLabel";
+  | "noaccount.promoCodeLabel"
+  | "noaccount.haveFarm"
+  | "noaccount.letsGo";
 
 export type NoBumpkin =
   | "noBumpkin.readyToFarm"


### PR DESCRIPTION
# Description

Simplify the sign up step to avoid player confusion when they have purchased a farm on opensea. This change is to try to stop them from accidentally creating a new farm when they were trying to use the farm they purchased.

<img width="505" alt="Screenshot 2024-06-04 at 4 16 07 PM" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/619bc5c7-96a8-4c3c-9c41-26f22a8b3417">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test to make sure the flows all still work. This is basically just a UX change as requested by CM's.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
