### PR TITLE
[FIX] Digby Default Tab

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -1114,8 +1114,15 @@ export class BeachScene extends BaseScene {
 
     if (attemptsToday + 1 < 4) {
       const totalCoins = this.treasuresFound.reduce((acc, item) => {
-        return (acc +=
-          SELLABLE_TREASURE[item as BeachBountyTreasure].sellPrice);
+        const treasure = SELLABLE_TREASURE[item as BeachBountyTreasure];
+
+        if (!treasure) {
+          // eslint-disable-next-line no-console
+          console.log("Treasure not found in SELLABLE_TREASURE", item);
+          return acc;
+        }
+
+        return (acc += treasure.sellPrice);
       }, 0);
 
       const percentageFound = Math.floor(

--- a/src/features/world/ui/beach/Digby.tsx
+++ b/src/features/world/ui/beach/Digby.tsx
@@ -34,10 +34,7 @@ import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { CollectibleName } from "features/game/types/craftables";
 import Decimal from "decimal.js-light";
-import {
-  getRegularMaxDigs,
-  getRemainingDigs,
-} from "features/island/hud/components/DesertDiggingDisplay";
+import { getRemainingDigs } from "features/island/hud/components/DesertDiggingDisplay";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
 import { ResizableBar } from "components/ui/ProgressBar";
 import { Revealed } from "features/game/components/Revealed";
@@ -368,9 +365,7 @@ const getDefaultTab = (game: GameState) => {
     return 0;
   }
 
-  const digging = game.desert.digging;
-  const maxDigs = getRegularMaxDigs(game);
-  const remainingDigs = maxDigs - digging.grid.length;
+  const remainingDigs = getRemainingDigs(game);
 
   if (remainingDigs <= 0) {
     return 2;


### PR DESCRIPTION
# Description

Update Digby default tab logic to use the new `getRemainingDigs` function so that it only defaults to tab 2 if you have no remaining digs. 

Also put in a catch to prevent a bug where it tries to find `sellPrice` on `undefined`. I have a log in there too to hopefully catch what the item is.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Locally.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
