### PR TITLE
[FEAT] End of July Prizes

### DIFF
--- a/src/features/game/lib/factions.ts
+++ b/src/features/game/lib/factions.ts
@@ -5,6 +5,8 @@ import {
   FactionName,
   FactionPrize,
   GameState,
+  InventoryItemName,
+  Wardrobe,
 } from "../types/game";
 import { isWearableActive } from "./wearables";
 
@@ -236,6 +238,73 @@ export function calculatePoints(
 
   return Math.max(basePoints - fulfilledCount * 2, 1);
 }
+
+// Rewarded items from treasury
+type MonthlyFactionPrize = {
+  wearables?: Wardrobe;
+  items?: Partial<Record<InventoryItemName, number>>;
+};
+
+export const BONUS_FACTION_PRIZES: Record<
+  string,
+  Record<number, MonthlyFactionPrize>
+> = {
+  "2024-07-22": {
+    1: {
+      items: {
+        "Turbo Sprout": 1,
+      },
+    },
+    2: {
+      wearables: {
+        "Crimstone Hammer": 1,
+      },
+    },
+    3: {
+      wearables: {
+        "Oil Can": 1,
+      },
+    },
+    4: {
+      items: {
+        Soybliss: 1,
+      },
+    },
+    5: {
+      wearables: {
+        "Olive Shield": 1,
+      },
+    },
+    // 6th - 10th
+    ...new Array(5)
+      .fill({
+        items: {
+          "Luxury Key": 2,
+        },
+      })
+      .reduce(
+        (acc, item, i) => ({
+          ...acc,
+          [i + 6]: item,
+        }),
+        {},
+      ),
+    // 11th - 50th
+    ...new Array(40)
+      .fill({
+        items: {
+          "Rare Key": 2,
+        },
+      })
+      .reduce(
+        (acc, item, i) => ({
+          ...acc,
+          [i + 11]: item,
+        }),
+        {},
+      ),
+  },
+};
 
 export const FACTION_PRIZES: Record<number, FactionPrize> = {
   1: {

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -10,7 +10,9 @@ import {
   KingdomLeaderboard,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import {
+  BONUS_FACTION_PRIZES,
   FACTION_PRIZES,
+  getFactionWeek,
   getPreviousWeek,
   getWeekNumber,
 } from "features/game/lib/factions";
@@ -207,6 +209,9 @@ type PrizeRow = FactionPrize & { from: number; to?: number };
 export const ChampionsPrizes: React.FC = () => {
   const { t } = useAppTranslation();
 
+  const week = getFactionWeek();
+  const MONTHLY_PRIZES = BONUS_FACTION_PRIZES[week];
+
   // Group together rows that have the same prize
   const prizes: PrizeRow[] = [];
   let previous: PrizeRow | undefined = undefined;
@@ -237,9 +242,14 @@ export const ChampionsPrizes: React.FC = () => {
 
   return (
     <>
-      <Label type="default" className="mb-2 ml-1" icon={trophy}>
-        {t("leaderboard.faction.champion")}
-      </Label>
+      <div className="flex justify-between items-center">
+        <Label type="default" className="mb-2 ml-1" icon={trophy}>
+          {t("leaderboard.faction.champion")}
+        </Label>
+        <Label type="vibrant" className="mb-2 ml-1" icon={gift}>
+          {t("leaderboard.faction.bonusPrizeWeek")}
+        </Label>
+      </div>
       <p className="text-xs mb-2">{t("leaderboard.faction.championPrizes")}</p>
       <table className="w-full text-xs table-auto border-collapse mb-2">
         <tbody>
@@ -265,6 +275,7 @@ export const ChampionsPrizes: React.FC = () => {
         <tbody>
           {prizes.map((prize, index) => {
             const trophy = TROPHIES["goblins"][index + 1];
+            const bonus = MONTHLY_PRIZES?.[prize.from];
 
             return (
               <tr key={index}>
@@ -312,6 +323,30 @@ export const ChampionsPrizes: React.FC = () => {
                       </div>
                     )}
                   </div>
+                  {getKeys(bonus?.items ?? {}).map((item, index) => {
+                    return (
+                      <Label
+                        key={index}
+                        type="vibrant"
+                        icon={ITEM_DETAILS[item].image}
+                        className="m-1"
+                      >
+                        {`${bonus.items?.[item] ?? 0} x ${item} `}
+                      </Label>
+                    );
+                  })}
+                  {getKeys(bonus?.wearables ?? {}).map((item, index) => {
+                    return (
+                      <Label
+                        key={index}
+                        type="vibrant"
+                        icon={gift}
+                        className="mt-1 ml-2 mb-1"
+                      >
+                        {`${bonus.wearables?.[item] ?? 0} x ${item} `}
+                      </Label>
+                    );
+                  })}
                 </td>
               </tr>
             );

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4693,6 +4693,8 @@ const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.bonusMarks":
     ENGLISH_TERMS["leaderboard.faction.bonusMarks"],
   "leaderboard.faction.topPlayers":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5353,6 +5353,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.prizes": "Prizes",
   "leaderboard.faction.description": "Each week you can win bonus prizes.",
   "leaderboard.faction.champion": "Champion faction",
+  "leaderboard.faction.bonusPrizeWeek": "Bonus prize week",
   "leaderboard.faction.championPrizes":
     "The players in the winning faction will receive:",
   "leaderboard.faction.bonusMarks": "Bonus +10% Marks",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5489,6 +5489,8 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.faction.description":
     ENGLISH_TERMS["leaderboard.faction.description"],
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],
   "leaderboard.faction.bonusMarks":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5349,7 +5349,11 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],
   "leaderboard.faction.description":
     ENGLISH_TERMS["leaderboard.faction.description"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],
   "leaderboard.faction.bonusMarks":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5352,8 +5352,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.faction.bonusPrizeWeek":
     ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
-  "leaderboard.faction.bonusPrizeWeek":
-    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
+
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],
   "leaderboard.faction.bonusMarks":

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -5313,6 +5313,8 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],
   "leaderboard.faction.description":
     ENGLISH_TERMS["leaderboard.faction.description"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -5338,6 +5338,8 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.prizes": ENGLISH_TERMS["leaderboard.prizes"],
   "leaderboard.faction.description":
     ENGLISH_TERMS["leaderboard.faction.description"],
+  "leaderboard.faction.bonusPrizeWeek":
+    ENGLISH_TERMS["leaderboard.faction.bonusPrizeWeek"],
   "leaderboard.faction.champion": ENGLISH_TERMS["leaderboard.faction.champion"],
   "leaderboard.faction.championPrizes":
     ENGLISH_TERMS["leaderboard.faction.championPrizes"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3633,6 +3633,7 @@ export type Leaderboard =
   | "leaderboard.faction.description"
   | "leaderboard.faction.champion"
   | "leaderboard.faction.championPrizes"
+  | "leaderboard.faction.bonusPrizeWeek"
   | "leaderboard.faction.bonusMarks"
   | "leaderboard.faction.topPlayers"
   | "leaderboard.faction.topPlayerPrizes";


### PR DESCRIPTION
# Description

At the end of each month, perform a Mega faction week 🚀 🏆 

During this week, top members of each faction can win bonus prizes. Players will receive an in-game mailbox alert during this period.

Since these are on-chain items, they cannot be automatically give in chests. The treasury will need to manually send. 🤝

## How to test?

1. Update `getFactionWeek` to return "2024-07-22"
2. Visit Kingdom Throne and view weekly prizes. 

<img width="594" alt="Screenshot 2024-07-19 at 8 35 08 AM" src="https://github.com/user-attachments/assets/8b2ecc26-6ba2-491b-a516-b1547cb1c673">


<img width="585" alt="Screenshot 2024-07-19 at 8 35 04 AM" src="https://github.com/user-attachments/assets/4ec861b3-3e55-4ddd-9d6d-c4d7145a9bbb">
