### PR TITLE
[FEAT] Emblem Claim Shortcut

### DIFF
--- a/src/features/island/hud/EmblemAirdropCountdown.tsx
+++ b/src/features/island/hud/EmblemAirdropCountdown.tsx
@@ -11,10 +11,20 @@ import { useSelector } from "@xstate/react";
 import { FACTION_POINT_ICONS } from "features/world/ui/factions/FactionDonationPanel";
 import { MachineState } from "features/game/lib/gameMachine";
 import classNames from "classnames";
-import { hasFeatureAccess } from "lib/flags";
-import { TEST_FARM } from "features/game/lib/constants";
+import { Button } from "components/ui/Button";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { Modal } from "components/ui/Modal";
+import { NPC_WEARABLES } from "lib/npcs";
+import { formatDateTime } from "lib/utils/time";
+import { FACTION_EMBLEM_ICONS } from "features/world/ui/factions/components/ClaimEmblems";
+import { useLocation, useNavigate } from "react-router-dom";
+import { capitalize } from "lib/utils/capitalize";
+import { FACTION_RECRUITERS } from "features/world/ui/factions/JoinFaction";
 
 export const EMBLEM_AIRDROP_DATE = new Date("2024-06-14T00:00:00Z");
+export const EMBLEM_AIRDROP_CLOSES = new Date("2024-07-31T00:00:00Z");
+
+const KINGDOM_ROUTE = "/world/kingdom";
 
 const _faction = (state: MachineState) => state.context.state.faction;
 
@@ -23,68 +33,133 @@ const Countdown: React.FC<{ time: Date; onComplete: () => void }> = ({
   onComplete,
 }) => {
   const start = useCountdown(time.getTime());
-  const { t } = useAppTranslation();
-
-  const { showAnimations, gameService } = useContext(Context);
-  const faction = useSelector(gameService, _faction);
 
   useEffect(() => {
     if (time.getTime() < Date.now()) {
-      if (showAnimations) confetti();
       onComplete();
     }
   }, [start]);
 
-  if (time.getTime() < Date.now()) {
-    return null;
-  }
-
-  return (
-    <div>
-      <div className="h-6 flex justify-center">
-        <Label
-          type="info"
-          icon={SUNNYSIDE.icons.stopwatch}
-          className={classNames("ml-1", { "mr-1": !!faction })}
-          secondaryIcon={
-            faction ? FACTION_POINT_ICONS[faction.name] : undefined
-          }
-        >
-          {t("faction.emblemAirdrop")}
-        </Label>
-        <img
-          src={SUNNYSIDE.icons.close}
-          className="h-5 cursor-pointer ml-2"
-          onClick={onComplete}
-        />
-      </div>
-      <TimerDisplay time={start} />
-    </div>
-  );
+  return <TimerDisplay time={start} />;
 };
 
 export const EmblemAirdropCountdown: React.FC = () => {
-  const [airdropDate, setAirdropDate] = useState<Date>();
+  const { showAnimations, gameService } = useContext(Context);
+  const faction = useSelector(gameService, _faction);
+
+  const [isClosed, setIsClosed] = useState(false);
+  const [showClaimModal, setShowClaimModal] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
+
+  const { t } = useAppTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
-    if (
-      hasFeatureAccess(TEST_FARM, "EMBLEM_COUNTDOWN_TIMER") &&
-      EMBLEM_AIRDROP_DATE.getTime() > Date.now()
-    ) {
-      setAirdropDate(EMBLEM_AIRDROP_DATE);
-    }
-  }, []);
+    if (!showConfetti) return;
 
-  if (!airdropDate) {
-    return null;
-  }
+    if (showAnimations) confetti();
+  }, [showConfetti]);
+
+  const travel = () => {
+    navigate(KINGDOM_ROUTE);
+    setIsClosed(true);
+  };
+
+  const now = Date.now();
+
+  const isKingdom = location.pathname === KINGDOM_ROUTE;
+  const hasEmblemsToClaim = !!faction?.points && !faction?.emblemsClaimedAt;
+  const isCountingDown = EMBLEM_AIRDROP_DATE.getTime() > now;
+  const hasEnded = EMBLEM_AIRDROP_CLOSES.getTime() < now;
+
+  const showClaim = hasEmblemsToClaim || isCountingDown;
+
+  if (isClosed || hasEnded) return null;
+  if (!showClaim) return null;
 
   return (
     <InnerPanel className="flex justify-center" id="emblem-airdrop">
-      <Countdown
-        time={EMBLEM_AIRDROP_DATE}
-        onComplete={() => setAirdropDate(undefined)}
-      />
+      <div>
+        <div className="h-6 flex justify-center">
+          <Label
+            type="info"
+            icon={SUNNYSIDE.icons.stopwatch}
+            className={classNames("ml-1", { "mr-1": !!faction })}
+            secondaryIcon={
+              faction ? FACTION_POINT_ICONS[faction.name] : undefined
+            }
+          >
+            {t("faction.emblemAirdrop")}
+          </Label>
+          <img
+            src={SUNNYSIDE.icons.close}
+            className="h-5 cursor-pointer ml-2"
+            onClick={() => setIsClosed(true)}
+          />
+        </div>
+        {isCountingDown && (
+          <Countdown
+            time={EMBLEM_AIRDROP_DATE}
+            onComplete={() => setShowConfetti(true)}
+          />
+        )}
+        {!isCountingDown && (
+          <Button className="mt-1 p-0" onClick={() => setShowClaimModal(true)}>
+            {t("claim")}
+          </Button>
+        )}
+      </div>
+      {faction && (
+        <Modal show={showClaimModal} onHide={() => setShowClaimModal(false)}>
+          <CloseButtonPanel
+            bumpkinParts={NPC_WEARABLES[FACTION_RECRUITERS[faction.name]]}
+          >
+            <div className="flex justify-between p-1">
+              <Label type="default" className="capitalize">
+                {FACTION_RECRUITERS[faction.name]}
+              </Label>
+              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                {t("faction.emblemAirdrop.closes", {
+                  date: formatDateTime(EMBLEM_AIRDROP_CLOSES.toISOString()),
+                })}
+              </Label>
+            </div>
+            <div className="p-2 text-xs">
+              {t("faction.claimEmblems.visitMe", {
+                recruiterName: capitalize(FACTION_RECRUITERS[faction.name]),
+              })}
+            </div>
+            <div className="flex items-center justify-between py-2 pr-1">
+              <Label
+                className="ml-2"
+                type="success"
+                icon={FACTION_EMBLEM_ICONS[faction.name]}
+              >
+                {t("faction.claimEmblems.emblemsEarned")}
+              </Label>
+
+              <div className="flex items-center">
+                <img
+                  src={FACTION_EMBLEM_ICONS[faction.name]}
+                  className="w-4 h-auto"
+                />
+                <Label type="transparent">{faction.points}</Label>
+              </div>
+            </div>
+            {isKingdom && (
+              <Button onClick={() => setShowClaimModal(false)}>
+                {t("close")}
+              </Button>
+            )}
+            {!isKingdom && (
+              <Button onClick={travel}>
+                {t("faction.claimEmblems.travelNow")}
+              </Button>
+            )}
+          </CloseButtonPanel>
+        </Modal>
+      )}
     </InnerPanel>
   );
 };

--- a/src/features/world/ui/factions/JoinFaction.tsx
+++ b/src/features/world/ui/factions/JoinFaction.tsx
@@ -20,8 +20,12 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { InlineDialogue } from "../TypingMessage";
 import { ClaimEmblems } from "./components/ClaimEmblems";
 import { hasFeatureAccess } from "lib/flags";
+import { NPCName } from "lib/npcs";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { EMBLEM_AIRDROP_CLOSES } from "features/island/hud/EmblemAirdropCountdown";
+import { formatDateTime } from "lib/utils/time";
 
-const RECRUITER_VOICE: Record<FactionName, string> = {
+export const FACTION_RECRUITERS: Record<FactionName, NPCName> = {
   goblins: "graxle",
   bumpkins: "barlow",
   sunflorians: "reginald",
@@ -50,7 +54,7 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
   // Cheap way to memoize this value
   const [emblemsClaimed] = useState(!!joinedFaction?.emblemsClaimedAt);
 
-  const recruiterVoice = useSound(RECRUITER_VOICE[faction] as any);
+  const recruiterVoice = useSound(FACTION_RECRUITERS[faction] as any);
 
   const sameFaction = joinedFaction && joinedFaction.name === faction;
   const hasSFL = gameService.state.context.state.balance.gte(SFL_COST);
@@ -101,12 +105,20 @@ export const JoinFaction: React.FC<Props> = ({ faction, onClose }) => {
     joinedFaction &&
     !emblemsClaimed &&
     !!joinedFaction.points &&
-    hasFeatureAccess(gameService.state.context.state, "CLAIM_EMBLEMS")
+    hasFeatureAccess(gameService.state.context.state, "CLAIM_EMBLEMS") &&
+    EMBLEM_AIRDROP_CLOSES.getTime() > Date.now()
   ) {
     return (
       <div className="flex flex-col">
-        <div className="pt-1">
-          <Label type="default">{capitalize(faction)}</Label>
+        <div className="flex justify-between px-1 pt-1">
+          <Label type="default" className="capitalize">
+            {FACTION_RECRUITERS[faction]}
+          </Label>
+          <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+            {t("faction.emblemAirdrop.closes", {
+              date: formatDateTime(EMBLEM_AIRDROP_CLOSES.toISOString()),
+            })}
+          </Label>
         </div>
         <ClaimEmblems
           faction={joinedFaction}

--- a/src/features/world/ui/factions/components/ClaimEmblems.tsx
+++ b/src/features/world/ui/factions/components/ClaimEmblems.tsx
@@ -23,7 +23,7 @@ import { ShareClaimedEmblems } from "./ShareClaimedEmblems";
 import { fetchLeaderboardData } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import Decimal from "decimal.js-light";
 
-const FACTION_EMBLEM_ICONS: Record<FactionName, string> = {
+export const FACTION_EMBLEM_ICONS: Record<FactionName, string> = {
   goblins: goblinEmblem,
   bumpkins: bumpkinEmblem,
   sunflorians: sunflorianEmblem,

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -36,7 +36,6 @@ export type FeatureName =
   | "DESERT_RECIPES"
   | "KINGDOM"
   | "FACTION_HOUSE"
-  | "EMBLEM_COUNTDOWN_TIMER"
   | "CLAIM_EMBLEMS";
 
 // Used for testing production features
@@ -73,9 +72,6 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
   PRESTIGE_DESERT: defaultFeatureFlag,
   // Just in case we need to disable the crop machine, leave the flag in temporarily
   CROP_MACHINE: () => true,
-  EMBLEM_COUNTDOWN_TIMER: timeBasedFeatureFlag(
-    new Date("2024-06-10T00:00:00Z")
-  ),
   CLAIM_EMBLEMS: timeBasedFeatureFlag(new Date("2024-06-14T00:00:00Z")),
 };
 

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1811,6 +1811,7 @@ const factions: Record<Factions, string> = {
   "faction.points.title": "派系点数",
   "faction.points.pledge.warning": "请效忠一宗派系以获取派系点数！",
   "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
+  "faction.emblemAirdrop.closes": ENGLISH_TERMS["faction.emblemAirdrop.closes"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],
@@ -1852,6 +1853,9 @@ const factions: Record<Factions, string> = {
     ENGLISH_TERMS["faction.claimEmblems.totalEmblems"],
   "faction.claimEmblems.percentile":
     ENGLISH_TERMS["faction.claimEmblems.percentile"],
+  "faction.claimEmblems.travelNow":
+    ENGLISH_TERMS["faction.claimEmblems.travelNow"],
+  "faction.claimEmblems.visitMe": ENGLISH_TERMS["faction.claimEmblems.visitMe"],
 };
 
 const festiveTree: Record<FestiveTree, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1993,7 +1993,7 @@ const factions: Record<Factions, string> = {
   "faction.points.pledge.warning":
     "Pledge a faction to receive faction points!",
   "faction.emblemAirdrop": "Emblem Airdrop",
-  "faction.emblemAirdrop.closes": "Airdrop Ends: {{date}}",
+  "faction.emblemAirdrop.closes": "Ends: {{date}}",
 
   // Kingdom NPCs
   "faction.restrited.area":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1993,6 +1993,7 @@ const factions: Record<Factions, string> = {
   "faction.points.pledge.warning":
     "Pledge a faction to receive faction points!",
   "faction.emblemAirdrop": "Emblem Airdrop",
+  "faction.emblemAirdrop.closes": "Airdrop Ends: {{date}}",
 
   // Kingdom NPCs
   "faction.restrited.area":
@@ -2031,6 +2032,9 @@ const factions: Record<Factions, string> = {
   "faction.claimEmblems.totalMembers": "Total Faction Members",
   "faction.claimEmblems.totalEmblems": "Total Faction Emblems",
   "faction.claimEmblems.percentile": "Top {{percentile}}%",
+  "faction.claimEmblems.travelNow": "Travel Now",
+  "faction.claimEmblems.visitMe":
+    "Visit me, {{recruiterName}}, in the Kingdom to claim your emblems.",
 };
 
 const festiveTree: Record<FestiveTree, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -2071,6 +2071,7 @@ const factions: Record<Factions, string> = {
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
   "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
+  "faction.emblemAirdrop.closes": ENGLISH_TERMS["faction.emblemAirdrop.closes"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],
@@ -2112,6 +2113,9 @@ const factions: Record<Factions, string> = {
     ENGLISH_TERMS["faction.claimEmblems.totalEmblems"],
   "faction.claimEmblems.percentile":
     ENGLISH_TERMS["faction.claimEmblems.percentile"],
+  "faction.claimEmblems.travelNow":
+    ENGLISH_TERMS["faction.claimEmblems.travelNow"],
+  "faction.claimEmblems.visitMe": ENGLISH_TERMS["faction.claimEmblems.visitMe"],
 };
 
 const festiveTree: Record<FestiveTree, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -2016,6 +2016,7 @@ const factions: Record<Factions, string> = {
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
   "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
+  "faction.emblemAirdrop.closes": ENGLISH_TERMS["faction.emblemAirdrop.closes"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],
@@ -2057,6 +2058,9 @@ const factions: Record<Factions, string> = {
     ENGLISH_TERMS["faction.claimEmblems.totalEmblems"],
   "faction.claimEmblems.percentile":
     ENGLISH_TERMS["faction.claimEmblems.percentile"],
+  "faction.claimEmblems.travelNow":
+    ENGLISH_TERMS["faction.claimEmblems.travelNow"],
+  "faction.claimEmblems.visitMe": ENGLISH_TERMS["faction.claimEmblems.visitMe"],
 };
 
 const festiveTree: Record<FestiveTree, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -2000,6 +2000,7 @@ const factions: Record<Factions, string> = {
   "faction.points.pledge.warning":
     ENGLISH_TERMS["faction.points.pledge.warning"],
   "faction.emblemAirdrop": ENGLISH_TERMS["faction.emblemAirdrop"],
+  "faction.emblemAirdrop.closes": ENGLISH_TERMS["faction.emblemAirdrop.closes"],
 
   // Kingdom
   "faction.restrited.area": ENGLISH_TERMS["faction.restrited.area"],
@@ -2040,6 +2041,9 @@ const factions: Record<Factions, string> = {
     ENGLISH_TERMS["faction.claimEmblems.totalEmblems"],
   "faction.claimEmblems.percentile":
     ENGLISH_TERMS["faction.claimEmblems.percentile"],
+  "faction.claimEmblems.travelNow":
+    ENGLISH_TERMS["faction.claimEmblems.travelNow"],
+  "faction.claimEmblems.visitMe": ENGLISH_TERMS["faction.claimEmblems.visitMe"],
 };
 
 const festiveTree: Record<FestiveTree, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1428,6 +1428,7 @@ export type Factions =
   | "faction.points.title"
   | "faction.points.pledge.warning"
   | "faction.emblemAirdrop"
+  | "faction.emblemAirdrop.closes"
   // Kingdom
   | "faction.restrited.area"
   | "faction.not.pledged"
@@ -1453,7 +1454,9 @@ export type Factions =
   | "faction.claimEmblems.comparison"
   | "faction.claimEmblems.totalMembers"
   | "faction.claimEmblems.totalEmblems"
-  | "faction.claimEmblems.percentile";
+  | "faction.claimEmblems.percentile"
+  | "faction.claimEmblems.travelNow"
+  | "faction.claimEmblems.visitMe";
 
 export type FestiveTree =
   | "festivetree.greedyBumpkin"


### PR DESCRIPTION
# Description

Adds a shortcut when the emblem countdown ticks over to allow players to fast travel to the kingdom.

## How to Test

1. Comment out `VITE_API_URL` to access ART_MODE
2. Modify `EMBLEM_AIRDROP_DATE` and `EMBLEM_AIRDROP_CLOSES` in `features/island/hud/EmblemAirdropCountdown.tsx`

```ts
export const EMBLEM_AIRDROP_DATE = new Date(Date.now() + 10000);
```

3. Test the following cases
  - Player has collected emblems and clicks the claim button
  - Player has joined a faction but has no emblems and shortcut disappears
  - Player has not joined a faction and shortcut disappears
  - Claim window has ended

## Shortcut Button

<img width="427" alt="claim0" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/6b8fcc04-a117-49d0-b350-45b70dc73113">
<img width="456" alt="claim1" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/c60e1ae9-ae42-40e4-9058-4edba869b15c">

## Travel Shortcut

<img width="478" alt="claim2" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/691af6f1-f756-4ca5-bda2-def1f2da3b46">


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost (art mode)

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
