### PR TITLE
[FIX] Tomato showing before start date

### DIFF
--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -195,6 +195,8 @@ describe("sell", () => {
   });
 
   it("sells tomato for two times the normal price during La Tomatina", () => {
+    const now = new Date().getTime();
+
     const coins = 1;
     const state = sellCrop({
       state: {
@@ -207,8 +209,8 @@ describe("sell", () => {
           current: {
             "La Tomatina": {
               text: "La Tomatina",
-              endAt: new Date().getTime() + 1000,
-              startAt: new Date().getTime(),
+              endAt: now + 1000,
+              startAt: now,
               isEligible: true,
               requiresWallet: false,
               tasks: [],
@@ -221,6 +223,7 @@ describe("sell", () => {
           },
           history: {},
         },
+        createdAt: now,
       },
       action: {
         type: "crop.sold",

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -31,9 +31,14 @@ export const SELLABLE = {
 type Options = {
   state: GameState;
   action: SellCropAction;
+  createdAt?: number;
 };
 
-export function sellCrop({ state, action }: Options): GameState {
+export function sellCrop({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
   const game = cloneDeep(state);
 
   const { bumpkin } = game;
@@ -62,6 +67,7 @@ export function sellCrop({ state, action }: Options): GameState {
   const price = getSellPrice({
     item: sellables,
     game,
+    now: new Date(createdAt),
   });
 
   const coinsEarned = price * action.amount;

--- a/src/features/game/expansion/components/LaTomatina.tsx
+++ b/src/features/game/expansion/components/LaTomatina.tsx
@@ -14,7 +14,13 @@ export const LaTomatina: React.FC<{ event: SpecialEvent | undefined }> = ({
 }) => {
   const [showSpecialEvent, setShowSpecialEvent] = useState(false);
 
-  if (!event || !event.isEligible) return null;
+  if (
+    !event ||
+    !event.isEligible ||
+    event.endAt < Date.now() ||
+    event.startAt > Date.now()
+  )
+    return null;
 
   return (
     <>

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -47,8 +47,8 @@ describe("boosts", () => {
               "La Tomatina": {
                 isEligible: true,
                 text: "La Tomatina",
-                startAt: new Date("2024-04-04").getTime(),
-                endAt: new Date("2024-04-05").getTime(),
+                startAt: 0,
+                endAt: Number.MAX_SAFE_INTEGER,
                 requiresWallet: false,
                 tasks: [],
                 bonus: {
@@ -74,8 +74,8 @@ describe("boosts", () => {
               "La Tomatina": {
                 isEligible: false,
                 text: "La Tomatina",
-                startAt: new Date("2024-04-04").getTime(),
-                endAt: new Date("2024-04-05").getTime(),
+                startAt: 0,
+                endAt: Number.MAX_SAFE_INTEGER,
                 requiresWallet: false,
                 tasks: [],
                 bonus: {

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -76,6 +76,8 @@ export const getSellPrice = ({
   // Special Events
   const specialEventMultiplier = Object.values(game.specialEvents.current)
     .filter((event) => !!event?.isEligible)
+    .filter((event) => (event?.endAt ?? Infinity) > Date.now())
+    .filter((event) => (event?.startAt ?? 0) < Date.now())
     .find((event) => event?.bonus?.[item.name]?.saleMultiplier)?.bonus?.[
     item.name
   ]?.saleMultiplier;

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -76,8 +76,8 @@ export const getSellPrice = ({
   // Special Events
   const specialEventMultiplier = Object.values(game.specialEvents.current)
     .filter((event) => !!event?.isEligible)
-    .filter((event) => (event?.endAt ?? Infinity) > Date.now())
-    .filter((event) => (event?.startAt ?? 0) < Date.now())
+    .filter((event) => (event?.endAt ?? Infinity) > now.getTime())
+    .filter((event) => (event?.startAt ?? 0) < now.getTime())
     .find((event) => event?.bonus?.[item.name]?.saleMultiplier)?.bonus?.[
     item.name
   ]?.saleMultiplier;

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -77,7 +77,7 @@ export const getSellPrice = ({
   const specialEventMultiplier = Object.values(game.specialEvents.current)
     .filter((event) => !!event?.isEligible)
     .filter((event) => (event?.endAt ?? Infinity) > now.getTime())
-    .filter((event) => (event?.startAt ?? 0) < now.getTime())
+    .filter((event) => (event?.startAt ?? 0) <= now.getTime())
     .find((event) => event?.bonus?.[item.name]?.saleMultiplier)?.bonus?.[
     item.name
   ]?.saleMultiplier;


### PR DESCRIPTION
# Description

- Prevents Tomato NPC showing before event started
- Prevents bonus sale from being applied before event has started