### PR TITLE
[FIX] Mineral Removal Restriction

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -1,9 +1,15 @@
 import { canChop } from "features/game/events/landExpansion/chop";
-import { CHICKEN_TIME_TO_EGG } from "features/game/lib/constants";
+import {
+  CHICKEN_TIME_TO_EGG,
+  CRIMSTONE_RECOVERY_TIME,
+  GOLD_RECOVERY_TIME,
+  IRON_RECOVERY_TIME,
+  STONE_RECOVERY_TIME,
+} from "features/game/lib/constants";
 import { FruitName, GreenHouseFruitName } from "features/game/types/fruits";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { CropName, GreenHouseCropName } from "features/game/types/crops";
-import { canMine } from "features/game/events/landExpansion/stoneMine";
+import { canMine } from "../expansion/lib/utils";
 import { areUnsupportedChickensBrewing } from "features/game/events/landExpansion/removeBuilding";
 import { Bud, StemTrait, TypeTrait } from "./buds";
 import {
@@ -142,28 +148,28 @@ function areAnyTreesChopped(game: GameState): Restriction {
 
 function areAnyStonesMined(game: GameState): Restriction {
   const stoneMined = Object.values(game.stones ?? {}).some(
-    (stone) => !canMine(stone)
+    (stone) => !canMine(stone, STONE_RECOVERY_TIME)
   );
   return [stoneMined, translate("restrictionReason.stoneMined")];
 }
 
 function areAnyIronsMined(game: GameState): Restriction {
   const ironMined = Object.values(game.iron ?? {}).some(
-    (iron) => !canMine(iron)
+    (iron) => !canMine(iron, IRON_RECOVERY_TIME)
   );
   return [ironMined, translate("restrictionReason.ironMined")];
 }
 
 function areAnyGoldsMined(game: GameState): Restriction {
   const goldMined = Object.values(game.gold ?? {}).some(
-    (gold) => !canMine(gold)
+    (gold) => !canMine(gold, GOLD_RECOVERY_TIME)
   );
   return [goldMined, translate("restrictionReason.goldMined")];
 }
 
 export function areAnyCrimstonesMined(game: GameState): Restriction {
   const crimstoneMined = Object.values(game.crimstones ?? {}).some(
-    (crimstone) => !canMine(crimstone)
+    (crimstone) => !canMine(crimstone, CRIMSTONE_RECOVERY_TIME)
   );
   return [crimstoneMined, translate("restrictionReason.crimstoneMined")];
 }


### PR DESCRIPTION
# Description

Currently the removal restrictions for Minerals is using the stone `canMine` function, so the ones for iron, gold, crimstone are not using the correct one. Using the `canMine` function from `utils.ts` so that it works for all minerals

Below is the `canMine` function that the minerals are currently using from `src\features\game\events\landExpansion\stoneMine.ts`
```typescript
export function canMine(rock: Rock, now: number = Date.now()) {
  const recoveryTime = STONE_RECOVERY_TIME;
  return now - rock.stone.minedAt > recoveryTime * 1000;
}
```
This is the incorrect function to use as it uses stone recovery time, which wouldn't be correct for iron, gold and crimstone.

This is the function that I applied in the PR from `src\features\game\expansion\lib\utils.ts`
```typescript
export function canMine(
  rock: Rock,
  recoveryTime: number,
  now: number = Date.now()
) {
  return now - rock.stone.minedAt > recoveryTime * 1000;
}
```
This Function has an extra parameter `recoveryTime` which I can apply the respective recovery times of the various stones to apply the restriction

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
