### PR TITLE
[CHORE] Add custom number input component

### DIFF
--- a/src/components/ui/BulkSellModal.tsx
+++ b/src/components/ui/BulkSellModal.tsx
@@ -1,18 +1,19 @@
-import React, { ChangeEvent } from "react";
+import React from "react";
 import Decimal from "decimal.js-light";
 import { Button } from "components/ui/Button";
 import coins from "assets/icons/coins.webp";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
-import classNames from "classnames";
+import { NumberInput } from "./NumberInput";
+import { setPrecision } from "lib/utils/formatNumber";
 
 interface BulkSellProps {
   show: boolean;
   onHide: () => void;
   cropAmount: Decimal;
-  customInputAmount: string;
-  setCustomInputAmount: (amount: string) => void;
+  customAmount: Decimal;
+  setCustomAmount: (amount: Decimal) => void;
   onCancel: () => void;
   onSell: () => void;
   coinAmount: Decimal;
@@ -22,30 +23,16 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
   show,
   onHide,
   cropAmount,
-  customInputAmount,
-  setCustomInputAmount,
+  customAmount,
+  setCustomAmount,
   onCancel,
   onSell,
   coinAmount,
 }) => {
   const { t } = useAppTranslation();
-  const customAmount = Number(customInputAmount);
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/^0+(?!\.)/, "");
-
-    // Check if the value has a decimal point
-    const parts = value.split(".");
-
-    // Limit the decimal places to 4
-    if (parts.length > 1 && parts[1].length > 4) {
-      parts[1] = parts[1].slice(0, 4);
-    }
-
-    const formattedValue = parts.join(".");
-
-    setCustomInputAmount(formattedValue ? formattedValue.slice(0, 10) : "");
-  };
+  const isOutOfRange =
+    customAmount.greaterThan(cropAmount) || customAmount.lessThanOrEqualTo(0);
 
   return (
     <Modal show={show} onHide={onHide}>
@@ -55,35 +42,20 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
             {t("confirmation.enterAmount")}
           </p>
           <div className="flex items-center w-full">
-            <input
-              type="number"
-              placeholder="0"
-              min={1}
-              value={customInputAmount}
-              onChange={handleInputChange}
-              className={classNames(
-                "mb-2 text-shadow rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10 placeholder-error",
-                {
-                  "text-error": new Decimal(customAmount).greaterThan(
-                    cropAmount,
-                  ),
-                },
-              )}
-              style={{
-                boxShadow: "#b96e50 0px 1px 1px 1px inset",
-                border: "2px solid #ead4aa",
-              }}
+            <NumberInput
+              value={customAmount}
+              maxDecimalPlaces={4}
+              isOutOfRange={isOutOfRange}
+              onValueChange={setCustomAmount}
             />
             <Button
-              onClick={() =>
-                setCustomInputAmount(cropAmount.mul(0.5).toString())
-              }
+              onClick={() => setCustomAmount(setPrecision(cropAmount.mul(0.5)))}
               className="ml-2 px-1 py-1 w-auto"
             >
               {`50%`}
             </Button>
             <Button
-              onClick={() => setCustomInputAmount(cropAmount.toString())}
+              onClick={() => setCustomAmount(cropAmount)}
               className="ml-2 px-1 py-1 w-auto"
             >
               {t("max")}
@@ -96,13 +68,7 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
         </div>
         <div className="flex justify-content-around mt-2 space-x-1">
           <Button onClick={onCancel}>{t("cancel")}</Button>
-          <Button
-            disabled={
-              new Decimal(customAmount).greaterThan(cropAmount) ||
-              new Decimal(customAmount).lessThanOrEqualTo(0)
-            }
-            onClick={onSell}
-          >
+          <Button disabled={isOutOfRange} onClick={onSell}>
             {t("sell")}
           </Button>
         </div>

--- a/src/components/ui/NumberInput.tsx
+++ b/src/components/ui/NumberInput.tsx
@@ -1,0 +1,87 @@
+import classNames from "classnames";
+import Decimal from "decimal.js-light";
+import { setPrecision } from "lib/utils/formatNumber";
+import React, { ChangeEvent, useEffect, useState } from "react";
+
+const VALID_INTEGER = new RegExp(/^\d+$/);
+
+type Props = {
+  value: Decimal | number;
+  maxDecimalPlaces: number;
+  isRightAligned?: boolean;
+  isOutOfRange?: boolean;
+  onValueChange?: (value: Decimal) => void;
+};
+
+/**
+ * A number input component that only accepts numbers and up to `maxDecimalPlaces` decimal places.
+ * @param value The value of the input.
+ * @param maxDecimalPlaces The maximum number of decimal places allowed.
+ * @param isRightAligned Whether the text should be right-aligned.
+ * @param isOutOfRange Whether the input is out of range.
+ * @param onValueChange A callback function that is called when the value changes.
+ */
+export const NumberInput: React.FC<Props> = ({
+  value,
+  maxDecimalPlaces,
+  isRightAligned,
+  isOutOfRange,
+  onValueChange,
+}) => {
+  const VALID_DECIMAL_NUMBER = new RegExp(
+    `^\\d*(\\.\\d{0,${maxDecimalPlaces}})?$`,
+  );
+  const INPUT_MAX_CHAR = Math.max(maxDecimalPlaces + 4, 10);
+
+  const [numberDisplay, setNumberDisplay] = useState("");
+
+  useEffect(() => {
+    // do not change the display if the value is the same
+    if (
+      new Decimal(value).equals(new Decimal(numberDisplay ? numberDisplay : 0))
+    )
+      return;
+
+    setNumberDisplay(
+      setPrecision(new Decimal(value), maxDecimalPlaces).toString(),
+    );
+  }, [value]);
+
+  return (
+    <input
+      style={{
+        boxShadow: "#b96e50 0px 1px 1px 1px inset",
+        border: "2px solid #ead4aa",
+        textAlign: isRightAligned ? "right" : "left",
+        fontSize: "36px",
+      }}
+      type="number"
+      placeholder="0"
+      value={numberDisplay}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        // strip the leading zero from numbers
+        if (/^0+(?!\.)/.test(e.target.value) && e.target.value.length > 1) {
+          e.target.value = e.target.value.replace(/^0/, "");
+        }
+
+        if (e.target.value === "") {
+          setNumberDisplay(""); // reset to 0 if input is empty
+        } else if (
+          (maxDecimalPlaces > 0 ? VALID_DECIMAL_NUMBER : VALID_INTEGER).test(
+            e.target.value,
+          )
+        ) {
+          const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
+          setNumberDisplay(amount);
+          onValueChange?.(new Decimal(amount ?? 0));
+        }
+      }}
+      className={classNames(
+        "mb-2 rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10 placeholder-error font-secondary",
+        {
+          "text-error": isOutOfRange,
+        },
+      )}
+    />
+  );
+};

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -1,6 +1,5 @@
 import { useActor } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
-import classNames from "classnames";
 import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
@@ -12,7 +11,7 @@ import {
   TradeListing,
 } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
-import React, { ChangeEvent, useContext, useState } from "react";
+import React, { useContext, useState } from "react";
 import token from "assets/icons/sfl.webp";
 import lock from "assets/skills/lock.png";
 import tradeIcon from "assets/icons/trade.png";
@@ -34,10 +33,8 @@ import { VIPAccess } from "features/game/components/VipAccess";
 import { getDayOfYear } from "lib/utils/time";
 import { ListingCategoryCard } from "components/ui/ListingCategoryCard";
 import { FACTION_EMBLEMS } from "features/game/events/landExpansion/joinFaction";
+import { NumberInput } from "components/ui/NumberInput";
 
-const VALID_INTEGER = new RegExp(/^\d+$/);
-const VALID_FOUR_DECIMAL_NUMBER = new RegExp(/^\d*(\.\d{0,4})?$/);
-const INPUT_MAX_CHAR = 10;
 const MAX_NON_VIP_LISTINGS = 1;
 const MAX_SFL = 150;
 
@@ -62,13 +59,10 @@ const ListTrade: React.FC<{
 }> = ({ inventory, onList, onCancel, isSaving, floorPrices }) => {
   const { t } = useAppTranslation();
   const [selected, setSelected] = useState<InventoryItemName>();
-  const [quantityDisplay, setQuantityDisplay] = useState("");
-  const [sflDisplay, setSflDisplay] = useState("");
+  const [quantity, setQuantity] = useState(new Decimal(0));
+  const [sfl, setSfl] = useState(new Decimal(0));
 
-  const quantity = Number(quantityDisplay);
-  const sfl = Number(sflDisplay);
-
-  const maxSFL = sfl > MAX_SFL;
+  const maxSFL = sfl.greaterThan(MAX_SFL);
 
   if (!selected) {
     return (
@@ -98,8 +92,9 @@ const ListTrade: React.FC<{
     );
   }
 
-  const unitPrice = sfl / quantity;
-  const tooLittle = !!quantity && quantity < (TRADE_MINIMUMS[selected] ?? 0);
+  const unitPrice = sfl.dividedBy(quantity);
+  const tooLittle =
+    !!quantity && quantity.lessThan(TRADE_MINIMUMS[selected] ?? 0);
 
   const isTooHigh =
     !!sfl &&
@@ -136,9 +131,9 @@ const ListTrade: React.FC<{
       <div className="flex items-center justify-between">
         <Label
           type={
-            sfl / quantity < (floorPrices[selected] ?? 0)
+            unitPrice.lessThan(floorPrices[selected] ?? 0)
               ? "danger"
-              : sfl / quantity > (floorPrices[selected] ?? 0)
+              : unitPrice.greaterThan(floorPrices[selected] ?? 0)
                 ? "success"
                 : "warning"
           }
@@ -180,7 +175,7 @@ const ListTrade: React.FC<{
             >
               {t("bumpkinTrade.quantity")}
             </Label>
-            {quantity > (TRADE_LIMITS[selected] ?? 0) && (
+            {quantity.greaterThan(TRADE_LIMITS[selected] ?? 0) && (
               <Label type="danger" className="my-1 ml-2 mr-1">
                 {t("bumpkinTrade.max", { max: TRADE_LIMITS[selected] ?? 0 })}
               </Label>
@@ -192,54 +187,30 @@ const ListTrade: React.FC<{
             )}
           </div>
 
-          <input
-            style={{
-              boxShadow: "#b96e50 0px 1px 1px 1px inset",
-              border: "2px solid #ead4aa",
-              fontSize: "36px",
-            }}
-            type="number"
-            placeholder="0"
-            min={1}
-            value={quantityDisplay}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              // Strip the leading zero from numbers
-              if (
-                /^0+(?!\.)/.test(e.target.value) &&
-                e.target.value.length > 1
-              ) {
-                e.target.value = e.target.value.replace(/^0/, "");
-              }
+          <NumberInput
+            value={quantity}
+            maxDecimalPlaces={0}
+            isOutOfRange={
+              inventory[selected]?.lt(quantity) ||
+              quantity.greaterThan(TRADE_LIMITS[selected] ?? 0) ||
+              quantity.equals(0)
+            }
+            onValueChange={(value) => {
+              setQuantity(value);
 
-              if (e.target.value === "") {
-                setQuantityDisplay(""); // Reset to 0 if input is empty
-              } else if (VALID_INTEGER.test(e.target.value)) {
-                const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
-                setQuantityDisplay(amount);
-
-                // Auto generate price
-                if (floorPrices[selected]) {
-                  const estimated = setPrecision(
-                    new Decimal(floorPrices[selected] ?? 0).mul(amount),
-                  );
-                  setSflDisplay(estimated.toString());
-                }
+              // auto generate price
+              if (floorPrices[selected]) {
+                const estimated = setPrecision(
+                  new Decimal(floorPrices[selected] ?? 0).mul(value),
+                );
+                setSfl(estimated);
               }
             }}
-            className={classNames(
-              "mb-2  mr-2 rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10 placeholder-error font-secondary",
-              {
-                "text-error":
-                  inventory[selected]?.lt(quantity) ||
-                  quantity > (TRADE_LIMITS[selected] ?? 0) ||
-                  quantity === 0,
-              },
-            )}
           />
         </div>
         <div className="flex-1 flex flex-col items-end ml-2">
           <div className="flex items-center">
-            {sfl > MAX_SFL && (
+            {sfl.greaterThan(MAX_SFL) && (
               <Label type="danger" className="my-1 ml-2 mr-1">
                 {t("bumpkinTrade.max", { max: MAX_SFL })}
               </Label>
@@ -248,38 +219,14 @@ const ListTrade: React.FC<{
               {t("bumpkinTrade.price")}
             </Label>
           </div>
-          <input
-            style={{
-              boxShadow: "#b96e50 0px 1px 1px 1px inset",
-              border: "2px solid #ead4aa",
-              textAlign: "right",
-              fontSize: "36px",
+          <NumberInput
+            value={sfl}
+            maxDecimalPlaces={4}
+            isRightAligned={true}
+            isOutOfRange={maxSFL || sfl.equals(0) || isTooHigh || isTooLow}
+            onValueChange={(value) => {
+              setSfl(value);
             }}
-            type="number"
-            placeholder="0"
-            value={sflDisplay}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              // Strip the leading zero from numbers
-              if (
-                /^0+(?!\.)/.test(e.target.value) &&
-                e.target.value.length > 1
-              ) {
-                e.target.value = e.target.value.replace(/^0/, "");
-              }
-
-              if (e.target.value === "") {
-                setSflDisplay(""); // Reset to 0 if input is empty
-              } else if (VALID_FOUR_DECIMAL_NUMBER.test(e.target.value)) {
-                const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
-                setSflDisplay(amount);
-              }
-            }}
-            className={classNames(
-              "mb-2  rounded-sm shadow-inner shadow-black bg-brown-200 w-full p-2 h-10 placeholder-error font-secondary",
-              {
-                "text-error": maxSFL || sfl === 0 || isTooHigh || isTooLow,
-              },
-            )}
           />
         </div>
       </div>
@@ -307,9 +254,9 @@ const ListTrade: React.FC<{
           {t("bumpkinTrade.pricePerUnit", { resource: selected })}
         </span>
         <p className="text-xs font-secondary">
-          {quantity === 0
+          {quantity.equals(0)
             ? "0.0000 SFL"
-            : `${setPrecision(new Decimal(sfl / quantity)).toFixed(4)} SFL`}
+            : `${setPrecision(unitPrice).toFixed(4)} SFL`}
         </p>
       </div>
       <div
@@ -321,7 +268,7 @@ const ListTrade: React.FC<{
       >
         <span className="text-xs"> {t("bumpkinTrade.tradingFee")}</span>
         <p className="text-xs font-secondary">{`${setPrecision(
-          new Decimal(sfl * 0.1),
+          sfl.mul(0.1),
         ).toFixed(4)} SFL`}</p>
       </div>
       <div
@@ -332,7 +279,7 @@ const ListTrade: React.FC<{
       >
         <span className="text-xs"> {t("bumpkinTrade.youWillReceive")}</span>
         <p className="text-xs font-secondary">{`${setPrecision(
-          new Decimal(sfl * 0.9),
+          sfl.mul(0.9),
         ).toFixed(4)} SFL`}</p>
       </div>
       <div className="flex mt-2">
@@ -346,11 +293,11 @@ const ListTrade: React.FC<{
             isTooLow ||
             maxSFL ||
             (inventory[selected]?.lt(quantity) ?? false) ||
-            quantity === 0 || // Disable when quantity is 0
-            sfl === 0 || // Disable when sfl is 0
+            quantity.equals(0) || // Disable when quantity is 0
+            sfl.equals(0) || // Disable when sfl is 0
             isSaving
           }
-          onClick={() => onList({ [selected]: quantity }, sfl)}
+          onClick={() => onList({ [selected]: quantity }, sfl.toNumber())}
         >
           {t("bumpkinTrade.list")}
         </Button>

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -42,8 +42,7 @@ export const Crops: React.FC = () => {
   );
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
-  const [customInputAmount, setCustomInputAmount] = useState("");
-  const customAmount = Number(customInputAmount);
+  const [customAmount, setCustomAmount] = useState(new Decimal(0));
   const [isCustomSellModalOpen, showCustomSellModal] = useState(false);
 
   const { gameService } = useContext(Context);
@@ -95,7 +94,7 @@ export const Crops: React.FC = () => {
   const handleSell = (amount: Decimal) => {
     sell(amount);
     setShowConfirmationModal(false);
-    setCustomInputAmount("");
+    setCustomAmount(new Decimal(0));
   };
 
   const openConfirmationModal = () => {
@@ -104,7 +103,7 @@ export const Crops: React.FC = () => {
   };
   const closeConfirmationModal = () => {
     setShowConfirmationModal(false);
-    setCustomInputAmount("");
+    setCustomAmount(new Decimal(0));
   };
 
   const openBulkSellModal = () => {
@@ -112,7 +111,7 @@ export const Crops: React.FC = () => {
   };
   const closeBulkSellModal = () => {
     showCustomSellModal(false);
-    setCustomInputAmount("");
+    setCustomAmount(new Decimal(0));
   };
 
   const exotics = getKeys(EXOTIC_CROPS)
@@ -348,8 +347,8 @@ export const Crops: React.FC = () => {
       <BulkSellModal
         show={isCustomSellModalOpen}
         onHide={closeBulkSellModal}
-        customInputAmount={customInputAmount}
-        setCustomInputAmount={setCustomInputAmount}
+        customAmount={customAmount}
+        setCustomAmount={setCustomAmount}
         cropAmount={cropAmount}
         onCancel={closeBulkSellModal}
         onSell={openConfirmationModal}


### PR DESCRIPTION
# Description

- add custom number input component
  - other number inputs in the game will be refactored to use this new component in the future

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- existing trade screen for items and emblems does not break

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes