### PR TITLE
[FEAT] Faction balancing - champions top 100

### DIFF
--- a/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
@@ -50,6 +50,7 @@ export type KingdomLeaderboard = {
     topTens: Record<FactionName, RankData[]>;
     totalMembers: Record<FactionName, number>;
     totalTickets: Record<FactionName, number>;
+    score: Record<FactionName, number>;
     marksRankingData?: RankData[] | null;
   };
   lastUpdated: number;

--- a/src/features/game/lib/factions.ts
+++ b/src/features/game/lib/factions.ts
@@ -1,5 +1,7 @@
+import { KingdomLeaderboard } from "../expansion/components/leaderboard/actions/leaderboard";
 import { BoostType, BoostValue } from "../types/boosts";
 import { BumpkinItem } from "../types/bumpkin";
+import { getKeys } from "../types/decorations";
 import {
   FactionBanner,
   FactionName,
@@ -439,4 +441,37 @@ export function getFactionPetBoostMultiplier(game: GameState) {
   if (lastWeekStreak >= 6 && lastWeekStreak < 8) return 1.3;
 
   return 1.5;
+}
+
+export function getFactionScores({
+  leaderboard,
+}: {
+  leaderboard: KingdomLeaderboard;
+}) {
+  let scores = {
+    bumpkins: 0,
+    goblins: 0,
+    nightshades: 0,
+    sunflorians: 0,
+  };
+
+  if (!leaderboard.marks) {
+    return { scores };
+  }
+
+  scores = leaderboard.marks.score;
+
+  // In the past, faction score was calculated by total marks from faction
+  if (new Date(leaderboard.week).getTime() < new Date("2024-08-05").getTime()) {
+    scores = leaderboard.marks.totalTickets;
+  }
+
+  const winner = getKeys(scores).reduce((winner, name) => {
+    return scores[winner] > scores[name] ? winner : name;
+  }, "bumpkins");
+
+  return {
+    scores,
+    winner,
+  };
 }

--- a/src/features/island/hud/components/codex/pages/FactionLeaderboard.tsx
+++ b/src/features/island/hud/components/codex/pages/FactionLeaderboard.tsx
@@ -19,7 +19,10 @@ import {
   RankData,
 } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import { Loading } from "features/auth/components";
-import { secondsTillWeekReset } from "features/game/lib/factions";
+import {
+  getFactionScores,
+  secondsTillWeekReset,
+} from "features/game/lib/factions";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
@@ -71,7 +74,9 @@ export const FactionLeaderboard: React.FC<Props> = ({
 
   const data = leaderboard.marks;
 
-  const sortedFactions = Object.entries(data.totalTickets)
+  const { scores } = getFactionScores({ leaderboard });
+
+  const sortedFactions = Object.entries(scores)
     .sort((a, b) => b[1] - a[1])
     .map(([key], i) => [key, POSITION_LABELS[i]]);
 

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -21,6 +21,7 @@ import { getKeys } from "features/game/types/decorations";
 import { JoinFactionAction } from "features/game/events/landExpansion/joinFaction";
 import { hasFeatureAccess } from "lib/flags";
 import {
+  getFactionScores,
   getPreviousWeek,
   secondsTillWeekReset,
 } from "features/game/lib/factions";
@@ -403,17 +404,16 @@ export class KingdomScene extends BaseScene {
       return;
     }
 
-    const totals = leaderboard.marks.totalTickets;
-    const winningFaction = getKeys(totals).reduce((winner, name) => {
-      return totals[winner] > totals[name] ? winner : name;
-    }, "bumpkins");
+    const { winner } = getFactionScores({ leaderboard });
+
+    if (!winner) return;
 
     if (this.champions.active) {
       this.champions.destroy();
     }
     this.champions = undefined;
 
-    const throne = THRONES[winningFaction];
+    const throne = THRONES[winner];
 
     if (!this.textures.exists(throne)) {
       return;

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -12,6 +12,7 @@ import {
 import {
   BONUS_FACTION_PRIZES,
   FACTION_PRIZES,
+  getFactionScores,
   getFactionWeek,
   getPreviousWeek,
   getWeekNumber,
@@ -111,14 +112,13 @@ export const ChampionsLeaderboard: React.FC<Props> = ({ onClose }) => {
     return <Label type="formula">{t("leaderboard.resultsPending")}</Label>;
   }
 
-  const totals = leaderboard.marks.totalTickets;
+  const { winner } = getFactionScores({ leaderboard });
 
-  // Get faction with highest
-  const winningFaction = getKeys(totals).reduce((winner, name) => {
-    return totals[winner] > totals[name] ? winner : name;
-  }, "bumpkins");
+  if (!winner) {
+    return null;
+  }
 
-  const topRanks = leaderboard.marks.topTens[winningFaction];
+  const topRanks = leaderboard.marks.topTens[winner];
 
   const playerId = gameState.context.state.username ?? gameState.context.farmId;
 
@@ -131,7 +131,7 @@ export const ChampionsLeaderboard: React.FC<Props> = ({ onClose }) => {
         <Label type="formula">{`Week #${getWeekNumber() - 3}`}</Label>
       </div>
       <p className="text-sm mb-2 pl-1">
-        {t("leaderboard.congratulations", { faction: winningFaction })}
+        {t("leaderboard.congratulations", { faction: winner })}
       </p>
       <Label type="default" className="mb-2">
         {t("leaderboard.leaderboard")}
@@ -258,6 +258,7 @@ export const ChampionsPrizes: React.FC = () => {
         )}
       </div>
       <p className="text-xs mb-2">{t("leaderboard.faction.championPrizes")}</p>
+
       <table className="w-full text-xs table-auto border-collapse mb-2">
         <tbody>
           <tr>
@@ -274,6 +275,7 @@ export const ChampionsPrizes: React.FC = () => {
           </tr>
         </tbody>
       </table>
+
       <Label type="default" className="mb-2 ml-1" icon={gift}>
         {t("leaderboard.faction.topPlayers")}
       </Label>

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5503,7 +5503,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.faction.champion": "Champion faction",
   "leaderboard.faction.bonusPrizeWeek": "Bonus prize week",
   "leaderboard.faction.championPrizes":
-    "The players in the winning faction will receive:",
+    "Your factions score is calculated by how many marks the top 100 players earn. All players in the winning faction will receive:",
   "leaderboard.faction.bonusMarks": "Bonus +10% Marks",
   "leaderboard.faction.topPlayers": "Top Player Prizes",
   "leaderboard.faction.topPlayerPrizes":

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5503,7 +5503,7 @@ export const leaderboardTerms: Record<Leaderboard, string> = {
   "leaderboard.faction.champion": "Champion faction",
   "leaderboard.faction.bonusPrizeWeek": "Bonus prize week",
   "leaderboard.faction.championPrizes":
-    "Your factions score is calculated by how many marks the top 100 players earn. All players in the winning faction will receive:",
+    "Your faction score is calculated by how many marks the top 100 players earn. All players in the winning faction will receive:",
   "leaderboard.faction.bonusMarks": "Bonus +10% Marks",
   "leaderboard.faction.topPlayers": "Top Player Prizes",
   "leaderboard.faction.topPlayerPrizes":


### PR DESCRIPTION
# Description

This is the first of the faction balancing changes. We've investigated a few different options - the biggest area of discrepancy came from the amount of people in a faction.

Going forward, the Faction Score will be based on the top 100 warriors in each faction.

This levels the playing fields since it does not matter how many players are in each faction.

<img width="813" alt="Screenshot 2024-08-02 at 3 47 07 PM" src="https://github.com/user-attachments/assets/b827685f-50a3-4930-9197-d1b8dea9396b">
