### PR TITLE
[FEAT] Change URL Route when warping

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -220,6 +220,7 @@ export const PhaserComponent: React.FC<Props> = ({
     game.current.registry.set("gameService", gameService);
     game.current.registry.set("id", gameService.state.context.farmId);
     game.current.registry.set("initialScene", scene);
+    game.current.registry.set("navigate", navigate);
 
     gameService.onEvent((e) => {
       if (e.type === "bumpkin.equipped") {

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -1020,6 +1020,9 @@ export abstract class BaseScene extends Phaser.Scene {
     if (this.switchToScene) {
       const warpTo = this.switchToScene;
       this.switchToScene = undefined;
+
+      this.registry.get("navigate")(`/world/${warpTo}`);
+
       // this.mmoService?.state.context.server?.send(0, { sceneId: warpTo });
       this.mmoService?.send("SWITCH_SCENE", { sceneId: warpTo });
       this.scene.start(warpTo, { previousSceneId: this.sceneId });


### PR DESCRIPTION
# Description

Sets the URL correctly when warping between scenes.

I don't believe this should impact portals as portals generally do not warp.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
