### PR TITLE
[CHORE] Bump Phaser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash.shuffle": "^4.2.0",
     "mitt": "^3.0.1",
     "mobile-device-detect": "^0.4.3",
-    "phaser": "^3.60.0",
+    "phaser": "^3.80.1",
     "phaser-navmesh": "^2.3.1",
     "phaser3-rex-plugins": "^1.60.1",
     "process": "^0.11.10",

--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -25,7 +25,6 @@ export const TEST_BUMPKIN: Bumpkin = {
     background: "Farm Background",
     beard: "Santa Beard",
     hat: "Deep Sea Helm",
-    aura: "Coin Aura",
   },
   skills: {},
   achievements: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -6597,7 +6597,7 @@ eventemitter3@^3.1.2:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^5.0.0:
+eventemitter3@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
@@ -9419,12 +9419,12 @@ phaser3-rex-plugins@^1.60.1:
     papaparse "^5.4.1"
     webfontloader "^1.6.28"
 
-phaser@^3.60.0:
-  version "3.60.0"
-  resolved "https://registry.yarnpkg.com/phaser/-/phaser-3.60.0.tgz#8a555623e64c707482e6321485b4bda84604590d"
-  integrity sha512-IKUy35EnoEVcl2EmJ8WOyK4X8OoxHYdlhZLgRGpNrvD1fEagYffhVmwHcapE/tGiLgyrnezmXIo5RrH2NcrTHw==
+phaser@^3.80.1:
+  version "3.80.1"
+  resolved "https://registry.yarnpkg.com/phaser/-/phaser-3.80.1.tgz#d387d7e04042218f74b9d22e261f437e54464440"
+  integrity sha512-VQGAWoDOkEpAWYkI+PUADv5Ql+SM0xpLuAMBJHz9tBcOLqjJ2wd8bUhxJgOqclQlLTg97NmMd9MhS75w16x1Cw==
   dependencies:
-    eventemitter3 "^5.0.0"
+    eventemitter3 "^5.0.1"
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Description

Phaser 3.80.0 contains a fix when tearing down containers, where this.anims is undefined:
https://github.com/phaserjs/phaser/releases/tag/v3.80.0

This impacts our scene swap

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]