### PR TITLE
[FIX] Add Composters to Removeables

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -430,6 +430,9 @@ export const REMOVAL_RESTRICTIONS: Partial<
 
   // Buildings
   "Crop Machine": (game) => hasSeedsCropsInMachine(game),
+  "Compost Bin": (game) => areAnyCropsGrowing(game),
+  "Turbo Composter": (game) => areAnyCropsGrowing(game),
+  "Premium Composter": (game) => areAnyCropsGrowing(game),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<


### PR DESCRIPTION
# Description

Adds Composters to `removeables` in order to correctly display remove requirement label.

![growing](https://github.com/sunflower-land/sunflower-land/assets/41215134/9b0f8409-bf5d-4628-9b5a-60674ac722df)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
