### PR TITLE
[CHORE] Withdrawal Restrictions for several boost wearables

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -40,7 +40,7 @@ type CanRemoveGreenhouseCropsArgs = {
   game: GameState;
 };
 
-function greenhouseCropIsGrowing({
+export function greenhouseCropIsGrowing({
   crop,
   game,
 }: CanRemoveGreenhouseCropsArgs): Restriction {
@@ -161,7 +161,7 @@ function areAnyGoldsMined(game: GameState): Restriction {
   return [goldMined, translate("restrictionReason.goldMined")];
 }
 
-function areAnyCrimstonessMined(game: GameState): Restriction {
+export function areAnyCrimstonesMined(game: GameState): Restriction {
   const crimstoneMined = Object.values(game.crimstones ?? {}).some(
     (crimstone) => !canMine(crimstone)
   );
@@ -220,7 +220,7 @@ function hasFishedToday(game: GameState): Restriction {
   ];
 }
 
-function areFlowersGrowing(game: GameState): Restriction {
+export function areFlowersGrowing(game: GameState): Restriction {
   const flowerGrowing = Object.values(game.flowers.flowerBeds).some(
     (flowerBed) => {
       const flower = flowerBed.flower;
@@ -246,7 +246,7 @@ function isBeehivesFull(game: GameState): boolean {
   );
 }
 
-function isProducingHoney(game: GameState): Restriction {
+export function isProducingHoney(game: GameState): Restriction {
   return [
     areFlowersGrowing(game)[0] && !isBeehivesFull(game),
     translate("restrictionReason.beesBusy"),
@@ -297,7 +297,7 @@ function hasShakenTree(game: GameState): Restriction {
   return [hasShakenRecently, translate("restrictionReason.festiveSeason")];
 }
 
-function areAnyOilReservesDrilled(game: GameState): Restriction {
+export function areAnyOilReservesDrilled(game: GameState): Restriction {
   const now = Date.now();
 
   const oilReservesDrilled = Object.values(game.oilReserves).some(
@@ -330,7 +330,7 @@ export const REMOVAL_RESTRICTIONS: Partial<
   Rooster: (game) => areAnyChickensFed(game),
   Bale: (game) => areAnyChickensFed(game),
   "Banana Chicken": (game) => areFruitsGrowing(game, "Banana"),
-  "Crim Peckster": (game) => areAnyCrimstonessMined(game),
+  "Crim Peckster": (game) => areAnyCrimstonesMined(game),
 
   // Crop Boosts
   Nancy: (game) => areAnyCropsGrowing(game),

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -2,10 +2,15 @@ import { BumpkinItem } from "./bumpkin";
 import { getDailyFishingCount } from "./fishing";
 import {
   areAnyChickensFed,
+  areAnyCrimstonesMined,
   areAnyCropsGrowing,
   areAnyFruitsGrowing,
+  areAnyOilReservesDrilled,
+  areFlowersGrowing,
   areFruitsGrowing,
   cropIsGrowing,
+  greenhouseCropIsGrowing,
+  isProducingHoney,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -48,11 +53,23 @@ export const canWithdrawBoostedWearable = (
     return !cropIsGrowing({ item: "Corn", game: state })[0];
   }
 
+  if (name === "Tofu Mask") {
+    return !cropIsGrowing({ item: "Soybean", game: state })[0];
+  }
+
+  if (name === "Non La Hat") {
+    return !greenhouseCropIsGrowing({ crop: "Rice", game: state })[0];
+  }
+
+  if (name === "Olive Shield") {
+    return !greenhouseCropIsGrowing({ crop: "Olive", game: state })[0];
+  }
+
   if (name === "Fruit Picker Apron") {
     return !areAnyFruitsGrowing(state)[0];
   }
 
-  if (name === "Banana Amulet") {
+  if (name === "Banana Amulet" || name === "Banana Onesie") {
     return !areFruitsGrowing(state, "Banana")[0];
   }
 
@@ -75,6 +92,26 @@ export const canWithdrawBoostedWearable = (
 
   if (name === "Ancient Rod") {
     return getDailyFishingCount(state) == 0;
+  }
+
+  if (name === "Flower Crown") {
+    return !areFlowersGrowing(state)[0];
+  }
+
+  if (
+    name === "Beekeeper Hat" ||
+    name === "Bee Suit" ||
+    name === "Honeycomb Shield"
+  ) {
+    return !isProducingHoney(state)[0];
+  }
+
+  if (name === "Crimstone Amulet" || name === "Crimstone Armor") {
+    return !areAnyCrimstonesMined(state)[0];
+  }
+
+  if (name === "Oil Can") {
+    return !areAnyOilReservesDrilled(state)[0];
   }
 
   // Safety check

--- a/src/features/game/types/withdrawables.test.ts
+++ b/src/features/game/types/withdrawables.test.ts
@@ -66,7 +66,7 @@ describe("withdrawables", () => {
       const timers = jest.useFakeTimers();
       timers.setSystemTime(new Date("Thu August 7 2023 10:01:00 GMT+1000"));
 
-      const enabled = BUMPKIN_WITHDRAWABLES["Crimstone Amulet"]();
+      const enabled = BUMPKIN_WITHDRAWABLES["Pan"]();
       expect(enabled).toBeFalsy();
     });
 
@@ -74,7 +74,7 @@ describe("withdrawables", () => {
       const timers = jest.useFakeTimers();
       timers.setSystemTime(new Date("Thu July 7 2023 10:01:00 GMT+1000"));
 
-      const enabled = WITHDRAWABLES["Queen Bee"]();
+      const enabled = WITHDRAWABLES["Turbo Sprout"]();
       expect(enabled).toBeFalsy();
     });
 

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1279,7 +1279,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Tiki Pants": () => true,
   "Banana Amulet": (state) =>
     canWithdrawBoostedWearable("Banana Amulet", state),
-  "Banana Onesie": () => true,
+  "Banana Onesie": (state) =>
+    canWithdrawBoostedWearable("Banana Onesie", state),
   "Basic Dumbo": () => false,
   "Companion Cap": () => false,
   "Dazzling Dumbo": () => false,
@@ -1307,24 +1308,32 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   // Spring Blossom
   "Beehive Staff": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
   "Bee Smoker": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Bee Suit": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
+  "Bee Suit": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-03-01")) &&
+    canWithdrawBoostedWearable("Bee Suit", state),
   "Bee Wings": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Beekeeper Hat": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
+  "Beekeeper Hat": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-05-01")) &&
+    canWithdrawBoostedWearable("Beekeeper Hat", state),
   "Beekeeper Suit": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
   "Crimstone Boots": () => false,
   "Crimstone Pants": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
-  "Crimstone Armor": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
+  "Crimstone Armor": (state) =>
+    canWithdrawBoostedWearable("Crimstone Armor", state),
   "Gardening Overalls": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Crimstone Hammer": () => canWithdrawTimebasedItem(new Date("2024-04-13")), // Last Auction 2024/04/12 3pm UTC
-  "Crimstone Amulet": () => canWithdrawTimebasedItem(new Date("2024-04-19")), // Last Auction 2024/04/18 5pm UTC
+  "Crimstone Hammer": () => true,
+  "Crimstone Amulet": (state) =>
+    canWithdrawBoostedWearable("Crimstone Amulet", state),
   "Full Bloom Shirt": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
   "Blue Blossom Shirt": () => canWithdrawTimebasedItem(new Date("2024-03-07")), // Last Auction 2024/03/06 3pm UTC
   "Fairy Sandals": () => false,
   "Daisy Tee": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
   "Propeller Hat": () => canWithdrawTimebasedItem(new Date("2024-04-04")), // Last Auction 2024/04/03 5pm UTC,
-  "Honeycomb Shield": () => canWithdrawTimebasedItem(new Date("2024-04-10")), // Last Auction 2024/04/09 5pm UTC
-  "Hornet Mask": () => canWithdrawTimebasedItem(new Date("2024-04-16")), // Last Auction 2024/04/15 3pm UTC
-  "Flower Crown": () => canWithdrawTimebasedItem(new Date("2024-03-10")), // Last Auction 2024/03/10 3pm UTC
+  "Honeycomb Shield": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-04-10")) &&
+    canWithdrawBoostedWearable("Honeycomb Shield", state),
+  "Hornet Mask": () => canWithdrawTimebasedItem(new Date("2024-04-16")),
+  "Flower Crown": (state) => canWithdrawBoostedWearable("Flower Crown", state),
   "Blue Monarch Dress": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
   "Green Monarch Dress": () => false,
   "Orange Monarch Dress": () =>
@@ -1350,16 +1359,24 @@ export const BUMPKIN_WITHDRAWABLES: Record<
     canWithdrawTimebasedItem(new Date("2023-04-04")),
 
   // Clash of Factions Auction
-  "Non La Hat": () => canWithdrawTimebasedItem(new Date("2024-06-27")), // Last Auction 2024/06/26
-  "Oil Can": () => canWithdrawTimebasedItem(new Date("2024-07-07")), // Last Auction 2024/07/06
-  "Olive Shield": () => canWithdrawTimebasedItem(new Date("2024-07-06")), // Last Auction 2024/07/05
+  "Non La Hat": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-06-27")) &&
+    canWithdrawBoostedWearable("Non La Hat", state), // Last Auction 2024/06/26
+  "Oil Can": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-07-07")) &&
+    canWithdrawBoostedWearable("Oil Can", state), // Last Auction 2024/07/06
+  "Olive Shield": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-07-06")) &&
+    canWithdrawBoostedWearable("Olive Shield", state), // Last Auction 2024/07/05
   "Paw Shield": () => canWithdrawTimebasedItem(new Date("2024-07-24")), // Last Auction 2024/07/23
   Pan: () => canWithdrawTimebasedItem(new Date("2024-07-21")), // Last Auction 2024/07/20
   // Clash of Factions Megastore
   "Royal Robe": () => canWithdrawTimebasedItem(new Date("2024-04-04")),
   Crown: () => canWithdrawTimebasedItem(new Date("2024-04-04")),
   "Soybean Onesie": () => canWithdrawTimebasedItem(new Date("2024-08-01")),
-  "Tofu Mask": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
+  "Tofu Mask": (state) =>
+    canWithdrawTimebasedItem(new Date("2024-07-01")) &&
+    canWithdrawBoostedWearable("Tofu Mask", state),
   "Olive Royalty Shirt": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
   "Royal Scepter": () => false,
 

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -704,10 +704,10 @@ const soldOut: Record<SoldOutCollectibleName, () => boolean> = {
   Anchor: () => true,
   "Rubber Ducky": () => true,
   "Kraken Head": () => true,
-  "Blossom Royale": () => canWithdrawTimebasedItem(new Date("2024-04-25")), // Last Auction 2024/04/24 5pm UTC
-  "Humming Bird": () => canWithdrawTimebasedItem(new Date("2024-04-22")), // Last Auction 2024/04/21 5pm UTC
-  "Hungry Caterpillar": () => canWithdrawTimebasedItem(new Date("2024-03-31")), // Last Auction 2024/03/30 5pm UTC
-  "Queen Bee": () => canWithdrawTimebasedItem(new Date("2024-03-19")), // Last Auction 2024/03/18 5pm UTC
+  "Blossom Royale": () => true,
+  "Humming Bird": () => true,
+  "Hungry Caterpillar": () => true,
+  "Queen Bee": () => true,
   "Turbo Sprout": () => canWithdrawTimebasedItem(new Date("2024-07-12")), // Last Auction 2024/07/11
   Soybliss: () => canWithdrawTimebasedItem(new Date("2024-06-24")), // Last Auction 2024/06/23
   "Grape Granny": () => canWithdrawTimebasedItem(new Date("2024-06-30")), // Last Auction 2024/06/29
@@ -794,9 +794,9 @@ const beachBounty: Record<BeachBountyTreasure, () => boolean> = {
 };
 
 const eventDecoration: Record<EventDecorationName, () => boolean> = {
-  "Hungry Hare": () => canWithdrawTimebasedItem(new Date("2024-04-04")),
+  "Hungry Hare": () => true,
   "Community Egg": () => true,
-  "Baby Panda": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
+  "Baby Panda": () => true,
   Baozi: () => true,
   "Valentine Bear": () => true,
   "Easter Bear": () => true,
@@ -920,18 +920,18 @@ const interiors: Record<InteriorDecorationName, () => boolean> = {
 };
 
 const megastore: Record<MegaStoreCollectibleName, () => boolean> = {
-  Rainbow: () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  Capybara: () => canWithdrawTimebasedItem(new Date("2024-04-01")),
-  "Enchanted Rose": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
-  "Flower Fox": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
-  "Sunrise Bloom Rug": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
-  "Flower Rug": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
-  "Green Field Rug": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Flower Cart": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
-  "Tea Rug": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
-  "Fancy Rug": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  Clock: () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  Vinny: () => canWithdrawTimebasedItem(new Date("2024-05-01")),
+  Rainbow: () => true,
+  Capybara: () => true,
+  "Enchanted Rose": () => true,
+  "Flower Fox": () => true,
+  "Sunrise Bloom Rug": () => true,
+  "Flower Rug": () => true,
+  "Green Field Rug": () => true,
+  "Flower Cart": () => true,
+  "Tea Rug": () => true,
+  "Fancy Rug": () => true,
+  Clock: () => true,
+  Vinny: () => true,
   "Regular Pawn": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
   "Novice Knight": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
   "Golden Garrison": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
@@ -1306,57 +1306,49 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Winter Jacket": () => false,
 
   // Spring Blossom
-  "Beehive Staff": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
-  "Bee Smoker": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Bee Suit": (state) =>
-    canWithdrawTimebasedItem(new Date("2024-03-01")) &&
-    canWithdrawBoostedWearable("Bee Suit", state),
-  "Bee Wings": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
+  "Beehive Staff": () => true,
+  "Bee Smoker": () => true,
+  "Bee Suit": (state) => canWithdrawBoostedWearable("Bee Suit", state),
+  "Bee Wings": () => true,
   "Beekeeper Hat": (state) =>
-    canWithdrawTimebasedItem(new Date("2024-05-01")) &&
     canWithdrawBoostedWearable("Beekeeper Hat", state),
-  "Beekeeper Suit": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
+  "Beekeeper Suit": () => true,
   "Crimstone Boots": () => false,
   "Crimstone Pants": () => canWithdrawTimebasedItem(new Date("2024-07-01")),
   "Crimstone Armor": (state) =>
     canWithdrawBoostedWearable("Crimstone Armor", state),
-  "Gardening Overalls": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
+  "Gardening Overalls": () => true,
   "Crimstone Hammer": () => true,
   "Crimstone Amulet": (state) =>
     canWithdrawBoostedWearable("Crimstone Amulet", state),
-  "Full Bloom Shirt": () => canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Blue Blossom Shirt": () => canWithdrawTimebasedItem(new Date("2024-03-07")), // Last Auction 2024/03/06 3pm UTC
+  "Full Bloom Shirt": () => true,
+  "Blue Blossom Shirt": () => true,
   "Fairy Sandals": () => false,
-  "Daisy Tee": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
-  "Propeller Hat": () => canWithdrawTimebasedItem(new Date("2024-04-04")), // Last Auction 2024/04/03 5pm UTC,
+  "Daisy Tee": () => true,
+  "Propeller Hat": () => true,
   "Honeycomb Shield": (state) =>
-    canWithdrawTimebasedItem(new Date("2024-04-10")) &&
-    canWithdrawBoostedWearable("Honeycomb Shield", state),
-  "Hornet Mask": () => canWithdrawTimebasedItem(new Date("2024-04-16")),
+    canWithdrawBoostedWearable("Honeycomb Shield", state), // Last Auction 2024/04/09 5pm UTC
+  "Hornet Mask": () => true,
   "Flower Crown": (state) => canWithdrawBoostedWearable("Flower Crown", state),
-  "Blue Monarch Dress": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
+  "Blue Monarch Dress": () => true,
   "Green Monarch Dress": () => false,
-  "Orange Monarch Dress": () =>
-    canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Blue Monarch Shirt": () => canWithdrawTimebasedItem(new Date("2024-04-01")),
+  "Orange Monarch Dress": () => true,
+  "Blue Monarch Shirt": () => true,
   "Green Monarch Shirt": () => false,
-  "Orange Monarch Shirt": () =>
-    canWithdrawTimebasedItem(new Date("2024-05-01")),
-  "Queen Bee Crown": () => canWithdrawTimebasedItem(new Date("2024-03-01")),
+  "Orange Monarch Shirt": () => true,
+  "Queen Bee Crown": () => true,
   "Rose Dress": () => false,
   "Blue Rose Dress": () => false,
 
-  "Lucky Red Hat": () => canWithdrawTimebasedItem(new Date("2024-02-14")),
-  "Lucky Red Suit": () => canWithdrawTimebasedItem(new Date("2024-02-14")),
+  "Lucky Red Hat": () => true,
+  "Lucky Red Suit": () => true,
   "Chicken Hat": () => false,
 
-  "Love's Topper": () => canWithdrawTimebasedItem(new Date("2024-02-15")),
-  "Valentine's Field Background": () =>
-    canWithdrawTimebasedItem(new Date("2024-02-15")),
+  "Love's Topper": () => true,
+  "Valentine's Field Background": () => true,
 
-  "Striped Red Shirt": () => canWithdrawTimebasedItem(new Date("2023-04-04")),
-  "Striped Yellow Shirt": () =>
-    canWithdrawTimebasedItem(new Date("2023-04-04")),
+  "Striped Red Shirt": () => true,
+  "Striped Yellow Shirt": () => true,
 
   // Clash of Factions Auction
   "Non La Hat": (state) =>
@@ -1371,8 +1363,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Paw Shield": () => canWithdrawTimebasedItem(new Date("2024-07-24")), // Last Auction 2024/07/23
   Pan: () => canWithdrawTimebasedItem(new Date("2024-07-21")), // Last Auction 2024/07/20
   // Clash of Factions Megastore
-  "Royal Robe": () => canWithdrawTimebasedItem(new Date("2024-04-04")),
-  Crown: () => canWithdrawTimebasedItem(new Date("2024-04-04")),
+  "Royal Robe": () => true,
+  Crown: () => true,
   "Soybean Onesie": () => canWithdrawTimebasedItem(new Date("2024-08-01")),
   "Tofu Mask": (state) =>
     canWithdrawTimebasedItem(new Date("2024-07-01")) &&


### PR DESCRIPTION
# Description

Added removal restrictions for the following wearables:
- Banana Onesie
- Bee Suit
- Beekeeper Hat
- Crimstone Armour
- Crimstone Amulet
- Flower Crown
- Honeycomb Shield
- Non La Hat
- Oil Can
- Olive Shield
- Tofu Mask

Crimstone Hammer and Hornet Mask will be worked on in different PRs
Hornet Mask: #3845 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
