### PR TITLE
[FEAT] Separate leaderboards

### DIFF
--- a/src/features/game/expansion/components/leaderboard/actions/cache.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/cache.ts
@@ -2,6 +2,7 @@ import {
   TicketLeaderboard,
   FactionLeaderboard,
   KingdomLeaderboard,
+  EmblemsLeaderboard,
 } from "./leaderboard";
 // Leaderboard data is updated every 1 hour
 const CACHE_DURATION_IN_MS = 1 * 60 * 60 * 1000;
@@ -12,6 +13,7 @@ export type Leaderboards = {
   tickets: TicketLeaderboard;
   factions: FactionLeaderboard;
   kingdom: KingdomLeaderboard;
+  emblems: EmblemsLeaderboard;
   lastUpdated: number;
 };
 

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -258,7 +258,7 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
                 emblemLeaderboard={data?.emblems ?? null}
                 marksLeaderboard={data?.kingdom ?? null}
                 isLoading={data === undefined}
-                id={id}
+                playerId={id}
                 faction={state.faction.name}
               />
             )}

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -255,8 +255,9 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
             )}
             {currentTab === 6 && state.faction && (
               <MarksLeaderboard
-                emblemLeaderboard={data.emblems}
-                marksLeaderboard={data.kingdom}
+                emblemLeaderboard={data?.emblems ?? null}
+                marksLeaderboard={data?.kingdom ?? null}
+                isLoading={data === undefined}
                 id={id}
                 faction={state.faction.name}
               />

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -248,12 +248,19 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
                   id={id}
                   faction={state.faction.name}
                   isLoading={data === undefined}
-                  data={data?.kingdom.emblems ?? null}
+                  data={data?.emblems.emblems ?? null}
                   lastUpdated={data?.kingdom.lastUpdated ?? null}
                 />
               </InnerPanel>
             )}
-            {currentTab === 6 && state.faction && <MarksLeaderboard />}
+            {currentTab === 6 && state.faction && (
+              <MarksLeaderboard
+                emblemLeaderboard={data.emblems}
+                marksLeaderboard={data.kingdom}
+                id={id}
+                faction={state.faction.name}
+              />
+            )}
           </div>
         </OuterPanel>
         {showMilestoneReached && (

--- a/src/features/island/hud/components/codex/pages/FactionsLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/FactionsLeaderboard.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import { Label } from "components/ui/Label";
 import { ButtonPanel } from "components/ui/Panel";
 import { Loading } from "features/auth/components";
-import { KingdomLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import { EmblemsLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getRelativeTime } from "lib/utils/time";
@@ -34,7 +34,7 @@ interface LeaderboardProps {
   id: string;
   faction: FactionName;
   isLoading: boolean;
-  data: KingdomLeaderboard["emblems"] | null;
+  data: EmblemsLeaderboard["emblems"] | null;
   lastUpdated: number | null;
 }
 

--- a/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
@@ -17,6 +17,11 @@ import factions from "assets/icons/factions.webp";
 import { FACTION_EMBLEM_ICONS } from "features/world/ui/factions/components/ClaimEmblems";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { getKeys } from "features/game/types/craftables";
+import {
+  EmblemsLeaderboard,
+  KingdomLeaderboard,
+  RankData,
+} from "features/game/expansion/components/leaderboard/actions/leaderboard";
 
 interface LeaderboardEntry {
   username: string;
@@ -29,106 +34,106 @@ interface LeaderboardEntry {
 
 /* TODO feat/marks-leaderboard REPLACE with real data  */
 
-const PLAYER_ID = 1;
-const PLAYER_FACTION = "nightshades";
-const DATA: LeaderboardEntry[] = [
-  {
-    username: "Parsley",
-    marks: 100,
-    emblems: 10,
-    faction: "nightshades",
-    rank: 1,
-    farmId: 1,
-  },
-  {
-    username: "Sage",
-    marks: 50,
-    faction: "bumpkins",
-    rank: 2,
-    farmId: 2,
-    emblems: 5,
-  },
-  {
-    username: "Rosemary",
-    marks: 25,
-    faction: "goblins",
-    rank: 3,
-    farmId: 3,
-    emblems: 20000,
-  },
-  {
-    username: "Thyme",
-    marks: 10,
-    faction: "sunflorians",
-    rank: 4,
-    farmId: 4,
-    emblems: 60000,
-  },
-  {
-    username: "Parsley",
-    marks: 100,
-    emblems: 10,
-    faction: "nightshades",
-    rank: 1,
-    farmId: 1,
-  },
-  {
-    username: "Sage",
-    marks: 50,
-    faction: "bumpkins",
-    rank: 2,
-    farmId: 2,
-    emblems: 5,
-  },
-  {
-    username: "Rosemary",
-    marks: 25,
-    faction: "goblins",
-    rank: 3,
-    farmId: 3,
-    emblems: 20000,
-  },
-  {
-    username: "Thyme",
-    marks: 10,
-    faction: "sunflorians",
-    rank: 4,
-    farmId: 4,
-    emblems: 60000,
-  },
-  {
-    username: "Parsley",
-    marks: 100,
-    emblems: 10,
-    faction: "nightshades",
-    rank: 1,
-    farmId: 1,
-  },
-  {
-    username: "Sage",
-    marks: 50,
-    faction: "bumpkins",
-    rank: 2,
-    farmId: 2,
-    emblems: 5,
-  },
-  {
-    username: "Rosemary",
-    marks: 25,
-    faction: "goblins",
-    rank: 3,
-    farmId: 3,
-    emblems: 20000,
-  },
-  {
-    username: "Thyme",
-    marks: 10,
-    faction: "sunflorians",
-    rank: 4,
-    farmId: 4,
-    emblems: 60000,
-  },
-];
+// const PLAYER_ID = 1;
+// const PLAYER_FACTION = "nightshades";
+// const DATA: LeaderboardEntry[] = [
+//   {
+//     username: "Parsley",
+//     marks: 100,
+//     emblems: 10,
+//     faction: "nightshades",
+//     rank: 1,
+//     farmId: 1,
+//   },
+//   {
+//     username: "Sage",
+//     marks: 50,
+//     faction: "bumpkins",
+//     rank: 2,
+//     farmId: 2,
+//     emblems: 5,
+//   },
+//   {
+//     username: "Rosemary",
+//     marks: 25,
+//     faction: "goblins",
+//     rank: 3,
+//     farmId: 3,
+//     emblems: 20000,
+//   },
+//   {
+//     username: "Thyme",
+//     marks: 10,
+//     faction: "sunflorians",
+//     rank: 4,
+//     farmId: 4,
+//     emblems: 60000,
+//   },
+//   {
+//     username: "Parsley",
+//     marks: 100,
+//     emblems: 10,
+//     faction: "nightshades",
+//     rank: 1,
+//     farmId: 1,
+//   },
+//   {
+//     username: "Sage",
+//     marks: 50,
+//     faction: "bumpkins",
+//     rank: 2,
+//     farmId: 2,
+//     emblems: 5,
+//   },
+//   {
+//     username: "Rosemary",
+//     marks: 25,
+//     faction: "goblins",
+//     rank: 3,
+//     farmId: 3,
+//     emblems: 20000,
+//   },
+//   {
+//     username: "Thyme",
+//     marks: 10,
+//     faction: "sunflorians",
+//     rank: 4,
+//     farmId: 4,
+//     emblems: 60000,
+//   },
+//   {
+//     username: "Parsley",
+//     marks: 100,
+//     emblems: 10,
+//     faction: "nightshades",
+//     rank: 1,
+//     farmId: 1,
+//   },
+//   {
+//     username: "Sage",
+//     marks: 50,
+//     faction: "bumpkins",
+//     rank: 2,
+//     farmId: 2,
+//     emblems: 5,
+//   },
+//   {
+//     username: "Rosemary",
+//     marks: 25,
+//     faction: "goblins",
+//     rank: 3,
+//     farmId: 3,
+//     emblems: 20000,
+//   },
+//   {
+//     username: "Thyme",
+//     marks: 10,
+//     faction: "sunflorians",
+//     rank: 4,
+//     farmId: 4,
+//     emblems: 60000,
+//   },
+// ];
 
 /* END TODO */
 
@@ -156,7 +161,19 @@ const FilterCheckbox: React.FC<FilterCheckboxProps> = ({
   </OuterPanel>
 );
 
-export const MarksLeaderboard: React.FC = () => {
+interface Props {
+  emblemLeaderboard: EmblemsLeaderboard;
+  marksLeaderboard: KingdomLeaderboard;
+  // Either username or fallback to farm ID
+  playerId: string;
+  faction: FactionName;
+}
+export const MarksLeaderboard: React.FC<Props> = ({
+  emblemLeaderboard,
+  marksLeaderboard,
+  playerId,
+  faction,
+}) => {
   const { t } = useAppTranslation();
 
   const [selected, setSelected] = useState({
@@ -174,6 +191,36 @@ export const MarksLeaderboard: React.FC = () => {
 
     setSelected(updated);
   };
+
+  const data =
+    leaderboard === "marks"
+      ? marksLeaderboard.marks
+      : emblemLeaderboard.emblems;
+
+  const topRanks: (RankData & { faction: FactionName })[] = getKeys(
+    data.topTens,
+  )
+    .filter((name) => !!selected[name])
+    .reduce(
+      (rows, faction) => {
+        return [
+          ...rows,
+          ...data.topTens[faction].map((r) => ({ ...r, faction })),
+        ];
+      },
+      [] as (RankData & { faction: FactionName })[],
+    );
+
+  let playerRanks: RankData[] = [];
+
+  const showPlayerRank = !!selected[faction];
+  if (showPlayerRank && leaderboard === "marks") {
+    playerRanks = marksLeaderboard.marks.marksRankingData ?? [];
+  }
+
+  if (showPlayerRank && leaderboard === "marks") {
+    playerRanks = emblemLeaderboard.emblems.emblemRankingData ?? [];
+  }
 
   return (
     <InnerPanel
@@ -239,63 +286,56 @@ export const MarksLeaderboard: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {DATA.filter(({ faction }) => selected[faction])
-            .slice(0, 7)
-            .map(
-              ({ farmId, rank, marks, username, faction, emblems }, index) => (
-                <tr
-                  key={index}
-                  className={classNames({
-                    "bg-[#ead4aa]": farmId === PLAYER_ID,
-                  })}
-                >
-                  <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
-                    {rank ?? index + 1}
-                  </td>
-                  <td
-                    style={{ border: "1px solid #b96f50" }}
-                    className="truncate"
-                  >
-                    <div className="flex items-center space-x-1">
-                      <span className="p-1.5">{username}</span>
-                      {faction === "nightshades" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                      {faction === "goblins" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                      {faction === "bumpkins" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                    </div>
-                  </td>
+          {topRanks.slice(0, 7).map(({ id, rank, count, faction }, index) => (
+            <tr
+              key={index}
+              className={classNames({
+                "bg-[#ead4aa]": id === playerId,
+              })}
+            >
+              <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
+                {rank ?? index + 1}
+              </td>
+              <td style={{ border: "1px solid #b96f50" }} className="truncate">
+                <div className="flex items-center space-x-1">
+                  <span className="p-1.5">{id}</span>
+                  {faction === "nightshades" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                  {faction === "goblins" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                  {faction === "bumpkins" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                </div>
+              </td>
 
-                  <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
-                    <div className="flex items-center space-x-1 justify-end">
-                      {/* <img
+              <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
+                <div className="flex items-center space-x-1 justify-end">
+                  {/* <img
                         src={FACTION_EMBLEM_ICONS[faction]}
                         className="w-4"
                       /> */}
-                      {leaderboard === "emblems" && (
-                        <>
-                          <span>{emblems}</span>
-                          <img
-                            src={FACTION_EMBLEM_ICONS[faction]}
-                            className="h-4"
-                          />
-                        </>
-                      )}
-                      {leaderboard === "marks" && (
-                        <>
-                          <span>{marks}</span>
-                          <img src={mark} className="h-4" />
-                        </>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ),
-            )}
+                  {leaderboard === "emblems" && (
+                    <>
+                      <span>{count}</span>
+                      <img
+                        src={FACTION_EMBLEM_ICONS[faction]}
+                        className="h-4"
+                      />
+                    </>
+                  )}
+                  {leaderboard === "marks" && (
+                    <>
+                      <span>{count}</span>
+                      <img src={mark} className="h-4" />
+                    </>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
           <tr>
             <td colSpan={3}>
               <div className="flex justify-center items-center">
@@ -303,63 +343,52 @@ export const MarksLeaderboard: React.FC = () => {
               </div>
             </td>
           </tr>
-          {DATA.filter(({ faction }) => selected[faction])
-            .slice(0, 3)
-            .map(
-              ({ farmId, rank, marks, username, faction, emblems }, index) => (
-                <tr
-                  key={index}
-                  className={classNames({
-                    "bg-[#ead4aa]": farmId === PLAYER_ID,
-                  })}
-                >
-                  <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
-                    {rank ?? index + 1}
-                  </td>
-                  <td
-                    style={{ border: "1px solid #b96f50" }}
-                    className="truncate"
-                  >
-                    <div className="flex items-center space-x-1">
-                      <span className="p-1.5">{username}</span>
-                      {faction === "nightshades" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                      {faction === "goblins" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                      {faction === "bumpkins" && (
-                        <img src={chevron} className="h-auto" />
-                      )}
-                    </div>
-                  </td>
+          {playerRanks.slice(0, 3).map(({ id, rank, count }, index) => (
+            <tr
+              key={index}
+              className={classNames({
+                "bg-[#ead4aa]": id === playerId,
+              })}
+            >
+              <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
+                {rank ?? index + 1}
+              </td>
+              <td style={{ border: "1px solid #b96f50" }} className="truncate">
+                <div className="flex items-center space-x-1">
+                  <span className="p-1.5">{id}</span>
+                  {faction === "nightshades" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                  {faction === "goblins" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                  {faction === "bumpkins" && (
+                    <img src={chevron} className="h-auto" />
+                  )}
+                </div>
+              </td>
 
-                  <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
-                    <div className="flex items-center space-x-1 justify-end">
-                      {/* <img
+              <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
+                <div className="flex items-center space-x-1 justify-end">
+                  {leaderboard === "emblems" && (
+                    <>
+                      <span>{count}</span>
+                      <img
                         src={FACTION_EMBLEM_ICONS[faction]}
-                        className="w-4"
-                      /> */}
-                      {leaderboard === "emblems" && (
-                        <>
-                          <span>{emblems}</span>
-                          <img
-                            src={FACTION_EMBLEM_ICONS[faction]}
-                            className="h-4"
-                          />
-                        </>
-                      )}
-                      {leaderboard === "marks" && (
-                        <>
-                          <span>{marks}</span>
-                          <img src={mark} className="h-4" />
-                        </>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ),
-            )}
+                        className="h-4"
+                      />
+                    </>
+                  )}
+                  {leaderboard === "marks" && (
+                    <>
+                      <span>{count}</span>
+                      <img src={mark} className="h-4" />
+                    </>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
         </tbody>
       </table>
       <div className="flex justify-between font-secondary text-xs pt-1">

--- a/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
@@ -22,6 +22,7 @@ import {
   KingdomLeaderboard,
   RankData,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import { Loading } from "features/auth/components";
 
 interface LeaderboardEntry {
   username: string;
@@ -162,17 +163,19 @@ const FilterCheckbox: React.FC<FilterCheckboxProps> = ({
 );
 
 interface Props {
-  emblemLeaderboard: EmblemsLeaderboard;
-  marksLeaderboard: KingdomLeaderboard;
+  emblemLeaderboard: EmblemsLeaderboard | null;
+  marksLeaderboard: KingdomLeaderboard | null;
   // Either username or fallback to farm ID
   playerId: string;
   faction: FactionName;
+  isLoading: boolean;
 }
 export const MarksLeaderboard: React.FC<Props> = ({
   emblemLeaderboard,
   marksLeaderboard,
   playerId,
   faction,
+  isLoading,
 }) => {
   const { t } = useAppTranslation();
 
@@ -183,6 +186,21 @@ export const MarksLeaderboard: React.FC<Props> = ({
     sunflorians: true,
   });
   const [leaderboard, setLeaderboard] = useState<"marks" | "emblems">("marks");
+
+  if (isLoading) {
+    return (
+      <InnerPanel className="p-1">
+        <Loading />
+      </InnerPanel>
+    );
+  }
+
+  if (!emblemLeaderboard || !marksLeaderboard)
+    return (
+      <InnerPanel className="p-1">
+        <Label type="danger">{t("leaderboard.error")}</Label>
+      </InnerPanel>
+    );
 
   const select = (faction: FactionName) => {
     const updated = { ...selected, [faction]: !selected[faction] };
@@ -395,7 +413,6 @@ export const MarksLeaderboard: React.FC<Props> = ({
         <span>
           {t("last.updated")} {getRelativeTime(Date.now())}
         </span>
-        <span>{`Total: 123k`}</span>
       </div>
     </InnerPanel>
   );

--- a/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
@@ -236,7 +236,7 @@ export const MarksLeaderboard: React.FC<Props> = ({
     playerRanks = marksLeaderboard.marks.marksRankingData ?? [];
   }
 
-  if (showPlayerRank && leaderboard === "marks") {
+  if (showPlayerRank && leaderboard === "emblems") {
     playerRanks = emblemLeaderboard.emblems.emblemRankingData ?? [];
   }
 


### PR DESCRIPTION
# Description

Separate the endpoints for the Emblems + Kingdom leaderboards.

Also hooks up the UI with the actual data 🚀 

**Next steps**

1. Show countdown on leaderboard (E.g. 3 days left)
2. Show previous week results in Kingdom area

<img width="780" alt="Screenshot 2024-07-02 at 11 44 54 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/ce4e620a-74a0-4287-9891-56ba4002426e">


## How to test?

1. Point your game to local API
4. View the leaderboard
5. Deliver Food to the Kitchen (get marks)
6. Wait up to 5 minutes (or manually change the `isStale` code in API)
7. Open leaderboard and you should pop up!

Note: The frontend caches leaderboards in localstorage. If nothing shows, clear the leaderboard key