### PR TITLE
[FIX] Bug where you can list above trade limit/inventory amount

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -158,13 +158,19 @@ const ListTrade: React.FC<{
         </div>
         <div className="flex flex-col items-end pr-1">
           <Label
-            type={inventory[selected]?.lt(quantity) ? "danger" : "info"}
+            type={
+              (inventory?.[selected] ?? new Decimal(0)).lt(quantity)
+                ? "danger"
+                : "info"
+            }
             className="my-1"
           >
             {t("bumpkinTrade.available")}
           </Label>
           <span className="text-sm mr-1 font-secondary">
-            {formatNumber(inventory?.[selected] ?? 0, { decimalPlaces: 0 })}
+            {formatNumber(inventory?.[selected] ?? new Decimal(0), {
+              decimalPlaces: 0,
+            })}
           </span>
         </div>
       </div>
@@ -347,7 +353,8 @@ const ListTrade: React.FC<{
             isTooHigh ||
             isTooLow ||
             maxSFL ||
-            (inventory[selected]?.lt(quantity) ?? false) ||
+            quantity.gt(inventory?.[selected] ?? new Decimal(0)) ||
+            quantity.gt(TRADE_LIMITS[selected] ?? new Decimal(0)) ||
             quantity.equals(0) || // Disable when quantity is 0
             sfl.equals(0) || // Disable when sfl is 0
             isSaving

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -85,11 +85,18 @@ const ListTrade: React.FC<{
           <span className="text-sm">{emblem}</span>
         </div>
         <div className="flex flex-col items-end pr-1">
-          <Label type={"info"} className="my-1">
+          <Label
+            type={
+              (inventory?.[emblem] ?? new Decimal(0)).lt(quantity)
+                ? "danger"
+                : "info"
+            }
+            className="my-1"
+          >
             {t("bumpkinTrade.available")}
           </Label>
           <span className="text-sm mr-1">
-            {formatNumber(inventory?.[emblem] ?? 0, {
+            {formatNumber(inventory?.[emblem] ?? new Decimal(0), {
               decimalPlaces: 0,
             })}
           </span>
@@ -278,7 +285,8 @@ const ListTrade: React.FC<{
             isTooHigh ||
             isTooLow ||
             maxSFL ||
-            (inventory[emblem]?.lt(quantity) ?? false) ||
+            quantity.gt(inventory?.[emblem] ?? new Decimal(0)) ||
+            quantity.gt(EMBLEM_TRADE_LIMITS?.[emblem] ?? new Decimal(0)) ||
             quantity.equals(0) || // Disable when quantity is 0
             sfl.equals(0) || // Disable when sfl is 0
             isSaving


### PR DESCRIPTION
# Description

The Disabled condition for the list button wasn't properly working for the following 2 conditions:
- Entering an amount over trade limit
- Enter an amount over inventory amount

This PR Resolves this

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
