### PR TITLE
[FIX] Add onHide Condition for selected GameWrapper Modals

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -436,12 +436,18 @@ export const GameWrapper: React.FC = ({ children }) => {
 
   const stateValue = typeof state === "object" ? Object.keys(state)[0] : state;
 
+  const onHide = () => {
+    listed || listingDeleted || traded || sniped || marketPriceChanged
+      ? gameService.send("CONTINUE")
+      : undefined;
+  };
+
   return (
     <>
       <ToastProvider>
         <ToastPanel />
 
-        <Modal show={SHOW_MODAL[stateValue as StateValues]}>
+        <Modal show={SHOW_MODAL[stateValue as StateValues]} onHide={onHide}>
           <Panel>
             {loading && <Loading />}
             {refreshing && <Refreshing />}


### PR DESCRIPTION
# Description

Some Modals in the GameWrapper doesn't have an onHide Condition, 
I added a check for the listed, listingDeleted, traded, sniped, marketPriceChanged modals to close onHide and everything else remains undefined

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
