### PR TITLE
[FIX] Hide Achievement Claim Button when reward already claimed

### DIFF
--- a/src/features/bumpkins/components/AchievementDetails.tsx
+++ b/src/features/bumpkins/components/AchievementDetails.tsx
@@ -33,7 +33,6 @@ export const AchievementDetails: React.FC<Props> = ({
   onClaim,
   name,
   state,
-  readonly,
 }) => {
   const achievement = ACHIEVEMENTS()[name];
   const progress = achievement.progress(state);
@@ -144,7 +143,7 @@ export const AchievementDetails: React.FC<Props> = ({
             )}
           </>
         </div>
-        {!readonly && (
+        {!isAlreadyClaimed && (
           <Button className="text-xs" onClick={onClaim} disabled={!isComplete}>
             <span>{t("claim")}</span>
           </Button>


### PR DESCRIPTION
# Description

Before:
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/3bd59418-4873-4928-a69a-5fbf6af9bef4)

After:
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/fb9556f8-3444-4f4e-8534-d5c16e79aa02)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
