### PR TITLE
[FEAT] MMO Reward Reactions

### DIFF
--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -418,9 +418,12 @@ export abstract class BaseScene extends Phaser.Scene {
       }
 
       if (this.playerEntities[reaction.sessionId]) {
-        this.playerEntities[reaction.sessionId].react(reaction.reaction);
+        this.playerEntities[reaction.sessionId].react(
+          reaction.reaction,
+          reaction.quantity,
+        );
       } else if (reaction.sessionId === server.sessionId) {
-        this.currentPlayer?.react(reaction.reaction);
+        this.currentPlayer?.react(reaction.reaction, reaction.quantity);
       }
     });
 

--- a/src/features/world/scenes/examples/AnimationScene.ts
+++ b/src/features/world/scenes/examples/AnimationScene.ts
@@ -16,7 +16,9 @@ export class ExampleAnimationScene extends Phaser.Scene {
   }
 
   preload() {
-    const bumpkin: BumpkinParts = NPC_WEARABLES["raven"];
+    const bumpkin: BumpkinParts = {
+      ...NPC_WEARABLES["phantom face"],
+    };
 
     getKeys(ANIMATION).forEach((animationName) => {
       /**

--- a/src/features/world/types/Room.ts
+++ b/src/features/world/types/Room.ts
@@ -54,6 +54,7 @@ export interface Message extends Schema {
 
 export interface Reaction extends Schema {
   reaction: "heart" | "sad" | "happy";
+  quantity?: number;
   farmId?: number;
   sessionId: string;
   sceneId: SceneId;


### PR DESCRIPTION
# Description

Adds Popups when items are acquired in the MMO World

Note: this functionality relies on the `ToastProvider` which is updated by the `ToastPanel`. If the `ToastPanel` or `ToastProvider` is ever removed this functionality will dissapear.

## Screenshot

![mmoreward](https://github.com/user-attachments/assets/0bd72f77-06a4-4831-a145-9af9bc1a53e2)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes