### PR TITLE
[FEAT] Adjust ranges for yield colours

### DIFF
--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -40,15 +40,15 @@ import Decimal from "decimal.js-light";
 import { hasFeatureAccess } from "lib/flags";
 
 export function getYieldColour(yieldAmount: number) {
-  if (yieldAmount <= 1) {
+  if (yieldAmount < 2) {
     return "white";
   }
 
-  if (yieldAmount <= 1.5) {
-    return "#ffeb37";
+  if (yieldAmount < 10) {
+    return "#ffeb37"; // Yellow
   }
 
-  return "#71e358";
+  return "#71e358"; // Green
 }
 
 const selectCrops = (state: MachineState) => state.context.state.crops;


### PR DESCRIPTION
# Description

Right now the colour range is quite limited, as most players have boosts that give them more than 1.5 yields for most of their crops, it would mostly be green for them

Currently:
1 and below: White
1-1.5: Yellow
1.5 and above: Green

Change:
Less than 2 : White  
2-10: Yellow // Simulating Happy Crop Proc
10+: Green // Simulating Green Amulet Proc/Gnome Boost

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
