### PR TITLE
[FIX] Can't Leave Faction

### DIFF
--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -757,12 +757,12 @@ export abstract class BaseScene extends Phaser.Scene {
     // Update faction
     const faction = this.gameService.state.context.state.faction?.name;
 
-    if (faction && this.currentPlayer.faction !== faction) {
+    if (this.currentPlayer.faction !== faction) {
       this.currentPlayer.faction = faction;
       this.mmoServer?.send(0, { faction });
       this.checkAndUpdateNameColor(
         this.currentPlayer,
-        FACTION_NAME_COLORS[faction],
+        faction ? FACTION_NAME_COLORS[faction] : "white",
       );
     }
 

--- a/src/features/world/ui/factions/LeaveFaction.tsx
+++ b/src/features/world/ui/factions/LeaveFaction.tsx
@@ -5,6 +5,7 @@ import { FACTION_EMBLEMS } from "features/game/events/landExpansion/joinFaction"
 import { Label } from "components/ui/Label";
 import { Button } from "components/ui/Button";
 import mark from "assets/icons/faction_mark.webp";
+import Decimal from "decimal.js-light";
 
 export const LeaveFaction: React.FC<{
   game: GameState;
@@ -14,10 +15,13 @@ export const LeaveFaction: React.FC<{
   const { t } = useAppTranslation();
 
   const emblem = FACTION_EMBLEMS[game.faction!.name];
-  const emblems = game.inventory[emblem];
+  const hasEmblems = (game.inventory[emblem] ?? new Decimal(0)).gt(0);
   const marks = game.inventory.Mark;
   const isNew =
     Date.now() - (game.faction?.pledgedAt ?? 0) < 24 * 60 * 60 * 1000;
+  const hasEmblemsListed = Object.values(game.trades.listings ?? {}).some(
+    (listing) => (listing.items[emblem] ?? 0) > 0,
+  );
 
   return (
     <div>
@@ -26,7 +30,7 @@ export const LeaveFaction: React.FC<{
           <Label type="danger" className="mb-1">
             {t("faction.leave")}
           </Label>
-          {!!emblems && (
+          {!!hasEmblems && (
             <Label type="danger" className="mb-1">
               {t("faction.leave.hasEmblems")}
             </Label>
@@ -34,7 +38,7 @@ export const LeaveFaction: React.FC<{
         </div>
         <p className="text-sm mb-2">{t("faction.leave.areYouSure")}</p>
         <p className="text-sm mb-2">{t("faction.leave.marks")}</p>
-        {!!emblems && (
+        {!!hasEmblems && (
           <p className="text-sm mb-2">{t("faction.leave.sellEmblems")}</p>
         )}
         {!!isNew && <p className="text-sm mb-2">{t("faction.leave.isNew")}</p>}
@@ -50,7 +54,10 @@ export const LeaveFaction: React.FC<{
         <Button onClick={onClose} className="mr-1">
           {t("no")}
         </Button>
-        <Button disabled={isNew || !!emblems} onClick={onLeave}>
+        <Button
+          disabled={isNew || !!hasEmblems || !!hasEmblemsListed}
+          onClick={onLeave}
+        >
           {t("yes")}
         </Button>
       </div>

--- a/src/features/world/ui/factions/emblemTrading/Emblems.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Emblems.tsx
@@ -54,7 +54,7 @@ export const Emblems: React.FC<Props> = ({ emblem, factionName }) => {
   const leave = () => {
     gameService.send("faction.left");
     gameService.send("SAVE");
-    navigate("/");
+    navigate("/world/kingdom");
   };
 
   if (showLeaveFaction) {


### PR DESCRIPTION
# Description

When player tries to leave faction, somehow it doesn't remove the faction from their gameState when they were sent back home.

Fixed the following:
- Player not able to leave the faction when they were sent back home
- Player color doesn't get removed when leaving faction
- Player able to leave faction when they have emblems still listed

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
