### PR TITLE
[CHORE] Standardize confirmation modal button placements

### DIFF
--- a/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/HeliosBlacksmithItems.tsx
@@ -135,14 +135,14 @@ export const HeliosBlacksmithItems: React.FC = () => {
                       </span>
                     </div>
                     <div className="flex justify-content-around mt-2 space-x-1">
+                      <Button onClick={closeConfirmationModal}>
+                        {t("cancel")}
+                      </Button>
                       <Button
                         disabled={lessIngredients() || isNotReady(selectedItem)}
                         onClick={handleBuy}
                       >
                         {t("craft")}
-                      </Button>
-                      <Button onClick={closeConfirmationModal}>
-                        {t("cancel")}
                       </Button>
                     </div>
                   </CloseButtonPanel>

--- a/src/features/helios/components/decorations/component/DecorationItems.tsx
+++ b/src/features/helios/components/decorations/component/DecorationItems.tsx
@@ -129,14 +129,14 @@ export const DecorationItems: React.FC<Props> = ({ items }) => {
                     </span>
                   </div>
                   <div className="flex justify-content-around mt-2 space-x-1">
+                    <Button onClick={closeConfirmationModal}>
+                      {t("cancel")}
+                    </Button>
                     <Button
                       disabled={lessFunds() || lessIngredients()}
                       onClick={handleBuy}
                     >
                       {t("buy")}
-                    </Button>
-                    <Button onClick={closeConfirmationModal}>
-                      {t("cancel")}
                     </Button>
                   </div>
                 </CloseButtonPanel>

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -302,6 +302,9 @@ export const ComposterModal: React.FC<Props> = ({
                       </span>
                     </div>
                     <div className="flex justify-content-around mt-2 space-x-1">
+                      <Button onClick={() => showConfirmBoostModal(false)}>
+                        {t("cancel")}
+                      </Button>
                       <Button
                         disabled={
                           !state.inventory.Egg?.gte(
@@ -311,9 +314,6 @@ export const ComposterModal: React.FC<Props> = ({
                         onClick={applyBoost}
                       >
                         {t("guide.compost.addEggs")}
-                      </Button>
-                      <Button onClick={() => showConfirmBoostModal(false)}>
-                        {t("cancel")}
                       </Button>
                     </div>
                   </CloseButtonPanel>

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -201,6 +201,9 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
               </span>
             </div>
             <div className="flex justify-content-around mt-2 space-x-1">
+              <Button onClick={() => showConfirmBuyModal(false)}>
+                {t("cancel")}
+              </Button>
               <Button
                 onClick={() => {
                   buy(bulkSeedBuyAmount);
@@ -208,9 +211,6 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
                 }}
               >
                 {t("buy")} {bulkSeedBuyAmount}
-              </Button>
-              <Button onClick={() => showConfirmBuyModal(false)}>
-                {t("cancel")}
               </Button>
             </div>
           </Panel>

--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -207,10 +207,10 @@ const GameOptions: React.FC<ContentComponentProps> = ({
             </span>
           </div>
           <div className="flex justify-content-around mt-2 space-x-1">
-            <Button onClick={onLogout}>{t("gameOptions.logout")}</Button>
             <Button onClick={() => showConfirmLogoutModal(false)}>
               {t("cancel")}
             </Button>
+            <Button onClick={onLogout}>{t("gameOptions.logout")}</Button>
           </div>
         </CloseButtonPanel>
       </Modal>

--- a/src/features/world/ui/stylist/StylistWearables.tsx
+++ b/src/features/world/ui/stylist/StylistWearables.tsx
@@ -144,6 +144,7 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
               </span>
             </div>
             <div className="flex justify-content-around mt-2 space-x-1">
+              <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
               <Button
                 disabled={
                   isNotReady(selected, state) ||
@@ -154,7 +155,6 @@ export const StylistWearables: React.FC<Props> = ({ wearables }) => {
               >
                 {t("buy")}
               </Button>
-              <Button onClick={closeConfirmationModal}>{t("cancel")}</Button>
             </div>
           </CloseButtonPanel>
         </Modal>


### PR DESCRIPTION
# Description

- Make sure the confirm / yes / action button is on the right, and the no / back / cancel button is on the left for confirmation dialogs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- check various confirmation dialogs

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
