### PR TITLE
[FEAT] Buy extra farm hand

### DIFF
--- a/src/features/game/events/landExpansion/buyFarmHand.test.ts
+++ b/src/features/game/events/landExpansion/buyFarmHand.test.ts
@@ -83,7 +83,7 @@ describe("buyFarmHand", () => {
       },
     });
 
-    expect(state.inventory["Block Buck"]).toEqual(new Decimal(10));
+    expect(state.inventory["Block Buck"]).toEqual(new Decimal(15));
     expect(state.farmHands.bumpkins).toEqual({
       "1": {
         equipped: {
@@ -97,5 +97,33 @@ describe("buyFarmHand", () => {
         },
       },
     });
+  });
+
+  it("buys a second farm hand", () => {
+    let state = buyFarmhand({
+      action: {
+        type: "farmHand.bought",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Block Buck": new Decimal(50),
+        },
+        island: {
+          type: "spring",
+        },
+      },
+    });
+
+    expect(state.inventory["Block Buck"]).toEqual(new Decimal(40));
+
+    state = buyFarmhand({
+      action: {
+        type: "farmHand.bought",
+      },
+      state,
+    });
+
+    expect(state.inventory["Block Buck"]).toEqual(new Decimal(25));
   });
 });

--- a/src/features/game/events/landExpansion/buyFarmHand.ts
+++ b/src/features/game/events/landExpansion/buyFarmHand.ts
@@ -26,10 +26,8 @@ const FARM_HAND_PARTS: BumpkinParts = {
 export const ISLAND_BUMPKIN_CAPACITY: Record<IslandType, number> = {
   basic: 2,
   spring: 3,
-  desert: 4,
+  desert: 5,
 };
-
-export const FARM_HAND_COST = 15;
 
 export function buyFarmhand({
   state,
@@ -47,17 +45,19 @@ export function buyFarmhand({
     throw new Error("No space for a farm hand");
   }
 
+  const cost = (farmHands + 2) * 5;
+
   // Use coupon, otherwise Block Bucks
   const coupons = game.inventory["Farmhand Coupon"];
   if (coupons?.gte(1)) {
     game.inventory["Farmhand Coupon"] = coupons.sub(1);
   } else {
     const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
-    if (blockBucks.lt(FARM_HAND_COST)) {
+    if (blockBucks.lt(cost)) {
       throw new Error("Insufficient Block Bucks");
     }
 
-    game.inventory["Block Buck"] = blockBucks.sub(FARM_HAND_COST);
+    game.inventory["Block Buck"] = blockBucks.sub(cost);
   }
 
   const id = Object.keys(game.farmHands.bumpkins).length + 1;

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -451,7 +451,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Mashed Potato": new Decimal(1),
     "Treasure Key": new Decimal(1),
     "Hungry Hare": new Decimal(1),
-    "Farmhand Coupon": new Decimal(1),
     "White Festive Fox": new Decimal(3),
     "Red Pansy": new Decimal(3),
     "White Pansy": new Decimal(3),
@@ -766,10 +765,10 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   buildings: {
-    "Town Center": [
+    Manor: [
       {
         coordinates: {
-          x: -2,
+          x: 2,
           y: -2,
         },
         createdAt: 0,

--- a/src/features/home/components/BuyFarmHand.tsx
+++ b/src/features/home/components/BuyFarmHand.tsx
@@ -10,10 +10,7 @@ import lockIcon from "assets/skills/lock.png";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { GameState } from "features/game/types/game";
-import {
-  FARM_HAND_COST,
-  ISLAND_BUMPKIN_CAPACITY,
-} from "features/game/events/landExpansion/buyFarmHand";
+import { ISLAND_BUMPKIN_CAPACITY } from "features/game/events/landExpansion/buyFarmHand";
 import { Panel } from "components/ui/Panel";
 import confetti from "canvas-confetti";
 import { NPC } from "features/island/bumpkin/components/NPC";
@@ -34,6 +31,13 @@ export const BuyFarmHand: React.FC<Props> = ({ onClose, gameState }) => {
 
   const hasCoupon = !!gameState.inventory["Farmhand Coupon"]?.gte(1);
 
+  const capacity = ISLAND_BUMPKIN_CAPACITY[gameState.island.type];
+  const farmHands = Object.keys(gameState.farmHands.bumpkins).length;
+  const hasSpace = farmHands + 1 < capacity;
+  const cost = (farmHands + 2) * 5;
+
+  const hasBlockBucks = !!gameState.inventory["Block Buck"]?.gte(cost);
+
   const onAdd = () => {
     gameService.send("farmHand.bought");
     gameService.send("SAVE");
@@ -43,19 +47,12 @@ export const BuyFarmHand: React.FC<Props> = ({ onClose, gameState }) => {
     if (!hasCoupon) {
       gameAnalytics.trackSink({
         currency: "Block Buck",
-        amount: FARM_HAND_COST,
+        amount: cost,
         item: "Farmhand",
         type: "Collectible",
       });
     }
   };
-
-  const hasBlockBucks =
-    !!gameState.inventory["Block Buck"]?.gte(FARM_HAND_COST);
-
-  const capacity = ISLAND_BUMPKIN_CAPACITY[gameState.island.type];
-  const farmHands = Object.keys(gameState.farmHands.bumpkins).length;
-  const hasSpace = farmHands + 1 < capacity;
 
   if (showSuccess) {
     const latestFarmHand = Object.keys(gameState.farmHands.bumpkins).pop();
@@ -91,7 +88,7 @@ export const BuyFarmHand: React.FC<Props> = ({ onClose, gameState }) => {
                 src={ITEM_DETAILS["Block Buck"].image}
                 className="h-4 mr-2"
               />
-              <p className="text-xs">{`${FARM_HAND_COST} Block Bucks`}</p>
+              <p className="text-xs">{`${cost} Block Bucks`}</p>
             </div>
           )}
 
@@ -130,7 +127,7 @@ export const BuyFarmHand: React.FC<Props> = ({ onClose, gameState }) => {
         {!hasCoupon && (
           <div className="flex items-center my-2">
             <img src={ITEM_DETAILS["Block Buck"].image} className="h-4 mr-2" />
-            <p className="text-xs">{`${FARM_HAND_COST} Block Bucks`}</p>
+            <p className="text-xs">{`${cost} Block Bucks`}</p>
           </div>
         )}
 

--- a/src/features/island/buildings/components/building/house/HomeBumpkins.tsx
+++ b/src/features/island/buildings/components/building/house/HomeBumpkins.tsx
@@ -32,19 +32,21 @@ export const HomeBumpkins: React.FC<Props> = ({ game }) => {
           <PlayerNPC parts={bumpkin.equipped} />
         </div>
 
-        {getKeys(farmHands).map((id) => (
-          <div
-            key={id}
-            className="mr-1 cursor-pointer relative hover:img-highlight"
-            onClick={() => setSelectedFarmHandId(id)}
-            style={{ width: `${GRID_WIDTH_PX}px` }}
-          >
-            <NPC
-              key={JSON.stringify(farmHands[id].equipped)}
-              parts={farmHands[id].equipped}
-            />
-          </div>
-        ))}
+        {getKeys(farmHands)
+          .slice(0, 3)
+          .map((id) => (
+            <div
+              key={id}
+              className="mr-1 cursor-pointer relative hover:img-highlight"
+              onClick={() => setSelectedFarmHandId(id)}
+              style={{ width: `${GRID_WIDTH_PX}px` }}
+            >
+              <NPC
+                key={JSON.stringify(farmHands[id].equipped)}
+                parts={farmHands[id].equipped}
+              />
+            </div>
+          ))}
       </div>
 
       <Modal


### PR DESCRIPTION
# Description

Allow players on **Desert Island** to buy a farm hand. Note, the 4th one will only show inside.

We have also adjusted the pricing, so it is cheaper to get your first Farmhand but gets gradually more expensive.

1st Farmhand - 10 BBs
2nd Farmhand - 15 BBs
3rd Farmhand - 20 BBs
...

<img width="267" alt="Screenshot 2024-07-10 at 7 45 39 PM" src="https://github.com/sunflower-land/sunflower-land/assets/11745561/ef5f61db-594c-44d6-a256-595251806aeb">
