### PR TITLE
[FIX] Chores Crash when not in Faction

### DIFF
--- a/src/features/island/hud/components/codex/pages/Chores.tsx
+++ b/src/features/island/hud/components/codex/pages/Chores.tsx
@@ -46,6 +46,7 @@ export const Chores: React.FC<Props> = ({ farmId }) => {
     gameService.send("kingdomChores.refreshed");
     gameService.send("SAVE");
   };
+  const joinedFaction = gameService.state.context.state.faction;
 
   return (
     <div className="scrollable overflow-y-auto max-h-[100%] overflow-x-hidden">
@@ -70,7 +71,7 @@ export const Chores: React.FC<Props> = ({ farmId }) => {
         </InnerPanel>
       )}
       <ChoreV2 isReadOnly isCodex />
-      {kingdomChores && (
+      {!!joinedFaction && kingdomChores && (
         <div className="mt-3">
           <InnerPanel className="mb-1 w-full">
             <div className="p-1 text-xs">


### PR DESCRIPTION
# Description

There were reports of players not in a faction crashing when they try to open the chore dex. I wasn't able to replicate that error, but for security, I've added an additional condition where the faction chores won't show if a player isn't in a faction

![image](https://github.com/user-attachments/assets/f1e5b3a2-9f71-4604-856c-438235fcf5df)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
