### PR TITLE
[FEAT] Delivery Updates

### DIFF
--- a/src/features/game/events/landExpansion/plantFlower.test.ts
+++ b/src/features/game/events/landExpansion/plantFlower.test.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { getFlowerTime, plantFlower } from "./plantFlower";
 import { GameState } from "features/game/types/game";
 import { TEST_FARM } from "features/game/lib/constants";
-import { INITIAL_BUMPKIN } from "features/game/lib/bumpkinData";
+import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
 import {
   FLOWER_CROSS_BREED_AMOUNTS,
   FLOWER_SEEDS,
@@ -10,7 +10,7 @@ import {
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
-  bumpkin: INITIAL_BUMPKIN,
+  bumpkin: TEST_BUMPKIN,
   flowers: {
     discovered: {},
     flowerBeds: {
@@ -93,7 +93,7 @@ describe("plantFlower", () => {
   it("does not plant an invalid seed", () => {
     expect(() =>
       plantFlower({
-        state: { ...GAME_STATE, bumpkin: INITIAL_BUMPKIN },
+        state: { ...GAME_STATE, bumpkin: TEST_BUMPKIN },
         createdAt: dateNow,
         action: {
           type: "flower.planted",
@@ -108,7 +108,7 @@ describe("plantFlower", () => {
   it("does not plant if user does not have seeds", () => {
     expect(() =>
       plantFlower({
-        state: { ...GAME_STATE, bumpkin: INITIAL_BUMPKIN },
+        state: { ...GAME_STATE, bumpkin: TEST_BUMPKIN },
         createdAt: dateNow,
         action: {
           type: "flower.planted",
@@ -125,7 +125,7 @@ describe("plantFlower", () => {
       plantFlower({
         state: {
           ...GAME_STATE,
-          bumpkin: INITIAL_BUMPKIN,
+          bumpkin: TEST_BUMPKIN,
           inventory: { "Sunpetal Seed": new Decimal(1) },
         },
         createdAt: dateNow,
@@ -147,7 +147,7 @@ describe("plantFlower", () => {
     const state = plantFlower({
       state: {
         ...GAME_STATE,
-        bumpkin: INITIAL_BUMPKIN,
+        bumpkin: TEST_BUMPKIN,
         inventory: {
           "Sunpetal Seed": seedAmount,
           Sunflower: new Decimal(100),
@@ -178,7 +178,7 @@ describe("plantFlower", () => {
     const state = plantFlower({
       state: {
         ...GAME_STATE,
-        bumpkin: INITIAL_BUMPKIN,
+        bumpkin: TEST_BUMPKIN,
         inventory: {
           "Sunpetal Seed": new Decimal(1),
           Sunflower: new Decimal(100),
@@ -198,7 +198,7 @@ describe("plantFlower", () => {
   it("deducts the seed from the inventory", () => {
     const initialState = {
       ...GAME_STATE,
-      bumpkin: INITIAL_BUMPKIN,
+      bumpkin: TEST_BUMPKIN,
       inventory: {
         "Sunpetal Seed": new Decimal(1),
         Sunflower: new Decimal(100),
@@ -223,7 +223,7 @@ describe("plantFlower", () => {
   it("deducts the amount of cross breed required", () => {
     const initialState = {
       ...GAME_STATE,
-      bumpkin: INITIAL_BUMPKIN,
+      bumpkin: TEST_BUMPKIN,
       inventory: {
         "Sunpetal Seed": new Decimal(1),
         Sunflower: new Decimal(100),
@@ -257,8 +257,8 @@ describe("plantFlower", () => {
       state: {
         ...GAME_STATE,
         bumpkin: {
-          ...INITIAL_BUMPKIN,
-          equipped: { ...INITIAL_BUMPKIN.equipped, hat: "Flower Crown" },
+          ...TEST_BUMPKIN,
+          equipped: { ...TEST_BUMPKIN.equipped, hat: "Flower Crown" },
         },
         inventory: {
           "Sunpetal Seed": seedAmount,
@@ -327,8 +327,8 @@ describe("plantFlower", () => {
       state: {
         ...GAME_STATE,
         bumpkin: {
-          ...INITIAL_BUMPKIN,
-          equipped: { ...INITIAL_BUMPKIN.equipped, hat: "Flower Crown" },
+          ...TEST_BUMPKIN,
+          equipped: { ...TEST_BUMPKIN.equipped, hat: "Flower Crown" },
         },
         inventory: {
           "Sunpetal Seed": seedAmount,

--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -10,9 +10,9 @@ export const INITIAL_EXPANSIONS =
     ? 3
     : getLandLimit(INITIAL_BUMPKIN_LEVEL as BumpkinLevel);
 
-export const INITIAL_BUMPKIN: Bumpkin = {
+export const TEST_BUMPKIN: Bumpkin = {
   id: 1,
-  experience: 1,
+  experience: 1000,
   tokenUri: "bla",
   equipped: {
     body: "Beige Farmer Potion",

--- a/src/features/game/lib/landDataDynamic.ts
+++ b/src/features/game/lib/landDataDynamic.ts
@@ -5,7 +5,7 @@ import { BumpkinLevel } from "features/game/lib/level";
 import { INITIAL_BUMPKIN_LEVEL, INITIAL_EXPANSIONS } from "./bumpkinData";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { INITIAL_RESOURCES } from "./landDataStatic";
-import { INITIAL_BUMPKIN } from "./bumpkinData";
+import { TEST_BUMPKIN } from "./bumpkinData";
 import { STATIC_OFFLINE_FARM } from "./landDataStatic";
 import { getBuildingBumpkinLevelRequired } from "../expansion/lib/buildingRequirements";
 
@@ -149,7 +149,7 @@ const DYNAMIC_INITIAL_RESOURCES: Pick<
 };
 
 const DYNAMIC_INITIAL_BUMPKIN: Bumpkin = {
-  ...INITIAL_BUMPKIN,
+  ...TEST_BUMPKIN,
   experience: LEVEL_EXPERIENCE[INITIAL_BUMPKIN_LEVEL as BumpkinLevel],
 };
 

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -3,12 +3,10 @@
 import Decimal from "decimal.js-light";
 import { ChoreV2, ChoreV2Name, GameState, Inventory } from "../types/game";
 
-import { BumpkinLevel, getBumpkinLevel } from "features/game/lib/level";
+import { BumpkinLevel } from "features/game/lib/level";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
 import { TEST_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
 import { EMPTY, makeMegaStoreAvailableDates } from "./constants";
-import { DELIVERY_LEVELS } from "features/island/delivery/lib/delivery";
-import { getKeys } from "../types/craftables";
 export const INITIAL_RESOURCES: Pick<
   GameState,
   | "crops"

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -853,24 +853,21 @@ export const STATIC_OFFLINE_FARM: GameState = {
   auctioneer: {},
   delivery: {
     fulfilledCount: 10,
-    orders: getKeys(DELIVERY_LEVELS)
-      .filter(
-        (name) =>
-          getBumpkinLevel(TEST_BUMPKIN.experience) >= DELIVERY_LEVELS[name]
-      )
-      .map((name) => ({
+    orders: [
+      {
         createdAt: Date.now(),
         readyAt: Date.now(),
-        from: name,
+        from: "betty",
         reward: {
           items: {},
           coins: 100,
         },
-        id: `${name}-delivery`,
+        id: `betty-delivery`,
         items: {
           Sunflower: 20,
         },
-      })),
+      },
+    ],
 
     milestone: {
       goal: 10,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -3,10 +3,12 @@
 import Decimal from "decimal.js-light";
 import { ChoreV2, ChoreV2Name, GameState, Inventory } from "../types/game";
 
-import { BumpkinLevel } from "features/game/lib/level";
+import { BumpkinLevel, getBumpkinLevel } from "features/game/lib/level";
 import { getEnabledNodeCount } from "../expansion/lib/expansionNodes";
-import { INITIAL_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
+import { TEST_BUMPKIN, INITIAL_BUMPKIN_LEVEL } from "./bumpkinData";
 import { EMPTY, makeMegaStoreAvailableDates } from "./constants";
+import { DELIVERY_LEVELS } from "features/island/delivery/lib/delivery";
+import { getKeys } from "../types/craftables";
 export const INITIAL_RESOURCES: Pick<
   GameState,
   | "crops"
@@ -307,7 +309,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     spawnedAt: 0,
   },
   farmHands: { bumpkins: {} },
-  bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+  bumpkin: { ...TEST_BUMPKIN },
   buds: {
     1: {
       aura: "Basic",
@@ -350,7 +352,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     chores: {
       2: {
         activity: "Sunflower Planted",
-        bumpkinId: INITIAL_BUMPKIN.id,
+        bumpkinId: TEST_BUMPKIN.id,
         createdAt: Date.now(),
         description: "Plant a sunflower",
         requirement: 1,
@@ -851,62 +853,25 @@ export const STATIC_OFFLINE_FARM: GameState = {
   auctioneer: {},
   delivery: {
     fulfilledCount: 10,
-    orders: [
-      {
+    orders: getKeys(DELIVERY_LEVELS)
+      .filter(
+        (name) =>
+          getBumpkinLevel(TEST_BUMPKIN.experience) >= DELIVERY_LEVELS[name]
+      )
+      .map((name) => ({
         createdAt: Date.now(),
         readyAt: Date.now(),
-        from: "pumpkin' pete",
+        from: name,
         reward: {
           items: {},
+          coins: 100,
         },
-        id: "1",
+        id: `${name}-delivery`,
         items: {
           Sunflower: 20,
-          Potato: 20,
-          Pumpkin: 20,
         },
-      },
-      {
-        createdAt: Date.now(),
-        readyAt: Date.now(),
-        from: "victoria",
-        reward: {
-          coins: 10000,
-        },
-        id: "12",
-        items: {
-          Sunflower: 20,
-          Potato: 20,
-          Pumpkin: 20,
-        },
-      },
-      // {
-      //   createdAt: Date.now(),
-      //   readyAt: Date.now(),
-      //   from: "grimbly",
-      //   reward: {
-      //     items: {},
-      //     sfl: 0.15,
-      //   },
-      //   id: "3",
-      //   items: {
-      //     Potato: 2,
-      //   },
-      // },
-      {
-        createdAt: Date.now(),
-        readyAt: Date.now(),
-        from: "grubnuk",
-        reward: {
-          items: {},
-          sfl: 0.2,
-        },
-        id: "2",
-        items: {
-          "Pumpkin Soup": 1,
-        },
-      },
-    ],
+      })),
+
     milestone: {
       goal: 10,
       total: 10,

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -145,7 +145,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
   });
 
   return (
-    <div className="py-1 px-2" key={order.id}>
+    <div className="py-1 px-1" key={order.id}>
       <ButtonPanel
         onClick={() => onClick(order.id)}
         className={classNames("w-full  !py-2 relative", {
@@ -271,7 +271,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
 
 export const LockedOrderCard: React.FC<{ npc: NPCName }> = ({ npc }) => {
   return (
-    <div className="py-1 px-2">
+    <div className="py-1 px-1">
       <ButtonPanel
         disabled
         className={classNames(
@@ -304,7 +304,7 @@ export const LockedOrderCard: React.FC<{ npc: NPCName }> = ({ npc }) => {
             height: "25px",
           }}
         >
-          {`Lvl ${DELIVERY_LEVELS[npc]}`}
+          {`Lvl ${DELIVERY_LEVELS[npc as DeliveryNpcName]}`}
         </Label>
       </ButtonPanel>
     </div>
@@ -499,9 +499,11 @@ export const DeliveryOrders: React.FC<Props> = ({
               {`${getSeasonalTicket()}s`}
             </Label>
           </div>
-          <span className="text-xs mb-2">
-            Earn scrolls to craft exclusive items.
-          </span>
+          {level <= 8 && (
+            <span className="text-xs mb-2">
+              {t("bumpkin.delivery.earnScrolls")}
+            </span>
+          )}
         </div>
         <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">
           {ticketOrders.map((order) => {
@@ -524,9 +526,11 @@ export const DeliveryOrders: React.FC<Props> = ({
               {`SFL`}
             </Label>
           </div>
-          <span className="text-xs mb-2">
-            Earn SFL to trade & build your empire.
-          </span>
+          {level <= 12 && (
+            <span className="text-xs mb-2">
+              {t("bumpkin.delivery.earnSFL")}
+            </span>
+          )}
         </div>
 
         <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -29,6 +29,7 @@ import { NPCName, NPC_WEARABLES } from "lib/npcs";
 import { getDayOfYear, secondsToString } from "lib/utils/time";
 import {
   DELIVERY_LEVELS,
+  DeliveryNpcName,
   acknowledgeOrders,
   generateDeliveryMessage,
 } from "../lib/delivery";
@@ -186,9 +187,9 @@ export const DeliveryOrders: React.FC<Props> = ({
   } = getSeasonChangeover({ id: gameService.state.context.farmId });
 
   const level = getBumpkinLevel(gameState.bumpkin?.experience ?? 0);
-  const nextNpcUnlock = getKeys(DELIVERY_LEVELS).find(
-    (npc) => level < (DELIVERY_LEVELS?.[npc] ?? 0),
-  );
+  const nextNpcUnlock = getKeys(DELIVERY_LEVELS)
+    .sort((a, b) => (DELIVERY_LEVELS[a] > DELIVERY_LEVELS[b] ? 1 : -1))
+    .find((npc) => level < (DELIVERY_LEVELS?.[npc] ?? 0));
 
   return (
     <div className="flex md:flex-row flex-col-reverse md:mr-1 items-start h-full">
@@ -548,7 +549,7 @@ export const DeliveryOrders: React.FC<Props> = ({
               <div className="text-xs space-y-2">
                 <p>
                   {generateDeliveryMessage({
-                    from: previewOrder?.from,
+                    from: previewOrder?.from as DeliveryNpcName,
                     id: previewOrder.id,
                   })}
                 </p>

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -16,12 +16,14 @@ import lockIcon from "assets/icons/lock.png";
 import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
 import { Context } from "features/game/GameProvider";
 import {
+  QuestNPCName,
+  TICKET_REWARDS,
   generateDeliveryTickets,
   getOrderSellPrice,
 } from "features/game/events/landExpansion/deliver";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getKeys } from "features/game/types/craftables";
-import { Inventory, Order } from "features/game/types/game";
+import { GameState, Inventory, Order } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 
@@ -32,6 +34,9 @@ import {
   DeliveryNpcName,
   acknowledgeOrders,
   generateDeliveryMessage,
+  isCoinNPC,
+  isSFLNPC,
+  isTicketNPC,
 } from "../lib/delivery";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { Button } from "components/ui/Button";
@@ -101,6 +106,210 @@ export function hasOrderRequirements({
     return count.gte(amount);
   });
 }
+
+const makeRewardAmountForLabel = ({
+  order,
+  gameState,
+}: {
+  order: Order;
+  gameState: GameState;
+}) => {
+  if (order.reward.sfl !== undefined) {
+    const sfl = getOrderSellPrice<Decimal>(gameState, order);
+
+    return sfl.toFixed(2);
+  }
+
+  const coins = getOrderSellPrice<number>(gameState, order);
+
+  return coins % 1 === 0 ? coins.toString() : coins.toFixed(2);
+};
+
+export type OrderCardProps = {
+  order: Order;
+  selected: Order;
+  onClick: (id: string) => void;
+  gameState: GameState;
+};
+export const OrderCard: React.FC<OrderCardProps> = ({
+  order,
+  selected,
+  onClick,
+  gameState,
+}) => {
+  const { coins, balance: sfl, inventory } = gameState;
+
+  const tickets = generateDeliveryTickets({
+    game: gameState,
+    npc: order.from,
+  });
+
+  return (
+    <div className="py-1 px-2" key={order.id}>
+      <ButtonPanel
+        onClick={() => onClick(order.id)}
+        className={classNames("w-full  !py-2 relative", {
+          "sm:!bg-brown-200": order.id === selected?.id,
+        })}
+        style={{ paddingBottom: "20px" }}
+      >
+        {hasOrderRequirements({ order, coins, sfl, inventory }) &&
+          !order.completedAt && (
+            <img
+              src={SUNNYSIDE.icons.heart}
+              className="absolute top-0.5 right-0.5 w-3 sm:w-4"
+            />
+          )}
+
+        <div className="flex flex-col pb-2">
+          <div className="flex items-center my-1">
+            <div className="relative mb-2 mr-0.5 -ml-1">
+              <NPCIcon parts={NPC_WEARABLES[order.from]} />
+            </div>
+            <div className="flex-1 flex justify-center h-8 items-center w-6 ">
+              {getKeys(order.items).map((name) => {
+                let img: string;
+
+                if (name === "coins") {
+                  img = coinsImg;
+                } else if (name === "sfl") {
+                  img = sflIcon;
+                } else {
+                  img = ITEM_DETAILS[name].image;
+                }
+
+                return (
+                  <img key={name} src={img} className="w-6 img-highlight" />
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {order.completedAt && (
+          <Label
+            type="success"
+            className="absolute -bottom-2 text-center mt-1 p-1 left-[-8px] z-10 h-6"
+            style={{ width: "calc(100% + 15px)" }}
+          >
+            <img src={SUNNYSIDE.icons.confirm} className="h-4" />
+          </Label>
+        )}
+        {!order.completedAt && order.reward.sfl !== undefined && (
+          <Label
+            type="warning"
+            iconWidth={8}
+            icon={sflIcon}
+            className={"absolute -bottom-2 text-center p-1 "}
+            style={{
+              left: `${PIXEL_SCALE * -3}px`,
+              right: `${PIXEL_SCALE * -3}px`,
+              width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+              height: "25px",
+            }}
+          >
+            {`${`${makeRewardAmountForLabel({ order, gameState })}`}`}
+          </Label>
+        )}
+        {!order.completedAt && order.reward.coins !== undefined && (
+          <Label
+            type="warning"
+            icon={coinsImg}
+            className={"absolute -bottom-2 text-center p-1 "}
+            style={{
+              left: `${PIXEL_SCALE * -3}px`,
+              right: `${PIXEL_SCALE * -3}px`,
+              width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+              height: "25px",
+            }}
+          >
+            {`${makeRewardAmountForLabel({ order, gameState })}`}
+          </Label>
+        )}
+        {!order.completedAt && !!tickets && (
+          <Label
+            icon={ITEM_DETAILS[getSeasonalTicket()].image}
+            type="warning"
+            className={"absolute -bottom-2 text-center p-1 "}
+            style={{
+              left: `${PIXEL_SCALE * -3}px`,
+              right: `${PIXEL_SCALE * -3}px`,
+              width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+              height: "25px",
+            }}
+          >
+            {tickets}
+          </Label>
+        )}
+
+        {order.id === selected?.id && (
+          <div id="select-box" className="hidden md:block">
+            <img
+              className="absolute pointer-events-none"
+              src={selectBoxTL}
+              style={{
+                top: `${PIXEL_SCALE * -3}px`,
+                left: `${PIXEL_SCALE * -3}px`,
+                width: `${PIXEL_SCALE * 8}px`,
+              }}
+            />
+            <img
+              className="absolute pointer-events-none"
+              src={selectBoxTR}
+              style={{
+                top: `${PIXEL_SCALE * -3}px`,
+                right: `${PIXEL_SCALE * -3}px`,
+                width: `${PIXEL_SCALE * 8}px`,
+              }}
+            />
+          </div>
+        )}
+      </ButtonPanel>
+    </div>
+  );
+};
+
+export const LockedOrderCard: React.FC<{ npc: NPCName }> = ({ npc }) => {
+  return (
+    <div className="py-1 px-2">
+      <ButtonPanel
+        disabled
+        className={classNames(
+          "w-full  !py-2 relative h-full flex items-center justify-center cursor-not-allowed",
+        )}
+        style={{ paddingBottom: "20px" }}
+      >
+        <div className="flex flex-col pb-2">
+          <div className="flex items-center my-1">
+            <div className="relative mb-2 mr-0.5 -ml-1">
+              <NPCIcon parts={NPC_WEARABLES[npc]} />
+            </div>
+            <div className="flex-1 flex justify-center h-8 items-center w-6 ">
+              <img
+                src={SUNNYSIDE.icons.expression_confused}
+                className="h-6 img-highlight"
+              />
+            </div>
+          </div>
+        </div>
+
+        <Label
+          type="formula"
+          icon={lockIcon}
+          className={"absolute -bottom-2 text-center p-1 "}
+          style={{
+            left: `${PIXEL_SCALE * -3}px`,
+            right: `${PIXEL_SCALE * -3}px`,
+            width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+            height: "25px",
+          }}
+        >
+          {`Lvl ${DELIVERY_LEVELS[npc]}`}
+        </Label>
+      </ButtonPanel>
+    </div>
+  );
+};
 
 export const DeliveryOrders: React.FC<Props> = ({
   selectedId,
@@ -187,7 +396,25 @@ export const DeliveryOrders: React.FC<Props> = ({
   } = getSeasonChangeover({ id: gameService.state.context.farmId });
 
   const level = getBumpkinLevel(gameState.bumpkin?.experience ?? 0);
-  const nextNpcUnlock = getKeys(DELIVERY_LEVELS)
+
+  const coinOrders = orders.filter((order) => order.reward.coins);
+  const sflOrders = orders.filter((order) => order.reward.sfl);
+  const ticketOrders = orders.filter(
+    (order) => !!TICKET_REWARDS[order.from as QuestNPCName],
+  );
+
+  const nextCoinUnlock = getKeys(DELIVERY_LEVELS)
+    .filter((name) => isCoinNPC(name))
+    .sort((a, b) => (DELIVERY_LEVELS[a] > DELIVERY_LEVELS[b] ? 1 : -1))
+    .find((npc) => level < (DELIVERY_LEVELS?.[npc] ?? 0));
+
+  const nextTicketUnlock = getKeys(DELIVERY_LEVELS)
+    .filter((name) => isTicketNPC(name))
+    .sort((a, b) => (DELIVERY_LEVELS[a] > DELIVERY_LEVELS[b] ? 1 : -1))
+    .find((npc) => level < (DELIVERY_LEVELS?.[npc] ?? 0));
+
+  const nextSFLUnlock = getKeys(DELIVERY_LEVELS)
+    .filter((name) => isSFLNPC(name))
     .sort((a, b) => (DELIVERY_LEVELS[a] > DELIVERY_LEVELS[b] ? 1 : -1))
     .find((npc) => level < (DELIVERY_LEVELS?.[npc] ?? 0));
 
@@ -195,7 +422,7 @@ export const DeliveryOrders: React.FC<Props> = ({
     <div className="flex md:flex-row flex-col-reverse md:mr-1 items-start h-full">
       <InnerPanel
         className={classNames(
-          "flex flex-col h-full overflow-hidden overflow-y-auto scrollable md:flex flex-col w-full md:w-2/3 h-full",
+          "flex flex-col h-full overflow-hidden scrollable overflow-y-auto pl-1 md:flex flex-col w-full md:w-2/3 h-full",
           {
             hidden: selectedId,
           },
@@ -245,181 +472,78 @@ export const DeliveryOrders: React.FC<Props> = ({
           </div>
         )}
 
-        <div className="grid grid-cols-3 sm:grid-cols-4 w-full scrollable overflow-y-auto pl-1">
-          {orders.map((order) => {
-            const tickets = generateDeliveryTickets({
-              game: gameState,
-              npc: order.from,
-            });
-
+        <Label type="default" className="ml-2 mb-2" icon={coinsImg}>
+          {`Coins`}
+        </Label>
+        <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">
+          {coinOrders.map((order) => {
             return (
-              <div className="py-1 px-2" key={order.id}>
-                <ButtonPanel
-                  onClick={() => select(order.id)}
-                  className={classNames("w-full  !py-2 relative", {
-                    "sm:!bg-brown-200": order.id === previewOrder?.id,
-                  })}
-                  style={{ paddingBottom: "20px" }}
-                >
-                  {hasOrderRequirements({ order, coins, sfl, inventory }) &&
-                    !order.completedAt && (
-                      <img
-                        src={SUNNYSIDE.icons.heart}
-                        className="absolute top-0.5 right-0.5 w-3 sm:w-4"
-                      />
-                    )}
-
-                  <div className="flex flex-col pb-2">
-                    <div className="flex items-center my-1">
-                      <div className="relative mb-2 mr-0.5 -ml-1">
-                        <NPCIcon parts={NPC_WEARABLES[order.from]} />
-                      </div>
-                      <div className="flex-1 flex justify-center h-8 items-center w-6 ">
-                        {getKeys(order.items).map((name) => {
-                          let img: string;
-
-                          if (name === "coins") {
-                            img = coinsImg;
-                          } else if (name === "sfl") {
-                            img = sflIcon;
-                          } else {
-                            img = ITEM_DETAILS[name].image;
-                          }
-
-                          return (
-                            <img
-                              key={name}
-                              src={img}
-                              className="w-6 img-highlight"
-                            />
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-
-                  {order.completedAt && (
-                    <Label
-                      type="success"
-                      className="absolute -bottom-2 text-center mt-1 p-1 left-[-8px] z-10 h-6"
-                      style={{ width: "calc(100% + 15px)" }}
-                    >
-                      <img src={SUNNYSIDE.icons.confirm} className="h-4" />
-                    </Label>
-                  )}
-                  {!order.completedAt && order.reward.sfl !== undefined && (
-                    <Label
-                      type="warning"
-                      iconWidth={8}
-                      icon={sflIcon}
-                      className={"absolute -bottom-2 text-center p-1 "}
-                      style={{
-                        left: `${PIXEL_SCALE * -3}px`,
-                        right: `${PIXEL_SCALE * -3}px`,
-                        width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
-                        height: "25px",
-                      }}
-                    >
-                      {`${`${makeRewardAmountForLabel(order)}`}`}
-                    </Label>
-                  )}
-                  {!order.completedAt && order.reward.coins !== undefined && (
-                    <Label
-                      type="warning"
-                      icon={coinsImg}
-                      className={"absolute -bottom-2 text-center p-1 "}
-                      style={{
-                        left: `${PIXEL_SCALE * -3}px`,
-                        right: `${PIXEL_SCALE * -3}px`,
-                        width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
-                        height: "25px",
-                      }}
-                    >
-                      {`${makeRewardAmountForLabel(order)}`}
-                    </Label>
-                  )}
-                  {!order.completedAt && !!tickets && (
-                    <Label
-                      icon={ITEM_DETAILS[getSeasonalTicket()].image}
-                      type="warning"
-                      className={"absolute -bottom-2 text-center p-1 "}
-                      style={{
-                        left: `${PIXEL_SCALE * -3}px`,
-                        right: `${PIXEL_SCALE * -3}px`,
-                        width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
-                        height: "25px",
-                      }}
-                    >
-                      {tickets}
-                    </Label>
-                  )}
-
-                  {order.id === previewOrder?.id && (
-                    <div id="select-box" className="hidden md:block">
-                      <img
-                        className="absolute pointer-events-none"
-                        src={selectBoxTL}
-                        style={{
-                          top: `${PIXEL_SCALE * -3}px`,
-                          left: `${PIXEL_SCALE * -3}px`,
-                          width: `${PIXEL_SCALE * 8}px`,
-                        }}
-                      />
-                      <img
-                        className="absolute pointer-events-none"
-                        src={selectBoxTR}
-                        style={{
-                          top: `${PIXEL_SCALE * -3}px`,
-                          right: `${PIXEL_SCALE * -3}px`,
-                          width: `${PIXEL_SCALE * 8}px`,
-                        }}
-                      />
-                    </div>
-                  )}
-                </ButtonPanel>
-              </div>
+              <OrderCard
+                gameState={gameState}
+                key={order.id}
+                order={order}
+                selected={previewOrder}
+                onClick={(id) => select(id)}
+              />
             );
           })}
-          {nextNpcUnlock && (
-            <div className="py-1 px-2">
-              <ButtonPanel
-                disabled
-                className={classNames(
-                  "w-full  !py-2 relative h-full flex items-center justify-center cursor-not-allowed",
-                )}
-                style={{ paddingBottom: "20px" }}
-              >
-                <div className="flex flex-col pb-2">
-                  <div className="flex items-center my-1">
-                    <div className="relative mb-2 mr-0.5 -ml-1">
-                      <NPCIcon parts={NPC_WEARABLES[nextNpcUnlock]} />
-                    </div>
-                    <div className="flex-1 flex justify-center h-8 items-center w-6 ">
-                      <img
-                        src={SUNNYSIDE.icons.expression_confused}
-                        className="h-6 img-highlight"
-                      />
-                    </div>
-                  </div>
-                </div>
-
-                <Label
-                  type="formula"
-                  icon={lockIcon}
-                  className={"absolute -bottom-2 text-center p-1 "}
-                  style={{
-                    left: `${PIXEL_SCALE * -3}px`,
-                    right: `${PIXEL_SCALE * -3}px`,
-                    width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
-                    height: "25px",
-                  }}
-                >
-                  {`Lvl ${DELIVERY_LEVELS[nextNpcUnlock]}`}
-                </Label>
-              </ButtonPanel>
-            </div>
-          )}
+          {nextCoinUnlock && <LockedOrderCard npc={nextCoinUnlock} />}
         </div>
+
+        <div className="px-2 mt-2">
+          <div className="flex justify-between">
+            <Label
+              type="default"
+              icon={ITEM_DETAILS[getSeasonalTicket()].image}
+            >
+              {`${getSeasonalTicket()}s`}
+            </Label>
+          </div>
+          <span className="text-xs mb-2">
+            Earn scrolls to craft exclusive items.
+          </span>
+        </div>
+        <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">
+          {ticketOrders.map((order) => {
+            return (
+              <OrderCard
+                gameState={gameState}
+                key={order.id}
+                order={order}
+                selected={previewOrder}
+                onClick={(id) => select(id)}
+              />
+            );
+          })}
+          {nextTicketUnlock && <LockedOrderCard npc={nextTicketUnlock} />}
+        </div>
+
+        <div className="px-2 mt-2">
+          <div className="flex justify-between">
+            <Label type="default" icon={sflIcon}>
+              {`SFL`}
+            </Label>
+          </div>
+          <span className="text-xs mb-2">
+            Earn SFL to trade & build your empire.
+          </span>
+        </div>
+
+        <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">
+          {sflOrders.map((order) => {
+            return (
+              <OrderCard
+                gameState={gameState}
+                key={order.id}
+                order={order}
+                selected={previewOrder}
+                onClick={(id) => select(id)}
+              />
+            );
+          })}
+          {nextSFLUnlock && <LockedOrderCard npc={nextSFLUnlock} />}
+        </div>
+
         {nextOrder && !skippedOrder && (
           <div className="w-1/2 sm:w-1/3 p-1">
             <OuterPanel
@@ -662,6 +786,7 @@ export const DeliveryOrders: React.FC<Props> = ({
                   <Button
                     className="!text-xs !mt-0 !-mb-1"
                     onClick={() => {
+                      gameService.send("SAVE");
                       onClose();
                       {
                         if (

--- a/src/features/island/delivery/lib/delivery.ts
+++ b/src/features/island/delivery/lib/delivery.ts
@@ -1,3 +1,8 @@
+import {
+  QuestNPCName,
+  TICKET_REWARDS,
+} from "features/game/events/landExpansion/deliver";
+import { TICKETS_REWARDED } from "features/game/events/landExpansion/tradeFlowerShop";
 import { Delivery } from "features/game/types/game";
 import { translate } from "lib/i18n/translate";
 import { NPCName } from "lib/npcs";
@@ -46,6 +51,36 @@ export type CoinNPCName =
   | "victoria";
 
 export type DeliveryNpcName = TicketNPCName | GoblinNPCName | CoinNPCName;
+
+export const COIN_NPC_NAMES: CoinNPCName[] = [
+  "betty",
+  "corale",
+  "blacksmith",
+  "tango",
+  "victoria",
+  "peggy",
+];
+
+export function isCoinNPC(value: string): value is CoinNPCName {
+  return (COIN_NPC_NAMES as string[]).includes(value);
+}
+
+export const GOBLIN_NPC_NAMES: GoblinNPCName[] = [
+  "grimbly",
+  "grimtooth",
+  "grubnuk",
+  "gordo",
+  "guria",
+  "gambit",
+];
+
+export function isSFLNPC(value: string): value is GoblinNPCName {
+  return (GOBLIN_NPC_NAMES as string[]).includes(value);
+}
+
+export function isTicketNPC(value: string): value is QuestNPCName {
+  return !!TICKET_REWARDS[value as QuestNPCName];
+}
 
 const NPC_MESSAGES: Record<DeliveryNpcName, string[]> = {
   betty: [

--- a/src/features/island/delivery/lib/delivery.ts
+++ b/src/features/island/delivery/lib/delivery.ts
@@ -2,10 +2,8 @@ import {
   QuestNPCName,
   TICKET_REWARDS,
 } from "features/game/events/landExpansion/deliver";
-import { TICKETS_REWARDED } from "features/game/events/landExpansion/tradeFlowerShop";
 import { Delivery } from "features/game/types/game";
 import { translate } from "lib/i18n/translate";
-import { NPCName } from "lib/npcs";
 
 export type DeliveryMessage = { from: DeliveryNpcName; id: string };
 

--- a/src/features/island/delivery/lib/delivery.ts
+++ b/src/features/island/delivery/lib/delivery.ts
@@ -2,7 +2,7 @@ import { Delivery } from "features/game/types/game";
 import { translate } from "lib/i18n/translate";
 import { NPCName } from "lib/npcs";
 
-export type DeliveryMessage = { from: NPCName; id: string };
+export type DeliveryMessage = { from: DeliveryNpcName; id: string };
 
 const GOBLIN_MESSAGES = [
   translate("goblinMessages.msg1"),
@@ -17,7 +17,37 @@ const GOBLIN_MESSAGES = [
   translate("goblinMessages.msg10"),
 ];
 
-const NPC_MESSAGES: Partial<Record<NPCName, string[]>> = {
+export type TicketNPCName =
+  | "pumpkin' pete"
+  | "bert"
+  | "raven"
+  | "timmy"
+  | "tywin"
+  | "cornwell"
+  | "finn"
+  | "finley"
+  | "miranda"
+  | "jester";
+
+export type GoblinNPCName =
+  | "grimbly"
+  | "grimtooth"
+  | "grubnuk"
+  | "gordo"
+  | "guria"
+  | "gambit";
+
+export type CoinNPCName =
+  | "betty"
+  | "peggy"
+  | "tango"
+  | "corale"
+  | "blacksmith"
+  | "victoria";
+
+export type DeliveryNpcName = TicketNPCName | GoblinNPCName | CoinNPCName;
+
+const NPC_MESSAGES: Record<DeliveryNpcName, string[]> = {
   betty: [
     translate("npcMessages.betty.msg1"),
     translate("npcMessages.betty.msg2"),
@@ -39,6 +69,9 @@ const NPC_MESSAGES: Partial<Record<NPCName, string[]>> = {
   grubnuk: GOBLIN_MESSAGES,
   grimbly: GOBLIN_MESSAGES,
   grimtooth: GOBLIN_MESSAGES,
+  gambit: GOBLIN_MESSAGES,
+  gordo: GOBLIN_MESSAGES,
+  guria: GOBLIN_MESSAGES,
   "pumpkin' pete": [
     translate("npcMessages.pumpkinpete.msg1"),
     translate("npcMessages.pumpkinpete.msg2"),
@@ -144,6 +177,9 @@ const NPC_MESSAGES: Partial<Record<NPCName, string[]>> = {
     translate("npcMessages.corale.msg7"),
     "Seaweed is like a gourmet treat for Parrotfish",
   ],
+  jester: [translate("npcMessages.betty.msg1")],
+  peggy: [translate("npcMessages.betty.msg1")],
+  victoria: [translate("npcMessages.betty.msg1")],
 };
 
 export function generateDeliveryMessage({ from, id }: DeliveryMessage) {
@@ -176,21 +212,32 @@ export function acknowledgeOrders(delivery: Delivery) {
   localStorage.setItem(`orders.read`, JSON.stringify(ids));
 }
 
-export const DELIVERY_LEVELS: Partial<Record<NPCName, number>> = {
-  grimbly: 3,
-  betty: 3,
-  grimtooth: 3,
-  "pumpkin' pete": 3,
-  grubnuk: 5,
-  blacksmith: 5,
-  bert: 5,
-  finley: 6,
-  raven: 7,
-  miranda: 7,
+export const DELIVERY_LEVELS: Record<DeliveryNpcName, number> = {
+  // Coins
+  betty: 1,
+  blacksmith: 1,
+  peggy: 3,
   corale: 7,
-  finn: 7,
-  timmy: 9,
-  tango: 9,
-  cornwell: 9,
-  tywin: 14,
+  tango: 13,
+  victoria: 30,
+
+  // SFL
+  grimbly: 10,
+  grimtooth: 12,
+  grubnuk: 16,
+  gambit: 25,
+  gordo: 30,
+  guria: 40,
+
+  // Tickets
+  "pumpkin' pete": 5,
+  bert: 8,
+  finley: 12,
+  raven: 14,
+  miranda: 15,
+  finn: 16,
+  cornwell: 18,
+  timmy: 20,
+  tywin: 22,
+  jester: 26,
 };

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -25,6 +25,11 @@ export type FactionNPC = {
 
 export const PLAZA_BUMPKINS: NPCBumpkin[] = [
   {
+    x: 207,
+    y: 379,
+    npc: "peggy",
+  },
+  {
     x: 600,
     y: 197,
     npc: "hammerin harry",

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -187,6 +187,7 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
         {npc === "blacksmith" && (
           <DeliveryPanel npc={npc} onClose={closeModal} />
         )}
+        {npc === "peggy" && <DeliveryPanel npc={npc} onClose={closeModal} />}
         {npc === "raven" && <DeliveryPanel npc={npc} onClose={closeModal} />}
         {npc === "victoria" && <DeliveryPanel npc={npc} onClose={closeModal} />}
         {npc === "jester" && <DeliveryPanel npc={npc} onClose={closeModal} />}

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -28,7 +28,10 @@ import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 import { defaultDialogue, npcDialogues } from "./dialogues";
 import { useRandomItem } from "lib/utils/hooks/useRandomItem";
 import { getTotalExpansions } from "./DeliveryPanelContent";
-import { DELIVERY_LEVELS } from "features/island/delivery/lib/delivery";
+import {
+  DELIVERY_LEVELS,
+  DeliveryNpcName,
+} from "features/island/delivery/lib/delivery";
 import {
   getSeasonalBanner,
   getSeasonalTicket,
@@ -616,7 +619,8 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
   }
 
   const missingExpansions =
-    (DELIVERY_LEVELS[npc] ?? 0) - getTotalExpansions({ game }).toNumber();
+    (DELIVERY_LEVELS[npc as DeliveryNpcName] ?? 0) -
+    getTotalExpansions({ game }).toNumber();
   const missingVIPAccess = requiresSeasonPass && !hasSeasonPass && !hasVIP;
   const isLocked = missingExpansions >= 1;
   const isTicketOrder = tickets > 0;

--- a/src/features/world/ui/deliveries/dialogues.ts
+++ b/src/features/world/ui/deliveries/dialogues.ts
@@ -368,6 +368,33 @@ export const npcDialogues: Partial<Record<NPCName, DeliveryNPCDialogue>> = {
       translate("npcDialogues.gambit.noOrder2"),
     ],
   },
+  peggy: {
+    intro: [
+      translate("npcDialogues.peggy.intro1"),
+      translate("npcDialogues.peggy.intro2"),
+      translate("npcDialogues.peggy.intro3"),
+      translate("npcDialogues.peggy.intro4"),
+      translate("npcDialogues.peggy.intro5"),
+    ],
+    positiveDelivery: [
+      translate("npcDialogues.peggy.positiveDelivery1"),
+      translate("npcDialogues.peggy.positiveDelivery2"),
+      translate("npcDialogues.peggy.positiveDelivery3"),
+      translate("npcDialogues.peggy.positiveDelivery4"),
+      translate("npcDialogues.peggy.positiveDelivery5"),
+    ],
+    negativeDelivery: [
+      translate("npcDialogues.peggy.negativeDelivery1"),
+      translate("npcDialogues.peggy.negativeDelivery2"),
+      translate("npcDialogues.peggy.negativeDelivery3"),
+      translate("npcDialogues.peggy.negativeDelivery4"),
+      translate("npcDialogues.peggy.negativeDelivery5"),
+    ],
+    noOrder: [
+      translate("npcDialogues.peggy.noOrder1"),
+      translate("npcDialogues.peggy.noOrder2"),
+    ],
+  },
 };
 
 export const defaultDialogue: DeliveryNPCDialogue = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -967,6 +967,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "我一直就是在等这个。非常感谢！请尽快回来获取更多送货订单。",
   "bumpkin.delivery.proveYourself":
     "证明你的价值。再扩展你的岛屿 {{missingExpansions}} 次。",
+  "bumpkin.delivery.earnScrolls": ENGLISH_TERMS["bumpkin.delivery.earnScrolls"],
+  "bumpkin.delivery.earnSFL": ENGLISH_TERMS["bumpkin.delivery.earnSFL"],
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3287,6 +3287,34 @@ const npc: Record<Npc, string> = {
 };
 
 const npcDialogues: Record<NpcDialogues, string> = {
+  "npcDialogues.peggy.intro1": ENGLISH_TERMS["npcDialogues.peggy.intro1"],
+  "npcDialogues.peggy.intro2": ENGLISH_TERMS["npcDialogues.peggy.intro2"],
+  "npcDialogues.peggy.intro3": ENGLISH_TERMS["npcDialogues.peggy.intro3"],
+  "npcDialogues.peggy.intro4": ENGLISH_TERMS["npcDialogues.peggy.intro4"],
+  "npcDialogues.peggy.intro5": ENGLISH_TERMS["npcDialogues.peggy.intro5"],
+  "npcDialogues.peggy.positiveDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery1"],
+  "npcDialogues.peggy.positiveDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery2"],
+  "npcDialogues.peggy.positiveDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery3"],
+  "npcDialogues.peggy.positiveDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery4"],
+  "npcDialogues.peggy.positiveDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery5"],
+  "npcDialogues.peggy.negativeDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery1"],
+  "npcDialogues.peggy.negativeDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery2"],
+  "npcDialogues.peggy.negativeDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery3"],
+  "npcDialogues.peggy.negativeDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery4"],
+  "npcDialogues.peggy.negativeDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery5"],
+  "npcDialogues.peggy.noOrder1": ENGLISH_TERMS["npcDialogues.peggy.noOrder1"],
+  "npcDialogues.peggy.noOrder2": ENGLISH_TERMS["npcDialogues.peggy.noOrder2"],
+
   "npcDialogues.queenVictoria.intro1":
     ENGLISH_TERMS["npcDialogues.queenVictoria.intro1"],
   "npcDialogues.queenVictoria.intro2":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4158,6 +4158,43 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.pumpkinPete.noOrder2":
     "Oh, no active order for you today, my friend. But don't worry! Feel free to explore the plaza, and if you need any assistance, I'm your trusty Bumpkin.",
 
+  // Peggy
+  "npcDialogues.peggy.intro1":
+    "Hello there, darling! Have you come to bring me some scrumptious delights? I can't wait to see what you've cooked up!",
+  "npcDialogues.peggy.intro2":
+    "Well, butter my biscuits! Have you got those tasty treats ready for me? I'm all set for some delicious fun!",
+  "npcDialogues.peggy.intro3":
+    "Howdy, partner! I’ve been waiting to see what delicious creation you’ve brought me. Ready to share some culinary joy?",
+  "npcDialogues.peggy.intro4":
+    "Hiya, sweetie! What’s cookin’? Did you bring me some of those mouthwatering dishes I’ve been dreaming of?",
+  "npcDialogues.peggy.intro5":
+    "Oh, hello there! I’m so excited to see what delectable delights you’ve prepared. Have you got my order?",
+
+  "npcDialogues.peggy.positiveDelivery1":
+    "Yum-tastic! You've cooked up just what I was craving. You're the best cook in the plaza!",
+  "npcDialogues.peggy.positiveDelivery2":
+    "Oh, my taste buds are dancing! You've delivered the perfect dish. You're a culinary superstar!",
+  "npcDialogues.peggy.positiveDelivery3":
+    "Deliciousness achieved! You've whipped up exactly what I needed. You're a true kitchen hero!",
+  "npcDialogues.peggy.positiveDelivery4":
+    "Fantastic feast! You've brought me exactly what I was hoping for. The whole plaza will enjoy this!",
+  "npcDialogues.peggy.positiveDelivery5":
+    "Wow, what a treat! You've cooked and delivered the perfect meal. You've made my day, and the plaza too!",
+  "npcDialogues.peggy.negativeDelivery1":
+    "Oh dear, it looks like this isn’t quite what I needed. No worries, though! Keep cooking and bring it back when you can.",
+  "npcDialogues.peggy.negativeDelivery2":
+    "Oops, this isn’t quite right. But don’t fret! Cook up another dish and come back soon!",
+  "npcDialogues.peggy.negativeDelivery3":
+    "This isn’t what I was hoping for, but don’t give up! Keep those cooking skills sharp and try again later.",
+  "npcDialogues.peggy.negativeDelivery4":
+    "Oh, this isn’t quite the dish I was craving. Keep exploring your recipes and bring me something else when you can!",
+  "npcDialogues.peggy.negativeDelivery5":
+    "Not quite the meal I was after, but don’t worry! Try cooking something else and come back with your next culinary creation.",
+  "npcDialogues.peggy.noOrder1":
+    "Ah, it seems I don’t have an active order for you at the moment. But feel free to explore and cook up a storm in the plaza!",
+  "npcDialogues.peggy.noOrder2":
+    "No current order for you today, but don’t let that stop you! If you need any cooking advice or just want to chat, I’m here!",
+
   // NPC gift dialogues
   "npcDialogues.pumpkinPete.reward":
     "Thank you kindly for your deliveries. Here's a token of appreciation for you.",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2985,8 +2985,7 @@ const guideTerms: Record<GuideTerms, string> = {
     "Deliveries in Sunflower Land provide an exciting opportunity to help hungry Goblins and fellow Bumpkins while earning rewards. Every day you will be able to see all the orders you have by clicking on the delivery board on the bottom left of the screen. The orders have been placed by some local NPCs that can be found hanging around Pumpkin Plaza. To fulfill an order, you will need to take a boat ride to Pumpkin Plaza and look for the NPC expecting the delivery. Once you find them, click on them to deliver the order and receive your reward.",
   "deliveries.guide.two":
     "As a new player, you start with three order slots, but as you expand your farm, you will unlock additional slots, allowing advanced players to take on more orders. New orders come in every 24 hours, offering a range of tasks from farming produce to cooking food and gathering resources. Completing orders will earn you milestone bonuses, including Block Bucks, SFL, Coins, delicious cakes, and other rewards. The reward system is based on the difficulty of the request, so consider prioritizing orders that offer greater rewards to maximize your gains. Keep an eye on the board and challenge yourself with a variety of orders, leveling up and unlocking new buildings as needed to fulfill more demanding requests.",
-  "deliveries.intro":
-    "Travel to different islands and deliver goods to earn rewards.",
+  "deliveries.intro": "Travel and deliver goods to earn rewards.",
   "deliveries.new": "New delivery",
   "chores.hank": "Hank's Chores",
   "chores.hank.intro":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -997,6 +997,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "I've been waiting for this. Thanks a bunch! Come back soon for more deliveries.",
   "bumpkin.delivery.proveYourself":
     "Prove yourself worthy. Expand your island {{missingExpansions}} more times.",
+  "bumpkin.delivery.earnScrolls": "Earn scrolls to craft exclusive items.",
+  "bumpkin.delivery.earnSFL": "Earn SFL to trade & build your empire.",
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4391,6 +4391,34 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.pumpkinPete.noOrder2":
     "Oh, pas de commande active pour toi aujourd'hui, mon ami. Mais ne t'inquiète pas ! N'hésite pas à explorer la place, et si tu as besoin d'aide, je suis ton fidèle Bumpkin.",
 
+  "npcDialogues.peggy.intro1": ENGLISH_TERMS["npcDialogues.peggy.intro1"],
+  "npcDialogues.peggy.intro2": ENGLISH_TERMS["npcDialogues.peggy.intro2"],
+  "npcDialogues.peggy.intro3": ENGLISH_TERMS["npcDialogues.peggy.intro3"],
+  "npcDialogues.peggy.intro4": ENGLISH_TERMS["npcDialogues.peggy.intro4"],
+  "npcDialogues.peggy.intro5": ENGLISH_TERMS["npcDialogues.peggy.intro5"],
+  "npcDialogues.peggy.positiveDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery1"],
+  "npcDialogues.peggy.positiveDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery2"],
+  "npcDialogues.peggy.positiveDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery3"],
+  "npcDialogues.peggy.positiveDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery4"],
+  "npcDialogues.peggy.positiveDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery5"],
+  "npcDialogues.peggy.negativeDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery1"],
+  "npcDialogues.peggy.negativeDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery2"],
+  "npcDialogues.peggy.negativeDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery3"],
+  "npcDialogues.peggy.negativeDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery4"],
+  "npcDialogues.peggy.negativeDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery5"],
+  "npcDialogues.peggy.noOrder1": ENGLISH_TERMS["npcDialogues.peggy.noOrder1"],
+  "npcDialogues.peggy.noOrder2": ENGLISH_TERMS["npcDialogues.peggy.noOrder2"],
+
   // NPC gift dialogues
   "npcDialogues.pumpkinPete.reward":
     "Merci beaucoup pour tes livraisons. Voici un petit geste d'appréciation pour toi.",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1029,6 +1029,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "J'attendais ça. Merci beaucoup ! Reviens bientôt pour plus de livraisons.",
   "bumpkin.delivery.proveYourself":
     "Prouve que tu es digne. Agrandis ton île {{missingExpansions}} fois de plus.",
+  "bumpkin.delivery.earnScrolls": ENGLISH_TERMS["bumpkin.delivery.earnScrolls"],
+  "bumpkin.delivery.earnSFL": ENGLISH_TERMS["bumpkin.delivery.earnSFL"],
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1021,6 +1021,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "Eu estava esperando por isso. Obrigado! Volte logo para mais entregas.",
   "bumpkin.delivery.proveYourself":
     ENGLISH_TERMS["bumpkin.delivery.proveYourself"],
+  "bumpkin.delivery.earnScrolls": ENGLISH_TERMS["bumpkin.delivery.earnScrolls"],
+  "bumpkin.delivery.earnSFL": ENGLISH_TERMS["bumpkin.delivery.earnSFL"],
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3960,6 +3960,35 @@ const npcDialogues: Record<NpcDialogues, string> = {
     "Sem pedido ativo para eu cumprir agora, mas isso não me impede de oferecer as melhores sementes e colheitas para você. Entre e vejamos o que você está procurando!",
   "npcDialogues.betty.noOrder2":
     "Nenhum pedido específico de mim hoje, mas isso não é um problema. Estou aqui com um pulo no passo, pronto para lhe fornecer as melhores sementes e comprar suas deliciosas colheitas!",
+
+  "npcDialogues.peggy.intro1": ENGLISH_TERMS["npcDialogues.peggy.intro1"],
+  "npcDialogues.peggy.intro2": ENGLISH_TERMS["npcDialogues.peggy.intro2"],
+  "npcDialogues.peggy.intro3": ENGLISH_TERMS["npcDialogues.peggy.intro3"],
+  "npcDialogues.peggy.intro4": ENGLISH_TERMS["npcDialogues.peggy.intro4"],
+  "npcDialogues.peggy.intro5": ENGLISH_TERMS["npcDialogues.peggy.intro5"],
+  "npcDialogues.peggy.positiveDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery1"],
+  "npcDialogues.peggy.positiveDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery2"],
+  "npcDialogues.peggy.positiveDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery3"],
+  "npcDialogues.peggy.positiveDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery4"],
+  "npcDialogues.peggy.positiveDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery5"],
+  "npcDialogues.peggy.negativeDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery1"],
+  "npcDialogues.peggy.negativeDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery2"],
+  "npcDialogues.peggy.negativeDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery3"],
+  "npcDialogues.peggy.negativeDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery4"],
+  "npcDialogues.peggy.negativeDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery5"],
+  "npcDialogues.peggy.noOrder1": ENGLISH_TERMS["npcDialogues.peggy.noOrder1"],
+  "npcDialogues.peggy.noOrder2": ENGLISH_TERMS["npcDialogues.peggy.noOrder2"],
+
   // Grimbly Intro
   "npcDialogues.grimbly.intro1":
     "Com fome. Preciso de comida. Tem algo saboroso para um goblin faminto?",

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1009,6 +1009,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "То что надо. Огромное спасибо! Возвращайся позже за новыми доставками.",
   "bumpkin.delivery.proveYourself":
     "Докажи, что ты достоин. Расширь свой остров еще {{missingExpansions}} раз.",
+  "bumpkin.delivery.earnScrolls": ENGLISH_TERMS["bumpkin.delivery.earnScrolls"],
+  "bumpkin.delivery.earnSFL": ENGLISH_TERMS["bumpkin.delivery.earnSFL"],
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -4390,6 +4390,34 @@ const npcDialogues: Record<NpcDialogues, string> = {
     "Oh no, this flower is as funny as a wet sock! Try again, will you?",
   "npcDialogues.jester.goodFlower":
     "Splendid! This flower is perfect. Almost as good as one of my jokes!",
+
+  "npcDialogues.peggy.intro1": ENGLISH_TERMS["npcDialogues.peggy.intro1"],
+  "npcDialogues.peggy.intro2": ENGLISH_TERMS["npcDialogues.peggy.intro2"],
+  "npcDialogues.peggy.intro3": ENGLISH_TERMS["npcDialogues.peggy.intro3"],
+  "npcDialogues.peggy.intro4": ENGLISH_TERMS["npcDialogues.peggy.intro4"],
+  "npcDialogues.peggy.intro5": ENGLISH_TERMS["npcDialogues.peggy.intro5"],
+  "npcDialogues.peggy.positiveDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery1"],
+  "npcDialogues.peggy.positiveDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery2"],
+  "npcDialogues.peggy.positiveDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery3"],
+  "npcDialogues.peggy.positiveDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery4"],
+  "npcDialogues.peggy.positiveDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery5"],
+  "npcDialogues.peggy.negativeDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery1"],
+  "npcDialogues.peggy.negativeDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery2"],
+  "npcDialogues.peggy.negativeDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery3"],
+  "npcDialogues.peggy.negativeDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery4"],
+  "npcDialogues.peggy.negativeDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery5"],
+  "npcDialogues.peggy.noOrder1": ENGLISH_TERMS["npcDialogues.peggy.noOrder1"],
+  "npcDialogues.peggy.noOrder2": ENGLISH_TERMS["npcDialogues.peggy.noOrder2"],
 };
 
 const nyeButton: Record<NyeButton, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1010,6 +1010,8 @@ const bumpkinDelivery: Record<BumpkinDelivery, string> = {
     "Bunun için bekliyordum. Çok teşekkürler! Daha fazla teslimat için yakında tekrar gel.",
   "bumpkin.delivery.proveYourself":
     ENGLISH_TERMS["bumpkin.delivery.proveYourself"],
+  "bumpkin.delivery.earnScrolls": ENGLISH_TERMS["bumpkin.delivery.earnScrolls"],
+  "bumpkin.delivery.earnSFL": ENGLISH_TERMS["bumpkin.delivery.earnSFL"],
 };
 
 const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4268,6 +4268,34 @@ const npcDialogues: Record<NpcDialogues, string> = {
   "npcDialogues.pumpkinPete.noOrder2":
     "Ah, bugün sizin için aktif bir sipariş yok, dostum. Ama endişelenme! Plazayı keşfetmekte özgürsünüz ve herhangi bir yardıma ihtiyacınız varsa, ben buradayım.",
 
+  "npcDialogues.peggy.intro1": ENGLISH_TERMS["npcDialogues.peggy.intro1"],
+  "npcDialogues.peggy.intro2": ENGLISH_TERMS["npcDialogues.peggy.intro2"],
+  "npcDialogues.peggy.intro3": ENGLISH_TERMS["npcDialogues.peggy.intro3"],
+  "npcDialogues.peggy.intro4": ENGLISH_TERMS["npcDialogues.peggy.intro4"],
+  "npcDialogues.peggy.intro5": ENGLISH_TERMS["npcDialogues.peggy.intro5"],
+  "npcDialogues.peggy.positiveDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery1"],
+  "npcDialogues.peggy.positiveDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery2"],
+  "npcDialogues.peggy.positiveDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery3"],
+  "npcDialogues.peggy.positiveDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery4"],
+  "npcDialogues.peggy.positiveDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.positiveDelivery5"],
+  "npcDialogues.peggy.negativeDelivery1":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery1"],
+  "npcDialogues.peggy.negativeDelivery2":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery2"],
+  "npcDialogues.peggy.negativeDelivery3":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery3"],
+  "npcDialogues.peggy.negativeDelivery4":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery4"],
+  "npcDialogues.peggy.negativeDelivery5":
+    ENGLISH_TERMS["npcDialogues.peggy.negativeDelivery5"],
+  "npcDialogues.peggy.noOrder1": ENGLISH_TERMS["npcDialogues.peggy.noOrder1"],
+  "npcDialogues.peggy.noOrder2": ENGLISH_TERMS["npcDialogues.peggy.noOrder2"],
+
   // NPC gift dialogues
   "npcDialogues.pumpkinPete.reward":
     "Teslimatlarınız için nazik olmanızı takdir ederim. İşte minnettarlığımı göstermek için küçük bir şey.",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -682,7 +682,9 @@ export type BumpkinDelivery =
   | "bumpkin.delivery.noFlowers"
   | "bumpkin.delivery.thanks"
   | "bumpkin.delivery.waiting"
-  | "bumpkin.delivery.proveYourself";
+  | "bumpkin.delivery.proveYourself"
+  | "bumpkin.delivery.earnScrolls"
+  | "bumpkin.delivery.earnSFL";
 
 export type BumpkinItemBuff =
   | "bumpkinItemBuff.chef.apron.boost"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2958,7 +2958,24 @@ export type NpcDialogues =
   | "npcDialogues.jester.averageFlower"
   | "npcDialogues.jester.badFlower"
   | "npcDialogues.jester.goodFlower"
-  | "npcDialogues.tywin.goodFlower";
+  | "npcDialogues.tywin.goodFlower"
+  | "npcDialogues.peggy.intro1"
+  | "npcDialogues.peggy.intro2"
+  | "npcDialogues.peggy.intro3"
+  | "npcDialogues.peggy.intro4"
+  | "npcDialogues.peggy.intro5"
+  | "npcDialogues.peggy.positiveDelivery1"
+  | "npcDialogues.peggy.positiveDelivery2"
+  | "npcDialogues.peggy.positiveDelivery3"
+  | "npcDialogues.peggy.positiveDelivery4"
+  | "npcDialogues.peggy.positiveDelivery5"
+  | "npcDialogues.peggy.negativeDelivery1"
+  | "npcDialogues.peggy.negativeDelivery2"
+  | "npcDialogues.peggy.negativeDelivery3"
+  | "npcDialogues.peggy.negativeDelivery4"
+  | "npcDialogues.peggy.negativeDelivery5"
+  | "npcDialogues.peggy.noOrder1"
+  | "npcDialogues.peggy.noOrder2";
 
 export type NyeButton = "plaza.magicButton.query";
 

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -97,7 +97,8 @@ export type NPCName =
   | "flora"
   | "eldric"
   | "jafar" // desert merchant
-  | "pet"; // faction pet
+  | "pet" // faction pet
+  | "peggy";
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   digby: {
@@ -109,6 +110,17 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     tool: "Grave Diggers Shovel",
     background: "Farm Background",
     shoes: "Black Farmer Boots",
+  },
+  peggy: {
+    body: "Beige Farmer Potion",
+    shirt: "Red Farmer Shirt",
+    pants: "Farmer Pants",
+    coat: "Chef Apron",
+    hair: "Royal Braids",
+    hat: "Chef Hat",
+    background: "Farm Background",
+    shoes: "Black Farmer Boots",
+    tool: "Parsnip",
   },
   "chef tuck": {
     body: "Goblin Potion",


### PR DESCRIPTION
# Description

This PR introduces multiple improvements to deliveries with an aim to improve onboarding for new users.

1. Categorise delivery section
2. Add **1 extra** Bumpkin NPC which rewards coins - `peggy`
3. For your first 15 **coin** deliveries, they will instantly regenerate instead of waiting for next day.
4. Use Bumpkin level (instead of expansion level) to unlock NPCs = clearer for user to understand. See https://github.com/sunflower-land/sunflower-land/pull/3925/files#diff-37e790da4a76190eb16a6a507e270f9138834583a2c67218f39e48a8a25c15c1R252

<img width="508" alt="Screenshot 2024-06-23 at 10 29 58 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/c4193c00-297d-474c-92ed-8d8891db6195">
