### PR TITLE
[FEAT] Oil Overalls Boost

### DIFF
--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -5,6 +5,7 @@ import {
   drillOilReserve,
 } from "./drillOilReserve";
 import { TEST_FARM } from "features/game/lib/constants";
+import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
 
 describe("drillOilReserve", () => {
   it("throws an error if the oil reserve does not exist", () => {
@@ -332,8 +333,94 @@ describe("drillOilReserve", () => {
     expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + boost);
   });
 
-  it("gives a +0.15 Bonus with Battle Fish and Knight Chicken", () => {
-    const boost = 0.15;
+  it("gives a +2 boost with Oil Can equipped", () => {
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              amount: 10,
+              drilledAt: 0,
+            },
+          },
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            tool: "Oil Can",
+          },
+        },
+      },
+    });
+
+    const reserve = game.oilReserves["1"];
+
+    expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + 2);
+  });
+
+  it("gives a +10 Bonus with Oil Overalls", () => {
+    const boost = 10;
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            pants: "Oil Overalls",
+          },
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              amount: 10,
+              drilledAt: 0,
+            },
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const reserve = game.oilReserves["1"];
+
+    expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + boost);
+  });
+
+  it("gives a +12.15 Bonus with Battle Fish, Knight Chicken, Oil Overalls and Oil Can", () => {
+    const boost = 12.15;
     const now = Date.now();
 
     const game = drillOilReserve({
@@ -347,6 +434,14 @@ describe("drillOilReserve", () => {
           "Oil Drill": new Decimal(2),
           "Battle Fish": new Decimal(1),
           "Knight Chicken": new Decimal(1),
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            pants: "Oil Overalls",
+            tool: "Oil Can",
+          },
         },
         collectibles: {
           "Battle Fish": [

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isWearableActive } from "features/game/lib/wearables";
 import { GameState, OilReserve } from "features/game/types/game";
 import cloneDeep from "lodash.clonedeep";
 
@@ -31,6 +32,14 @@ function getNextOilDropAmount(game: GameState, reserve: OilReserve) {
 
   if (isCollectibleBuilt({ name: "Knight Chicken", game })) {
     amount = amount.add(0.1);
+  }
+
+  if (isWearableActive({ name: "Oil Can", game })) {
+    amount = amount.add(2);
+  }
+
+  if (isWearableActive({ game, name: "Oil Overalls" })) {
+    amount = amount.add(10);
   }
 
   return amount.toDecimalPlaces(4).toNumber();

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -391,7 +391,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Oil.image,
     },
     "Oil Overalls": {
-      shortDescription: "+10 Oil",
+      shortDescription: translate("bumpkinItemBuff.oil.overalls.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1032,6 +1032,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% 徽记",
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1061,6 +1061,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% Marks",
   "bumpkinItemBuff.crab.trap": "+1 Crab when digging or drilling",
   "bumpkinItemBuff.bionic.drill": "+5 Desert Digs",
+  "bumpkinItemBuff.oil.overalls.boost": "+10 Oil",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1116,6 +1116,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1104,6 +1104,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1077,6 +1077,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% Marks",
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1093,6 +1093,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -744,7 +744,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.bumpkin.pants"
   | "bumpkinItemBuff.bumpkin.sabatons"
   | "bumpkinItemBuff.crab.trap"
-  | "bumpkinItemBuff.bionic.drill";
+  | "bumpkinItemBuff.bionic.drill"
+  | "bumpkinItemBuff.oil.overalls.boost";
 
 export type BumpkinPart =
   | "equip.background"


### PR DESCRIPTION
# Description

Adds +10 Oil when Oil Overalls is equipped

Secondary addition: Adds Oil Can boost to the FE (already present in the BE)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
