### PR TITLE
[CHORE] Sort emblem rank display by decreasing order

### DIFF
--- a/src/features/world/ui/factions/emblemTrading/Emblems.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Emblems.tsx
@@ -81,6 +81,7 @@ export const Emblems: React.FC<Props> = ({ emblem, factionName }) => {
         <tbody>
           {Object.values(RANKS)
             .filter((rank) => rank.faction === factionName)
+            .sort((a, b) => b.emblemsRequired - a.emblemsRequired)
             .map((rank) => (
               <tr
                 key={rank.name}


### PR DESCRIPTION
# Description

- sort emblem rank display by decreasing order
  - makes more sense in terms of UX because you need to climb the ranks

Before|After
---|---
![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/4123812c-6b87-4865-9d39-5b71bd1bde23)|![image](https://github.com/sunflower-land/sunflower-land/assets/107602352/dd9d9a1c-1d40-44b3-bd38-98acc3d657c9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
