### PR TITLE
[FIX] Fix bugs related to scene transitions, beach HUD, and dug items

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -18,7 +18,12 @@ import { PlazaScene } from "./scenes/PlazaScene";
 
 import { InteractableModals } from "./ui/InteractableModals";
 import { NPCModals } from "./ui/NPCModals";
-import { MachineInterpreter, MachineState, mmoBus } from "./mmoMachine";
+import {
+  MachineInterpreter,
+  MachineState,
+  mmoBus,
+  SceneId,
+} from "./mmoMachine";
 import { Context } from "features/game/GameProvider";
 import { Modal } from "components/ui/Modal";
 import { InnerPanel, Panel } from "components/ui/Panel";
@@ -29,7 +34,6 @@ import { EquipBumpkinAction } from "features/game/events/landExpansion/equip";
 import { Label } from "components/ui/Label";
 import { CommunityModals } from "./ui/CommunityModalManager";
 import { CommunityToasts } from "./ui/CommunityToastManager";
-import { SceneId } from "./mmoMachine";
 import { useNavigate } from "react-router-dom";
 import { PlayerModals } from "./ui/PlayerModals";
 import { prepareAPI } from "features/community/lib/CommunitySDK";
@@ -272,6 +276,10 @@ export const PhaserComponent: React.FC<Props> = ({
     if (activeScene) {
       activeScene.scene.start(route);
       mmoService.send("SWITCH_SCENE", { sceneId: route });
+      mmoService.send("UPDATE_PREVIOUS_SCENE", {
+        previousSceneId:
+          game.current?.scene.getScenes(true)[0]?.scene.key ?? scene,
+      });
     }
   }, [route]);
 

--- a/src/features/world/World.tsx
+++ b/src/features/world/World.tsx
@@ -86,6 +86,11 @@ export const MMO: React.FC<MMOProps> = ({ isCommunity }) => {
       username: gameState.context.state.username,
     },
   }) as unknown as MMOMachineInterpreter;
+  const [mmoState] = useActor(mmoService);
+
+  useEffect(() => {
+    navigate(`/world/${mmoState.context.sceneId}`);
+  }, [mmoState.context.sceneId]);
 
   // We need to listen to events outside of MMO scope (Settings Panel)
   useEffect(() => {

--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -121,6 +121,7 @@ export interface MMOContext {
   server?: Room<PlazaRoomState> | undefined;
   serverId: ServerId;
   sceneId: SceneId;
+  previousSceneId: SceneId | null;
   experience: number;
   isCommunity?: boolean;
   moderation: Moderation;
@@ -155,6 +156,11 @@ export type SwitchScene = {
   sceneId: SceneId;
 };
 
+export type UpdatePreviousScene = {
+  type: "UPDATE_PREVIOUS_SCENE";
+  previousSceneId: SceneId;
+};
+
 export type MMOEvent =
   | PickServer
   | { type: "CONTINUE" }
@@ -162,7 +168,8 @@ export type MMOEvent =
   | { type: "RETRY" }
   | { type: "CHANGE_SERVER" }
   | ConnectEvent
-  | SwitchScene;
+  | SwitchScene
+  | UpdatePreviousScene;
 
 export type MachineState = State<MMOContext, MMOEvent, MMOState>;
 
@@ -183,6 +190,7 @@ export const mmoMachine = createMachine<MMOContext, MMOEvent, MMOState>({
     availableServers: SERVERS,
     serverId: "sunflorea_bliss",
     sceneId: "plaza",
+    previousSceneId: null,
     experience: 0,
     isCommunity: false,
     moderation: {
@@ -404,6 +412,11 @@ export const mmoMachine = createMachine<MMOContext, MMOEvent, MMOState>({
         }),
         (context, event) => context.server?.send(0, { sceneId: event.sceneId }),
       ],
+    },
+    UPDATE_PREVIOUS_SCENE: {
+      actions: assign({
+        previousSceneId: (_, event) => event.previousSceneId,
+      }),
     },
   },
 });

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -35,10 +35,6 @@ import { MachineInterpreter } from "features/game/lib/gameMachine";
 import { MachineInterpreter as AuthMachineInterpreter } from "features/auth/lib/authMachine";
 import { capitalize } from "lib/utils/capitalize";
 
-type SceneTransitionData = {
-  previousSceneId: SceneId;
-};
-
 export type NPCBumpkin = {
   x: number;
   y: number;
@@ -92,7 +88,6 @@ export abstract class BaseScene extends Phaser.Scene {
   eventListener?: (event: EventObject) => void;
 
   public joystick?: VirtualJoystick;
-  private sceneTransitionData?: SceneTransitionData;
   private switchToScene?: SceneId;
   private options: Required<BaseSceneOptions>;
 
@@ -177,10 +172,6 @@ export abstract class BaseScene extends Phaser.Scene {
     }
   }
 
-  init(data: SceneTransitionData) {
-    this.sceneTransitionData = data;
-  }
-
   create() {
     const errorLogger = createErrorLogger("phaser_base_scene", Number(this.id));
 
@@ -196,7 +187,7 @@ export abstract class BaseScene extends Phaser.Scene {
         this.initialiseControls();
       }
 
-      const from = this.sceneTransitionData?.previousSceneId as SceneId;
+      const from = this.mmoService?.state.context.previousSceneId as SceneId;
 
       let spawn = this.options.player.spawn;
 
@@ -1034,7 +1025,6 @@ export abstract class BaseScene extends Phaser.Scene {
 
       // this.mmoService?.state.context.server?.send(0, { sceneId: warpTo });
       this.mmoService?.send("SWITCH_SCENE", { sceneId: warpTo });
-      this.scene.start(warpTo, { previousSceneId: this.sceneId });
     }
   }
   updateOtherPlayers() {

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -604,12 +604,14 @@ export class BeachScene extends BaseScene {
       const existing = this.dugItems.find(
         (item) => item.x === offsetX && item.y === offsetY,
       );
+
       if (existing) {
-        existing.setTexture(key);
-      } else {
-        const image = this.add.image(offsetX, offsetY, key).setScale(0.8);
-        this.dugItems.push(image);
+        existing.destroy();
+        this.dugItems = this.dugItems.filter((item) => item !== existing);
       }
+
+      const image = this.add.image(offsetX, offsetY, key).setScale(0.8);
+      this.dugItems.push(image);
     });
 
     // Clean up any sprites that are no longer in game state


### PR DESCRIPTION
# Description

There were some bugs when transitioning between scenes, so the method for changing scenes was replaced from `this.scene.start(warpTo, { previousSceneId: this.sceneId })` to using the `useNavigate()` hook when the `SWITCH_SCENE` event is triggered. Consequently, the `UPDATE_PREVIOUS_SCENE` event was added to update the `previousSceneId` state and identify the spawn position based on the previous scene, as it worked before.

By updating the transitions this way, the HUDs for each scene will remain in their respective scenes and avoid the following situation:

| Beach HUD in the Plaza |
| -------------------------- |
| ![HUD de beach en la plaza](https://github.com/user-attachments/assets/5f5ed539-0e62-4ec9-af48-fb33b88d7a72) |

Additionally, a bug was fixed where the sprites of dug items were not rendering in cases where the player moved around the map and returned to the beach. Test route (always travel with the minimap):

- Dig in Pharaoh's puzzle -> Home -> Beach (check that the sprites of dug items are still there) -> Plaza -> Retreat -> Beach (check that the sprites of dug items disappear)

| Before the test route | After the test route |
| -------------------------- | -------------------------- |
| ![Full Pharaoh's puzzle](https://github.com/user-attachments/assets/cdbfe317-8fa3-4c34-be8d-479d61cef3b7) | ![Empty Pharaoh's puzzle](https://github.com/user-attachments/assets/14ed0249-c6f3-427d-934a-26fb81642cbc) |

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Travel across the map without using the minimap
- Perform the route: Dig in Pharaoh's puzzle -> Home -> Beach (check that the sprites of dug items are still there) -> Plaza -> Retreat -> Beach (check that the sprites of dug items disappear)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
