### PR TITLE
[FIX] Bumpkin Equip Image URL

### DIFF
--- a/src/lib/utils/getImageURLS.ts
+++ b/src/lib/utils/getImageURLS.ts
@@ -1,9 +1,3 @@
-import { CONFIG } from "lib/config";
-
 export function getImageUrl(wearableId: number) {
-  if (CONFIG.NETWORK === "mainnet") {
-    return `https://bumpkins.io/erc1155/images/${wearableId}.png`;
-  }
-
-  return `https://testnet.bumpkins.io/erc1155/images/${wearableId}.png`;
+  return `wearables/images/${wearableId}.png`;
 }


### PR DESCRIPTION
# Description

Newer assets don't load in the Bumpkin Equip Screen. This PR Updates all bumpkin images to use the new URL for wearables

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]