### PR TITLE
[FIX] Separate kingdom caches

### DIFF
--- a/src/features/game/expansion/components/leaderboard/actions/cache.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/cache.ts
@@ -15,6 +15,7 @@ export type Leaderboards = {
   factions?: FactionLeaderboard;
   kingdom?: KingdomLeaderboard;
   emblems?: EmblemsLeaderboard;
+  champions?: KingdomLeaderboard;
 };
 
 export function cacheLeaderboard<T extends keyof Leaderboards>({

--- a/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
@@ -120,7 +120,7 @@ export async function getChampionsLeaderboard<T>({
     cache?.week === getFactionWeek({ date: new Date(date) });
 
   if (cache && isCorrectWeek) {
-    return cache as T;
+    return cache;
   }
 
   const url = `${API_URL}/leaderboard/kingdom/${farmId}?date=${date}`;

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -5,7 +5,7 @@ import { BaseScene, NPCBumpkin } from "./BaseScene";
 import {
   KingdomLeaderboard,
   fetchLeaderboardData,
-  getKingdomLeaderboard,
+  getChampionsLeaderboard,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import { interactableModalManager } from "../ui/InteractableModals";
 import { translate } from "lib/i18n/translate";
@@ -337,9 +337,8 @@ export class KingdomScene extends BaseScene {
         interactableModalManager.open("champions");
       });
 
-    const leaderboard = await getKingdomLeaderboard<KingdomLeaderboard>({
+    const leaderboard = await getChampionsLeaderboard<KingdomLeaderboard>({
       farmId: Number(this.gameService.state.context.farmId),
-      leaderboardName: "kingdom",
       date: getPreviousWeek(),
     });
 

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -6,8 +6,8 @@ import { Label } from "components/ui/Label";
 import { Loading } from "features/auth/components";
 import { Context } from "features/game/GameProvider";
 import {
+  getChampionsLeaderboard,
   KingdomLeaderboard,
-  getKingdomLeaderboard,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import {
   FACTION_PRIZES,
@@ -70,9 +70,8 @@ export const ChampionsLeaderboard: React.FC<Props> = ({ onClose }) => {
   useEffect(() => {
     const load = async () => {
       setIsLoading(true);
-      const data = await getKingdomLeaderboard<KingdomLeaderboard>({
+      const data = await getChampionsLeaderboard({
         farmId: Number(gameState.context.farmId),
-        leaderboardName: "kingdom",
         date: getPreviousWeek(),
       });
 


### PR DESCRIPTION
# Description

We need 2 cache separate kingdom leaderboards.

1. The current active leaderboard
2. The past week leaderboard (champions)

They were previously reusing the same cache causing reloads every time