### PR TITLE
[FEAT] Emblem Trading

### DIFF
--- a/src/features/game/events/landExpansion/joinFaction.test.ts
+++ b/src/features/game/events/landExpansion/joinFaction.test.ts
@@ -21,6 +21,7 @@ describe("joinFaction", () => {
       joinFaction({
         state: {
           ...TEST_FARM,
+          balance: new Decimal(20),
           faction: {
             name: "bumpkins",
             pledgedAt: Date.now() - 1000,
@@ -44,7 +45,7 @@ describe("joinFaction", () => {
 
   it("joins a faction", () => {
     const state = joinFaction({
-      state: TEST_FARM,
+      state: { ...TEST_FARM, balance: new Decimal(20) },
       action: {
         type: "faction.joined",
         faction: "sunflorians",
@@ -64,7 +65,7 @@ describe("joinFaction", () => {
 
   it("adds the faction banner to the players inventory", () => {
     const state = joinFaction({
-      state: TEST_FARM,
+      state: { ...TEST_FARM, balance: new Decimal(20) },
       action: {
         type: "faction.joined",
         faction: "sunflorians",
@@ -96,7 +97,7 @@ describe("joinFaction", () => {
 
   it("adds 5 Emblems to the players inventory", () => {
     const state = joinFaction({
-      state: TEST_FARM,
+      state: { ...TEST_FARM, balance: new Decimal(20) },
       action: {
         type: "faction.joined",
         faction: "sunflorians",
@@ -104,5 +105,19 @@ describe("joinFaction", () => {
     });
 
     expect(state.inventory["Sunflorian Emblem"]).toEqual(new Decimal(5));
+  });
+  it("throws an error if the player doesn't have enough SFL", () => {
+    expect(() =>
+      joinFaction({
+        state: {
+          ...TEST_FARM,
+          balance: new Decimal(0),
+        },
+        action: {
+          type: "faction.joined",
+          faction: "sunflorians",
+        },
+      })
+    ).toThrow("Not enough SFL");
   });
 });

--- a/src/features/game/events/landExpansion/joinFaction.ts
+++ b/src/features/game/events/landExpansion/joinFaction.ts
@@ -57,6 +57,11 @@ export function joinFaction({
     throw new Error("You already pledged a faction");
   }
 
+  // not enough SFL
+  if (stateCopy.balance.lt(SFL_COST)) {
+    throw new Error("Not enough SFL");
+  }
+
   stateCopy.faction = {
     name: action.faction,
     pledgedAt: createdAt,

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -48,6 +48,7 @@ import { RetreatScene } from "./scenes/RetreatScene";
 import { KingdomScene } from "./scenes/Kingdom";
 import { hasFeatureAccess } from "lib/flags";
 import { FactionHouseScene } from "./scenes/FactionHouse";
+import { GoblinHouseScene } from "./scenes/GoblinHouseScene";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -119,6 +120,9 @@ export const PhaserComponent: React.FC<Props> = ({
       : []),
     ...(hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [FactionHouseScene]
+      : []),
+    ...(hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
+      ? [GoblinHouseScene]
       : []),
   ];
 

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -51,6 +51,7 @@ import { FactionHouseScene } from "./scenes/FactionHouse";
 import { GoblinHouseScene } from "./scenes/GoblinHouseScene";
 import { SunflorianHouseScene } from "./scenes/SunflorianHouseScene";
 import { NightshadeHouseScene } from "./scenes/NightshadeHouse";
+import { BumpkinHouseScene } from "./scenes/BumpkinHouse";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -138,6 +139,10 @@ export const PhaserComponent: React.FC<Props> = ({
     ...(hasHouseAccess(gameService.state.context.state, "nightshades") &&
     hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [NightshadeHouseScene]
+      : []),
+    ...(true &&
+    hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
+      ? [BumpkinHouseScene]
       : []),
   ];
 

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -140,7 +140,7 @@ export const PhaserComponent: React.FC<Props> = ({
     hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [NightshadeHouseScene]
       : []),
-    ...(true &&
+    ...(hasHouseAccess(gameService.state.context.state, "bumpkins") &&
     hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [BumpkinHouseScene]
       : []),

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -50,6 +50,7 @@ import { hasFeatureAccess } from "lib/flags";
 import { FactionHouseScene } from "./scenes/FactionHouse";
 import { GoblinHouseScene } from "./scenes/GoblinHouseScene";
 import { SunflorianHouseScene } from "./scenes/SunflorianHouseScene";
+import { NightshadeHouseScene } from "./scenes/NightshadeHouse";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -133,6 +134,10 @@ export const PhaserComponent: React.FC<Props> = ({
     ...(hasHouseAccess(gameService.state.context.state, "sunflorians") &&
     hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [SunflorianHouseScene]
+      : []),
+    ...(hasHouseAccess(gameService.state.context.state, "nightshades") &&
+    hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
+      ? [NightshadeHouseScene]
       : []),
   ];
 

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -40,7 +40,7 @@ import SoundOffIcon from "assets/icons/sound_off.png";
 import { handleCommand } from "./lib/chatCommands";
 import { Moderation, UpdateUsernameEvent } from "features/game/lib/gameMachine";
 import { BeachScene } from "./scenes/BeachScene";
-import { Inventory } from "features/game/types/game";
+import { FactionName, GameState, Inventory } from "features/game/types/game";
 import { FishingModal } from "./ui/FishingModal";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { HudContainer } from "components/ui/HudContainer";
@@ -49,6 +49,7 @@ import { KingdomScene } from "./scenes/Kingdom";
 import { hasFeatureAccess } from "lib/flags";
 import { FactionHouseScene } from "./scenes/FactionHouse";
 import { GoblinHouseScene } from "./scenes/GoblinHouseScene";
+import { SunflorianHouseScene } from "./scenes/SunflorianHouseScene";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -109,6 +110,10 @@ export const PhaserComponent: React.FC<Props> = ({
   const mmoState = useSelector(mmoService, _roomState);
   const scene = useSelector(mmoService, _scene);
 
+  const hasHouseAccess = (gameState: GameState, factionHouse: FactionName) => {
+    return gameState.faction?.name === factionHouse;
+  };
+
   const scenes = [
     Preloader,
     new WoodlandsScene({ gameState: gameService.state.context.state }),
@@ -121,8 +126,13 @@ export const PhaserComponent: React.FC<Props> = ({
     ...(hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [FactionHouseScene]
       : []),
-    ...(hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
+    ...(hasHouseAccess(gameService.state.context.state, "goblins") &&
+    hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
       ? [GoblinHouseScene]
+      : []),
+    ...(hasHouseAccess(gameService.state.context.state, "sunflorians") &&
+    hasFeatureAccess(gameService.state.context.state, "FACTION_HOUSE")
+      ? [SunflorianHouseScene]
       : []),
   ];
 

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -37,6 +37,15 @@ export const SPAWNS: () => SpawnLocation = () => ({
       y: 200,
     },
   },
+  bumpkin_house: {
+    // Make sure everyone doesn't spawn in same spot
+    default: {
+      // x: 230 + randomXOffset,
+      // y: 420 - randomYOffset,
+      x: 410,
+      y: 200,
+    },
+  },
   faction_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -28,6 +28,15 @@ export const SPAWNS: () => SpawnLocation = () => ({
       y: 200,
     },
   },
+  nightshade_house: {
+    // Make sure everyone doesn't spawn in same spot
+    default: {
+      // x: 230 + randomXOffset,
+      // y: 420 - randomYOffset,
+      x: 410,
+      y: 200,
+    },
+  },
   faction_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -19,6 +19,15 @@ export const SPAWNS: () => SpawnLocation = () => ({
       y: 200,
     },
   },
+  sunflorian_house: {
+    // Make sure everyone doesn't spawn in same spot
+    default: {
+      // x: 230 + randomXOffset,
+      // y: 420 - randomYOffset,
+      x: 410,
+      y: 200,
+    },
+  },
   faction_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -13,37 +13,29 @@ export const SPAWNS: () => SpawnLocation = () => ({
   goblin_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {
-      // x: 230 + randomXOffset,
-      // y: 420 - randomYOffset,
-      x: 410,
-      y: 200,
+      x: 230 + randomXOffset,
+      y: 420 - randomYOffset,
     },
   },
   sunflorian_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {
-      // x: 230 + randomXOffset,
-      // y: 420 - randomYOffset,
-      x: 410,
-      y: 200,
+      x: 230 + randomXOffset,
+      y: 420 - randomYOffset,
     },
   },
   nightshade_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {
-      // x: 230 + randomXOffset,
-      // y: 420 - randomYOffset,
-      x: 410,
-      y: 200,
+      x: 230 + randomXOffset,
+      y: 420 - randomYOffset,
     },
   },
   bumpkin_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {
-      // x: 230 + randomXOffset,
-      // y: 420 - randomYOffset,
-      x: 410,
-      y: 200,
+      x: 230 + randomXOffset,
+      y: 420 - randomYOffset,
     },
   },
   faction_house: {

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -10,6 +10,15 @@ const randomXOffset = Math.random() * 60;
 const randomYOffset = Math.random() * 20;
 
 export const SPAWNS: () => SpawnLocation = () => ({
+  goblin_house: {
+    // Make sure everyone doesn't spawn in same spot
+    default: {
+      // x: 230 + randomXOffset,
+      // y: 420 - randomYOffset,
+      x: 410,
+      y: 200,
+    },
+  },
   faction_house: {
     // Make sure everyone doesn't spawn in same spot
     default: {

--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -25,6 +25,7 @@ export type Scenes = {
   faction_house: Room<PlazaRoomState> | undefined;
   goblin_house: Room<PlazaRoomState> | undefined;
   sunflorian_house: Room<PlazaRoomState> | undefined;
+  nightshade_house: Room<PlazaRoomState> | undefined;
 };
 
 export type SceneId = keyof Scenes;

--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -23,6 +23,7 @@ export type Scenes = {
   retreat: Room<PlazaRoomState> | undefined;
   kingdom: Room<PlazaRoomState> | undefined;
   faction_house: Room<PlazaRoomState> | undefined;
+  goblin_house: Room<PlazaRoomState> | undefined;
 };
 
 export type SceneId = keyof Scenes;

--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -26,6 +26,7 @@ export type Scenes = {
   goblin_house: Room<PlazaRoomState> | undefined;
   sunflorian_house: Room<PlazaRoomState> | undefined;
   nightshade_house: Room<PlazaRoomState> | undefined;
+  bumpkin_house: Room<PlazaRoomState> | undefined;
 };
 
 export type SceneId = keyof Scenes;

--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -24,6 +24,7 @@ export type Scenes = {
   kingdom: Room<PlazaRoomState> | undefined;
   faction_house: Room<PlazaRoomState> | undefined;
   goblin_house: Room<PlazaRoomState> | undefined;
+  sunflorian_house: Room<PlazaRoomState> | undefined;
 };
 
 export type SceneId = keyof Scenes;

--- a/src/features/world/scenes/BumpkinHouse.ts
+++ b/src/features/world/scenes/BumpkinHouse.ts
@@ -1,0 +1,38 @@
+import mapJSON from "assets/map/faction_house.json";
+
+import { SceneId } from "../mmoMachine";
+import { BaseScene, NPCBumpkin } from "./BaseScene";
+
+export const BUMPKIN_HOUSE_NPCS: NPCBumpkin[] = [
+  {
+    x: 410,
+    y: 200,
+    npc: "haymitch",
+    direction: "left",
+  },
+];
+
+export class BumpkinHouseScene extends BaseScene {
+  sceneId: SceneId = "bumpkin_house";
+
+  constructor() {
+    super({
+      name: "bumpkin_house",
+      map: { json: mapJSON },
+      audio: { fx: { walk_key: "wood_footstep" } },
+    });
+  }
+
+  preload() {
+    super.preload();
+  }
+
+  create() {
+    super.create();
+    this.map = this.make.tilemap({
+      key: "faction_house",
+    });
+
+    this.initialiseNPCs(BUMPKIN_HOUSE_NPCS);
+  }
+}

--- a/src/features/world/scenes/GoblinHouseScene.ts
+++ b/src/features/world/scenes/GoblinHouseScene.ts
@@ -1,0 +1,38 @@
+import mapJSON from "assets/map/faction_house.json";
+
+import { SceneId } from "../mmoMachine";
+import { BaseScene, NPCBumpkin } from "./BaseScene";
+
+export const GOBLIN_HOUSE_NPCS: NPCBumpkin[] = [
+  {
+    x: 410,
+    y: 200,
+    npc: "glinteye",
+    direction: "left",
+  },
+];
+
+export class GoblinHouseScene extends BaseScene {
+  sceneId: SceneId = "goblin_house";
+
+  constructor() {
+    super({
+      name: "goblin_house",
+      map: { json: mapJSON },
+      audio: { fx: { walk_key: "dirt_footstep" } },
+    });
+  }
+
+  preload() {
+    super.preload();
+  }
+
+  create() {
+    super.create();
+    this.map = this.make.tilemap({
+      key: "faction_house",
+    });
+
+    this.initialiseNPCs(GOBLIN_HOUSE_NPCS);
+  }
+}

--- a/src/features/world/scenes/NightshadeHouse.ts
+++ b/src/features/world/scenes/NightshadeHouse.ts
@@ -1,0 +1,38 @@
+import mapJSON from "assets/map/faction_house.json";
+
+import { SceneId } from "../mmoMachine";
+import { BaseScene, NPCBumpkin } from "./BaseScene";
+
+export const NIGHTSHADE_HOUSE_NPCS: NPCBumpkin[] = [
+  {
+    x: 410,
+    y: 200,
+    npc: "dusk",
+    direction: "left",
+  },
+];
+
+export class NightshadeHouseScene extends BaseScene {
+  sceneId: SceneId = "nightshade_house";
+
+  constructor() {
+    super({
+      name: "nightshade_house",
+      map: { json: mapJSON },
+      audio: { fx: { walk_key: "wood_footstep" } },
+    });
+  }
+
+  preload() {
+    super.preload();
+  }
+
+  create() {
+    super.create();
+    this.map = this.make.tilemap({
+      key: "faction_house",
+    });
+
+    this.initialiseNPCs(NIGHTSHADE_HOUSE_NPCS);
+  }
+}

--- a/src/features/world/scenes/SunflorianHouseScene.ts
+++ b/src/features/world/scenes/SunflorianHouseScene.ts
@@ -3,21 +3,21 @@ import mapJSON from "assets/map/faction_house.json";
 import { SceneId } from "../mmoMachine";
 import { BaseScene, NPCBumpkin } from "./BaseScene";
 
-export const GOBLIN_HOUSE_NPCS: NPCBumpkin[] = [
+export const SUNFLORIAN_HOUSE_NPCS: NPCBumpkin[] = [
   {
     x: 410,
     y: 200,
-    npc: "glinteye",
+    npc: "solara",
     direction: "left",
   },
 ];
 
-export class GoblinHouseScene extends BaseScene {
-  sceneId: SceneId = "goblin_house";
+export class SunflorianHouseScene extends BaseScene {
+  sceneId: SceneId = "sunflorian_house";
 
   constructor() {
     super({
-      name: "goblin_house",
+      name: "sunflorian_house",
       map: { json: mapJSON },
       audio: { fx: { walk_key: "wood_footstep" } },
     });
@@ -33,6 +33,6 @@ export class GoblinHouseScene extends BaseScene {
       key: "faction_house",
     });
 
-    this.initialiseNPCs(GOBLIN_HOUSE_NPCS);
+    this.initialiseNPCs(SUNFLORIAN_HOUSE_NPCS);
   }
 }

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -216,12 +216,13 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "glinteye" && (
           <EmblemsTrading onClose={closeModal} emblem="Goblin Emblem" />
         )}
-
         {npc === "solara" && (
           <EmblemsTrading onClose={closeModal} emblem="Sunflorian Emblem" />
         )}
-
         {npc === "dusk" && (
+          <EmblemsTrading onClose={closeModal} emblem="Nightshade Emblem" />
+        )}
+        {npc === "haymitch" && (
           <EmblemsTrading onClose={closeModal} emblem="Nightshade Emblem" />
         )}
       </Modal>

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -216,6 +216,10 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "glinteye" && (
           <EmblemsTrading onClose={closeModal} emblem="Goblin Emblem" />
         )}
+
+        {npc === "solara" && (
+          <EmblemsTrading onClose={closeModal} emblem="Sunflorian Emblem" />
+        )}
       </Modal>
 
       {npc === "hammerin harry" && (

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -23,12 +23,12 @@ import { Stylist } from "./stylist/Stylist";
 import { AuctionHouseModal } from "./AuctionHouseModal";
 import { translate } from "lib/i18n/translate";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { SpecialEventModal } from "./SpecialEventModal";
 import { GarbageCollectorModal } from "features/helios/components/garbageCollector/components/GarbageCollectorModal";
 import { Hopper } from "./npcs/Hopper";
 import { FactionModalContent } from "./factions/FactionModalContent";
 import { ChickenRescue } from "./portals/ChickenRescue";
 import { JoinFactionModal } from "./factions/JoinFactionModal";
+import { EmblemsTrading } from "./factions/emblemTrading/EmblemsTrading";
 
 class NpcModalManager {
   private listener?: (npc: NPCName, isOpen: boolean) => void;
@@ -201,6 +201,7 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "robert" && <FactionModalContent onClose={closeModal} />}
         {npc === "grommy" && <FactionModalContent onClose={closeModal} />}
 
+        {/* Kingdom NPCs */}
         {npc === "barlow" && (
           <JoinFactionModal npc={npc} onClose={closeModal} />
         )}
@@ -211,15 +212,11 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "reginald" && (
           <JoinFactionModal npc={npc} onClose={closeModal} />
         )}
+
+        {npc === "glinteye" && (
+          <EmblemsTrading onClose={closeModal} emblem="Goblin Emblem" />
+        )}
       </Modal>
-      {npc === "Chun Long" && (
-        <SpecialEventModal
-          onClose={closeModal}
-          show={npc === "Chun Long"}
-          npc={npc}
-          eventName="Lunar New Year"
-        />
-      )}
 
       {npc === "hammerin harry" && (
         <AuctionHouseModal

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -220,6 +220,10 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "solara" && (
           <EmblemsTrading onClose={closeModal} emblem="Sunflorian Emblem" />
         )}
+
+        {npc === "dusk" && (
+          <EmblemsTrading onClose={closeModal} emblem="Nightshade Emblem" />
+        )}
       </Modal>
 
       {npc === "hammerin harry" && (

--- a/src/features/world/ui/factions/JoinFaction.tsx
+++ b/src/features/world/ui/factions/JoinFaction.tsx
@@ -8,10 +8,11 @@ import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { capitalize } from "lib/utils/capitalize";
-import { FactionEmblem, FactionName } from "features/game/types/game";
+import { FactionName } from "features/game/types/game";
 import { FACTION_BANNERS } from "features/game/events/landExpansion/pledgeFaction";
 import {
   EMBLEM_QTY,
+  FACTION_EMBLEMS,
   SFL_COST,
 } from "features/game/events/landExpansion/joinFaction";
 import { ClaimReward } from "features/game/expansion/components/ClaimReward";
@@ -19,13 +20,6 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { InlineDialogue } from "../TypingMessage";
 import { ClaimEmblems } from "./components/ClaimEmblems";
 import { hasFeatureAccess } from "lib/flags";
-
-const FACTION_EMBLEM: Record<FactionName, FactionEmblem> = {
-  sunflorians: "Sunflorian Emblem",
-  bumpkins: "Bumpkin Emblem",
-  goblins: "Goblin Emblem",
-  nightshades: "Nightshade Emblem",
-};
 
 const RECRUITER_VOICE: Record<FactionName, string> = {
   goblins: "graxle",
@@ -59,6 +53,7 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
   const recruiterVoice = useSound(RECRUITER_VOICE[faction] as any);
 
   const sameFaction = joinedFaction && joinedFaction.name === faction;
+  const hasSFL = gameService.state.context.state.balance.gte(SFL_COST);
 
   useEffect(() => {
     if (sameFaction) {
@@ -147,7 +142,7 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
           <div className="flex flex-col p-2 pt-1 space-y-2">
             <div className="flex justify-between">
               <Label type="default">{capitalize(faction)}</Label>
-              <Label type="warning" icon={sflIcon}>
+              <Label type={hasSFL ? "warning" : "danger"} icon={sflIcon}>
                 {`${SFL_COST} SFL`}
               </Label>
             </div>
@@ -166,7 +161,9 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
           </Label>
           <div className="flex space-x-1">
             <Button onClick={onClose}>{t("cancel")}</Button>
-            <Button onClick={() => setConfirmed(true)}>{t("continue")}</Button>
+            <Button disabled={!hasSFL} onClick={() => setConfirmed(true)}>
+              {t("continue")}
+            </Button>
           </div>
         </>
       )}
@@ -179,7 +176,7 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
               factionPoints: 0,
               items: {
                 [FACTION_BANNERS[faction]]: 1,
-                [FACTION_EMBLEM[faction]]: EMBLEM_QTY,
+                [FACTION_EMBLEMS[faction]]: EMBLEM_QTY,
               },
               coins: 0,
               createdAt: new Date().getTime(),

--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -259,6 +259,7 @@ export const BuyPanel: React.FC<{
                 className="mt-2"
                 onClick={() => {
                   setLoading(false);
+                  onSearch();
                 }}
               >
                 {t("continue")}

--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -1,0 +1,376 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useActor } from "@xstate/react";
+
+import { Context } from "features/game/GameProvider";
+import { ITEM_DETAILS } from "features/game/types/images";
+
+import { Button } from "components/ui/Button";
+
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { OuterPanel } from "components/ui/Panel";
+import { Box } from "components/ui/Box";
+import Decimal from "decimal.js-light";
+import token from "assets/icons/sfl.webp";
+import lock from "assets/skills/lock.png";
+import { getKeys } from "features/game/types/craftables";
+import { FactionEmblem } from "features/game/types/game";
+import { SUNNYSIDE } from "assets/sunnyside";
+import {
+  Listing,
+  getTradeListings,
+} from "features/game/actions/getTradeListings";
+import { Context as AuthContext } from "features/auth/lib/Provider";
+import { hasMaxItems } from "features/game/lib/processEvent";
+import { makeListingType } from "lib/utils/makeTradeListingType";
+import { Label } from "components/ui/Label";
+import { Loading } from "features/auth/components";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { hasVipAccess } from "features/game/lib/vipAccess";
+import { VIPAccess } from "features/game/components/VipAccess";
+import { getDayOfYear } from "lib/utils/time";
+import { setPrecision } from "lib/utils/formatNumber";
+
+export const TRADE_LIMITS: Record<FactionEmblem, number> = {
+  "Goblin Emblem": 200,
+  "Sunflorian Emblem": 200,
+  "Bumpkin Emblem": 200,
+  "Nightshade Emblem": 200,
+};
+
+export const TRADE_MINIMUMS: Record<FactionEmblem, number> = {
+  "Goblin Emblem": 1,
+  "Sunflorian Emblem": 1,
+  "Bumpkin Emblem": 1,
+  "Nightshade Emblem": 1,
+};
+
+const MAX_NON_VIP_PURCHASES = 3;
+
+function getRemainingFreePurchases(dailyPurchases: {
+  count: number;
+  date: number;
+}) {
+  if (dailyPurchases.date != getDayOfYear(new Date())) {
+    return MAX_NON_VIP_PURCHASES;
+  }
+  return MAX_NON_VIP_PURCHASES - dailyPurchases.count;
+}
+
+export const BuyPanel: React.FC<{
+  emblem: FactionEmblem;
+}> = ({ emblem }) => {
+  const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+  const { authService } = useContext(AuthContext);
+  const [authState] = useActor(authService);
+
+  const { openModal } = useContext(ModalContext);
+
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [selectedListing, setSelectedListing] = useState<Listing>();
+  const [isSearching, setIsSearching] = useState(false);
+  const [warning, setWarning] = useState<"pendingTransaction" | "hoarding">();
+  const [loading, setLoading] = useState(false);
+  const [
+    {
+      context: { state, transaction, farmId },
+    },
+  ] = useActor(gameService);
+  const inventory = state.inventory;
+
+  useEffect(() => {
+    onSearch();
+  }, []);
+
+  const isVIP = hasVipAccess(state.inventory);
+  const dailyPurchases = state.trades.dailyPurchases ?? { count: 0, date: 0 };
+  const remainingFreePurchases = getRemainingFreePurchases(dailyPurchases);
+  const hasPurchasesRemaining = isVIP || remainingFreePurchases > 0;
+
+  const listView = (listings: Listing[]) => {
+    if (listings.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full w-full">
+          <div className="flex flex-col items-center justify-center pb-4">
+            <img src={SUNNYSIDE.icons.search} className="w-16 mx-auto my-2" />
+            <p className="text-sm">{t("trading.no.listings")}</p>
+          </div>
+        </div>
+      );
+    }
+
+    const confirm = (listing: Listing) => {
+      const updatedInventory = getKeys(listing.items).reduce(
+        (acc, name) => ({
+          ...acc,
+          [name]: (inventory[name] ?? new Decimal(0)).add(
+            listing.items[name] ?? 0
+          ),
+        }),
+        inventory
+      );
+
+      const hasMaxedOut = hasMaxItems({
+        current: updatedInventory,
+        old: state.previousInventory,
+      });
+
+      if (hasMaxedOut) {
+        setWarning("hoarding");
+        return;
+      }
+
+      if (transaction && transaction.expiresAt > Date.now()) {
+        setWarning("pendingTransaction");
+        return;
+      }
+
+      setSelectedListing(listing);
+    };
+
+    const onConfirm = async (listing: Listing) => {
+      gameService.send("FULFILL_TRADE_LISTING", {
+        sellerId: listing.farmId,
+        listingId: listing.id,
+        listingType: makeListingType(listing.items),
+      });
+      setLoading(true);
+    };
+
+    const getAction = (listing: Listing) => {
+      if (listing.farmId == farmId) {
+        return (
+          <div className="flex items-center mt-1  justify-end mr-0.5">
+            <Label type="danger" className="mb-4">
+              {t("trading.your.listing")}
+            </Label>
+          </div>
+        );
+      }
+
+      if (selectedListing?.id == listing.id) {
+        return (
+          <Button onClick={() => onConfirm(listing)}>
+            <div className="flex items-center">
+              <img src={SUNNYSIDE.icons.confirm} className="h-4 mr-1" />
+              <span className="text-xs">{t("confirm")}</span>
+            </div>
+          </Button>
+        );
+      }
+
+      const hasSFL = state.balance.gte(listing.sfl);
+      const disabled = !hasSFL || !hasPurchasesRemaining;
+
+      return (
+        <Button
+          disabled={disabled}
+          onClick={() => {
+            confirm(listing);
+          }}
+        >
+          {t("buy")}
+        </Button>
+      );
+    };
+
+    if (warning === "hoarding") {
+      return (
+        <div className="p-1 flex flex-col items-center">
+          <img src={lock} className="w-1/5 mb-2" />
+          <p className="text-sm mb-1 text-center">
+            {t("playerTrade.max.item")}
+          </p>
+          <p className="text-xs mb-1 text-center">
+            {t("playerTrade.Progress")}
+          </p>
+        </div>
+      );
+    }
+
+    if (warning === "pendingTransaction") {
+      return (
+        <div className="p-1 flex flex-col items-center">
+          <img src={SUNNYSIDE.icons.timer} className="w-1/6 mb-2" />
+          <p className="text-sm mb-1 text-center">
+            {t("playerTrade.transaction")}
+          </p>
+          <p className="text-xs mb-1 text-center">{t("playerTrade.Please")}</p>
+        </div>
+      );
+    }
+
+    if (loading) {
+      if (gameService.state.matches("fulfillTradeListing")) {
+        return <Loading text={t("trading")} />;
+      }
+
+      if (selectedListing) {
+        const listingItem = selectedListing.items[
+          getKeys(selectedListing.items)[0]
+        ] as number;
+        const unitPrice = selectedListing.sfl / listingItem;
+
+        return (
+          <>
+            <div className="flex flex-col w-full p-2">
+              <img src={SUNNYSIDE.icons.confirm} className="mx-auto h-6 my-2" />
+              <p className="text-sm mb-2 text-center">
+                {t("trading.listing.fulfilled")}
+              </p>
+              <OuterPanel>
+                <div className="flex justify-between">
+                  <div>
+                    <div className="flex flex-wrap w-52 items-center">
+                      {getKeys(selectedListing.items).map((item, index) => (
+                        <Box
+                          image={ITEM_DETAILS[item].image}
+                          count={new Decimal(selectedListing.items[item] ?? 0)}
+                          disabled
+                          key={`items-${index}`}
+                        />
+                      ))}
+                      <div className="ml-1">
+                        <div className="flex items-center mb-1">
+                          <img src={token} className="h-6 mr-1" />
+                          <p className="text-xs">{`${selectedListing.sfl} SFL`}</p>
+                        </div>
+                        <p className="text-xxs">
+                          {t("bumpkinTrade.price/unit", {
+                            price: setPrecision(new Decimal(unitPrice)).toFixed(
+                              4
+                            ),
+                          })}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="">
+                    <div className="flex items-center mt-1  justify-end mr-0.5">
+                      <Label type="success" className="mb-4 capitalize">
+                        {t("purchased")}
+                      </Label>
+                    </div>
+                  </div>
+                </div>
+              </OuterPanel>
+              <Button
+                className="mt-2"
+                onClick={() => {
+                  setLoading(false);
+                }}
+              >
+                {t("continue")}
+              </Button>
+            </div>
+          </>
+        );
+      }
+    }
+
+    return (
+      <div className="flex flex-col w-full pl-2 pt-1">
+        <div className="flex items-center ml-1">
+          <Label type="default" icon={ITEM_DETAILS[emblem].image}>
+            {emblem}
+          </Label>
+        </div>
+        <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">
+          {listings.map((listing, index) => {
+            // only one resource listing
+            const listingItem = listing.items[
+              getKeys(listing.items)[0]
+            ] as number;
+            const unitPrice = listing.sfl / listingItem;
+            return (
+              <OuterPanel className="mb-2" key={`data-${index}`}>
+                <div className="flex justify-between">
+                  <div className="justify-start">
+                    <div className="flex flex-wrap w-52 items-center">
+                      {getKeys(listing.items).map((item) => (
+                        <Box
+                          image={ITEM_DETAILS[item].image}
+                          count={new Decimal(listing.items[item] ?? 0)}
+                          disabled
+                          key={`items-${index}`}
+                        />
+                      ))}
+                      <div className="ml-1">
+                        <div className="flex items-center mb-1">
+                          <img src={token} className="h-6 mr-1" />
+                          <p className="text-xs">{`${listing.sfl} SFL`}</p>
+                        </div>
+                        <p className="text-xxs">
+                          {t("bumpkinTrade.price/unit", {
+                            price: setPrecision(new Decimal(unitPrice)).toFixed(
+                              4
+                            ),
+                          })}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div>{getAction(listing)}</div>
+                </div>
+              </OuterPanel>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  const onSearch = async () => {
+    setIsSearching(true);
+    const listings = await getTradeListings(
+      makeListingType({ [emblem]: 1 }),
+      authState.context.user.rawToken
+    );
+
+    setListings(listings);
+    setIsSearching(false);
+  };
+
+  return (
+    <>
+      <div className="flex flex-col max-h-[400px] divide-brown-600">
+        <div className="pl-2 pt-2 space-y-1 sm:space-y-0 sm:flex items-center justify-between ml-1.5">
+          <VIPAccess
+            isVIP={isVIP}
+            onUpgrade={() => {
+              openModal("BUY_BANNER");
+            }}
+          />
+          {!isVIP && (
+            <Label
+              type={hasPurchasesRemaining ? "success" : "danger"}
+              className="-ml-2"
+            >
+              {remainingFreePurchases == 0
+                ? `${t("remaining.free.purchase")}`
+                : `${t("remaining.free.purchases", {
+                    purchasesRemaining: hasPurchasesRemaining
+                      ? remainingFreePurchases
+                      : t("no"),
+                  })}`}
+            </Label>
+          )}
+        </div>
+        <div className="flex flex-col min-h-[150px] items-start justify-between">
+          {isSearching && (
+            <div className="flex items-center justify-center w-full mt-4">
+              <p className="loading mt-1">{t("searching")}</p>
+            </div>
+          )}
+          {!isSearching && (
+            <div className="flex overflow-y-auto relative w-full mt-4">
+              {listView(listings)}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/features/world/ui/factions/emblemTrading/EmblemsTrading.tsx
+++ b/src/features/world/ui/factions/emblemTrading/EmblemsTrading.tsx
@@ -1,0 +1,62 @@
+import { SUNNYSIDE } from "assets/sunnyside";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import React, { useContext, useEffect, useState } from "react";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { Context } from "features/game/GameProvider";
+import { Context as AuthContext } from "features/auth/lib/Provider";
+import { useActor } from "@xstate/react";
+
+import tradeIcon from "assets/icons/trade.png";
+import {
+  FloorPrices,
+  getListingsFloorPrices,
+} from "features/game/actions/getListingsFloorPrices";
+import { BuyPanel } from "./BuyPanel";
+import { Trade } from "./Trade";
+import { FactionEmblem } from "features/game/types/game";
+
+interface Props {
+  onClose: () => void;
+  emblem: FactionEmblem;
+}
+
+export const EmblemsTrading: React.FC<Props> = ({ onClose, emblem }) => {
+  const [tab, setTab] = useState(0);
+  const { t } = useAppTranslation();
+
+  const { gameService } = useContext(Context);
+  const { authService } = useContext(AuthContext);
+  const [authState] = useActor(authService);
+
+  const [floorPrices, setFloorPrices] = useState<FloorPrices>({});
+
+  const notCloseable = gameService.state.matches("fulfillTradeListing");
+
+  useEffect(() => {
+    const load = async () => {
+      const floorPrices = await getListingsFloorPrices(
+        authState.context.user.rawToken
+      );
+      setFloorPrices((prevFloorPrices) => ({
+        ...prevFloorPrices,
+        ...floorPrices,
+      }));
+    };
+    load();
+  }, []);
+
+  return (
+    <CloseButtonPanel
+      onClose={notCloseable ? undefined : onClose}
+      tabs={[
+        { icon: SUNNYSIDE.icons.search, name: t("buy") },
+        { icon: tradeIcon, name: t("sell") },
+      ]}
+      setCurrentTab={setTab}
+      currentTab={tab}
+    >
+      {tab === 0 && <BuyPanel emblem={emblem} />}
+      {tab === 1 && <Trade floorPrices={floorPrices} emblem={emblem} />}
+    </CloseButtonPanel>
+  );
+};

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -67,6 +67,7 @@ const ListTrade: React.FC<{
 
   const tooLittle = !!quantity && quantity < (TRADE_MINIMUMS[emblem] ?? 0);
 
+  const cantSellAll = inventory[emblem]?.sub(quantity).lt(1);
   return (
     <>
       <div className="flex justify-between">
@@ -76,10 +77,14 @@ const ListTrade: React.FC<{
         </div>
         <div className="flex flex-col items-end pr-1">
           <Label
-            type={inventory[emblem]?.lt(quantity) ? "danger" : "info"}
+            type={
+              inventory[emblem]?.lt(quantity) || cantSellAll ? "danger" : "info"
+            }
             className="my-1"
           >
-            {t("bumpkinTrade.available")}
+            {inventory[emblem]?.sub(quantity).lt(1)
+              ? `Can't sell all`
+              : t("bumpkinTrade.available")}
           </Label>
           <span className="text-sm mr-1">
             {`${setPrecision(new Decimal(inventory?.[emblem] ?? 0), 0)}`}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3551,11 +3551,6 @@ const npcDialogues: Record<NpcDialogues, string> = {
     ENGLISH_TERMS["npcDialogues.default.goodFlower"],
   "npcDialogues.default.reward": ENGLISH_TERMS["npcDialogues.default.reward"],
   "npcDialogues.default.locked": ENGLISH_TERMS["npcDialogues.default.locked"],
-  // Glinteye
-  "npcDialogues.glinteye.intro1": ENGLISH_TERMS["npcDialogues.glinteye.intro1"],
-  "npcDialogues.glinteye.intro2": ENGLISH_TERMS["npcDialogues.glinteye.intro2"],
-  "npcDialogues.glinteye.intro3": ENGLISH_TERMS["npcDialogues.glinteye.intro3"],
-  "npcDialogues.glinteye.intro4": ENGLISH_TERMS["npcDialogues.glinteye.intro4"],
 };
 
 const nyeButton: Record<NyeButton, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -999,6 +999,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.maximumFloor": "最高单价： {{max}}",
   "bumpkinTrade.sellConfirmation":
     "确认卖出 {{quantity}} {{resource}} 以赚 {{price}} SFL？",
+  "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
 };
 
 const buyFarmHand: Record<BuyFarmHand, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3958,16 +3958,6 @@ const npcDialogues: Record<NpcDialogues, string> = {
     "Wow, thanks Bumpkin. Here is a small gift for your help!",
   "npcDialogues.default.locked": "Please come back tomorrow.",
 
-  // Glinteye Intro
-  "npcDialogues.glinteye.intro1":
-    "Ah, adventurer! Glinteye at your service. Ready to trade secrets and resources? Dive into my listings or add your own. Let's make a deal!",
-  "npcDialogues.glinteye.intro2":
-    "Welcome, curious soul! I'm Glinteye, your guide to trading wonders. Seek or list resources with me; fortune favors the bold!",
-  "npcDialogues.glinteye.intro3":
-    "Glinteye's my name, trading's my game! Browse or list, there's always a twist. What's your fancy today?",
-  "npcDialogues.glinteye.intro4":
-    "Hello there! I'm Glinteye, the goblin of trade. Explore player trades or list your items. Let's see what we can find together!",
-
   // Queen Victoria Intro
   "npcDialogues.queenVictoria.intro1":
     "Oh, it's you. Do you have my taxes ready, peasant?",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1063,6 +1063,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.price/unit": "{{price}} / unit",
   "bumpkinTrade.sellConfirmation":
     "Sell {{quantity}} {{resource}} for {{price}} SFL?",
+  "bumpkinTrade.cant.sell.all": "Can't sell all",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4187,16 +4187,6 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.default.reward":
     "Wow, merci Bumpkin. Voici un petit cadeau pour ton aide!",
   "npcDialogues.default.locked": "Veuillez revenir demain.",
-
-  // Glinteye Intro
-  "npcDialogues.glinteye.intro1":
-    "Ah, adventurer! Glinteye at your service. Ready to trade secrets and resources? Dive into my listings or add your own. Let's make a deal!",
-  "npcDialogues.glinteye.intro2":
-    "Welcome, curious soul! I'm Glinteye, your guide to trading wonders. Seek or list resources with me; fortune favors the bold!",
-  "npcDialogues.glinteye.intro3":
-    "Glinteye's my name, trading's my game! Browse or list, there's always a twist. What's your fancy today?",
-  "npcDialogues.glinteye.intro4":
-    "Hello there! I'm Glinteye, the goblin of trade. Explore player trades or list your items. Let's see what we can find together!",
 };
 
 const nyeButton: Record<NyeButton, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1090,6 +1090,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.price/unit": "{{price}} / unité",
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
+  "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4067,16 +4067,6 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.default.reward":
     "Uau, obrigado Bumpkin. Aqui está um pequeno presente pela sua ajuda!",
   "npcDialogues.default.locked": "Por favor, volte amanhã.",
-
-  // Glinteye Intro
-  "npcDialogues.glinteye.intro1":
-    "Ah, aventureiro! Glinteye à sua disposição. Pronto para negociar segredos e recursos? Mergulhe em minhas listagens ou adicione as suas. Vamos fazer um acordo!",
-  "npcDialogues.glinteye.intro2":
-    "Bem-vindo, alma curiosa! Sou Glinteye, seu guia para trocar maravilhas. Procure ou liste recursos comigo; a sorte favorece os ousados!",
-  "npcDialogues.glinteye.intro3":
-    "Glinteye é meu nome, trocar é meu lema! Navegue ou liste, sempre uma trama. O que te agrada hoje?",
-  "npcDialogues.glinteye.intro4":
-    "Olá! Sou Glinteye, o goblin do comércio. Explore trocas de jogadores ou liste seus itens. Vamos ver o que podemos encontrar juntos!",
 };
 
 const nyeButton: Record<NyeButton, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1076,6 +1076,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.price/unit": ENGLISH_TERMS["bumpkinTrade.price/unit"],
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
+  "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4059,15 +4059,6 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.default.reward":
     "Vay be, teşekkürler Bumpkin.  İşte yardımınız için küçük bir hediye!",
   "npcDialogues.default.locked": "Lütfen yarın tekrar gelin.",
-  // Glinteye Intro
-  "npcDialogues.glinteye.intro1":
-    "Ah, maceracı!  Glinteye hizmetinizde. Sırları ve kaynakları takas etmeye hazır mısınız?  Listelerime dalın veya kendinizinkini ekleyin.  Bir anlaşma yapalım!",
-  "npcDialogues.glinteye.intro2":
-    "Hoş geldin meraklı ruh!  Ben Glinteye, ticaret harikaları rehberiniz.  Kaynakları benimle arayın veya listeleyin;  şans cesurdan yanadır!",
-  "npcDialogues.glinteye.intro3":
-    "Benim adım Glinteye, ticaret benim oyunum! Göz atın veya listeleyin, her zaman bir değişiklik vardır. Bugünkü hayalin ne?",
-  "npcDialogues.glinteye.intro4":
-    "Selamlar! Ben Glinteye, ticaretin gobliniyim. Oyuncu takaslarını keşfedin veya eşyalarınızı listeleyin. Gelin birlikte neler bulabileceğimize bakalım!",
 };
 
 const nyeButton: Record<NyeButton, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1060,6 +1060,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.maximumFloor": ENGLISH_TERMS["bumpkinTrade.maximumFloor"],
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
+  "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2662,12 +2662,6 @@ export type NpcDialogues =
   | "npcDialogues.tywin.badFlower"
   | "npcDialogues.tywin.goodFlower"
 
-  // Glinteye dialogue
-  | "npcDialogues.glinteye.intro1"
-  | "npcDialogues.glinteye.intro2"
-  | "npcDialogues.glinteye.intro3"
-  | "npcDialogues.glinteye.intro4"
-
   // Queen Victoria NoOrde
   | "npcDialogues.queenVictoria.intro1"
   | "npcDialogues.queenVictoria.intro2"
@@ -2731,7 +2725,8 @@ export type NpcDialogues =
   | "npcDialogues.jester.flowerIntro"
   | "npcDialogues.jester.averageFlower"
   | "npcDialogues.jester.badFlower"
-  | "npcDialogues.jester.goodFlower";
+  | "npcDialogues.jester.goodFlower"
+  | "npcDialogues.tywin.goodFlower";
 
 export type NyeButton = "plaza.magicButton.query";
 

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -744,7 +744,8 @@ export type BumpkinTrade =
   | "bumpkinTrade.minimumFloor"
   | "bumpkinTrade.maximumFloor"
   | "bumpkinTrade.floorPrice"
-  | "bumpkinTrade.sellConfirmation";
+  | "bumpkinTrade.sellConfirmation"
+  | "bumpkinTrade.cant.sell.all";
 
 export type GoblinTrade =
   | "goblinTrade.select"

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -82,7 +82,8 @@ export type NPCName =
   | "barlow" // faction recruiter;
   | "nyx" // faction recruiter;
   | "reginald" // faction recruiter;
-  | "glinteye";
+  | "glinteye"
+  | "solara";
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   gambit: {
@@ -901,6 +902,16 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     tool: "Auction Megaphone",
     shoes: "Black Farmer Boots",
     background: "Farm Background",
+  },
+
+  solara: {
+    body: "Sunburst Potion",
+    hair: "Blondie",
+    shirt: "Fancy Top",
+    pants: "Sunflorian Pants",
+    tool: "Sunflorian Sword",
+    background: "Farm Background",
+    shoes: "Sunflorian Sabaton",
   },
 };
 

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -83,7 +83,8 @@ export type NPCName =
   | "nyx" // faction recruiter;
   | "reginald" // faction recruiter;
   | "glinteye"
-  | "solara";
+  | "solara"
+  | "dusk";
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   gambit: {
@@ -912,6 +913,16 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     tool: "Sunflorian Sword",
     background: "Farm Background",
     shoes: "Sunflorian Sabaton",
+  },
+
+  dusk: {
+    body: "Pale Potion",
+    hair: "Red Long Hair",
+    shirt: "Olive Royalty Shirt",
+    pants: "Nightshade Pants",
+    tool: "Nightshade Sword",
+    background: "Farm Background",
+    shoes: "Nightshade Sabaton",
   },
 };
 

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -84,7 +84,8 @@ export type NPCName =
   | "reginald" // faction recruiter;
   | "glinteye"
   | "solara"
-  | "dusk";
+  | "dusk"
+  | "haymitch";
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   gambit: {
@@ -923,6 +924,15 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     tool: "Nightshade Sword",
     background: "Farm Background",
     shoes: "Nightshade Sabaton",
+  },
+  haymitch: {
+    body: "Beige Farmer Potion",
+    hair: "Explorer Hair",
+    shirt: "Orange Monarch Shirt",
+    pants: "Bumpkin Pants",
+    tool: "Bumpkin Sword",
+    background: "Farm Background",
+    shoes: "Bumpkin Sabaton",
   },
 };
 

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -81,7 +81,8 @@ export type NPCName =
   | "graxle" // faction recruiter;
   | "barlow" // faction recruiter;
   | "nyx" // faction recruiter;
-  | "reginald"; // faction recruiter;
+  | "reginald" // faction recruiter;
+  | "glinteye";
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   gambit: {
@@ -889,6 +890,17 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     tool: "Sunflorian Sword",
     background: "Farm Background",
     shoes: "Sunflorian Sabaton",
+  },
+
+  glinteye: {
+    body: "Goblin Potion",
+    hair: "Greyed Glory",
+    shirt: "Fancy Top",
+    pants: "Fancy Pants",
+    beard: "Wise Beard",
+    tool: "Auction Megaphone",
+    shoes: "Black Farmer Boots",
+    background: "Farm Background",
   },
 };
 

--- a/src/lib/utils/makeTradeListing.test.ts
+++ b/src/lib/utils/makeTradeListing.test.ts
@@ -1,0 +1,15 @@
+import { makeListingType } from "./makeTradeListingType";
+
+describe("makeListingType", () => {
+  it("should return a trade listing", () => {
+    const result = makeListingType({ Apple: 1, Orange: 2 });
+
+    expect(result).toEqual("apple-orange");
+  });
+
+  it("should return a trade listing with two words", () => {
+    const result = makeListingType({ "Goblin Emblem": 1, Orange: 2 });
+
+    expect(result).toEqual("goblinEmblem-orange");
+  });
+});

--- a/src/lib/utils/makeTradeListingType.ts
+++ b/src/lib/utils/makeTradeListingType.ts
@@ -3,5 +3,20 @@ import { InventoryItemName } from "features/game/types/game";
 export function makeListingType(
   items: Partial<Record<InventoryItemName, number>>
 ): string {
-  return Object.keys(items).sort().join("-").toLowerCase();
+  // Function to convert items to camelCase if they have multiple words
+  function formatItemName(itemName: string): string {
+    return itemName
+      .split(" ")
+      .map((word, index) =>
+        index === 0
+          ? word.toLowerCase()
+          : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+      )
+      .join("");
+  }
+
+  return Object.keys(items)
+    .map(formatItemName) // Apply formatting to each item name
+    .sort()
+    .join("-");
 }


### PR DESCRIPTION
# Description

This PR implements Emblem Trading for each faction.

* Emblem listings wont show at the Plaza Trading Board neither on the Bumpkin Modal, you can only see/manage them at the trader NPC at the faction house you are a member of.
* Player cannot sell all Emblems, you have to hold at least 1 emblem.
* Player cannot access other factions houses.
* Player cannot trade (buy/sell) Emblems from other factions.
* Player will need to be part of the faction to be able to access the house.


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
