### PR TITLE
[FIX] Use once listeners to help cleanup and listener leaks

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -197,7 +197,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         },
       );
 
-      idleLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+      idleLoader.once(Phaser.Loader.Events.COMPLETE, () => {
         if (
           !scene.textures.exists(this.idleSpriteKey as string) ||
           this.ready
@@ -261,7 +261,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         frameHeight: 64,
       });
 
-      digLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+      digLoader.once(Phaser.Loader.Events.COMPLETE, () => {
         this.createDigAnimation();
         digLoader.removeAllListeners();
       });
@@ -276,7 +276,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         frameHeight: 64,
       });
 
-      drillLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+      drillLoader.once(Phaser.Loader.Events.COMPLETE, () => {
         this.createDrillAnimation();
         drillLoader.removeAllListeners();
       });
@@ -490,7 +490,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
           },
         );
 
-        backauraLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+        backauraLoader.once(Phaser.Loader.Events.COMPLETE, () => {
           if (
             !container.scene.textures.exists(this.backAuraKey as string) ||
             this.ready
@@ -528,7 +528,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
           },
         );
 
-        frontauraLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+        frontauraLoader.once(Phaser.Loader.Events.COMPLETE, () => {
           if (
             !container.scene.textures.exists(this.frontAuraKey as string) ||
             this.ready

--- a/src/features/world/containers/FishermanContainer.ts
+++ b/src/features/world/containers/FishermanContainer.ts
@@ -39,7 +39,7 @@ export class FishermanContainer extends Phaser.GameObjects.Container {
       },
     );
 
-    spriteLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+    spriteLoader.once(Phaser.Loader.Events.COMPLETE, () => {
       if (this.sprite) return;
 
       const idle = scene.add.sprite(0, 0, "fisherman").setOrigin(0.5);

--- a/src/features/world/containers/PlaceableContainer.ts
+++ b/src/features/world/containers/PlaceableContainer.ts
@@ -34,7 +34,7 @@ export class PlaceableContainer extends Phaser.GameObjects.Container {
       frameHeight: 32,
     });
 
-    spriteLoader.addListener(Phaser.Loader.Events.COMPLETE, () => {
+    spriteLoader.once(Phaser.Loader.Events.COMPLETE, () => {
       if (this.sprite) return;
 
       const idle = scene.add.sprite(0, 0, key).setOrigin(0.5);


### PR DESCRIPTION
# Description

Updates the Plaza to use `once` when adding listeners when we don't need the listener to trigger multiple times.

## How To Test

Walk around the plaza

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]