### PR TITLE
[FIX] Crash when opening chores if player is not in a faction

### DIFF
--- a/src/features/game/lib/factions.ts
+++ b/src/features/game/lib/factions.ts
@@ -166,10 +166,11 @@ export function getFactionWearableBoostAmount(
   game: GameState,
   baseAmount: number,
 ): [number, Partial<Record<BoostType, BoostValue>>] {
-  const factionName = game.faction?.name as FactionName;
-
   let boost = 0;
   const boostLabels: Partial<Record<BoostType, BoostValue>> = {};
+
+  const factionName = game.faction?.name;
+  if (!factionName) return [boost, boostLabels];
 
   if (
     isWearableActive({
@@ -221,7 +222,7 @@ export function getFactionWearableBoostAmount(
     boostLabels[FACTION_OUTFITS[factionName].shirt] = `+${0.2 * 100}%`;
   }
 
-  return [boost, boostLabels] as const;
+  return [boost, boostLabels];
 }
 
 /**


### PR DESCRIPTION
# Description

- remove unnecessary cast

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- open faction chores when not in a faction

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
