### PR TITLE
[FIX] Remaining Digs 

### DIFF
--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -10,9 +10,8 @@ import { Digby } from "features/world/ui/beach/Digby";
 import { useTranslation } from "react-i18next";
 import { isWearableActive } from "features/game/lib/wearables";
 
-export const getMaxDigs = (game: GameState) => {
+export const getRegularMaxDigs = (game: GameState) => {
   let maxDigs = 25;
-  const extraDigs = game.desert.digging.extraDigs ?? 0;
 
   if (isCollectibleBuilt({ name: "Heart of Davy Jones", game })) {
     maxDigs += 20;
@@ -31,13 +30,30 @@ export const getMaxDigs = (game: GameState) => {
     maxDigs += 5;
   }
 
-  return maxDigs + extraDigs;
+  return maxDigs;
+};
+
+export const getRemainingDigs = (game: GameState) => {
+  const { desert } = game;
+  const dugCount = desert.digging.grid.length;
+  const extraDigs = desert.digging.extraDigs ?? 0;
+  const regularMaxDigs = getRegularMaxDigs(game);
+  let digsLeft = regularMaxDigs - dugCount;
+
+  if (digsLeft < 0) {
+    digsLeft = 0;
+  }
+
+  digsLeft += extraDigs;
+
+  return digsLeft;
 };
 
 export const DesertDiggingDisplay = () => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const [show, setShow] = useState(false);
+  const { desert } = gameState.context.state;
 
   const { t } = useTranslation();
 
@@ -48,10 +64,8 @@ export const DesertDiggingDisplay = () => {
     setShow(!show);
   };
 
-  const dugCount = gameState.context.state.desert.digging.grid.length;
-
-  const maxDigs = getMaxDigs(gameState.context.state);
-  const digsLeft = maxDigs - dugCount;
+  const dugCount = desert.digging.grid.length;
+  const digsLeft = getRemainingDigs(gameState.context.state);
 
   return (
     <>

--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -40,6 +40,8 @@ export const getRemainingDigs = (game: GameState) => {
   const regularMaxDigs = getRegularMaxDigs(game);
   let digsLeft = regularMaxDigs - dugCount;
 
+  // This is the case where a player has bought and used extra digs
+  // The dug count is higher than the regular max digs
   if (digsLeft < 0) {
     digsLeft = 0;
   }

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -28,7 +28,7 @@ import { hasReadDesertNotice as hasReadDesertNotice } from "../ui/beach/DesertNo
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import Decimal from "decimal.js-light";
 import { isTouchDevice } from "../lib/device";
-import { getMaxDigs } from "features/island/hud/components/DesertDiggingDisplay";
+import { getRemainingDigs } from "features/island/hud/components/DesertDiggingDisplay";
 
 const convertToSnakeCase = (str: string) => {
   return str.replace(" ", "_").toLowerCase();
@@ -1027,18 +1027,8 @@ export class BeachScene extends BaseScene {
     return this.gameService.state.context.state.desert.digging.grid.length ?? 0;
   }
 
-  get allowedDigs() {
-    const game = this.gameService.state.context.state;
-    const maxDigs = getMaxDigs(game);
-
-    return maxDigs;
-  }
-
   get hasDigsLeft() {
-    const totalHolesDug =
-      this.gameService.state.context.state.desert.digging.grid.length ?? 0;
-
-    return totalHolesDug < this.allowedDigs;
+    return getRemainingDigs(this.gameService.state.context.state) > 0;
   }
 
   public handleDig = async (row: number, col: number) => {

--- a/src/features/world/ui/beach/Digby.tsx
+++ b/src/features/world/ui/beach/Digby.tsx
@@ -31,7 +31,7 @@ import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { CollectibleName } from "features/game/types/craftables";
 import Decimal from "decimal.js-light";
-import { getMaxDigs } from "features/island/hud/components/DesertDiggingDisplay";
+import { getRegularMaxDigs } from "features/island/hud/components/DesertDiggingDisplay";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
 
 function hasReadIntro() {
@@ -259,7 +259,7 @@ const getDefaultTab = (game: GameState) => {
   if (!hasReadIntro()) return 1;
 
   const digging = game.desert.digging;
-  const maxDigs = getMaxDigs(game);
+  const maxDigs = getRegularMaxDigs(game);
   const remainingDigs = maxDigs - digging.grid.length;
 
   return remainingDigs === 0 ? 2 : 0;
@@ -274,7 +274,7 @@ export const Digby: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const inventory = gameState.context.state.inventory;
   const dugCount = gameState.context.state.desert.digging.grid.length;
 
-  const maxDigs = getMaxDigs(gameState.context.state);
+  const maxDigs = getRegularMaxDigs(gameState.context.state);
   const digsLeft = maxDigs - dugCount;
 
   const { t } = useAppTranslation();


### PR DESCRIPTION
# Description

There was an issue with the way digs remaining was being calculated when it came to "Extra Digs" that had been purchased. It was sending the remaining count into the negative as extra digs are added and then subtracted when they're used.

This PR fixes the issue.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dig dig dig and then buy some extra digs and dig dig dig. You should be allowed to dig so long as you have an extra dig. The `digs remaining` label should show how many digs you have.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
