### PR TITLE
[FEAT] Add Inventory Amount in Buy Screen

### DIFF
--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -277,7 +277,7 @@ export const BuyPanel: React.FC<{
             {emblem}
           </Label>
           <Label type="warning" className="ml-auto">
-            {`Inventory: ${inventory[emblem]}`}
+            {`${t("inventory")}: ${inventory[emblem]}`}
           </Label>
         </div>
         <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">

--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -276,6 +276,9 @@ export const BuyPanel: React.FC<{
           <Label type="default" icon={ITEM_DETAILS[emblem].image}>
             {emblem}
           </Label>
+          <Label type="warning" className="ml-auto">
+            {`Inventory: ${inventory[emblem]}`}
+          </Label>
         </div>
         <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">
           {listings.map((listing, index) => {

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -393,7 +393,7 @@ export const BuyPanel: React.FC<{
             {selected.current}
           </Label>
           <Label type="warning" className="ml-auto">
-            {`Inventory: ${inventory[selected.current as InventoryItemName]}`}
+            {`${t("inventory")}: ${inventory[selected.current as InventoryItemName]}`}
           </Label>
         </div>
         <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -392,6 +392,9 @@ export const BuyPanel: React.FC<{
           >
             {selected.current}
           </Label>
+          <Label type="warning" className="ml-auto">
+            {`Inventory: ${inventory[selected.current as InventoryItemName]}`}
+          </Label>
         </div>
         <div className="flex-1 pr-2 overflow-y-auto scrollable mt-1">
           {listings.map((listing, index) => {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -438,6 +438,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   expired: ENGLISH_TERMS.expired,
   "sell.amount": "出售 {{amount}}",
   "sell.inBulk": "批量销售",
+  inventory: "存货",
 };
 
 const timeUnits: Record<TimeUnits, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -283,6 +283,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "hungry?": "Hungry?",
   info: "Info",
   item: "Item:",
+  inventory: "Inventory",
   land: "Land",
   landscaping: "Landscaping",
   "last.updated": "Last updated:",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -438,6 +438,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   bought: ENGLISH_TERMS.bought,
   "time.remaining": ENGLISH_TERMS["time.remaining"],
   expired: ENGLISH_TERMS.expired,
+  inventory: "Inventaire",
 };
 
 const timeUnits: Record<TimeUnits, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -438,6 +438,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   bought: ENGLISH_TERMS.bought,
   "time.remaining": ENGLISH_TERMS["time.remaining"],
   expired: ENGLISH_TERMS.expired,
+  inventory: "Inventário",
 };
 
 const timeUnits: Record<TimeUnits, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -438,6 +438,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   bought: ENGLISH_TERMS.bought,
   "time.remaining": ENGLISH_TERMS["time.remaining"],
   expired: ENGLISH_TERMS.expired,
+  inventory: "Envanter",
 };
 
 const timeUnits: Record<TimeUnits, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -103,6 +103,7 @@ export type GeneralTerms =
   | "honey"
   | "hungry?"
   | "info"
+  | "inventory"
   | "item"
   | "land"
   | "landscaping"


### PR DESCRIPTION
This PR allows players to see their inventory amount in the buy screen, so that users don't have to go to their basket to check their stock while buying

![image](https://github.com/user-attachments/assets/b6cc9150-be99-43c4-a216-38efb32e957a)
