### PR TITLE
[FEAT] Mark Leaderboard Improvements

### DIFF
--- a/src/features/game/events/minigames/claimMinigamePrize.test.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.test.ts
@@ -331,4 +331,58 @@ describe("minigame.prizeClaimed", () => {
       ].prizeClaimedAt,
     ).toEqual(date.getTime());
   });
+
+  it("increases weekly kingdom score", () => {
+    const date = new Date("2024-07-05T00:00:00");
+
+    const state = claimMinigamePrize({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Mark: new Decimal(10),
+        },
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 10002000,
+          points: 0,
+          history: {},
+        },
+        minigames: {
+          games: {
+            "chicken-rescue": {
+              highscore: 30,
+              history: {
+                [date.toISOString().substring(0, 10)]: {
+                  attempts: 2,
+                  highscore: 30,
+                },
+              },
+            },
+          },
+          prizes: {
+            "chicken-rescue": {
+              coins: 100,
+              startAt: date.getTime() - 100,
+              endAt: date.getTime() + 1000,
+              items: {
+                Mark: 20,
+              },
+              wearables: {},
+              score: 20,
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        type: "minigame.prizeClaimed",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.faction?.history["2024-07-01"]).toEqual({
+      score: 20,
+      petXP: 0,
+    });
+  });
 });

--- a/src/features/game/events/minigames/claimMinigamePrize.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.ts
@@ -6,6 +6,7 @@ import {
 } from "features/game/types/minigames";
 import { GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
+import { getFactionWeek } from "features/game/lib/factions";
 
 export function isMinigameComplete({
   game,
@@ -116,6 +117,19 @@ export function claimMinigamePrize({
 
     game.wardrobe[name] = count + (prize.wearables[name] ?? 0);
   });
+
+  if (game.faction && prize.items.Mark) {
+    const week = getFactionWeek({ date: new Date(createdAt) });
+    const leaderboard = game.faction.history[week] ?? {
+      score: 0,
+      petXP: 0,
+    };
+
+    game.faction.history[week] = {
+      ...leaderboard,
+      score: leaderboard.score + prize.items.Mark,
+    };
+  }
 
   return game;
 }

--- a/src/features/island/hud/components/codex/pages/FactionLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/FactionLeaderboard.tsx
@@ -23,9 +23,10 @@ import { secondsTillWeekReset } from "features/game/lib/factions";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
-import { formatNumber } from "lib/utils/formatNumber";
+import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import { NPCName, NPC_WEARABLES } from "lib/npcs";
 import { ChampionsPrizes } from "features/world/ui/factions/Champions";
+import Decimal from "decimal.js-light";
 
 const npcs: Record<FactionName, NPCName> = {
   nightshades: "nyx",
@@ -222,7 +223,7 @@ export const FactionDetails: React.FC<{
               <p>{t("player")}</p>
             </th>
             <th style={{ border: "1px solid #b96f50" }} className="w-2/5 p-1.5">
-              <p>{`Marks`}</p>
+              <p>{t("leaderboard.weeklyScore")}</p>
             </th>
           </tr>
         </thead>
@@ -297,7 +298,7 @@ export const FactionDetails: React.FC<{
               <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
                 <div className="flex items-center space-x-1 justify-end">
                   <>
-                    <span>{count}</span>
+                    <span>{setPrecision(new Decimal(count), 2)}</span>
                     <img src={mark} className="h-4" />
                   </>
                 </div>

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -31,6 +31,8 @@ import {
 import { Fireworks } from "./components/ClaimEmblems";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { hasFeatureAccess } from "lib/flags";
+import { setPrecision } from "lib/utils/formatNumber";
+import Decimal from "decimal.js-light";
 
 interface Props {
   onClose: () => void;
@@ -165,7 +167,7 @@ export const ChampionsLeaderboard: React.FC<Props> = ({ onClose }) => {
               <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
                 <div className="flex items-center space-x-1 justify-end">
                   <>
-                    <span>{count}</span>
+                    <span>{setPrecision(new Decimal(count))}</span>
                   </>
                 </div>
               </td>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4661,6 +4661,7 @@ const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.champions": ENGLISH_TERMS["leaderboard.champions"],
   "leaderboard.congratulations": ENGLISH_TERMS["leaderboard.congratulations"],
   "leaderboard.position": ENGLISH_TERMS["leaderboard.position"],
+  "leaderboard.weeklyScore": ENGLISH_TERMS["leaderboard.weeklyScore"],
   "leaderboard.player": ENGLISH_TERMS["leaderboard.player"],
   "leaderboard.score": ENGLISH_TERMS["leaderboard.score"],
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5319,6 +5319,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.resultsPending": "Results pending...",
 
   "leaderboard.position": "Position",
+  "leaderboard.weeklyScore": "Weekly score",
   "leaderboard.player": "Player",
   "leaderboard.score": "Score",
   "leaderboard.prizes": "Prizes",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5458,6 +5458,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.champions": ENGLISH_TERMS["leaderboard.champions"],
   "leaderboard.congratulations": ENGLISH_TERMS["leaderboard.congratulations"],
   "leaderboard.position": ENGLISH_TERMS["leaderboard.position"],
+  "leaderboard.weeklyScore": ENGLISH_TERMS["leaderboard.weeklyScore"],
   "leaderboard.player": ENGLISH_TERMS["leaderboard.player"],
   "leaderboard.score": ENGLISH_TERMS["leaderboard.score"],
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5318,6 +5318,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.champions": ENGLISH_TERMS["leaderboard.champions"],
   "leaderboard.congratulations": ENGLISH_TERMS["leaderboard.congratulations"],
   "leaderboard.position": ENGLISH_TERMS["leaderboard.position"],
+  "leaderboard.weeklyScore": ENGLISH_TERMS["leaderboard.weeklyScore"],
   "leaderboard.player": ENGLISH_TERMS["leaderboard.player"],
   "leaderboard.score": ENGLISH_TERMS["leaderboard.score"],
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -5307,6 +5307,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.champions": ENGLISH_TERMS["leaderboard.champions"],
   "leaderboard.congratulations": ENGLISH_TERMS["leaderboard.congratulations"],
   "leaderboard.position": ENGLISH_TERMS["leaderboard.position"],
+  "leaderboard.weeklyScore": ENGLISH_TERMS["leaderboard.weeklyScore"],
   "leaderboard.player": ENGLISH_TERMS["leaderboard.player"],
   "leaderboard.score": ENGLISH_TERMS["leaderboard.score"],
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3605,6 +3605,7 @@ export type Leaderboard =
   | "leaderboard.champions"
   | "leaderboard.congratulations"
   | "leaderboard.position"
+  | "leaderboard.weeklyScore"
   | "leaderboard.player"
   | "leaderboard.score"
   | "leaderboard.prizes"


### PR DESCRIPTION
# Description

This PR adds 3 improvements to the leaderboard.

1. Change the header "Marks" to "Weekly Score" to make it clear it is not about total marks
2. Limit Mark decimal places to 2 to avoid overflow
3. Include Chicken Rescue marks in weekly score