### PR TITLE
[FIX] Responsive Faction Board

### DIFF
--- a/src/features/game/expansion/components/leaderboard/FactionTicketTable.tsx
+++ b/src/features/game/expansion/components/leaderboard/FactionTicketTable.tsx
@@ -32,13 +32,13 @@ export const FactionTicketsTable: React.FC<Props> = ({
             <th style={{ border: "1px solid #b96f50" }} className="p-1.5">
               <p>{t("player")}</p>
             </th>
-            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/5">
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/4">
               <p>{t("total")}</p>
             </th>
           </tr>
         </thead>
       )}
-      <tbody>
+      <tbody className="text-xxs sm:text-xs">
         {rankings.map(({ id, count, rank }, index) => {
           const playerRank = [...RANKS[faction]]
             .reverse()

--- a/src/features/world/ui/factions/emblemTrading/Emblems.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Emblems.tsx
@@ -40,6 +40,9 @@ import goblins_chevron_five from "assets/icons/factions/goblins/chevron_five.web
 import goblins_chevron_six from "assets/icons/factions/goblins/chevron_six.webp";
 import Decimal from "decimal.js-light";
 
+import mark from "assets/icons/faction_mark.webp";
+import lightning from "assets/icons/lightning.png";
+
 type Rank = {
   name: string;
   emblemsRequired: number;
@@ -253,7 +256,20 @@ export const Emblems: React.FC<Props> = ({ emblem, factionName }) => {
       </Label>
       <p className="mb-2">{t("faction.tradeEmblems")}</p>
 
-      <table className="w-full text-xs table-fixed border-collapse">
+      <table className="w-full text-xxs sm:text-xs table-fixed border-collapse">
+        <thead>
+          <tr>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/3">
+              <p>{t("rank")}</p>
+            </th>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5 w-1/4">
+              <p>{t("faction.emblems")}</p>
+            </th>
+            <th style={{ border: "1px solid #b96f50" }} className="p-1.5">
+              <p>{t("buff")}</p>
+            </th>
+          </tr>
+        </thead>
         <tbody>
           {RANKS[factionName].map((rank) => (
             <tr
@@ -264,21 +280,27 @@ export const Emblems: React.FC<Props> = ({ emblem, factionName }) => {
             >
               <td style={{ border: "1px solid #b96f50" }}>
                 <div className="flex items-center">
-                  <img src={rank.icon} className="mx-2" />
-                  <p className="p-1.5">{rank.name}</p>
+                  <img src={rank.icon} className="mx-1 sm:mx-2" />
+                  <p className="p-1.5 truncate">{rank.name}</p>
                 </div>
               </td>
               <td
                 style={{ border: "1px solid #b96f50" }}
                 className="p-1.5 truncate"
               >
-                {`${rank.emblemsRequired} ${t("faction.emblems")}`}
+                {rank.emblemsRequired}
               </td>
               <td
                 style={{ border: "1px solid #b96f50" }}
                 className="p-1.5 relative"
               >
-                {rank.boost && <Label type="vibrant">{rank.boost}</Label>}
+                {rank.boost && (
+                  <Label type="vibrant" icon={lightning} secondaryIcon={mark}>
+                    <span className="text-xxs sm:text-xs whitespace-nowrap">
+                      {rank.boost}
+                    </span>
+                  </Label>
+                )}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
# Description

Updates the faction board and faction leaderboard to be a bit more responsive and make room on small resolutions.

## Faction Board

**Small**
![small](https://github.com/sunflower-land/sunflower-land/assets/41215134/f3ecbb3f-08b8-4063-a6f3-f8b1f0efc0ff)

**Medium** 
![medium](https://github.com/sunflower-land/sunflower-land/assets/41215134/da7e1ae6-5b29-4829-97fd-eb3ec7d07c02)

## Faction Leaderboard

**Small**
![small1](https://github.com/sunflower-land/sunflower-land/assets/41215134/7e5c0b72-ea29-46e5-9e05-8bd46e5428d1)

**Medium**
![medium2](https://github.com/sunflower-land/sunflower-land/assets/41215134/93667d9a-1950-43d1-b8ab-d1bcf1987373)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
