### PR TITLE
[CHORE] Improve intl in BudBox modal

### DIFF
--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -192,9 +192,11 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
                   type="info"
                   className="absolute -top-3 -right-2"
                 >
-                  {`${t("budBox.today")} - ${secondsToString(secondsLeftToday, {
-                    length: "short",
-                  })} ${t("budBox.left")}`}
+                  {t("budBox.today", {
+                    timeLeft: secondsToString(secondsLeftToday, {
+                      length: "short",
+                    }),
+                  })}
                 </Label>
               )}
               {index > 0 && (

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -9,7 +9,6 @@ import { Revealed } from "features/game/components/Revealed";
 
 import React, { useContext, useState } from "react";
 
-import budIcon from "assets/icons/bud.png";
 import chestIcon from "assets/icons/gift.png";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -47,23 +46,10 @@ export function getDailyBudBoxType(date: Date): TypeTrait {
   return BUD_ORDER[index];
 }
 
-const ICONS: Record<TypeTrait, string> = {
-  Plaza: budIcon,
-  Woodlands: budIcon,
-  Cave: budIcon,
-  Sea: budIcon,
-  Castle: budIcon,
-  Port: budIcon,
-  Retreat: budIcon,
-  Saphiro: budIcon,
-  Snow: budIcon,
-  Beach: budIcon,
-};
-
 export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
-  const { t } = useAppTranslation();
+  const { t, i18n } = useAppTranslation();
 
   // Just a prolonged UI state to show the shuffle of items animation
   const [isPicking, setIsPicking] = useState(false);
@@ -85,6 +71,27 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
     setIsRevealing(true);
     setIsPicking(false);
     setIsLoading && setIsLoading(false);
+  };
+
+  const getDayOfWeek = (date: Date): string => {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: "long",
+    };
+
+    switch (i18n.language) {
+      case "fr":
+        return date.toLocaleDateString("fr-FR", options);
+      case "pt":
+        return date.toLocaleDateString("pt-PT", options);
+      case "tk":
+        return date.toLocaleDateString("tr-TR", options);
+      case "zh-CN":
+        return date.toLocaleDateString("zh-CN", options);
+      case "ru":
+        return date.toLocaleDateString("ru-RU", options);
+      default:
+        return date.toLocaleDateString("en-US", options);
+    }
   };
 
   if (isPicking || (gameState.matches("revealing") && isRevealing)) {
@@ -142,12 +149,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
         {days.map((_, index) => {
           const date = new Date(now + 24 * 60 * 60 * 1000 * index);
           const dailyBud = getDailyBudBoxType(date);
-
           const hasBud = playerBudTypes.includes(dailyBud);
-
-          const dayOfWeek = date.toLocaleDateString("en-US", {
-            weekday: "long",
-          });
 
           return (
             <OuterPanel
@@ -170,7 +172,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
                 <Button
                   onClick={open}
                   disabled={!hasBud}
-                  className="w-16 h-8 text-xs mt-4"
+                  className="w-auto h-8 text-xs mt-4"
                 >
                   {t("budBox.open")}
                 </Button>
@@ -188,16 +190,19 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
                 <Label
                   icon={SUNNYSIDE.icons.stopwatch}
                   type="info"
-                  className="absolute -top-2 -right-2"
+                  className="absolute -top-3 -right-2"
                 >
-                  {`Today - ${secondsToString(secondsLeftToday, {
+                  {`${t("budBox.today")} - ${secondsToString(secondsLeftToday, {
                     length: "short",
-                  })} left`}
+                  })} ${t("budBox.left")}`}
                 </Label>
               )}
               {index > 0 && (
-                <Label type="default" className="absolute -top-2 -right-2">
-                  {dayOfWeek}
+                <Label
+                  type="default"
+                  className="absolute -top-2 -right-2 capitalize"
+                >
+                  {getDayOfWeek(date)}
                 </Label>
               )}
             </OuterPanel>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -628,7 +628,7 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": "已打开",
   "budBox.title": "蕾芽箱",
   "budBox.description": "每天，对应的蕾芽类型可以解锁宝箱奖励。", // Farming rewards -> Chest rewards
-  "budBox.today": ENGLISH_TERMS["budBox.today"],
+  "budBox.today": "今天 - 剩下 {{timeLeft}}",
   "raffle.title": "哥布林抽奖",
   "raffle.description":
     "每个月您都有机会赢得奖励。获奖者名单将在 Discord 上公布。",

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -628,6 +628,8 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": "已打开",
   "budBox.title": "蕾芽箱",
   "budBox.description": "每天，对应的蕾芽类型可以解锁宝箱奖励。", // Farming rewards -> Chest rewards
+  "budBox.today": ENGLISH_TERMS["budBox.today"],
+  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "哥布林抽奖",
   "raffle.description":
     "每个月您都有机会赢得奖励。获奖者名单将在 Discord 上公布。",

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -629,7 +629,6 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.title": "蕾芽箱",
   "budBox.description": "每天，对应的蕾芽类型可以解锁宝箱奖励。", // Farming rewards -> Chest rewards
   "budBox.today": ENGLISH_TERMS["budBox.today"],
-  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "哥布林抽奖",
   "raffle.description":
     "每个月您都有机会赢得奖励。获奖者名单将在 Discord 上公布。",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -639,6 +639,8 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": "Opened today",
   "budBox.title": "Bud box",
   "budBox.description": "Each day, a bud type can unlock farming rewards.",
+  "budBox.today": "Today",
+  "budBox.left": "left",
   "raffle.title": "Goblin Raffle",
   "raffle.description":
     "Each month, you have a chance to win rewards. Winners will be announced on Discord.",

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -639,8 +639,7 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": "Opened today",
   "budBox.title": "Bud box",
   "budBox.description": "Each day, a bud type can unlock farming rewards.",
-  "budBox.today": "Today",
-  "budBox.left": "left",
+  "budBox.today": "Today - {{timeLeft}} left",
   "raffle.title": "Goblin Raffle",
   "raffle.description":
     "Each month, you have a chance to win rewards. Winners will be announced on Discord.",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -645,7 +645,6 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.description":
     "Chaque jour, un type de tête peut débloquer des récompenses agricoles.",
   "budBox.today": ENGLISH_TERMS["budBox.today"],
-  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "Tombola Gobelin",
   "raffle.description":
     "Chaque mois, vous avez une chance de gagner des récompenses. Les gagnants seront annoncés sur Discord.",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -644,6 +644,8 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.title": "Bud Box",
   "budBox.description":
     "Chaque jour, un type de tête peut débloquer des récompenses agricoles.",
+  "budBox.today": ENGLISH_TERMS["budBox.today"],
+  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "Tombola Gobelin",
   "raffle.description":
     "Chaque mois, vous avez une chance de gagner des récompenses. Les gagnants seront annoncés sur Discord.",

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -640,6 +640,8 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": ENGLISH_TERMS["budBox.opened"],
   "budBox.title": ENGLISH_TERMS["budBox.title"],
   "budBox.description": ENGLISH_TERMS["budBox.description"],
+  "budBox.today": ENGLISH_TERMS["budBox.today"],
+  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": ENGLISH_TERMS["raffle.title"],
   "raffle.description": ENGLISH_TERMS["raffle.description"],
   "raffle.entries": ENGLISH_TERMS["raffle.entries"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -641,7 +641,6 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.title": ENGLISH_TERMS["budBox.title"],
   "budBox.description": ENGLISH_TERMS["budBox.description"],
   "budBox.today": ENGLISH_TERMS["budBox.today"],
-  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": ENGLISH_TERMS["raffle.title"],
   "raffle.description": ENGLISH_TERMS["raffle.description"],
   "raffle.entries": ENGLISH_TERMS["raffle.entries"],

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -639,8 +639,7 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.title": "Сундук бадов",
   "budBox.description":
     "Каждый день определенный вид бада поможет получить тебе награду.",
-  "budBox.today": "Сегодня",
-  "budBox.left": "осталось",
+  "budBox.today": "Сегодня - {{timeLeft}} осталось",
   "raffle.title": "Розыгрыш от гоблинов",
   "raffle.description":
     "Каждый месяц у тебя есть шанс выиграть награды. Победители будут объявлены в Discord.",

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -638,7 +638,9 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.opened": "Уже открыт сегодня",
   "budBox.title": "Сундук бадов",
   "budBox.description":
-    "Каждый день определенный вид бада может получать фермерские награды.",
+    "Каждый день определенный вид бада поможет получить тебе награду.",
+  "budBox.today": "Сегодня",
+  "budBox.left": "осталось",
   "raffle.title": "Розыгрыш от гоблинов",
   "raffle.description":
     "Каждый месяц у тебя есть шанс выиграть награды. Победители будут объявлены в Discord.",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -642,6 +642,8 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.title": "Tomurcuk kutusu",
   "budBox.description":
     "Her gün bir tomurcuk türü çiftçilik ödüllerinin kilidini açabilir.",
+  "budBox.today": ENGLISH_TERMS["budBox.today"],
+  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "Goblin Çekilişi",
   "raffle.description":
     "Her ay ödül kazanma şansınız var. Kazananlar Discord'da duyurulacaktır.",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -643,7 +643,6 @@ const basicTreasure: Record<BasicTreasure, string> = {
   "budBox.description":
     "Her gün bir tomurcuk türü çiftçilik ödüllerinin kilidini açabilir.",
   "budBox.today": ENGLISH_TERMS["budBox.today"],
-  "budBox.left": ENGLISH_TERMS["budBox.left"],
   "raffle.title": "Goblin Çekilişi",
   "raffle.description":
     "Her ay ödül kazanma şansınız var. Kazananlar Discord'da duyurulacaktır.",

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -412,7 +412,6 @@ export type BasicTreasure =
   | "budBox.title"
   | "budBox.description"
   | "budBox.today"
-  | "budBox.left"
   | "raffle.title"
   | "raffle.description"
   | "raffle.entries"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -411,6 +411,8 @@ export type BasicTreasure =
   | "budBox.opened"
   | "budBox.title"
   | "budBox.description"
+  | "budBox.today"
+  | "budBox.left"
   | "raffle.title"
   | "raffle.description"
   | "raffle.entries"

--- a/src/lib/i18n/useAppTranslations.ts
+++ b/src/lib/i18n/useAppTranslations.ts
@@ -5,7 +5,7 @@ import Decimal from "decimal.js-light";
 
 // Define a custom hook that wraps the original useTranslation hook
 export const useAppTranslation = () => {
-  const { t: originalT } = useOriginalTranslation();
+  const { t: originalT, i18n } = useOriginalTranslation();
 
   // Here we cast the original t function to a more strictly typed version
   const t = (
@@ -13,5 +13,5 @@ export const useAppTranslation = () => {
     args?: { [key: string]: string | number | Decimal },
   ) => originalT(key, args);
 
-  return { t };
+  return { t, i18n };
 };


### PR DESCRIPTION
# Description
1. Today/TimeLeft were not translated
2. Open button had fixed width
3. Weekdays were not translated

Before: 
![image](https://github.com/user-attachments/assets/d0624d5e-c374-46cc-856d-e34603b779d5)

After: 
![Screenshot 2024-08-10 182217](https://github.com/user-attachments/assets/b8044621-8e2a-480c-805c-ea955a68339f)
