### PR TITLE
[FIX] Cooking Buildings Modal Flash

### DIFF
--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -10,15 +10,24 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { setImageWidth } from "lib/images";
 import { Context } from "features/game/GameProvider";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { bakeryAudio, loadAudio } from "lib/utils/sfx";
 import { gameAnalytics } from "lib/gameAnalytics";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import { FIRE_PIT_VARIANTS } from "features/island/lib/alternateArt";
 import shadow from "assets/npcs/shadow.png";
+import { MachineState } from "features/game/lib/gameMachine";
+import Decimal from "decimal.js-light";
 
 type Props = BuildingProps & Partial<CraftingMachineChildProps>;
+
+const _mashedPotatoCooked = (state: MachineState) =>
+  state.context.state.bumpkin?.activity?.["Mashed Potato Cooked"];
+const _experience = (state: MachineState) =>
+  state.context.state.bumpkin?.experience;
+const _potatoCount = (state: MachineState) =>
+  state.context.state.inventory.Potato ?? new Decimal(0);
 
 export const FirePit: React.FC<Props> = ({
   buildingId,
@@ -31,10 +40,12 @@ export const FirePit: React.FC<Props> = ({
   island,
   onRemove,
 }) => {
+  const { gameService } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
 
-  const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
+  const mashedPotatoCooked = useSelector(gameService, _mashedPotatoCooked);
+  const experience = useSelector(gameService, _experience);
+  const potatoCount = useSelector(gameService, _potatoCount);
 
   useEffect(() => {
     loadAudio([bakeryAudio]);
@@ -48,10 +59,7 @@ export const FirePit: React.FC<Props> = ({
       buildingId,
     });
 
-    if (
-      item === "Mashed Potato" &&
-      !gameState.context.state.bumpkin?.activity?.[`${item} Cooked`]
-    ) {
+    if (item === "Mashed Potato" && !mashedPotatoCooked) {
       gameAnalytics.trackMilestone({
         event: "Tutorial:Cooked:Completed",
       });
@@ -89,10 +97,7 @@ export const FirePit: React.FC<Props> = ({
     }
   };
 
-  const showHelper =
-    gameState.context.state.inventory.Potato?.gte(8) &&
-    gameState.context.state.bumpkin?.experience === 0 &&
-    !crafting;
+  const showHelper = potatoCount.gte(8) && experience === 0 && !crafting;
 
   return (
     <>

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -57,6 +57,7 @@ interface Props {
  * @crafting Whether the building is in the process of crafting a food item.
  * @craftingService The crafting service.
  */
+
 export const Recipes: React.FC<Props> = ({
   selected,
   setSelected,

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -83,28 +83,11 @@ export const Recipes: React.FC<Props> = ({
       selected?.ingredients[name]?.greaterThan(inventory[name] || 0),
     );
 
-  const cook = () => {
-    onCook(selected.name);
+  const cook = async () => {
     onClose();
-  };
-
-  const Action = () => {
-    return (
-      <>
-        <Button
-          disabled={lessIngredients() || crafting || selected.disabled}
-          className="text-xxs sm:text-sm mt-1 whitespace-nowrap"
-          onClick={() => cook()}
-        >
-          {t("cook")}
-        </Button>
-        {crafting && (
-          <p className="sm:text-xs text-center my-1">
-            {t("sceneDialogues.chefIsBusy")}
-          </p>
-        )}
-      </>
-    );
+    // delay to allow the modal to close to avoid content flashing
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    onCook(selected.name);
   };
 
   const validRecipes = recipes.filter((recipes) => {
@@ -154,7 +137,22 @@ export const Recipes: React.FC<Props> = ({
                 state,
               ),
             }}
-            actionView={Action()}
+            actionView={
+              <>
+                <Button
+                  disabled={lessIngredients() || crafting || selected.disabled}
+                  className="text-xxs sm:text-sm mt-1 whitespace-nowrap"
+                  onClick={() => cook()}
+                >
+                  {t("cook")}
+                </Button>
+                {crafting && (
+                  <p className="sm:text-xs text-center my-1">
+                    {t("sceneDialogues.chefIsBusy")}
+                  </p>
+                )}
+              </>
+            }
           />
         </>
       }


### PR DESCRIPTION
# Description

This PR fixes this issue that occurs when selecting to cook a recipe inside of a building modal, you see a flash of the "cooking" UI right before the modal closes.

_Before_
![modal-flash-before](https://github.com/user-attachments/assets/72c5f5c1-0991-4605-9414-fcf223fdd3ac)

_After_
![modal-flash-after](https://github.com/user-attachments/assets/407cf4e2-abdb-47b6-9b8a-297886be4de0)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Open a cooking modal and select to cook a recipe. You should not see a flash of content.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
