### PR TITLE
[FIX] Listing Upper Trade limit

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -105,8 +105,8 @@ const ListTrade: React.FC<{
     !!sfl &&
     !!quantity &&
     !!floorPrices[selected] &&
-    // new Decimal(floorPrices[selected] ?? 0).mul(1.5).lt(unitPrice); // Either we change the label to 1.5, or change this limit to 1.2
     new Decimal(floorPrices[selected] ?? 0).mul(1.2).lt(unitPrice);
+
   const isTooLow =
     !!sfl &&
     !!quantity &&
@@ -163,7 +163,6 @@ const ListTrade: React.FC<{
           <Label type="danger" className="my-1 ml-2 mr-1">
             {t("bumpkinTrade.maximumFloor", {
               max: setPrecision(new Decimal(floorPrices[selected] ?? 0))
-                //.mul(1.5) // Either we change the label to 1.5, or change the limit to 1.2
                 .mul(1.2)
                 .toNumber(),
             })}

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -105,8 +105,8 @@ const ListTrade: React.FC<{
     !!sfl &&
     !!quantity &&
     !!floorPrices[selected] &&
-    new Decimal(floorPrices[selected] ?? 0).mul(1.5).lt(unitPrice);
-
+    // new Decimal(floorPrices[selected] ?? 0).mul(1.5).lt(unitPrice); // Either we change the label to 1.5, or change this limit to 1.2
+    new Decimal(floorPrices[selected] ?? 0).mul(1.2).lt(unitPrice);
   const isTooLow =
     !!sfl &&
     !!quantity &&
@@ -163,6 +163,7 @@ const ListTrade: React.FC<{
           <Label type="danger" className="my-1 ml-2 mr-1">
             {t("bumpkinTrade.maximumFloor", {
               max: setPrecision(new Decimal(floorPrices[selected] ?? 0))
+                //.mul(1.5) // Either we change the label to 1.5, or change the limit to 1.2
                 .mul(1.2)
                 .toNumber(),
             })}


### PR DESCRIPTION
# Description

The Upper limit is currently coded to 1.5x floor price, but the label writes 1.2x
Updated the code limit to 1.2 instead of 1.5

Current
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/79877872-8494-45d1-bf53-a285c1e6aa6c)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
