### PR TITLE
[FEAT] Allow Withdrawals of extra wearables

### DIFF
--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -130,27 +130,7 @@ export const WithdrawItems: React.FC<Props> = ({
     <>
       <div className="mt-3">
         <div className="flex items-center border-2 rounded-md border-black p-2 bg-green-background mb-3">
-          <span className="text-xs">
-            {t("withdraw.restricted")}{" "}
-            <a
-              href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-blue-500"
-            >
-              {"in use"}
-            </a>
-            {" or are "}
-            <a
-              href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-blue-500"
-            >
-              {"still being built"}
-            </a>
-            {"."}
-          </span>
+          <span className="text-xs">{t("withdraw.restricted")}</span>
         </div>
         <h2 className="mb-3">{t("withdraw.select.item")}</h2>
         <div className="flex flex-wrap h-fit -ml-1.5">

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -57,7 +57,7 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
     }, {} as Wardrobe);
 
     setWardrobe(available);
-  }, []);
+  }, [gameState.context.state]);
 
   const withdraw = () => {
     const ids = getKeys(selected).map((item) => ITEM_IDS[item]);
@@ -84,10 +84,15 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
       [itemName]: (prev[itemName] ?? 0) + 1,
     }));
 
-    setSelected((prev) => ({
-      ...prev,
-      [itemName]: (prev[itemName] ?? 0) - 1,
-    }));
+    setSelected((prev) => {
+      const newSelected = { ...prev };
+      if (newSelected[itemName] === 1) {
+        delete newSelected[itemName];
+      } else {
+        newSelected[itemName] = (newSelected[itemName] ?? 0) - 1;
+      }
+      return newSelected;
+    });
   };
 
   const withdrawableItems = [...new Set([...getKeys(wardrobe)])]
@@ -105,32 +110,11 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
     <>
       <div className="p-2 mt-3">
         <div className="flex items-center border-2 rounded-md border-black p-2 bg-green-background mb-3">
-          <span className="text-xs">
-            {t("withdraw.restricted")}
-            <a
-              href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-blue-500"
-            >
-              {"in use"}
-            </a>
-            {" or are "}
-            <a
-              href="https://docs.sunflower-land.com/fundamentals/withdrawing#why-cant-i-withdraw-some-items"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-blue-500"
-            >
-              {"still being built"}
-            </a>
-            {"."}
-          </span>
+          <span className="text-xs">{t("withdraw.restricted")}</span>
         </div>
         <h2 className="mb-3">{t("withdraw.select.item")}</h2>
         <div className="flex flex-wrap h-fit -ml-1.5">
           {withdrawableItems.map((itemName) => {
-            // The wardrobe amount that is not placed
             const wardrobeCount = wardrobe[itemName];
 
             return (
@@ -139,7 +123,8 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
                 key={itemName}
                 onClick={() => onAdd(itemName)}
                 disabled={
-                  !BUMPKIN_WITHDRAWABLES[itemName](gameState.context.state)
+                  !BUMPKIN_WITHDRAWABLES[itemName](gameState.context.state) ||
+                  selected[itemName] !== undefined
                 }
                 image={getImageUrl(ITEM_IDS[itemName])}
               />

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -18,138 +18,79 @@ import {
 } from "./removeables";
 import { GameState } from "./game";
 
+interface isWithdrawable {
+  (state: GameState): boolean;
+}
+
+const conditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
+  "Green Amulet": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
+  "Angel Wings": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
+  "Devil Wings": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
+  "Infernal Pitchfork": (state) =>
+    !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
+  "Sunflower Amulet": (state) =>
+    !cropIsGrowing({ item: "Sunflower", game: state })[0],
+  "Carrot Amulet": (state) =>
+    !cropIsGrowing({ item: "Carrot", game: state })[0],
+  "Beetroot Amulet": (state) =>
+    !cropIsGrowing({ item: "Beetroot", game: state })[0],
+  Parsnip: (state) => !cropIsGrowing({ item: "Parsnip", game: state })[0],
+  "Eggplant Onesie": (state) =>
+    !cropIsGrowing({ item: "Eggplant", game: state })[0],
+  "Corn Onesie": (state) => !cropIsGrowing({ item: "Corn", game: state })[0],
+  "Tofu Mask": (state) => !cropIsGrowing({ item: "Soybean", game: state })[0],
+  "Non La Hat": (state) =>
+    !greenhouseCropIsGrowing({ crop: "Rice", game: state })[0],
+  "Olive Shield": (state) =>
+    !greenhouseCropIsGrowing({ crop: "Olive", game: state })[0],
+  "Olive Royalty Shirt": (state) =>
+    !greenhouseCropIsGrowing({ crop: "Olive", game: state })[0],
+  "Fruit Picker Apron": (state) => !areAnyOGFruitsGrowing(state)[0],
+  "Camel Onesie": (state) => !areAnyFruitsGrowing(state)[0],
+  "Banana Amulet": (state) => !areFruitsGrowing(state, "Banana")[0],
+  "Banana Onesie": (state) => !areFruitsGrowing(state, "Banana")[0],
+  "Grape Pants": (state) =>
+    !greenhouseCropIsGrowing({ crop: "Grape", game: state })[0],
+  "Lemon Shield": (state) => !areFruitsGrowing(state, "Lemon")[0],
+  Cattlegrim: (state) => !areAnyChickensFed(state)[0],
+  "Luna's Hat": (state) =>
+    !(
+      state.buildings["Fire Pit"]?.[0].crafting ||
+      state.buildings["Kitchen"]?.[0].crafting ||
+      state.buildings["Bakery"]?.[0].crafting ||
+      state.buildings["Deli"]?.[0].crafting ||
+      state.buildings["Smoothie Shack"]?.[0].crafting
+    ),
+  "Ancient Rod": (state) => !hasFishedToday(state)[0],
+  "Flower Crown": (state) => !areFlowersGrowing(state)[0],
+  "Beekeeper Hat": (state) => !isProducingHoney(state)[0],
+  "Bee Suit": (state) => !isProducingHoney(state)[0],
+  "Honeycomb Shield": (state) => !isProducingHoney(state)[0],
+  "Crimstone Amulet": (state) => !areAnyCrimstonesMined(state)[0],
+  "Crimstone Armor": (state) => !areAnyCrimstonesMined(state)[0],
+  "Crimstone Hammer": (state) => !isCrimstoneHammerActive(state)[0],
+  "Oil Can": (state) => !areAnyOilReservesDrilled(state)[0],
+  "Infernal Drill": (state) => !areAnyOilReservesDrilled(state)[0],
+  "Dev Wrench": (state) => !areAnyOilReservesDrilled(state)[0],
+  "Oil Overalls": (state) => !areAnyOilReservesDrilled(state)[0],
+  "Hornet Mask": (state) => isBeehivesFull(state)[0],
+  "Ancient Shovel": (state) => areBonusTreasureHolesDug(state)[0],
+};
+
 export const canWithdrawBoostedWearable = (
   name: BumpkinItem,
   state?: GameState,
 ) => {
   if (!state) return false;
 
-  if (
-    name === "Green Amulet" ||
-    name === "Angel Wings" ||
-    name === "Devil Wings" ||
-    name === "Infernal Pitchfork"
-  ) {
-    return !areAnyCropsOrGreenhouseCropsGrowing(state)[0];
-  }
-
-  if (name === "Sunflower Amulet") {
-    return !cropIsGrowing({ item: "Sunflower", game: state })[0];
-  }
-
-  if (name === "Carrot Amulet") {
-    return !cropIsGrowing({ item: "Carrot", game: state })[0];
-  }
-
-  if (name === "Beetroot Amulet") {
-    return !cropIsGrowing({ item: "Beetroot", game: state })[0];
-  }
-
-  if (name === "Parsnip") {
-    return !cropIsGrowing({ item: "Parsnip", game: state })[0];
-  }
-
-  if (name === "Eggplant Onesie") {
-    return !cropIsGrowing({ item: "Eggplant", game: state })[0];
-  }
-
-  if (name === "Corn Onesie") {
-    return !cropIsGrowing({ item: "Corn", game: state })[0];
-  }
-
-  if (name === "Tofu Mask") {
-    return !cropIsGrowing({ item: "Soybean", game: state })[0];
-  }
-
-  if (name === "Non La Hat") {
-    return !greenhouseCropIsGrowing({ crop: "Rice", game: state })[0];
-  }
-
-  if (name === "Olive Shield") {
-    return !greenhouseCropIsGrowing({ crop: "Olive", game: state })[0];
-  }
-  if (name === "Olive Royalty Shirt") {
-    return !greenhouseCropIsGrowing({ crop: "Olive", game: state })[0];
-  }
-
-  if (name === "Fruit Picker Apron") {
-    return !areAnyOGFruitsGrowing(state)[0];
-  }
-
-  if (name === "Camel Onesie") {
-    return !areAnyFruitsGrowing(state)[0];
-  }
-
-  if (name === "Banana Amulet" || name === "Banana Onesie") {
-    return !areFruitsGrowing(state, "Banana")[0];
-  }
-
-  if (name === "Grape Pants") {
-    return !greenhouseCropIsGrowing({ crop: "Grape", game: state })[0];
-  }
-
-  if (name === "Lemon Shield") {
-    return !areFruitsGrowing(state, "Lemon")[0];
-  }
-
-  if (name === "Cattlegrim") {
-    return !areAnyChickensFed(state)[0];
-  }
-
-  if (name === "Luna's Hat") {
-    if (
-      state.buildings["Fire Pit"]?.[0].crafting ||
-      state.buildings["Kitchen"]?.[0].crafting ||
-      state.buildings["Bakery"]?.[0].crafting ||
-      state.buildings["Deli"]?.[0].crafting ||
-      state.buildings["Smoothie Shack"]?.[0].crafting
-    ) {
-      return false;
-    }
+  if (state.wardrobe?.[name] != undefined && state.wardrobe?.[name] > 1) {
     return true;
   }
 
-  if (name === "Ancient Rod") {
-    return !hasFishedToday(state)[0];
+  const condition = conditions[name];
+  if (condition) {
+    return condition(state);
   }
 
-  if (name === "Flower Crown") {
-    return !areFlowersGrowing(state)[0];
-  }
-
-  if (
-    name === "Beekeeper Hat" ||
-    name === "Bee Suit" ||
-    name === "Honeycomb Shield"
-  ) {
-    return !isProducingHoney(state)[0];
-  }
-
-  if (name === "Crimstone Amulet" || name === "Crimstone Armor") {
-    return !areAnyCrimstonesMined(state)[0];
-  }
-
-  if (name === "Crimstone Hammer") {
-    return !isCrimstoneHammerActive(state)[0];
-  }
-
-  if (
-    name === "Oil Can" ||
-    name === "Infernal Drill" ||
-    name === "Dev Wrench" ||
-    name === "Oil Overalls"
-  ) {
-    return !areAnyOilReservesDrilled(state)[0];
-  }
-
-  if (name === "Hornet Mask") {
-    return isBeehivesFull(state)[0];
-  }
-
-  if (name === "Ancient Shovel") {
-    return areBonusTreasureHolesDug(state)[0];
-  }
-
-  // Safety check
   return false;
 };

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -22,7 +22,7 @@ interface isWithdrawable {
   (state: GameState): boolean;
 }
 
-const conditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
+const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
   "Green Amulet": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
   "Angel Wings": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
   "Devil Wings": (state) => !areAnyCropsOrGreenhouseCropsGrowing(state)[0],
@@ -80,17 +80,10 @@ const conditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
 export const canWithdrawBoostedWearable = (
   name: BumpkinItem,
   state?: GameState,
-) => {
+): boolean => {
   if (!state) return false;
 
-  if (state.wardrobe?.[name] != undefined && state.wardrobe?.[name] > 1) {
-    return true;
-  }
+  if ((state.wardrobe?.[name] ?? 0) > 1) return true;
 
-  const condition = conditions[name];
-  if (condition) {
-    return condition(state);
-  }
-
-  return false;
+  return withdrawConditions[name]?.(state) ?? false;
 };

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4693,7 +4693,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.receive": "您将收到： {{sflReceived}} SFL",
   "withdraw.select.item": "请选择要提取的商品",
   "withdraw.opensea": "提现成功后，您将能够在 OpenSea 上查看您的物品。",
-  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"], // To interpolate
+  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"],
   "withdraw.bumpkin.wearing":
     "你的乡巴佬目前穿着以下无法撤回的衣服。你需要先更换衣服，然后才能撤回。",
   "withdraw.bumpkin.sure.withdraw": "您确定要撤回您的乡巴佬吗？",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5386,7 +5386,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.opensea":
     "Once withdrawn, you will be able to view your items on OpenSea.",
   "withdraw.restricted":
-    "Some items cannot be withdrawn. Other items may be restricted when",
+    "Some items cannot be withdrawn. Other items may be restricted when in use or still being built.",
   "withdraw.bumpkin.wearing":
     "Your Bumpkin is currently wearing the following item(s) that can't be withdrawn. You will need to unequip them before you can withdraw.",
   "withdraw.bumpkin.sure.withdraw":

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5486,8 +5486,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.opensea":
     "Une fois retirés, vous pourrez voir vos objets sur OpenSea.",
   "withdraw.budRestricted": "Utilisé dans la boîte à bud d'aujourd'hui.",
-  "withdraw.restricted":
-    "Certains objets ne peuvent pas être retirés. D'autres objets peuvent être restreints lorsque",
+  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"],
   "withdraw.bumpkin.wearing":
     "Votre Bumpkin porte actuellement les objets suivants qui ne peuvent pas être retirés. Vous devrez les déséquiper avant de pouvoir les retirer.",
   "withdraw.bumpkin.sure.withdraw":

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5315,8 +5315,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.opensea":
     "Depois de retirados, você poderá ver seus itens no OpenSea.",
   "withdraw.budRestricted": ENGLISH_TERMS["withdraw.budRestricted"],
-  "withdraw.restricted":
-    "Alguns itens não podem ser retirados. Outros itens podem ser restritos quando",
+  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"],
   "withdraw.bumpkin.wearing":
     "Seu Bumpkin está atualmente usando o(s) seguinte(s) item(ns) que não podem ser retirados. Você precisará desequipá-los antes de poder retirar.",
   "withdraw.bumpkin.sure.withdraw":

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -5318,8 +5318,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.select.item": "Select items to withdraw",
   "withdraw.opensea":
     "Once withdrawn, you will be able to view your items on OpenSea.",
-  "withdraw.restricted":
-    "Some items cannot be withdrawn. Other items may be restricted when",
+  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"],
   "withdraw.bumpkin.wearing":
     "Your Bumpkin is currently wearing the following item(s) that can't be withdrawn. You will need to unequip them before you can withdraw.",
   "withdraw.bumpkin.sure.withdraw":

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -5324,8 +5324,7 @@ const withdraw: Record<Withdraw, string> = {
   "withdraw.select.item": "Geri çekilecek öğeleri seçin",
   "withdraw.opensea":
     "Geri çekildikten sonra öğelerinizi OpenSea'de görebileceksiniz.",
-  "withdraw.restricted":
-    "Bazı öğeler geri alınamaz. Diğer öğeler şu durumlarda kısıtlanabilir",
+  "withdraw.restricted": ENGLISH_TERMS["withdraw.restricted"],
   "withdraw.bumpkin.wearing":
     "Bumpkin'iniz şu anda geri alınamayan aşağıdaki öğeleri giyiyor. Geri çekilmeden önce bunları donanımdan çıkarmanız gerekecek.",
   "withdraw.bumpkin.sure.withdraw":


### PR DESCRIPTION
# Description

Currently extra wearables of the same type are restricted when that withdrawal condition is in place

This PR makes it so that extra wearables can still be withdrawn, but as long as the withdrawal condition is active 1 of the wearable will still have to stay in the farm

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

How to test:

1. Go to Withdraw.tsx and comment out lines 125 to 134 to bypass the PoH check
2. Give yourself 2 copies of a wearable that has a boost in wardrobe and previousWardrobe
3. Do that action which will prevent the wearable to be withdrawn
4. Go to Goblin bank and go to wearables tab
5. Behaviour should be as follows: 

- Click on wearable that has boost that you want to withdraw. 
- the second copy of it should be disabled and you won't be able to select it again
- unselect the wearable, the wearable should be enabled again

Few more tests that can be done to make sure no exploits:
- Wear one of the items and go to the retreat. The other item should still be withdrawable
- Remove one of the wearables from your wardrobe and previousWardrobe. Make sure that the withdrawal restriction is still in place

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
