### PR TITLE
[CHORE] Change font to default when changing language out from Chinese

### DIFF
--- a/src/features/island/hud/components/settings-menu/general-settings/AppearanceSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/AppearanceSettings.tsx
@@ -8,6 +8,7 @@ import { Font, changeFont } from "lib/utils/fonts";
 export const AppearanceSettings: React.FC = () => {
   const { t } = useAppTranslation();
   const { isDarkMode, toggleDarkMode } = useIsDarkMode();
+  const currentLanguage = localStorage.getItem("language") || "en";
 
   const fonts: Font[] = ["Default", "Bold", "Sans Serif"];
 
@@ -24,7 +25,12 @@ export const AppearanceSettings: React.FC = () => {
         {t("gameOptions.generalSettings.font")}
       </Label>
       {fonts.map((font) => (
-        <Button key={font} className="mb-1" onClick={() => changeFont(font)}>
+        <Button
+          key={font}
+          className="mb-1"
+          disabled={currentLanguage === "zh-CN"}
+          onClick={() => changeFont(font)}
+        >
           <span>{font}</span>
         </Button>
       ))}

--- a/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/LanguageChangeModal.tsx
@@ -31,6 +31,10 @@ export const LanguageSwitcher: React.FC = () => {
     if (languageCode === "zh-CN") {
       changeFont("Sans Serif");
     }
+
+    if (languageCode !== "zh-CN") {
+      changeFont("Default");
+    }
   };
 
   return (

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4395,12 +4395,9 @@ const gameOptions: Record<GameOptions, string> = {
   "gameOptions.logout": "登出",
   "gameOptions.confirmLogout": "您确定要登出吗？",
 
-  "gameOptions.generalSettings.darkMode":
-    ENGLISH_TERMS["gameOptions.generalSettings.darkMode"],
-  "gameOptions.generalSettings.font":
-    ENGLISH_TERMS["gameOptions.generalSettings.font"],
-  "gameOptions.generalSettings.lightMode":
-    ENGLISH_TERMS["gameOptions.generalSettings.lightMode"],
+  "gameOptions.generalSettings.darkMode": "酷黑",
+  "gameOptions.generalSettings.font": "字体",
+  "gameOptions.generalSettings.lightMode": "明亮",
 
   // Testnet
   "gameOptions.amoyActions": ENGLISH_TERMS["gameOptions.amoyActions"], // Testnet
@@ -4427,7 +4424,7 @@ const gameOptions: Record<GameOptions, string> = {
   "gameOptions.plazaSettings": "广场设置",
   "gameOptions.plazaSettings.title.mutedPlayers": "静音玩家",
   "gameOptions.plazaSettings.title.keybinds": "按键绑定",
-  "gameOptions.generalSettings.appearance": "Appearance Settings",
+  "gameOptions.generalSettings.appearance": "外观",
   "gameOptions.plazaSettings.mutedPlayers.description":
     "如果您使用 /mute 命令将某些玩家静音，您可以在此处查看并取消静音。",
   "gameOptions.plazaSettings.keybinds.description":


### PR DESCRIPTION
# Description

- When user changes language from Chinese to another language, change font back to default
- When Language is Chinese, Font buttons are disabled

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
