### PR TITLE
[FIX] Extend task limit

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -9,7 +9,7 @@ import {
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { getSeasonalTicket } from "features/game/types/seasons";
 
-const LAST_DAY_OF_SEASON = new Date("2023-10-31T16:00:00Z").getTime();
+const FIRST_DAY_OF_SEASON = new Date("2023-11-01T16:00:00Z").getTime();
 const MID_SEASON = new Date("2023-08-15T15:00:00Z").getTime();
 
 describe("deliver", () => {
@@ -547,7 +547,7 @@ describe("deliver", () => {
               {
                 id: "123",
                 createdAt: 0,
-                readyAt: LAST_DAY_OF_SEASON,
+                readyAt: FIRST_DAY_OF_SEASON,
                 from: "pumpkin' pete",
                 items: {
                   Sunflower: 50,
@@ -562,7 +562,7 @@ describe("deliver", () => {
           id: "123",
           type: "order.delivered",
         },
-        createdAt: LAST_DAY_OF_SEASON,
+        createdAt: FIRST_DAY_OF_SEASON,
       }),
     ).toThrow("Ticket tasks are frozen");
   });
@@ -581,7 +581,7 @@ describe("deliver", () => {
             {
               id: "123",
               createdAt: 0,
-              readyAt: LAST_DAY_OF_SEASON,
+              readyAt: FIRST_DAY_OF_SEASON,
               from: "betty",
               items: {
                 Sunflower: 50,
@@ -596,7 +596,7 @@ describe("deliver", () => {
         id: "123",
         type: "order.delivered",
       },
-      createdAt: LAST_DAY_OF_SEASON,
+      createdAt: FIRST_DAY_OF_SEASON,
     });
 
     expect(state.balance).toEqual(new Decimal(10));

--- a/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
+++ b/src/features/helios/components/hayseedHank/components/ChoreV2.tsx
@@ -7,11 +7,12 @@ import { getKeys } from "features/game/types/craftables";
 import { DailyChore } from "./DailyChore";
 import { acknowledgeChores } from "../lib/chores";
 import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
-import { SUNNYSIDE } from "assets/sunnyside";
 import { secondsToString } from "lib/utils/time";
 import { Label } from "components/ui/Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { MachineState } from "features/game/lib/gameMachine";
+import { InnerPanel } from "components/ui/Panel";
+import lock from "assets/icons/lock.png";
 
 interface Props {
   /** Is used to identify whether the chores are displayed in the codex or not. The codex requires smaller text sizes. */
@@ -44,40 +45,19 @@ export const ChoreV2: React.FC<Props> = ({
     );
   }
 
-  const {
-    ticketTasksAreClosing,
-    tasksStartAt,
-    tasksCloseAt,
-    ticketTasksAreFrozen,
-  } = getSeasonChangeover({ id: gameService.state.context.farmId });
+  const { tasksStartAt, tasksCloseAt, ticketTasksAreFrozen } =
+    getSeasonChangeover({ id: gameService.state.context.farmId });
   return (
     <>
-      {
-        // Give 24 hours heads up before tasks close
-        ticketTasksAreClosing && (
-          <div className="flex flex-col mx-1.5 space-y-2 my-1">
-            <p className="text-xxs">{t("chores.newSeason")}</p>
-            <Label type="info" className="ml-0.5" icon={SUNNYSIDE.icons.timer}>
-              {secondsToString((tasksCloseAt - Date.now()) / 1000, {
-                length: "full",
-              })}
-            </Label>
-          </div>
-        )
-      }
       {ticketTasksAreFrozen && (
-        <div className="flex flex-col mx-1.5 space-y-2 my-1">
+        <InnerPanel className="flex flex-col mb-1">
           <p className="text-xxs">{t("chores.choresFrozen")}</p>
-          <Label
-            type="danger"
-            className="ml-0.5"
-            icon={SUNNYSIDE.icons.stopwatch}
-          >
+          <Label type="danger" className="ml-0.5" icon={lock}>
             {secondsToString((tasksStartAt - Date.now()) / 1000, {
               length: "full",
             })}
           </Label>
-        </div>
+        </InnerPanel>
       )}
       {!ticketTasksAreFrozen && (
         <div className="flex flex-col space-y-1">

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -7,6 +7,7 @@ import Decimal from "decimal.js-light";
 import worldIcon from "assets/icons/world_small.png";
 import token from "assets/icons/sfl.webp";
 import chest from "assets/icons/chest.png";
+import lock from "assets/icons/lock.png";
 
 import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
 import { Context } from "features/game/GameProvider";
@@ -386,10 +387,10 @@ export const DeliveryOrders: React.FC<Props> = ({
   }
 
   const {
-    ticketTasksAreClosing,
     tasksStartAt,
     tasksCloseAt,
     ticketTasksAreFrozen,
+    ticketTasksAreClosing,
   } = getSeasonChangeover({ id: gameService.state.context.farmId });
 
   const level = getBumpkinLevel(gameState.bumpkin?.experience ?? 0);
@@ -428,46 +429,9 @@ export const DeliveryOrders: React.FC<Props> = ({
         <div className="p-1">
           <div className="flex justify-between gap-1">
             <Label type="default">{t("deliveries")}</Label>
-            {!ticketTasksAreFrozen && (
-              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-                {t("new.delivery.in", {
-                  timeLeft: secondsToString(secondsTillReset(), {
-                    length: "medium",
-                    removeTrailingZeros: true,
-                  }),
-                })}
-              </Label>
-            )}
           </div>
           <p className="my-2 ml-1 text-xs">{t("deliveries.intro")}</p>
         </div>
-        {
-          // Give 24 hours heads up before tasks close
-          ticketTasksAreClosing && (
-            <div className="flex flex-col mx-2 mb-1 space-y-1.5">
-              <p className="text-xs">{t("orderhelp.New.Season")}</p>
-              <Label type="info" icon={SUNNYSIDE.icons.timer} className="mt-1">
-                {secondsToString((tasksCloseAt - Date.now()) / 1000, {
-                  length: "full",
-                })}
-              </Label>
-            </div>
-          )
-        }
-        {ticketTasksAreFrozen && (
-          <div className="flex flex-col mx-2 mb-1 space-y-1.5">
-            <p className="text-xs">{t("orderhelp.New.Season.arrival")}</p>
-            <Label
-              type="info"
-              icon={SUNNYSIDE.icons.stopwatch}
-              className="mt-1"
-            >
-              {secondsToString((tasksStartAt - Date.now()) / 1000, {
-                length: "full",
-              })}
-            </Label>
-          </div>
-        )}
 
         <Label
           type="default"
@@ -492,17 +456,36 @@ export const DeliveryOrders: React.FC<Props> = ({
         </div>
 
         <div className="px-2 mt-2">
-          <div className="flex justify-between">
+          <div className="flex justify-between items-center">
             <Label
               type="default"
               icon={ITEM_DETAILS[getSeasonalTicket()].image}
             >
               {`${getSeasonalTicket()}s`}
             </Label>
+            {ticketTasksAreFrozen && (
+              <Label type="formula" icon={lock} className="mt-1">
+                {secondsToString((tasksStartAt - Date.now()) / 1000, {
+                  length: "medium",
+                })}
+              </Label>
+            )}
+            {ticketTasksAreClosing && (
+              <Label type="danger" icon={lock} className="mt-1">
+                {`${secondsToString((tasksCloseAt - Date.now()) / 1000, {
+                  length: "medium",
+                })} left`}
+              </Label>
+            )}
           </div>
           {level <= 8 && (
             <span className="text-xs mb-2">
               {t("bumpkin.delivery.earnScrolls")}
+            </span>
+          )}
+          {ticketTasksAreFrozen && (
+            <span className="text-xs mb-2">
+              {t("orderhelp.New.Season.arrival")}
             </span>
           )}
         </div>

--- a/src/features/island/hud/components/codex/pages/Chores.tsx
+++ b/src/features/island/hud/components/codex/pages/Chores.tsx
@@ -19,6 +19,7 @@ import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 import { secondsToString } from "lib/utils/time";
 import React, { useContext } from "react";
 
+import lock from "assets/icons/lock.png";
 import mark from "assets/icons/faction_mark.webp";
 import { setPrecision } from "lib/utils/formatNumber";
 import Decimal from "decimal.js-light";
@@ -37,9 +38,10 @@ export const Chores: React.FC<Props> = ({ farmId }) => {
 
   const { t } = useAppTranslation();
 
-  const { ticketTasksAreFrozen } = getSeasonChangeover({
-    id: farmId,
-  });
+  const { ticketTasksAreFrozen, ticketTasksAreClosing, tasksCloseAt } =
+    getSeasonChangeover({
+      id: farmId,
+    });
 
   const kingdomChores = useSelector(gameService, _kingdomChores);
   const handleReset = () => {
@@ -55,14 +57,22 @@ export const Chores: React.FC<Props> = ({ farmId }) => {
           <div className="p-1 text-xs">
             <div className="flex justify-between items-center gap-1">
               <Label type="default">{t("chores.hank")}</Label>
-              <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-                {t("hayseedHankv2.newChoresAvailable", {
-                  timeLeft: secondsToString(secondsTillReset(), {
+              {ticketTasksAreClosing ? (
+                <Label type="danger" icon={lock} className="mt-1">
+                  {`${secondsToString((tasksCloseAt - Date.now()) / 1000, {
                     length: "medium",
-                    removeTrailingZeros: true,
-                  }),
-                })}
-              </Label>
+                  })} left`}
+                </Label>
+              ) : (
+                <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                  {t("hayseedHankv2.newChoresAvailable", {
+                    timeLeft: secondsToString(secondsTillReset(), {
+                      length: "medium",
+                      removeTrailingZeros: true,
+                    }),
+                  })}
+                </Label>
+              )}
             </div>
             <div className="my-1 space-y-1">
               <span className="w-fit">{t("chores.hank.intro")}</span>

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4651,7 +4651,7 @@ const orderhelp: Record<OrderHelp, string> = {
   "orderhelp.Skip.hour": "You're only able to skip an order after 24 hours!",
   "orderhelp.New.Season":
     "A new season approaches, ticket deliveries will temporarily close.",
-  "orderhelp.New.Season.arrival": "New seasonal deliveries opening soon.",
+  "orderhelp.New.Season.arrival": "Seasonal deliveries opening soon...",
   "orderhelp.Wisely": "Choose wisely!",
   "orderhelp.SkipIn": "Skip in",
   "orderhelp.NoRight": "Not Right Now",

--- a/src/lib/utils/getSeasonWeek.test.ts
+++ b/src/lib/utils/getSeasonWeek.test.ts
@@ -9,20 +9,6 @@ describe("getSeasonChangeover", () => {
     expect(result.tasksStartAt).toEqual(new Date("2024-05-08").getTime());
   });
 
-  it("tasks end one day before seasons finishes", () => {
-    const now = new Date("2024-04-25");
-    const result = getSeasonChangeover({ id: 100, now: now.getTime() });
-
-    expect(result.tasksCloseAt).toEqual(new Date("2024-04-30").getTime());
-  });
-
-  it("tasks end one day before seasons finishes", () => {
-    const now = new Date("2024-04-25");
-    const result = getSeasonChangeover({ id: 100, now: now.getTime() });
-
-    expect(result.tasksCloseAt).toEqual(new Date("2024-04-30").getTime());
-  });
-
   it("tasks are frozen for non-admins", () => {
     const now = new Date("2024-05-07");
     const result = getSeasonChangeover({ id: 100, now: now.getTime() });

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -35,14 +35,12 @@ export function getSeasonChangeover({
   now?: number;
 }) {
   const season = getCurrentSeason(new Date(now));
-  const incomingSeason = getCurrentSeason(new Date(now + 24 * 60 * 60 * 1000));
 
-  // 24 hours before the season ends
-  const tasksCloseAt = SEASONS[season].endDate.getTime() - 24 * 60 * 60 * 1000;
+  const tasksCloseAt = SEASONS[season].endDate.getTime();
 
   // 7 days after the season starts
   const tasksStartAt =
-    SEASONS[incomingSeason].startDate.getTime() + 7 * 24 * 60 * 60 * 1000;
+    SEASONS[season].startDate.getTime() + 7 * 24 * 60 * 60 * 1000;
 
   const isAdmin = ADMIN_IDS.includes(id);
 


### PR DESCRIPTION
# Description

Allow players to complete seasonal tasks on last day of season.

Also improved the UI, labels + messaging when the countdown is on and the locked period.

<img width="450" alt="Screenshot 2024-07-31 at 4 12 22 PM" src="https://github.com/user-attachments/assets/1c3b1472-5b04-47c9-8bca-c11b177a23c8">
<img width="724" alt="Screenshot 2024-07-31 at 4 16 45 PM" src="https://github.com/user-attachments/assets/b7bd2d42-91e8-4351-b915-bfc7bf539e42">
<img width="450" alt="Screenshot 2024-07-31 at 4 14 44 PM" src="https://github.com/user-attachments/assets/2986ac21-789d-4eaf-a573-a96752e2ada2">
