### PR TITLE
[FIX] Diminishing Marks Reward (1)

### DIFF
--- a/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.test.ts
@@ -570,4 +570,45 @@ describe("factionKitchenDeliver", () => {
     expect(state.faction?.history?.[week].score).toBe(20 * 5.05);
     expect(state.inventory["Mark"]?.toNumber()).toBe(20 * 5.05);
   });
+
+  it("rewards 400% bonus marks if top rank in faction and on the lowest reward (1)", () => {
+    const state = deliverFactionKitchen({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+          },
+        },
+        inventory: {
+          Honey: new Decimal(5),
+          "Goblin Emblem": new Decimal(100_000),
+        },
+        faction: {
+          ...(GAME_STATE.faction as Faction),
+          kitchen: {
+            week,
+            requests: [
+              {
+                item: "Honey",
+                amount: 1,
+                dailyFulfilled: {
+                  1: 100,
+                },
+              },
+            ],
+          },
+        },
+      },
+      action: {
+        type: "factionKitchen.delivered",
+        resourceIndex: 0,
+      },
+      createdAt: startTime,
+    });
+
+    expect(state.faction?.history?.[week].score).toBe(1 * 5);
+    expect(state.inventory["Mark"]?.toNumber()).toBe(1 * 5);
+  });
 });

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   START_DATE,
+  calculatePoints,
   getFactionWearableBoostAmount,
   getFactionWeek,
   getFactionWeekday,
@@ -79,7 +80,7 @@ export function deliverFactionKitchen({
   const marksBalance = inventory["Mark"] ?? new Decimal(0);
   const fulfilledToday = request.dailyFulfilled[day] ?? 0;
 
-  const points = BASE_POINTS - fulfilledToday * 2;
+  const points = calculatePoints(fulfilledToday, BASE_POINTS);
   const boostPoints = getKingdomKitchenBoost(stateCopy, points);
   const totalPoints = points + boostPoints;
 
@@ -88,19 +89,11 @@ export function deliverFactionKitchen({
     petXP: 0,
   };
 
-  if (totalPoints < 2) {
-    faction.history[week] = {
-      ...leaderboard,
-      score: leaderboard.score + 1,
-    };
-    inventory["Mark"] = marksBalance.plus(1);
-  } else {
-    faction.history[week] = {
-      ...leaderboard,
-      score: leaderboard.score + totalPoints,
-    };
-    inventory["Mark"] = marksBalance.plus(totalPoints);
-  }
+  faction.history[week] = {
+    ...leaderboard,
+    score: leaderboard.score + totalPoints,
+  };
+  inventory["Mark"] = marksBalance.plus(totalPoints);
 
   request.dailyFulfilled[day] = fulfilledToday + 1;
 

--- a/src/features/world/ui/factions/FactionKitchenPanel.tsx
+++ b/src/features/world/ui/factions/FactionKitchenPanel.tsx
@@ -68,25 +68,31 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
     !hasFeatureAccess(game, "FACTION_KITCHEN")
   ) {
     return (
-      <CloseButtonPanel bumpkinParts={bumpkinParts}>
-        <div className="p-1 space-y-2 mb-1">
-          <div className="flex justify-between">
-            <Label type="default">{`Kitchen`}</Label>
-            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-              {t("faction.kitchen.opensIn", {
-                time: secondsToString(
-                  (FACTION_KITCHEN_START_TIME - now) / 1000,
-                  { length: "medium", removeTrailingZeros: true },
-                ),
-              })}
-            </Label>
+      <>
+        <Label
+          type="info"
+          icon={SUNNYSIDE.icons.stopwatch}
+          className="absolute right-0 -top-7 shadow-md"
+        >
+          {t("faction.kitchen.opensIn", {
+            time: secondsToString((FACTION_KITCHEN_START_TIME - now) / 1000, {
+              length: "medium",
+              removeTrailingZeros: true,
+            }),
+          })}
+        </Label>
+        <CloseButtonPanel bumpkinParts={bumpkinParts}>
+          <div className="p-1 space-y-2 mb-1">
+            <div className="flex justify-between">
+              <Label type="default">{`Kitchen`}</Label>
+            </div>
+            <TypingMessage
+              message={t("faction.kitchen.notReady")}
+              onMessageEnd={() => undefined}
+            />
           </div>
-          <TypingMessage
-            message={t("faction.kitchen.notReady")}
-            onMessageEnd={() => undefined}
-          />
-        </div>
-      </CloseButtonPanel>
+        </CloseButtonPanel>
+      </>
     );
   }
 
@@ -134,186 +140,192 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
   ).toNumber();
 
   return (
-    <CloseButtonPanel bumpkinParts={bumpkinParts}>
-      <div className="p-1 space-y-2">
-        <div className="flex justify-between">
-          <Label type="default">{`Kitchen`}</Label>
-          <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-            {t("faction.kitchen.newRequests", {
-              time: secondsToString(secondsTillWeekEnd, {
-                length: "medium",
-                removeTrailingZeros: true,
-              }),
-            })}
-          </Label>
-        </div>
-        {!showConfirm && (
-          <>
-            <p className="block sm:hidden text-xs pb-1">
-              {t("faction.kitchen.gatherResources")}
-            </p>
-            <SplitScreenView
-              mobileReversePanelOrder
-              content={
-                <div className="flex flex-col space-y-2 w-full">
-                  <p className="hidden sm:block text-xs p-1 pb-2">
-                    {t("faction.kitchen.gatherResources")}
-                  </p>
-                  <div className="flex w-full justify-between gap-2 pl-0.5 pb-2">
-                    {kitchen.requests.map((request, idx) => {
-                      const fulfilled = request.dailyFulfilled[day] ?? 0;
-                      const points = calculatePoints(fulfilled, BASE_POINTS);
+    <>
+      <Label
+        type="info"
+        icon={SUNNYSIDE.icons.stopwatch}
+        className="absolute right-0 -top-7 shadow-md"
+      >
+        {t("faction.kitchen.newRequests", {
+          time: secondsToString(secondsTillWeekEnd, {
+            length: "medium",
+            removeTrailingZeros: true,
+          }),
+        })}
+      </Label>
+      <CloseButtonPanel bumpkinParts={bumpkinParts}>
+        <div className="p-1 space-y-2">
+          <div className="flex justify-between">
+            <Label type="default">{`Kitchen`}</Label>
+          </div>
+          {!showConfirm && (
+            <>
+              <p className="block sm:hidden text-xs pb-1">
+                {t("faction.kitchen.gatherResources")}
+              </p>
+              <SplitScreenView
+                mobileReversePanelOrder
+                content={
+                  <div className="flex flex-col space-y-2 w-full">
+                    <p className="hidden sm:block text-xs p-1 pb-2">
+                      {t("faction.kitchen.gatherResources")}
+                    </p>
+                    <div className="flex w-full justify-between gap-2 pl-0.5 pb-2">
+                      {kitchen.requests.map((request, idx) => {
+                        const fulfilled = request.dailyFulfilled[day] ?? 0;
+                        const points = calculatePoints(fulfilled, BASE_POINTS);
 
-                      const boost = getKingdomKitchenBoost(
-                        gameService.state.context.state,
-                        points,
-                      );
+                        const boost = getKingdomKitchenBoost(
+                          gameService.state.context.state,
+                          points,
+                        );
 
-                      const boostedMarks = setPrecision(
-                        new Decimal(points + boost),
-                        2,
-                      ).toNumber();
+                        const boostedMarks = setPrecision(
+                          new Decimal(points + boost),
+                          2,
+                        ).toNumber();
 
-                      return (
-                        <OuterPanel
-                          key={JSON.stringify(request)}
-                          className={classNames(
-                            "flex relative flex-col flex-1 items-center p-2 cursor-pointer hover:bg-brown-300",
-                            {
-                              "img-highlight": selectedRequestIdx === idx,
-                            },
-                          )}
-                          onClick={() => setSelectedRequestIdx(idx)}
-                        >
-                          <div className="flex flex-1 justify-center items-center mb-4 w-full relative">
-                            <SquareIcon
-                              width={24}
-                              icon={ITEM_DETAILS[request.item].image}
-                            />
-                            <Label
-                              icon={ITEM_DETAILS["Mark"].image}
-                              type="warning"
-                              className="absolute h-6"
-                              iconWidth={10}
-                              secondaryIcon={boost ? lightning : null}
-                              style={{
-                                width: isMobile ? "113%" : "117%",
-                                bottom: "-24px",
-                                left: "-4px",
-                              }}
-                            >
-                              <span className={boost ? "pl-1.5" : ""}>
-                                {boostedMarks}
-                              </span>
-                            </Label>
-                          </div>
-                          {selectedRequestIdx === idx && (
-                            <div id="select-box">
-                              <img
-                                className="absolute pointer-events-none"
-                                src={selectBoxTL}
-                                style={{
-                                  top: `${PIXEL_SCALE * -3}px`,
-                                  left: `${PIXEL_SCALE * -3}px`,
-                                  width: `${PIXEL_SCALE * 8}px`,
-                                }}
+                        return (
+                          <OuterPanel
+                            key={JSON.stringify(request)}
+                            className={classNames(
+                              "flex relative flex-col flex-1 items-center p-2 cursor-pointer hover:bg-brown-300",
+                              {
+                                "img-highlight": selectedRequestIdx === idx,
+                              },
+                            )}
+                            onClick={() => setSelectedRequestIdx(idx)}
+                          >
+                            <div className="flex flex-1 justify-center items-center mb-4 w-full relative">
+                              <SquareIcon
+                                width={24}
+                                icon={ITEM_DETAILS[request.item].image}
                               />
-                              <img
-                                className="absolute pointer-events-none"
-                                src={selectBoxTR}
+                              <Label
+                                icon={ITEM_DETAILS["Mark"].image}
+                                type="warning"
+                                className="absolute h-6"
+                                iconWidth={10}
+                                secondaryIcon={boost ? lightning : null}
                                 style={{
-                                  top: `${PIXEL_SCALE * -3}px`,
-                                  right: `${PIXEL_SCALE * -3}px`,
-                                  width: `${PIXEL_SCALE * 8}px`,
+                                  width: isMobile ? "113%" : "117%",
+                                  bottom: "-24px",
+                                  left: "-4px",
                                 }}
-                              />
+                              >
+                                <span className={boost ? "pl-1.5" : ""}>
+                                  {boostedMarks}
+                                </span>
+                              </Label>
                             </div>
-                          )}
-                        </OuterPanel>
-                      );
-                    })}
+                            {selectedRequestIdx === idx && (
+                              <div id="select-box">
+                                <img
+                                  className="absolute pointer-events-none"
+                                  src={selectBoxTL}
+                                  style={{
+                                    top: `${PIXEL_SCALE * -3}px`,
+                                    left: `${PIXEL_SCALE * -3}px`,
+                                    width: `${PIXEL_SCALE * 8}px`,
+                                  }}
+                                />
+                                <img
+                                  className="absolute pointer-events-none"
+                                  src={selectBoxTR}
+                                  style={{
+                                    top: `${PIXEL_SCALE * -3}px`,
+                                    right: `${PIXEL_SCALE * -3}px`,
+                                    width: `${PIXEL_SCALE * 8}px`,
+                                  }}
+                                />
+                              </div>
+                            )}
+                          </OuterPanel>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              }
-              panel={
-                <div className="flex flex-col justify-between h-full sm:items-center">
-                  <div className="flex flex-col space-y-1 px-1.5 mb-1">
-                    <Label
-                      icon={ITEM_DETAILS["Mark"].image}
-                      secondaryIcon={boost ? lightning : null}
-                      type="warning"
-                      className="m-1"
-                    >
-                      <span className={boost ? "pl-1.5" : ""}>
-                        {`${boostedMarks} ${t("marks")}`}
-                      </span>
-                    </Label>
-                    <div className="hidden sm:flex flex-col space-y-1 w-full justify-center items-center">
-                      <p className="text-sm">{selectedRequest.item}</p>
-                      <SquareIcon
-                        icon={ITEM_DETAILS[selectedRequest.item].image}
-                        width={12}
+                }
+                panel={
+                  <div className="flex flex-col justify-between h-full sm:items-center">
+                    <div className="flex flex-col space-y-1 px-1.5 mb-1">
+                      <Label
+                        icon={ITEM_DETAILS["Mark"].image}
+                        secondaryIcon={boost ? lightning : null}
+                        type="warning"
+                        className="m-1"
+                      >
+                        <span className={boost ? "pl-1.5" : ""}>
+                          {`${boostedMarks} ${t("marks")}`}
+                        </span>
+                      </Label>
+                      <div className="hidden sm:flex flex-col space-y-1 w-full justify-center items-center">
+                        <p className="text-sm">{selectedRequest.item}</p>
+                        <SquareIcon
+                          icon={ITEM_DETAILS[selectedRequest.item].image}
+                          width={12}
+                        />
+                      </div>
+                      <RequirementLabel
+                        className={classNames(
+                          "flex justify-between items-center sm:justify-center",
+                          {
+                            "-mt-1": isMobile,
+                          },
+                        )}
+                        showLabel={isMobile}
+                        hideIcon={!isMobile}
+                        type="item"
+                        item={selectedRequest.item}
+                        balance={
+                          inventory[selectedRequest.item] ?? new Decimal(0)
+                        }
+                        requirement={new Decimal(selectedRequest.amount)}
                       />
                     </div>
-                    <RequirementLabel
-                      className={classNames(
-                        "flex justify-between items-center sm:justify-center",
-                        {
-                          "-mt-1": isMobile,
-                        },
-                      )}
-                      showLabel={isMobile}
-                      hideIcon={!isMobile}
-                      type="item"
-                      item={selectedRequest.item}
-                      balance={
-                        inventory[selectedRequest.item] ?? new Decimal(0)
-                      }
-                      requirement={new Decimal(selectedRequest.amount)}
-                    />
+                    <Button
+                      disabled={!canFulfillRequest}
+                      onClick={() => setShowConfirm(true)}
+                    >{`${t("deliver")} ${selectedRequest.amount}`}</Button>
                   </div>
-                  <Button
-                    disabled={!canFulfillRequest}
-                    onClick={() => setShowConfirm(true)}
-                  >{`${t("deliver")} ${selectedRequest.amount}`}</Button>
-                </div>
-              }
-            />
-          </>
-        )}
-        {showConfirm && (
-          <>
-            <div className="space-y-3">
-              <span className="text-xs sm:text-sm">
-                {t("faction.donation.confirm", {
-                  factionPoints: boostedMarks,
-                  reward: boostedMarks > 1 ? "marks" : "mark",
-                })}
-              </span>
-              <div className="flex flex-col space-y-1">
-                <div className="flex justify-between">
-                  <div className="flex items-center">
-                    <SquareIcon
-                      icon={ITEM_DETAILS[selectedRequest.item].image}
-                      width={7}
-                    />
-                    <span className="text-xs sm:text-sm ml-1">
-                      {selectedRequest.item}
-                    </span>
+                }
+              />
+            </>
+          )}
+          {showConfirm && (
+            <>
+              <div className="space-y-3">
+                <span className="text-xs sm:text-sm">
+                  {t("faction.donation.confirm", {
+                    factionPoints: boostedMarks,
+                    reward: boostedMarks > 1 ? "marks" : "mark",
+                  })}
+                </span>
+                <div className="flex flex-col space-y-1">
+                  <div className="flex justify-between">
+                    <div className="flex items-center">
+                      <SquareIcon
+                        icon={ITEM_DETAILS[selectedRequest.item].image}
+                        width={7}
+                      />
+                      <span className="text-xs sm:text-sm ml-1">
+                        {selectedRequest.item}
+                      </span>
+                    </div>
+                    <span className="text-xs">{`${selectedRequest.amount}`}</span>
                   </div>
-                  <span className="text-xs">{`${selectedRequest.amount}`}</span>
                 </div>
               </div>
-            </div>
-            <div className="flex space-x-1 mt-2">
-              <Button onClick={() => setShowConfirm(false)}>
-                {t("cancel")}
-              </Button>
-              <Button onClick={handleDeliver}>{t("confirm")}</Button>
-            </div>
-          </>
-        )}
-      </div>
-    </CloseButtonPanel>
+              <div className="flex space-x-1 mt-2">
+                <Button onClick={() => setShowConfirm(false)}>
+                  {t("cancel")}
+                </Button>
+                <Button onClick={handleDeliver}>{t("confirm")}</Button>
+              </div>
+            </>
+          )}
+        </div>
+      </CloseButtonPanel>
+    </>
   );
 };


### PR DESCRIPTION
# Description

Fix the boosted marks rewards when players are on the final reward number (1).
Move kitchen modal timer outside of modal.
<img width="543" alt="Screenshot 2024-07-08 at 11 42 37 AM" src="https://github.com/sunflower-land/sunflower-land/assets/17863697/b3bf4ba8-cc9f-446c-9109-426b68cddac4">

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests and test locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
