### PR TITLE
[FEAT] Update Leaderboard Toggle

### DIFF
--- a/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/MarksLeaderboard.tsx
@@ -89,12 +89,7 @@ export const MarksLeaderboard: React.FC<Props> = ({
 }) => {
   const { t } = useAppTranslation();
 
-  const [selected, setSelected] = useState({
-    nightshades: true,
-    bumpkins: true,
-    goblins: true,
-    sunflorians: true,
-  });
+  const [selected, setSelected] = useState<FactionName>();
   const [leaderboard, setLeaderboard] = useState<"marks" | "emblems">("marks");
 
   if (isLoading) {
@@ -113,11 +108,9 @@ export const MarksLeaderboard: React.FC<Props> = ({
     );
 
   const select = (faction: FactionName) => {
-    const updated = { ...selected, [faction]: !selected[faction] };
-    // At least one must be true
-    if (!Object.values(updated).some((s) => s)) return;
-
-    setSelected(updated);
+    setSelected((prevFaction) =>
+      prevFaction === faction ? undefined : faction,
+    );
   };
 
   const data =
@@ -128,7 +121,7 @@ export const MarksLeaderboard: React.FC<Props> = ({
   const topRanks: (RankData & { faction: FactionName })[] = getKeys(
     data.topTens,
   )
-    .filter((name) => !!selected[name])
+    .filter(([faction]) => !selected || selected === faction)
     .reduce(
       (rows, faction) => {
         return [
@@ -141,7 +134,7 @@ export const MarksLeaderboard: React.FC<Props> = ({
 
   let playerRanks: RankData[] = [];
 
-  const showPlayerRank = !!selected[faction];
+  const showPlayerRank = selected === faction;
   if (showPlayerRank && leaderboard === "marks") {
     playerRanks = marksLeaderboard.marks.marksRankingData ?? [];
   }
@@ -233,7 +226,7 @@ export const MarksLeaderboard: React.FC<Props> = ({
               <FilterCheckbox
                 key={`faction-${faction}`}
                 faction={faction}
-                selected={selected[faction]}
+                selected={selected === faction}
                 onClick={() => select(faction)}
               />
             ))}


### PR DESCRIPTION
# Description

Updates the leaderboard toggle to be one of two state. Quality of life improvement instead of needing to deselect all the other factions

State 1: Faction selected
State 2: No faction selected

![1](https://github.com/sunflower-land/sunflower-land/assets/41215134/a966b09b-95bc-47bc-927b-d6cd8e3266b5)
![2](https://github.com/sunflower-land/sunflower-land/assets/41215134/6b89bc3a-dc5c-4db9-9ced-29a54c317e8a)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes