### PR TITLE
[FIX] Crop Proc Sprites Not Loading

### DIFF
--- a/src/features/island/plots/lib/plant.ts
+++ b/src/features/island/plots/lib/plant.ts
@@ -2,21 +2,36 @@ import { CropName } from "features/game/types/crops";
 import { getKeys } from "features/game/types/craftables";
 import { CONFIG } from "lib/config";
 
+import sunflowerProc from "assets/crops/sunflower/proc_sprite.png";
+import potatoProc from "assets/crops/potato/proc_sprite.png";
+import pumpkinProc from "assets/crops/pumpkin/proc_sprite.png";
+import carrotProc from "assets/crops/carrot/proc_sprite.png";
+import cabbageProc from "assets/crops/cabbage/proc_sprite.png";
+import beetrootProc from "assets/crops/beetroot/proc_sprite.png";
+import cauliflowerProc from "assets/crops/cauliflower/proc_sprite.png";
+import parsnipProc from "assets/crops/parsnip/proc_sprite.png";
+import eggplantProc from "assets/crops/eggplant/proc_sprite.png";
+import cornProc from "assets/crops/corn/proc_sprite.png";
+import radishProc from "assets/crops/radish/proc_sprite.png";
+import wheatProc from "assets/crops/wheat/proc_sprite.png";
+import kaleProc from "assets/crops/kale/proc_sprite.png";
+import soybeanProc from "assets/crops/soybean/proc_sprite.png";
+
 const HARVEST_PROC_SPRITES: Record<CropName, any> = {
-  Sunflower: "assets/crops/sunflower/proc_sprite.png",
-  Potato: "assets/crops/potato/proc_sprite.png",
-  Pumpkin: "assets/crops/pumpkin/proc_sprite.png",
-  Carrot: "assets/crops/carrot/proc_sprite.png",
-  Cabbage: "assets/crops/cabbage/proc_sprite.png",
-  Beetroot: "assets/crops/beetroot/proc_sprite.png",
-  Cauliflower: "assets/crops/cauliflower/proc_sprite.png",
-  Parsnip: "assets/crops/parsnip/proc_sprite.png",
-  Eggplant: "assets/crops/eggplant/proc_sprite.png",
-  Corn: "assets/crops/corn/proc_sprite.png",
-  Radish: "assets/crops/radish/proc_sprite.png",
-  Wheat: "assets/crops/wheat/proc_sprite.png",
-  Kale: "assets/crops/kale/proc_sprite.png",
-  Soybean: "assets/crops/soybean/proc_sprite.png",
+  Sunflower: sunflowerProc,
+  Potato: potatoProc,
+  Pumpkin: pumpkinProc,
+  Carrot: carrotProc,
+  Cabbage: cabbageProc,
+  Beetroot: beetrootProc,
+  Cauliflower: cauliflowerProc,
+  Parsnip: parsnipProc,
+  Eggplant: eggplantProc,
+  Corn: cornProc,
+  Radish: radishProc,
+  Wheat: wheatProc,
+  Kale: kaleProc,
+  Soybean: soybeanProc,
 };
 
 export const HARVEST_PROC_ANIMATION = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -2952,7 +2952,7 @@ const guideFactionPet: Record<GuideFactionPet, string> = {
   "guide.factionPet.one":
     "Each week the pet will request 3 foods. When fed, the XP from the food will go to the total XP tally for the faction.",
   "guide.factionPet.two":
-    "Your faction will have a goal xp they need to reach each week. If the faction reaches the goal, the next week goal will be 30% harder than the total xp achieved for the week! If the goal isn't reached, it will be reset back to 500 x faction members.",
+    "Your faction will have a goal xp they need to reach each week. If the faction reaches the goal, the next week goal will be 15% harder than the total xp achieved for the week! If the goal isn't reached, it will be reset back to 1000 x faction members.",
   "guide.factionPet.three":
     "If the faction doesn't reach the goal then the pet will go to sleep for 1 week.",
   "guide.factionPet.four":


### PR DESCRIPTION
# Description

The sprites for crop procs were not loading correctly. This PR fixes that issue. 

![proc-fix](https://github.com/user-attachments/assets/7c969ccc-1656-4f17-8b0b-fa5b6a0046b8)

I have also updated the faction pet guide which was left out of a previous PR.

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

- Locally you can add a crop with an amount of 10 and then harvest. You should see the proc animation.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
