### PR TITLE
[FIX] Remove Hoarding limit for Treasures

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -202,17 +202,6 @@ export const maxItems: Inventory = {
   "Red Wiggler": new Decimal(100),
   "Fishing Lure": new Decimal(100),
 
-  //Treasure Island Beach Bounty
-  "Pirate Bounty": new Decimal(50),
-  Pearl: new Decimal(50),
-  Coral: new Decimal(50),
-  "Clam Shell": new Decimal(50),
-  Pipi: new Decimal(50),
-  Starfish: new Decimal(50),
-  Seaweed: new Decimal(50),
-  "Sea Cucumber": new Decimal(50),
-  Crab: new Decimal(1000),
-
   // Seasonal decorations - Dawnbreaker
   Clementine: new Decimal(1),
   Blossombeard: new Decimal(1),


### PR DESCRIPTION
# Description

Hoarding limit for treasures was recently removed on the BE. However players were still getting Hoarding limit messages cuz it wasn't removed on the FE

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
