### PR TITLE
[FIX] Remove Chinese Language Font altogether

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,6 @@
       href="https://fonts.googleapis.com/css2?family=Paytone+One&display=swap"
       rel="stylesheet"
     />
-    <link
-      href="https://fonts.googleapis.com/css2?family=LXGW+WenKai+TC&display=swap"
-      rel="stylesheet"
-    />
     <!-- We will have to update the font link for the fonts for other non-alphabetical languages as well -->
 
     <!-- PWA -->

--- a/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
@@ -14,7 +14,6 @@ import portugalFlag from "assets/sfts/flags/portugal_flag.gif";
 import franceFlag from "assets/sfts/flags/france_flag.gif";
 import turkeyFlag from "assets/sfts/flags/turkey_flag.gif";
 import chinaFlag from "assets/sfts/flags/china_flag.gif";
-import { changeFont } from "lib/utils/fonts";
 
 export const LanguageSwitcher: React.FC = () => {
   const { t } = useAppTranslation();
@@ -27,10 +26,6 @@ export const LanguageSwitcher: React.FC = () => {
     localStorage.setItem("language", languageCode);
     i18n.changeLanguage(languageCode);
     setLanguage(languageCode);
-
-    if (languageCode === "zh-CN") {
-      changeFont("sans-serif");
-    }
   };
 
   return (

--- a/src/styles.css
+++ b/src/styles.css
@@ -112,7 +112,7 @@
 }
 
 :root {
-  --font-family: "Basic", sans-serif, "LXGW WenKai TC", cursive;
+  --font-family: "Basic", sans-serif;
 
   /* Font Size Variables */
   --text-xxs-size: 18px;


### PR DESCRIPTION
# Description

Removes Chinese font as a temporary solution

Problem with forcing sans-serif is that it will affect the english text as well.
Removing the Chinese font will allow the english text to be in the basic or secondary font, while the Chinese font will fallback to san-serif because 'Basic' and 'Secondary' doesn't support Chinese language

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
