### PR TITLE
[FEAT] Apply Kingdom Rank Boost to Pet and Kitchen

### DIFF
--- a/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
@@ -503,4 +503,71 @@ describe("factionKitchenDeliver", () => {
     expect(state.faction?.history?.[week].score).toBe(30);
     expect(state.inventory["Mark"]?.toNumber()).toBe(30);
   });
+
+  it("rewards 400% bonus marks if top rank in faction", () => {
+    const state = deliverFactionKitchen({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+          },
+        },
+        inventory: {
+          Honey: new Decimal(5),
+          "Goblin Emblem": new Decimal(100_000),
+        },
+        faction: {
+          ...(GAME_STATE.faction as Faction),
+          kitchen: {
+            week,
+            requests: [{ item: "Honey", amount: 1, dailyFulfilled: {} }],
+          },
+        },
+      },
+      action: {
+        type: "factionKitchen.delivered",
+        resourceIndex: 0,
+      },
+      createdAt: startTime,
+    });
+
+    expect(state.faction?.history?.[week].score).toBe(20 * 5);
+    expect(state.inventory["Mark"]?.toNumber()).toBe(20 * 5);
+  });
+
+  it("rewards 405% bonus marks if top rank and wearing faction shoes", () => {
+    const state = deliverFactionKitchen({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            shoes: "Goblin Sabatons",
+          },
+        },
+        inventory: {
+          Honey: new Decimal(5),
+          "Goblin Emblem": new Decimal(100_000),
+        },
+        faction: {
+          ...(GAME_STATE.faction as Faction),
+          kitchen: {
+            week,
+            requests: [{ item: "Honey", amount: 1, dailyFulfilled: {} }],
+          },
+        },
+      },
+      action: {
+        type: "factionKitchen.delivered",
+        resourceIndex: 0,
+      },
+      createdAt: startTime,
+    });
+
+    expect(state.faction?.history?.[week].score).toBe(20 * 5.05);
+    expect(state.inventory["Mark"]?.toNumber()).toBe(20 * 5.05);
+  });
 });

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   START_DATE,
   getFactionWearableBoostAmount,
@@ -17,6 +18,13 @@ export enum DELIVER_FACTION_KITCHEN_ERRORS {
 }
 
 export const BASE_POINTS = 20;
+
+const getKingdomKitchenBoost = (game: GameState, marks: number) => {
+  const wearablesBoost = getFactionWearableBoostAmount(game, marks);
+  const rankBoost = getFactionRankBoostAmount(game, marks);
+
+  return wearablesBoost + rankBoost;
+};
 
 export type DeliverFactionKitchenAction = {
   type: "factionKitchen.delivered";
@@ -72,7 +80,7 @@ export function deliverFactionKitchen({
   const fulfilledToday = request.dailyFulfilled[day] ?? 0;
 
   const points = BASE_POINTS - fulfilledToday * 2;
-  const boostPoints = getFactionWearableBoostAmount(stateCopy, points);
+  const boostPoints = getKingdomKitchenBoost(stateCopy, points);
   const totalPoints = points + boostPoints;
 
   const leaderboard = faction.history[week] ?? {

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -19,7 +19,7 @@ export enum DELIVER_FACTION_KITCHEN_ERRORS {
 
 export const BASE_POINTS = 20;
 
-const getKingdomKitchenBoost = (game: GameState, marks: number) => {
+export const getKingdomKitchenBoost = (game: GameState, marks: number) => {
   const wearablesBoost = getFactionWearableBoostAmount(game, marks);
   const rankBoost = getFactionRankBoostAmount(game, marks);
 

--- a/src/features/game/events/landExpansion/feedFactionPet.test.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.test.ts
@@ -464,4 +464,103 @@ describe("feedFactionPet", () => {
 
     expect(result.inventory["Mark"]?.toNumber()).toBe(12.6);
   });
+
+  it("rewards 400% bonus marks if top rank in faction", () => {
+    const result = feedFactionPet({
+      state: {
+        ...state,
+        inventory: {
+          "Carrot Cake": new Decimal(1),
+          Mark: new Decimal(0),
+          "Goblin Emblem": new Decimal(100_000),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+          },
+        },
+        faction: {
+          ...state.faction,
+          pet: {
+            week,
+            requests: [
+              {
+                food: "Pumpkin Soup",
+                quantity: new Decimal(2),
+                dailyFulfilled: {},
+              },
+              {
+                food: "Sunflower Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+              {
+                food: "Carrot Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+            ],
+          },
+          history: {
+            [week]: { petXP: 0, score: 0 },
+          },
+        } as Faction,
+      },
+      createdAt: startTime,
+      action: { type: "factionPet.fed", requestIndex: 2 },
+    });
+
+    expect(result.inventory["Mark"]?.toNumber()).toBe(12 * 5);
+  });
+
+  it("rewards 405% bonus marks if top rank and wearing faction shoes", () => {
+    const result = feedFactionPet({
+      state: {
+        ...state,
+        inventory: {
+          "Carrot Cake": new Decimal(1),
+          Mark: new Decimal(0),
+          "Goblin Emblem": new Decimal(100_000),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            shoes: "Goblin Sabatons",
+          },
+        },
+        faction: {
+          ...state.faction,
+          pet: {
+            week,
+            requests: [
+              {
+                food: "Pumpkin Soup",
+                quantity: new Decimal(2),
+                dailyFulfilled: {},
+              },
+              {
+                food: "Sunflower Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+              {
+                food: "Carrot Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+            ],
+          },
+          history: {
+            [week]: { petXP: 0, score: 0 },
+          },
+        } as Faction,
+      },
+      createdAt: startTime,
+      action: { type: "factionPet.fed", requestIndex: 2 },
+    });
+
+    expect(result.inventory["Mark"]?.toNumber()).toBeCloseTo(12 * 5.05);
+  });
 });

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -11,7 +11,7 @@ import { CONSUMABLES } from "features/game/types/consumables";
 import { FactionPetRequest, GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
 
-const getKingdomPetBoost = (game: GameState, marks: number) => {
+export const getKingdomPetBoost = (game: GameState, marks: number) => {
   const wearablesBoost = getFactionWearableBoostAmount(game, marks);
   const rankBoost = getFactionRankBoostAmount(game, marks);
 

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   START_DATE,
   calculatePoints,
@@ -9,6 +10,13 @@ import {
 import { CONSUMABLES } from "features/game/types/consumables";
 import { FactionPetRequest, GameState } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
+
+const getKingdomPetBoost = (game: GameState, marks: number) => {
+  const wearablesBoost = getFactionWearableBoostAmount(game, marks);
+  const rankBoost = getFactionRankBoostAmount(game, marks);
+
+  return wearablesBoost + rankBoost;
+};
 
 export enum DifficultyIndex {
   EASY = 0,
@@ -90,7 +98,7 @@ export function feedFactionPet({
     fulfilled,
     PET_FED_REWARDS_KEY[action.requestIndex],
   );
-  const boostAmount = getFactionWearableBoostAmount(stateCopy, baseReward);
+  const boostAmount = getKingdomPetBoost(stateCopy, baseReward);
   const totalAmount = baseReward + boostAmount;
 
   stateCopy.inventory.Mark = marksBalance.add(totalAmount);

--- a/src/features/world/ui/factions/FactionKitchenPanel.tsx
+++ b/src/features/world/ui/factions/FactionKitchenPanel.tsx
@@ -9,12 +9,16 @@ import { useSelector } from "@xstate/react";
 import { Faction, ResourceRequest } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SquareIcon } from "components/ui/SquareIcon";
-import { BASE_POINTS } from "features/game/events/landExpansion/deliverFactionKitchen";
+import {
+  BASE_POINTS,
+  getKingdomKitchenBoost,
+} from "features/game/events/landExpansion/deliverFactionKitchen";
 import { Button } from "components/ui/Button";
 import { OuterPanel } from "components/ui/Panel";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import selectBoxTL from "assets/ui/select/selectbox_tl.png";
 import selectBoxTR from "assets/ui/select/selectbox_tr.png";
+import lightning from "assets/icons/lightning.png";
 import { isMobile } from "mobile-device-detect";
 import Decimal from "decimal.js-light";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
@@ -121,6 +125,8 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
     inventory[selectedRequest.item] ?? new Decimal(0)
   ).gte(selectedRequest.amount);
 
+  const boost = getKingdomKitchenBoost(game, selectedRequestReward);
+
   return (
     <CloseButtonPanel bumpkinParts={bumpkinParts}>
       <div className="p-1 space-y-2">
@@ -152,6 +158,11 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
                       const fulfilled = request.dailyFulfilled[day] ?? 0;
                       const points = calculatePoints(fulfilled, BASE_POINTS);
 
+                      const boost = getKingdomKitchenBoost(
+                        gameService.state.context.state,
+                        points,
+                      );
+
                       return (
                         <OuterPanel
                           key={JSON.stringify(request)}
@@ -173,13 +184,16 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
                               type="warning"
                               className="absolute h-6"
                               iconWidth={10}
+                              secondaryIcon={boost ? lightning : null}
                               style={{
                                 width: isMobile ? "113%" : "117%",
                                 bottom: "-24px",
                                 left: "-4px",
                               }}
                             >
-                              {points}
+                              <span className={boost ? "pl-1.5" : ""}>
+                                {points + boost}
+                              </span>
                             </Label>
                           </div>
                           {selectedRequestIdx === idx && (
@@ -215,10 +229,13 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
                   <div className="flex flex-col space-y-1 px-1.5 mb-1">
                     <Label
                       icon={ITEM_DETAILS["Mark"].image}
+                      secondaryIcon={boost ? lightning : null}
                       type="warning"
                       className="m-1"
                     >
-                      {`${selectedRequestReward} marks`}
+                      <span className={boost ? "pl-1.5" : ""}>
+                        {`${selectedRequestReward + boost} ${t("marks")}`}
+                      </span>
                     </Label>
                     <div className="hidden sm:flex flex-col space-y-1 w-full justify-center items-center">
                       <p className="text-sm">{selectedRequest.item}</p>

--- a/src/features/world/ui/factions/FactionPetPanel.tsx
+++ b/src/features/world/ui/factions/FactionPetPanel.tsx
@@ -30,6 +30,7 @@ import selectBoxTR from "assets/ui/select/selectbox_tr.png";
 import {
   DifficultyIndex,
   PET_FED_REWARDS_KEY,
+  getKingdomPetBoost,
   getTotalXPForRequest,
 } from "features/game/events/landExpansion/feedFactionPet";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -41,6 +42,8 @@ import { secondsToString } from "lib/utils/time";
 import { getFactionPetUpdate } from "./actions/getFactionPetUpdate";
 
 import powerup from "assets/icons/level_up.png";
+import lightning from "assets/icons/lightning.png";
+
 import { hasFeatureAccess } from "lib/flags";
 
 export const PET_SLEEP_DURATION = 24 * 60 * 60 * 1000;
@@ -236,6 +239,11 @@ export const FactionPetPanel: React.FC<Props> = () => {
     inventory[selectedRequest.food] ?? new Decimal(0)
   ).gte(selectedRequest.quantity);
 
+  const boost = getKingdomPetBoost(
+    gameService.state.context.state,
+    selectedRequestReward,
+  );
+
   return (
     <>
       <Label
@@ -293,6 +301,11 @@ export const FactionPetPanel: React.FC<Props> = () => {
                           PET_FED_REWARDS_KEY[idx as DifficultyIndex],
                         );
 
+                        const boost = getKingdomPetBoost(
+                          gameService.state.context.state,
+                          points,
+                        );
+
                         return (
                           <OuterPanel
                             key={JSON.stringify(request)}
@@ -315,6 +328,7 @@ export const FactionPetPanel: React.FC<Props> = () => {
                               />
                               <Label
                                 icon={ITEM_DETAILS["Mark"].image}
+                                secondaryIcon={boost ? lightning : undefined}
                                 type="warning"
                                 className="absolute h-6"
                                 iconWidth={10}
@@ -324,7 +338,9 @@ export const FactionPetPanel: React.FC<Props> = () => {
                                   left: "-4px",
                                 }}
                               >
-                                {points}
+                                <span className={boost ? "pl-1.5" : ""}>
+                                  {points + boost}
+                                </span>
                               </Label>
                             </div>
                             {selectedRequestIdx === idx && (
@@ -360,10 +376,13 @@ export const FactionPetPanel: React.FC<Props> = () => {
                     <div className="flex flex-col items-center space-y-1 px-1.5 mb-1">
                       <Label
                         icon={ITEM_DETAILS["Mark"].image}
+                        secondaryIcon={boost ? lightning : undefined}
                         type="warning"
                         className="m-1"
                       >
-                        {`${selectedRequestReward} marks`}
+                        <span className={boost ? "pl-1.5" : ""}>
+                          {`${selectedRequestReward + boost} ${t("marks")}`}
+                        </span>
                       </Label>
                       <div className="hidden sm:flex flex-col space-y-1 w-full justify-center items-center">
                         <p className="text-sm">{selectedRequest.food}</p>

--- a/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
+++ b/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
@@ -304,7 +304,7 @@ const Panel: React.FC<PanelProps> = ({
             secondaryIcon={boost ? lightning : null}
             className="text-center whitespace-nowrap"
           >
-            <span className="pl-1.5">
+            <span className={boost ? "pl-1.5" : ""}>
               {`${chore.marks + boost} ${t("marks")}`}
             </span>
           </Label>


### PR DESCRIPTION
# Description

Adds bonus marks to Kingdom Pet and Kingdom Kitchen.

## How to Test

**Test one**

1. Remove emblems from farm
2. Ensure no boost is applied after feeding pet / delivering kitchen and autosaving

**Test two**

1. Add emblems to farm
2. Ensure boost labels appear and boost is applied after feeding pet / delivering kitchen and autosaving

![1](https://github.com/sunflower-land/sunflower-land/assets/41215134/bd33c680-8608-47d2-846b-dcce85f5dd6f)
![2](https://github.com/sunflower-land/sunflower-land/assets/41215134/67986ca3-44f0-459a-925b-ff3fb5d41acc)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
