### PR TITLE
[FEAT] Add faction teleport to map

### DIFF
--- a/src/features/island/hud/components/deliveries/WorldMap.tsx
+++ b/src/features/island/hud/components/deliveries/WorldMap.tsx
@@ -29,20 +29,22 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const level = getBumpkinLevel(
     gameService.state.context.state.bumpkin?.experience ?? 0,
   );
-
-  const canTeleportToFactionHouse =
-    level >= 7 && gameService.state.context.state.faction;
+  const hasFaction = gameService.state.context.state.faction;
+  const canTeleportToFactionHouse = level >= 7 && hasFaction;
 
   const getFactionHouseRoute = () => {
-    if (gameService.state.context.state.faction?.name === "goblins")
-      return "/world/goblin_house";
-    if (gameService.state.context.state.faction?.name === "sunflorians")
-      return "/world/sunflorian_house";
-    if (gameService.state.context.state.faction?.name === "nightshades")
-      return "/world/nightshade_house";
-    if (gameService.state.context.state.faction?.name === "bumpkins")
-      return "/world/bumpkin_house";
-    return "";
+    switch (hasFaction?.name) {
+      case "bumpkins":
+        return "/world/bumpkin_house";
+      case "goblins":
+        return "/world/goblin_house";
+      case "nightshades":
+        return "/world/nightshade_house";
+      case "sunflorians":
+        return "/world/sunflorian_house";
+      default:
+        return "";
+    }
   };
 
   return (

--- a/src/features/island/hud/components/deliveries/WorldMap.tsx
+++ b/src/features/island/hud/components/deliveries/WorldMap.tsx
@@ -30,6 +30,21 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     gameService.state.context.state.bumpkin?.experience ?? 0,
   );
 
+  const canTeleportToFactionHouse =
+    level >= 7 && gameService.state.context.state.faction;
+
+  const getFactionHouseRoute = () => {
+    if (gameService.state.context.state.faction?.name === "goblins")
+      return "/world/goblin_house";
+    if (gameService.state.context.state.faction?.name === "sunflorians")
+      return "/world/sunflorian_house";
+    if (gameService.state.context.state.faction?.name === "nightshades")
+      return "/world/nightshade_house";
+    if (gameService.state.context.state.faction?.name === "bumpkins")
+      return "/world/bumpkin_house";
+    return "";
+  };
+
   return (
     <OuterPanel className="w-full relative shadow-xl">
       <img src={worldMap} className="w-full" />
@@ -104,11 +119,11 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       <div
         style={{
           width: "18%",
-          height: "24%",
+          height: "19%",
           border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "35%",
-          bottom: "50%",
+          bottom: "45%",
         }}
         className="flex justify-center items-center cursor-pointer"
         onClick={() => {
@@ -123,6 +138,32 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         ) : (
           <span className="balance-text text-xxs sm:text-sm">
             {t("world.kingdom")}
+          </span>
+        )}
+      </div>
+
+      <div
+        style={{
+          width: "18%",
+          height: "12%",
+          border: showDebugBorders ? "2px solid red" : "",
+          position: "absolute",
+          left: "35%",
+          bottom: "64%",
+        }}
+        className="flex justify-center items-center cursor-pointer"
+        onClick={() => {
+          if (!canTeleportToFactionHouse) return;
+          travel.play();
+          navigate(getFactionHouseRoute());
+          onClose();
+        }}
+      >
+        {!canTeleportToFactionHouse ? (
+          <img src={lockIcon} className="h-6 ml-1 img-highlight-heavy" />
+        ) : (
+          <span className="balance-text text-xxs sm:text-sm">
+            {t("world.faction")}
           </span>
         )}
       </div>

--- a/src/features/island/hud/components/deliveries/WorldMap.tsx
+++ b/src/features/island/hud/components/deliveries/WorldMap.tsx
@@ -119,11 +119,11 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       <div
         style={{
           width: "18%",
-          height: "19%",
+          height: "15%",
           border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "35%",
-          bottom: "45%",
+          bottom: "61%",
         }}
         className="flex justify-center items-center cursor-pointer"
         onClick={() => {
@@ -145,11 +145,11 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       <div
         style={{
           width: "18%",
-          height: "12%",
+          height: "15%",
           border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "35%",
-          bottom: "64%",
+          bottom: "46%",
         }}
         className="flex justify-center items-center cursor-pointer"
         onClick={() => {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4646,6 +4646,7 @@ const world: Record<World, string> = {
   "world.retreat": "聚居地", //Retreat -> Residence
   "world.home": "家园",
   "world.kingdom": "王城",
+  "world.faction": ENGLISH_TERMS["world.faction"],
   "world.woodlands": "林地",
   "world.travelTo": "前往 {{location}}",
 };

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5280,6 +5280,7 @@ const world: Record<World, string> = {
   "world.retreat": "Retreat",
   "world.home": "Home",
   "world.kingdom": "Kingdom",
+  "world.faction": "Faction",
   "world.travelTo": "Travel to {{location}}",
 };
 

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5387,12 +5387,13 @@ const world: Record<World, string> = {
     "Pour interagir avec un Bumpkin ou un objet, approchez-vous et cliquez dessus.",
   "world.intro.seven":
     "Aucun harcèlement, injure ou intimidation. Merci de respecter les autres.",
-  "world.plaza": "Plaza",
-  "world.beach": "Beach",
-  "world.retreat": "Retreat",
+  "world.plaza": ENGLISH_TERMS["world.plaza"],
+  "world.beach": ENGLISH_TERMS["world.beach"],
+  "world.retreat": ENGLISH_TERMS["world.retreat"],
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
-  "world.home": "Home",
-  "world.kingdom": "Kingdom",
+  "world.home": ENGLISH_TERMS["world.home"],
+  "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.faction": ENGLISH_TERMS["world.faction"],
   "world.travelTo": ENGLISH_TERMS["world.travelTo"],
 };
 

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5218,6 +5218,7 @@ const world: Record<World, string> = {
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.faction": ENGLISH_TERMS["world.faction"],
   "world.travelTo": ENGLISH_TERMS["world.travelTo"],
 };
 

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -5174,13 +5174,14 @@ const world: Record<World, string> = {
     "To interact with a Bumpkin or an object, walk near it and click it",
   "world.intro.seven":
     "No harrasment, swearing or bullying. Thank you for respecting others.",
-  "world.plaza": "Plaza",
-  "world.beach": "Beach",
-  "world.woodlands": "Woodlands",
-  "world.retreat": "Retreat",
-  "world.home": "Home",
-  "world.kingdom": "Kingdom",
-  "world.travelTo": "Travel to {{location}}",
+  "world.plaza": ENGLISH_TERMS["world.plaza"],
+  "world.beach": ENGLISH_TERMS["world.beach"],
+  "world.retreat": ENGLISH_TERMS["world.retreat"],
+  "world.woodlands": ENGLISH_TERMS["world.woodlands"],
+  "world.home": ENGLISH_TERMS["world.home"],
+  "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.faction": ENGLISH_TERMS["world.faction"],
+  "world.travelTo": ENGLISH_TERMS["world.travelTo"],
 };
 
 const wornDescription: Record<WornDescription, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -5229,6 +5229,7 @@ const world: Record<World, string> = {
   "world.woodlands": ENGLISH_TERMS["world.woodlands"],
   "world.home": ENGLISH_TERMS["world.home"],
   "world.kingdom": ENGLISH_TERMS["world.kingdom"],
+  "world.faction": ENGLISH_TERMS["world.faction"],
   "world.travelTo": ENGLISH_TERMS["world.travelTo"],
 };
 

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3546,6 +3546,7 @@ export type World =
   | "world.woodlands"
   | "world.home"
   | "world.kingdom"
+  | "world.faction"
   | "world.travelTo";
 
 export type Event =


### PR DESCRIPTION
# Description

- add faction teleport to map

Note: there is an existing bug where entering the faction house, leaving it then entering it again causes a crash

![image](https://github.com/user-attachments/assets/d8b97200-18b6-4faa-bb8c-bb43f55ed96b)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- test teleport when level is below 7
- test teleport when player is not in factoin
- test teleport when player is in different factions

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
