### PR TITLE
[FEAT] Split leaderboard caching

### DIFF
--- a/src/features/game/expansion/components/leaderboard/Leaderboard.tsx
+++ b/src/features/game/expansion/components/leaderboard/Leaderboard.tsx
@@ -55,7 +55,7 @@ export const Leaderboard: React.FC<Props> = ({ farmId, username }) => {
         loaded={!loading}
         onClick={data ? handleOpen : undefined}
       />
-      {data && (
+      {data?.tickets && (
         <Modal show={showLeaderboard} onHide={handleClose}>
           <CloseButtonPanel
             onClose={handleClose}
@@ -73,7 +73,8 @@ export const Leaderboard: React.FC<Props> = ({ farmId, username }) => {
                 <div className="p-1 mb-1 space-y-1">
                   <p className="text-sm">{`${seasonTicket} Leaderboard`}</p>
                   <p className="text-xs">
-                    {t("last.updated")} {getRelativeTime(data.lastUpdated)}
+                    {t("last.updated")}{" "}
+                    {getRelativeTime(data.tickets.lastUpdated)}
                   </p>
                 </div>
                 {data.tickets.topTen && (

--- a/src/features/game/expansion/components/leaderboard/actions/cache.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/cache.ts
@@ -5,8 +5,8 @@ import {
   EmblemsLeaderboard,
 } from "./leaderboard";
 
-// Leaderboard data is updated every 10 minutes
-const CACHE_DURATION_IN_MS = 10 * 60 * 1000;
+// Default leaderboard data is updated every 1 hour
+const CACHE_DURATION_IN_MS = 1 * 60 * 60 * 1000;
 
 const CACHE_KEY = "leaderboardData";
 
@@ -34,8 +34,10 @@ export function cacheLeaderboard<T extends keyof Leaderboards>({
 
 export function getCachedLeaderboardData<T extends keyof Leaderboards>({
   name,
+  duration = CACHE_DURATION_IN_MS,
 }: {
   name: T;
+  duration?: number;
 }): Leaderboards[T] | null {
   try {
     const cachedData = localStorage.getItem(`${name as string}.${CACHE_KEY}`);
@@ -44,7 +46,7 @@ export function getCachedLeaderboardData<T extends keyof Leaderboards>({
     const parsedData = JSON.parse(cachedData);
     const now = Date.now();
 
-    if (now - parsedData.lastUpdated > CACHE_DURATION_IN_MS) {
+    if (now - parsedData.lastUpdated > duration) {
       localStorage.removeItem(`${name as string}.${CACHE_KEY}`);
       return null;
     }

--- a/src/features/game/expansion/components/leaderboard/actions/cache.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/cache.ts
@@ -4,38 +4,48 @@ import {
   KingdomLeaderboard,
   EmblemsLeaderboard,
 } from "./leaderboard";
-// Leaderboard data is updated every 1 hour
-const CACHE_DURATION_IN_MS = 1 * 60 * 60 * 1000;
+
+// Leaderboard data is updated every 10 minutes
+const CACHE_DURATION_IN_MS = 10 * 60 * 1000;
 
 const CACHE_KEY = "leaderboardData";
 
 export type Leaderboards = {
-  tickets: TicketLeaderboard;
-  factions: FactionLeaderboard;
-  kingdom: KingdomLeaderboard;
-  emblems: EmblemsLeaderboard;
-  lastUpdated: number;
+  tickets?: TicketLeaderboard;
+  factions?: FactionLeaderboard;
+  kingdom?: KingdomLeaderboard;
+  emblems?: EmblemsLeaderboard;
 };
 
-export function cacheLeaderboardData(data: Leaderboards): void {
+export function cacheLeaderboard<T extends keyof Leaderboards>({
+  name,
+  data,
+}: {
+  name: T;
+  data: Leaderboards[T];
+}): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+    localStorage.setItem(`${name}.${CACHE_KEY}`, JSON.stringify(data));
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);
   }
 }
 
-export function getCachedLeaderboardData(): Leaderboards | null {
+export function getCachedLeaderboardData<T extends keyof Leaderboards>({
+  name,
+}: {
+  name: T;
+}): Leaderboards[T] | null {
   try {
-    const cachedData = localStorage.getItem(CACHE_KEY);
+    const cachedData = localStorage.getItem(`${name as string}.${CACHE_KEY}`);
     if (!cachedData) return null;
 
     const parsedData = JSON.parse(cachedData);
     const now = Date.now();
 
     if (now - parsedData.lastUpdated > CACHE_DURATION_IN_MS) {
-      localStorage.removeItem(CACHE_KEY);
+      localStorage.removeItem(`${name as string}.${CACHE_KEY}`);
       return null;
     }
 

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -233,7 +233,7 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
               >
                 <TicketsLeaderboard
                   id={id}
-                  isLoading={data === undefined}
+                  isLoading={data?.tickets === undefined}
                   data={data?.tickets ?? null}
                 />
               </InnerPanel>
@@ -247,9 +247,9 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
                 <FactionsLeaderboard
                   id={id}
                   faction={state.faction.name}
-                  isLoading={data === undefined}
+                  isLoading={data?.emblems === undefined}
                   data={data?.emblems?.emblems ?? null}
-                  lastUpdated={data?.kingdom.lastUpdated ?? null}
+                  lastUpdated={data?.kingdom?.lastUpdated ?? null}
                 />
               </InnerPanel>
             )}
@@ -257,7 +257,7 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
               <MarksLeaderboard
                 emblemLeaderboard={data?.emblems ?? null}
                 marksLeaderboard={data?.kingdom ?? null}
-                isLoading={data === undefined}
+                isLoading={data?.kingdom === undefined}
                 playerId={id}
                 faction={state.faction.name}
               />

--- a/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
@@ -112,13 +112,6 @@ export const MarksLeaderboard: React.FC<Props> = ({
       </InnerPanel>
     );
 
-  if (marksLeaderboard.status === "pending")
-    return (
-      <InnerPanel className="p-1">
-        <Label type="formula">{t("leaderboard.resultsPending")}</Label>
-      </InnerPanel>
-    );
-
   const select = (faction: FactionName) => {
     const updated = { ...selected, [faction]: !selected[faction] };
     // At least one must be true

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -5,7 +5,7 @@ import { BaseScene, NPCBumpkin } from "./BaseScene";
 import {
   KingdomLeaderboard,
   fetchLeaderboardData,
-  getLeaderboard,
+  getKingdomLeaderboard,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import { interactableModalManager } from "../ui/InteractableModals";
 import { translate } from "lib/i18n/translate";
@@ -337,7 +337,7 @@ export class KingdomScene extends BaseScene {
         interactableModalManager.open("champions");
       });
 
-    const leaderboard = await getLeaderboard<KingdomLeaderboard>({
+    const leaderboard = await getKingdomLeaderboard<KingdomLeaderboard>({
       farmId: Number(this.gameService.state.context.farmId),
       leaderboardName: "kingdom",
       date: getPreviousWeek(),

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -5,10 +5,7 @@ import classNames from "classnames";
 import { Label } from "components/ui/Label";
 import { Loading } from "features/auth/components";
 import { Context } from "features/game/GameProvider";
-import {
-  KingdomLeaderboard,
-  getLeaderboard,
-} from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import { KingdomLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import {
   FACTION_PRIZES,
   getPreviousWeek,
@@ -70,7 +67,7 @@ export const ChampionsLeaderboard: React.FC<Props> = ({ onClose }) => {
   useEffect(() => {
     const load = async () => {
       setIsLoading(true);
-      const data = await getLeaderboard<KingdomLeaderboard>({
+      const data = await getKingdomLeaderboard<KingdomLeaderboard>({
         farmId: Number(gameState.context.farmId),
         leaderboardName: "kingdom",
         date: getPreviousWeek(),

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -5,7 +5,10 @@ import classNames from "classnames";
 import { Label } from "components/ui/Label";
 import { Loading } from "features/auth/components";
 import { Context } from "features/game/GameProvider";
-import { KingdomLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import {
+  KingdomLeaderboard,
+  getKingdomLeaderboard,
+} from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import {
   FACTION_PRIZES,
   getPreviousWeek,

--- a/src/features/world/ui/factions/components/ClaimEmblems.tsx
+++ b/src/features/world/ui/factions/components/ClaimEmblems.tsx
@@ -100,7 +100,7 @@ export const ClaimEmblems: React.FC<ClaimEmblemsProps> = ({
         const data = await fetchLeaderboardData(farmId);
 
         // Error
-        if (!data) {
+        if (!data?.factions) {
           setStatistics(null);
           return;
         }


### PR DESCRIPTION
# Description

This PR splits the caching of leaderboard data. This enables us to:

1. Cache past weeks Kingdom leaderboards
2. Still load leaderboards if one fails (currently codex will not show any leaderboards if one fails)

I have also bumped cache time down to 10 minutes.

<img width="504" alt="Screenshot 2024-07-04 at 10 32 45 AM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/c8073e30-f435-460d-b0db-2f5121a51476">

## How to test?

1. Point at api-dev
2. Check Codex
4. Check Kingdom Throne