### PR TITLE
[FEAT] Dig SFX + Move Digs Hud UI

### DIFF
--- a/src/assets/sound-effects/soundEffects.ts
+++ b/src/assets/sound-effects/soundEffects.ts
@@ -101,4 +101,9 @@ export const SOUNDS = {
     nyx: `${CONFIG.PROTECTED_IMAGE_URL}/sound-effects/nightshade-recruiter.mp3`,
     reginald: `${CONFIG.PROTECTED_IMAGE_URL}/sound-effects/sunflorian-recruiter.mp3`,
   },
+  desert: {
+    dig: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Farming/Dig/Farm_Game_Farming_Dig_Hoe_Soil_Dirt_1_Garden.mp3`,
+    drill: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Farming/Engines/Farm_Game_Farming_Tool_Engine_Contraption_Other_Garden_Machine_1_Device_Craft.mp3`,
+    reveal: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Menu_UI/Collects/Farm_Game_User_Interface_Collect_Item_1_Click_Pop_Fun_Cartoon.mp3`,
+  },
 };

--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -72,7 +72,7 @@ export const DesertDiggingDisplay = () => {
   return (
     <>
       <div
-        className="absolute top-36 left-4 cursor-pointer z-50 hover:img-highlight"
+        className="absolute bottom-3 left-1/2 -translate-x-1/2 cursor-pointer z-50 hover:img-highlight"
         onClick={handleClick}
       >
         {!!digsLeft && dugCount > 0 && (

--- a/src/features/pumpkinPlaza/components/ChatUI.tsx
+++ b/src/features/pumpkinPlaza/components/ChatUI.tsx
@@ -8,7 +8,6 @@ import { Label } from "components/ui/Label";
 import { SceneId } from "features/world/mmoMachine";
 import { ReactionName, Reactions } from "./Reactions";
 import { GameState } from "features/game/types/game";
-import { useLocation } from "react-router-dom";
 
 export type Message = {
   farmId: number;
@@ -111,8 +110,6 @@ export const ChatUI: React.FC<Props> = ({
   const showChatMessages = showOptions && option === "chat";
   const showReactions = showOptions && option === "reaction";
 
-  const { pathname } = useLocation();
-
   return (
     <>
       <div
@@ -148,13 +145,11 @@ export const ChatUI: React.FC<Props> = ({
 
       <div
         className={classNames(
-          "absolute cursor-pointer transition-transform origin-top-left ease-in-out duration-300",
+          "absolute cursor-pointer top-36 transition-transform origin-top-left ease-in-out duration-300",
           {
             "scale-50": showOptions,
             "opacity-50": isMuted,
             "cursor-not-allowed": isMuted,
-            "top-44": pathname.includes("beach"),
-            "top-36": !pathname.includes("beach"),
           },
         )}
         style={{

--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -56,6 +56,10 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   private backAuraAnimationKey: string | undefined;
   private direction: "left" | "right" = "right";
 
+  // sounds
+  private digSFX: Phaser.Sound.BaseSound | undefined;
+  private drillSFX: Phaser.Sound.BaseSound | undefined;
+
   constructor({
     scene,
     x,
@@ -687,6 +691,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     ) {
       try {
         this.sprite.anims.play(this.digAnimationKey as string, true);
+        this.scene.sound.play("dig", { volume: 0.1 });
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log("Bumpkin Container: Error playing dig animation: ", e);
@@ -702,6 +707,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     ) {
       try {
         this.sprite.anims.play(this.drillAnimationKey as string, true);
+        this.scene.sound.play("drill", { volume: 0.1 });
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log("Bumpkin Container: Error playing drill animation: ", e);

--- a/src/features/world/scenes/Preloader.ts
+++ b/src/features/world/scenes/Preloader.ts
@@ -31,8 +31,10 @@ export abstract class Preloader extends Phaser.Scene {
       this.load.audio("wood_footstep", SOUNDS.footsteps.wood);
       this.load.audio("sand_footstep", SOUNDS.footsteps.sand);
       this.load.audio("nature_1", SOUNDS.loops.nature_1);
-      this.load.audio("portal_travel", SOUNDS.notifications.portal_travel);
       this.load.audio("boat", SOUNDS.loops.engine);
+      this.load.audio("dig", SOUNDS.desert.dig);
+      this.load.audio("drill", SOUNDS.desert.drill);
+      this.load.audio("reveal", SOUNDS.desert.reveal);
 
       // Phaser assets must be served from an URL
       this.load.image(

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -71,7 +71,7 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
   CROP_MACHINE: () => true,
   FACTION_KITCHEN: betaTimeBasedFeatureFlag(new Date("2022-07-08T00:00:00Z")),
   FACTION_CHORES: betaTimeBasedFeatureFlag(new Date("2022-07-08T00:00:00Z")),
-  TEST_DIGGING: defaultFeatureFlag,
+  TEST_DIGGING: betaTimeBasedFeatureFlag(new Date("2022-08-01T00:00:00Z")),
   NEW_FRUITS: betaTimeBasedFeatureFlag(new Date("2024-08-01T00:00:00Z")),
   DESERT_PLAZA: betaTimeBasedFeatureFlag(new Date("2024-08-01T00:00:00Z")),
 };


### PR DESCRIPTION
# Description

- Add SFX for Drill, Dig, Reveal
- Move the `Digs left` hud element to the bottom of the screen as it was getting blocked by Toast
- Change the digging flag to time based

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Do some digs and drill and listen to the sound. Make sure it does not play if sounds are muted.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
