### PR TITLE
[FEAT] Crop machine single pack harvest

### DIFF
--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -1,4 +1,5 @@
-import { INITIAL_FARM } from "./constants";
+// import { INITIAL_FARM } from "./constants";
+import { STATIC_OFFLINE_FARM } from "./landDataStatic";
 
-// export const OFFLINE_FARM = STATIC_OFFLINE_FARM;
-export const OFFLINE_FARM = INITIAL_FARM;
+export const OFFLINE_FARM = STATIC_OFFLINE_FARM;
+// export const OFFLINE_FARM = INITIAL_FARM;

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -369,6 +369,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Oil: new Decimal(500),
     Manor: new Decimal(1),
     House: new Decimal(1),
+    "Sunflower Seed": new Decimal(100),
     "Rice Seed": new Decimal(10),
     "Grape Seed": new Decimal(10),
     "Olive Seed": new Decimal(10),
@@ -710,6 +711,29 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   buildings: {
+    "Crop Machine": [
+      {
+        coordinates: {
+          x: -2,
+          y: 6,
+        },
+        createdAt: 0,
+        id: "1",
+        readyAt: 0,
+        oil: 100,
+        queue: [
+          {
+            amount: 10,
+            crop: "Sunflower",
+            readyAt: Date.now() - 1000,
+            startTime: Date.now() - 61500,
+            seeds: 10,
+            totalGrowTime: 60000,
+            growTimeRemaining: 0,
+          },
+        ],
+      },
+    ],
     "Town Center": [
       {
         coordinates: {

--- a/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachine.tsx
@@ -98,8 +98,11 @@ export const CropMachine: React.FC<Props> = ({ id }) => {
     });
   };
 
-  const handleHarvest = () => {
-    const updated = gameService.send({ type: "cropMachine.harvested" });
+  const handleHarvestPack = (packIndex: number) => {
+    const updated = gameService.send({
+      type: "cropMachine.harvested",
+      packIndex,
+    });
 
     const machines = updated.context.state.buildings[
       "Crop Machine"
@@ -219,7 +222,7 @@ export const CropMachine: React.FC<Props> = ({ id }) => {
         show={showModal}
         onClose={() => setShowModal(false)}
         onAddSeeds={handleAddSeeds}
-        onHarvest={handleHarvest}
+        onHarvestPack={handleHarvestPack}
         onAddOil={handleAddOil}
       />
     </>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1316,7 +1316,7 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.growTime": "生长时长： {{time}}",
   "cropMachine.growTimeRemaining": "生长剩余时长: {{time}}",
   "cropMachine.harvest": "收割",
-  "cropMachine.harvestAllCrops": "收割所有庄稼",
+  "cropMachine.harvestCropPack": "收割所有庄稼",
   "cropMachine.machineRuntime": "机器运作时长： {{time}}",
   "cropMachine.maxRuntime": "最高运作时长: {{time}}",
   "cropMachine.moreOilRequired": "需要更多的石油",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1432,8 +1432,8 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.seedPacks": "Seed packs",
   "cropMachine.readyCropPacks": "Ready crop packs",
   "cropMachine.readyCropPacks.description":
-    "You currently have {{totalReady}} crop packs to harvest! Click the harvest button to collect all your crops.",
-  "cropMachine.harvestAllCrops": "Harvest all crops",
+    "You currently have {{totalReady}} crop packs to harvest! Click the the pack you want to harvest.",
+  "cropMachine.harvestCropPack": "Harvest crop pack",
   "cropMachine.addOil": "Add oil",
   "cropMachine.oil.description":
     "Your machine needs oil to run. Every seed pack will require a certain amount of oil based on how long the crops take to grow. As you add oil you can see how long the machine will run when given that amount.",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1466,7 +1466,7 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.growTimeRemaining":
     ENGLISH_TERMS["cropMachine.growTimeRemaining"],
   "cropMachine.harvest": ENGLISH_TERMS["cropMachine.harvest"],
-  "cropMachine.harvestAllCrops": ENGLISH_TERMS["cropMachine.harvestAllCrops"],
+  "cropMachine.harvestCropPack": ENGLISH_TERMS["cropMachine.harvestCropPack"],
   "cropMachine.machineRuntime": ENGLISH_TERMS["cropMachine.machineRuntime"],
   "cropMachine.maxRuntime": ENGLISH_TERMS["cropMachine.maxRuntime"],
   "cropMachine.moreOilRequired": ENGLISH_TERMS["cropMachine.moreOilRequired"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1437,7 +1437,7 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.growTimeRemaining":
     ENGLISH_TERMS["cropMachine.growTimeRemaining"],
   "cropMachine.harvest": ENGLISH_TERMS["cropMachine.harvest"],
-  "cropMachine.harvestAllCrops": ENGLISH_TERMS["cropMachine.harvestAllCrops"],
+  "cropMachine.harvestCropPack": ENGLISH_TERMS["cropMachine.harvestCropPack"],
   "cropMachine.machineRuntime": ENGLISH_TERMS["cropMachine.machineRuntime"],
   "cropMachine.maxRuntime": ENGLISH_TERMS["cropMachine.maxRuntime"],
   "cropMachine.moreOilRequired": ENGLISH_TERMS["cropMachine.moreOilRequired"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1426,7 +1426,7 @@ const cropMachine: Record<CropMachine, string> = {
   "cropMachine.growTimeRemaining":
     ENGLISH_TERMS["cropMachine.growTimeRemaining"],
   "cropMachine.harvest": ENGLISH_TERMS["cropMachine.harvest"],
-  "cropMachine.harvestAllCrops": ENGLISH_TERMS["cropMachine.harvestAllCrops"],
+  "cropMachine.harvestCropPack": ENGLISH_TERMS["cropMachine.harvestCropPack"],
   "cropMachine.machineRuntime": ENGLISH_TERMS["cropMachine.machineRuntime"],
   "cropMachine.maxRuntime": ENGLISH_TERMS["cropMachine.maxRuntime"],
   "cropMachine.moreOilRequired": ENGLISH_TERMS["cropMachine.moreOilRequired"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -1017,7 +1017,7 @@ export type CropMachine =
   | "cropMachine.seedPacks"
   | "cropMachine.readyCropPacks"
   | "cropMachine.readyCropPacks.description"
-  | "cropMachine.harvestAllCrops"
+  | "cropMachine.harvestCropPack"
   | "cropMachine.maxRuntime"
   | "cropMachine.oilToAdd"
   | "cropMachine.totalRuntime"


### PR DESCRIPTION
# Description

This PR changes the harvest of the crop machine to be a single pack at a time. This is to avoid a player hitting the hoarding limit when trying to harvest a lot of packs. 

<img width="500" alt="Screenshot 2024-06-18 at 12 10 04 PM" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/525404af-f206-43c2-96f2-c3872cc274eb">

Fixes [issue](https://discord.com/channels/880987707214544966/880987707692687381/1252378866580717618)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally. Have a crop pack ready and harvest it.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
