### PR TITLE
[FEAT] Pharaoh's Treasure auction item boosts

### DIFF
--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -2,7 +2,9 @@ import Decimal from "decimal.js-light";
 import {
   BASE_OIL_DROP_AMOUNT,
   OIL_BONUS_DROP_AMOUNT,
+  OIL_RESERVE_RECOVERY_TIME,
   drillOilReserve,
+  getDrilledAt,
 } from "./drillOilReserve";
 import { TEST_FARM } from "features/game/lib/constants";
 import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
@@ -434,5 +436,27 @@ describe("drillOilReserve", () => {
     const reserve = game.oilReserves["1"];
 
     expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + boost);
+  });
+
+  describe("getDrilledAt", () => {
+    it("replenishes oil faster with Dev Wrench", () => {
+      const now = Date.now();
+
+      const time = getDrilledAt({
+        game: {
+          ...TEST_FARM,
+          bumpkin: {
+            ...TEST_BUMPKIN,
+            equipped: {
+              ...TEST_BUMPKIN.equipped,
+              tool: "Dev Wrench",
+            },
+          },
+        },
+        createdAt: now,
+      });
+
+      expect(time).toEqual(now - OIL_RESERVE_RECOVERY_TIME * 0.5 * 1000);
+    });
   });
 });

--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -5,6 +5,7 @@ import {
   drillOilReserve,
 } from "./drillOilReserve";
 import { TEST_FARM } from "features/game/lib/constants";
+import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
 
 describe("drillOilReserve", () => {
   it("throws an error if the oil reserve does not exist", () => {
@@ -134,6 +135,52 @@ describe("drillOilReserve", () => {
     expect(reserve.oil.drilledAt).toBe(now);
     expect(reserve.drilled).toBe(1);
     expect(game.inventory["Oil Drill"]?.toNumber()).toBe(1);
+    expect(game.inventory.Oil?.toNumber()).toEqual(BASE_OIL_DROP_AMOUNT);
+  });
+
+  it("drills the oil reserve without oil drill with infernal drill equipped", () => {
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            secondaryTool: "Infernal Drill",
+          },
+        },
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              amount: BASE_OIL_DROP_AMOUNT,
+              drilledAt: 0,
+            },
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const reserve = game.oilReserves["1"];
+
+    expect(reserve.oil.drilledAt).toBe(now);
+    expect(reserve.drilled).toBe(1);
+    expect(game.inventory["Oil Drill"]?.toNumber()).toBe(2);
     expect(game.inventory.Oil?.toNumber()).toEqual(BASE_OIL_DROP_AMOUNT);
   });
 

--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -381,8 +381,94 @@ describe("drillOilReserve", () => {
     expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + boost);
   });
 
-  it("gives a +0.15 Bonus with Battle Fish and Knight Chicken", () => {
-    const boost = 0.15;
+  it("gives a +2 boost with Oil Can equipped", () => {
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              amount: 10,
+              drilledAt: 0,
+            },
+          },
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            tool: "Oil Can",
+          },
+        },
+      },
+    });
+
+    const reserve = game.oilReserves["1"];
+
+    expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + 2);
+  });
+
+  it("gives a +10 Bonus with Oil Overalls", () => {
+    const boost = 10;
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            pants: "Oil Overalls",
+          },
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            height: 2,
+            width: 2,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              amount: 10,
+              drilledAt: 0,
+            },
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const reserve = game.oilReserves["1"];
+
+    expect(reserve.oil.amount).toEqual(BASE_OIL_DROP_AMOUNT + boost);
+  });
+
+  it("gives a +12.15 Bonus with Battle Fish, Knight Chicken, Oil Overalls and Oil Can", () => {
+    const boost = 12.15;
     const now = Date.now();
 
     const game = drillOilReserve({
@@ -396,6 +482,14 @@ describe("drillOilReserve", () => {
           "Oil Drill": new Decimal(2),
           "Battle Fish": new Decimal(1),
           "Knight Chicken": new Decimal(1),
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            pants: "Oil Overalls",
+            tool: "Oil Can",
+          },
         },
         collectibles: {
           "Battle Fish": [

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -51,6 +51,20 @@ export function getRequiredOilDrillAmount(gameState: GameState) {
   return new Decimal(1);
 }
 
+type getDrilledAtArgs = {
+  createdAt: number;
+  game: GameState;
+};
+
+export function getDrilledAt({ createdAt, game }: getDrilledAtArgs): number {
+  let time = createdAt;
+
+  if (isWearableActive({ game, name: "Dev Wrench" })) {
+    time -= OIL_RESERVE_RECOVERY_TIME * 0.5 * 1000;
+  }
+  return time;
+}
+
 export function drillOilReserve({
   state,
   action,
@@ -81,7 +95,7 @@ export function drillOilReserve({
   // Take away one drill
   game.inventory["Oil Drill"] = drillAmount.sub(requiredDrills);
   // Update drilled at time
-  oilReserve.oil.drilledAt = createdAt;
+  oilReserve.oil.drilledAt = getDrilledAt({ createdAt, game: game });
   // Increment drilled count
   oilReserve.drilled += 1;
   // Set next drill drop amount

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -34,6 +34,14 @@ function getNextOilDropAmount(game: GameState, reserve: OilReserve) {
     amount = amount.add(0.1);
   }
 
+  if (isWearableActive({ name: "Oil Can", game })) {
+    amount = amount.add(2);
+  }
+
+  if (isWearableActive({ game, name: "Oil Overalls" })) {
+    amount = amount.add(10);
+  }
+
   return amount.toDecimalPlaces(4).toNumber();
 }
 

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -465,6 +465,56 @@ describe("fruitHarvested", () => {
     );
   });
 
+  it("includes Lemon Tea Bath bonus on Lemons", () => {
+    const { fruitPatches } = GAME_STATE;
+    const fruitPatch = (fruitPatches as Record<number, FruitPatch>)[0];
+    const initialHarvest = 2;
+
+    const state = harvestFruit({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Lemon Tea Bath": new Decimal(1),
+        },
+        collectibles: {
+          "Lemon Tea Bath": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+        fruitPatches: {
+          0: {
+            ...fruitPatch,
+            fruit: {
+              name: "Lemon",
+              plantedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+              amount: 1,
+              harvestsLeft: initialHarvest,
+              harvestedAt: 2,
+            },
+          },
+        },
+      },
+      action: {
+        type: "fruit.harvested",
+        index: "0",
+      },
+      createdAt: dateNow,
+    });
+
+    const { fruitPatches: fruitPatchesAfterHarvest } = state;
+    const fruit = fruitPatchesAfterHarvest?.[0].fruit;
+
+    expect(fruit?.amount).toEqual(1);
+    expect(fruit?.harvestedAt).toEqual(
+      dateNow - (FRUIT_SEEDS()["Lemon Seed"].plantSeconds * 1000) / 2,
+    );
+  });
+
   it("harvests the fruit when one harvest is left", () => {
     const { fruitPatches } = GAME_STATE;
     const fruitPatch = (fruitPatches as Record<number, FruitPatch>)[0];

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -515,6 +515,56 @@ describe("fruitHarvested", () => {
     );
   });
 
+  it("includes Tomato Clown bonus on Oranges", () => {
+    const { fruitPatches } = GAME_STATE;
+    const fruitPatch = (fruitPatches as Record<number, FruitPatch>)[0];
+    const initialHarvest = 2;
+
+    const state = harvestFruit({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Tomato Clown": new Decimal(1),
+        },
+        collectibles: {
+          "Tomato Clown": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+        fruitPatches: {
+          0: {
+            ...fruitPatch,
+            fruit: {
+              name: "Tomato",
+              plantedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+              amount: 1,
+              harvestsLeft: initialHarvest,
+              harvestedAt: 2,
+            },
+          },
+        },
+      },
+      action: {
+        type: "fruit.harvested",
+        index: "0",
+      },
+      createdAt: dateNow,
+    });
+
+    const { fruitPatches: fruitPatchesAfterHarvest } = state;
+    const fruit = fruitPatchesAfterHarvest?.[0].fruit;
+
+    expect(fruit?.amount).toEqual(1);
+    expect(fruit?.harvestedAt).toEqual(
+      dateNow - (FRUIT_SEEDS()["Tomato Seed"].plantSeconds * 1000) / 2,
+    );
+  });
+
   it("harvests the fruit when one harvest is left", () => {
     const { fruitPatches } = GAME_STATE;
     const fruitPatch = (fruitPatches as Record<number, FruitPatch>)[0];

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -124,8 +124,13 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
     amount += 0.1;
   }
 
+  // Lemon
   if (name === "Lemon" && isCollectibleBuilt({ name: "Lemon Shark", game })) {
     amount += 0.2;
+  }
+
+  if (name === "Lemon" && isWearableActive({ name: "Lemon Shield", game })) {
+    amount += 1;
   }
 
   // Grape

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -22,6 +22,7 @@ import { FruitPatch } from "features/game/types/game";
 import { FruitCompostName } from "features/game/types/composters";
 import { getPlantedAt } from "./fruitPlanted";
 import { isWearableActive } from "features/game/lib/wearables";
+import { isGreenhouseFruit } from "./plantGreenhouse";
 
 export type HarvestFruitAction = {
   type: "fruit.harvested";
@@ -134,6 +135,13 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
 
   if (name === "Grape" && isCollectibleBuilt({ name: "Grape Granny", game })) {
     amount += 1;
+  }
+
+  if (
+    isGreenhouseFruit(name) &&
+    isCollectibleBuilt({ name: "Pharaoh Gnome", game })
+  ) {
+    amount += 2;
   }
   amount += getBudYieldBoosts(game.buds ?? {}, name);
 

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -761,6 +761,104 @@ describe("fruitPlanted", () => {
       }),
     );
   });
+
+  it("includes +1 Lemons when Lemon Shield is equipped", () => {
+    const seedAmount = new Decimal(5);
+
+    const patchIndex = "1";
+
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            secondaryTool: "Lemon Shield",
+          },
+        },
+        inventory: {
+          "Lemon Seed": seedAmount,
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+
+        seed: "Lemon Seed",
+      },
+      harvestsLeft: () => 3,
+    });
+
+    const fruitPatches = state.fruitPatches;
+
+    expect((fruitPatches as Record<number, FruitPatch>)[patchIndex]).toEqual(
+      expect.objectContaining({
+        fruit: expect.objectContaining({
+          name: "Lemon",
+          plantedAt: expect.any(Number),
+          amount: 2,
+          harvestedAt: 0,
+          harvestsLeft: 3,
+        }),
+      }),
+    );
+  });
+
+  it("includes +1.2 Lemons when Lemon Shield is equipped and Lemon Shark is placed", () => {
+    const seedAmount = new Decimal(5);
+
+    const patchIndex = "1";
+
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            secondaryTool: "Lemon Shield",
+          },
+        },
+        inventory: {
+          "Lemon Seed": seedAmount,
+        },
+        collectibles: {
+          "Lemon Shark": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 10,
+              id: "123",
+              readyAt: 10,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+
+        seed: "Lemon Seed",
+      },
+      harvestsLeft: () => 3,
+    });
+
+    const fruitPatches = state.fruitPatches;
+
+    expect((fruitPatches as Record<number, FruitPatch>)[patchIndex]).toEqual(
+      expect.objectContaining({
+        fruit: expect.objectContaining({
+          name: "Lemon",
+          plantedAt: expect.any(Number),
+          amount: 2.2,
+          harvestedAt: 0,
+          harvestsLeft: 3,
+        }),
+      }),
+    );
+  });
 });
 
 describe("getFruitTime", () => {

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -413,6 +413,48 @@ describe("fruitPlanted", () => {
     ).toEqual(dateNow - (FRUIT_SEEDS()["Orange Seed"].plantSeconds * 1000) / 2);
   });
 
+  it("includes Lemon Tea Bath bonus on Lemons", () => {
+    const seedAmount = new Decimal(5);
+
+    const patchIndex = "1";
+
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Lemon Seed": seedAmount,
+          "Lemon Tea Bath": new Decimal(1),
+        },
+        collectibles: {
+          "Lemon Tea Bath": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+        seed: "Lemon Seed",
+      },
+    });
+
+    const fruitPatches = state.fruitPatches;
+
+    expect(
+      (fruitPatches as Record<number, FruitPatch>)[patchIndex].fruit?.amount,
+    ).toEqual(1);
+    expect(
+      (fruitPatches as Record<number, FruitPatch>)[patchIndex].fruit?.plantedAt,
+    ).toEqual(dateNow - (FRUIT_SEEDS()["Lemon Seed"].plantSeconds * 1000) / 2);
+  });
+
   it("includes Black Bearry bonus on Blueberries", () => {
     const seedAmount = new Decimal(5);
 
@@ -723,6 +765,29 @@ describe("getFruitTime", () => {
       INITIAL_BUMPKIN.equipped,
     );
     expect(time).toEqual(applePlantSeconds);
+  });
+
+  it("applies a 50% time reduction for Lemons when Lemon Tea Bath is placed", () => {
+    const seed = "Lemon Seed";
+    const lemonPlantSeconds = FRUIT_SEEDS()[seed].plantSeconds;
+    const time = getFruitPatchTime(
+      seed,
+      {
+        ...TEST_FARM,
+        collectibles: {
+          "Lemon Tea Bath": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      INITIAL_BUMPKIN.equipped,
+    );
+    expect(time).toEqual(lemonPlantSeconds * 0.5);
   });
 
   it("applies a 10% speed boost with Nana placed for Banana plant", () => {

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -455,6 +455,48 @@ describe("fruitPlanted", () => {
     ).toEqual(dateNow - (FRUIT_SEEDS()["Lemon Seed"].plantSeconds * 1000) / 2);
   });
 
+  it("includes Tomato Clown bonus on Tomatoes", () => {
+    const seedAmount = new Decimal(5);
+
+    const patchIndex = "1";
+
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Tomato Seed": seedAmount,
+          "Tomato Clown": new Decimal(1),
+        },
+        collectibles: {
+          "Tomato Clown": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+        seed: "Tomato Seed",
+      },
+    });
+
+    const fruitPatches = state.fruitPatches;
+
+    expect(
+      (fruitPatches as Record<number, FruitPatch>)[patchIndex].fruit?.amount,
+    ).toEqual(1);
+    expect(
+      (fruitPatches as Record<number, FruitPatch>)[patchIndex].fruit?.plantedAt,
+    ).toEqual(dateNow - (FRUIT_SEEDS()["Tomato Seed"].plantSeconds * 1000) / 2);
+  });
+
   it("includes Black Bearry bonus on Blueberries", () => {
     const seedAmount = new Decimal(5);
 
@@ -788,6 +830,29 @@ describe("getFruitTime", () => {
       INITIAL_BUMPKIN.equipped,
     );
     expect(time).toEqual(lemonPlantSeconds * 0.5);
+  });
+
+  it("gives a 50% growth time reduction for tomatoes when Tomato Clown is placed", () => {
+    const seed = "Tomato Seed";
+    const tomatoPlantSeconds = FRUIT_SEEDS()[seed].plantSeconds;
+    const time = getFruitPatchTime(
+      seed,
+      {
+        ...TEST_FARM,
+        collectibles: {
+          "Tomato Clown": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      INITIAL_BUMPKIN.equipped,
+    );
+    expect(time).toEqual(tomatoPlantSeconds * 0.5);
   });
 
   it("applies a 10% speed boost with Nana placed for Banana plant", () => {

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -110,6 +110,13 @@ export const getFruitPatchTime = (
     seconds = seconds * 0.5;
   }
 
+  if (
+    fruitSeedName === "Tomato Seed" &&
+    isCollectibleBuilt({ name: "Tomato Clown", game })
+  ) {
+    seconds = seconds * 0.5;
+  }
+
   return seconds;
 };
 

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -103,6 +103,13 @@ export const getFruitPatchTime = (
     seconds = seconds * 0.8;
   }
 
+  if (
+    fruitSeedName === "Lemon Seed" &&
+    isCollectibleBuilt({ name: "Lemon Tea Bath", game })
+  ) {
+    seconds = seconds * 0.5;
+  }
+
   return seconds;
 };
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -39,6 +39,7 @@ import {
 import { getBumpkinLevel } from "features/game/lib/level";
 import { isBuildingEnabled } from "features/game/expansion/lib/buildingRequirements";
 import { isWearableActive } from "features/game/lib/wearables";
+import { isGreenhouseCrop } from "./plantGreenhouse";
 
 export type LandExpansionPlantAction = {
   type: "seed.planted";
@@ -586,6 +587,12 @@ export function getCropYieldAmount({
     amount += 0.25;
   }
 
+  if (
+    isGreenhouseCrop(crop) &&
+    isCollectibleBuilt({ name: "Pharaoh Gnome", game })
+  ) {
+    amount += 2;
+  }
   return Number(setPrecision(new Decimal(amount)));
 }
 

--- a/src/features/game/events/landExpansion/plantGreenhouse.test.ts
+++ b/src/features/game/events/landExpansion/plantGreenhouse.test.ts
@@ -311,6 +311,61 @@ describe("plantGreenhouse", () => {
     });
   });
 
+  it("boosts +2 Greenhouse Crop yield when Pharaoh Gnome is placed", () => {
+    const now = Date.now();
+    const state = plantGreenhouse({
+      action: {
+        type: "greenhouse.planted",
+        id: 1,
+        seed: "Rice Seed",
+      },
+      state: {
+        ...farm,
+        inventory: {
+          "Rice Seed": new Decimal(1),
+        },
+        greenhouse: {
+          oil: 50,
+          pots: {
+            1: {},
+          },
+        },
+        collectibles: {
+          "Pharaoh Gnome": [
+            {
+              id: "1",
+              createdAt: 0,
+              coordinates: {
+                x: 0,
+                y: 0,
+              },
+              readyAt: 0,
+            },
+          ],
+        },
+        buildings: {
+          Greenhouse: [
+            {
+              coordinates: { x: 0, y: 0 },
+              id: "1",
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: now,
+    });
+
+    expect(state.greenhouse.pots[1]).toEqual({
+      plant: {
+        amount: 3,
+        name: "Rice",
+        plantedAt: now,
+      },
+    });
+  });
+
   it("gives a 50% time boost when Turbo Sprout is placed", () => {
     const now = Date.now();
     const state = plantGreenhouse({
@@ -355,6 +410,58 @@ describe("plantGreenhouse", () => {
         amount: 1,
         name: "Rice",
         plantedAt: now - boostedTime,
+      },
+    });
+  });
+
+  it("boosts +2 Greenhouse Fruit yield when Pharaoh Gnome is placed", () => {
+    const now = Date.now();
+    const state = plantGreenhouse({
+      action: {
+        type: "greenhouse.planted",
+        id: 1,
+        seed: "Grape Seed",
+      },
+      state: {
+        ...farm,
+        inventory: {
+          "Grape Seed": new Decimal(1),
+        },
+        greenhouse: {
+          oil: 50,
+          pots: {
+            1: {},
+          },
+        },
+        buildings: {
+          Greenhouse: [
+            {
+              coordinates: { x: 0, y: 0 },
+              id: "1",
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+        collectibles: {
+          "Pharaoh Gnome": [
+            {
+              id: "1",
+              createdAt: 0,
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: now,
+    });
+
+    expect(state.greenhouse.pots[1]).toEqual({
+      plant: {
+        amount: 3,
+        name: "Grape",
+        plantedAt: now,
       },
     });
   });

--- a/src/features/game/events/landExpansion/plantGreenhouse.ts
+++ b/src/features/game/events/landExpansion/plantGreenhouse.ts
@@ -8,6 +8,7 @@ import {
   GreenHouseCropSeedName,
 } from "features/game/types/crops";
 import {
+  GREENHOUSE_FRUIT,
   GreenHouseFruitName,
   GreenHouseFruitSeedName,
 } from "features/game/types/fruits";
@@ -21,6 +22,7 @@ import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { getCropTime, getCropYieldAmount } from "./plant";
 import { getFruitYield } from "./fruitHarvested";
 import { getFruitTime } from "./fruitPlanted";
+import { Resource } from "features/game/lib/getBudYieldBoosts";
 
 export type PlantGreenhouseAction = {
   type: "greenhouse.planted";
@@ -61,10 +63,14 @@ export const OIL_USAGE: Record<GreenhouseSeed, number> = {
 
 export const MAX_POTS = 4;
 
-function isGreenhouseCrop(
-  plant: GreenHouseCropName | GreenHouseFruitName,
-): plant is GreenHouseCropName {
+export function isGreenhouseCrop(plant: Resource): plant is GreenHouseCropName {
   return (plant as GreenHouseCropName) in GREENHOUSE_CROPS();
+}
+
+export function isGreenhouseFruit(
+  fruit: Resource,
+): fruit is GreenHouseFruitName {
+  return (fruit as GreenHouseFruitName) in GREENHOUSE_FRUIT();
 }
 
 export function getGreenhouseYieldAmount({

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -378,7 +378,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Lemon.image,
     },
     "Infernal Drill": {
-      shortDescription: "Drill Oil without Oil Drill",
+      shortDescription: translate("bumpkinItemBuff.infernal.drill.boost"),
       labelType: "vibrant",
       boostTypeIcon: lightning,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -397,7 +397,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Oil.image,
     },
     "Dev Wrench": {
-      shortDescription: "-50% Oil Regeneration Time",
+      shortDescription: translate("bumpkinItemBuff.dev.wrench.boost"),
       labelType: "info",
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -384,8 +384,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Oil.image,
     },
     "Ancient Shovel": {
-      shortDescription: "Dig treasure without Shovel",
-      // Will clarify whether it will also allow users to dig treasure without the Sand Drill
+      shortDescription: translate("bumpkinItemBuff.ancient.shovel.boost"),
       labelType: "vibrant",
       boostTypeIcon: lightning,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -372,7 +372,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Crab.image,
     },
     "Lemon Shield": {
-      shortDescription: "+1 Lemon",
+      shortDescription: translate("bumpkinItemBuff.lemon.shield.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
       boostedItemIcon: ITEM_DETAILS.Lemon.image,

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -391,7 +391,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostedItemIcon: ITEM_DETAILS.Oil.image,
     },
     "Oil Overalls": {
-      shortDescription: "+10 Oil",
+      shortDescription: translate("bumpkinItemBuff.oil.overalls.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -652,7 +652,7 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     boostedItemIcon: powerup,
   },
   "Lemon Tea Bath": {
-    shortDescription: "-50% Lemon Growth Time",
+    shortDescription: translate("description.lemon.tea.bath.boost"),
     labelType: "info",
     boostedItemIcon: SUNNYSIDE.icons.stopwatch,
     boostTypeIcon: ITEM_DETAILS.Lemon.image,

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -647,7 +647,7 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     boostedItemIcon: SUNNYSIDE.icons.plant,
   },
   "Pharaoh Gnome": {
-    shortDescription: "+2 Greenhouse Crop",
+    shortDescription: translate("description.pharaoh.gnome.boost"),
     labelType: "success",
     boostedItemIcon: powerup,
   },

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -658,7 +658,7 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     boostTypeIcon: ITEM_DETAILS.Lemon.image,
   },
   "Tomato Clown": {
-    shortDescription: "-50% Tomato Growth Time",
+    shortDescription: translate("description.tomato.clown.boost"),
     labelType: "info",
     boostedItemIcon: SUNNYSIDE.icons.stopwatch,
     boostTypeIcon: ITEM_DETAILS.Tomato.image,

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1046,6 +1046,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
   "bumpkinItemBuff.oil.overalls.boost":
     ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
+  "bumpkinItemBuff.ancient.shovel.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.ancient.shovel.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -918,6 +918,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.desert.rose.boost"],
   "description.pharaoh.gnome.boost":
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
+  "description.lemon.tea.bath.boost":
+    ENGLISH_TERMS["description.lemon.tea.bath.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1040,6 +1040,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
   "bumpkinItemBuff.infernal.drill.boost":
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
+  "bumpkinItemBuff.lemon.shield.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -916,6 +916,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
 
   "description.desert.rose.boost":
     ENGLISH_TERMS["description.desert.rose.boost"],
+  "description.pharaoh.gnome.boost":
+    ENGLISH_TERMS["description.pharaoh.gnome.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -920,6 +920,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
   "description.lemon.tea.bath.boost":
     ENGLISH_TERMS["description.lemon.tea.bath.boost"],
+  "description.tomato.clown.boost":
+    ENGLISH_TERMS["description.tomato.clown.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1042,6 +1042,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
   "bumpkinItemBuff.lemon.shield.boost":
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
+  "bumpkinItemBuff.dev.wrench.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1038,6 +1038,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% 徽记",
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.infernal.drill.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1044,6 +1044,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
   "bumpkinItemBuff.dev.wrench.boost":
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPartRequirements: Record<BumpkinPartRequirements, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -937,6 +937,7 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
   "description.hourglass.expired":
     "Your {{hourglass}} has expired. Time to grab another one!",
   "description.desert.rose.boost": "10% Chance for +1 Flower",
+  "description.pharaoh.gnome.boost": "+2 Greenhouse Plants",
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1064,6 +1064,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% Marks",
   "bumpkinItemBuff.crab.trap": "+1 Crab when digging or drilling",
   "bumpkinItemBuff.bionic.drill": "+5 Desert Digs",
+  "bumpkinItemBuff.infernal.drill.boost": "Drill Oil without Oil Drill",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1066,6 +1066,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": "+5 Desert Digs",
   "bumpkinItemBuff.infernal.drill.boost": "Drill Oil without Oil Drill",
   "bumpkinItemBuff.lemon.shield.boost": "+1 Lemon",
+  "bumpkinItemBuff.dev.wrench.boost": "-50% Oil Regeneration Time",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1067,6 +1067,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.infernal.drill.boost": "Drill Oil without Oil Drill",
   "bumpkinItemBuff.lemon.shield.boost": "+1 Lemon",
   "bumpkinItemBuff.dev.wrench.boost": "-50% Oil Regeneration Time",
+  "bumpkinItemBuff.oil.overalls.boost": "+10 Oil",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -938,6 +938,7 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     "Your {{hourglass}} has expired. Time to grab another one!",
   "description.desert.rose.boost": "10% Chance for +1 Flower",
   "description.pharaoh.gnome.boost": "+2 Greenhouse Plants",
+  "description.lemon.tea.bath.boost": "-50% Lemon Growth Time",
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1065,6 +1065,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.crab.trap": "+1 Crab when digging or drilling",
   "bumpkinItemBuff.bionic.drill": "+5 Desert Digs",
   "bumpkinItemBuff.infernal.drill.boost": "Drill Oil without Oil Drill",
+  "bumpkinItemBuff.lemon.shield.boost": "+1 Lemon",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1068,6 +1068,7 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.lemon.shield.boost": "+1 Lemon",
   "bumpkinItemBuff.dev.wrench.boost": "-50% Oil Regeneration Time",
   "bumpkinItemBuff.oil.overalls.boost": "+10 Oil",
+  "bumpkinItemBuff.ancient.shovel.boost": "Dig treasure without Sand Shovel",
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -939,6 +939,7 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
   "description.desert.rose.boost": "10% Chance for +1 Flower",
   "description.pharaoh.gnome.boost": "+2 Greenhouse Plants",
   "description.lemon.tea.bath.boost": "-50% Lemon Growth Time",
+  "description.tomato.clown.boost": "-50% Tomato Growth Time",
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -973,6 +973,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.desert.rose.boost"],
   "description.pharaoh.gnome.boost":
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
+  "description.lemon.tea.bath.boost":
+    ENGLISH_TERMS["description.lemon.tea.bath.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1128,6 +1128,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
   "bumpkinItemBuff.dev.wrench.boost":
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1122,6 +1122,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.infernal.drill.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1130,6 +1130,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
   "bumpkinItemBuff.oil.overalls.boost":
     ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
+  "bumpkinItemBuff.ancient.shovel.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.ancient.shovel.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -975,6 +975,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
   "description.lemon.tea.bath.boost":
     ENGLISH_TERMS["description.lemon.tea.bath.boost"],
+  "description.tomato.clown.boost":
+    ENGLISH_TERMS["description.tomato.clown.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -971,6 +971,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.hourglass.running"],
   "description.desert.rose.boost":
     ENGLISH_TERMS["description.desert.rose.boost"],
+  "description.pharaoh.gnome.boost":
+    ENGLISH_TERMS["description.pharaoh.gnome.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1126,6 +1126,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
   "bumpkinItemBuff.lemon.shield.boost":
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
+  "bumpkinItemBuff.dev.wrench.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1124,6 +1124,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
   "bumpkinItemBuff.infernal.drill.boost":
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
+  "bumpkinItemBuff.lemon.shield.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -966,6 +966,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.desert.rose.boost"],
   "description.pharaoh.gnome.boost":
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
+  "description.lemon.tea.bath.boost":
+    ENGLISH_TERMS["description.lemon.tea.bath.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -964,6 +964,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.hourglass.running"],
   "description.desert.rose.boost":
     ENGLISH_TERMS["description.desert.rose.boost"],
+  "description.pharaoh.gnome.boost":
+    ENGLISH_TERMS["description.pharaoh.gnome.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1116,6 +1116,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
   "bumpkinItemBuff.dev.wrench.boost":
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1112,6 +1112,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
   "bumpkinItemBuff.infernal.drill.boost":
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
+  "bumpkinItemBuff.lemon.shield.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -968,6 +968,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
   "description.lemon.tea.bath.boost":
     ENGLISH_TERMS["description.lemon.tea.bath.boost"],
+  "description.tomato.clown.boost":
+    ENGLISH_TERMS["description.tomato.clown.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1110,6 +1110,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.infernal.drill.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1114,6 +1114,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
   "bumpkinItemBuff.lemon.shield.boost":
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
+  "bumpkinItemBuff.dev.wrench.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1118,6 +1118,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
   "bumpkinItemBuff.oil.overalls.boost":
     ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
+  "bumpkinItemBuff.ancient.shovel.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.ancient.shovel.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -957,6 +957,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
   "description.lemon.tea.bath.boost":
     ENGLISH_TERMS["description.lemon.tea.bath.boost"],
+  "description.tomato.clown.boost":
+    ENGLISH_TERMS["description.tomato.clown.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -953,6 +953,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     "Your {{hourglass}} has expired. Time to grab another one!",
   "description.desert.rose.boost":
     ENGLISH_TERMS["description.desert.rose.boost"],
+  "description.pharaoh.gnome.boost":
+    ENGLISH_TERMS["description.pharaoh.gnome.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1087,6 +1087,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
   "bumpkinItemBuff.lemon.shield.boost":
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
+  "bumpkinItemBuff.dev.wrench.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1085,6 +1085,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
   "bumpkinItemBuff.infernal.drill.boost":
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
+  "bumpkinItemBuff.lemon.shield.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1089,6 +1089,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
   "bumpkinItemBuff.dev.wrench.boost":
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1083,6 +1083,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bumpkin.sabatons": "+5% Marks",
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.infernal.drill.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -955,6 +955,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.desert.rose.boost"],
   "description.pharaoh.gnome.boost":
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
+  "description.lemon.tea.bath.boost":
+    ENGLISH_TERMS["description.lemon.tea.bath.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1091,6 +1091,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
   "bumpkinItemBuff.oil.overalls.boost":
     ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
+  "bumpkinItemBuff.ancient.shovel.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.ancient.shovel.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1103,6 +1103,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
   "bumpkinItemBuff.lemon.shield.boost":
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
+  "bumpkinItemBuff.dev.wrench.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -958,6 +958,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.desert.rose.boost"],
   "description.pharaoh.gnome.boost":
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
+  "description.lemon.tea.bath.boost":
+    ENGLISH_TERMS["description.lemon.tea.bath.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -960,6 +960,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.pharaoh.gnome.boost"],
   "description.lemon.tea.bath.boost":
     ENGLISH_TERMS["description.lemon.tea.bath.boost"],
+  "description.tomato.clown.boost":
+    ENGLISH_TERMS["description.tomato.clown.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1101,6 +1101,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
   "bumpkinItemBuff.infernal.drill.boost":
     ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
+  "bumpkinItemBuff.lemon.shield.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1099,6 +1099,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.bumpkin.sabatons"],
   "bumpkinItemBuff.crab.trap": ENGLISH_TERMS["bumpkinItemBuff.crab.trap"],
   "bumpkinItemBuff.bionic.drill": ENGLISH_TERMS["bumpkinItemBuff.bionic.drill"],
+  "bumpkinItemBuff.infernal.drill.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.infernal.drill.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -956,6 +956,8 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
     ENGLISH_TERMS["description.hourglass.running"],
   "description.desert.rose.boost":
     ENGLISH_TERMS["description.desert.rose.boost"],
+  "description.pharaoh.gnome.boost":
+    ENGLISH_TERMS["description.pharaoh.gnome.boost"],
 };
 
 const bountyDescription: Record<BountyDescription, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1107,6 +1107,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
   "bumpkinItemBuff.oil.overalls.boost":
     ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
+  "bumpkinItemBuff.ancient.shovel.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.ancient.shovel.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1105,6 +1105,8 @@ const bumpkinItemBuff: Record<BumpkinItemBuff, string> = {
     ENGLISH_TERMS["bumpkinItemBuff.lemon.shield.boost"],
   "bumpkinItemBuff.dev.wrench.boost":
     ENGLISH_TERMS["bumpkinItemBuff.dev.wrench.boost"],
+  "bumpkinItemBuff.oil.overalls.boost":
+    ENGLISH_TERMS["bumpkinItemBuff.oil.overalls.boost"],
 };
 
 const bumpkinPart: Record<BumpkinPart, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -638,7 +638,8 @@ export type BoostEffectDescriptions =
   | "description.blossom.hourglass.boost"
   | "description.hourglass.expired"
   | "description.hourglass.running"
-  | "description.desert.rose.boost";
+  | "description.desert.rose.boost"
+  | "description.pharaoh.gnome.boost";
 
 export type BountyDescription =
   | "description.clam.shell"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -751,7 +751,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.infernal.drill.boost"
   | "bumpkinItemBuff.lemon.shield.boost"
   | "bumpkinItemBuff.dev.wrench.boost"
-  | "bumpkinItemBuff.oil.overalls.boost";
+  | "bumpkinItemBuff.oil.overalls.boost"
+  | "bumpkinItemBuff.ancient.shovel.boost";
 
 export type BumpkinPart =
   | "equip.background"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -748,7 +748,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.bumpkin.sabatons"
   | "bumpkinItemBuff.crab.trap"
   | "bumpkinItemBuff.bionic.drill"
-  | "bumpkinItemBuff.infernal.drill.boost";
+  | "bumpkinItemBuff.infernal.drill.boost"
+  | "bumpkinItemBuff.lemon.shield.boost";
 
 export type BumpkinPart =
   | "equip.background"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -750,7 +750,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.bionic.drill"
   | "bumpkinItemBuff.infernal.drill.boost"
   | "bumpkinItemBuff.lemon.shield.boost"
-  | "bumpkinItemBuff.dev.wrench.boost";
+  | "bumpkinItemBuff.dev.wrench.boost"
+  | "bumpkinItemBuff.oil.overalls.boost";
 
 export type BumpkinPart =
   | "equip.background"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -639,7 +639,8 @@ export type BoostEffectDescriptions =
   | "description.hourglass.expired"
   | "description.hourglass.running"
   | "description.desert.rose.boost"
-  | "description.pharaoh.gnome.boost";
+  | "description.pharaoh.gnome.boost"
+  | "description.lemon.tea.bath.boost";
 
 export type BountyDescription =
   | "description.clam.shell"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -747,7 +747,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.bumpkin.pants"
   | "bumpkinItemBuff.bumpkin.sabatons"
   | "bumpkinItemBuff.crab.trap"
-  | "bumpkinItemBuff.bionic.drill";
+  | "bumpkinItemBuff.bionic.drill"
+  | "bumpkinItemBuff.infernal.drill.boost";
 
 export type BumpkinPart =
   | "equip.background"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -640,7 +640,8 @@ export type BoostEffectDescriptions =
   | "description.hourglass.running"
   | "description.desert.rose.boost"
   | "description.pharaoh.gnome.boost"
-  | "description.lemon.tea.bath.boost";
+  | "description.lemon.tea.bath.boost"
+  | "description.tomato.clown.boost";
 
 export type BountyDescription =
   | "description.clam.shell"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -749,7 +749,8 @@ export type BumpkinItemBuff =
   | "bumpkinItemBuff.crab.trap"
   | "bumpkinItemBuff.bionic.drill"
   | "bumpkinItemBuff.infernal.drill.boost"
-  | "bumpkinItemBuff.lemon.shield.boost";
+  | "bumpkinItemBuff.lemon.shield.boost"
+  | "bumpkinItemBuff.dev.wrench.boost";
 
 export type BumpkinPart =
   | "equip.background"


### PR DESCRIPTION
# Description

This PR adds Boosts for the Auction Items in Pharaoh's Treasure:
- Infernal Drill: Drill Oil without Drill
- Ancient Shovel: Dig treasure without Sand Shovel (boost applied to BE)
- Lemon Tea Bath: -50% Lemon Growth Time
- Tomato Clown: -50% Tomato Growth Time
- Lemon Shield: +1 Lemon
- Oil Overalls: +10 Oil
- Dev Wrench: -50% Oil Regeneration Time
- Pharaoh Gnome: +2 Greenhouse Produce (Fruit & Crop)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
