### PR TITLE
[FIX] Disable clicking the Maneki Neko a second time inside the house

### DIFF
--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -24,7 +24,10 @@ export const ManekiNeko: React.FC<Props> = ({ id }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const [showTooltip, setShowTooltip] = useState(false);
-  const manekiNekos = gameState.context.state.collectibles["Maneki Neko"] ?? [];
+  const manekiNekos =
+    gameState.context.state.collectibles["Maneki Neko"] ??
+    gameState.context.state.home.collectibles["Maneki Neko"] ??
+    [];
 
   useUiRefresher();
 


### PR DESCRIPTION
# Description

Disable clicking the Maneki Neko a second time inside the house. This happens because it doesn't recognize any Maneki Neko collectibles, leaving the array `manekiNekos` empty, which always results in a `false` in this operation:

```typescript
const hasShakenRecently = manekiNekos.some((maneki) => {
    const shakenAt = maneki.shakenAt || 0;

    return !canShake(shakenAt);
});
```

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Moving the maneki neko in and out of the house to check how it reacts when clicked.
- Changing the shakenAt dates to check if it still works correctly.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
