### PR TITLE
[FIX] Stop Expansions past Spring 16

### DIFF
--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -230,12 +230,15 @@ export const IslandUpgrader: React.FC<Props> = ({ gameState, offset }) => {
     if (showAnimations) confetti();
   };
 
-  const nextExpansioon =
+  const nextExpansion =
     (gameState.inventory["Basic Land"]?.toNumber() ?? 3) + 1;
 
   const getPosition = () => {
-    if (island === "basic" && nextExpansioon == 10) {
+    if (island === "basic" && nextExpansion === 10) {
       return { x: 1, y: -5 };
+    }
+    if (island === "spring" && nextExpansion === 17) {
+      return { x: -26, y: 14 };
     }
 
     return { x: 7, y: 0 };

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -297,10 +297,13 @@ export const UpcomingExpansion: React.FC = () => {
     // Only pulsate first 5 times
     state.inventory["Basic Land"]?.lte(4);
 
-  const maxExpanded = expansions > 9;
   const islandType = state.island.type;
-
-  const hasFullBasicIsland = maxExpanded && islandType === "basic";
+  const maxExpanded =
+    islandType === "basic"
+      ? expansions > 9
+      : islandType === "spring"
+        ? expansions > 16
+        : null;
 
   return (
     <>
@@ -312,7 +315,7 @@ export const UpcomingExpansion: React.FC = () => {
         />
       )}
 
-      {!state.expansionConstruction && requirements && !hasFullBasicIsland && (
+      {!state.expansionConstruction && requirements && !maxExpanded && (
         <ExpandIcon
           canExpand={canExpand}
           inventory={state.inventory}

--- a/src/features/portal/example/PortalExamplePhaser.tsx
+++ b/src/features/portal/example/PortalExamplePhaser.tsx
@@ -55,7 +55,7 @@ export const PortalExamplePhaser: React.FC = () => {
         default: "arcade",
         arcade: {
           debug: true,
-          gravity: { y: 0 },
+          gravity: { x: 0, y: 0 },
         },
       },
       scene: scenes,

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -220,7 +220,7 @@ export const PhaserComponent: React.FC<Props> = ({
         default: "arcade",
         arcade: {
           debug: true,
-          gravity: { y: 0 },
+          gravity: { x: 0, y: 0 },
         },
       },
       scene: scenes,


### PR DESCRIPTION
# Description

Players are still able to expand past Spring expansion 16 even though they are presented the option to upgrade to desert island.
This PR moves the raft to the place where expansion 17 is and disables the expand button at expansion 17

![image](https://github.com/user-attachments/assets/28df9541-09b8-40bf-b00c-f3c5131ebe20)


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Set Island Type to Basic and number of basic land to 9
- basic land raft should still be there as it was before

- Set Island type to spring and number of basic land to 16
- raft should teleport form the right to next to the place where expansion 17 would be


# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
