### PR TITLE
[FEAT] Apply Paw Shield Boost

### DIFF
--- a/src/features/game/events/landExpansion/feedFactionPet.test.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.test.ts
@@ -563,4 +563,100 @@ describe("feedFactionPet", () => {
 
     expect(result.inventory["Mark"]?.toNumber()).toBeCloseTo(12 * 5.05);
   });
+
+  it("adds 25% marks when Paw Shield is active", () => {
+    const result = feedFactionPet({
+      state: {
+        ...state,
+        inventory: { "Carrot Cake": new Decimal(1), Mark: new Decimal(0) },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            secondaryTool: "Paw Shield",
+          },
+        },
+        faction: {
+          ...state.faction,
+          pet: {
+            week,
+            requests: [
+              {
+                food: "Pumpkin Soup",
+                quantity: new Decimal(2),
+                dailyFulfilled: {},
+              },
+              {
+                food: "Sunflower Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+              {
+                food: "Carrot Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+            ],
+          },
+          history: {
+            [week]: { petXP: 0, score: 0 },
+          },
+        } as Faction,
+      },
+      createdAt: startTime,
+      action: { type: "factionPet.fed", requestIndex: 2 },
+    });
+
+    expect(result.inventory["Mark"]?.toNumber()).toBe(12 * 1.25);
+    expect(result.faction?.history[week]?.score).toBe(12 * 1.25);
+  });
+
+  it("adds 25% XP to pet when Paw Shield is active", () => {
+    const result = feedFactionPet({
+      state: {
+        ...state,
+        inventory: { "Pumpkin Soup": new Decimal(3) },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            secondaryTool: "Paw Shield",
+          },
+        },
+        faction: {
+          ...state.faction,
+          pet: {
+            week,
+            requests: [
+              {
+                food: "Pumpkin Soup",
+                quantity: new Decimal(2),
+                dailyFulfilled: {},
+              },
+              {
+                food: "Sunflower Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+              {
+                food: "Carrot Cake",
+                quantity: 1,
+                dailyFulfilled: {},
+              },
+            ],
+          },
+          history: {
+            [week]: { petXP: 0, score: 0 },
+          },
+        } as Faction,
+      },
+      action: { type: "factionPet.fed", requestIndex: 0 },
+      createdAt: startTime,
+    });
+
+    const pumpkinSoupXP = CONSUMABLES["Pumpkin Soup"].experience;
+    const totalXPForRequest = pumpkinSoupXP * 2;
+
+    expect(result.faction?.history[week]?.petXP).toBe(totalXPForRequest * 1.25);
+  });
 });

--- a/src/features/world/ui/factions/FactionKitchenPanel.tsx
+++ b/src/features/world/ui/factions/FactionKitchenPanel.tsx
@@ -131,7 +131,7 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
   const boostedMarks = setPrecision(
     new Decimal(selectedRequestReward + boost),
     2,
-  );
+  ).toNumber();
 
   return (
     <CloseButtonPanel bumpkinParts={bumpkinParts}>
@@ -172,7 +172,7 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
                       const boostedMarks = setPrecision(
                         new Decimal(points + boost),
                         2,
-                      );
+                      ).toNumber();
 
                       return (
                         <OuterPanel
@@ -287,7 +287,7 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
               <span className="text-xs sm:text-sm">
                 {t("faction.donation.confirm", {
                   factionPoints: boostedMarks,
-                  reward: Number(boostedMarks) > 1 ? "marks" : "mark",
+                  reward: boostedMarks > 1 ? "marks" : "mark",
                 })}
               </span>
               <div className="flex flex-col space-y-1">

--- a/src/features/world/ui/factions/FactionPetPanel.tsx
+++ b/src/features/world/ui/factions/FactionPetPanel.tsx
@@ -200,7 +200,10 @@ export const FactionPetPanel: React.FC<Props> = () => {
     });
     if (!autosaving) gameService.send("SAVE");
 
-    const totalXP = getTotalXPForRequest(pet.requests[selectedRequestIdx]);
+    const totalXP = getTotalXPForRequest(
+      gameService.state.context.state,
+      pet.requests[selectedRequestIdx],
+    );
     setFedXP((prev) => prev + totalXP);
     setShowConfirm(false);
   };

--- a/src/features/world/ui/factions/FactionPetPanel.tsx
+++ b/src/features/world/ui/factions/FactionPetPanel.tsx
@@ -251,7 +251,7 @@ export const FactionPetPanel: React.FC<Props> = () => {
   const boostedMarks = setPrecision(
     new Decimal(selectedRequestReward + boost),
     2,
-  );
+  ).toNumber();
 
   return (
     <>
@@ -318,7 +318,7 @@ export const FactionPetPanel: React.FC<Props> = () => {
                         const boostedMarks = setPrecision(
                           new Decimal(points + boost),
                           2,
-                        );
+                        ).toNumber();
 
                         return (
                           <OuterPanel
@@ -441,7 +441,7 @@ export const FactionPetPanel: React.FC<Props> = () => {
                 <span className="text-xs sm:text-sm">
                   {t("faction.donation.confirm", {
                     factionPoints: boostedMarks,
-                    reward: Number(boostedMarks) > 1 ? "marks" : "mark",
+                    reward: boostedMarks > 1 ? "marks" : "mark",
                   })}
                 </span>
                 <div className="flex flex-col space-y-1">

--- a/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
+++ b/src/features/world/ui/factions/chores/KingdomChoresContent.tsx
@@ -290,7 +290,10 @@ const Panel: React.FC<PanelProps> = ({
 
   const boost = getKingdomChoreBoost(gameService.state.context.state, chore);
 
-  const boostedMarks = setPrecision(new Decimal(chore.marks + boost), 2);
+  const boostedMarks = setPrecision(
+    new Decimal(chore.marks + boost),
+    2,
+  ).toNumber();
 
   return (
     <div className="flex flex-col justify-center">
@@ -414,7 +417,10 @@ const ConfirmSkip: React.FC<{
 
   const boost = getKingdomChoreBoost(gameService.state.context.state, chore);
 
-  const boostedMarks = setPrecision(new Decimal(chore.marks + boost), 2);
+  const boostedMarks = setPrecision(
+    new Decimal(chore.marks + boost),
+    2,
+  ).toNumber();
 
   return (
     <InnerPanel>


### PR DESCRIPTION
# Description

Applies Paw Shield Boost when feeding the faction pet

Boost:
+25% Marks
+25% XP to the Pet

## How to test

1. Apply the paw shield
2. Ensure UI updates to show new XP amount

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]