### PR TITLE
[FIX] Greenhouse Crop Bud Removal Restrictions

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -67,6 +67,17 @@ function areAnyGreenhouseCropGrowing(game: GameState): Restriction {
   return [cropsPlanted, translate("restrictionReason.cropsGrowing")];
 }
 
+export function areAnyCropsOrGreenhouseCropsGrowing(
+  game: GameState,
+): Restriction {
+  const [greenhouseCropsGrowing] = areAnyGreenhouseCropGrowing(game);
+  const [cropsGrowing] = areAnyCropsGrowing(game);
+
+  const anyCropsGrowing = greenhouseCropsGrowing || cropsGrowing;
+
+  return [anyCropsGrowing, translate("restrictionReason.cropsGrowing")];
+}
+
 function beanIsPlanted(game: GameState): Restriction {
   const beanPlanted = game.collectibles["Magic Bean"]?.length ?? 0;
 
@@ -359,10 +370,10 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Crim Peckster": (game) => areAnyCrimstonesMined(game),
 
   // Crop Boosts
-  Nancy: (game) => areAnyCropsGrowing(game),
-  Scarecrow: (game) => areAnyCropsGrowing(game),
-  Kuebiko: (game) => areAnyCropsGrowing(game),
-  "Lunar Calendar": (game) => areAnyCropsGrowing(game),
+  Nancy: (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
+  Scarecrow: (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
+  Kuebiko: (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
+  "Lunar Calendar": (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
   "Basic Scarecrow": (game) => areAnyBasicCropsGrowing(game),
   "Sir Goldensnout": (game) => areAnyCropsGrowing(game),
   "Scary Mike": (game) => areAnyMediumCropsGrowing(game),
@@ -506,8 +517,7 @@ export const BUD_REMOVAL_RESTRICTIONS: Record<
   RemoveCondition
 > = {
   // HATS
-  "3 Leaf Clover": (game) =>
-    areAnyCropsGrowing(game) || areAnyGreenhouseCropGrowing(game),
+  "3 Leaf Clover": (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
   "Fish Hat": (game) => hasFishedToday(game),
   "Diamond Gem": (game) => areAnyMineralsMined(game),
   "Gold Gem": (game) => areAnyGoldsMined(game),
@@ -549,8 +559,7 @@ export const BUD_REMOVAL_RESTRICTIONS: Record<
   // TODO Port needs to be implemented
   Port: () => [false, translate("restrictionReason.noRestriction")],
   Retreat: (game) => areAnyChickensFed(game),
-  Saphiro: (game) =>
-    areAnyCropsGrowing(game) || areAnyGreenhouseCropGrowing(game),
+  Saphiro: (game) => areAnyCropsOrGreenhouseCropsGrowing(game),
   Snow: (game) => areAnyAdvancedCropsGrowing(game),
   Beach: (game) => areAnyFruitsGrowing(game),
 };

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -506,7 +506,8 @@ export const BUD_REMOVAL_RESTRICTIONS: Record<
   RemoveCondition
 > = {
   // HATS
-  "3 Leaf Clover": (game) => areAnyCropsGrowing(game),
+  "3 Leaf Clover": (game) =>
+    areAnyCropsGrowing(game) || areAnyGreenhouseCropGrowing(game),
   "Fish Hat": (game) => hasFishedToday(game),
   "Diamond Gem": (game) => areAnyMineralsMined(game),
   "Gold Gem": (game) => areAnyGoldsMined(game),
@@ -515,41 +516,29 @@ export const BUD_REMOVAL_RESTRICTIONS: Record<
   "Basic Leaf": (game) => areAnyBasicCropsGrowing(game),
   "Sunflower Hat": (game) => cropIsGrowing({ item: "Sunflower", game }),
   "Ruby Gem": (game) => areAnyStonesMined(game),
-  Mushroom: (game) => [false, translate("restrictionReason.noRestriction")],
-  "Magic Mushroom": (game) => [
-    false,
-    translate("restrictionReason.noRestriction"),
-  ],
+  Mushroom: () => [false, translate("restrictionReason.noRestriction")],
+  "Magic Mushroom": () => [false, translate("restrictionReason.noRestriction")],
   "Acorn Hat": (game) => areAnyTreesChopped(game),
   Banana: (game) => areAnyFruitsGrowing(game),
   "Tree Hat": (game) => areAnyTreesChopped(game),
   "Egg Head": (game) => areAnyChickensFed(game),
   "Apple Head": (game) => areAnyFruitsGrowing(game),
 
-  "Axe Head": (game) => [false, translate("restrictionReason.noRestriction")],
-  "Rainbow Horn": (game) => [
+  "Axe Head": () => [false, translate("restrictionReason.noRestriction")],
+  "Rainbow Horn": () => [false, translate("restrictionReason.noRestriction")],
+  "Red Bow": () => [false, translate("restrictionReason.noRestriction")],
+  "Silver Horn": () => [false, translate("restrictionReason.noRestriction")],
+  "Sunflower Headband": () => [
     false,
     translate("restrictionReason.noRestriction"),
   ],
-  "Red Bow": (game) => [false, translate("restrictionReason.noRestriction")],
-  "Silver Horn": (game) => [
+  "Sunshield Foliage": () => [
     false,
     translate("restrictionReason.noRestriction"),
   ],
-  "Sunflower Headband": (game) => [
-    false,
-    translate("restrictionReason.noRestriction"),
-  ],
-  "Sunshield Foliage": (game) => [
-    false,
-    translate("restrictionReason.noRestriction"),
-  ],
-  "Tender Coral": (game) => [
-    false,
-    translate("restrictionReason.noRestriction"),
-  ],
-  Seashell: (game) => [false, translate("restrictionReason.noRestriction")],
-  Hibiscus: (game) => [false, translate("restrictionReason.noRestriction")],
+  "Tender Coral": () => [false, translate("restrictionReason.noRestriction")],
+  Seashell: () => [false, translate("restrictionReason.noRestriction")],
+  Hibiscus: () => [false, translate("restrictionReason.noRestriction")],
 
   // TYPES
   Plaza: (game) => areAnyBasicCropsGrowing(game),
@@ -558,9 +547,10 @@ export const BUD_REMOVAL_RESTRICTIONS: Record<
   Sea: (game) => hasFishedToday(game),
   Castle: (game) => areAnyMediumCropsGrowing(game),
   // TODO Port needs to be implemented
-  Port: (game) => [false, translate("restrictionReason.noRestriction")],
+  Port: () => [false, translate("restrictionReason.noRestriction")],
   Retreat: (game) => areAnyChickensFed(game),
-  Saphiro: (game) => areAnyCropsGrowing(game),
+  Saphiro: (game) =>
+    areAnyCropsGrowing(game) || areAnyGreenhouseCropGrowing(game),
   Snow: (game) => areAnyAdvancedCropsGrowing(game),
   Beach: (game) => areAnyFruitsGrowing(game),
 };

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -2,7 +2,6 @@ import { BumpkinItem } from "./bumpkin";
 import {
   areAnyChickensFed,
   areAnyCrimstonesMined,
-  areAnyCropsGrowing,
   areAnyFruitsGrowing,
   areAnyOilReservesDrilled,
   areFlowersGrowing,
@@ -15,6 +14,7 @@ import {
   areAnyOGFruitsGrowing,
   hasFishedToday,
   areBonusTreasureHolesDug,
+  areAnyCropsOrGreenhouseCropsGrowing,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -30,7 +30,7 @@ export const canWithdrawBoostedWearable = (
     name === "Devil Wings" ||
     name === "Infernal Pitchfork"
   ) {
-    return !areAnyCropsGrowing(state)[0];
+    return !areAnyCropsOrGreenhouseCropsGrowing(state)[0];
   }
 
   if (name === "Sunflower Amulet") {


### PR DESCRIPTION
# Description

Greenhouse Crops didn't prevent removals of a few buds, collectibles and wearables. This PR Fixes that exploit

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
