### PR TITLE
[FEAT] Update Faction Leaderboard to Emblems

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -9,7 +9,6 @@ import {
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { SEASONS, getSeasonalTicket } from "features/game/types/seasons";
 import { Quest } from "features/game/types/game";
-import { FACTION_POINT_CUTOFF } from "./donateToFaction";
 
 const LAST_DAY_OF_SEASON = new Date("2023-10-31T16:00:00Z").getTime();
 const MID_SEASON = new Date("2023-08-15T15:00:00Z").getTime();
@@ -653,7 +652,7 @@ describe("deliver", () => {
         id: "123",
         type: "order.delivered",
       },
-      createdAt: new Date(FACTION_POINT_CUTOFF.getTime() + 1).getTime(),
+      createdAt: new Date().getTime(),
     });
 
     expect(state.faction?.points).toBe(0);

--- a/src/features/game/expansion/components/leaderboard/FactionTicketTable.tsx
+++ b/src/features/game/expansion/components/leaderboard/FactionTicketTable.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import classNames from "classnames";
+import { RankData } from "./actions/leaderboard";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { FACTION_EMBLEM_ICONS } from "features/world/ui/factions/components/ClaimEmblems";
+import { RANKS } from "features/world/ui/factions/emblemTrading/Emblems";
+import { FactionName } from "features/game/types/game";
+
+interface Props {
+  rankings: RankData[];
+  showHeader?: boolean;
+  id: string;
+  factionName: FactionName;
+}
+
+export const FactionTicketsTable: React.FC<Props> = ({
+  rankings,
+  id: playerId,
+  factionName: faction,
+  showHeader = true,
+}) => {
+  const { t } = useAppTranslation();
+
+  return (
+    <table className="w-full text-xs table-fixed border-collapse">
+      {showHeader && (
+        <thead>
+          <tr>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/5">
+              <p>{t("rank")}</p>
+            </th>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5">
+              <p>{t("player")}</p>
+            </th>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/5">
+              <p>{t("total")}</p>
+            </th>
+          </tr>
+        </thead>
+      )}
+      <tbody>
+        {rankings.map(({ id, count, rank }, index) => {
+          const playerRank = [...RANKS[faction]]
+            .reverse()
+            .find((r) => count >= r.emblemsRequired);
+
+          return (
+            <tr
+              key={index}
+              className={classNames({ "bg-[#ead4aa]": id === playerId })}
+            >
+              <td style={{ border: "1px solid #b96f50" }} className="p-1">
+                {rank ?? index + 1}
+              </td>
+              <td style={{ border: "1px solid #b96f50" }} className="truncate">
+                <div className="flex items-center">
+                  {playerRank && <img src={playerRank.icon} className="mx-2" />}
+                  <p className="p-1">{id}</p>
+                </div>
+              </td>
+              <td style={{ border: "1px solid #b96f50" }}>
+                <div>
+                  <div className="flex items-center p-1">
+                    <span>{count}</span>
+                    <img src={FACTION_EMBLEM_ICONS[faction]} className="h-4" />
+                  </div>
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
@@ -44,11 +44,19 @@ export type FactionLeaderboard = {
 };
 
 export type KingdomLeaderboard = {
-  topTens: Record<FactionName, RankData[]>;
-  totalMembers: Record<FactionName, number>;
-  totalTickets: Record<FactionName, number>;
+  emblems: {
+    topTens: Record<FactionName, RankData[]>;
+    totalMembers: Record<FactionName, number>;
+    totalTickets: Record<FactionName, number>;
+    emblemRankingData?: RankData[] | null;
+  };
+  marks: {
+    topTens: Record<FactionName, RankData[]>;
+    totalMembers: Record<FactionName, number>;
+    totalTickets: Record<FactionName, number>;
+    marksRankingData?: RankData[] | null;
+  };
   lastUpdated: number;
-  farmRankingDetails?: RankData[] | null;
 };
 
 export async function getLeaderboard<T>({

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -248,7 +248,8 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
                   id={id}
                   faction={state.faction.name}
                   isLoading={data === undefined}
-                  data={data?.factions ?? null}
+                  data={data?.kingdom.emblems ?? null}
+                  lastUpdated={data?.kingdom.lastUpdated ?? null}
                 />
               </InnerPanel>
             )}

--- a/src/features/island/hud/components/codex/pages/FactionsLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/FactionsLeaderboard.tsx
@@ -4,8 +4,7 @@ import classNames from "classnames";
 import { Label } from "components/ui/Label";
 import { ButtonPanel } from "components/ui/Panel";
 import { Loading } from "features/auth/components";
-import { TicketTable } from "features/game/expansion/components/leaderboard/TicketTable";
-import { FactionLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import { KingdomLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getRelativeTime } from "lib/utils/time";
@@ -25,8 +24,9 @@ import shadow from "assets/npcs/shadow.png";
 import { Button } from "components/ui/Button";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { formatNumber } from "lib/utils/formatNumber";
-import { FACTION_POINT_ICONS } from "features/world/ui/factions/FactionDonationPanel";
 import { useSound } from "lib/utils/hooks/useSound";
+import { FACTION_EMBLEM_ICONS } from "features/world/ui/factions/components/ClaimEmblems";
+import { FactionTicketsTable } from "features/game/expansion/components/leaderboard/FactionTicketTable";
 
 const POSITION_LABELS = ["1st", "2nd", "3rd", "4th"];
 
@@ -34,7 +34,8 @@ interface LeaderboardProps {
   id: string;
   faction: FactionName;
   isLoading: boolean;
-  data: FactionLeaderboard | null;
+  data: KingdomLeaderboard["emblems"] | null;
+  lastUpdated: number | null;
 }
 
 export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
@@ -42,6 +43,7 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
   faction,
   isLoading,
   data,
+  lastUpdated,
 }) => {
   const { t } = useAppTranslation();
 
@@ -78,7 +80,7 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
     .sort((a, b) => b[1] - a[1])
     .map(([key], i) => [key, POSITION_LABELS[i]]);
 
-  const showLabel = !isMobile || mobileFullScreen || data.farmRankingDetails;
+  const showLabel = !isMobile || mobileFullScreen || data.emblemRankingData;
 
   return (
     <>
@@ -116,9 +118,11 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
               -1
             )} ${t("leaderboard.leaderboard")}`}</Label>
           </div>
-          <p className="font-secondary text-xs">
-            {t("last.updated")} {getRelativeTime(data.lastUpdated)}
-          </p>
+          {lastUpdated && (
+            <p className="font-secondary text-xs">
+              {t("last.updated")} {getRelativeTime(lastUpdated)}
+            </p>
+          )}
         </div>
       ) : (
         <div className="p-1 pt-2">
@@ -128,15 +132,16 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
 
       {(!isMobile || mobileFullScreen) && (
         <div className="scrollable overflow-y-auto max-h-full p-1">
-          {selected === faction && data.farmRankingDetails && (
+          {selected === faction && data.emblemRankingData && (
             <div className="mb-3">
               <Label type="info" className="my-2">
                 {t("leaderboard.yourPosition")}
               </Label>
-              <TicketTable
+              <FactionTicketsTable
                 showHeader={true}
-                rankings={data.farmRankingDetails}
+                rankings={data.emblemRankingData}
                 id={id}
+                factionName={selected}
               />
             </div>
           )}
@@ -146,7 +151,11 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
               <Label type="info" className="my-2">
                 {t("leaderboard.topTen")}
               </Label>
-              <TicketTable rankings={topTen} id={id} />
+              <FactionTicketsTable
+                rankings={topTen}
+                id={id}
+                factionName={selected}
+              />
             </>
           )}
           <div className="flex justify-end">
@@ -161,11 +170,12 @@ export const FactionsLeaderboard: React.FC<LeaderboardProps> = ({
 
       {isMobile && !mobileFullScreen && (
         <>
-          {data.farmRankingDetails && (
-            <TicketTable
+          {data.emblemRankingData && (
+            <FactionTicketsTable
               showHeader={true}
-              rankings={data.farmRankingDetails}
+              rankings={data.emblemRankingData}
               id={id}
+              factionName={selected}
             />
           )}
           <div className="flex flex-col h-full justify-end">
@@ -232,7 +242,7 @@ const Faction: React.FC<FactionProps> = ({
                 </div>
                 <div className="flex pt-2">
                   <img
-                    src={FACTION_POINT_ICONS[name]}
+                    src={FACTION_EMBLEM_ICONS[name]}
                     className="w-4 h-4 inline-block mx-1"
                   />
                   <span className="font-secondary text-xs">
@@ -247,7 +257,7 @@ const Faction: React.FC<FactionProps> = ({
                 </div>
                 <div className="flex pt-1">
                   <img
-                    src={FACTION_POINT_ICONS[name]}
+                    src={FACTION_EMBLEM_ICONS[name]}
                     className="w-4 h-4 inline-block mx-1"
                   />
                   <span className="font-secondary text-xs">

--- a/src/features/world/ui/factions/emblemTrading/Emblems.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Emblems.tsx
@@ -223,7 +223,7 @@ const SUNFLORIAN_RANKS: Rank[] = [
   },
 ];
 
-const RANKS: Record<FactionName, Rank[]> = {
+export const RANKS: Record<FactionName, Rank[]> = {
   bumpkins: BUMPKIN_RANKS,
   nightshades: NIGHTSHADE_RANKS,
   goblins: GOBLIN_RANKS,


### PR DESCRIPTION
# Description

Updates the faction leaderboard to emblems

<img width="460" alt="1" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/12e0f9e5-2efd-4f73-baec-3e0afb1c7c76">
<img width="423" alt="2" src="https://github.com/sunflower-land/sunflower-land/assets/41215134/5de27d06-fa12-49e8-8253-02e559c9d95d">

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
