### PR TITLE
[CHORE] Appearance Settings Navigation

### DIFF
--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -42,6 +42,7 @@ import { AmoyTestnetActions } from "./amoy-actions/AmoyTestnetActions";
 import { Discord } from "./general-settings/DiscordModal";
 import { DepositWrapper } from "features/goblins/bank/components/Deposit";
 import { useSound } from "lib/utils/hooks/useSound";
+import { AppearanceSettings } from "./general-settings/AppearanceSettings";
 
 export interface ContentComponentProps {
   onSubMenuClick: (id: SettingMenuId) => void;
@@ -271,7 +272,8 @@ export type SettingMenuId =
   // General Settings
   | "discord"
   | "changeLanguage"
-  | "share";
+  | "share"
+  | "appearance";
 
 interface SettingMenu {
   title: string;
@@ -354,5 +356,10 @@ export const settingMenus: Record<SettingMenuId, SettingMenu> = {
     title: translate("share.ShareYourFarmLink"),
     parent: "general",
     content: Share,
+  },
+  appearance: {
+    title: translate("gameOptions.generalSettings.appearance"),
+    parent: "general",
+    content: AppearanceSettings,
   },
 };

--- a/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
@@ -1,9 +1,8 @@
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 import { ContentComponentProps } from "../GameOptions";
-import { AppearanceSettings } from "./AppearanceSettings";
 
 export const GeneralSettings: React.FC<ContentComponentProps> = ({
   onSubMenuClick,
@@ -11,15 +10,10 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
   const { t } = useAppTranslation();
 
   const { showAnimations, toggleAnimations } = useContext(Context);
-  const [showFonts, setShowFonts] = useState(false);
 
   const onToggleAnimations = () => {
     toggleAnimations();
   };
-
-  if (showFonts) {
-    return <AppearanceSettings />;
-  }
 
   return (
     <>
@@ -30,7 +24,7 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
         <span>{t("gameOptions.generalSettings.changeLanguage")}</span>
       </Button>
 
-      <Button className="mb-1" onClick={() => setShowFonts(true)}>
+      <Button className="mb-1" onClick={() => onSubMenuClick("appearance")}>
         <span>{t("gameOptions.generalSettings.appearance")}</span>
       </Button>
       <Button className="mb-1" onClick={onToggleAnimations}>

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5060,7 +5060,7 @@ const gameOptions: Record<GameOptions, string> = {
   "gameOptions.generalSettings.changeLanguage": "Change Language",
   "gameOptions.generalSettings.darkMode": "Dark Mode",
   "gameOptions.generalSettings.lightMode": "Light Mode",
-  "gameOptions.generalSettings.appearance": "Appearance Settings",
+  "gameOptions.generalSettings.appearance": "Appearance",
   "gameOptions.generalSettings.font": "Font",
 
   "gameOptions.generalSettings.disableAnimations": "Disable Animations",


### PR DESCRIPTION
# Description

Changed the way the Appearanace Settings is coded, to be in line with the rest of the options. 

This change mainly makes it so that the back arrow from appearance settings will navigate back to general settings, instead of going back to Game Options

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
