### PR TITLE
[FEAT] Increase listings by level

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -55,6 +55,21 @@ function getRemainingListings({ game }: { game: GameState }) {
     remaining = 1;
   }
 
+  // Bonus trades based on level
+  const level = getBumpkinLevel(game.bumpkin?.experience ?? 0);
+
+  if (level >= 70) {
+    remaining += 10;
+  }
+
+  if (level >= 60) {
+    remaining += 10;
+  }
+
+  if (level >= 50) {
+    remaining += 10;
+  }
+
   const dailyListings = game.trades.dailyListings ?? {
     count: 0,
     date: 0,


### PR DESCRIPTION
# Description

Give bonus listings based on Bumpkin level:

Lvl 50 +10
Lvl 60 +10
Lvl 70 +10

When the next island upgrade is released, it will also give +10 listings - at that point the Lvl 50 perk will be replaced by the island upgrade perk.