### PR TITLE
[FEAT] Fix faction pet sprite change

### DIFF
--- a/src/features/world/scenes/BumpkinHouseScene.ts
+++ b/src/features/world/scenes/BumpkinHouseScene.ts
@@ -2,8 +2,7 @@ import mapJSON from "assets/map/bumpkin_house.json";
 
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
-import { FactionHouseScene, PET_STATE_COORDS } from "./FactionHouseScene";
-import { npcModalManager } from "../ui/NPCModals";
+import { FactionHouseScene } from "./FactionHouseScene";
 
 export const BUMPKIN_HOUSE_NPCS: NPCBumpkin[] = [
   {
@@ -43,21 +42,6 @@ export class BumpkinHouseScene extends FactionHouseScene {
     this.load.image("pet_sleeping", "world/bumpkins_pet_sleeping.webp");
     this.load.image("pet_happy", "world/bumpkins_pet_happy.webp");
     this.load.image("pet_hungry", "world/bumpkins_pet_hungry.webp");
-  }
-
-  setUpPet() {
-    this.pet = this.add.sprite(
-      PET_STATE_COORDS.bumpkins[this.petState].x,
-      PET_STATE_COORDS.bumpkins[this.petState].y,
-      this.petState,
-    );
-    this.pet
-      .setInteractive({ cursor: "pointer" })
-      .on("pointerdown", (p: Phaser.Input.Pointer) => {
-        if (p.downElement.nodeName === "CANVAS") {
-          npcModalManager.open("tater");
-        }
-      });
   }
 
   create() {

--- a/src/features/world/scenes/BumpkinHouseScene.ts
+++ b/src/features/world/scenes/BumpkinHouseScene.ts
@@ -2,8 +2,7 @@ import mapJSON from "assets/map/bumpkin_house.json";
 
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
-import { FactionHouseScene } from "./FactionHouseScene";
-import { PetStateSprite } from "./SunflorianHouseScene";
+import { FactionHouseScene, PET_STATE_COORDS } from "./FactionHouseScene";
 import { npcModalManager } from "../ui/NPCModals";
 
 export const BUMPKIN_HOUSE_NPCS: NPCBumpkin[] = [
@@ -27,27 +26,8 @@ export const BUMPKIN_HOUSE_NPCS: NPCBumpkin[] = [
   },
 ];
 
-const PET_STATE_COORDS: { [key in PetStateSprite]: { x: number; y: number } } =
-  {
-    pet_hungry: {
-      x: 241,
-      y: 286,
-    },
-    pet_sleeping: {
-      x: 239,
-      y: 289,
-    },
-    pet_happy: {
-      x: 239,
-      y: 283,
-    },
-  };
-
 export class BumpkinHouseScene extends FactionHouseScene {
   sceneId: SceneId = "bumpkin_house";
-
-  public tater: Phaser.GameObjects.Sprite | undefined;
-  private _petState: PetStateSprite = "pet_hungry";
 
   constructor() {
     super({
@@ -66,36 +46,18 @@ export class BumpkinHouseScene extends FactionHouseScene {
   }
 
   setUpPet() {
-    this.petState = this.getPetState();
-    this.tater = this.add.sprite(
-      PET_STATE_COORDS[this.petState].x,
-      PET_STATE_COORDS[this.petState].y,
-      "pet_hungry",
+    this.pet = this.add.sprite(
+      PET_STATE_COORDS.bumpkins[this.petState].x,
+      PET_STATE_COORDS.bumpkins[this.petState].y,
+      this.petState,
     );
-    this.tater
+    this.pet
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", (p: Phaser.Input.Pointer) => {
         if (p.downElement.nodeName === "CANVAS") {
-          npcModalManager.open("blaze");
+          npcModalManager.open("tater");
         }
       });
-  }
-
-  set petState(newValue: PetStateSprite) {
-    this._petState = newValue;
-    this.onPetStateChange(newValue); // Call the function when value changes
-  }
-
-  get petState() {
-    return this._petState;
-  }
-
-  onPetStateChange(newValue: PetStateSprite) {
-    this.tater?.setTexture(newValue);
-    this.tater?.setPosition(
-      PET_STATE_COORDS[newValue].x,
-      PET_STATE_COORDS[newValue].y,
-    );
   }
 
   create() {

--- a/src/features/world/scenes/FactionHouseScene.ts
+++ b/src/features/world/scenes/FactionHouseScene.ts
@@ -4,24 +4,101 @@ import { translate } from "lib/i18n/translate";
 import { getFactionPrize } from "../ui/factions/weeklyPrize/FactionWeeklyPrize";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { getFactionWeek } from "features/game/lib/factions";
-import { CollectivePet } from "features/game/types/game";
+import { CollectivePet, FactionName } from "features/game/types/game";
 import {
   FACTION_PET_REFRESH_INTERVAL,
   PET_SLEEP_DURATION,
 } from "../ui/factions/FactionPetPanel";
 import { getFactionPetUpdate } from "../ui/factions/actions/getFactionPetUpdate";
 import { hasReadFactionNotice } from "../ui/factions/FactionNoticeboard";
+import { PetStateSprite } from "./SunflorianHouseScene";
+
+type FactionPetStateCoords = Record<
+  FactionName,
+  Record<PetStateSprite, Coordinates>
+>;
+
+export const PET_STATE_COORDS: FactionPetStateCoords = {
+  sunflorians: {
+    pet_hungry: {
+      x: 243,
+      y: 220,
+    },
+    pet_sleeping: {
+      x: 243,
+      y: 229,
+    },
+    pet_happy: {
+      x: 243,
+      y: 220,
+    },
+  },
+  nightshades: {
+    pet_hungry: {
+      x: 241,
+      y: 284,
+    },
+    pet_sleeping: {
+      x: 241,
+      y: 284,
+    },
+    pet_happy: {
+      x: 241,
+      y: 284,
+    },
+  },
+  bumpkins: {
+    pet_hungry: {
+      x: 241,
+      y: 286,
+    },
+    pet_sleeping: {
+      x: 239,
+      y: 289,
+    },
+    pet_happy: {
+      x: 239,
+      y: 283,
+    },
+  },
+  goblins: {
+    pet_hungry: {
+      x: 242,
+      y: 237,
+    },
+    pet_sleeping: {
+      x: 242,
+      y: 237,
+    },
+    pet_happy: {
+      x: 242,
+      y: 237,
+    },
+  },
+};
 
 export abstract class FactionHouseScene extends BaseScene {
   public collectivePet: CollectivePet | undefined;
   private fetchInterval: NodeJS.Timeout | null = null;
+  private _petState: PetStateSprite = "pet_hungry";
+  public pet: Phaser.GameObjects.Sprite | undefined;
+  public factionName: FactionName | undefined;
 
   preload() {
     super.preload();
 
     this.load.image("basic_chest", "world/basic_chest.png");
     this.load.image("question_disc", "world/question_disc.png");
-    this.makeFetchRequest();
+
+    const week = getFactionWeek({ date: new Date() });
+    const faction = this.gameService.state.context.state.faction;
+    this.factionName = faction?.name;
+
+    if (faction) {
+      // Collective pet is put on the game state during session state
+      this.collectivePet = faction.history[week].collectivePet;
+      this.petState = this.getPetState();
+    }
   }
 
   create() {
@@ -36,7 +113,8 @@ export abstract class FactionHouseScene extends BaseScene {
     const { farmId } = this.gameService.state.context;
     const data = await getFactionPetUpdate({ farmId });
 
-    this.collectivePet = data;
+    // this.collectivePet = data;
+    this.petState = this.getPetState();
   }
 
   shutdown() {
@@ -51,15 +129,35 @@ export abstract class FactionHouseScene extends BaseScene {
     }
   }
 
+  set petState(newValue: PetStateSprite) {
+    this._petState = newValue;
+    this.onPetStateChange(newValue); // Call the function when value changes
+  }
+
+  get petState() {
+    return this._petState;
+  }
+
+  onPetStateChange(newValue: PetStateSprite) {
+    if (!this.pet) return;
+
+    this.pet?.setTexture(newValue);
+    this.pet?.setPosition(
+      PET_STATE_COORDS[this.factionName as FactionName][newValue].x,
+      PET_STATE_COORDS[this.factionName as FactionName][newValue].y,
+    );
+  }
+
   getPetState() {
     const week = getFactionWeek({ date: new Date() });
     const beginningOfWeek = new Date(week).getTime();
     const firstWeek = "2024-07-08";
 
-    if (!this.collectivePet || week === firstWeek) return "pet_hungry";
+    if (!this.collectivePet) return "pet_hungry";
 
     if (
       this.collectivePet.streak === 0 &&
+      week !== firstWeek &&
       Date.now() < beginningOfWeek + PET_SLEEP_DURATION
     ) {
       return "pet_sleeping";

--- a/src/features/world/scenes/FactionHouseScene.ts
+++ b/src/features/world/scenes/FactionHouseScene.ts
@@ -12,6 +12,7 @@ import {
 import { getFactionPetUpdate } from "../ui/factions/actions/getFactionPetUpdate";
 import { hasReadFactionNotice } from "../ui/factions/FactionNoticeboard";
 import { PetStateSprite } from "./SunflorianHouseScene";
+import { npcModalManager } from "../ui/NPCModals";
 
 type FactionPetStateCoords = Record<
   FactionName,
@@ -98,6 +99,23 @@ export abstract class FactionHouseScene extends BaseScene {
       this.collectivePet = faction.history[week].collectivePet;
       this.petState = this.getPetState();
     }
+  }
+
+  setUpPet() {
+    if (!this.factionName) return;
+
+    this.pet = this.add.sprite(
+      PET_STATE_COORDS[this.factionName][this.petState].x,
+      PET_STATE_COORDS[this.factionName][this.petState].y,
+      this.petState,
+    );
+    this.pet
+      .setInteractive({ cursor: "pointer" })
+      .on("pointerdown", (p: Phaser.Input.Pointer) => {
+        if (p.downElement.nodeName === "CANVAS") {
+          npcModalManager.open("pet");
+        }
+      });
   }
 
   create() {

--- a/src/features/world/scenes/FactionHouseScene.ts
+++ b/src/features/world/scenes/FactionHouseScene.ts
@@ -95,7 +95,6 @@ export abstract class FactionHouseScene extends BaseScene {
     this.factionName = faction?.name;
 
     if (faction) {
-      // Collective pet is put on the game state during session state
       this.collectivePet = faction.history[week].collectivePet;
       this.petState = this.getPetState();
     }
@@ -113,7 +112,7 @@ export abstract class FactionHouseScene extends BaseScene {
     const { farmId } = this.gameService.state.context;
     const data = await getFactionPetUpdate({ farmId });
 
-    // this.collectivePet = data;
+    this.collectivePet = data;
     this.petState = this.getPetState();
   }
 

--- a/src/features/world/scenes/GoblinHouseScene.ts
+++ b/src/features/world/scenes/GoblinHouseScene.ts
@@ -3,7 +3,6 @@ import mapJSON from "assets/map/goblin_house.json";
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
 import { FactionHouseScene } from "./FactionHouseScene";
-import { PetStateSprite } from "./SunflorianHouseScene";
 import { npcModalManager } from "../ui/NPCModals";
 
 export const GOBLIN_HOUSE_NPCS: NPCBumpkin[] = [
@@ -29,8 +28,6 @@ export const GOBLIN_HOUSE_NPCS: NPCBumpkin[] = [
 
 export class GoblinHouseScene extends FactionHouseScene {
   sceneId: SceneId = "goblin_house";
-  public snaggle: Phaser.GameObjects.Sprite | undefined;
-  private _petState: PetStateSprite = "pet_hungry";
 
   constructor() {
     super({
@@ -49,28 +46,14 @@ export class GoblinHouseScene extends FactionHouseScene {
   }
 
   setUpPet() {
-    this.petState = this.getPetState();
-    this.snaggle = this.add.sprite(242, 237, this.petState);
-    this.snaggle
+    this.pet = this.add.sprite(242, 237, this.petState);
+    this.pet
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", (p: Phaser.Input.Pointer) => {
         if (p.downElement.nodeName === "CANVAS") {
           npcModalManager.open("snaggle");
         }
       });
-  }
-
-  set petState(newValue: PetStateSprite) {
-    this._petState = newValue;
-    this.onPetStateChange(newValue); // Call the function when value changes
-  }
-
-  get petState() {
-    return this._petState;
-  }
-
-  onPetStateChange(newValue: PetStateSprite) {
-    this.snaggle?.setTexture(newValue);
   }
 
   create() {

--- a/src/features/world/scenes/GoblinHouseScene.ts
+++ b/src/features/world/scenes/GoblinHouseScene.ts
@@ -3,7 +3,6 @@ import mapJSON from "assets/map/goblin_house.json";
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
 import { FactionHouseScene } from "./FactionHouseScene";
-import { npcModalManager } from "../ui/NPCModals";
 
 export const GOBLIN_HOUSE_NPCS: NPCBumpkin[] = [
   {
@@ -41,19 +40,8 @@ export class GoblinHouseScene extends FactionHouseScene {
     super.preload();
 
     this.load.image("pet_sleeping", "world/goblins_pet_sleeping.webp");
-    this.load.image("pet_satiated", "world/goblins_pet_happy.webp");
+    this.load.image("pet_happy", "world/goblins_pet_happy.webp");
     this.load.image("pet_hungry", "world/goblins_pet_hungry.webp");
-  }
-
-  setUpPet() {
-    this.pet = this.add.sprite(242, 237, this.petState);
-    this.pet
-      .setInteractive({ cursor: "pointer" })
-      .on("pointerdown", (p: Phaser.Input.Pointer) => {
-        if (p.downElement.nodeName === "CANVAS") {
-          npcModalManager.open("snaggle");
-        }
-      });
   }
 
   create() {

--- a/src/features/world/scenes/NightshadeHouseScene.ts
+++ b/src/features/world/scenes/NightshadeHouseScene.ts
@@ -3,7 +3,6 @@ import mapJSON from "assets/map/nightshade_house.json";
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
 import { FactionHouseScene } from "./FactionHouseScene";
-import { npcModalManager } from "../ui/NPCModals";
 
 export const NIGHTSHADE_HOUSE_NPCS: NPCBumpkin[] = [
   {
@@ -48,17 +47,6 @@ export class NightshadeHouseScene extends FactionHouseScene {
     this.load.image("pet_sleeping", "world/nightshades_pet_sleeping.webp");
     this.load.image("pet_happy", "world/nightshades_pet_happy.webp");
     this.load.image("pet_hungry", "world/nightshades_pet_hungry.webp");
-  }
-
-  setUpPet() {
-    this.pet = this.add.sprite(241, 284, this.petState);
-    this.pet
-      .setInteractive({ cursor: "pointer" })
-      .on("pointerdown", (p: Phaser.Input.Pointer) => {
-        if (p.downElement.nodeName === "CANVAS") {
-          npcModalManager.open("sable");
-        }
-      });
   }
 
   create() {

--- a/src/features/world/scenes/NightshadeHouseScene.ts
+++ b/src/features/world/scenes/NightshadeHouseScene.ts
@@ -3,7 +3,6 @@ import mapJSON from "assets/map/nightshade_house.json";
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
 import { FactionHouseScene } from "./FactionHouseScene";
-import { PetStateSprite } from "./SunflorianHouseScene";
 import { npcModalManager } from "../ui/NPCModals";
 
 export const NIGHTSHADE_HOUSE_NPCS: NPCBumpkin[] = [
@@ -30,9 +29,6 @@ export const NIGHTSHADE_HOUSE_NPCS: NPCBumpkin[] = [
 export class NightshadeHouseScene extends FactionHouseScene {
   sceneId: SceneId = "nightshade_house";
 
-  public sable: Phaser.GameObjects.Sprite | undefined;
-  private _petState: PetStateSprite = "pet_hungry";
-
   constructor() {
     super({
       name: "nightshade_house",
@@ -55,9 +51,8 @@ export class NightshadeHouseScene extends FactionHouseScene {
   }
 
   setUpPet() {
-    this.petState = this.getPetState();
-    this.sable = this.add.sprite(241, 284, this.petState);
-    this.sable
+    this.pet = this.add.sprite(241, 284, this.petState);
+    this.pet
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", (p: Phaser.Input.Pointer) => {
         if (p.downElement.nodeName === "CANVAS") {
@@ -92,18 +87,5 @@ export class NightshadeHouseScene extends FactionHouseScene {
     this.setUpPet();
 
     this.setupNotice({ x: 313, y: 368 });
-  }
-
-  set petState(newValue: PetStateSprite) {
-    this._petState = newValue;
-    this.onPetStateChange(newValue); // Call the function when value changes
-  }
-
-  get petState() {
-    return this._petState;
-  }
-
-  onPetStateChange(newValue: PetStateSprite) {
-    this.sable?.setTexture(newValue);
   }
 }

--- a/src/features/world/scenes/SunflorianHouseScene.ts
+++ b/src/features/world/scenes/SunflorianHouseScene.ts
@@ -2,8 +2,7 @@ import mapJSON from "assets/map/sunflorian_house.json";
 
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
-import { FactionHouseScene, PET_STATE_COORDS } from "./FactionHouseScene";
-import { npcModalManager } from "../ui/NPCModals";
+import { FactionHouseScene } from "./FactionHouseScene";
 
 export const SUNFLORIAN_HOUSE_NPCS: NPCBumpkin[] = [
   {
@@ -45,21 +44,6 @@ export class SunflorianHouseScene extends FactionHouseScene {
     this.load.image("pet_happy", "world/sunflorians_pet_happy.webp");
     this.load.image("pet_hungry", "world/sunflorians_pet_hungry.webp");
     this.makeFetchRequest();
-  }
-
-  setUpPet() {
-    this.pet = this.add.sprite(
-      PET_STATE_COORDS.sunflorians[this.petState].x,
-      PET_STATE_COORDS.sunflorians[this.petState].y,
-      this.petState,
-    );
-    this.pet
-      .setInteractive({ cursor: "pointer" })
-      .on("pointerdown", (p: Phaser.Input.Pointer) => {
-        if (p.downElement.nodeName === "CANVAS") {
-          npcModalManager.open("blaze");
-        }
-      });
   }
 
   create() {

--- a/src/features/world/scenes/SunflorianHouseScene.ts
+++ b/src/features/world/scenes/SunflorianHouseScene.ts
@@ -2,7 +2,7 @@ import mapJSON from "assets/map/sunflorian_house.json";
 
 import { SceneId } from "../mmoMachine";
 import { NPCBumpkin } from "./BaseScene";
-import { FactionHouseScene } from "./FactionHouseScene";
+import { FactionHouseScene, PET_STATE_COORDS } from "./FactionHouseScene";
 import { npcModalManager } from "../ui/NPCModals";
 
 export const SUNFLORIAN_HOUSE_NPCS: NPCBumpkin[] = [
@@ -27,27 +27,8 @@ export const SUNFLORIAN_HOUSE_NPCS: NPCBumpkin[] = [
 
 export type PetStateSprite = "pet_sleeping" | "pet_hungry" | "pet_happy";
 
-const PET_STATE_COORDS: { [key in PetStateSprite]: { x: number; y: number } } =
-  {
-    pet_hungry: {
-      x: 243,
-      y: 220,
-    },
-    pet_sleeping: {
-      x: 243,
-      y: 229,
-    },
-    pet_happy: {
-      x: 243,
-      y: 220,
-    },
-  };
-
 export class SunflorianHouseScene extends FactionHouseScene {
   sceneId: SceneId = "sunflorian_house";
-
-  public blaze: Phaser.GameObjects.Sprite | undefined;
-  private _petState: PetStateSprite = "pet_hungry";
 
   constructor() {
     super({
@@ -67,36 +48,18 @@ export class SunflorianHouseScene extends FactionHouseScene {
   }
 
   setUpPet() {
-    this.petState = this.getPetState();
-    this.blaze = this.add.sprite(
-      PET_STATE_COORDS[this.petState].x,
-      PET_STATE_COORDS[this.petState].y,
+    this.pet = this.add.sprite(
+      PET_STATE_COORDS.sunflorians[this.petState].x,
+      PET_STATE_COORDS.sunflorians[this.petState].y,
       this.petState,
     );
-    this.blaze
+    this.pet
       .setInteractive({ cursor: "pointer" })
       .on("pointerdown", (p: Phaser.Input.Pointer) => {
         if (p.downElement.nodeName === "CANVAS") {
           npcModalManager.open("blaze");
         }
       });
-  }
-
-  set petState(newValue: PetStateSprite) {
-    this._petState = newValue;
-    this.onPetStateChange(newValue); // Call the function when value changes
-  }
-
-  get petState() {
-    return this._petState;
-  }
-
-  onPetStateChange(newValue: PetStateSprite) {
-    this.blaze?.setTexture(newValue);
-    this.blaze?.setPosition(
-      PET_STATE_COORDS[newValue].x,
-      PET_STATE_COORDS[newValue].y,
-    );
   }
 
   create() {

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -260,10 +260,7 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
           <FactionKitchenPanel bumpkinParts={NPC_WEARABLES["chef lumen"]} />
         )}
         {npc === "eldric" && <FactionShop onClose={closeModal} />}
-        {npc === "blaze" && <FactionPetPanel onClose={closeModal} />}
-        {npc === "tater" && <FactionPetPanel onClose={closeModal} />}
-        {npc === "snaggle" && <FactionPetPanel onClose={closeModal} />}
-        {npc === "sable" && <FactionPetPanel onClose={closeModal} />}
+        {npc === "pet" && <FactionPetPanel onClose={closeModal} />}
       </Modal>
 
       {npc === "hammerin harry" && (

--- a/src/features/world/ui/factions/FactionKitchenPanel.tsx
+++ b/src/features/world/ui/factions/FactionKitchenPanel.tsx
@@ -32,7 +32,6 @@ import {
   getFactionWeekEndTime,
   getFactionWeekday,
 } from "features/game/lib/factions";
-import { hasFeatureAccess } from "lib/flags";
 import { setPrecision } from "lib/utils/formatNumber";
 
 interface Props {
@@ -55,48 +54,16 @@ export const FactionKitchenPanel: React.FC<Props> = ({ bumpkinParts }) => {
 
   const inventory = useSelector(gameService, _inventory);
   const faction = useSelector(gameService, _faction);
+  const game = useSelector(gameService, _game);
+
   const kitchen = faction.kitchen;
+
   const [selectedRequestIdx, setSelectedRequestIdx] = useState<number>(0);
   const [showConfirm, setShowConfirm] = useState<boolean>(false);
 
-  // TODO: Remove when feature released
-  const game = useSelector(gameService, _game);
   const now = Date.now();
 
-  if (
-    now < FACTION_KITCHEN_START_TIME &&
-    !hasFeatureAccess(game, "FACTION_KITCHEN")
-  ) {
-    return (
-      <>
-        <Label
-          type="info"
-          icon={SUNNYSIDE.icons.stopwatch}
-          className="absolute right-0 -top-7 shadow-md"
-        >
-          {t("faction.kitchen.opensIn", {
-            time: secondsToString((FACTION_KITCHEN_START_TIME - now) / 1000, {
-              length: "medium",
-              removeTrailingZeros: true,
-            }),
-          })}
-        </Label>
-        <CloseButtonPanel bumpkinParts={bumpkinParts}>
-          <div className="p-1 space-y-2 mb-1">
-            <div className="flex justify-between">
-              <Label type="default">{`Kitchen`}</Label>
-            </div>
-            <TypingMessage
-              message={t("faction.kitchen.notReady")}
-              onMessageEnd={() => undefined}
-            />
-          </div>
-        </CloseButtonPanel>
-      </>
-    );
-  }
-
-  if (!kitchen) {
+  if (!kitchen || kitchen.requests.length === 0) {
     return (
       <CloseButtonPanel bumpkinParts={bumpkinParts}>
         <div className="p-1 space-y-2">

--- a/src/features/world/ui/factions/FactionPetPanel.tsx
+++ b/src/features/world/ui/factions/FactionPetPanel.tsx
@@ -46,7 +46,6 @@ import powerup from "assets/icons/level_up.png";
 import lightning from "assets/icons/lightning.png";
 import xpIcon from "assets/icons/xp.png";
 
-import { hasFeatureAccess } from "lib/flags";
 import { setPrecision } from "lib/utils/formatNumber";
 import { FACTION_EMBLEM_ICONS } from "./components/ClaimEmblems";
 
@@ -113,16 +112,12 @@ interface Props {
 export type PetState = "sleeping" | "hungry" | "happy";
 
 export const FACTION_PET_REFRESH_INTERVAL = 10 * 1000;
-const FACTION_PET_START_TIME = new Date("2024-07-08T00:00:00Z").getTime();
 
 const _autosaving = (state: MachineState) => state.matches("autosaving");
 const _farmId = (state: MachineState) => state.context.farmId;
 const _faction = (state: MachineState) =>
   state.context.state.faction as Faction;
 const _inventory = (state: MachineState) => state.context.state.inventory;
-
-// TODO: Remove when feature released
-const _game = (state: MachineState) => state.context.state;
 
 const getPetState = (collectivePet: CollectivePet): PetState => {
   const week = getFactionWeek({ date: new Date() });
@@ -153,8 +148,6 @@ export const FactionPetPanel: React.FC<Props> = ({ onClose }) => {
   const farmId = useSelector(gameService, _farmId);
   const inventory = useSelector(gameService, _inventory);
   const autosaving = useSelector(gameService, _autosaving);
-  // TODO: Remove when feature released
-  const game = useSelector(gameService, _game);
 
   const week = getFactionWeek({ date: new Date() });
   const pet = faction.pet as FactionPet;
@@ -185,11 +178,7 @@ export const FactionPetPanel: React.FC<Props> = ({ onClose }) => {
     return () => clearInterval(interval);
   });
 
-  if (
-    (now < FACTION_PET_START_TIME &&
-      !hasFeatureAccess(game, "FACTION_KITCHEN")) ||
-    petState === "sleeping"
-  ) {
+  if (petState === "sleeping") {
     return (
       <PetSleeping onWake={() => setPetState(getPetState(collectivePet))} />
     );

--- a/src/lib/npcs.ts
+++ b/src/lib/npcs.ts
@@ -96,10 +96,7 @@ export type NPCName =
   | "shadow"
   | "flora"
   | "eldric"
-  | "blaze" // sunflorian pet
-  | "snaggle" // goblin pet
-  | "tater" // bumpkin pet
-  | "sable"; // nightshade pet
+  | "pet"; // faction pet
 
 export const NPC_WEARABLES: Record<NPCName, Equipped> = {
   "chef tuck": {
@@ -1051,34 +1048,7 @@ export const NPC_WEARABLES: Record<NPCName, Equipped> = {
     coat: "Royal Robe",
   },
   // Placeholder values. Pets are an image.
-  blaze: {
-    body: "Sunburst Potion",
-    hair: "Blondie",
-    shirt: "Fancy Top",
-    pants: "Sunflorian Pants",
-    tool: "Sunflorian Sword",
-    background: "Farm Background",
-    shoes: "Sunflorian Sabatons",
-  },
-  tater: {
-    body: "Sunburst Potion",
-    hair: "Blondie",
-    shirt: "Fancy Top",
-    pants: "Sunflorian Pants",
-    tool: "Sunflorian Sword",
-    background: "Farm Background",
-    shoes: "Sunflorian Sabatons",
-  },
-  snaggle: {
-    body: "Sunburst Potion",
-    hair: "Blondie",
-    shirt: "Fancy Top",
-    pants: "Sunflorian Pants",
-    tool: "Sunflorian Sword",
-    background: "Farm Background",
-    shoes: "Sunflorian Sabatons",
-  },
-  sable: {
+  pet: {
     body: "Sunburst Potion",
     hair: "Blondie",
     shirt: "Fancy Top",


### PR DESCRIPTION
# Description

- Update the pet sprite when the state changes eg `pet_hungry` -> `pet_happy`.
- Refactored the pet to just use the one `pet` modal. 
- Removed flag code
 
Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against local data and in art mode

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
