### PR TITLE
[FIX] Bulk Buy Improvements

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -163,12 +163,14 @@ export const CraftingRequirements: React.FC<Props> = ({
     const { count, limit } = getDetails(gameState, details);
 
     const isInventoryFull =
-      limit === undefined ? false : count.greaterThan(limit);
+      limit === undefined ? false : count.greaterThanOrEqualTo(limit);
 
     return (
       <div className="flex justify-center mt-0 sm:mb-1">
         <Label type={isInventoryFull ? "danger" : "info"}>
-          {`${stock} ${isLimitedItem ? t("left") : t("statements.inStock")}`}
+          {isLimitedItem
+            ? t("stock.left", { stock: stock })
+            : t("stock.inStock", { stock: stock })}
         </Label>
       </div>
     );

--- a/src/features/game/expansion/components/SpecialOffer.tsx
+++ b/src/features/game/expansion/components/SpecialOffer.tsx
@@ -212,9 +212,11 @@ export const PromotingModal: React.FC<Props> = ({
                     <p className="ml-2">{price}</p>
                   </div>
                   <Label type="danger">
-                    {`${secondsToString(secondsLeft, {
-                      length: "medium",
-                    })} left!`}
+                    {t("megaStore.timeRemaining", {
+                      timeRemaining: secondsToString(secondsLeft, {
+                        length: "medium",
+                      }),
+                    })}
                   </Label>
                 </>
               ) : (

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -158,7 +158,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
               {t("buy")} {`10`}
             </Button>
           )}
-          {bulkSeedBuyAmount <= 10 && (
+          {bulkSeedBuyAmount > 1 && bulkSeedBuyAmount <= 10 && (
             <Button
               disabled={lessFunds(bulkSeedBuyAmount)}
               onClick={() => buy(bulkSeedBuyAmount)}
@@ -172,7 +172,13 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
             <Button
               className="mt-1"
               disabled={lessFunds(bulkSeedBuyAmount)}
-              onClick={() => showConfirmBuyModal(true)}
+              onClick={() => {
+                if (price > 0) {
+                  showConfirmBuyModal(true);
+                } else {
+                  buy(bulkSeedBuyAmount);
+                }
+              }}
             >
               {t("buy")} {bulkSeedBuyAmount}
             </Button>

--- a/src/features/world/ui/factions/chores/Chores.tsx
+++ b/src/features/world/ui/factions/chores/Chores.tsx
@@ -122,8 +122,9 @@ export const Chores: React.FC<Props> = ({ chores }) => {
                   {`Upcoming`}
                 </Label>
                 <p className="text-xxs">
-                  {chores.weeklyChores - chores.weeklyChoresCompleted}{" "}
-                  {t("left")}
+                  {t("chores.left", {
+                    chores: chores.weeklyChores - chores.weeklyChoresCompleted,
+                  })}
                 </p>
               </div>
             }

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1038,6 +1038,7 @@ const choresStart: Record<ChoresStart, string> = {
   "chores.newSeason": "新时季就要来临，日常农活暂时停单。",
   "chores.choresFrozen":
     "新时季日常农活即将发单。先前时季的日常农活与进度会被重置。",
+  "chores.left": ENGLISH_TERMS["chores.left"],
 };
 
 const chumDetails: Record<ChumDetails, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -265,7 +265,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   item: "物品：",
   land: "农场",
   "last.updated": "最近更新时间：",
-  left: "剩余", // context is amount of stock left, Megashop time left
   "lets.go": "走吧！",
   limit: "上限", // Megastore error message, Limit: Balance / Limit
   list: "上架",
@@ -2272,6 +2271,8 @@ const gameTerms: Record<GameTerms, string> = {
   "harvest.number": ENGLISH_TERMS["harvest.number"],
   "level.number": ENGLISH_TERMS["level.number"],
   "visiting.farmId": ENGLISH_TERMS["visiting.farmId"],
+  "stock.left": "剩下 {{stock}} 个",
+  "stock.inStock": "库存 {{stock}} 个",
 };
 
 const garbageCollector: Record<GarbageCollector, string> = {
@@ -4074,7 +4075,6 @@ const statements: Record<Statements, string> = {
   "statements.water.well.needed.two":
     "为了支持更多的庄稼，建造更多的 Water Well。",
   "statements.soldOut": "售罄",
-  "statements.inStock": "库存",
   "statements.soldOutWearables": ENGLISH_TERMS["statements.soldOutWearables"],
   "statements.craft.composter": ENGLISH_TERMS["statements.craft.composter"],
   "statements.wallet.to.inventory.transfer":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -284,7 +284,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   item: "Item:",
   land: "Land",
   "last.updated": "Last updated:",
-  left: "Left",
   "lets.go": "Let's Go!",
   limit: "Limit",
   "linked.wallet": "Linked wallet",
@@ -2522,6 +2521,8 @@ const gameTerms: Record<GameTerms, string> = {
   "aoe.locked": "AOE Locked",
   sunflowerLandCodex: "Sunflower Land Codex",
   "visiting.farmId": "Visting #{{farmId}}",
+  "stock.inStock": "{{stock}} in stock",
+  "stock.left": "{{stock}} left",
 };
 
 const garbageCollector: Record<GarbageCollector, string> = {
@@ -4662,7 +4663,6 @@ const statements: Record<Statements, string> = {
   "statements.water.well.needed.two":
     "In order to support more crops, build a well.",
   "statements.soldOut": "Sold out",
-  "statements.inStock": "in stock",
   "statements.soldOutWearables": "View sold out wearables",
   "statements.craft.composter": "Craft at Composter",
   "statements.wallet.to.inventory.transfer": "Deposit items from your wallet",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1109,6 +1109,7 @@ const choresStart: Record<ChoresStart, string> = {
   "chores.noChore": "Sorry, I don't have any chores that need doing right now.",
   "chores.newSeason": "A new season approaches, chores will temporarily close.",
   "chores.choresFrozen": "New seasonal chores will be available soon.",
+  "chores.left": "{{chores}} left",
 };
 
 const chumDetails: Record<ChumDetails, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1143,6 +1143,7 @@ const choresStart: Record<ChoresStart, string> = {
   "chores.newSeason":
     "Une nouvelle saison approche, les tâches seront temporairement fermées.",
   "chores.choresFrozen": ENGLISH_TERMS["chores.choresFrozen"],
+  "chores.left": ENGLISH_TERMS["chores.left"],
 };
 
 const chumDetails: Record<ChumDetails, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -301,7 +301,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   land: "Île",
   "last.updated": "Dernière mise à jour",
   layouts: "Mises en page",
-  left: "Restant",
   "lets.go": "C'est parti!",
   limit: "Limite",
   "linked.wallet": "Portefeuille lié",
@@ -2625,6 +2624,8 @@ const gameTerms: Record<GameTerms, string> = {
   "visiting.farmId": ENGLISH_TERMS["visiting.farmId"],
   "harvest.number": ENGLISH_TERMS["harvest.number"],
   "level.number": ENGLISH_TERMS["level.number"],
+  "stock.left": ENGLISH_TERMS["stock.left"],
+  "stock.inStock": ENGLISH_TERMS["stock.inStock"],
 };
 
 const garbageCollector: Record<GarbageCollector, string> = {
@@ -4758,7 +4759,6 @@ const statements: Record<Statements, string> = {
   "statements.water.well.needed.two":
     "Pour soutenir davantage de cultures, construisez un puits.",
   "statements.soldOut": "Épuisé",
-  "statements.inStock": "En stock",
   "statements.soldOutWearables": "Voir les articles épuisés",
   "statements.craft.composter": "Fabriquez au composteur",
   "statements.wallet.to.inventory.transfer":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1133,6 +1133,7 @@ const choresStart: Record<ChoresStart, string> = {
   "chores.newSeason":
     "Uma nova temporada se aproxima, as tarefas serão temporariamente encerradas.",
   "chores.noChore": "Desculpe, não tenho tarefas para fazer agora.",
+  "chores.left": ENGLISH_TERMS["chores.left"],
 };
 
 const chumDetails: Record<ChumDetails, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -277,7 +277,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   item: "Item",
   land: "Terra",
   "last.updated": "Última atualização",
-  left: "Esquerda",
   "lets.go": "Vamos lá!",
   limit: "Limite",
   list: "Listar",
@@ -2544,6 +2543,8 @@ const gameTerms: Record<GameTerms, string> = {
   "visiting.farmId": ENGLISH_TERMS["visiting.farmId"],
   "harvest.number": ENGLISH_TERMS["harvest.number"],
   "level.number": ENGLISH_TERMS["level.number"],
+  "stock.left": ENGLISH_TERMS["stock.left"],
+  "stock.inStock": ENGLISH_TERMS["stock.inStock"],
 };
 
 const genieLamp: Record<GenieLamp, string> = {
@@ -4605,7 +4606,6 @@ const statements: Record<Statements, string> = {
   "statements.water.well.needed.two":
     "Para suportar mais culturas, construa um poço.",
   "statements.soldOut": "Esgotado",
-  "statements.inStock": "em estoque",
   "statements.soldOutWearables": "Ver wearables esgotados",
   "statements.craft.composter": "Produzir no Composter",
   "statements.wallet.to.inventory.transfer": "Deposite itens de sua carteira",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -283,7 +283,6 @@ const generalTerms: Record<GeneralTerms, string> = {
   item: "Öğe",
   land: "Ada",
   "last.updated": "Son güncelleme:",
-  left: "Çıktı",
   "lets.go": "Hadi Gidelim!",
   limit: "Sınır",
   "linked.wallet": "Bağlantılı Cüzdan",
@@ -2515,6 +2514,8 @@ const gameTerms: Record<GameTerms, string> = {
   "visiting.farmId": ENGLISH_TERMS["visiting.farmId"],
   "harvest.number": ENGLISH_TERMS["harvest.number"],
   "level.number": ENGLISH_TERMS["level.number"],
+  "stock.left": ENGLISH_TERMS["stock.left"],
+  "stock.inStock": ENGLISH_TERMS["stock.inStock"],
 };
 
 const garbageCollector: Record<GarbageCollector, string> = {
@@ -4597,7 +4598,6 @@ const statements: Record<Statements, string> = {
   "statements.water.well.needed.two":
     "Daha fazla mahsulü desteklemek için bir kuyu inşa edin.",
   "statements.soldOut": "Hepsi satıldı",
-  "statements.inStock": "Stokta var",
   "statements.soldOutWearables": "Tükenen giyilebilir ürünleri görüntüle",
   "statements.craft.composter": "Composter'da üret",
   "statements.wallet.to.inventory.transfer": "Cüzdanınızdan eşya yatırma",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1112,6 +1112,7 @@ const choresStart: Record<ChoresStart, string> = {
   "chores.newSeason":
     "Yeni bir sezon yaklaşıyor, işler geçici olarak kapanacak.",
   "chores.choresFrozen": ENGLISH_TERMS["chores.choresFrozen"],
+  "chores.left": ENGLISH_TERMS["chores.left"],
 };
 
 const chumDetails: Record<ChumDetails, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -105,7 +105,6 @@ export type GeneralTerms =
   | "item"
   | "land"
   | "last.updated"
-  | "left"
   | "lets.go"
   | "linked.wallet"
   | "limit"
@@ -1809,7 +1808,9 @@ export type GameTerms =
   | "compost.complete"
   | "aoe.locked"
   | "sunflowerLandCodex"
-  | "visiting.farmId";
+  | "visiting.farmId"
+  | "stock.left"
+  | "stock.inStock";
 
 export type GarbageCollector =
   | "garbageCollector.welcome"
@@ -3114,7 +3115,6 @@ export type Statements =
   | "statements.water.well.needed.one"
   | "statements.water.well.needed.two"
   | "statements.soldOut"
-  | "statements.inStock"
   | "statements.soldOutWearables"
   | "statements.wallet.to.inventory.transfer"
   | "statements.crop.water"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -782,7 +782,8 @@ export type ChoresStart =
   | "chores.helpWithTrees"
   | "chores.noChore"
   | "chores.newSeason"
-  | "chores.choresFrozen";
+  | "chores.choresFrozen"
+  | "chores.left";
 
 export type ChumDetails =
   | "chumDetails.gold"


### PR DESCRIPTION
# Description

Couple of improvement to Bulk Buy:
- [FIX] Label Colour not changing to red when it's just at the inventory limit
- [FEAT] Don't show confirmation message if seeds are free (Kuebiko, Hungry Caterpillar (flower seeds), Sunflower Shield (sunflowers))
- [FIX] Bulk Buy button showing when exactly 1 left (making it 2 `buy 1` buttons in the UI)

Before
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f7852dec-660d-4080-86b1-13e5f80f42bc)

After
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/da4acaf3-4082-4d76-bc6d-e58c4804b8da)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
