### PR TITLE
[FIX] Clicking outside dig modal does not close it

### DIFF
--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -105,7 +105,7 @@ export const DesertDiggingDisplay = () => {
           </Label>
         )}
       </div>
-      <Modal show={show}>
+      <Modal show={show} onHide={() => setShow(false)}>
         <Digby onClose={() => setShow(false)} />
       </Modal>
     </>


### PR DESCRIPTION
# Description

- Fix issue where clicking outside dig modal does not close it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Click outside of dig modal when clicking the label on top of the chat button on the left of the screen

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
