### PR TITLE
[FEAT] Handle Beach Digging for Ancient Shovel

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -788,22 +788,10 @@ export class BeachScene extends BaseScene {
     const hasTool =
       (this.selectedItem === "Sand Drill" && sandDrillsCount > 0) ||
       (this.selectedItem === "Sand Shovel" && sandShovelsCount > 0) ||
-      isWearableActive({
-        name: "Ancient Shovel",
-        game: this.gameService.state.context.state,
-      });
+      this.isAncientShovelActive;
 
     if (!hasTool || !this.hasDigsLeft) {
       if (!hasDugHere) {
-        if (
-          isWearableActive({
-            name: "Ancient Shovel",
-            game: this.gameService.state.context.state,
-          })
-        ) {
-          return;
-        }
-
         // If the player has the drill selected then return as the no dig icon is handled in the drill hover
         // due to the different size of the hover box
         if (this.selectedItem === "Sand Drill") return;
@@ -1134,6 +1122,13 @@ export class BeachScene extends BaseScene {
     );
   }
 
+  get isAncientShovelActive() {
+    return isWearableActive({
+      name: "Ancient Shovel",
+      game: this.gameService.state.context.state,
+    });
+  }
+
   get holesDugCount() {
     return this.gameService.state.context.state.desert.digging.grid.length ?? 0;
   }
@@ -1385,15 +1380,11 @@ export class BeachScene extends BaseScene {
     const sandDrills =
       this.gameService.state.context.state.inventory["Sand Drill"] ??
       new Decimal(0);
-    const isAncientShovelActive = isWearableActive({
-      name: "Ancient Shovel",
-      game: this.gameService.state.context.state,
-    });
 
     if (
       sandShovels.lt(1) &&
       this.selectedItem !== "Sand Drill" &&
-      !isAncientShovelActive
+      !this.isAncientShovelActive
     ) {
       this.npcs.digby?.speak(translate("digby.noShovels"));
 
@@ -1645,6 +1636,15 @@ export class BeachScene extends BaseScene {
 
     this.handleUpdateSelectedItem();
     this.handleNameTagVisibility();
+
+    // Get Digby to hold his tongue if the player doesn't have the drill selected and is rocking the ancient shovel
+    if (
+      this.isAncientShovelActive &&
+      this.currentSelectedItem !== "Sand Drill" &&
+      this.npcs.digby?.isSpeaking
+    ) {
+      this.npcs.digby?.stopSpeaking();
+    }
 
     if (this.isPlayerInDigArea(this.currentPlayer.x, this.currentPlayer.y)) {
       this.updatePlayer();


### PR DESCRIPTION
# Description

The Ancient Shovel allows a player to dig without Sand Shovels. This PR updates the beach digging to be able to handle when a player is holding the Ancient Shovel.

- If a player has the Ancient Shovel active they should be able to dig without having and Sand Shovels.
- If a player has Sand Drills selected, they should use a Sand Drill to drill a spot. This is consume the Sand Drill after use.
- Digby should not give missing Sand Shovel warnings when the player has an active Ancient Shovel.
- Digging with the Ancient Shovel still decrements the daily dig count just as a normal Sand Shovel would.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Activate an Ancient Shovel and test the above scenarios

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
