### PR TITLE
[FIX] Building shifting issues when going into edit mode

### DIFF
--- a/src/features/island/buildings/components/building/BuildingComponents.tsx
+++ b/src/features/island/buildings/components/building/BuildingComponents.tsx
@@ -223,18 +223,20 @@ export const READONLY_BUILDINGS: (
   "Hen House": () => (
     <img
       src={HEN_HOUSE_VARIANTS[island]}
-      className="absolute"
-      style={{ width: `${PIXEL_SCALE * 61}px`, bottom: 0 }}
+      className="absolute bottom-0"
+      style={{
+        width: `${PIXEL_SCALE * 61}px`,
+        left: `${PIXEL_SCALE * 1}px`,
+      }}
     />
   ),
   "Town Center": () => (
     <img
       src={ITEM_DETAILS["Town Center"].image}
-      className="relative"
+      className="absolute bottom-0"
       style={{
         width: `${PIXEL_SCALE * 62}px`,
-        left: `${PIXEL_SCALE * 2}px`,
-        bottom: `${PIXEL_SCALE * 11}px`,
+        left: `${PIXEL_SCALE * 1}px`,
       }}
     />
   ),
@@ -286,7 +288,7 @@ export const READONLY_BUILDINGS: (
       style={{
         width: `${PIXEL_SCALE * 27}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
-        left: `${PIXEL_SCALE * 2}px`,
+        left: `${PIXEL_SCALE * 3}px`,
       }}
     >
       <img

--- a/src/features/island/buildings/components/building/composters/Composter.tsx
+++ b/src/features/island/buildings/components/building/composters/Composter.tsx
@@ -82,7 +82,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
     <>
       <BuildingImageWrapper name={name} onClick={handleClick} ready={ready}>
         <div
-          className="absolute cursor-pointer hover:img-highlight"
+          className="absolute pointer-events-none"
           style={{
             width: `${PIXEL_SCALE * width}px`,
             bottom: `${PIXEL_SCALE * 0}px`,
@@ -93,7 +93,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
             style={{
               width: `${PIXEL_SCALE * width}px`,
               bottom: `${PIXEL_SCALE * 0}px`,
-              left: `${PIXEL_SCALE * ((32 - width) / 2)}px`,
+              left: `${PIXEL_SCALE * Math.round((32 - width) / 2)}px`,
             }}
             className="absolute"
             alt={name}

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -36,6 +36,8 @@ import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { OuterPanel } from "components/ui/Panel";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { setImageWidth } from "lib/images";
+import { Loading } from "features/auth/components";
 
 const WORM_OUTPUT: Record<ComposterName, string> = {
   "Compost Bin": "2-4",
@@ -347,12 +349,16 @@ export const ComposterModal: React.FC<Props> = ({
     if (getKeys(requires).length === 0) {
       return (
         <>
-          <div className="flex p-2 -mt-2">
+          <div className="flex p-2 -mt-2 items-center">
             <img
               src={COMPOSTER_IMAGES[composterName].ready}
-              className="w-14 object-contain mr-2"
+              className="object-contain mr-2"
+              onLoad={(e) => setImageWidth(e.currentTarget)}
+              style={{
+                opacity: 0,
+              }}
             />
-            <span className="mt-2 text-sm loading">{t("loading")}</span>
+            <Loading text={t("loading")} />
           </div>
         </>
       );

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -45,7 +45,6 @@ export const ChickenHouse: React.FC<BuildingProps> = ({
           className="absolute bottom-0 pointer-events-none"
           style={{
             width: `${PIXEL_SCALE * 61}px`,
-            height: `${PIXEL_SCALE * 49}px`,
             left: `${PIXEL_SCALE * 1}px`,
           }}
         />

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -79,7 +79,6 @@ export const Market: React.FC<BuildingProps> = ({
           className="absolute bottom-0 pointer-events-none"
           style={{
             width: `${PIXEL_SCALE * 48}px`,
-            height: `${PIXEL_SCALE * 38}px`,
           }}
         />
 

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -147,7 +147,7 @@ const LandscapingHudComponent: React.FC<{
                 style={{
                   width: `${PIXEL_SCALE * 22}px`,
                   height: `${PIXEL_SCALE * 22}px`,
-                  marginBottom: `${PIXEL_SCALE * 4}px`,
+                  marginBottom: `${PIXEL_SCALE * 5}px`,
                 }}
               >
                 <img
@@ -161,9 +161,9 @@ const LandscapingHudComponent: React.FC<{
                   src={SUNNYSIDE.icons.cancel}
                   className="absolute"
                   style={{
-                    top: `${PIXEL_SCALE * 5}px`,
-                    left: `${PIXEL_SCALE * 5}px`,
-                    width: `${PIXEL_SCALE * 12}px`,
+                    top: `${PIXEL_SCALE * 5.5}px`,
+                    left: `${PIXEL_SCALE * 5.5}px`,
+                    width: `${PIXEL_SCALE * 11}px`,
                   }}
                 />
               </div>
@@ -177,7 +177,7 @@ const LandscapingHudComponent: React.FC<{
                   style={{
                     width: `${PIXEL_SCALE * 22}px`,
                     height: `${PIXEL_SCALE * 22}px`,
-                    marginBottom: `${PIXEL_SCALE * 4}px`,
+                    marginBottom: `${PIXEL_SCALE * 5}px`,
                   }}
                 >
                   <img
@@ -346,7 +346,12 @@ const Chest: React.FC<{
         />
         <Label
           type="default"
-          className="px-0.5 text-xxs absolute -top-2 -right-2"
+          className="text-xxs absolute -top-1.5 -right-0.5"
+          style={{
+            paddingLeft: "2.5px",
+            paddingRight: "1.5px",
+            height: "24px",
+          }}
         >
           {getKeys(chestItems).reduce(
             (acc, key) => acc + (chestItems[key]?.toNumber() ?? 0),


### PR DESCRIPTION
# Description

- Fix issue where the position of some buildings are shifted when entering build/edit mode

![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/7cf87bc2-4481-4fef-85ab-887bd00b5414)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Place all buildings on island, then toggle between play and build/edit mode

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
