### PR TITLE
[FEAT] Crop Quick select

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -470,7 +470,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Town Center": new Decimal(1),
     Market: new Decimal(1),
     Workbench: new Decimal(1),
-    "Basic Land": new Decimal(3),
+    "Basic Land": new Decimal(10),
     "Gold Pass": new Decimal(1),
     "Crop Plot": new Decimal(OFFLINE_FARM_CROPS),
     "Water Well": new Decimal(4),
@@ -526,7 +526,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Sunpetal Seed": new Decimal(20),
     "Bloom Seed": new Decimal(10),
     "Lily Seed": new Decimal(5),
-    "Sunflower Seed": new Decimal(992),
+    // "Sunflower Seed": new Decimal(992),
 
     // Foods
     "Pumpkin Soup": new Decimal(1),
@@ -768,7 +768,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
         readyAt: 0,
       },
     ],
-    "Hen House": [
+    Greenhouse: [
       {
         coordinates: {
           x: -5,

--- a/src/features/greenhouse/GreenhousePot.tsx
+++ b/src/features/greenhouse/GreenhousePot.tsx
@@ -168,6 +168,7 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
             ]}
             onClose={() => setShowQuickSelect(false)}
             onSelected={() => setPulsating(true)}
+            type={t("quickSelect.greenhouseSeeds")}
           />
         </Transition>
 

--- a/src/features/greenhouse/QuickSelect.tsx
+++ b/src/features/greenhouse/QuickSelect.tsx
@@ -14,6 +14,7 @@ interface Props {
   options: { name: InventoryItemName; icon?: InventoryItemName }[];
   onClose: () => void;
   onSelected?: (name: InventoryItemName) => void;
+  type: string;
 }
 
 const selectInventory = (state: MachineState) => state.context.state.inventory;
@@ -23,6 +24,7 @@ export const QuickSelect: React.FC<Props> = ({
   options,
   onClose,
   onSelected,
+  type,
 }) => {
   const { gameService, selectedItem, shortcutItem } = useContext(Context);
   const ref = useRef<HTMLDivElement>(null); // Create a ref to the component
@@ -56,8 +58,11 @@ export const QuickSelect: React.FC<Props> = ({
   const available = options.filter((option) => inventory[option.name]?.gte(1));
 
   return (
-    <div ref={ref} style={{ minWidth: "190px" }}>
-      <InnerPanel>
+    <div ref={ref}>
+      <InnerPanel
+        style={{ width: "195px" }}
+        className="overflow-x-auto scrollable shadow-2xl"
+      >
         <Label className="absolute -top-3 left-4" type="default" icon={icon}>
           {t("quickSelect.label")}
         </Label>
@@ -75,7 +80,7 @@ export const QuickSelect: React.FC<Props> = ({
           ))}
           {available.length === 0 && (
             <span className="text-xs p-0.5 py-1 font-secondary">
-              {t("quickSelect.empty")}
+              {t("quickSelect.purchase", { name: type })}
             </span>
           )}
         </div>

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -40,6 +40,7 @@ interface Props {
   procAnimation?: JSX.Element;
   touchCount: number;
   showTimers: boolean;
+  pulsating: boolean;
 }
 
 const FertilePlotComponent: React.FC<Props> = ({
@@ -53,6 +54,7 @@ const FertilePlotComponent: React.FC<Props> = ({
   procAnimation,
   touchCount,
   showTimers,
+  pulsating,
 }) => {
   const [showTimerPopover, setShowTimerPopover] = useState(false);
 
@@ -117,7 +119,9 @@ const FertilePlotComponent: React.FC<Props> = ({
       >
         {/* Crop base image */}
         <div
-          className={"absolute pointer-events-none"}
+          className={classNames("absolute pointer-events-none", {
+            "animate-pulsate": pulsating,
+          })}
           style={{
             width: `${PIXEL_SCALE * 16}px`,
           }}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -595,6 +595,9 @@ const availableSeeds: Record<AvailableSeeds, string> = {
   "availableSeeds.select.plant": "您希望选择哪个种子来种植？",
   "quickSelect.empty": "无温室种子",
   "quickSelect.label": "快速选择",
+  "quickSelect.cropSeeds": ENGLISH_TERMS["quickSelect.cropSeeds"],
+  "quickSelect.greenhouseSeeds": ENGLISH_TERMS["quickSelect.greenhouseSeeds"],
+  "quickSelect.purchase": ENGLISH_TERMS["quickSelect.purchase"],
 };
 
 const base: Record<Base, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -601,7 +601,10 @@ const availableSeeds: Record<AvailableSeeds, string> = {
   "availableSeeds.select.plant":
     "What seed would you like to select and plant?",
   "quickSelect.empty": "No greenhouse seeds.",
+  "quickSelect.purchase": "Purchase {{name}} at the Market.",
   "quickSelect.label": "Quick select",
+  "quickSelect.cropSeeds": "crop seeds",
+  "quickSelect.greenhouseSeeds": "greenhouse seeds",
 };
 
 const base: Record<Base, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -604,6 +604,9 @@ const availableSeeds: Record<AvailableSeeds, string> = {
     "Quelle graine souhaitez-vous sélectionner et planter?",
   "quickSelect.empty": ENGLISH_TERMS["quickSelect.empty"],
   "quickSelect.label": ENGLISH_TERMS["quickSelect.label"],
+  "quickSelect.cropSeeds": ENGLISH_TERMS["quickSelect.cropSeeds"],
+  "quickSelect.greenhouseSeeds": ENGLISH_TERMS["quickSelect.greenhouseSeeds"],
+  "quickSelect.purchase": ENGLISH_TERMS["quickSelect.purchase"],
 };
 
 const base: Record<Base, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -603,6 +603,9 @@ const availableSeeds: Record<AvailableSeeds, string> = {
     "Qual semente você gostaria de selecionar e plantar?",
   "quickSelect.empty": ENGLISH_TERMS["quickSelect.empty"],
   "quickSelect.label": ENGLISH_TERMS["quickSelect.label"],
+  "quickSelect.cropSeeds": ENGLISH_TERMS["quickSelect.cropSeeds"],
+  "quickSelect.greenhouseSeeds": ENGLISH_TERMS["quickSelect.greenhouseSeeds"],
+  "quickSelect.purchase": ENGLISH_TERMS["quickSelect.purchase"],
 };
 
 const base: Record<Base, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -603,6 +603,9 @@ const availableSeeds: Record<AvailableSeeds, string> = {
   "availableSeeds.select.plant": "Hangi tohumu seçip dikmek istersiniz?",
   "quickSelect.empty": ENGLISH_TERMS["quickSelect.empty"],
   "quickSelect.label": ENGLISH_TERMS["quickSelect.label"],
+  "quickSelect.cropSeeds": ENGLISH_TERMS["quickSelect.cropSeeds"],
+  "quickSelect.greenhouseSeeds": ENGLISH_TERMS["quickSelect.greenhouseSeeds"],
+  "quickSelect.purchase": ENGLISH_TERMS["quickSelect.purchase"],
 };
 
 const base: Record<Base, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -378,7 +378,10 @@ export type AvailableSeeds =
   | "availableSeeds.select"
   | "availableSeeds.select.plant"
   | "quickSelect.label"
-  | "quickSelect.empty";
+  | "quickSelect.empty"
+  | "quickSelect.purchase"
+  | "quickSelect.cropSeeds"
+  | "quickSelect.greenhouseSeeds";
 
 export type Base = "base.far.away" | "base.iam.far.away";
 


### PR DESCRIPTION
# Description

Introduces seed quick select, similar to Greenhouse functionality. The aim is to help new players learning to plant crops & also make it easier for veterans to select seeds.

The panel is placed much higher than the crop to ensure quick harvesters are not obstructed by the message that pops up (if clicked accidentally).

<img width="251" alt="Screenshot 2024-06-15 at 7 58 47 PM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/5adfa4ac-1f88-4032-acdf-c98d4052327c">
<img width="266" alt="Screenshot 2024-06-15 at 7 59 12 PM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/37e01127-76e9-460f-b66d-9e892c90f7e7">
