### PR TITLE
[FEAT/PROPOSAL] Support achievements for Portals

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -336,6 +336,10 @@ import {
   SkipKingdomChoreAction,
 } from "./landExpansion/skipKingdomChore";
 import { leaveFaction, LeaveFactionAction } from "./landExpansion/leaveFaction";
+import {
+  unlockMinigameAchievements,
+  UnlockMinigameAchievementsAction,
+} from "./minigames/unlockMinigameAchievements";
 
 export type PlayingEvent =
   | OilGreenhouseAction
@@ -422,6 +426,7 @@ export type PlayingEvent =
   | ClaimMinigamePrizeAction
   | PurchaseMinigameAction
   | PlayMinigameAction
+  | UnlockMinigameAchievementsAction
   | SupplyCropMachineAction
   | HarvestCropMachineAction
   | SupplyCookingOilAction
@@ -508,6 +513,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "minigame.itemPurchased": purchaseMinigameItem,
   "minigame.prizeClaimed": claimMinigamePrize,
   "minigame.played": playMinigame,
+  "minigame.achievementsUnlocked": unlockMinigameAchievements,
   "airdrop.claimed": claimAirdrop,
   "bot.detected": detectBot,
   "seed.planted": landExpansionPlant,

--- a/src/features/game/events/minigames/unlockMinigameAchievements.test.ts
+++ b/src/features/game/events/minigames/unlockMinigameAchievements.test.ts
@@ -1,0 +1,171 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { unlockMinigameAchievements } from "./unlockMinigameAchievements";
+
+describe("minigame.achievementUnlocked", () => {
+  it("requires minigame exists", () => {
+    expect(() =>
+      unlockMinigameAchievements({
+        state: TEST_FARM,
+        action: {
+          id: "not-a-game" as any,
+          achievementNames: ["Achievement Name 1"],
+          type: "minigame.achievementsUnlocked",
+        },
+      }),
+    ).toThrow("not-a-game is not a valid minigame");
+  });
+
+  it("does not unlock an achievement twice", () => {
+    const unlockedAtDate = new Date("2024-05-04T00:00:00Z");
+    const now = new Date();
+    const state = unlockMinigameAchievements({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {},
+              achievements: {
+                "Achievement Name 1": {
+                  unlockedAt: unlockedAtDate.getTime(),
+                },
+              },
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        achievementNames: ["Achievement Name 1"],
+        type: "minigame.achievementsUnlocked",
+      },
+      createdAt: now.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {},
+      achievements: {
+        "Achievement Name 1": {
+          unlockedAt: unlockedAtDate.getTime(),
+        },
+      },
+    });
+  });
+
+  it("unlocks an achievement", () => {
+    const now = new Date();
+    const state = unlockMinigameAchievements({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {},
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        achievementNames: ["Achievement Name 1"],
+        type: "minigame.achievementsUnlocked",
+      },
+      createdAt: now.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {},
+      achievements: {
+        "Achievement Name 1": {
+          unlockedAt: now.getTime(),
+        },
+      },
+    });
+  });
+
+  it("unlocks multiple achievements", () => {
+    const now = new Date();
+    const state = unlockMinigameAchievements({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {},
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        achievementNames: ["Achievement Name 1", "Achievement Name 2"],
+        type: "minigame.achievementsUnlocked",
+      },
+      createdAt: now.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {},
+      achievements: {
+        "Achievement Name 1": {
+          unlockedAt: now.getTime(),
+        },
+        "Achievement Name 2": {
+          unlockedAt: now.getTime(),
+        },
+      },
+    });
+  });
+
+  it("for multiple achievements, only unlocks the ones that have not been unlocked", () => {
+    const unlockedAtDate = new Date("2024-05-04T00:00:00Z");
+    const now = new Date();
+    const state = unlockMinigameAchievements({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {},
+              achievements: {
+                "Achievement Name 1": {
+                  unlockedAt: unlockedAtDate.getTime(),
+                },
+              },
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        achievementNames: ["Achievement Name 1", "Achievement Name 2"],
+        type: "minigame.achievementsUnlocked",
+      },
+      createdAt: now.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {},
+      achievements: {
+        "Achievement Name 1": {
+          unlockedAt: unlockedAtDate.getTime(),
+        },
+        "Achievement Name 2": {
+          unlockedAt: now.getTime(),
+        },
+      },
+    });
+  });
+});

--- a/src/features/game/events/minigames/unlockMinigameAchievements.ts
+++ b/src/features/game/events/minigames/unlockMinigameAchievements.ts
@@ -1,0 +1,66 @@
+import { GameState } from "features/game/types/game";
+import {
+  MinigameName,
+  SUPPORTED_MINIGAMES,
+} from "features/game/types/minigames";
+
+import cloneDeep from "lodash.clonedeep";
+
+export type UnlockMinigameAchievementsAction = {
+  type: "minigame.achievementsUnlocked";
+  id: MinigameName;
+  achievementNames: string[];
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: UnlockMinigameAchievementsAction;
+  createdAt?: number;
+};
+
+export function unlockMinigameAchievements({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  const game = cloneDeep<GameState>(state);
+
+  if (!SUPPORTED_MINIGAMES.includes(action.id)) {
+    throw new Error(`${action.id} is not a valid minigame`);
+  }
+
+  const minigames = (game.minigames ?? {}) as Required<GameState>["minigames"];
+
+  const minigame = minigames.games[action.id] ?? {
+    history: {},
+    highscore: 0,
+  };
+
+  // Filter out achievements that have already been unlocked and log an error for each one
+  const alreadyUnlockedAchievements = action.achievementNames.filter(
+    (achievementName) => minigame.achievements?.[achievementName],
+  );
+  alreadyUnlockedAchievements.forEach((achievementName) => {
+    // eslint-disable-next-line no-console
+    console.error(`Achievement "${achievementName}" already unlocked`);
+  });
+
+  // if all achievements have already been unlocked, return early
+  const newAchievements = action.achievementNames.filter(
+    (achievementName) => !minigame.achievements?.[achievementName],
+  );
+  if (newAchievements.length === 0) return game;
+
+  // unlock all new achievements
+  newAchievements.forEach((achievementName) => {
+    minigame.achievements = {
+      ...(minigame?.achievements ?? {}),
+      [achievementName]: {
+        unlockedAt: createdAt,
+      },
+    };
+  });
+  minigames.games[action.id] = minigame;
+
+  return game;
+}

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -877,6 +877,10 @@ export type MinigameHistory = {
   prizeClaimedAt?: number;
 };
 
+export type MinigameAchievement = {
+  unlockedAt: number;
+};
+
 export type Minigame = {
   highscore: number;
   purchases?: {
@@ -885,6 +889,7 @@ export type Minigame = {
     purchasedAt: number;
   }[];
   history: Record<string, MinigameHistory>;
+  achievements?: Record<string, MinigameAchievement>;
 };
 
 export type TradeListing = {

--- a/src/features/portal/example/components/PortalNPCExample.tsx
+++ b/src/features/portal/example/components/PortalNPCExample.tsx
@@ -1,7 +1,11 @@
 import { Button } from "components/ui/Button";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
-import { claimPrize, purchase } from "features/portal/lib/portalUtil";
+import {
+  achievementsUnlocked,
+  claimPrize,
+  purchase,
+} from "features/portal/lib/portalUtil";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { NPC_WEARABLES } from "lib/npcs";
 import React, { useState } from "react";
@@ -28,7 +32,11 @@ export const PortalNPCExample: React.FC<Props> = ({ onClose }) => {
   }
 
   return (
-    <CloseButtonPanel onClose={onClose} bumpkinParts={NPC_WEARABLES.portaller}>
+    <CloseButtonPanel
+      title={t("portal.examples")}
+      onClose={onClose}
+      bumpkinParts={NPC_WEARABLES.portaller}
+    >
       <Button
         onClick={() => {
           // What it costs
@@ -51,6 +59,17 @@ export const PortalNPCExample: React.FC<Props> = ({ onClose }) => {
         }}
       >
         {t("portal.example.claimPrize")}
+      </Button>
+      <Button
+        onClick={() => {
+          // Unlock multiple achievements at the same time
+          achievementsUnlocked({
+            achievementNames: ["Achievement 1", "Achievement 2"],
+          });
+          onClose();
+        }}
+      >
+        {t("portal.example.unlockAchievements")}
       </Button>
     </CloseButtonPanel>
   );

--- a/src/features/portal/lib/portalUtil.ts
+++ b/src/features/portal/lib/portalUtil.ts
@@ -82,6 +82,24 @@ export function played({ score }: { score: number }) {
   }
 }
 
+/**
+ * When a player unlocks achievements
+ */
+export function achievementsUnlocked({
+  achievementNames,
+}: {
+  achievementNames: string[];
+}) {
+  if (!isInIframe) {
+    alert(`Sunflower Land running in test mode - achievements unlocked`);
+  } else {
+    window.parent.postMessage(
+      { event: "achievementsUnlocked", achievementNames },
+      "*",
+    );
+  }
+}
+
 export function authorisePortal() {
   if (isInIframe) {
     window.parent.postMessage("closePortal", "*");

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -120,6 +120,16 @@ export const Portal: React.FC<Props> = ({ portalName, onClose }) => {
       gameService.send("SAVE");
       return;
     }
+
+    // achievement
+    if (event.data.event === "achievementsUnlocked") {
+      gameService.send("minigame.achievementsUnlocked", {
+        id: portalName,
+        achievementNames: event.data.achievementNames,
+      });
+      gameService.send("SAVE");
+      return;
+    }
   };
 
   useEffect(() => {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3970,9 +3970,12 @@ const playerTrade: Record<PlayerTrade, string> = {
 const portal: Record<Portal, string> = {
   "portal.wrong": ENGLISH_TERMS["portal.wrong"],
   "portal.unauthorised": ENGLISH_TERMS["portal.unauthorised"],
+  "portal.examples": ENGLISH_TERMS["portal.examples"],
   "portal.example.intro": ENGLISH_TERMS["portal.example.intro"],
   "portal.example.claimPrize": ENGLISH_TERMS["portal.example.claimPrize"],
   "portal.example.purchase": ENGLISH_TERMS["portal.example.purchase"],
+  "portal.example.unlockAchievements":
+    ENGLISH_TERMS["portal.example.unlockAchievements"],
 };
 
 const promo: Record<Promo, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4578,9 +4578,11 @@ const playerTrade: Record<PlayerTrade, string> = {
 const portal: Record<Portal, string> = {
   "portal.wrong": "Something went wrong",
   "portal.unauthorised": "unauthorised",
+  "portal.examples": "Examples",
   "portal.example.claimPrize": "Claim your prize!",
   "portal.example.intro": "Howdy Howdy, welcome to this test portal",
   "portal.example.purchase": "Purchase fake pass",
+  "portal.example.unlockAchievements": "Unlock achievements",
 };
 
 const promo: Record<Promo, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4664,9 +4664,12 @@ const playerTrade: Record<PlayerTrade, string> = {
 const portal: Record<Portal, string> = {
   "portal.wrong": "Quelque chose s'est mal passé",
   "portal.unauthorised": "non autorisé",
+  "portal.examples": ENGLISH_TERMS["portal.examples"],
   "portal.example.intro": ENGLISH_TERMS["portal.example.intro"],
   "portal.example.claimPrize": ENGLISH_TERMS["portal.example.claimPrize"],
   "portal.example.purchase": ENGLISH_TERMS["portal.example.purchase"],
+  "portal.example.unlockAchievements":
+    ENGLISH_TERMS["portal.example.unlockAchievements"],
 };
 
 const promo: Record<Promo, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4519,9 +4519,12 @@ const playerTrade: Record<PlayerTrade, string> = {
 const portal: Record<Portal, string> = {
   "portal.wrong": "Algo deu errado",
   "portal.unauthorised": "não autorizado",
+  "portal.examples": ENGLISH_TERMS["portal.examples"],
   "portal.example.intro": ENGLISH_TERMS["portal.example.intro"],
   "portal.example.claimPrize": ENGLISH_TERMS["portal.example.claimPrize"],
   "portal.example.purchase": ENGLISH_TERMS["portal.example.purchase"],
+  "portal.example.unlockAchievements":
+    ENGLISH_TERMS["portal.example.unlockAchievements"],
 };
 
 const promo: Record<Promo, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -4519,11 +4519,14 @@ const playerTrade: Record<PlayerTrade, string> = {
 };
 
 const portal: Record<Portal, string> = {
-  "portal.wrong": "Something went wrong",
-  "portal.unauthorised": "unauthorised",
-  "portal.example.claimPrize": "Claim your prize!",
-  "portal.example.intro": "Howdy Howdy, welcome to this test portal",
-  "portal.example.purchase": "Purchase fake pass",
+  "portal.wrong": ENGLISH_TERMS["portal.wrong"],
+  "portal.unauthorised": ENGLISH_TERMS["portal.unauthorised"],
+  "portal.examples": ENGLISH_TERMS["portal.examples"],
+  "portal.example.intro": ENGLISH_TERMS["portal.example.intro"],
+  "portal.example.claimPrize": ENGLISH_TERMS["portal.example.claimPrize"],
+  "portal.example.purchase": ENGLISH_TERMS["portal.example.purchase"],
+  "portal.example.unlockAchievements":
+    ENGLISH_TERMS["portal.example.unlockAchievements"],
 };
 
 const purchaseableBaitTranslation: Record<PurchaseableBaitTranslation, string> =

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4532,9 +4532,12 @@ const playerTrade: Record<PlayerTrade, string> = {
 const portal: Record<Portal, string> = {
   "portal.wrong": "Bir şeyler yanlış gitti",
   "portal.unauthorised": "Yetkisiz",
+  "portal.examples": ENGLISH_TERMS["portal.examples"],
   "portal.example.intro": ENGLISH_TERMS["portal.example.intro"],
   "portal.example.claimPrize": ENGLISH_TERMS["portal.example.claimPrize"],
   "portal.example.purchase": ENGLISH_TERMS["portal.example.purchase"],
+  "portal.example.unlockAchievements":
+    ENGLISH_TERMS["portal.example.unlockAchievements"],
 };
 
 const promo: Record<Promo, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3053,9 +3053,11 @@ export type PlayerTrade =
 export type Portal =
   | "portal.wrong"
   | "portal.unauthorised"
+  | "portal.examples"
   | "portal.example.intro"
   | "portal.example.purchase"
-  | "portal.example.claimPrize";
+  | "portal.example.claimPrize"
+  | "portal.example.unlockAchievements";
 
 export type PurchaseableBaitTranslation =
   "purchaseableBait.fishingLure.description";


### PR DESCRIPTION
# Description

- add achievements support for portals
  - add achievement button to sample portal
  - **backend changes needed**
  - to see how the achievement is used in action, run crops-and-chickens locally and try to get achievements

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- talk to sample npc and try to get achievements

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
