### PR TITLE
[FEAT] Delivery onboarding improvements

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -53,8 +53,9 @@ export const Button: React.FC<Props> = ({
   return (
     <button
       className={classnames(
-        "w-full p-1 text-sm object-contain justify-center items-center hover:brightness-90 cursor-pointer flex disabled:opacity-50",
-        className
+        "w-full p-1 text-sm object-contain justify-center items-center hover:brightness-90 cursor-pointer flex disabled:opacity-50 ",
+        className,
+        { "cursor-not-allowed": disabled }
       )}
       type={type}
       disabled={disabled}

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -315,7 +315,7 @@ const INITIAL_EQUIPMENT: BumpkinParts = {
 
 export const INITIAL_BUMPKIN: Bumpkin = {
   equipped: INITIAL_EQUIPMENT as Equipped,
-  experience: 0,
+  experience: 100,
 
   id: 1,
   skills: {},
@@ -342,6 +342,9 @@ export const INITIAL_FARM: GameState = {
     Rug: new Decimal(1),
     Wardrobe: new Decimal(1),
     Shovel: new Decimal(1),
+
+    Sunflower: new Decimal(100),
+    "Pumpkin Soup": new Decimal(100),
   },
   previousInventory: {},
   wardrobe: {},

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -342,9 +342,6 @@ export const INITIAL_FARM: GameState = {
     Rug: new Decimal(1),
     Wardrobe: new Decimal(1),
     Shovel: new Decimal(1),
-
-    Sunflower: new Decimal(100),
-    "Pumpkin Soup": new Decimal(100),
   },
   previousInventory: {},
   wardrobe: {},

--- a/src/features/island/hud/components/codex/CodexButton.tsx
+++ b/src/features/island/hud/components/codex/CodexButton.tsx
@@ -27,7 +27,11 @@ export const CodexButton: React.FC = () => {
   const deliveries = useSelector(gameService, _delivery);
   const level = useSelector(gameService, _level);
 
-  const hasDeliveries = hasNewOrders(deliveries) && level >= 2;
+  const hasDeliveries =
+    // Show if any new orders has popped up (but not for new players)
+    (hasNewOrders(deliveries) && level >= 2) ||
+    // For new players, always show until they fulfill a delivery
+    (level >= 2 && deliveries.fulfilledCount === 0);
 
   const { t } = useAppTranslation();
 

--- a/src/features/world/ui/WorldIntroduction.tsx
+++ b/src/features/world/ui/WorldIntroduction.tsx
@@ -1,30 +1,71 @@
-import React from "react";
+import React, { useContext, useState } from "react";
 import { NPC_WEARABLES } from "lib/npcs";
 import { SpeakingText } from "features/game/components/SpeakingModal";
 import { Panel } from "components/ui/Panel";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Label } from "components/ui/Label";
+import { useActor } from "@xstate/react";
+import { Context } from "features/game/GameProvider";
+import { hasOrderRequirements } from "features/island/delivery/components/Orders";
+import { InlineDialogue } from "./TypingMessage";
+import { Button } from "components/ui/Button";
+import { NPCIcon } from "features/island/bumpkin/components/NPC";
 
 interface Props {
   onClose: () => void;
 }
 
 export const WorldIntroduction: React.FC<Props> = ({ onClose }) => {
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+
+  const [showNPCFind, setShowNPCFind] = useState(false);
+
   const { t } = useAppTranslation();
+
+  const { balance, coins, inventory } = gameState.context.state;
+
+  // Find a delivery that is ready
+  const delivery = gameState.context.state.delivery.orders.find((order) =>
+    hasOrderRequirements({ order, sfl: balance, coins, inventory })
+  );
+
+  if (showNPCFind && delivery) {
+    return (
+      <Panel bumpkinParts={NPC_WEARABLES["pumpkin' pete"]}>
+        <div className="h-40 flex flex-col justify-between">
+          <div className="p-1">
+            <Label type={"default"} className="capitalize mb-1">{`${t(
+              "world.intro.find"
+            )} ${delivery.from}`}</Label>
+            <InlineDialogue
+              message={t("world.intro.findNPC", { name: delivery.from })}
+            />
+            <div className="relative mt-3 mb-2 mr-0.5 -ml-1">
+              <NPCIcon parts={NPC_WEARABLES[delivery.from]} />
+            </div>
+          </div>
+          <Button onClick={onClose}>{t("ok")}</Button>
+        </div>
+      </Panel>
+    );
+  }
 
   return (
     <Panel bumpkinParts={NPC_WEARABLES["pumpkin' pete"]}>
       <div className="h-40 flex flex-col ">
         <Label type={"default"}>{`Pumpkin' Pete`}</Label>
         <SpeakingText
-          onClose={onClose}
+          onClose={delivery ? () => setShowNPCFind(true) : () => onClose()}
           message={[
             {
               text: t("world.intro.one"),
             },
             {
-              text: t("world.intro.two"),
+              text: delivery
+                ? t("world.intro.delivery")
+                : t("world.intro.missingDelivery"),
             },
           ]}
         />

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4366,6 +4366,9 @@ const world: Record<World, string> = {
   "world.home": "家园",
   "world.kingdom": "王国",
   "world.woodlands": "林地",
+  "world.travelTo": ENGLISH_TERMS["world.travelTo"],
+  "world.plazaShort": ENGLISH_TERMS["world.plazaShort"],
+  "world.retreatShort": ENGLISH_TERMS["world.retreatShort"],
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4345,7 +4345,10 @@ const withdraw: Record<Withdraw, string> = {
 const world: Record<World, string> = {
   "world.intro.one": "你好，旅行者！欢迎来到南瓜广场。",
   "world.intro.two": "广场上住着一群饥饿的乡巴佬和妖精，他们需要你的帮助！",
-  "world.intro.three": "踏上旅程之前，请注意以下几点：",
+  "world.intro.delivery": ENGLISH_TERMS["world.intro.delivery"],
+  "world.intro.find": ENGLISH_TERMS["world.intro.find"],
+  "world.intro.findNPC": ENGLISH_TERMS["world.intro.findNPC"],
+  "world.intro.missingDelivery": ENGLISH_TERMS["world.intro.missingDelivery"],
   "world.intro.visit":
     "与非玩家角色进行互动并成功完成运送任务以获取 SFL 和特殊奖励。",
   "world.intro.craft": "在不同的商店制作稀有的收藏品、可穿戴物品和装饰品。",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4996,6 +4996,9 @@ const world: Record<World, string> = {
   "world.retreat": "Retreat",
   "world.home": "Home",
   "world.kingdom": "Kingdom",
+  "world.travelTo": "Travel to",
+  "world.plazaShort": "Plaza",
+  "world.retreatShort": "Retreat",
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4973,7 +4973,12 @@ const world: Record<World, string> = {
     "Howdy Bumpkin, welcome to the Pumpkin Plaza. Here Bumpkins from far and wide come together to trade, complete deliveries and play mini-games.",
   "world.intro.two":
     "Explore the Plaza and find Bumpkins who are waiting for your deliveries. In exchange, they will give you rewards!",
-  "world.intro.three": "A few quick hints before you begin your adventure:",
+  "world.intro.missingDelivery":
+    "Hmmm, it looks like you haven't gathered resources for a delivery yet. You can still explore in the meantime.",
+  "world.intro.delivery":
+    "Oh great, it looks like you've got the resources for a delivery!",
+  "world.intro.findNPC": "Explore the plaza and find {{name}}.",
+  "world.intro.find": "Find",
   "world.intro.visit":
     "Visit NPCs and complete deliveries to earn SFL, Coins and rare rewards.",
   "world.intro.craft":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5087,8 +5087,10 @@ const world: Record<World, string> = {
     "Salut Bumpkin, bienvenue au Pumpkin Plaza. Ici, des Bumpkins du monde entier se réunissent pour échanger, effectuer des livraisons et jouer à des mini-jeux.",
   "world.intro.two":
     "Explorez la Plaza et trouvez des Bumpkins qui attendent vos livraisons. En échange, ils vous donneront des récompenses !",
-  "world.intro.three":
-    "Quelques indices rapides avant de commencer votre aventure :",
+  "world.intro.delivery": ENGLISH_TERMS["world.intro.delivery"],
+  "world.intro.find": ENGLISH_TERMS["world.intro.find"],
+  "world.intro.findNPC": ENGLISH_TERMS["world.intro.findNPC"],
+  "world.intro.missingDelivery": ENGLISH_TERMS["world.intro.missingDelivery"],
   "world.intro.visit":
     "Visitez les PNJ et accomplissez des livraisons pour gagner des SFL, Coins et des récompenses rares.",
   "world.intro.craft":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5112,6 +5112,9 @@ const world: Record<World, string> = {
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": "Home",
   "world.kingdom": "Kingdom",
+  "world.travelTo": ENGLISH_TERMS["world.travelTo"],
+  "world.plazaShort": ENGLISH_TERMS["world.plazaShort"],
+  "world.retreatShort": ENGLISH_TERMS["world.retreatShort"],
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4945,6 +4945,9 @@ const world: Record<World, string> = {
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.travelTo": ENGLISH_TERMS["world.travelTo"],
+  "world.plazaShort": ENGLISH_TERMS["world.plazaShort"],
+  "world.retreatShort": ENGLISH_TERMS["world.retreatShort"],
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4922,7 +4922,10 @@ const world: Record<World, string> = {
   "world.intro.one": "Olá Viajante! Bem-vindo à Pumpkin Plaza!",
   "world.intro.two":
     "A praça é lar de um grupo diversificado de Bumpkins e Goblins famintos que precisam da sua ajuda!",
-  "world.intro.three": "Algumas dicas rápidas antes de começar sua aventura:",
+  "world.intro.delivery": ENGLISH_TERMS["world.intro.delivery"],
+  "world.intro.find": ENGLISH_TERMS["world.intro.find"],
+  "world.intro.findNPC": ENGLISH_TERMS["world.intro.findNPC"],
+  "world.intro.missingDelivery": ENGLISH_TERMS["world.intro.missingDelivery"],
   "world.intro.visit":
     "Visite NPCs e complete entregas para ganhar SFL, Coins e recompensas raras.",
   "world.intro.craft":

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4917,7 +4917,10 @@ const world: Record<World, string> = {
   "world.intro.one": "Merhaba Gezgin! Balkabağı Plazasına hoş geldiniz.",
   "world.intro.two":
     "Plaza, yardımınıza ihtiyacı olan çok çeşitli aç Bumpkins ve Goblinlere ev sahipliği yapıyor!",
-  "world.intro.three": "Maceranıza başlamadan önce birkaç kısa ipucu:",
+  "world.intro.delivery": ENGLISH_TERMS["world.intro.delivery"],
+  "world.intro.find": ENGLISH_TERMS["world.intro.find"],
+  "world.intro.findNPC": ENGLISH_TERMS["world.intro.findNPC"],
+  "world.intro.missingDelivery": ENGLISH_TERMS["world.intro.missingDelivery"],
   "world.intro.visit":
     "NPC'leri ziyaret edin ve teslimatları tamamlayarak SFL, Coins ve nadir ödüller kazanın.",
   "world.intro.craft":

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4941,6 +4941,9 @@ const world: Record<World, string> = {
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.travelTo": ENGLISH_TERMS["world.travelTo"],
+  "world.plazaShort": ENGLISH_TERMS["world.plazaShort"],
+  "world.retreatShort": ENGLISH_TERMS["world.retreatShort"],
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3346,7 +3346,10 @@ export type World =
   | "world.retreat"
   | "world.woodlands"
   | "world.home"
-  | "world.kingdom";
+  | "world.kingdom"
+  | "world.retreatShort"
+  | "world.plazaShort"
+  | "world.travelTo";
 
 export type Event =
   | "event.christmas"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3331,7 +3331,10 @@ export type WornDescription =
 export type World =
   | "world.intro.one"
   | "world.intro.two"
-  | "world.intro.three"
+  | "world.intro.missingDelivery"
+  | "world.intro.delivery"
+  | "world.intro.findNPC"
+  | "world.intro.find"
   | "world.intro.visit"
   | "world.intro.craft"
   | "world.intro.carf.limited"


### PR DESCRIPTION
# Description

This PR include FE improvements to deliveries:

- Always show the "Deliveries" codex indicator until a delivery is fulfilled
- Include a "Travel to" button in the codex
- Show upcoming 'locked' delivery NPC
- Improve Plaza introduction message
- Lock other areas on world map