### PR TITLE
[FEAT] Sell Custom Amount of Crops to Betty

### DIFF
--- a/src/components/ui/BulkSellModal.tsx
+++ b/src/components/ui/BulkSellModal.tsx
@@ -1,0 +1,112 @@
+import React, { ChangeEvent } from "react";
+import Decimal from "decimal.js-light";
+import { Button } from "components/ui/Button";
+import coins from "assets/icons/coins.webp";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { Modal } from "components/ui/Modal";
+import { Panel } from "components/ui/Panel";
+import classNames from "classnames";
+
+interface BulkSellProps {
+  show: boolean;
+  onHide: () => void;
+  cropAmount: Decimal;
+  customInputAmount: string;
+  setCustomInputAmount: (amount: string) => void;
+  onCancel: () => void;
+  onSell: () => void;
+  coinAmount: Decimal;
+}
+
+export const BulkSellModal: React.FC<BulkSellProps> = ({
+  show,
+  onHide,
+  cropAmount,
+  customInputAmount,
+  setCustomInputAmount,
+  onCancel,
+  onSell,
+  coinAmount,
+}) => {
+  const { t } = useAppTranslation();
+  const customAmount = Number(customInputAmount);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/^0+(?!\.)/, "");
+
+    // Check if the value has a decimal point
+    const parts = value.split(".");
+
+    // Limit the decimal places to 4
+    if (parts.length > 1 && parts[1].length > 4) {
+      parts[1] = parts[1].slice(0, 4);
+    }
+
+    const formattedValue = parts.join(".");
+
+    setCustomInputAmount(formattedValue ? formattedValue.slice(0, 10) : "");
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Panel className="w-4/5 m-auto">
+        <div className="flex flex-col items-center">
+          <p className="text-sm text-start w-full mb-1">
+            {t("confirmation.enterAmount")}
+          </p>
+          <div className="flex items-center w-full">
+            <input
+              type="number"
+              placeholder="0"
+              min={1}
+              value={customInputAmount}
+              onChange={handleInputChange}
+              className={classNames(
+                "mb-2 text-shadow rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10 placeholder-error",
+                {
+                  "text-error": new Decimal(customAmount).greaterThan(
+                    cropAmount,
+                  ),
+                },
+              )}
+              style={{
+                boxShadow: "#b96e50 0px 1px 1px 1px inset",
+                border: "2px solid #ead4aa",
+              }}
+            />
+            <Button
+              onClick={() =>
+                setCustomInputAmount(cropAmount.mul(0.5).toString())
+              }
+              className="ml-2 px-1 py-1 w-auto"
+            >
+              {`50%`}
+            </Button>
+            <Button
+              onClick={() => setCustomInputAmount(cropAmount.toString())}
+              className="ml-2 px-1 py-1 w-auto"
+            >
+              {t("max")}
+            </Button>
+          </div>
+          <div className="inline-flex items-center">
+            {`${t("bumpkinTrade.youWillReceive")}: ${coinAmount}`}
+            <img src={coins} alt="coins" className="ml-2 mt-1" />
+          </div>
+        </div>
+        <div className="flex justify-content-around mt-2 space-x-1">
+          <Button onClick={onCancel}>{t("cancel")}</Button>
+          <Button
+            disabled={
+              new Decimal(customAmount).greaterThan(cropAmount) ||
+              new Decimal(customAmount).lessThanOrEqualTo(0)
+            }
+            onClick={onSell}
+          >
+            {t("sell")}
+          </Button>
+        </div>
+      </Panel>
+    </Modal>
+  );
+};

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -438,6 +438,8 @@ const generalTerms: Record<GeneralTerms, string> = {
   requirements: "需要",
   "time.remaining": ENGLISH_TERMS["time.remaining"],
   expired: ENGLISH_TERMS.expired,
+  "sell.amount": "出售 {{amount}}",
+  "sell.inBulk": "批量销售",
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1224,6 +1226,7 @@ const confirmationTerms: Record<ConfirmationTerms, string> = {
     "您确定要卖掉 {{cropAmount}} {{cropName}} 以换取 {{coinAmount}} 枚硬币吗？",
   "confirmation.buyCrops":
     "您确定要花 {{coinAmount}} 枚硬币购买 {{seedNo}} {{seedName}}s 吗？",
+  "confirmation.enterAmount": ENGLISH_TERMS["confirmation.enterAmount"],
 };
 
 const confirmSkill: Record<ConfirmSkill, string> = {
@@ -4119,6 +4122,7 @@ const restock: Record<Restock, string> = {
   "restock.sure": "你确定要补货吗？",
   "restock.tooManySeeds": "你的篮子里的种子太多了！",
   "seeds.reachingInventoryLimit": ENGLISH_TERMS["seeds.reachingInventoryLimit"],
+  "crops.noCropsToSell": ENGLISH_TERMS["crops.noCropsToSell"],
 };
 
 const retreatTerms: Record<RetreatTerms, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -367,6 +367,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "sell.all": "Sell All",
   "sell.one": "Sell 1",
   "sell.ten": "Sell 10",
+  "sell.inBulk": "Sell in Bulk",
   "session.expired": "Session expired!",
   share: "Share",
   skillPts: "Skill Points:",
@@ -437,6 +438,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "sfl/coins": "SFL/Coins",
   vipAccess: "VIP Access",
   bought: "Bought",
+  "sell.amount": "Sell {{amount}}",
 };
 
 const timeUnits: Record<TimeUnits, string> = {
@@ -1284,6 +1286,7 @@ const confirmationTerms: Record<ConfirmationTerms, string> = {
     "Are you sure you want to sell {{cropAmount}} {{cropName}} for {{coinAmount}} Coins?",
   "confirmation.buyCrops":
     "Are you sure you want to spend {{coinAmount}} Coins to buy {{seedNo}} {{seedName}}s?",
+  "confirmation.enterAmount": "Enter Amount to Sell:",
 };
 
 const confirmSkill: Record<ConfirmSkill, string> = {
@@ -4667,6 +4670,7 @@ const restock: Record<Restock, string> = {
   "restock.sure": "Are you sure you want to Restock?",
   "restock.tooManySeeds": "You have too many seeds in your basket!",
   "seeds.reachingInventoryLimit": "You are reaching your seed basket limit!",
+  "crops.noCropsToSell": "You have no {{cropName}} to Sell!",
 };
 
 const retreatTerms: Record<RetreatTerms, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -384,6 +384,8 @@ const generalTerms: Record<GeneralTerms, string> = {
   "sell.all": "Tout vendre",
   "sell.one": "Vendre 1",
   "sell.ten": "Vendre 10",
+  "sell.amount": ENGLISH_TERMS["sell.amount"],
+  "sell.inBulk": ENGLISH_TERMS["sell.inBulk"],
   "session.expired": "Session expirée!",
   share: "Partager",
   skillPts: "Points de compétence",
@@ -1356,6 +1358,7 @@ const confirmationTerms: Record<ConfirmationTerms, string> = {
   "confirmation.sellCrops":
     "Êtes-vous sûr de vouloir vendre {{cropAmount}} {{cropName}} pour {{coinAmount}} pièces ?",
   "confirmation.buyCrops": ENGLISH_TERMS["confirmation.buyCrops"],
+  "confirmation.enterAmount": ENGLISH_TERMS["confirmation.enterAmount"],
 };
 
 const conversations: Record<Conversations, string> = {
@@ -4762,6 +4765,7 @@ const restock: Record<Restock, string> = {
   "restock.sure": "Êtes-vous sûr de vouloir recharger ?",
   "restock.tooManySeeds": "Vous avez trop de graines dans votre panier!",
   "seeds.reachingInventoryLimit": ENGLISH_TERMS["seeds.reachingInventoryLimit"],
+  "crops.noCropsToSell": ENGLISH_TERMS["crops.noCropsToSell"],
 };
 
 const retreatTerms: Record<RetreatTerms, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -344,6 +344,8 @@ const generalTerms: Record<GeneralTerms, string> = {
   "sell.all": "Vender Todos",
   "sell.one": "Vender 1",
   "sell.ten": "Vender 10",
+  "sell.amount": ENGLISH_TERMS["sell.amount"],
+  "sell.inBulk": ENGLISH_TERMS["sell.inBulk"],
   "session.expired": "Sessão expirada!",
   share: "Compartilhar",
   skillPts: "Pontos de Habilidade",
@@ -1341,6 +1343,7 @@ const confirmSkill: Record<ConfirmSkill, string> = {
 const confirmationTerms: Record<ConfirmationTerms, string> = {
   "confirmation.sellCrops": ENGLISH_TERMS["confirmation.sellCrops"],
   "confirmation.buyCrops": ENGLISH_TERMS["confirmation.buyCrops"],
+  "confirmation.enterAmount": ENGLISH_TERMS["confirmation.enterAmount"],
 };
 
 const conversations: Record<Conversations, string> = {
@@ -4602,6 +4605,7 @@ const restock: Record<Restock, string> = {
   "restock.sure": "Você tem certeza de que deseja reabastecer?",
   "restock.tooManySeeds": "Você tem muitas sementes em sua cesta!",
   "seeds.reachingInventoryLimit": ENGLISH_TERMS["seeds.reachingInventoryLimit"],
+  "crops.noCropsToSell": ENGLISH_TERMS["crops.noCropsToSell"],
 };
 
 const retreatTerms: Record<RetreatTerms, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -361,6 +361,8 @@ const generalTerms: Record<GeneralTerms, string> = {
   "sell.all": "Hepsini Sat",
   "sell.one": "1 Adet Sat",
   "sell.ten": "10 Adet Sat",
+  "sell.amount": ENGLISH_TERMS["sell.amount"],
+  "sell.inBulk": ENGLISH_TERMS["sell.inBulk"],
   "session.expired": "Oturum süresi doldu!",
   share: "Paylaş",
   skillPts: "Yetenek Puanları",
@@ -1310,6 +1312,7 @@ const composterDescription: Record<ComposterDescription, string> = {
 const confirmationTerms: Record<ConfirmationTerms, string> = {
   "confirmation.sellCrops": ENGLISH_TERMS["confirmation.sellCrops"],
   "confirmation.buyCrops": ENGLISH_TERMS["confirmation.buyCrops"],
+  "confirmation.enterAmount": ENGLISH_TERMS["confirmation.enterAmount"],
 };
 
 const confirmSkill: Record<ConfirmSkill, string> = {
@@ -4610,6 +4613,7 @@ const restock: Record<Restock, string> = {
   "restock.sure": "Yenilemek istediğinizden emin misiniz?",
   "restock.tooManySeeds": "Sepetinizde fazla tohum var!",
   "seeds.reachingInventoryLimit": ENGLISH_TERMS["seeds.reachingInventoryLimit"],
+  "crops.noCropsToSell": ENGLISH_TERMS["crops.noCropsToSell"],
 };
 
 const retreatTerms: Record<RetreatTerms, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -185,6 +185,8 @@ export type GeneralTerms =
   | "sell.all"
   | "sell.one"
   | "sell.ten"
+  | "sell.amount"
+  | "sell.inBulk"
   | "sell"
   | "session.expired"
   | "sfl/coins"
@@ -918,7 +920,8 @@ export type ConfirmSkill = "confirm.skillClaim";
 
 export type ConfirmationTerms =
   | "confirmation.sellCrops"
-  | "confirmation.buyCrops";
+  | "confirmation.buyCrops"
+  | "confirmation.enterAmount";
 
 export type Conversations =
   | "hank-intro.headline"
@@ -3092,7 +3095,8 @@ export type Restock =
   | "restock.one.buck"
   | "restock.sure"
   | "restock.tooManySeeds"
-  | "seeds.reachingInventoryLimit";
+  | "seeds.reachingInventoryLimit"
+  | "crops.noCropsToSell";
 
 export type RetreatTerms =
   | "retreatTerms.lookingForRareItems"


### PR DESCRIPTION
# Description

- Adds Modal that asks for Custom Crop Amount
This feature is available to players after Petal Paradise
- Streamlined all the sell functions to one function
- Add no crop message

Replaces Sell All Button
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/b9e1bd7a-350f-4dfd-aef3-eba7ea7001d7)

Custom Sell Input Modal
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/81938a91-30c8-465a-99bf-7d7f2ed55770)

Confirmation Modal (same as before)
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/5c2beec3-e546-40e5-93e3-7c7319352a5d)

No Crop Message
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/b0364152-021b-4c3f-931a-23cbde023b05)

Mobile
![image](https://github.com/sunflower-land/sunflower-land/assets/101262042/f3a9a3c1-dd9f-4ce5-b8f2-de217bc3d5bd)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

### Input Field Tests
- Type letters and symbols, it shouldn't let you use them
- Empty the field, it should replace the empty field with 0
- Type Decimal points, it shouldn't allow you to type decimal points after 4dp
- Click on Max button, it should replace input field with total inventory amount (it should show the decimal points)
- Enter amount more than inventory amount. text should change to red and Sell Button is disabled

### Behaviour Tests
- Change Island to "Basic", `Sell All` Button will be there
- Click on Sell All Button. Value should return total amount in inventory and the corresponding coin value
- Change Island to "spring" or "desert" `Sell All` Button will be replaced with `Sell in Bulk` Button
- In Bulk Sell Modal, enter an amount in the input field and click on cancel. Now open Bulk Sell Modal again, input Field should reset to 0
- Enter an Amount in input field and Click on sell. Confirmation message pops up. Click on Cancel. Open Bulk Sell Modal, input field should reset to 0
- Now Look at Confirmation Modal, value should return the custom amount and the coin value corresponding to the customAmount
- Reduce inventory amount to less than 10. Sell in Bulk Button disappears and Sell 10 button will update to the amount less than 10.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
