### PR TITLE
[FIX] Add Close Button to Bumpkin Equip Modals

### DIFF
--- a/src/features/home/components/InteriorBumpkins.tsx
+++ b/src/features/home/components/InteriorBumpkins.tsx
@@ -114,7 +114,16 @@ export const InteriorBumpkins: React.FC<Props> = ({ game }) => {
         onHide={() => setShowBumpkinModal(false)}
         size="lg"
       >
-        <CloseButtonPanel bumpkinParts={game.bumpkin?.equipped}>
+        <CloseButtonPanel
+          bumpkinParts={game.bumpkin?.equipped}
+          onClose={() => setShowBumpkinModal(false)}
+          tabs={[
+            {
+              icon: SUNNYSIDE.icons.wardrobe,
+              name: t("equip"),
+            },
+          ]}
+        >
           <BumpkinEquip
             game={game}
             equipment={game.bumpkin?.equipped as BumpkinParts}
@@ -134,6 +143,13 @@ export const InteriorBumpkins: React.FC<Props> = ({ game }) => {
       >
         <CloseButtonPanel
           bumpkinParts={farmHands[selectedFarmHandId as string]?.equipped}
+          onClose={() => setSelectedFarmHandId(undefined)}
+          tabs={[
+            {
+              icon: SUNNYSIDE.icons.wardrobe,
+              name: t("equip"),
+            },
+          ]}
         >
           <BumpkinEquip
             game={game}

--- a/src/features/island/buildings/components/building/house/HomeBumpkins.tsx
+++ b/src/features/island/buildings/components/building/house/HomeBumpkins.tsx
@@ -8,6 +8,8 @@ import { getKeys } from "features/game/types/craftables";
 import { BumpkinEquip } from "features/bumpkins/components/BumpkinEquip";
 import { Context } from "features/game/GameProvider";
 import { PlayerNPC } from "features/island/bumpkin/components/PlayerNPC";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 interface Props {
   game: GameState;
@@ -20,6 +22,8 @@ export const HomeBumpkins: React.FC<Props> = ({ game }) => {
   const bumpkin = game.bumpkin as Bumpkin;
 
   const farmHands = game.farmHands.bumpkins;
+
+  const { t } = useAppTranslation();
 
   return (
     <>
@@ -50,6 +54,13 @@ export const HomeBumpkins: React.FC<Props> = ({ game }) => {
       >
         <CloseButtonPanel
           bumpkinParts={farmHands[selectedFarmHandId as string]?.equipped}
+          onClose={() => setSelectedFarmHandId(undefined)}
+          tabs={[
+            {
+              icon: SUNNYSIDE.icons.wardrobe,
+              name: t("equip"),
+            },
+          ]}
         >
           <BumpkinEquip
             game={game}


### PR DESCRIPTION
# Description

Add a Close Button at the top of the modal. This is mainly for smaller screens where the modal takes up the whole screen and it's hard to tap outside the modal to close it.

| Before |
| --- |
| ![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/8188100f-08a8-47d6-b961-421cd0648950) |
| After |
| ![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/3ef904df-f652-4030-9a3a-7c9062d952d9) |
| Mobile |
| ![Screenshot_20240611_212927_Brave](https://github.com/sunflower-land/sunflower-land/assets/101262042/e85d66ab-4cf4-4ec3-a863-ca5f30463e6b) |





Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
