### PR TITLE
[FEAT] Withdrawal Restriction for Crimstone Hammer

### DIFF
--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -5,6 +5,16 @@ import { TEST_FARM } from "../lib/constants";
 
 describe("canremove", () => {
   describe("prevents", () => {
+    it("prevents a user from removing Grinx Hammer if recently expanded", () => {
+      const [restricted] = hasRemoveRestriction("Grinx's Hammer", "1", {
+        ...TEST_FARM,
+        inventory: {
+          "Grinx's Hammer": new Decimal(1),
+        },
+        expandedAt: Date.now(),
+      });
+      expect(restricted).toBe(true);
+    });
     it("prevents a user from removing mutant chickens if some chicken is fed", () => {
       const [restricted] = hasRemoveRestriction("Rich Chicken", "1", {
         ...TEST_FARM,
@@ -377,6 +387,16 @@ describe("canremove", () => {
   });
 
   describe("enables", () => {
+    it("enables a user to remove Grinx Hammer 7 days after expanding", () => {
+      const [restricted] = hasRemoveRestriction("Grinx's Hammer", "1", {
+        ...TEST_FARM,
+        inventory: {
+          "Grinx's Hammer": new Decimal(1),
+        },
+        expandedAt: Date.now() - 7 * 24 * 60 * 60 * 1001,
+      });
+      expect(restricted).toBe(false);
+    });
     it("enables users to remove crops", () => {
       const [restricted] = hasRemoveRestriction("Sunflower", "1", {
         ...TEST_FARM,

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -174,6 +174,14 @@ export function areAnyCrimstonesMined(game: GameState): Restriction {
   return [crimstoneMined, translate("restrictionReason.crimstoneMined")];
 }
 
+export function isCrimstoneHammerActive(game: GameState): Restriction {
+  const crimstoneMined = Object.values(game.crimstones ?? {}).some(
+    (crimstone) => !canMine(crimstone, 7 * 24 * 60 * 60),
+    // 7 day cooldown (5 day cycle + 2 day buffer) to prevent crimstone hammer sharing exploits
+  );
+  return [crimstoneMined, translate("restrictionReason.crimstoneMined")];
+}
+
 function areAnyMineralsMined(game: GameState): Restriction {
   const areStonesMined = areAnyStonesMined(game);
   const areIronsMined = areAnyIronsMined(game);

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -12,6 +12,7 @@ import {
   greenhouseCropIsGrowing,
   isProducingHoney,
   isBeehivesFull,
+  isCrimstoneHammerActive,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -109,6 +110,10 @@ export const canWithdrawBoostedWearable = (
 
   if (name === "Crimstone Amulet" || name === "Crimstone Armor") {
     return !areAnyCrimstonesMined(state)[0];
+  }
+
+  if (name === "Crimstone Hammer") {
+    return !isCrimstoneHammerActive(state)[0];
   }
 
   if (name === "Oil Can") {

--- a/src/features/game/types/withdrawables.test.ts
+++ b/src/features/game/types/withdrawables.test.ts
@@ -310,6 +310,27 @@ describe("withdrawables", () => {
       const enabled = BUMPKIN_WITHDRAWABLES["Infernal Pitchfork"](state);
       expect(enabled).toBeFalsy();
     });
+    it("prevents withdrawal of Crimstone Hammer if less than 7 days after last crimstone mine", () => {
+      const state: GameState = {
+        ...TEST_FARM,
+        crimstones: {
+          "1": {
+            minesLeft: 5,
+            createdAt: 1715732768907,
+            x: 9,
+            width: 2,
+            y: 3,
+            height: 2,
+            stone: {
+              minedAt: Date.now(),
+              amount: 1.25,
+            },
+          },
+        },
+      };
+      const enabled = BUMPKIN_WITHDRAWABLES["Crimstone Hammer"](state);
+      expect(enabled).toBeFalsy();
+    });
   });
 
   describe("enables", () => {
@@ -539,6 +560,27 @@ describe("withdrawables", () => {
     };
 
     const enabled = BUMPKIN_WITHDRAWABLES["Infernal Pitchfork"](state);
+    expect(enabled).toBeTruthy();
+  });
+  it("enables withdrawal of Crimstone Hammer 7 days after last crimstone mine", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      crimstones: {
+        "1": {
+          minesLeft: 5,
+          createdAt: 1680494833651,
+          x: 9,
+          width: 2,
+          y: 3,
+          height: 2,
+          stone: {
+            minedAt: Date.now() - 7 * 24 * 60 * 60 * 1001,
+            amount: 1.25,
+          },
+        },
+      },
+    };
+    const enabled = BUMPKIN_WITHDRAWABLES["Crimstone Hammer"](state);
     expect(enabled).toBeTruthy();
   });
 });

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1387,7 +1387,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Crimstone Armor": (state) =>
     canWithdrawBoostedWearable("Crimstone Armor", state),
   "Gardening Overalls": () => true,
-  "Crimstone Hammer": () => true,
+  "Crimstone Hammer": (state) =>
+    canWithdrawBoostedWearable("Crimstone Hammer", state),
   "Crimstone Amulet": (state) =>
     canWithdrawBoostedWearable("Crimstone Amulet", state),
   "Full Bloom Shirt": () => true,


### PR DESCRIPTION
# Description

Withdrawal Restriction for Crimstone Hammer. 

We have to approach the withdrawal restriction fro Crimstone Hammer differently from Crimstone armour and amulet because the Hammer only needed to be equipped before mining the 4th mine for it to apply the +2 bonus to the 5th mine. We thought that adding a 7 day cooldown (5 days for full cycle + 2 day buffer) from the last Crimstone mine would be sufficient to prevent exploits with Crimstone Hammer Sharing. 

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
