### PR TITLE
[CHORE] Show usernames in auction results

### DIFF
--- a/src/features/game/lib/auctionMachine.ts
+++ b/src/features/game/lib/auctionMachine.ts
@@ -38,6 +38,7 @@ export type LeaderboardBid = {
   sfl: number;
   items: Partial<Record<InventoryItemName, number>>;
   farmId: number;
+  username?: string;
 };
 
 export type AuctionResults = {
@@ -52,6 +53,7 @@ export interface Context {
   farmId: number;
   token: string;
   deviceTrackerId: string;
+  username?: string;
   bid?: GameState["auctioneer"]["bid"];
   auctions: Auction[];
   auctionId: string;
@@ -146,6 +148,7 @@ export const createAuctioneerMachine = ({
               farmId: 44,
               experience: 10,
               items: { Gold: 50, "Block Buck": 30, Radish: 50 },
+              username: "Big Farmer",
               sfl: 1000,
               tickets: 5,
               rank: 1,
@@ -156,6 +159,7 @@ export const createAuctioneerMachine = ({
               items: { Gold: 5, "Block Buck": 3, Radish: 5 },
               sfl: 100,
               tickets: 5,
+              username: "Top Dog",
               rank: 2,
             },
             {
@@ -321,10 +325,6 @@ export const createAuctioneerMachine = ({
             src: async (context, event) => {
               const { tickets, auctionId } = event as BidEvent;
 
-              const auction = context.auctions.find(
-                (a) => a.auctionId === auctionId,
-              ) as Auction;
-
               const { game } = await bid({
                 farmId: Number(context.farmId),
                 token: context.token as string,
@@ -360,7 +360,7 @@ export const createAuctioneerMachine = ({
         checkingResults: {
           entry: "setTransactionId",
           invoke: {
-            src: async (context, event) => {
+            src: async (context) => {
               const auctionResult = await getAuctionResults({
                 farmId: Number(context.farmId),
                 token: context.token as string,

--- a/src/features/retreat/components/auctioneer/AuctionLeaderboardTable.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionLeaderboardTable.tsx
@@ -42,7 +42,7 @@ export const AuctionLeaderboardTable: React.FC<{
                 style={{ border: "1px solid #b96f50", textAlign: "left" }}
                 className="p-1.5"
               >
-                <p>{t("farm")}</p>
+                <p>{t("player")}</p>
               </th>
               <th
                 style={{ border: "1px solid #b96f50", textAlign: "left" }}
@@ -70,31 +70,32 @@ export const AuctionLeaderboardTable: React.FC<{
               >
                 {toOrdinalSuffix(result.rank)}
               </td>
-              <td
-                style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 flex flex-wrap"
-              >
-                {result.farmId}
+              <td style={{ border: "1px solid #b96f50" }} className="p-1.5">
+                <div className="flex flex-wrap">
+                  {result.username ?? result.farmId}
+                </div>
               </td>
               <td
                 style={{ border: "1px solid #b96f50" }}
                 className="p-1.5 w-2/5"
               >
-                {result.sfl > 0 && (
-                  <div className="flex w-16">
-                    <img src={sflIcon} className="h-4 mr-0.5" />
-                    <span className="text-xs">{result.sfl}</span>
-                  </div>
-                )}
-                {getKeys(result.items).map((name) => (
-                  <div className="flex w-16" key={name}>
-                    <img
-                      src={ITEM_DETAILS[name].image}
-                      className="h-4 mr-0.5"
-                    />
-                    <span className="text-xs">{result.items[name]}</span>
-                  </div>
-                ))}
+                <div className="flex space-x-1 flex-wrap space-y-1">
+                  {result.sfl > 0 && (
+                    <div className="flex w-16 items-center">
+                      <img src={sflIcon} className="h-4 mr-0.5" />
+                      <span className="text-xs">{result.sfl}</span>
+                    </div>
+                  )}
+                  {getKeys(result.items).map((name) => (
+                    <div className="flex w-16 items-center" key={name}>
+                      <img
+                        src={ITEM_DETAILS[name].image}
+                        className="h-4 mr-0.5"
+                      />
+                      <span className="text-xs">{result.items[name]}</span>
+                    </div>
+                  ))}
+                </div>
               </td>
             </tr>
           ))}

--- a/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
@@ -148,10 +148,6 @@ export const AuctioneerContent: React.FC<Props> = ({
   }
 
   if (auctioneerState.matches("winner")) {
-    const auction = auctioneerState.context.auctions.find(
-      (auction) => auction.auctionId === auctioneerState.context.bid?.auctionId,
-    ) as IAuction;
-
     return (
       <Winner
         onMint={onMint}

--- a/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
@@ -57,7 +57,7 @@ export const AuctioneerModal: React.FC<Props> = ({
     },
   }) as unknown as MachineInterpreter;
 
-  const [auctioneerState, send] = useActor(auctionService);
+  const [auctioneerState] = useActor(auctionService);
 
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION
# Description

Show usernames in the auction results. If there is no username, fallback to farm id.

<img width="502" alt="Screenshot 2024-08-09 at 11 01 22 AM" src="https://github.com/user-attachments/assets/bf4a062d-8c0b-4709-8763-c2036a8309be">


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run a short auction and see the results

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
