### PR TITLE
[FEAT] Set Seasonal Ticket Availability Date in Garbo

### DIFF
--- a/src/features/game/events/landExpansion/garbageSold.test.ts
+++ b/src/features/game/events/landExpansion/garbageSold.test.ts
@@ -168,4 +168,12 @@ describe("garbageSold", () => {
       amount,
     );
   });
+
+  it("prevents sale before a specific date", () => {
+    const timers = jest.useFakeTimers();
+    timers.setSystemTime(new Date("Thu August 1 2023 00:00:00 GMT+0000"));
+
+    const enabled = GARBAGE["Scroll"].available;
+    expect(enabled).toBeFalsy();
+  });
 });

--- a/src/features/game/types/garbage.ts
+++ b/src/features/game/types/garbage.ts
@@ -1,9 +1,6 @@
+import { SeasonalTicket } from "./seasons";
+
 export type GarbageName =
-  | "Solar Flare Ticket"
-  | "Dawn Breaker Ticket"
-  | "Crow Feather"
-  | "Mermaid Scale"
-  | "Tulip Bulb"
   | "War Bond"
   | "Love Letter"
   | "Red Envelope"
@@ -19,83 +16,115 @@ export type GarbageName =
   | "Tent"
   | "Earthworm"
   | "Grub"
-  | "Red Wiggler";
+  | "Red Wiggler"
+  | SeasonalTicket;
 
 export type Garbage = {
   sellPrice: number;
+  available: boolean;
+};
+/* Set date of availability */
+const garbageStartDate = (availableAt: Date) => {
+  const now = new Date();
+  return now >= availableAt;
 };
 
 export const GARBAGE: Record<GarbageName, Garbage> = {
   // Seasonal Tickets
   "Solar Flare Ticket": {
     sellPrice: 0.1,
+    available: true,
   },
   "Dawn Breaker Ticket": {
     sellPrice: 0.1,
+    available: true,
   },
   "Crow Feather": {
     sellPrice: 0.1,
+    available: true,
   },
   "Mermaid Scale": {
     sellPrice: 0.1,
+    available: true,
   },
   "Tulip Bulb": {
     sellPrice: 0.1,
+    available: true,
+  },
+  Scroll: {
+    sellPrice: 0.1,
+    available: garbageStartDate(new Date("2024-08-01")),
   },
 
   // Old event tickets
   "Jack-o-lantern": {
     sellPrice: 1,
+    available: true,
   },
   "Love Letter": {
     sellPrice: 1,
+    available: true,
   },
   "Red Envelope": {
     sellPrice: 1,
+    available: true,
   },
   "War Bond": {
     sellPrice: 0.1,
+    available: true,
   },
 
   // Easter Eggs
   "Blue Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Green Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Orange Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Pink Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Purple Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Red Egg": {
     sellPrice: 1,
+    available: true,
   },
   "Yellow Egg": {
     sellPrice: 1,
+    available: true,
   },
 
   // Others
   "Rapid Growth": {
     sellPrice: 160,
+    available: true,
   },
   Tent: {
     sellPrice: 20,
+    available: true,
   },
 
   // Worms
   Earthworm: {
     sellPrice: 0.1,
+    available: true,
   },
   Grub: {
     sellPrice: 0.1,
+    available: true,
   },
   "Red Wiggler": {
     sellPrice: 0.1,
+    available: true,
   },
 };

--- a/src/features/helios/components/garbageCollector/components/GarbageSale.tsx
+++ b/src/features/helios/components/garbageCollector/components/GarbageSale.tsx
@@ -16,11 +16,15 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const GarbageSale: React.FC = () => {
   const { t } = useAppTranslation();
-  const garbage = getKeys(GARBAGE).sort(
-    (a, b) => GARBAGE[a].sellPrice - GARBAGE[b].sellPrice,
-  );
+  // Filter out items that are not available
+  const availableGarbage = getKeys(GARBAGE)
+    .filter((name) => GARBAGE[name].available)
+    .sort((a, b) => GARBAGE[a].sellPrice - GARBAGE[b].sellPrice);
 
-  const [selectedName, setSelectedName] = useState<GarbageName>(garbage[0]);
+  // Ensure the selected item is one that is available
+  const [selectedName, setSelectedName] = useState<GarbageName>(
+    availableGarbage[0],
+  );
 
   const selected = GARBAGE[selectedName];
   const { gameService } = useContext(Context);
@@ -70,7 +74,7 @@ export const GarbageSale: React.FC = () => {
       }
       content={
         <>
-          {garbage.map((name: GarbageName) => (
+          {availableGarbage.map((name: GarbageName) => (
             <Box
               isSelected={selectedName === name}
               key={name}


### PR DESCRIPTION
# Description

Sets Availability date for Seasonal Ticket to be available in Garbo's shop. Makes it more dynamic in creating new tickets and making them available in Garbo as soon as season is over

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
