### PR TITLE
[CHORE] Fix Mobile UI for Buy button

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -465,7 +465,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Bumpkin Nutcracker": new Decimal(1),
     "Festive Tree": new Decimal(1),
     "Town Center": new Decimal(1),
-    Warehouse: new Decimal(1),
     Market: new Decimal(1),
     Workbench: new Decimal(1),
     "Basic Land": new Decimal(3),
@@ -523,7 +522,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Sunpetal Seed": new Decimal(20),
     "Bloom Seed": new Decimal(10),
     "Lily Seed": new Decimal(5),
-    "Sunflower Seed": new Decimal(1000),
+    "Sunflower Seed": new Decimal(992),
 
     // Foods
     "Pumpkin Soup": new Decimal(1),

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -158,26 +158,26 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
               {t("buy")} {`10`}
             </Button>
           )}
+          {bulkSeedBuyAmount <= 10 && (
+            <Button
+              disabled={lessFunds(bulkSeedBuyAmount)}
+              onClick={() => buy(bulkSeedBuyAmount)}
+            >
+              {t("buy")} {bulkSeedBuyAmount}
+            </Button>
+          )}
         </div>
-        {!!inventory.Warehouse && (
-          <div>
-            {bulkSeedBuyAmount > 1 && (
-              <Button
-                className="mt-1"
-                disabled={lessFunds(bulkSeedBuyAmount)}
-                onClick={() => {
-                  if (bulkSeedBuyAmount <= 10) {
-                    buy(bulkSeedBuyAmount);
-                  } else {
-                    showConfirmBuyModal(true);
-                  }
-                }}
-              >
-                {t("buy")} {bulkSeedBuyAmount}
-              </Button>
-            )}
-          </div>
-        )}
+        <div>
+          {!!inventory.Warehouse && bulkSeedBuyAmount > 10 && (
+            <Button
+              className="mt-1"
+              disabled={lessFunds(bulkSeedBuyAmount)}
+              onClick={() => showConfirmBuyModal(true)}
+            >
+              {t("buy")} {bulkSeedBuyAmount}
+            </Button>
+          )}
+        </div>
         {bulkSeedBuyAmount < stock.toNumber() && (
           <p className="text-xxs text-center mb-1">
             {t("seeds.reachingInventoryLimit")}


### PR DESCRIPTION
# Description

Fixed couple of Mobile UI issues (doesn't change PC UI)
This is caused mainly due to the Buy 10 button disappearing when stock/difference <10

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/4fb8c7af-cdef-47ae-9c6e-d7004e4b780d)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/85d5c16e-3c6f-41b9-9ea8-2ceaeb5df3d4)


Fixes #issue
- Buy 10 button disappears when stock/difference <10 for users without warehouse
- When buy screen has only 2 buttons, Buttons is on top of each other rather than side by side
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
