### PR TITLE
[FEAT] Remove cloneDeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gameanalytics": "^4.4.5",
     "howler": "^2.2.3",
     "i18next": "^23.6.0",
+    "immer": "^10.1.1",
     "jwt-decode": "^3.1.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",

--- a/src/features/game/events/claimAirdrop.ts
+++ b/src/features/game/events/claimAirdrop.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { getKeys } from "../types/craftables";
 import { GameState } from "../types/game";
 
@@ -14,7 +13,7 @@ type Options = {
 };
 
 export function claimAirdrop({ state, action }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   if (!game.airdrops || game.airdrops.length === 0) {
     throw new Error("No airdrops exist");

--- a/src/features/game/events/landExpansion/accelerateComposter.ts
+++ b/src/features/game/events/landExpansion/accelerateComposter.ts
@@ -3,7 +3,6 @@ import {
   composterDetails,
 } from "features/game/types/composters";
 import { CompostBuilding, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type AccelerateComposterAction = {
@@ -22,7 +21,7 @@ export function accelerateComposter({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const buildings = stateCopy.buildings[action.building] as CompostBuilding[];
   if (!buildings) {

--- a/src/features/game/events/landExpansion/bannerPurchased.ts
+++ b/src/features/game/events/landExpansion/bannerPurchased.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import {
   SEASONAL_BANNERS,
@@ -65,7 +64,7 @@ export function purchaseBanner({
   createdAt = Date.now(),
   farmId,
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin, inventory } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/burnCollectible.ts
+++ b/src/features/game/events/landExpansion/burnCollectible.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { CollectibleName } from "features/game/types/craftables";
 import { CollectibleLocation } from "features/game/types/collectibles";
@@ -33,7 +32,7 @@ export function burnCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
 
   if (
     action.name !== "Time Warp Totem" &&

--- a/src/features/game/events/landExpansion/buyChicken.ts
+++ b/src/features/game/events/landExpansion/buyChicken.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { ANIMALS } from "features/game/types/craftables";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { getSupportedChickens } from "./utils";
 
@@ -20,7 +19,7 @@ type Options = {
 };
 
 export function buyChicken({ state, action }: Options): GameState {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { bumpkin, inventory, coins } = stateCopy;
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/buyDecoration.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.ts
@@ -11,7 +11,6 @@ import {
   ShopDecorationName,
 } from "features/game/types/decorations";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type buyDecorationAction = {
   type: "decoration.bought";
@@ -34,7 +33,7 @@ export function buyDecoration({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { name } = action;
   const desiredItem = DECORATIONS[name];
 

--- a/src/features/game/events/landExpansion/buyFactionShopItem.ts
+++ b/src/features/game/events/landExpansion/buyFactionShopItem.ts
@@ -5,7 +5,6 @@ import {
   FACTION_SHOP_ITEMS,
 } from "features/game/types/factionShop";
 import { GameState, InventoryItemName } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type BuyFactionShopItemAction = {
   type: "factionShopItem.bought";
@@ -31,7 +30,7 @@ export function buyFactionShopItem({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { faction, inventory, wardrobe, bumpkin } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/buyFarmHand.ts
+++ b/src/features/game/events/landExpansion/buyFarmHand.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState, IslandType, Wardrobe } from "features/game/types/game";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
@@ -34,7 +33,7 @@ export function buyFarmhand({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   // TODO
   const island: IslandType = game.island?.type ?? "basic";

--- a/src/features/game/events/landExpansion/buyMegaStoreItem.ts
+++ b/src/features/game/events/landExpansion/buyMegaStoreItem.ts
@@ -7,7 +7,6 @@ import {
   MegaStoreItemName,
 } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
-import cloneDeep from "lodash.clonedeep";
 
 export type BuyMegaStoreItemAction = {
   type: "megastoreItem.bought";
@@ -25,7 +24,7 @@ export function buyMegaStoreItem({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { name } = action;
 
   if (!stateCopy.bumpkin) {

--- a/src/features/game/events/landExpansion/buyMoreDigs.ts
+++ b/src/features/game/events/landExpansion/buyMoreDigs.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type BuyMoreDigsAction = {
   type: "desert.digsBought";
@@ -16,7 +15,7 @@ const EXTRA_DIGS_AMOUNT = 5;
 export const GRID_DIG_SPOTS = 100;
 
 export function buyMoreDigs({ state }: Options) {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
 

--- a/src/features/game/events/landExpansion/buyWearable.ts
+++ b/src/features/game/events/landExpansion/buyWearable.ts
@@ -7,7 +7,6 @@ import { getKeys } from "features/game/types/craftables";
 
 import { GameState } from "features/game/types/game";
 import { STYLIST_WEARABLES } from "features/game/types/stylist";
-import cloneDeep from "lodash.clonedeep";
 
 export type BuyWearableAction = {
   type: "wearable.bought";
@@ -25,7 +24,7 @@ export function buyWearable({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { name } = action;
   const wearable = { ...STYLIST_WEARABLES, ...ARTEFACT_SHOP_WEARABLES }[name];
 

--- a/src/features/game/events/landExpansion/cancelTrade.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
@@ -19,7 +18,7 @@ export function cancelTrade({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const trade = game.trades.listings?.[action.tradeId];
 

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "../../types/game";
 import {
   CHUM_AMOUNTS,
@@ -32,7 +30,8 @@ export function castRod({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   const { bumpkin } = game;
   const now = new Date(createdAt);
   const today = new Date(now).toISOString().split("T")[0];

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -12,7 +12,6 @@ import {
   InventoryItemName,
   Tree,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum CHOP_ERRORS {
   MISSING_AXE = "No axe",
@@ -101,7 +100,7 @@ export function chop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { trees, bumpkin, collectibles, inventory } = stateCopy;
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/claimAchievement.ts
+++ b/src/features/game/events/landExpansion/claimAchievement.ts
@@ -6,7 +6,6 @@ import {
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type ClaimAchievementAction = {
@@ -20,7 +19,7 @@ type Options = {
 };
 
 const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
+  return state;
 };
 
 export function claimAchievement({ state, action }: Options): GameState {

--- a/src/features/game/events/landExpansion/claimBonus.ts
+++ b/src/features/game/events/landExpansion/claimBonus.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { BONUSES, BonusName } from "features/game/types/bonuses";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type ClaimBonusAction = {
   type: "bonus.claimed";
@@ -20,7 +19,7 @@ export function claimBonus({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const bonus = BONUSES[action.name];
 

--- a/src/features/game/events/landExpansion/claimBumpkinGift.ts
+++ b/src/features/game/events/landExpansion/claimBumpkinGift.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "features/game/types/game";
 import { NPCName } from "lib/npcs";
 import { BUMPKIN_GIFTS, BumpkinGift } from "features/game/types/gifts";
@@ -49,7 +48,7 @@ export function getNextGift({
 }
 
 export function claimGift({ state, action, createdAt = Date.now() }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   if (!game.npcs?.[action.bumpkin]) {
     throw new Error("Bumpkin does not exist");

--- a/src/features/game/events/landExpansion/claimFactionPrize.ts
+++ b/src/features/game/events/landExpansion/claimFactionPrize.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type ClaimFactionPrizeAction = {
   type: "faction.prizeClaimed";
@@ -19,7 +18,7 @@ export function claimFactionPrize({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
 
   const week = game.faction?.history?.[action.week];
   if (!week?.results?.reward) {

--- a/src/features/game/events/landExpansion/claimMilestone.ts
+++ b/src/features/game/events/landExpansion/claimMilestone.ts
@@ -6,7 +6,6 @@ import {
   MILESTONES,
   isInventoryItemReward,
 } from "features/game/types/milestones";
-import cloneDeep from "lodash.clonedeep";
 
 export type ClaimMilestoneAction = {
   type: "milestone.claimed";
@@ -19,7 +18,7 @@ type Options = {
 };
 
 export function claimMilestone({ state, action }: Options): GameState {
-  const copy = cloneDeep(state) as GameState;
+  const copy: GameState = state;
 
   const milestone = MILESTONES[action.milestone];
 

--- a/src/features/game/events/landExpansion/collectCompost.ts
+++ b/src/features/game/events/landExpansion/collectCompost.ts
@@ -3,7 +3,6 @@ import { trackActivity } from "features/game/types/bumpkinActivity";
 import { ComposterName } from "features/game/types/composters";
 import { getKeys } from "features/game/types/craftables";
 import { CompostBuilding, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type collectCompostAction = {
@@ -23,7 +22,7 @@ export function collectCompost({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin } = stateCopy;
 
   const building = stateCopy.buildings[action.building]?.find(

--- a/src/features/game/events/landExpansion/collectCropReward.ts
+++ b/src/features/game/events/landExpansion/collectCropReward.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 
 import { CROPS } from "../../types/crops";
 import { GameState } from "../../types/game";
@@ -20,7 +19,7 @@ export function collectCropReward({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const plot = stateCopy.crops[action.plotIndex];
 
   if (!plot) {

--- a/src/features/game/events/landExpansion/collectEgg.ts
+++ b/src/features/game/events/landExpansion/collectEgg.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 import { CHICKEN_TIME_TO_EGG } from "../../lib/constants";
 import { Chicken, GameState } from "../../types/game";
 
@@ -24,7 +23,7 @@ export function collectEggs({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const chickens = stateCopy.chickens || {};
   const chicken = chickens[action.id];
 

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { BuildingName } from "features/game/types/buildings";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type CollectRecipeAction = {
@@ -22,7 +21,8 @@ export function collectRecipe({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
+
   const { bumpkin } = game;
 
   const building = game.buildings[action.building]?.find(

--- a/src/features/game/events/landExpansion/collectTreeReward.ts
+++ b/src/features/game/events/landExpansion/collectTreeReward.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 
 import { GameState } from "../../types/game";
 import { canChop, CHOP_ERRORS } from "features/game/events/landExpansion/chop";
@@ -20,7 +19,7 @@ export function collectTreeReward({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const tree = stateCopy.trees[action.treeIndex];
 
   if (!tree) {

--- a/src/features/game/events/landExpansion/completeBertObsession.ts
+++ b/src/features/game/events/landExpansion/completeBertObsession.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type CompleteBertObsessionAction = {
@@ -19,7 +18,7 @@ export function completeBertObsession({
   state,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { ChoreV2Name, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import {
   getSeasonalBanner,
   getSeasonalTicket,
@@ -58,7 +57,7 @@ export function completeChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
   const { id } = action;
   const { chores, bumpkin } = game;
 

--- a/src/features/game/events/landExpansion/completeKingdomChore.ts
+++ b/src/features/game/events/landExpansion/completeKingdomChore.ts
@@ -73,7 +73,7 @@ export function completeKingdomChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
   const { id } = action;
   const { kingdomChores, bumpkin, inventory, faction } = game;
 

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
@@ -22,7 +21,7 @@ export function completeSpecialEventTask({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
 
   const event = stateCopy.specialEvents.current[action.event];
   if (!event) throw new Error("Event does not exist");

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 import { BuildingName, BUILDINGS } from "../../types/buildings";
 import { GameState, PlacedItem } from "../../types/game";
 import { getBumpkinLevel } from "features/game/lib/level";
@@ -34,7 +33,7 @@ export function constructBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const { bumpkin, inventory, coins } = stateCopy;
 
   const buildingNumber = inventory[action.name]?.toNumber() ?? 0;

--- a/src/features/game/events/landExpansion/constructBuilding.ts
+++ b/src/features/game/events/landExpansion/constructBuilding.ts
@@ -33,7 +33,7 @@ export function constructBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = state;
+  const stateCopy: GameState = state;
   const { bumpkin, inventory, coins } = stateCopy;
 
   const buildingNumber = inventory[action.name]?.toNumber() ?? 0;

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import {
   ConsumableName,
@@ -126,7 +125,7 @@ export function cook({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
 
   const { building: requiredBuilding, ingredients } = COOKABLES[action.item];
   const { buildings, bumpkin } = stateCopy;

--- a/src/features/game/events/landExpansion/craftCollectible.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.ts
@@ -6,7 +6,6 @@ import {
 } from "features/game/types/craftables";
 
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 
 import { GameState } from "../../types/game";
 import {
@@ -57,7 +56,7 @@ export function craftCollectible({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const bumpkin = stateCopy.bumpkin;
 
   const item = isPotionHouseItem(action.name)

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -8,7 +8,6 @@ import {
   WORKBENCH_TOOLS,
 } from "features/game/types/tools";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 
 import { GameState } from "../../types/game";
 import {
@@ -40,7 +39,7 @@ type Options = {
 };
 
 export function craftTool({ state, action }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const bumpkin = stateCopy.bumpkin;
 
   const tool = CRAFTABLE_TOOLS[action.tool];

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -10,7 +10,6 @@ import {
 } from "features/game/types/seasons";
 import { NPCName } from "lib/npcs";
 import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
-import cloneDeep from "lodash.clonedeep";
 import { isWearableActive } from "features/game/lib/wearables";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
@@ -168,7 +167,7 @@ export function populateOrders(
 }
 
 const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
+  return state;
 };
 
 export function getOrderSellPrice<T>(game: GameState, order: Order): T {

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -9,7 +9,6 @@ import {
 } from "features/game/lib/factions";
 import { BoostType, BoostValue } from "features/game/types/boosts";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum DELIVER_FACTION_KITCHEN_ERRORS {
   NO_FACTION = "Player has not joined a faction",
@@ -50,7 +49,7 @@ export function deliverFactionKitchen({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { faction, inventory } = stateCopy;
 
   if (!faction) {

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { isWearableActive } from "features/game/lib/wearables";
 import { GameState, OilReserve } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type DrillOilReserveAction = {
   type: "oilReserve.drilled";
@@ -78,7 +77,7 @@ export function drillOilReserve({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
 
   const oilReserve = game.oilReserves[action.id];
   const requiredDrills = getRequiredOilDrillAmount(state);

--- a/src/features/game/events/landExpansion/enterRaffle.ts
+++ b/src/features/game/events/landExpansion/enterRaffle.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 
@@ -19,7 +18,7 @@ export function enterRaffle({
   createdAt = Date.now(),
   randomGenerator = Math.random,
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const tickets = game.inventory["Prize Ticket"] ?? new Decimal(0);
 

--- a/src/features/game/events/landExpansion/equip.ts
+++ b/src/features/game/events/landExpansion/equip.ts
@@ -2,7 +2,6 @@ import { Equipped } from "features/game/types/bumpkin";
 import { getKeys } from "features/game/types/craftables";
 import { Bumpkin, GameState, Wardrobe } from "features/game/types/game";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
-import cloneDeep from "lodash.clonedeep";
 
 export type EquipBumpkinAction = {
   type: "bumpkin.equipped";
@@ -20,7 +19,8 @@ export function equip({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
+
   const { bumpkin } = game;
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/equipFarmHand.ts
+++ b/src/features/game/events/landExpansion/equipFarmHand.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { assertEquipment } from "./equip";
 import { Equipped } from "features/game/types/bumpkin";
 import { GameState } from "features/game/types/game";
@@ -20,7 +19,8 @@ export function equipFarmhand({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
+
   const bumpkin = game.farmHands.bumpkins[action.id];
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 type ExchangePackage = { sfl: number; coins: number };
 export type PackageId = 1 | 2 | 3;
@@ -29,7 +28,7 @@ export function exchangeSFLtoCoins({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
   const { bumpkin, balance } = game;
 
   if (!SFL_TO_COIN_PACKAGES[action.packageId]) {

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -4,7 +4,6 @@ import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 
-import cloneDeep from "lodash.clonedeep";
 import { expansionRequirements } from "./revealLand";
 
 export type ExpandLandAction = {
@@ -19,7 +18,8 @@ type Options = {
 };
 
 export function expandLand({ state, action, createdAt = Date.now() }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   const bumpkin = game.bumpkin;
 
   const requirements = expansionRequirements({ game });

--- a/src/features/game/events/landExpansion/feedBumpkin.ts
+++ b/src/features/game/events/landExpansion/feedBumpkin.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { ConsumableName, CONSUMABLES } from "features/game/types/consumables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getFoodExpBoost } from "features/game/expansion/lib/boosts";
 
 export enum FEED_BUMPKIN_ERRORS {
@@ -28,7 +27,7 @@ export function feedBumpkin({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
 
   const bumpkin = stateCopy.bumpkin;
   const buds = stateCopy.buds;

--- a/src/features/game/events/landExpansion/feedChicken.ts
+++ b/src/features/game/events/landExpansion/feedChicken.ts
@@ -5,7 +5,6 @@ import {
   MUTANT_CHICKEN_BOOST_AMOUNT,
 } from "features/game/lib/constants";
 import { Bumpkin, GameState, Inventory } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type LandExpansionFeedChickenAction = {
   type: "chicken.fed";
@@ -68,7 +67,7 @@ export function feedChicken({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin, inventory, collectibles } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -11,7 +11,6 @@ import { isWearableActive } from "features/game/lib/wearables";
 import { BoostType, BoostValue } from "features/game/types/boosts";
 import { CONSUMABLES } from "features/game/types/consumables";
 import { FactionPetRequest, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 const isPawShieldActive = (game: GameState) =>
   isWearableActive({ game, name: "Paw Shield" });
@@ -83,7 +82,7 @@ export function feedFactionPet({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
 
   if (createdAt < START_DATE.getTime()) {
     throw new Error("Faction pet feature is not active yet");

--- a/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
+++ b/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import {
   FRUIT_COMPOST,
   FruitCompostName,
@@ -40,7 +39,7 @@ export function fertiliseFruitPatch({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { fruitPatches, inventory } = stateCopy;
 
   const fruitPatch = fruitPatches[action.patchID];

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { CropCompostName } from "features/game/types/composters";
 import { CROPS, Crop } from "features/game/types/crops";
@@ -50,7 +49,7 @@ export function fertilisePlot({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { crops: plots, inventory, collectibles, bumpkin } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -16,7 +16,6 @@ import {
   GreenHouseFruitName,
 } from "features/game/types/fruits";
 import { Bumpkin, GameState, PlantedFruit } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getTimeLeft } from "lib/utils/time";
 import { FruitPatch } from "features/game/types/game";
 import { FruitCompostName } from "features/game/types/composters";
@@ -177,7 +176,7 @@ export function harvestFruit({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { fruitPatches, bumpkin, collectibles } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -12,7 +12,6 @@ import {
 } from "features/game/types/fruits";
 import { Bumpkin, GameState } from "features/game/types/game";
 import { randomInt } from "lib/utils/random";
-import cloneDeep from "lodash.clonedeep";
 import { getFruitYield } from "./fruitHarvested";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import { isWearableActive } from "features/game/lib/wearables";
@@ -147,7 +146,7 @@ export function plantFruit({
   createdAt = Date.now(),
   harvestsLeft = getHarvestsLeft,
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { fruitPatches, bumpkin } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/fruitTreeRemoved.ts
+++ b/src/features/game/events/landExpansion/fruitTreeRemoved.ts
@@ -6,7 +6,6 @@ import {
   Inventory,
   InventoryItemName,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum FRUIT_TREE_REMOVED_ERRORS {
   MISSING_AXE = "No axe",
@@ -49,7 +48,7 @@ export function removeFruitTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { fruitPatches, bumpkin, inventory, collectibles } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/garbageSold.ts
+++ b/src/features/game/events/landExpansion/garbageSold.ts
@@ -4,7 +4,6 @@ import { GameState } from "features/game/types/game";
 import { GARBAGE, GarbageName } from "features/game/types/garbage";
 
 import { setPrecision } from "lib/utils/formatNumber";
-import cloneDeep from "lodash.clonedeep";
 
 export type SellGarbageAction = {
   type: "garbage.sold";
@@ -18,7 +17,7 @@ type Options = {
 };
 
 export function sellGarbage({ state, action }: Options) {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
   const { item, amount } = action;
 
   const { bumpkin, inventory, coins } = game;

--- a/src/features/game/events/landExpansion/giftFlowers.ts
+++ b/src/features/game/events/landExpansion/giftFlowers.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "features/game/types/game";
 import { FLOWERS, FlowerName } from "features/game/types/flowers";
 import Decimal from "decimal.js-light";
@@ -25,7 +24,7 @@ export function giftFlowers({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   if (!(action.flower in FLOWERS)) {
     throw new Error("Item is not a flower");

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -7,7 +7,6 @@ import {
   GreenHouseCropName,
 } from "../../types/crops";
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import {
   BumpkinActivityName,
   trackActivity,
@@ -77,7 +76,7 @@ export function harvest({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin, crops: plots } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -75,7 +75,7 @@ export function harvestBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = state;
+  const stateCopy: GameState = state;
 
   if (!stateCopy.bumpkin) {
     throw new Error("You do not have a Bumpkin!");

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import {
@@ -76,7 +75,7 @@ export function harvestBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   if (!stateCopy.bumpkin) {
     throw new Error("You do not have a Bumpkin!");

--- a/src/features/game/events/landExpansion/harvestCropMachine.ts
+++ b/src/features/game/events/landExpansion/harvestCropMachine.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type HarvestCropMachineAction = {
   type: "cropMachine.harvested";
@@ -19,7 +18,7 @@ export function harvestCropMachine({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
   const machine = stateCopy.buildings["Crop Machine"]?.[0];
   const { bumpkin } = stateCopy;
 

--- a/src/features/game/events/landExpansion/harvestFlower.ts
+++ b/src/features/game/events/landExpansion/harvestFlower.ts
@@ -1,6 +1,5 @@
 import { FLOWERS, FLOWER_SEEDS } from "features/game/types/flowers";
 import { GameState } from "../../types/game";
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { trackActivity } from "features/game/types/bumpkinActivity";
@@ -25,7 +24,7 @@ export function harvestFlower({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
 
   stateCopy.beehives = updateBeehives({
     game: state,

--- a/src/features/game/events/landExpansion/harvestGreenHouse.ts
+++ b/src/features/game/events/landExpansion/harvestGreenHouse.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import { MAX_POTS } from "./plantGreenhouse";
 import {
@@ -55,7 +53,7 @@ export function harvestGreenHouse({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   // Requires Greenhouse exists
   if (!game.buildings.Greenhouse) {

--- a/src/features/game/events/landExpansion/ironMine.ts
+++ b/src/features/game/events/landExpansion/ironMine.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { canMine } from "features/game/expansion/lib/utils";
-import cloneDeep from "lodash.clonedeep";
 import { IRON_RECOVERY_TIME } from "../../lib/constants";
 import { trackActivity } from "../../types/bumpkinActivity";
 import { GameState } from "../../types/game";
@@ -55,7 +54,7 @@ export function mineIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { iron, bumpkin, collectibles } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/joinFaction.ts
+++ b/src/features/game/events/landExpansion/joinFaction.ts
@@ -5,7 +5,6 @@ import {
   FactionName,
   GameState,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export const FACTIONS: FactionName[] = [
   "bumpkins",
@@ -47,7 +46,7 @@ export function joinFaction({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
 
   if (!FACTIONS.includes(action.faction)) {
     throw new Error("Invalid faction");

--- a/src/features/game/events/landExpansion/leaveFaction.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { FACTION_BANNERS, FACTION_EMBLEMS } from "./joinFaction";
 import { GameState } from "features/game/types/game";
 
@@ -17,7 +16,7 @@ export function leaveFaction({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
 
   if (!game.faction) {
     throw new Error("You are not in a faction");

--- a/src/features/game/events/landExpansion/mineCrimstone.ts
+++ b/src/features/game/events/landExpansion/mineCrimstone.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 import { GameState, Rock } from "../../types/game";
 import { isWearableActive } from "features/game/lib/wearables";
 
@@ -41,7 +40,7 @@ export function mineCrimstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { crimstones, bumpkin } = stateCopy;
   const rock = crimstones?.[action.index];
 

--- a/src/features/game/events/landExpansion/mineGold.ts
+++ b/src/features/game/events/landExpansion/mineGold.ts
@@ -4,7 +4,6 @@ import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
 import { GOLD_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type LandExpansionMineGoldAction = {
   type: "goldRock.mined";
@@ -55,7 +54,7 @@ export function mineGold({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin, collectibles } = stateCopy;
 
   const { index } = action;

--- a/src/features/game/events/landExpansion/mineSunstone.ts
+++ b/src/features/game/events/landExpansion/mineSunstone.ts
@@ -3,7 +3,6 @@ import { canMine } from "features/game/expansion/lib/utils";
 import { SUNSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type MineSunstoneAction = {
   type: "sunstoneRock.mined";
@@ -28,7 +27,7 @@ export function mineSunstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin } = stateCopy;
   const { index } = action;
 

--- a/src/features/game/events/landExpansion/missFish.ts
+++ b/src/features/game/events/landExpansion/missFish.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "../../types/game";
 import { FishingLocation } from "features/game/types/fishing";
 
@@ -19,7 +17,8 @@ export function missFish({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   const location = action.location;
   if (!game.fishing[location].castedAt) {
     throw new Error("Nothing has been casted");

--- a/src/features/game/events/landExpansion/mixPotion.ts
+++ b/src/features/game/events/landExpansion/mixPotion.ts
@@ -4,7 +4,6 @@ import {
   PotionName,
   PotionStatus,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 const MAX_ATTEMPTS = 3;
 
@@ -41,7 +40,7 @@ export function calculateScore(attempt: Attempt): number {
 }
 
 export function mixPotion({ state, action }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const potions = action.potions;
   const attemptIndex = action.attemptNumber - 1;

--- a/src/features/game/events/landExpansion/moveBeehive.ts
+++ b/src/features/game/events/landExpansion/moveBeehive.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_BEEHIVE_ERRORS {
   NO_BEEHIVE = "This beehive does not exist.",
@@ -24,7 +23,7 @@ export function moveBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   if (!stateCopy.beehives[action.id]) {
     throw new Error(MOVE_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);

--- a/src/features/game/events/landExpansion/moveBud.ts
+++ b/src/features/game/events/landExpansion/moveBud.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_BUD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -25,7 +24,7 @@ export function moveBud({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const bud = stateCopy.buds?.[Number(action.id)];
 

--- a/src/features/game/events/landExpansion/moveBuilding.ts
+++ b/src/features/game/events/landExpansion/moveBuilding.ts
@@ -1,7 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { BuildingName } from "features/game/types/buildings";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_BUILDING_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -27,7 +26,7 @@ export function moveBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const buildings = stateCopy.buildings[action.name];
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveChicken.ts
+++ b/src/features/game/events/landExpansion/moveChicken.ts
@@ -7,7 +7,6 @@ import {
   GameState,
   Position,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { eggIsReady } from "./collectEgg";
 
 export enum MOVE_CHICKEN_ERRORS {
@@ -68,7 +67,7 @@ export function moveChicken({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const chickens = stateCopy.chickens;
   const collectibles = stateCopy.collectibles;
 

--- a/src/features/game/events/landExpansion/moveCollectible.ts
+++ b/src/features/game/events/landExpansion/moveCollectible.ts
@@ -3,7 +3,6 @@ import { CollectibleLocation } from "features/game/types/collectibles";
 import { CollectibleName } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 import { hasMoveRestriction } from "features/game/types/removeables";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_COLLECTIBLE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -30,7 +29,7 @@ export function moveCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const collectibleGroup =
     action.location === "home"

--- a/src/features/game/events/landExpansion/moveCrimstone.ts
+++ b/src/features/game/events/landExpansion/moveCrimstone.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { canMine } from "./stoneMine";
 
 export enum MOVE_CRIMSTONE_ERRORS {
@@ -36,7 +35,7 @@ export function moveCrimstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const crimstones = stateCopy.crimstones;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -7,7 +7,6 @@ import {
   GameState,
   Position,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { isReadyToHarvest } from "./harvest";
 import { CROPS } from "features/game/types/crops";
 import { isBasicCrop, isMediumCrop, isAdvancedCrop } from "./harvest";
@@ -213,7 +212,7 @@ export function moveCrop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const { crops, collectibles } = stateCopy;
   const plot = crops[action.id];
 

--- a/src/features/game/events/landExpansion/moveFlowerBed.ts
+++ b/src/features/game/events/landExpansion/moveFlowerBed.ts
@@ -2,7 +2,6 @@ import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { GameState } from "features/game/types/game";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type MoveFlowerBedAction = {
@@ -22,7 +21,7 @@ export function moveFlowerBed({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const flowerBed = stateCopy.flowers.flowerBeds[action.id];
 

--- a/src/features/game/events/landExpansion/moveFruitPatch.ts
+++ b/src/features/game/events/landExpansion/moveFruitPatch.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_FRUIT_PATCH_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,7 +23,7 @@ export function moveFruitPatch({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const fruitPatch = stateCopy.fruitPatches;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveGold.ts
+++ b/src/features/game/events/landExpansion/moveGold.ts
@@ -3,7 +3,6 @@ import { canMine } from "features/game/expansion/lib/utils";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
 import { GOLD_RECOVERY_TIME } from "features/game/lib/constants";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_GOLD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -42,7 +41,7 @@ export function moveGold({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const gold = stateCopy.gold;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveIron.ts
+++ b/src/features/game/events/landExpansion/moveIron.ts
@@ -3,7 +3,6 @@ import { canMine } from "features/game/expansion/lib/utils";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
 import { IRON_RECOVERY_TIME } from "features/game/lib/constants";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_IRON_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -43,7 +42,7 @@ export function moveIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const iron = stateCopy.iron;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveOilReserve.ts
+++ b/src/features/game/events/landExpansion/moveOilReserve.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_OIL_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,7 +23,7 @@ export function moveOilReserve({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const oilReserves = stateCopy.oilReserves;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveStone.ts
+++ b/src/features/game/events/landExpansion/moveStone.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { canMine } from "./stoneMine";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
 
@@ -41,7 +40,7 @@ export function moveStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const stones = stateCopy.stones;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveSunstone.ts
+++ b/src/features/game/events/landExpansion/moveSunstone.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_GOLD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,7 +23,7 @@ export function moveSunstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const sunstones = stateCopy.sunstones;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/moveTree.ts
+++ b/src/features/game/events/landExpansion/moveTree.ts
@@ -1,6 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum MOVE_TREE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,7 +23,7 @@ export function moveTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const trees = stateCopy.trees;
 
   if (stateCopy.bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/oilGreenHouse.ts
+++ b/src/features/game/events/landExpansion/oilGreenHouse.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 
@@ -21,7 +19,7 @@ export function oilGreenhouse({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const oil = game.inventory.Oil ?? new Decimal(0);
 

--- a/src/features/game/events/landExpansion/pickMushroom.ts
+++ b/src/features/game/events/landExpansion/pickMushroom.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 
 export type PickMushroomAction = {
@@ -18,7 +17,7 @@ export function pickMushroom({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const copy = cloneDeep<GameState>(state);
+  const copy: GameState = state;
   const mushrooms = copy.mushrooms?.mushrooms;
 
   if (!mushrooms) {

--- a/src/features/game/events/landExpansion/pickSkill.ts
+++ b/src/features/game/events/landExpansion/pickSkill.ts
@@ -5,7 +5,6 @@ import {
 } from "features/game/types/bumpkinSkills";
 import { getKeys } from "features/game/types/craftables";
 import { Bumpkin, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type PickSkillAction = {
   type: "skill.picked";
@@ -35,7 +34,7 @@ export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
 };
 
 export function pickSkill({ state, action, createdAt = Date.now() }: Options) {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin } = stateCopy;
   if (bumpkin == undefined) {
     throw new Error("You do not have a Bumpkin!");

--- a/src/features/game/events/landExpansion/placeBeehive.ts
+++ b/src/features/game/events/landExpansion/placeBeehive.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { Beehive, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type PlaceBeehiveAction = {
   type: "beehive.placed";
@@ -23,7 +22,7 @@ export function placeBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const copy: GameState = cloneDeep(state);
+  const copy: GameState = state;
 
   const available = (copy.inventory.Beehive || new Decimal(0)).minus(
     Object.keys(copy.beehives ?? {}).length,

--- a/src/features/game/events/landExpansion/placeBud.ts
+++ b/src/features/game/events/landExpansion/placeBud.ts
@@ -1,6 +1,5 @@
 import { CollectibleLocation } from "features/game/types/collectibles";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type PlaceBudAction = {
   type: "bud.placed";
@@ -23,7 +22,7 @@ export function placeBud({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const copy = cloneDeep(state);
+  const copy: GameState = state;
 
   const bud = copy.buds?.[Number(action.id)];
 

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 // import { randomUUID } from "crypto";
-import cloneDeep from "lodash.clonedeep";
 import { BuildingName } from "../../types/buildings";
 import { GameState, PlacedItem } from "../../types/game";
 
@@ -31,7 +30,7 @@ export function placeBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const bumpkin = stateCopy.bumpkin;
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/placeChicken.ts
+++ b/src/features/game/events/landExpansion/placeChicken.ts
@@ -1,5 +1,4 @@
 import { getKeys } from "features/game/types/craftables";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { getSupportedChickens } from "./utils";
 
@@ -23,7 +22,7 @@ export function placeChicken({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const bumpkin = stateCopy.bumpkin;
 
   if (bumpkin === undefined) {

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import {
   CollectibleName,
   COLLECTIBLES_DIMENSIONS,
@@ -29,7 +28,7 @@ export function placeCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { bumpkin } = stateCopy;
   const collectible = action.name;
 

--- a/src/features/game/events/landExpansion/placeCrimstone.ts
+++ b/src/features/game/events/landExpansion/placeCrimstone.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeCrimstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Crimstone Rock"] || new Decimal(0)).minus(
     Object.keys(game.crimstones).length,

--- a/src/features/game/events/landExpansion/placeFlowerBed.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
@@ -25,7 +23,7 @@ export function placeFlowerBed({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Flower Bed"] || new Decimal(0)).minus(
     Object.keys(game.flowers.flowerBeds).length,

--- a/src/features/game/events/landExpansion/placeFruitPatch.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeFruitPatch({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Fruit Patch"] || new Decimal(0)).minus(
     Object.keys(game.fruitPatches).length,

--- a/src/features/game/events/landExpansion/placeGold.ts
+++ b/src/features/game/events/landExpansion/placeGold.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeGold({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Gold Rock"] || new Decimal(0)).minus(
     Object.keys(game.gold).length,

--- a/src/features/game/events/landExpansion/placeIron.ts
+++ b/src/features/game/events/landExpansion/placeIron.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Iron Rock"] || new Decimal(0)).minus(
     Object.keys(game.iron).length,

--- a/src/features/game/events/landExpansion/placeOilReserve.ts
+++ b/src/features/game/events/landExpansion/placeOilReserve.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
@@ -24,7 +22,7 @@ export function placeOilReserve({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Oil Reserve"] || new Decimal(0)).minus(
     Object.keys(game.oilReserves).length,

--- a/src/features/game/events/landExpansion/placePlot.ts
+++ b/src/features/game/events/landExpansion/placePlot.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placePlot({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Crop Plot"] || new Decimal(0)).minus(
     Object.keys(game.crops).length,

--- a/src/features/game/events/landExpansion/placeStone.ts
+++ b/src/features/game/events/landExpansion/placeStone.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Stone Rock"] || new Decimal(0)).minus(
     Object.keys(game.stones).length,

--- a/src/features/game/events/landExpansion/placeSunstone.ts
+++ b/src/features/game/events/landExpansion/placeSunstone.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,7 @@ export function placeSunstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const available = (game.inventory["Sunstone Rock"] || new Decimal(0)).minus(
     Object.keys(game.sunstones).length,

--- a/src/features/game/events/landExpansion/placeTree.ts
+++ b/src/features/game/events/landExpansion/placeTree.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
@@ -28,7 +26,8 @@ export function placeTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   const available = (game.inventory.Tree || new Decimal(0)).minus(
     Object.keys(game.trees).length,
   );

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 
 import { CropName, CROPS, GreenHouseCropName } from "../../types/crops";
@@ -602,7 +601,7 @@ export function plant({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { crops: plots, bumpkin, inventory } = stateCopy;
   const buds = stateCopy.buds ?? {};
 

--- a/src/features/game/events/landExpansion/plantFlower.ts
+++ b/src/features/game/events/landExpansion/plantFlower.ts
@@ -10,7 +10,6 @@ import {
   isFlowerSeed,
 } from "features/game/types/flowers";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 import {
   isCollectibleActive,
@@ -76,7 +75,7 @@ export function plantFlower({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { flowers, bumpkin } = stateCopy;
 
   if (!bumpkin) {

--- a/src/features/game/events/landExpansion/plantGreenhouse.ts
+++ b/src/features/game/events/landExpansion/plantGreenhouse.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 
 import {
@@ -139,7 +137,7 @@ export function plantGreenhouse({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   // Requires Greenhouse exists
   if (!game.buildings.Greenhouse) {

--- a/src/features/game/events/landExpansion/receiveTrade.ts
+++ b/src/features/game/events/landExpansion/receiveTrade.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type ReceiveTradeAction = {
   type: "trade.received";
@@ -17,7 +16,7 @@ export function receiveTrade({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const trade = game.trades.listings?.[action.tradeId];
 

--- a/src/features/game/events/landExpansion/reelRod.ts
+++ b/src/features/game/events/landExpansion/reelRod.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "../../types/game";
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
@@ -22,7 +20,8 @@ export function reelRod({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   const location = action.location;
 
   if (!game.fishing[location].castedAt) {

--- a/src/features/game/events/landExpansion/refreshKingdomChores.ts
+++ b/src/features/game/events/landExpansion/refreshKingdomChores.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type RefreshKingdomChoresAction = {
   type: "kingdomChores.refreshed";
@@ -11,5 +10,5 @@ type Options = {
 };
 
 export function refreshKingdomChores({ state }: Options) {
-  return cloneDeep<GameState>(state);
+  return state;
 }

--- a/src/features/game/events/landExpansion/refundBid.ts
+++ b/src/features/game/events/landExpansion/refundBid.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type RefundBidAction = {
   type: "bid.refunded";
@@ -13,7 +12,7 @@ type Options = {
 };
 
 export function refundBid({ state }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   const bid = game.auctioneer.bid;
   if (!bid) {

--- a/src/features/game/events/landExpansion/removeBeehive.ts
+++ b/src/features/game/events/landExpansion/removeBeehive.ts
@@ -4,7 +4,6 @@ import {
   updateBeehives,
 } from "features/game/lib/updateBeehives";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum REMOVE_BEEHIVE_ERRORS {
   BEEHIVE_NOT_PLACED = "This beehive is not placed",
@@ -26,7 +25,7 @@ export function removeBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const copy: GameState = cloneDeep(state);
+  const copy: GameState = state;
 
   if (!copy.beehives[action.id]) {
     throw new Error(REMOVE_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);

--- a/src/features/game/events/landExpansion/removeBud.ts
+++ b/src/features/game/events/landExpansion/removeBud.ts
@@ -1,6 +1,5 @@
 import { GameState } from "features/game/types/game";
 import { hasBudRemoveRestriction } from "features/game/types/removeables";
-import cloneDeep from "lodash.clonedeep";
 
 export enum REMOVE_BUD_ERRORS {
   INVALID_BUD = "This bud does not exist",
@@ -23,7 +22,7 @@ export function removeBud({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const bud = stateCopy.buds?.[Number(action.id)];
 

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -3,7 +3,6 @@ import { BuildingName } from "features/game/types/buildings";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/craftables";
 import { Chicken, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getSupportedChickens } from "./utils";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { isBuildingEnabled } from "features/game/expansion/lib/buildingRequirements";
@@ -137,7 +136,7 @@ export function removeBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
   const { buildings, inventory, bumpkin } = stateCopy;
   const buildingGroup = buildings[action.name];
 

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -136,7 +136,7 @@ export function removeBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = state;
+  const stateCopy: GameState = state;
   const { buildings, inventory, bumpkin } = stateCopy;
   const buildingGroup = buildings[action.name];
 

--- a/src/features/game/events/landExpansion/removeChicken.ts
+++ b/src/features/game/events/landExpansion/removeChicken.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export enum REMOVE_CHICKEN_ERRORS {
   INVALID_CHICKEN = "This chicken does not exist",
@@ -18,7 +17,7 @@ type Options = {
 };
 
 export function removeChicken({ state, action }: Options) {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const { chickens, inventory, bumpkin } = stateCopy;
 

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -33,7 +33,7 @@ type Options = {
 };
 
 export function removeCollectible({ state, action }: Options) {
-  const stateCopy = state;
+  const stateCopy: GameState = state;
 
   const { inventory, bumpkin } = stateCopy;
   let collectibleGroup =

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { GameState, PlacedLamp } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import {
   areUnsupportedChickensBrewing,
   removeUnsupportedChickens,
@@ -34,7 +33,7 @@ type Options = {
 };
 
 export function removeCollectible({ state, action }: Options) {
-  const stateCopy = cloneDeep(state) as GameState;
+  const stateCopy = state;
 
   const { inventory, bumpkin } = stateCopy;
   let collectibleGroup =

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -1,6 +1,5 @@
 import Decimal from "decimal.js-light";
 import { screenTracker } from "lib/utils/screen";
-import cloneDeep from "lodash.clonedeep";
 import { CROPS } from "../../types/crops";
 import { GameState, InventoryItemName } from "../../types/game";
 import { isReadyToHarvest } from "./harvest";
@@ -29,7 +28,7 @@ type Options = {
 };
 
 export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { crops: plots, inventory } = stateCopy;
 
   if (action.index < 0) {

--- a/src/features/game/events/landExpansion/restock.ts
+++ b/src/features/game/events/landExpansion/restock.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
-import cloneDeep from "lodash.clonedeep";
 
 export type RestockAction = {
   type: "shops.restocked";
@@ -14,7 +13,7 @@ type Options = {
 };
 
 const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
+  return state;
 };
 
 export function restock({ state }: Options): GameState {

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -10,7 +10,6 @@ import {
 } from "features/game/types/expansions";
 import { Airdrop, GameState } from "features/game/types/game";
 
-import cloneDeep from "lodash.clonedeep";
 import { getKeys } from "features/game/types/craftables";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
@@ -50,7 +49,7 @@ export function revealLand({
   farmId = 0,
   promo,
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
 
   if (!game.expansionConstruction) {
     throw new Error("Land is not in construction");

--- a/src/features/game/events/landExpansion/seedBought.ts
+++ b/src/features/game/events/landExpansion/seedBought.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
@@ -56,7 +55,7 @@ type Options = {
 };
 
 export function seedBought({ state, action }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
+  const stateCopy: GameState = state;
   const { item, amount } = action;
 
   if (!(item in SEEDS())) {

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { Crop, CropName, CROPS, GREENHOUSE_CROPS } from "../../types/crops";
 import { GameState } from "../../types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { setPrecision } from "lib/utils/formatNumber";
@@ -39,7 +38,7 @@ export function sellCrop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const { bumpkin } = game;
 

--- a/src/features/game/events/landExpansion/skipChore.ts
+++ b/src/features/game/events/landExpansion/skipChore.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "features/game/types/game";
 import { isChoreId } from "./completeChore";
 
@@ -25,7 +24,8 @@ export function skipChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
+
   const { id } = action;
   const { chores, bumpkin } = game;
 

--- a/src/features/game/events/landExpansion/skipKingdomChore.ts
+++ b/src/features/game/events/landExpansion/skipKingdomChore.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { populateKingdomChores } from "./completeKingdomChore";
 
 export type SkipKingdomChoreAction = {
@@ -18,7 +17,7 @@ export function skipKingdomChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
   const { id } = action;
   const { kingdomChores, bumpkin } = game;
 

--- a/src/features/game/events/landExpansion/skipOrder.ts
+++ b/src/features/game/events/landExpansion/skipOrder.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { populateOrders } from "./deliver";
 import { getDayOfYear } from "lib/utils/time";
 
@@ -19,7 +18,7 @@ export function skipOrder({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  const game: GameState = state;
 
   const order = game.delivery.orders.find((order) => order.id === action.id);
 

--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -10,7 +10,6 @@ import {
   GameState,
   InventoryItemName,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 
 export type StartComposterAction = {
@@ -39,7 +38,7 @@ export function startComposter({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const buildings = stateCopy.buildings[action.building] as CompostBuilding[];
   if (!buildings) {

--- a/src/features/game/events/landExpansion/startPotion.ts
+++ b/src/features/game/events/landExpansion/startPotion.ts
@@ -16,7 +16,7 @@ type Options = {
 export const GAME_FEE = 320;
 
 export function startPotion({ state }: Options): GameState {
-  const stateCopy = state;
+  const stateCopy: GameState = state;
 
   const { bumpkin, coins } = stateCopy;
 

--- a/src/features/game/events/landExpansion/startPotion.ts
+++ b/src/features/game/events/landExpansion/startPotion.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { PotionName, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 
 export type Potions = [PotionName, PotionName, PotionName, PotionName];
 
@@ -17,7 +16,7 @@ type Options = {
 export const GAME_FEE = 320;
 
 export function startPotion({ state }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const { bumpkin, coins } = stateCopy;
 

--- a/src/features/game/events/landExpansion/stoneMine.ts
+++ b/src/features/game/events/landExpansion/stoneMine.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { STONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { BumpkinSkillName } from "features/game/types/bumpkinSkills";
-import cloneDeep from "lodash.clonedeep";
 import { GameState, Rock } from "../../types/game";
 import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
 
@@ -60,7 +59,7 @@ export function mineStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  const stateCopy = state;
   const { stones, bumpkin, collectibles } = stateCopy;
   const rock = stones?.[action.index];
 

--- a/src/features/game/events/landExpansion/supplyCookingOil.ts
+++ b/src/features/game/events/landExpansion/supplyCookingOil.ts
@@ -1,5 +1,4 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 import { CookingBuildingName } from "features/game/types/buildings";
 import Decimal from "decimal.js-light";
@@ -31,7 +30,7 @@ export function supplyCookingOil({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const buildings = stateCopy.buildings[action.building];
   if (!buildings) {

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { CROPS, CropName, CropSeedName } from "features/game/types/crops";
 import {
@@ -112,7 +111,7 @@ export function updateCropMachine({
   state: GameState;
   now: number;
 }) {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy: GameState = state;
 
   // Ensure the crop machine exists
   if (!stateCopy.buildings["Crop Machine"]) {
@@ -251,7 +250,7 @@ export function supplyCropMachine({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  const stateCopy = state;
 
   const oilAdded = action.oil ?? 0;
   const seedsAdded = action.seeds ?? {

--- a/src/features/game/events/landExpansion/tradeFlowerShop.ts
+++ b/src/features/game/events/landExpansion/tradeFlowerShop.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { FlowerName } from "features/game/types/flowers";
@@ -22,7 +21,7 @@ export function tradeFlowerShop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
 
   const flowerShop = game.flowerShop;
   if (!flowerShop) {

--- a/src/features/game/events/landExpansion/treasureSold.ts
+++ b/src/features/game/events/landExpansion/treasureSold.ts
@@ -9,7 +9,6 @@ import {
   SELLABLE_TREASURE,
 } from "features/game/types/treasure";
 import { setPrecision } from "lib/utils/formatNumber";
-import cloneDeep from "lodash.clonedeep";
 
 export type SellTreasureAction = {
   type: "treasure.sold";
@@ -44,7 +43,7 @@ export const isExoticCrop = (
 };
 
 export function sellTreasure({ state, action }: Options) {
-  const game: GameState = cloneDeep(state);
+  const game: GameState = state;
   const { item, amount } = action;
 
   const { bumpkin, coins } = game;

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -9,7 +9,6 @@ import {
   IslandType,
 } from "features/game/types/game";
 
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -661,7 +660,8 @@ export const ISLAND_UPGRADE: Record<
 };
 
 function springUpgrade(state: GameState) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   // Clear the house
   delete game.inventory["Town Center"];
 
@@ -728,7 +728,8 @@ export function expireItems({
 }
 
 function desertUpgrade(state: GameState) {
-  const game = cloneDeep(state) as GameState;
+  const game: GameState = state;
+
   // Clear the house
   delete game.inventory["Town Center"];
   delete game.inventory["House"];
@@ -770,7 +771,7 @@ function desertUpgrade(state: GameState) {
 }
 
 export function upgrade({ state, action, createdAt = Date.now() }: Options) {
-  let game = cloneDeep(state) as GameState;
+  let game: GameState = state;
 
   const upcoming = ISLAND_UPGRADE[game.island.type];
 

--- a/src/features/game/events/minigames/claimMinigamePrize.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import {
   MinigameName,
@@ -56,7 +55,7 @@ export function claimMinigamePrize({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
 
   if (!SUPPORTED_MINIGAMES.includes(action.id)) {
     throw new Error(`${action.id} is not a valid minigame`);

--- a/src/features/game/events/minigames/playMinigame.ts
+++ b/src/features/game/events/minigames/playMinigame.ts
@@ -4,8 +4,6 @@ import {
   SUPPORTED_MINIGAMES,
 } from "features/game/types/minigames";
 
-import cloneDeep from "lodash.clonedeep";
-
 export type PlayMinigameAction = {
   type: "minigame.played";
   id: MinigameName;
@@ -23,7 +21,7 @@ export function playMinigame({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
 
   if (!SUPPORTED_MINIGAMES.includes(action.id)) {
     throw new Error(`${action.id} is not a valid minigame`);

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -9,8 +9,6 @@ import {
 } from "features/game/types/minigames";
 import { COMMODITIES, CommodityName } from "features/game/types/resources";
 
-import cloneDeep from "lodash.clonedeep";
-
 export type MinigameCurrency = CropName | FruitName | CommodityName;
 
 const SFL_LIMIT = 100;
@@ -48,7 +46,7 @@ export function purchaseMinigameItem({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  const game: GameState = state;
 
   if (!SUPPORTED_MINIGAMES.includes(action.id)) {
     throw new Error(`${action.id} is not a valid minigame`);

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -12,6 +12,8 @@ import {
   LandscapingDecorationName,
 } from "../types/decorations";
 
+import { produce } from "immer";
+
 export const MAX_ITEMS: Inventory = {
   Sunflower: new Decimal("30000"),
   Potato: new Decimal("20000"),
@@ -446,13 +448,9 @@ export function processEvent({
     throw new Error(`Unknown event type: ${action}`);
   }
 
-  const newState = handler({
-    state,
-    // TODO - fix type error
-    action: action as never,
-    announcements,
-    farmId,
-  });
+  const newState = produce(state, (draft) =>
+    handler({ state: draft, action: action as never, announcements, farmId }),
+  );
 
   return newState;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7503,6 +7503,11 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"


### PR DESCRIPTION
# Description

Wraps every handler in an immer `produce` function. This library allows you to perform immutable updates using `mutable` syntax. e.g.

```js
hello.world = 1
``` 

instead of 

```js
{...hello, world: 1}
```

Immer is referenced in the xstate docs: https://stately.ai/docs/immer

Why:
- This removes cloneDeep from the code (which takes 6-8ms per gameState cloned).
- `useSelector` will not trigger a re-render unless the object truly reference changed. 

## How to Test

### Regression Test

1. Click around the game, chop a tree, harvest plants etc and ensure that the game renders correctly.

### Memoize Test

Test `useSelector` by:

1. Checkout `main`
1. Memoize The `CodexButton` and add a log to check if it renders

```diff
--- a/src/features/island/hud/components/codex/CodexButton.tsx
+++ b/src/features/island/hud/components/codex/CodexButton.tsx
@@ -17,7 +17,7 @@ const _delivery = (state: MachineState) => state.context.state.delivery;
 const _level = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
-export const CodexButton: React.FC = () => {
+export const CodexButtonFC: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const { gameService } = useContext(Context);
@@ -25,6 +25,7 @@ export const CodexButton: React.FC = () => {
   const deliveries = useSelector(gameService, _delivery);
   const level = useSelector(gameService, _level);
 
+  console.log({ render: "CodexButton", deliveries, level });
   const hasDeliveries =
     // Show if any new orders has popped up (but not for new players)
     (hasNewOrders(deliveries) && level >= 2) ||
@@ -143,3 +144,5 @@ export const CodexButton: React.FC = () => {
     </div>
   );
 };
+
+export const CodexButton = React.memo(CodexButtonFC);
```

3. Play the game and review the logs
4. Checkout `feat/immer-3` and see if the CodexButton still re-renders on state change

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
