### PR TITLE
[FEAT] Season banner bonus

### DIFF
--- a/src/features/game/components/modal/ModalProvider.tsx
+++ b/src/features/game/components/modal/ModalProvider.tsx
@@ -7,6 +7,8 @@ import { SpeakingModal } from "../SpeakingModal";
 import { NPC_WEARABLES } from "lib/npcs";
 import { translate } from "lib/i18n/translate";
 import { BuyCurrenciesModal } from "features/island/hud/components/BuyCurrenciesModal";
+import { VIPItems } from "./components/VIPItems";
+import { Panel } from "components/ui/Panel";
 
 type GlobalModal =
   | "BUY_BLOCK_BUCKS"
@@ -17,7 +19,8 @@ type GlobalModal =
   | "SECOND_LEVEL"
   | "FIREPIT"
   | "BETTY"
-  | "BLACKSMITH";
+  | "BLACKSMITH"
+  | "VIP_ITEMS";
 
 export const ModalContext = createContext<{
   openModal: (type: GlobalModal) => void;
@@ -53,6 +56,12 @@ export const ModalProvider: FC = ({ children }) => {
         onClose={handleClose}
         initialTab={2}
       />
+
+      <Modal show={opened === "VIP_ITEMS"} onHide={handleClose}>
+        <Panel>
+          <VIPItems onSkip={handleClose} onClose={handleClose} />
+        </Panel>
+      </Modal>
 
       <Modal show={opened === "STORE_ON_CHAIN"} onHide={handleClose}>
         <StoreOnChainModal onClose={handleClose} />

--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -6,6 +6,7 @@ import {
   getPreviousSeasonalBanner,
   getSeasonalBanner,
   getSeasonalBannerImage,
+  getSeasonalTicket,
 } from "features/game/types/seasons";
 import { ButtonPanel } from "components/ui/Panel";
 import { Label } from "components/ui/Label";
@@ -28,10 +29,11 @@ import { getSeasonWeek } from "lib/utils/getSeasonWeek";
 import classNames from "classnames";
 import { secondsToString } from "lib/utils/time";
 import { acknowledgeSeasonPass } from "features/announcements/announcementsStorage";
+import { ITEM_DETAILS } from "features/game/types/images";
 
 type VIPItem = SeasonalBanner | "Lifetime Farmer Banner";
 
-export const ORIGINAL_SEASONAL_BANNER_PRICE = 90;
+export const ORIGINAL_SEASONAL_BANNER_PRICE = 100;
 export const LIFETIME_FARMER_BANNER_PRICE = 740;
 
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -50,7 +52,7 @@ const SeasonVIPDiscountTime: React.FC = () => {
   const WEEK = 1000 * 60 * 60 * 24 * 7;
 
   const discountDates = [
-    seasonStartDate.getTime() + 2 * WEEK, // 2 weeks
+    seasonStartDate.getTime() + 1 * WEEK, // 1 weeks
     seasonStartDate.getTime() + 4 * WEEK, // 4 weeks
     seasonStartDate.getTime() + 8 * WEEK, // 8 weeks
     seasonEndDate.getTime(), // End of season
@@ -311,6 +313,15 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
                 </div>
               )}
               <div className="flex items-center space-x-2">
+                <SquareIcon
+                  icon={ITEM_DETAILS[getSeasonalTicket()].image}
+                  width={7}
+                />
+                <span>
+                  {t("season.ticket.bonus", { item: getSeasonalTicket() })}
+                </span>
+              </div>
+              <div className="flex items-center space-x-2">
                 <SquareIcon icon={vipIcon} width={7} />
                 <span>{t("season.vip.access")}</span>
               </div>
@@ -318,6 +329,15 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
                 <SquareIcon icon={xpIcon} width={7} />
                 <span>{t("season.xp.boost")}</span>
               </div>
+              {getCurrentSeason() === "Pharaoh's Treasure" && (
+                <div className="flex items-center space-x-2">
+                  <SquareIcon
+                    icon={ITEM_DETAILS["Sand Shovel"].image}
+                    width={7}
+                  />
+                  <span>{t("season.pharaohs.gift")}</span>
+                </div>
+              )}
               {hasDiscount && !hasSeasonBanner && (
                 <span
                   className="absolute right-2 bottom-8 text-xs discounted"

--- a/src/features/game/events/landExpansion/bannerPurchased.test.ts
+++ b/src/features/game/events/landExpansion/bannerPurchased.test.ts
@@ -63,8 +63,8 @@ describe("purchaseBanner", () => {
     ).toThrow("You already have this banner");
   });
 
-  it("purchases banner on first 2 weeks without previous banner", () => {
-    const WEEK = 1000 * 60 * 60 * 24 * 7;
+  it("purchases banner on first week without previous banner", () => {
+    const SIX_DAYS = 1000 * 60 * 60 * 24 * 6;
     const season = getCurrentSeason();
     const seasonStart = SEASONS[season].startDate;
     const banner = getSeasonalBanner();
@@ -80,7 +80,7 @@ describe("purchaseBanner", () => {
         type: "banner.purchased",
         name: banner,
       },
-      createdAt: seasonStart.getTime() + WEEK,
+      createdAt: seasonStart.getTime() + SIX_DAYS,
     });
 
     expect(result).toEqual({
@@ -92,8 +92,8 @@ describe("purchaseBanner", () => {
     });
   });
 
-  it("purchases banner on first 2 weeks with previous banner", () => {
-    const WEEK = 1000 * 60 * 60 * 24 * 7;
+  it("purchases banner on first week with previous banner", () => {
+    const SIX_DAYS = 1000 * 60 * 60 * 24 * 6;
     const season = getCurrentSeason();
     const seasonStart = SEASONS[season].startDate;
     const banner = getSeasonalBanner();
@@ -111,7 +111,7 @@ describe("purchaseBanner", () => {
         type: "banner.purchased",
         name: banner,
       },
-      createdAt: seasonStart.getTime() + WEEK,
+      createdAt: seasonStart.getTime() + SIX_DAYS,
     });
 
     expect(result).toEqual({
@@ -271,8 +271,8 @@ describe("purchaseBanner", () => {
     ).toThrow("Attempt to purchase Dawn Breaker Banner");
   });
 
-  it("purchases banner on first 2 weeks of Pharaohs Treasure without previous banner", () => {
-    const WEEK = 1000 * 60 * 60 * 24 * 7;
+  it("purchases banner on first week of Pharaohs Treasure without previous banner", () => {
+    const SIX_DAYS = 1000 * 60 * 60 * 24 * 6;
     const seasonStart = SEASONS["Pharaoh's Treasure"].startDate;
     const banner = getSeasonalBanner(seasonStart);
 
@@ -287,7 +287,7 @@ describe("purchaseBanner", () => {
         type: "banner.purchased",
         name: banner,
       },
-      createdAt: seasonStart.getTime() + WEEK,
+      createdAt: seasonStart.getTime() + SIX_DAYS,
     });
 
     expect(result).toEqual({

--- a/src/features/game/events/landExpansion/bannerPurchased.ts
+++ b/src/features/game/events/landExpansion/bannerPurchased.ts
@@ -46,7 +46,7 @@ export function getBannerPrice(
     (createdAt - seasonStartDate.getTime()) / WEEK,
   );
 
-  if (weeksElapsed < 2) {
+  if (weeksElapsed < 1) {
     const previousBannerDiscount = hasPreviousBanner ? 15 : 0;
     return new Decimal(75).sub(previousBannerDiscount);
   }

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -658,7 +658,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     // Banners
     "Human War Banner": new Decimal(1),
     "Goblin War Banner": new Decimal(1),
-    "Lifetime Farmer Banner": new Decimal(1),
+    // "Lifetime Farmer Banner": new Decimal(1),
     "Solar Flare Banner": new Decimal(1),
     "Dawn Breaker Banner": new Decimal(1),
     "Witches' Eve Banner": new Decimal(1),
@@ -672,7 +672,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Earn Alliance Banner": new Decimal(1),
     "Goblin Gold Champion": new Decimal(1),
     "Goblin Silver Champion": new Decimal(1),
-    "Pharaoh's Treasure Banner": new Decimal(1),
+    // "Pharaoh's Treasure Banner": new Decimal(1),
 
     "Pirate Bounty": new Decimal(1),
     Scarab: new Decimal(1),

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -23,6 +23,7 @@ import { BuyCurrenciesModal } from "./components/BuyCurrenciesModal";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSound } from "lib/utils/hooks/useSound";
 import { SpecialEventCountdown } from "./SpecialEventCountdown";
+import { SeasonBannerCountdown } from "./SeasonBannerCountdown";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _xp = (state: MachineState) =>
@@ -165,6 +166,7 @@ const HudComponent: React.FC<{
         >
           <AuctionCountdown />
           <SpecialEventCountdown />
+          <SeasonBannerCountdown />
         </div>
 
         <div

--- a/src/features/island/hud/SeasonBannerCountdown.tsx
+++ b/src/features/island/hud/SeasonBannerCountdown.tsx
@@ -1,0 +1,86 @@
+import React, { useContext, useState } from "react";
+import { ButtonPanel } from "components/ui/Panel";
+import { Label } from "components/ui/Label";
+import { SUNNYSIDE } from "assets/sunnyside";
+
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import { MachineState } from "features/game/lib/gameMachine";
+
+import {
+  getCurrentSeason,
+  getSeasonalBanner,
+  SEASONS,
+} from "features/game/types/seasons";
+import { getSeasonWeek } from "lib/utils/getSeasonWeek";
+import { getBumpkinLevel } from "features/game/lib/level";
+import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
+import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+
+const _level = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin.experience);
+
+const _hasBanner = (state: MachineState) =>
+  state.context.state.inventory[getSeasonalBanner()];
+
+export const SeasonBannerCountdown: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const level = useSelector(gameService, _level);
+  const hasBanner = useSelector(gameService, _hasBanner);
+  const { openModal } = useContext(ModalContext);
+
+  const season = getCurrentSeason();
+  const seasonWeek = getSeasonWeek();
+
+  const offerEndsAt =
+    SEASONS[season].startDate.getTime() + 7 * 24 * 60 * 60 * 1000;
+
+  const end = useCountdown(offerEndsAt);
+
+  const initialShow =
+    // They have not yet got the banner
+    !hasBanner &&
+    // Don't show for new players
+    level >= 10 &&
+    // Only show in week 1
+    seasonWeek === 1 &&
+    Date.now() < offerEndsAt;
+
+  const [isClosed, setIsClosed] = useState(!initialShow);
+
+  if (isClosed) return null;
+
+  return (
+    <ButtonPanel
+      onClick={() => {
+        openModal("VIP_ITEMS");
+        setIsClosed(true);
+      }}
+      className="flex justify-center"
+      id="emblem-airdrop"
+    >
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label
+            type="info"
+            className="ml-1 mr-1"
+            icon={SUNNYSIDE.icons.stopwatch}
+          >
+            {`Season offer`}
+          </Label>
+
+          <img
+            src={SUNNYSIDE.icons.close}
+            className="h-5 cursor-pointer"
+            onClick={(e) => {
+              setIsClosed(true);
+              e.stopPropagation();
+            }}
+          />
+        </div>
+        <TimerDisplay time={end} />
+      </div>
+    </ButtonPanel>
+  );
+};

--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -30,6 +30,13 @@ export const getRegularMaxDigs = (game: GameState) => {
     maxDigs += 5;
   }
 
+  if (
+    !!game.inventory["Pharaoh's Treasure Banner"] &&
+    getCurrentSeason() === "Pharaoh's Treasure"
+  ) {
+    maxDigs += 5;
+  }
+
   return maxDigs;
 };
 

--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -9,6 +9,7 @@ import { Modal } from "components/ui/Modal";
 import { Digby } from "features/world/ui/beach/Digby";
 import { useTranslation } from "react-i18next";
 import { isWearableActive } from "features/game/lib/wearables";
+import { getCurrentSeason } from "features/game/types/seasons";
 
 export const getRegularMaxDigs = (game: GameState) => {
   let maxDigs = 25;

--- a/src/features/world/ui/beach/Digby.tsx
+++ b/src/features/world/ui/beach/Digby.tsx
@@ -40,6 +40,7 @@ import { ResizableBar } from "components/ui/ProgressBar";
 import { Revealed } from "features/game/components/Revealed";
 import { ChestRevealing, ChestRewardType } from "../chests/ChestRevealing";
 import { gameAnalytics } from "lib/gameAnalytics";
+import { getCurrentSeason } from "features/game/types/seasons";
 
 export function hasReadDigbyIntro() {
   return !!localStorage.getItem("digging.intro");
@@ -353,6 +354,16 @@ const BoostDigItems: Partial<
     ...(BUMPKIN_ITEM_BUFF_LABELS["Bionic Drill"] as BuffLabel),
     location: "Artefact Shop",
   },
+  ...(getCurrentSeason() === "Pharaoh's Treasure"
+    ? {
+        "Pharaoh's Treasure Banner": {
+          shortDescription: "+5 digs",
+          labelType: "vibrant",
+          boostTypeIcon: gift,
+          location: "VIP Item",
+        },
+      }
+    : {}),
 };
 
 const getDefaultTab = (game: GameState) => {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4301,6 +4301,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
+  "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
+  "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4921,12 +4921,14 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.vip.access": "Season VIP Access",
   "season.vip.claim": "Claim your monthly seasonal airdrop.",
   "season.vip.description":
-    "Unlock perks, discounts, bonus tickets, airdrops and more!",
+    "Dominate the season with perks, discounts, bonus tickets, airdrops and more!",
   "season.vip.purchase": "Purchase VIP Items",
   "season.mystery.gift": "Mystery Gift",
   "season.xp.boost": "10% XP boost",
   "season.lifetime.farmer": "Lifetime Farmer",
   "season.free.with.lifetime": "Free with Lifetime Farmer",
+  "season.pharaohs.gift": "5 Extra Desert Digs",
+  "season.ticket.bonus": "+2 {{item}}s (deliveries & chores)",
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5002,6 +5002,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
+  "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
+  "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4851,6 +4851,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
+  "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
+  "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -4878,6 +4878,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.xp.boost": "10% XP буст",
   "season.lifetime.farmer": "Фермер на всю жизнь",
   "season.free.with.lifetime": "Free with Lifetime Farmer",
+  "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
+  "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4854,6 +4854,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.lifetime.farmer": ENGLISH_TERMS["season.lifetime.farmer"],
   "season.free.with.lifetime": ENGLISH_TERMS["season.free.with.lifetime"],
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
+  "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
+  "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3280,6 +3280,8 @@ export type SeasonTerms =
   | "season.supporter.gift"
   | "season.free.season.passes"
   | "season.vip.access"
+  | "season.ticket.bonus"
+  | "season.pharaohs.gift"
   | "season.vip.description"
   | "season.vip.claim"
   | "season.vip.purchase"


### PR DESCRIPTION
# Description

1. Include the amber fossils on the description
2. Add a +5 digs during this season (I think each season we should have a unique boost relating to the season)
3. Reduced the initial discount to only the cooldown period
4. A timer with the offer will appear in the bottom left for players

<img width="497" alt="Screenshot 2024-08-07 at 10 31 13 AM" src="https://github.com/user-attachments/assets/63eb3a2d-464a-43c5-a7e8-2d6aa468b2f0">
