### PR TITLE
[FIX] Scene destroys on lost objects

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -465,7 +465,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const container = this;
 
-    if (container.destroyed || !container.scene) {
+    if (container.destroyed || !container.scene || !container.active) {
       return;
     }
 

--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -104,7 +104,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
           if (p.downElement.nodeName === "CANVAS") {
             onClick();
 
-            if (name) {
+            if (name && this.alert?.active) {
               this.alert?.destroy();
             }
           }
@@ -147,7 +147,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
       this.sprite.play(this.idleAnimationKey, true);
 
-      this.silhouette?.destroy();
+      if (this.silhouette?.active) {
+        this.silhouette?.destroy();
+      }
 
       this.ready = true;
     } else {
@@ -182,7 +184,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         this.sprite.play(this.idleAnimationKey as string, true);
 
         this.ready = true;
-        this.silhouette?.destroy();
+        if (this.silhouette?.active) {
+          this.silhouette?.destroy();
+        }
 
         idleLoader.removeAllListeners();
       });
@@ -251,7 +255,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     if (tokenUriBuilder(clothing) === tokenUriBuilder(this.clothing)) return;
 
     this.ready = false;
-    this.sprite?.destroy();
+    if (this.sprite?.active) {
+      this.sprite?.destroy();
+    }
 
     if (
       this.clothing.shirt !== "Gift Giver" &&
@@ -300,13 +306,13 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   }
 
   private removeGift() {
-    if (this.icon) {
+    if (this.icon?.active) {
       this.icon.destroy();
     }
 
     this.icon = undefined;
 
-    if (this.fx) {
+    if (this.fx?.active) {
       this.fx.destroy();
     }
 
@@ -351,13 +357,17 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   }, 5000);
 
   public stopReaction() {
-    this.reaction?.destroy();
+    if (this.reaction?.active) {
+      this.reaction?.destroy();
+    }
     this.reaction = undefined;
 
     this.destroyReaction.cancel();
   }
   public stopSpeaking() {
-    this.speech?.destroy();
+    if (this.speech?.active) {
+      this.speech?.destroy();
+    }
     this.speech = undefined;
 
     this.destroySpeechBubble.cancel();
@@ -366,7 +376,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   public speak(text: string) {
     this.stopReaction();
 
-    if (this.speech) {
+    if (this.speech?.active) {
       this.speech.destroy();
     }
 
@@ -383,7 +393,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   public react(react: ReactionName) {
     this.stopSpeaking();
 
-    if (this.reaction) {
+    if (this.reaction?.active) {
       this.reaction.destroy();
     }
 
@@ -461,8 +471,12 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
     this.destroyed = true;
 
-    this.sprite?.destroy();
-    this.shadow?.destroy();
+    if (this.sprite?.active) {
+      this.sprite?.destroy();
+    }
+    if (this.shadow?.active) {
+      this.shadow?.destroy();
+    }
 
     const poof = this.scene.add.sprite(0, 4, "poof").setOrigin(0.5);
     this.add(poof);
@@ -481,7 +495,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
     // Listen for the animation complete event
     poof.on("animationcomplete", function (animation: { key: string }) {
-      if (animation.key === "poof_anim") {
+      if (animation.key === "poof_anim" && container.active) {
         container.destroy();
       }
     });
@@ -513,7 +527,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
       // Listen for the animation complete loop event
       poof.on("animationrepeat", function (animation: { key: string }) {
-        if (animation.key === "smoke_anim" && container.ready) {
+        if (animation.key === "smoke_anim" && container.ready && poof.active) {
           // This block will execute every time the animation loop completes
           poof.destroy();
         }

--- a/src/features/world/containers/FishermanContainer.ts
+++ b/src/features/world/containers/FishermanContainer.ts
@@ -176,7 +176,9 @@ export class FishermanContainer extends Phaser.GameObjects.Container {
   };
 
   private removeWeatherIndicator = () => {
-    this.weatherIndicator?.destroy();
+    if (this.weatherIndicator?.active) {
+      this.weatherIndicator?.destroy();
+    }
     this.weatherIndicator = undefined;
   };
 
@@ -188,7 +190,9 @@ export class FishermanContainer extends Phaser.GameObjects.Container {
   };
 
   private removeAlert = () => {
-    this.alert?.destroy();
+    if (this.alert?.active) {
+      this.alert?.destroy();
+    }
     this.alert = undefined;
   };
 }

--- a/src/features/world/containers/PlaceableContainer.ts
+++ b/src/features/world/containers/PlaceableContainer.ts
@@ -69,8 +69,8 @@ export class PlaceableContainer extends Phaser.GameObjects.Container {
   }
 
   public disappear() {
-    this.sprite?.destroy();
-    this.shadow?.destroy();
+    if (this.sprite?.active) this.sprite?.destroy();
+    if (this.shadow?.active) this.shadow?.destroy();
 
     const poof = this.scene.add.sprite(0, 4, "poof").setOrigin(0.5);
     this.add(poof);
@@ -92,7 +92,7 @@ export class PlaceableContainer extends Phaser.GameObjects.Container {
     const container = this;
     // Listen for the animation complete event
     poof.on("animationcomplete", function (animation: { key: string }) {
-      if (animation.key === "poof_anim") {
+      if (animation.key === "poof_anim" && container.active) {
         // Animation 'poof_anim' has completed, destroy the sprite
         container.destroy();
       }

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -3,8 +3,6 @@ import mapJSON from "assets/map/beach.json";
 import { SceneId } from "../mmoMachine";
 import { BaseScene, NPCBumpkin } from "./BaseScene";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { InventoryItemName } from "features/game/types/game";
-import { ITEM_DETAILS } from "features/game/types/images";
 import { FishermanContainer } from "../containers/FishermanContainer";
 import { interactableModalManager } from "../ui/InteractableModals";
 import { translate } from "lib/i18n/translate";
@@ -46,10 +44,6 @@ const BUMPKINS: NPCBumpkin[] = [
 export class BeachScene extends BaseScene {
   sceneId: SceneId = "beach";
 
-  krakenHunger: InventoryItemName | undefined;
-  krakenHungerSprite: Phaser.GameObjects.Sprite | undefined;
-  heartSprite: Phaser.GameObjects.Sprite | undefined;
-
   constructor() {
     super({ name: "beach", map: { json: mapJSON } });
   }
@@ -76,11 +70,6 @@ export class BeachScene extends BaseScene {
     this.load.spritesheet("beach_bud_3", "world/beach_bud_3.png", {
       frameWidth: 32,
       frameHeight: 32,
-    });
-
-    this.load.spritesheet("kraken", "world/kraken_sheet.png", {
-      frameWidth: 41,
-      frameHeight: 48,
     });
 
     this.load.spritesheet("bird", SUNNYSIDE.animals.bird, {
@@ -207,57 +196,6 @@ export class BeachScene extends BaseScene {
       }
     });
   }
-
-  public loadKrakenHunger = (hunger: InventoryItemName) => {
-    if (!hunger) {
-      this.heartSprite?.destroy();
-      this.krakenHungerSprite?.destroy();
-    }
-
-    if (this.krakenHunger === hunger) {
-      return;
-    }
-
-    if (!this.heartSprite) {
-      this.heartSprite = this.add.sprite(350, 740, "heart");
-    }
-
-    this.krakenHunger = hunger;
-
-    if (this.krakenHungerSprite) {
-      this.krakenHungerSprite.destroy();
-      this.krakenHungerSprite = undefined;
-    }
-
-    const image = ITEM_DETAILS[hunger].image;
-
-    let loader;
-
-    const key = `${hunger}_kraken_hunger`;
-
-    if (this.textures.exists(key)) {
-      this.krakenHungerSprite = this.add.sprite(338, 740, key);
-      return;
-    }
-
-    if (image.startsWith("data:")) {
-      this.textures.addBase64(key, image);
-
-      this.textures.once("addtexture", () => {
-        // Create the sprite once the texture is loaded
-        this.krakenHungerSprite = this.add.sprite(338, 740, key);
-      });
-    } else {
-      loader = this.load.image(key, image);
-
-      loader.once(Phaser.Loader.Events.COMPLETE, () => {
-        // This callback will be executed only once when "kraken_hunger" is loaded
-        this.krakenHungerSprite = this.add.sprite(338, 740, key);
-      });
-
-      this.load.start();
-    }
-  };
 }
 
 // PubSub.ts

--- a/src/features/world/scenes/FactionHouseScene.ts
+++ b/src/features/world/scenes/FactionHouseScene.ts
@@ -255,7 +255,7 @@ export abstract class FactionHouseScene extends BaseScene {
     );
   }
   onPetStateChange(newValue: PetStateSprite) {
-    if (!this.pet || !this.factionName) return;
+    if (!this.pet?.active || !this.factionName) return;
 
     this.pet?.setTexture(newValue);
     this.pet?.setPosition(
@@ -314,7 +314,7 @@ export abstract class FactionHouseScene extends BaseScene {
       this.physics.world.enable(basicChest);
 
       const listener = (e: EventObject) => {
-        if (e.type === "faction.prizeClaimed") {
+        if (e.type === "faction.prizeClaimed" && basicChest.active) {
           basicChest.destroy();
         }
       };

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -280,7 +280,8 @@ export class KingdomScene extends BaseScene {
       const listener = (e: EventObject) => {
         if (
           e.type === "faction.joined" &&
-          (e as JoinFactionAction).faction === key
+          (e as JoinFactionAction).faction === key &&
+          door.active
         ) {
           door.destroy();
         }
@@ -331,7 +332,7 @@ export class KingdomScene extends BaseScene {
   public champions: Phaser.GameObjects.Sprite | undefined;
 
   async setChampions() {
-    if (this.champions) {
+    if (this.champions?.active) {
       this.champions.destroy();
       this.showPoof();
       this.champions = undefined;
@@ -365,7 +366,9 @@ export class KingdomScene extends BaseScene {
       return totals[winner] > totals[name] ? winner : name;
     }, "bumpkins");
 
-    this.champions.destroy();
+    if (this.champions.active) {
+      this.champions.destroy();
+    }
     this.champions = undefined;
 
     const throne = THRONES[winningFaction];
@@ -411,7 +414,7 @@ export class KingdomScene extends BaseScene {
 
     // Listen for the animation complete event
     poof.on("animationcomplete", function (animation: { key: string }) {
-      if (animation.key === "poof_anim") {
+      if (animation.key === "poof_anim" && poof.active) {
         // Animation 'poof_anim' has completed, destroy the sprite
         poof.destroy();
       }


### PR DESCRIPTION
# Description

There were 2 cases where we were trying to destroy objects already removed causing fatal freezes. You could trigger these by repeatedly going in and out of scenes.

- Bumpkin Containers
- Pet textures in faction

It appears doing a null check e.g. (`this.sprite?.destory()`) isn't sufficient. We need to check if the object has already been recycled by the scene and do a `this.sprite.active` check first.

This PR goes through all the references to `destroy()` and adds this extra check.

## How to test?

Rapidly go in and out of different scenes