### PR TITLE
[FEAT] Claim Emblems Action

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -318,6 +318,7 @@ import {
   HarvestCropMachineAction,
 } from "./landExpansion/harvestCropMachine";
 import { joinFaction, JoinFactionAction } from "./landExpansion/joinFaction";
+import { claimEmblems, ClaimEmblemsAction } from "./landExpansion/claimEmblems";
 
 export type PlayingEvent =
   | OilGreenhouseAction
@@ -410,7 +411,8 @@ export type PlayingEvent =
   | HarvestCropMachineAction
   | SupplyCookingOilAction
   | PledgeFactionAction
-  | JoinFactionAction;
+  | JoinFactionAction
+  | ClaimEmblemsAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -569,6 +571,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "cropMachine.supplied": supplyCropMachine,
   "cropMachine.harvested": harvestCropMachine,
   "cookingOil.supplied": supplyCookingOil,
+  "emblems.claimed": claimEmblems,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/claimEmblems.test.ts
+++ b/src/features/game/events/landExpansion/claimEmblems.test.ts
@@ -1,0 +1,99 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { claimEmblems } from "./claimEmblems";
+import { FACTIONS, FACTION_EMBLEMS } from "./joinFaction";
+
+describe("claimEmblems", () => {
+  it("should throw if no faction has been pledged", () => {
+    expect(() =>
+      claimEmblems({
+        state: TEST_FARM,
+        action: {
+          type: "emblems.claimed",
+        },
+      })
+    ).toThrow("No faction has been pledged");
+  });
+
+  it("should throw if emblems have already been claimed", () => {
+    expect(() =>
+      claimEmblems({
+        state: {
+          ...TEST_FARM,
+          faction: {
+            name: "bumpkins",
+            pledgedAt: 1,
+            emblemsClaimedAt: 2,
+            points: 10,
+            donated: {
+              daily: {
+                resources: {},
+                sfl: {},
+              },
+              totalItems: {},
+            },
+          },
+        },
+        action: {
+          type: "emblems.claimed",
+        },
+      })
+    ).toThrow("Emblems have already been claimed");
+  });
+
+  it("sets the emblems claimed at date", () => {
+    const now = Date.now();
+
+    const state = claimEmblems({
+      state: {
+        ...TEST_FARM,
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 1,
+          points: 10,
+          donated: {
+            daily: {
+              resources: {},
+              sfl: {},
+            },
+            totalItems: {},
+          },
+        },
+        createdAt: now,
+      },
+      action: {
+        type: "emblems.claimed",
+      },
+    });
+
+    expect(state.faction?.emblemsClaimedAt).toEqual(now);
+  });
+
+  it.each(FACTIONS)("claims emblems for the %s faction", (faction) => {
+    const points = 10;
+
+    const state = claimEmblems({
+      state: {
+        ...TEST_FARM,
+        faction: {
+          name: faction,
+          pledgedAt: 1,
+          points,
+          donated: {
+            daily: {
+              resources: {},
+              sfl: {},
+            },
+            totalItems: {},
+          },
+        },
+      },
+      action: {
+        type: "emblems.claimed",
+      },
+    });
+
+    expect(state.inventory[FACTION_EMBLEMS[faction]]?.toNumber()).toStrictEqual(
+      points
+    );
+  });
+});

--- a/src/features/game/events/landExpansion/claimEmblems.ts
+++ b/src/features/game/events/landExpansion/claimEmblems.ts
@@ -1,0 +1,40 @@
+import cloneDeep from "lodash.clonedeep";
+import Decimal from "decimal.js-light";
+import { FACTION_EMBLEMS } from "./joinFaction";
+import { GameState } from "features/game/types/game";
+
+export type ClaimEmblemsAction = {
+  type: "emblems.claimed";
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: ClaimEmblemsAction;
+  createdAt?: number;
+};
+
+export function claimEmblems({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options) {
+  const game = cloneDeep<GameState>(state);
+
+  const faction = game.faction;
+
+  if (!faction) {
+    throw new Error("No faction has been pledged");
+  }
+
+  if (faction.emblemsClaimedAt) {
+    throw new Error("Emblems have already been claimed");
+  }
+
+  const emblemName = FACTION_EMBLEMS[faction.name];
+  const inventoryAmount = game.inventory[emblemName] ?? new Decimal(0);
+
+  game.inventory[emblemName] = inventoryAmount.add(faction.points);
+  faction.emblemsClaimedAt = createdAt;
+
+  return game;
+}

--- a/src/features/game/events/landExpansion/joinFaction.ts
+++ b/src/features/game/events/landExpansion/joinFaction.ts
@@ -32,7 +32,7 @@ export const FACTION_BANNERS: Record<FactionName, FactionBanner> = {
   nightshades: "Nightshade Faction Banner",
 };
 
-const FACTION_EMBLEMS: Record<FactionName, FactionEmblem> = {
+export const FACTION_EMBLEMS: Record<FactionName, FactionEmblem> = {
   bumpkins: "Bumpkin Emblem",
   sunflorians: "Sunflorian Emblem",
   goblins: "Goblin Emblem",

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -2,6 +2,7 @@ import mapJSON from "assets/map/kingdom.json";
 
 import { SceneId } from "../mmoMachine";
 import { BaseScene, NPCBumpkin } from "./BaseScene";
+import { fetchLeaderboardData } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 
 export const KINGDOM_NPCS: NPCBumpkin[] = [
   {
@@ -58,6 +59,10 @@ export class KingdomScene extends BaseScene {
 
   preload() {
     super.preload();
+
+    // Preload the leaderboard data (async).
+    // This is used by the faction spruikers when claiming emblems.
+    fetchLeaderboardData(this.id);
   }
 
   create() {

--- a/src/features/world/ui/factions/JoinFaction.tsx
+++ b/src/features/world/ui/factions/JoinFaction.tsx
@@ -41,6 +41,7 @@ interface Props {
 
 const _joinedFaction = (state: MachineState) => state.context.state.faction;
 const _username = (state: MachineState) => state.context.state.username;
+const _farmId = (state: MachineState) => state.context.farmId;
 
 export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
   const { gameService } = useContext(Context);
@@ -50,6 +51,8 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
 
   const username = useSelector(gameService, _username);
   const joinedFaction = useSelector(gameService, _joinedFaction);
+  const farmId = useSelector(gameService, _farmId);
+
   // Cheap way to memoize this value
   const [emblemsClaimed] = useState(!!joinedFaction?.emblemsClaimedAt);
 
@@ -112,8 +115,10 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
         </div>
         <ClaimEmblems
           faction={joinedFaction}
+          farmId={farmId}
           playerName={username}
           onClose={onClose}
+          onClaim={() => gameService.send("emblems.claimed")}
         />
       </div>
     );

--- a/src/features/world/ui/factions/components/ClaimEmblems.tsx
+++ b/src/features/world/ui/factions/components/ClaimEmblems.tsx
@@ -18,8 +18,10 @@ import goblinEmblem from "assets/icons/goblin_emblem.webp";
 import bumpkinEmblem from "assets/icons/bumpkin_emblem.webp";
 import sunflorianEmblem from "assets/icons/sunflorian_emblem.webp";
 import nightshadeEmblem from "assets/icons/nightshade_emblem.webp";
-import { formatNumber } from "lib/utils/formatNumber";
+import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import { ShareClaimedEmblems } from "./ShareClaimedEmblems";
+import { fetchLeaderboardData } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import Decimal from "decimal.js-light";
 
 const FACTION_EMBLEM_ICONS: Record<FactionName, string> = {
   goblins: goblinEmblem,
@@ -28,15 +30,18 @@ const FACTION_EMBLEM_ICONS: Record<FactionName, string> = {
   nightshades: nightshadeEmblem,
 };
 
-// TODO feat/emblem-airdrops
-const RANK = 10;
-const TOTAL_FACTION_MEMBERS = 10_000;
-const TOTAL_FACTION_EMBLEMS = 1_500_000;
-const PERCENTILE = 6;
+interface Statistics {
+  yourRank: number;
+  yourPercentile: number;
+  totalMembers: number;
+  totalEmblems: number;
+}
 
 interface ClaimEmblemsProps {
   faction: Faction;
+  farmId: number;
   playerName?: string;
+  onClaim: () => void;
   onClose: () => void;
 }
 
@@ -72,27 +77,76 @@ const Fireworks: React.FC = () => {
   return null;
 };
 
+const LoadingLabel: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Label type="default" className="loading">
+      {t("loading")}
+    </Label>
+  );
+};
+
 export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
   faction,
+  farmId,
   playerName,
+  onClaim,
   onClose,
 }) => {
+  const { t } = useTranslation();
+
   const [screen, setScreen] = useState<"claiming" | "claimed" | "sharing">(
     "claiming"
   );
 
-  const { t } = useTranslation();
+  const [statistics, setStatistics] = useState<Statistics | null | undefined>(
+    undefined
+  );
 
-  const alreadyClaimed = !!faction.emblemsClaimedAt;
+  useEffect(() => {
+    const fetchLeaderboards = async () => {
+      try {
+        const data = await fetchLeaderboardData(farmId);
 
-  // Failsafe we player already claimed emblems. Should not happen.
-  if (alreadyClaimed) {
-    return (
-      <div className="p-2">
-        <InlineDialogue message={t("faction.claimEmblems.alreadyClaimed")} />
-      </div>
-    );
-  }
+        // Error
+        if (!data) {
+          setStatistics(null);
+          return;
+        }
+
+        const rankDetails = data.factions.farmRankingDetails?.find(
+          (rank) => rank.id === playerName
+        );
+        const yourRank = rankDetails?.rank;
+
+        if (yourRank) {
+          const totalMembers = data.factions.totalMembers[faction.name];
+          const totalEmblems = data.factions.totalTickets[faction.name];
+
+          const yourPercentile = (yourRank / totalMembers) * 100;
+
+          setStatistics({
+            yourRank,
+            yourPercentile,
+            totalMembers,
+            totalEmblems,
+          });
+        } else {
+          // Something went wrong searching for the leaderboard
+          // Default to the basic screens without statistics
+          setStatistics(null);
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error("Error loading leaderboards", e);
+
+        if (!statistics) setStatistics(null);
+      }
+    };
+
+    fetchLeaderboards();
+  }, []);
 
   // Failsafe if player has no faction points. Should not happen.
   if (!faction.points) {
@@ -104,7 +158,7 @@ export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
   }
 
   const claim = () => {
-    // TODO claim emblems event here
+    onClaim();
     setScreen("claimed");
   };
 
@@ -115,63 +169,71 @@ export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
         <div
           className="p-2"
           style={{
-            minHeight: "65px",
+            minHeight: statistics ? "65px" : "32px",
           }}
         >
           <InlineDialogue
             key="claimed"
-            message={t("faction.claimEmblems.congratulations", {
+            message={`${t("faction.claimEmblems.congratulations", {
               count: faction.points,
-            })}
+            })} ${statistics ? t("faction.claimEmblems.comparison") : ""}`}
           />
         </div>
 
-        <div className="py-2">
-          <Label type="default">{t("faction.claimEmblems.statistics")}</Label>
-        </div>
-        <OuterPanel>
-          <div className="space-y-1">
-            <div className="flex items-center justify-between">
-              <Label type="transparent">
-                {t("faction.claimEmblems.totalMembers")}
-              </Label>
-              <Label type="transparent">
-                {formatNumber(TOTAL_FACTION_MEMBERS)}
-              </Label>
-            </div>
-            <div className="flex items-center justify-between">
-              <Label type="transparent">
-                {t("faction.claimEmblems.yourRank")}
-              </Label>
-              <Label type="transparent">{RANK}</Label>
-            </div>
-            <div className="flex items-center justify-between">
-              <Label type="transparent">
-                {t("faction.claimEmblems.yourPercentile")}
-              </Label>
-              <Label type="transparent">
-                {t("faction.claimEmblems.percentile", {
-                  percentile: PERCENTILE,
-                })}
+        {statistics && (
+          <>
+            <div className="py-2">
+              <Label type="default">
+                {t("faction.claimEmblems.statistics")}
               </Label>
             </div>
 
-            <div className="flex items-center justify-between">
-              <Label type="transparent">
-                {t("faction.claimEmblems.totalEmblems")}
-              </Label>
-              <div className="flex items-center">
-                <img
-                  src={FACTION_EMBLEM_ICONS[faction.name]}
-                  className="w-4 h-auto"
-                />
-                <Label type="transparent">
-                  {formatNumber(TOTAL_FACTION_EMBLEMS)}
-                </Label>
+            <OuterPanel>
+              <div className="space-y-1">
+                <div className="flex items-center justify-between">
+                  <Label type="transparent">
+                    {t("faction.claimEmblems.totalMembers")}
+                  </Label>
+                  <Label type="transparent">{statistics.totalMembers}</Label>
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label type="transparent">
+                    {t("faction.claimEmblems.yourRank")}
+                  </Label>
+                  <Label type="transparent">{statistics.yourRank}</Label>
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label type="transparent">
+                    {t("faction.claimEmblems.yourPercentile")}
+                  </Label>
+                  <Label type="transparent">
+                    {t("faction.claimEmblems.percentile", {
+                      percentile: setPrecision(
+                        new Decimal(statistics.yourPercentile),
+                        2
+                      ).toString(),
+                    })}
+                  </Label>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <Label type="transparent">
+                    {t("faction.claimEmblems.totalEmblems")}
+                  </Label>
+                  <div className="flex items-center">
+                    <img
+                      src={FACTION_EMBLEM_ICONS[faction.name]}
+                      className="w-4 h-auto"
+                    />
+                    <Label type="transparent">
+                      {formatNumber(statistics.totalEmblems)}
+                    </Label>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </OuterPanel>
+            </OuterPanel>
+          </>
+        )}
 
         <div className="flex items-center justify-between py-2 pr-1">
           <Label
@@ -227,36 +289,43 @@ export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
         />
       </div>
 
-      <OuterPanel className="space-y-1 ">
-        <div className="flex items-center justify-between">
-          <Label className="ml-2" type="info" icon={trophy}>
-            {t("faction.claimEmblems.yourRank")}
-          </Label>
-          <Label type="transparent">{RANK}</Label>
-        </div>
-        <div className="flex items-center justify-between">
-          <Label className="ml-2" type="warning" icon={factions}>
-            {t("faction.points.title")}
-          </Label>
+      {statistics && (
+        <>
+          <OuterPanel className="space-y-1 ">
+            <div className="flex items-center justify-between">
+              <Label className="ml-2" type="info" icon={trophy}>
+                {t("faction.claimEmblems.yourRank")}
+              </Label>
+              <Label type="transparent">{statistics.yourRank}</Label>
+            </div>
+            <div className="flex items-center justify-between">
+              <Label className="ml-2" type="warning" icon={factions}>
+                {t("faction.points.title")}
+              </Label>
 
-          <div className="flex items-center">
-            <img
-              src={FACTION_POINT_ICONS[faction.name]}
-              className="w-4 h-auto"
-            />
-            <Label type="transparent">{faction.points}</Label>
-          </div>
-        </div>
-      </OuterPanel>
+              <div className="flex items-center">
+                <img
+                  src={FACTION_POINT_ICONS[faction.name]}
+                  className="w-4 h-auto"
+                />
+                <Label type="transparent">{faction.points}</Label>
+              </div>
+            </div>
+          </OuterPanel>
 
-      <span className="leading-[1] text-[16px] p-2">
-        {t("faction.claimEmblems.claimMessage", {
-          count: faction.points,
-          Faction: capitalize(faction.name),
-          rank: RANK,
-          percentile: PERCENTILE,
-        })}
-      </span>
+          <span className="leading-[1] text-[16px] p-2">
+            {t("faction.claimEmblems.claimMessage", {
+              count: faction.points,
+              Faction: capitalize(faction.name),
+              rank: statistics.yourRank,
+              percentile: setPrecision(
+                new Decimal(statistics.yourPercentile),
+                2
+              ).toString(),
+            })}
+          </span>
+        </>
+      )}
 
       <div className="flex items-center justify-between pr-1">
         <Label

--- a/src/features/world/ui/factions/components/ClaimEmblems.tsx
+++ b/src/features/world/ui/factions/components/ClaimEmblems.tsx
@@ -77,16 +77,6 @@ const Fireworks: React.FC = () => {
   return null;
 };
 
-const LoadingLabel: React.FC = () => {
-  const { t } = useTranslation();
-
-  return (
-    <Label type="default" className="loading">
-      {t("loading")}
-    </Label>
-  );
-};
-
 export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
   faction,
   farmId,

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1937,6 +1937,8 @@ const factions: Record<Factions, string> = {
   "faction.claimEmblems.claim": ENGLISH_TERMS["faction.claimEmblems.claim"],
   "faction.claimEmblems.congratulations":
     ENGLISH_TERMS["faction.claimEmblems.congratulations"],
+  "faction.claimEmblems.comparison":
+    ENGLISH_TERMS["faction.claimEmblems.comparison"],
   "faction.claimEmblems.totalMembers":
     ENGLISH_TERMS["faction.claimEmblems.totalMembers"],
   "faction.claimEmblems.totalEmblems":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2123,7 +2123,9 @@ const factions: Record<Factions, string> = {
     "You contributed {{count}} faction points. Your rank was {{rank}}. You in the top {{percentile}}% of {{Faction}}.",
   "faction.claimEmblems.claim": "Claim {{count}} Emblems",
   "faction.claimEmblems.congratulations":
-    "Congratulations! You've received {{count}} emblems! Here is how you compare to your faction members.",
+    "Congratulations! You've received {{count}} emblems!",
+  "faction.claimEmblems.comparison":
+    "Here is how you compare to your faction members.",
   "faction.claimEmblems.totalMembers": "Total Faction Members",
   "faction.claimEmblems.totalEmblems": "Total Faction Emblems",
   "faction.claimEmblems.percentile": "Top {{percentile}}%",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -2201,6 +2201,8 @@ const factions: Record<Factions, string> = {
   "faction.claimEmblems.claim": ENGLISH_TERMS["faction.claimEmblems.claim"],
   "faction.claimEmblems.congratulations":
     ENGLISH_TERMS["faction.claimEmblems.congratulations"],
+  "faction.claimEmblems.comparison":
+    ENGLISH_TERMS["faction.claimEmblems.comparison"],
   "faction.claimEmblems.totalMembers":
     ENGLISH_TERMS["faction.claimEmblems.totalMembers"],
   "faction.claimEmblems.totalEmblems":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2147,6 +2147,8 @@ const factions: Record<Factions, string> = {
   "faction.claimEmblems.claim": ENGLISH_TERMS["faction.claimEmblems.claim"],
   "faction.claimEmblems.congratulations":
     ENGLISH_TERMS["faction.claimEmblems.congratulations"],
+  "faction.claimEmblems.comparison":
+    ENGLISH_TERMS["faction.claimEmblems.comparison"],
   "faction.claimEmblems.totalMembers":
     ENGLISH_TERMS["faction.claimEmblems.totalMembers"],
   "faction.claimEmblems.totalEmblems":

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2130,6 +2130,8 @@ const factions: Record<Factions, string> = {
   "faction.claimEmblems.claim": ENGLISH_TERMS["faction.claimEmblems.claim"],
   "faction.claimEmblems.congratulations":
     ENGLISH_TERMS["faction.claimEmblems.congratulations"],
+  "faction.claimEmblems.comparison":
+    ENGLISH_TERMS["faction.claimEmblems.comparison"],
   "faction.claimEmblems.totalMembers":
     ENGLISH_TERMS["faction.claimEmblems.totalMembers"],
   "faction.claimEmblems.totalEmblems":

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1536,6 +1536,7 @@ export type Factions =
   | "faction.claimEmblems.claimMessage"
   | "faction.claimEmblems.claim"
   | "faction.claimEmblems.congratulations"
+  | "faction.claimEmblems.comparison"
   | "faction.claimEmblems.totalMembers"
   | "faction.claimEmblems.totalEmblems"
   | "faction.claimEmblems.percentile";


### PR DESCRIPTION
# Description

- Adds an action `emblems.claimed` 
- Loads up statistics from leaderboard API
- Wires up emblems claim UI to show the new flow

## Screens when leaderboard loading failed

<img width="552" alt="fail1" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/7e2cfef6-eaf9-4d9d-be03-a10172eaa1ce">
<img width="544" alt="fail2" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/96de4c6e-81fe-4070-b832-ac00fb9b15cf">

## Screens when loading was successful

<img width="562" alt="success1" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/a7f7ec82-47bd-410c-851e-75f906ece4bc">
<img width="546" alt="success2" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/659e507a-bd76-46f4-80b7-97ae63fb04b3">


## How to Test

- Set up test farm with faction and some faction points
- Try the following scenarios:

1.  Faction Not Joined
2. Faction Joined with No Faction Points collected
3. Faction Joined with Faction Points collected
4. Faction Join and Leaderboard fails to load (comment out `fetchLeaderboards()` in `src/features/world/ui/factions/components/ClaimEmblems.tsx`
5. Factions Joined with Emblems Already Collected

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
