### PR TITLE
[FEAT] Auction preparation

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctionsComingSoon.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionsComingSoon.tsx
@@ -1,5 +1,8 @@
 import { SUNNYSIDE } from "assets/sunnyside";
+import { Label } from "components/ui/Label";
+import { secondsLeftInSeason } from "features/game/types/seasons";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { secondsToString } from "lib/utils/time";
 import React from "react";
 
 export const AuctionsComingSoon: React.FC = () => {
@@ -8,7 +11,9 @@ export const AuctionsComingSoon: React.FC = () => {
     <div className="p-2 flex flex-col items-center">
       <p>{t("auction.const")}</p>
       <img src={SUNNYSIDE.npcs.goblin_hammering} className="w-1/3" />
-      <p className="my-2 text-sm">{t("auction.const.soon")}</p>
+      <Label className="my-2" type="info" icon={SUNNYSIDE.icons.timer}>
+        {secondsToString(secondsLeftInSeason(), { length: "full" })}
+      </Label>
       <a
         href="https://docs.sunflower-land.com/player-guides/auctions"
         target="_blank"

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -604,7 +604,7 @@ const auction: Record<Auction, string> = {
   "auction.start": "Starting Time",
   "auction.period": "Auction Period",
   "auction.closed": "Auction closed",
-  "auction.const": "Under construction!",
+  "auction.const": "A new seasonal collection is coming...",
   "auction.const.soon": "This feature is coming soon.",
 };
 


### PR DESCRIPTION
# Description

More useful message when no Auctions are available.

<img width="535" alt="Screenshot 2024-07-29 at 9 23 23 AM" src="https://github.com/user-attachments/assets/10ad513a-8ea2-4bde-8d56-c0b664011d75">
