### PR TITLE
[FIX] VIP Gift Opened Text

### DIFF
--- a/src/features/world/ui/VIPGift.tsx
+++ b/src/features/world/ui/VIPGift.tsx
@@ -90,7 +90,7 @@ export const VIPGift: React.FC<Props> = ({ onClose }) => {
           />
           {hasOpened && (
             <Label type="success" icon={SUNNYSIDE.icons.confirm}>
-              {t("budBox.opened")}
+              {t("opened")}
             </Label>
           )}
         </div>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -293,6 +293,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   "offer.end": "报价截止余",
   ok: "好",
   on: "开",
+  opened: "已经开了",
   "open.gift": "打开礼物",
   "place.map": "放置地图上",
   "placing.bid": "投标中",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -321,6 +321,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   ok: "OK",
   on: "On",
   open: "Open",
+  opened: "Opened",
   optional: "Optional",
   "open.gift": "Open Gift",
   place: "Place",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -336,6 +336,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   ok: "OK",
   on: "Allumer",
   open: "Ouvrir",
+  opened: ENGLISH_TERMS.opened,
   opensea: "Opensea",
   "open.gift": "Ouvrir un Cadeau",
   optional: ENGLISH_TERMS["optional"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -306,6 +306,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   ok: "OK",
   on: "Ligado",
   "open.gift": "Abrir Presente",
+  opened: ENGLISH_TERMS.opened,
   optional: ENGLISH_TERMS["optional"],
   "place.map": "Colocar no mapa",
   "placing.bid": "Colocando lance",

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -321,6 +321,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   ok: "Ок",
   on: "В",
   open: "открыто",
+  opened: ENGLISH_TERMS.opened,
   optional: "Дополнительно",
   "open.gift": "Открыть подарок",
   place: "Место",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -317,6 +317,7 @@ const generalTerms: Record<GeneralTerms, string> = {
   ok: "TAMAM",
   on: "Açık",
   open: "Açık",
+  opened: ENGLISH_TERMS.opened,
   "open.gift": "Hediyeyi Aç",
   optional: ENGLISH_TERMS["optional"],
   place: "Yerleştir",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -143,6 +143,7 @@ export type GeneralTerms =
   | "on"
   | "open"
   | "open.gift"
+  | "opened"
   | "optional"
   | "pay.attention.feedback"
   | "place"


### PR DESCRIPTION
# Description

Fix a text error where VIP Gift says "opened today" which doesn't make sense cuz you can only open it once a month

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/388d125d-cf42-4342-8666-6c6c5f11c6b2)|![image](https://github.com/user-attachments/assets/7c804db0-9375-43bb-b98e-ce9cb866e41c)|

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
