### PR TITLE
[FEAT] Apply Marks Boost to Chores

### DIFF
--- a/src/features/game/events/landExpansion/completeKingdomChore.ts
+++ b/src/features/game/events/landExpansion/completeKingdomChore.ts
@@ -4,8 +4,20 @@ import {
   getFactionWearableBoostAmount,
   getFactionWeek,
 } from "features/game/lib/factions";
-import { Bumpkin, GameState, KingdomChores } from "features/game/types/game";
+import {
+  Bumpkin,
+  GameState,
+  KingdomChore,
+  KingdomChores,
+} from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
+
+export const getKingdomChoreBoost = (game: GameState, chore: KingdomChore) => {
+  const wearablesBoost = getFactionWearableBoostAmount(game, chore.marks);
+  const rankBoost = getFactionRankBoostAmount(game, chore.marks);
+
+  return wearablesBoost + rankBoost;
+};
 
 export function populateKingdomChores(
   kingdomChores: KingdomChores | undefined,
@@ -102,9 +114,7 @@ export function completeKingdomChore({
   game.kingdomChores = populateKingdomChores(kingdomChores, bumpkin, createdAt);
 
   const previousMarks = inventory["Mark"] ?? new Decimal(0);
-  const wearablesBoost = getFactionWearableBoostAmount(game, chore.marks);
-  const rankBoost = getFactionRankBoostAmount(game, chore.marks);
-  const marks = chore.marks + wearablesBoost + rankBoost;
+  const marks = chore.marks + getKingdomChoreBoost(game, chore);
 
   // Add to inventory
   inventory["Mark"] = previousMarks.add(marks);

--- a/src/features/game/lib/landData.ts
+++ b/src/features/game/lib/landData.ts
@@ -1,5 +1,5 @@
 // import { INITIAL_FARM } from "./constants";
-import { INITIAL_FARM } from "./constants";
+import { STATIC_OFFLINE_FARM } from "./landDataStatic";
 
-// export const OFFLINE_FARM = STATIC_OFFLINE_FARM;
-export const OFFLINE_FARM = INITIAL_FARM;
+export const OFFLINE_FARM = STATIC_OFFLINE_FARM;
+// export const OFFLINE_FARM = INITIAL_FARM;

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -218,6 +218,21 @@ export const STATIC_OFFLINE_FARM: GameState = {
     pots: {},
     oil: 50,
   },
+  kingdomChores: {
+    chores: [
+      {
+        activity: "Sunflower Harvested",
+        description: "Harvest 200 Sunflowers",
+        image: "Sunflower",
+        marks: 50,
+        requirement: 200,
+        startedAt: Date.now(),
+        startCount: 0,
+      },
+    ],
+    choresCompleted: 0,
+    choresSkipped: 0,
+  },
   home: {
     collectibles: {
       Wardrobe: [
@@ -307,7 +322,11 @@ export const STATIC_OFFLINE_FARM: GameState = {
     spawnedAt: 0,
   },
   farmHands: { bumpkins: {} },
-  bumpkin: { ...INITIAL_BUMPKIN, experience: 100000000 },
+  bumpkin: {
+    ...INITIAL_BUMPKIN,
+    experience: 100000000,
+    equipped: { ...INITIAL_BUMPKIN.equipped, shoes: "Goblin Sabatons" },
+  },
   buds: {
     1: {
       aura: "Basic",

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -57,7 +57,6 @@ interface Props {
 }
 
 function getInitialNPC(scene: SceneId): NPCName | undefined {
-  return "flora";
   return undefined;
 }
 

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -57,6 +57,7 @@ interface Props {
 }
 
 function getInitialNPC(scene: SceneId): NPCName | undefined {
+  return "flora";
   return undefined;
 }
 

--- a/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
+++ b/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
@@ -331,7 +331,7 @@ const Panel: React.FC<PanelProps> = ({
         </div>
         {chore.startedAt && (
           <>
-            <div className="col-span-full flex sm:flex-col gap-1">
+            <div className="col-span-full flex flex-row-reverse sm:flex-col gap-1">
               {chore.completedAt && (
                 <div className="ml-4 py-2">
                   <Label type="transparent" icon={SUNNYSIDE.icons.confirm}>

--- a/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
+++ b/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
@@ -24,9 +24,11 @@ import { ResizableBar } from "components/ui/ProgressBar";
 import mark from "assets/icons/faction_mark.webp";
 import levelup from "assets/icons/level_up.png";
 import chefsHat from "assets/icons/chef_hat.png";
+import lightning from "assets/icons/lightning.png";
 
 import { hasFeatureAccess } from "lib/flags";
 import { BumpkinActivityName } from "features/game/types/bumpkinActivity";
+import { getKingdomChoreBoost } from "features/game/events/landExpansion/completeKingdomChore";
 
 const getSecondaryImage = (activity: BumpkinActivityName) => {
   if (activity.endsWith("Cooked")) return chefsHat;
@@ -275,12 +277,16 @@ const Panel: React.FC<PanelProps> = ({
   chore,
   isRefreshing,
 }: PanelProps) => {
+  const { gameService } = useContext(Context);
+
   const { t } = useAppTranslation();
 
   useUiRefresher();
 
   const canSkip = skipAvailableAt < Date.now();
   const canComplete = progress >= chore.requirement;
+
+  const boost = getKingdomChoreBoost(gameService.state.context.state, chore);
 
   return (
     <div className="flex flex-col justify-center">
@@ -295,9 +301,12 @@ const Panel: React.FC<PanelProps> = ({
           <Label
             type="warning"
             icon={mark}
+            secondaryIcon={boost ? lightning : null}
             className="text-center whitespace-nowrap"
           >
-            {chore.marks} {t("marks")}
+            <span className="pl-1.5">
+              {`${chore.marks + boost} ${t("marks")}`}
+            </span>
           </Label>
         </div>
       </div>


### PR DESCRIPTION
# Description

Applies Marks Boost to Kingdom Chores. Marks boost can come from your faction rank (determined by emblems) or faction wearables.

## Screenshot of Boost applied

![boostappliedmarks](https://github.com/sunflower-land/sunflower-land/assets/41215134/c3c88953-2d1c-49e3-9932-414adaf9e968)


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- 
# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
