### PR TITLE
[FIX] Improve CROP and CROP_SEEDS performance

### DIFF
--- a/src/features/game/events/landExpansion/collectCropReward.ts
+++ b/src/features/game/events/landExpansion/collectCropReward.ts
@@ -37,7 +37,7 @@ export function collectCropReward({
     throw new Error("Crop does not have a reward");
   }
 
-  const crop = CROPS()[plantedCrop.name];
+  const crop = CROPS[plantedCrop.name];
 
   if (createdAt - plantedCrop.plantedAt < crop.harvestSeconds * 1000) {
     throw new Error("Not ready");

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -86,7 +86,7 @@ export function fertilisePlot({
   // Apply buff if already planted
   const crop = plot.crop;
   if (crop) {
-    const cropDetails = crop && CROPS()[crop.name];
+    const cropDetails = crop && CROPS[crop.name];
     if (cropDetails && isReadyToHarvest(createdAt, crop, cropDetails)) {
       throw new Error(FERTILISE_CROP_ERRORS.READY_TO_HARVEST);
     }

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -49,7 +49,7 @@ export const isOvernightCrop = (cropName: CropName | GreenHouseCropName) => {
     return cropDetails.harvestSeconds >= CROPS["Radish"].harvestSeconds;
   }
 
-  const details = GREENHOUSE_CROPS()[cropName];
+  const details = GREENHOUSE_CROPS[cropName];
   return (
     details.harvestSeconds >= 24 * 60 * 60 &&
     details.harvestSeconds <= 36 * 60 * 60

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -26,8 +26,8 @@ type Options = {
 };
 
 export const isBasicCrop = (cropName: CropName) => {
-  const cropDetails = CROPS()[cropName];
-  return cropDetails.harvestSeconds <= CROPS()["Pumpkin"].harvestSeconds;
+  const cropDetails = CROPS[cropName];
+  return cropDetails.harvestSeconds <= CROPS["Pumpkin"].harvestSeconds;
 };
 
 export const isMediumCrop = (cropName: CropName) => {
@@ -35,18 +35,18 @@ export const isMediumCrop = (cropName: CropName) => {
 };
 
 export const isAdvancedCrop = (cropName: CropName) => {
-  const cropDetails = CROPS()[cropName];
-  return cropDetails.harvestSeconds >= CROPS()["Eggplant"].harvestSeconds;
+  const cropDetails = CROPS[cropName];
+  return cropDetails.harvestSeconds >= CROPS["Eggplant"].harvestSeconds;
 };
 
 function isCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in CROPS();
+  return (plant as CropName) in CROPS;
 }
 
 export const isOvernightCrop = (cropName: CropName | GreenHouseCropName) => {
   if (isCrop(cropName)) {
-    const cropDetails = CROPS()[cropName];
-    return cropDetails.harvestSeconds >= CROPS()["Radish"].harvestSeconds;
+    const cropDetails = CROPS[cropName];
+    return cropDetails.harvestSeconds >= CROPS["Radish"].harvestSeconds;
   }
 
   const details = GREENHOUSE_CROPS()[cropName];
@@ -68,7 +68,7 @@ export function isCropGrowing(plot: CropPlot) {
   const crop = plot.crop;
   if (!crop) return false;
 
-  const cropDetails = CROPS()[crop.name];
+  const cropDetails = CROPS[crop.name];
   return !isReadyToHarvest(Date.now(), crop, cropDetails);
 }
 
@@ -96,7 +96,7 @@ export function harvest({
 
   const { name: cropName, plantedAt, amount = 1, reward } = plot.crop;
 
-  const { harvestSeconds } = CROPS()[cropName];
+  const { harvestSeconds } = CROPS[cropName];
 
   if (createdAt - plantedAt < harvestSeconds * 1000) {
     throw new Error("Not ready");

--- a/src/features/game/events/landExpansion/harvestGreenHouse.ts
+++ b/src/features/game/events/landExpansion/harvestGreenHouse.ts
@@ -21,8 +21,8 @@ export const GREENHOUSE_CROP_TIME_SECONDS: Record<
   number
 > = {
   Grape: GREENHOUSE_FRUIT_SEEDS()["Grape Seed"].plantSeconds,
-  Olive: GREENHOUSE_CROPS().Olive.harvestSeconds,
-  Rice: GREENHOUSE_CROPS().Rice.harvestSeconds,
+  Olive: GREENHOUSE_CROPS.Olive.harvestSeconds,
+  Rice: GREENHOUSE_CROPS.Rice.harvestSeconds,
 };
 
 export function getReadyAt({

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -43,7 +43,7 @@ export function isLocked(
   if (!crop || !plantedAt) return false;
 
   const cropName = crop.name;
-  const cropDetails = CROPS()[cropName];
+  const cropDetails = CROPS[cropName];
 
   if (isReadyToHarvest(createdAt, crop, cropDetails)) return false;
 

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -367,7 +367,7 @@ describe("plant", () => {
     });
 
     // Should be twice as fast! (Planted in the past)
-    const parsnipTime = CROPS().Parsnip.harvestSeconds * 1000;
+    const parsnipTime = CROPS.Parsnip.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -496,7 +496,7 @@ describe("plant", () => {
     });
 
     // Should be twice as fast! (Planted in the past)
-    const carrotTime = CROPS().Carrot.harvestSeconds * 1000;
+    const carrotTime = CROPS.Carrot.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -536,7 +536,7 @@ describe("plant", () => {
       },
     });
 
-    const sunflowerTime = CROPS().Sunflower.harvestSeconds * 1000;
+    const sunflowerTime = CROPS.Sunflower.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -1592,7 +1592,7 @@ describe("plant", () => {
     expect(plots).toBeDefined();
 
     expect((plots as Record<number, CropPlot>)[0].crop?.plantedAt).toEqual(
-      dateNow - 0.1 * CROPS().Parsnip.harvestSeconds * 1000,
+      dateNow - 0.1 * CROPS.Parsnip.harvestSeconds * 1000,
     );
   });
 });
@@ -1634,7 +1634,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 10% speed boost with Lunar Calendar placed.", () => {
-    const carrotHarvestSeconds = CROPS()["Carrot"].harvestSeconds;
+    const carrotHarvestSeconds = CROPS["Carrot"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Carrot",
       inventory: {},
@@ -1659,7 +1659,7 @@ describe("getCropTime", () => {
   });
 
   it("grows cabbage twice as fast with Cabbage Girl placed.", () => {
-    const cabbageHarvestSeconds = CROPS()["Cabbage"].harvestSeconds;
+    const cabbageHarvestSeconds = CROPS["Cabbage"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Cabbage",
       buds: {},
@@ -1684,7 +1684,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 25% speed boost with Obie placed", () => {
-    const baseHarvestSeconds = CROPS()["Eggplant"].harvestSeconds;
+    const baseHarvestSeconds = CROPS["Eggplant"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Eggplant",
       inventory: {},
@@ -1747,7 +1747,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 25% speed boost with Kernaldo placed", () => {
-    const baseHarvestSeconds = CROPS()["Corn"].harvestSeconds;
+    const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Corn",
       inventory: {},
@@ -1772,7 +1772,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Sunflower", () => {
-    const sunflowerHarvestSeconds = CROPS()["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -1798,7 +1798,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Potato", () => {
-    const potatoHarvestSeconds = CROPS()["Potato"].harvestSeconds;
+    const potatoHarvestSeconds = CROPS["Potato"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Potato",
@@ -1824,7 +1824,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Pumpkin", () => {
-    const pumpkinHarvestSeconds = CROPS()["Pumpkin"].harvestSeconds;
+    const pumpkinHarvestSeconds = CROPS["Pumpkin"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Pumpkin",
@@ -1850,7 +1850,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow if not basic crop", () => {
-    const beetrootHarvestSeconds = CROPS()["Beetroot"].harvestSeconds;
+    const beetrootHarvestSeconds = CROPS["Beetroot"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Beetroot",
@@ -1876,7 +1876,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow placed, if plot is outside AOE", () => {
-    const sunflowerHarvestSeconds = CROPS()["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -1902,7 +1902,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow placed, if it was moved within 10min", () => {
-    const sunflowerHarvestSeconds = CROPS()["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -2568,7 +2568,7 @@ describe("getCropYield", () => {
 
     it("applies the harvest hourglass boost of -25% crop growth time for 6 hours", () => {
       const now = Date.now();
-      const baseHarvestSeconds = CROPS()["Corn"].harvestSeconds;
+      const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
 
       const time = getPlantedAt({
         crop: "Corn",

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -181,7 +181,7 @@ export const getCropPlotTime = ({
   plot?: CropPlot;
   fertiliser?: CropCompostName;
 }) => {
-  let seconds = CROPS()[crop]?.harvestSeconds ?? 0;
+  let seconds = CROPS[crop]?.harvestSeconds ?? 0;
 
   if (game.bumpkin === undefined) return seconds;
 
@@ -287,7 +287,7 @@ export function getPlantedAt({
 }: GetPlantedAtArgs): number {
   if (!crop) return 0;
 
-  const cropTime = CROPS()[crop].harvestSeconds;
+  const cropTime = CROPS[crop].harvestSeconds;
   const boostedTime = getCropPlotTime({
     crop,
     inventory,
@@ -303,7 +303,7 @@ export function getPlantedAt({
 }
 
 function isPlotCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in CROPS();
+  return (plant as CropName) in CROPS;
 }
 
 /**

--- a/src/features/game/events/landExpansion/plantGreenhouse.ts
+++ b/src/features/game/events/landExpansion/plantGreenhouse.ts
@@ -64,7 +64,7 @@ export const OIL_USAGE: Record<GreenhouseSeed, number> = {
 export const MAX_POTS = 4;
 
 export function isGreenhouseCrop(plant: Resource): plant is GreenHouseCropName {
-  return (plant as GreenHouseCropName) in GREENHOUSE_CROPS();
+  return (plant as GreenHouseCropName) in GREENHOUSE_CROPS;
 }
 
 export function isGreenhouseFruit(

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -60,7 +60,7 @@ export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
     throw new Error(REMOVE_CROP_ERRORS.NO_SHOVEL_AVAILABLE);
   }
 
-  const cropDetails = CROPS()[crop.name];
+  const cropDetails = CROPS[crop.name];
   if (isReadyToHarvest(createdAt, crop, cropDetails)) {
     throw new Error(REMOVE_CROP_ERRORS.READY_TO_HARVEST);
   }

--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -111,7 +111,7 @@ describe("seedBought", () => {
     });
 
     expect(state.balance).toEqual(balance);
-    expect(state.coins).toEqual(coins - CROP_SEEDS()["Sunflower Seed"].price);
+    expect(state.coins).toEqual(coins - CROP_SEEDS["Sunflower Seed"].price);
   });
 
   it("adds the newly bought seed to a players inventory", () => {
@@ -157,7 +157,7 @@ describe("seedBought", () => {
 
     const oldAmount = GAME_STATE.inventory[item] ?? new Decimal(0);
 
-    expect(state.coins).toEqual(coins - CROP_SEEDS()[item].price);
+    expect(state.coins).toEqual(coins - CROP_SEEDS[item].price);
     expect(state.inventory[item]).toEqual(oldAmount.add(amount));
   });
 
@@ -183,7 +183,7 @@ describe("seedBought", () => {
 
     const oldAmount = GAME_STATE.inventory[item] ?? new Decimal(0);
 
-    expect(state.coins).toEqual(coins - CROP_SEEDS()[item].price * amount);
+    expect(state.coins).toEqual(coins - CROP_SEEDS[item].price * amount);
     expect(state.inventory[item]).toEqual(oldAmount.add(amount));
   });
 
@@ -216,7 +216,7 @@ describe("seedBought", () => {
       },
     });
     expect(state.bumpkin?.activity?.["Coins Spent"]).toEqual(
-      CROP_SEEDS()["Sunflower Seed"].price,
+      CROP_SEEDS["Sunflower Seed"].price,
     );
   });
 

--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -76,7 +76,7 @@ describe("sell", () => {
     });
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(4));
-    expect(state.coins).toEqual(GAME_STATE.coins + CROPS().Sunflower.sellPrice);
+    expect(state.coins).toEqual(GAME_STATE.coins + CROPS.Sunflower.sellPrice);
   });
 
   it("sell an item in bulk given sufficient quantity", () => {
@@ -97,7 +97,7 @@ describe("sell", () => {
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(1));
     expect(state.coins).toEqual(
-      GAME_STATE.coins + CROPS().Sunflower.sellPrice * 10,
+      GAME_STATE.coins + CROPS.Sunflower.sellPrice * 10,
     );
   });
 
@@ -135,7 +135,7 @@ describe("sell", () => {
       },
     });
 
-    expect(state.coins).toEqual(CROPS().Cauliflower.sellPrice);
+    expect(state.coins).toEqual(CROPS.Cauliflower.sellPrice);
   });
 
   it("increments coins earned when cauliflower is sold", () => {
@@ -154,7 +154,7 @@ describe("sell", () => {
     });
 
     expect(state.bumpkin?.activity?.["Coins Earned"]).toEqual(
-      CROPS().Cauliflower.sellPrice,
+      CROPS.Cauliflower.sellPrice,
     );
   });
 

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -22,9 +22,9 @@ export type SellCropAction = {
 };
 
 export const SELLABLE = {
-  ...CROPS(),
+  ...CROPS,
   ...FRUIT(),
-  ...GREENHOUSE_CROPS(),
+  ...GREENHOUSE_CROPS,
   ...GREENHOUSE_FRUIT(),
 };
 

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -75,7 +75,7 @@ export function calculateCropTime(seeds: {
 }): number {
   const cropName = seeds.type.split(" ")[0] as CropName;
 
-  const milliSeconds = CROPS()[cropName].harvestSeconds * 1000;
+  const milliSeconds = CROPS[cropName].harvestSeconds * 1000;
 
   return (milliSeconds * seeds.amount) / CROP_MACHINE_PLOTS;
 }

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -24,7 +24,7 @@ export const MINIGAME_CURRENCY_LIMITS: Record<MinigameCurrency, number> = {
     (acc, name) => ({ ...acc, [name]: 1000 }),
     {} as Record<CommodityName, number>,
   ),
-  ...getKeys(CROPS()).reduce(
+  ...getKeys(CROPS).reduce(
     (acc, name) => ({ ...acc, [name]: 1000 }),
     {} as Record<CropName, number>,
   ),

--- a/src/features/game/expansion/components/TravelTeaser.tsx
+++ b/src/features/game/expansion/components/TravelTeaser.tsx
@@ -44,7 +44,7 @@ const hint = (state: MachineState) => {
     return translate("expand.land");
   }
 
-  const harvestedCrops = getKeys(CROPS()).reduce(
+  const harvestedCrops = getKeys(CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Harvested`] ?? 0),
     0,
   );
@@ -53,7 +53,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.three");
   }
 
-  const soldCrops = getKeys(CROPS()).reduce(
+  const soldCrops = getKeys(CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Sold`] ?? 0),
     0,
   );
@@ -62,7 +62,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.four");
   }
 
-  const boughtCrops = getKeys(CROPS()).reduce(
+  const boughtCrops = getKeys(CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Seed Bought`] ?? 0),
     0,
   );
@@ -71,7 +71,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.five");
   }
 
-  const plantedCrops = getKeys(CROPS()).reduce(
+  const plantedCrops = getKeys(CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Planted`] ?? 0),
     0,
   );

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -9,7 +9,7 @@ describe("boosts", () => {
   it("applies crop shortage price", () => {
     expect(
       getSellPrice({
-        item: CROPS().Sunflower,
+        item: CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           inventory: { "Basic Land": new Decimal(3) },
@@ -17,14 +17,14 @@ describe("boosts", () => {
         },
         now: new Date(),
       }),
-    ).toEqual(CROPS().Sunflower.sellPrice * 2);
+    ).toEqual(CROPS.Sunflower.sellPrice * 2);
   });
 
   it("removes crop shortage price after 2 hours", () => {
     const now = new Date();
     expect(
       getSellPrice({
-        item: CROPS().Sunflower,
+        item: CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           inventory: { "Basic Land": new Decimal(3) },
@@ -33,7 +33,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS().Sunflower.sellPrice);
+    ).toEqual(CROPS.Sunflower.sellPrice);
   });
 
   it("applies special event pricing", () => {

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -19,7 +19,7 @@ import { isWearableActive } from "features/game/lib/wearables";
 import { SellableItem } from "features/game/events/landExpansion/sellCrop";
 import { getFactionPetBoostMultiplier } from "features/game/lib/factions";
 
-const crops = CROPS();
+const crops = CROPS;
 
 export function isCropShortage({ game }: { game: GameState }) {
   const bumpkinLevel = getBumpkinLevel(game.bumpkin?.experience ?? 0);
@@ -69,7 +69,7 @@ export const getSellPrice = ({
   const isCropShortage =
     game.createdAt + CROP_SHORTAGE_HOURS * 60 * 60 * 1000 > now.getTime();
 
-  if (item.name in CROPS() && isCropShortage) {
+  if (item.name in CROPS && isCropShortage) {
     price = price * 2;
   }
 

--- a/src/features/game/lib/conversion.ts
+++ b/src/features/game/lib/conversion.ts
@@ -12,12 +12,12 @@ import { FLOWER_SEEDS } from "../types/flowers";
  */
 export function getItemUnit(name: InventoryItemName) {
   if (
-    name in CROPS() ||
+    name in CROPS ||
     name in FRUIT() ||
-    name in GREENHOUSE_CROPS() ||
+    name in GREENHOUSE_CROPS ||
     name in GREENHOUSE_FRUIT() ||
     name in COMMODITIES ||
-    name in CROP_SEEDS() ||
+    name in CROP_SEEDS ||
     name in FRUIT_SEEDS() ||
     name in FLOWER_SEEDS() ||
     name in TOOLS ||

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -28,11 +28,11 @@ export type Resource =
   | GreenHouseFruitName;
 
 export const isPlotCrop = (resource: Resource): resource is CropName => {
-  return resource in CROPS();
+  return resource in CROPS;
 };
 
 export const isCrop = (resource: Resource): resource is CropName => {
-  return resource in CROPS() || resource in GREENHOUSE_CROPS();
+  return resource in CROPS || resource in GREENHOUSE_CROPS;
 };
 
 const isMineral = (resource: Resource): boolean => {

--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -121,7 +121,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Farm Hand": {
     description: translate("farmHand.description"),
     progress: (gameState: GameState) => {
-      const harvestEvents = getKeys(CROPS()).map(
+      const harvestEvents = getKeys(CROPS).map(
         (name) => `${name} Harvested` as HarvestEvent,
       );
 
@@ -205,7 +205,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Crop Champion": {
     description: translate("cropChampion.description"),
     progress: (gameState: GameState) => {
-      const harvestEvents = getKeys(CROPS()).map(
+      const harvestEvents = getKeys(CROPS).map(
         (name) => `${name} Harvested` as HarvestEvent,
       );
 

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -37,10 +37,7 @@ export type GreenHouseCrop = {
   disabled?: boolean;
 };
 
-export const GREENHOUSE_CROPS: () => Record<
-  GreenHouseCropName,
-  GreenHouseCrop
-> = () => ({
+export const GREENHOUSE_CROPS: Record<GreenHouseCropName, GreenHouseCrop> = {
   Rice: {
     sellPrice: 320,
     harvestSeconds: 32 * 60 * 60,
@@ -55,12 +52,9 @@ export const GREENHOUSE_CROPS: () => Record<
     description: "Zesty with a rich history.",
     bumpkinLevel: 10,
   },
-});
+};
 
-export const GREENHOUSE_SEEDS: () => Record<
-  GreenHouseCropSeedName,
-  Seed
-> = () => ({
+export const GREENHOUSE_SEEDS: Record<GreenHouseCropSeedName, Seed> = {
   "Rice Seed": {
     price: 240,
     description: "A staple food for many.",
@@ -75,7 +69,7 @@ export const GREENHOUSE_SEEDS: () => Record<
     plantSeconds: 44 * 60 * 60,
     plantingSpot: "Greenhouse",
   },
-});
+};
 
 export type GreenHouseCropSeedName = `${GreenHouseCropName} Seed`;
 

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -82,7 +82,7 @@ export type GreenHouseCropSeedName = `${GreenHouseCropName} Seed`;
 /**
  * Crops and their original prices
  */
-export const CROPS: () => Record<CropName, Crop> = () => ({
+export const CROPS: Record<CropName, Crop> = {
   Sunflower: {
     name: "Sunflower",
     description: translate("description.sunflower"),
@@ -181,11 +181,11 @@ export const CROPS: () => Record<CropName, Crop> = () => ({
     bumpkinLevel: 7,
     harvestSeconds: 36 * 60 * 60,
   },
-});
+};
 
 export type CropSeedName = `${CropName} Seed`;
 
-export const CROP_SEEDS: () => Record<CropSeedName, Seed> = () => ({
+export const CROP_SEEDS: Record<CropSeedName, Seed> = {
   "Sunflower Seed": {
     price: 0.01,
     description: translate("description.sunflower"),
@@ -298,4 +298,4 @@ export const CROP_SEEDS: () => Record<CropSeedName, Seed> = () => ({
     yield: "Kale",
     plantingSpot: "Crop Plot",
   },
-});
+};

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -701,8 +701,8 @@ export interface ItemDetails {
 
 type Items = Record<InventoryItemName | AchievementName, ItemDetails>;
 
-const crops = CROPS();
-const seeds = CROP_SEEDS();
+const crops = CROPS;
+const seeds = CROP_SEEDS;
 export const ITEM_DETAILS: Items = {
   Sunflower: {
     image: CROP_LIFECYCLE.Sunflower.crop,

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -40,7 +40,7 @@ export type Seed = {
 };
 
 export const SEEDS: () => Record<SeedName, Seed> = () => ({
-  ...CROP_SEEDS(),
+  ...CROP_SEEDS,
   ...FRUIT_SEEDS(),
   ...FLOWER_SEEDS(),
   ...GREENHOUSE_FRUIT_SEEDS(),

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -44,5 +44,5 @@ export const SEEDS: () => Record<SeedName, Seed> = () => ({
   ...FRUIT_SEEDS(),
   ...FLOWER_SEEDS(),
   ...GREENHOUSE_FRUIT_SEEDS(),
-  ...GREENHOUSE_SEEDS(),
+  ...GREENHOUSE_SEEDS,
 });

--- a/src/features/goblins/storageHouse/lib/storageItems.ts
+++ b/src/features/goblins/storageHouse/lib/storageItems.ts
@@ -21,7 +21,7 @@ export function getDeliverableItems({ game }: { game: GameState }) {
   return (Object.keys(inventory) as InventoryItemName[]).reduce(
     (acc, itemName) => {
       const isDeliverable =
-        itemName in CROPS() ||
+        itemName in CROPS ||
         itemName in FRUIT() ||
         (itemName in COMMODITIES &&
           itemName !== "Chicken" &&
@@ -57,7 +57,7 @@ export function getBankItems(game: GameState) {
   return (Object.keys(inventory) as InventoryItemName[]).reduce(
     (acc, itemName) => {
       if (
-        itemName in CROPS() ||
+        itemName in CROPS ||
         itemName in FRUIT() ||
         (itemName in COMMODITIES && itemName !== "Chicken")
       ) {

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -54,7 +54,7 @@ interface Props {
   onAddOil: (oil: number) => void;
 }
 
-const ALLOWED_SEEDS: CropSeedName[] = getKeys(CROP_SEEDS()).filter((seed) => {
+const ALLOWED_SEEDS: CropSeedName[] = getKeys(CROP_SEEDS).filter((seed) => {
   const crop = seed.split(" ")[0] as CropName;
 
   return isBasicCrop(crop);

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -37,7 +37,7 @@ export const isExoticCrop = (
 
 export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<Crop | Fruit | ExoticCrop>(
-    CROPS().Sunflower,
+    CROPS.Sunflower,
   );
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
@@ -128,11 +128,11 @@ export const Crops: React.FC = () => {
     );
 
   const cropsAndFruits = Object.values({
-    ...CROPS(),
+    ...CROPS,
     ...FRUIT(),
     ...exotics,
     ...GREENHOUSE_FRUIT(),
-    ...GREENHOUSE_CROPS(),
+    ...GREENHOUSE_CROPS,
   }) as Crop[];
 
   return (
@@ -217,7 +217,7 @@ export const Crops: React.FC = () => {
             </div>
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
-                .filter((crop) => !!crop.sellPrice && crop.name in CROPS())
+                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
                 .map((item) => (
                   <Box
                     isSelected={selected.name === item.name}
@@ -301,7 +301,7 @@ export const Crops: React.FC = () => {
                   .filter(
                     (crop) =>
                       !!crop.sellPrice &&
-                      (crop.name in GREENHOUSE_CROPS() ||
+                      (crop.name in GREENHOUSE_CROPS ||
                         crop.name in GREENHOUSE_FRUIT()),
                   )
                   .map((item) => (

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -35,7 +35,7 @@ const hasSoldCropsBefore = (bumpkin?: Bumpkin) => {
 
   const { activity = {} } = bumpkin;
 
-  return !!getKeys(CROPS()).find((crop) =>
+  return !!getKeys(CROPS).find((crop) =>
     getKeys(activity).includes(`${crop} Sold`),
   );
 };
@@ -45,7 +45,7 @@ const hasBoughtCropsBefore = (bumpkin?: Bumpkin) => {
 
   const { activity = {} } = bumpkin;
 
-  return !!getKeys(CROPS()).find((crop) =>
+  return !!getKeys(CROPS).find((crop) =>
     getKeys(activity).includes(`${crop} Seed Bought`),
   );
 };

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -222,7 +222,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
       );
 
     if (
-      selectedName in GREENHOUSE_SEEDS() ||
+      selectedName in GREENHOUSE_SEEDS ||
       selectedName in GREENHOUSE_FRUIT_SEEDS()
     ) {
       const plant = SEED_TO_PLANT[selectedName as GreenHouseCropSeedName];
@@ -371,7 +371,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
                 {seeds
                   .filter(
                     (name) =>
-                      name in GREENHOUSE_SEEDS() ||
+                      name in GREENHOUSE_SEEDS ||
                       name in GREENHOUSE_FRUIT_SEEDS(),
                   )
                   .map((name: SeedName) => (

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -290,7 +290,7 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
           </Label>
           <div className="flex flex-wrap mb-2">
             {seeds
-              .filter((name) => name in CROP_SEEDS())
+              .filter((name) => name in CROP_SEEDS)
               .map((name: SeedName) => (
                 <Box
                   isSelected={selectedName === name}

--- a/src/features/island/bumpkin/components/LevelUp.tsx
+++ b/src/features/island/bumpkin/components/LevelUp.tsx
@@ -73,8 +73,8 @@ function generateUnlockLabels(): Record<
   const unlocks = levels.reduce(
     (acc, id) => {
       const level = Number(id);
-      const crops = getKeys(CROPS())
-        .filter((name) => CROPS()[name].bumpkinLevel === level)
+      const crops = getKeys(CROPS)
+        .filter((name) => CROPS[name].bumpkinLevel === level)
         .map((name) => ({ text: name, icon: ITEM_DETAILS[name].image }));
 
       const buildings = getKeys(BUILDINGS)

--- a/src/features/island/common/chest-reward/StopTheGoblins.tsx
+++ b/src/features/island/common/chest-reward/StopTheGoblins.tsx
@@ -75,7 +75,7 @@ const generateImages = (
   let resourceImages;
   if (isMoonSeekerMode) {
     resourceImages = [
-      ...getKeys(CROPS()),
+      ...getKeys(CROPS),
       ...getKeys(FRUIT()),
       ...getKeys(COMMODITIES),
     ];

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -100,7 +100,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   ): selected is FruitSeedName => selected in FRUIT_SEEDS();
   const isSeed = (selected: InventoryItemName): selected is SeedName =>
     isFruitSeed(selected) ||
-    selected in CROP_SEEDS() ||
+    selected in CROP_SEEDS ||
     selected in FLOWER_SEEDS() ||
     selected in GREENHOUSE_SEEDS() ||
     selected in GREENHOUSE_FRUIT_SEEDS();
@@ -151,14 +151,14 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     return getKeys(items).filter((item) => item in basketMap);
   };
 
-  const seeds = getItems(CROP_SEEDS());
+  const seeds = getItems(CROP_SEEDS);
   const fruitSeeds = getItems(FRUIT_SEEDS());
   const greenhouseSeeds = [
     ...getItems(GREENHOUSE_FRUIT_SEEDS()),
     ...getItems(GREENHOUSE_SEEDS()),
   ];
   const flowerSeeds = getItems(FLOWER_SEEDS());
-  const crops = [...getItems(CROPS()), ...getItems(GREENHOUSE_CROPS())];
+  const crops = [...getItems(CROPS), ...getItems(GREENHOUSE_CROPS)];
   const fruits = [...getItems(FRUIT()), ...getItems(GREENHOUSE_FRUIT())];
   const flowers = getItems(FLOWERS);
   const workbenchTools = getItems(WORKBENCH_TOOLS);

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -102,7 +102,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     isFruitSeed(selected) ||
     selected in CROP_SEEDS ||
     selected in FLOWER_SEEDS() ||
-    selected in GREENHOUSE_SEEDS() ||
+    selected in GREENHOUSE_SEEDS ||
     selected in GREENHOUSE_FRUIT_SEEDS();
   const isFood = (selected: InventoryItemName) => selected in CONSUMABLES;
 
@@ -118,10 +118,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
         (gameState.bumpkin as Bumpkin)?.equipped ?? {},
       );
     }
-    if (
-      seedName in GREENHOUSE_SEEDS() ||
-      seedName in GREENHOUSE_FRUIT_SEEDS()
-    ) {
+    if (seedName in GREENHOUSE_SEEDS || seedName in GREENHOUSE_FRUIT_SEEDS()) {
       const plant = SEED_TO_PLANT[seedName as GreenHouseCropSeedName];
       const seconds = getGreenhouseCropTime({
         crop: plant,
@@ -155,7 +152,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   const fruitSeeds = getItems(FRUIT_SEEDS());
   const greenhouseSeeds = [
     ...getItems(GREENHOUSE_FRUIT_SEEDS()),
-    ...getItems(GREENHOUSE_SEEDS()),
+    ...getItems(GREENHOUSE_SEEDS),
   ];
   const flowerSeeds = getItems(FLOWER_SEEDS());
   const crops = [...getItems(CROPS), ...getItems(GREENHOUSE_CROPS)];

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -57,8 +57,7 @@ const selectLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 const selectHarvests = (state: MachineState) => {
-  const crops = CROPS;
-  return getKeys(crops).reduce(
+  return getKeys(CROPS).reduce(
     (total, crop) =>
       total +
       (state.context.state.bumpkin?.activity?.[`${crop} Harvested`] ?? 0),

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -56,16 +56,18 @@ const selectBuildings = (state: MachineState) => state.context.state.buildings;
 const selectLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
-const selectHarvests = (state: MachineState) =>
-  getKeys(CROPS()).reduce(
+const selectHarvests = (state: MachineState) => {
+  const crops = CROPS;
+  return getKeys(crops).reduce(
     (total, crop) =>
       total +
       (state.context.state.bumpkin?.activity?.[`${crop} Harvested`] ?? 0),
     0,
   );
+};
 
 const selectPlants = (state: MachineState) =>
-  getKeys(CROPS()).reduce(
+  getKeys(CROPS).reduce(
     (total, crop) =>
       total + (state.context.state.bumpkin?.activity?.[`${crop} Planted`] ?? 0),
     0,
@@ -207,7 +209,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
 
     // increase touch count if there is a reward
     const readyToHarvest =
-      !!crop && isReadyToHarvest(now, crop, CROPS()[crop.name]);
+      !!crop && isReadyToHarvest(now, crop, CROPS[crop.name]);
 
     if (crop?.reward && readyToHarvest) {
       if (touchCount < 1) {
@@ -242,7 +244,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     if (!crop) {
       if (
         hasFeatureAccess(state, "CROP_QUICK_SELECT") &&
-        (!seed || !(seed in CROP_SEEDS()) || !inventory[seed]?.gte(1))
+        (!seed || !(seed in CROP_SEEDS) || !inventory[seed]?.gte(1))
       ) {
         setShowQuickSelect(true);
         return;
@@ -309,9 +311,9 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
       >
         <QuickSelect
           icon={SUNNYSIDE.icons.seeds}
-          options={getKeys(CROP_SEEDS()).map((seed) => ({
+          options={getKeys(CROP_SEEDS).map((seed) => ({
             name: seed as InventoryItemName,
-            icon: CROP_SEEDS()[seed].yield as InventoryItemName,
+            icon: CROP_SEEDS[seed].yield as InventoryItemName,
           }))}
           onClose={() => setShowQuickSelect(false)}
           onSelected={(seed) => {

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -60,7 +60,7 @@ const FertilePlotComponent: React.FC<Props> = ({
 
   const [_, setRender] = useState<number>(0);
 
-  let harvestSeconds = cropName ? CROPS()[cropName].harvestSeconds : 0;
+  let harvestSeconds = cropName ? CROPS[cropName].harvestSeconds : 0;
   const readyAt = plantedAt ? plantedAt + harvestSeconds * 1000 : 0;
 
   let startAt = plantedAt ?? 0;

--- a/src/features/island/plots/components/SeedSelection.tsx
+++ b/src/features/island/plots/components/SeedSelection.tsx
@@ -19,7 +19,7 @@ export const SeedSelection: React.FC<Props> = ({ onPlant, inventory }) => {
 
   const [seed, setSeed] = useState<SeedName>();
 
-  const availableSeeds = getKeys(CROP_SEEDS()).filter((name) =>
+  const availableSeeds = getKeys(CROP_SEEDS).filter((name) =>
     inventory[name]?.gte(1),
   );
 


### PR DESCRIPTION
# Description

Removes `CROP` and `CROP_SEEDS` thunks. In `Plot.tsx`, these are calling translations over and over again, causing poor performance.

These thunks are no longer needed as we do not do dynamic pricing anymore.

## Screenshots:

Harvest Crop Before:

<img width="318" alt="slow" src="https://github.com/user-attachments/assets/b5d40176-5e8b-4295-afc6-c0dc839f017f">


Harvest Crop After:

<img width="292" alt="2" src="https://github.com/user-attachments/assets/7b9f64d9-e8cc-4998-888d-014dcb89249a">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
