### PR TITLE
[CHORE] Remove deep clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gameanalytics": "^4.4.5",
     "howler": "^2.2.3",
     "i18next": "^23.6.0",
+    "immer": "^10.1.1",
     "jwt-decode": "^3.1.2",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",

--- a/src/features/game/events/landExpansion/burnCollectible.ts
+++ b/src/features/game/events/landExpansion/burnCollectible.ts
@@ -1,9 +1,9 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { CollectibleName } from "features/game/types/craftables";
 import { CollectibleLocation } from "features/game/types/collectibles";
 import { HourglassType } from "features/island/collectibles/components/Hourglass";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type BurnCollectibleAction = {
   type: "collectible.burned";
@@ -33,56 +33,56 @@ export function burnCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-
-  if (
-    action.name !== "Time Warp Totem" &&
-    !hourglassTypes.includes(action.name as HourglassType)
-  ) {
-    throw new Error(`Cannot burn ${action.name}`);
-  }
-
-  let collectibleGroup =
-    action.location === "home"
-      ? stateCopy.home.collectibles[action.name]
-      : stateCopy.collectibles[action.name];
-
-  if (!collectibleGroup) {
-    throw new Error("Invalid collectible");
-  }
-
-  const collectibleToRemove = collectibleGroup.find(
-    (collectible) => collectible.id === action.id,
-  );
-
-  if (!collectibleToRemove) {
-    throw new Error("Collectible does not exist");
-  }
-
-  collectibleGroup = collectibleGroup.filter(
-    (collectible) => collectible.id !== collectibleToRemove.id,
-  );
-
-  if (collectibleGroup.length === 0) {
-    if (action.location === "home") {
-      delete stateCopy.home.collectibles[action.name];
+  return produce(state, (stateCopy) => {
+    if (
+      action.name !== "Time Warp Totem" &&
+      !hourglassTypes.includes(action.name as HourglassType)
+    ) {
+      throw new Error(`Cannot burn ${action.name}`);
     }
 
-    if (action.location === "farm") {
-      delete stateCopy.collectibles[action.name];
-    }
-  } else {
-    if (action.location === "home") {
-      stateCopy.home.collectibles[action.name] = collectibleGroup;
+    let collectibleGroup =
+      action.location === "home"
+        ? stateCopy.home.collectibles[action.name]
+        : stateCopy.collectibles[action.name];
+
+    if (!collectibleGroup) {
+      throw new Error("Invalid collectible");
     }
 
-    if (action.location === "farm") {
-      stateCopy.collectibles[action.name] = collectibleGroup;
+    const collectibleToRemove = collectibleGroup.find(
+      (collectible) => collectible.id === action.id,
+    );
+
+    if (!collectibleToRemove) {
+      throw new Error("Collectible does not exist");
     }
-  }
 
-  const previous = stateCopy.inventory[action.name] || new Decimal(0);
-  stateCopy.inventory[action.name] = previous.sub(1);
+    collectibleGroup = collectibleGroup.filter(
+      (collectible) => collectible.id !== collectibleToRemove.id,
+    );
 
-  return stateCopy;
+    if (collectibleGroup.length === 0) {
+      if (action.location === "home") {
+        delete stateCopy.home.collectibles[action.name];
+      }
+
+      if (action.location === "farm") {
+        delete stateCopy.collectibles[action.name];
+      }
+    } else {
+      if (action.location === "home") {
+        stateCopy.home.collectibles[action.name] = collectibleGroup;
+      }
+
+      if (action.location === "farm") {
+        stateCopy.collectibles[action.name] = collectibleGroup;
+      }
+    }
+
+    const previous = stateCopy.inventory[action.name] || new Decimal(0);
+    stateCopy.inventory[action.name] = previous.sub(1);
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/buyChicken.ts
+++ b/src/features/game/events/landExpansion/buyChicken.ts
@@ -1,9 +1,9 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { ANIMALS } from "features/game/types/craftables";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { getSupportedChickens } from "./utils";
+import { produce } from "immer";
 
 export type BuyChickenAction = {
   type: "chicken.bought";
@@ -20,38 +20,39 @@ type Options = {
 };
 
 export function buyChicken({ state, action }: Options): GameState {
-  const stateCopy: GameState = cloneDeep(state);
-  const { bumpkin, inventory, coins } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { bumpkin, inventory, coins } = stateCopy;
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const price = ANIMALS.Chicken.price ?? 0;
+    const price = ANIMALS.Chicken.price ?? 0;
 
-  if (coins < price) {
-    throw new Error("Insufficient Coins");
-  }
+    if (coins < price) {
+      throw new Error("Insufficient Coins");
+    }
 
-  const previousChickens = inventory.Chicken || new Decimal(0);
+    const previousChickens = inventory.Chicken || new Decimal(0);
 
-  if (previousChickens.gte(getSupportedChickens(state))) {
-    throw new Error("Insufficient space for more chickens");
-  }
+    if (previousChickens.gte(getSupportedChickens(state))) {
+      throw new Error("Insufficient space for more chickens");
+    }
 
-  bumpkin.activity = trackActivity("Chicken Bought", bumpkin.activity);
-  bumpkin.activity = trackActivity(
-    "Coins Spent",
-    bumpkin.activity,
-    new Decimal(price),
-  );
+    bumpkin.activity = trackActivity("Chicken Bought", bumpkin.activity);
+    bumpkin.activity = trackActivity(
+      "Coins Spent",
+      bumpkin.activity,
+      new Decimal(price),
+    );
 
-  stateCopy.chickens[action.id] = {
-    multiplier: 1,
-    coordinates: action.coordinates,
-  };
-  stateCopy.coins = coins - price;
-  stateCopy.inventory.Chicken = previousChickens.add(1);
+    stateCopy.chickens[action.id] = {
+      multiplier: 1,
+      coordinates: action.coordinates,
+    };
+    stateCopy.coins = coins - price;
+    stateCopy.inventory.Chicken = previousChickens.add(1);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/buyDecoration.ts
+++ b/src/features/game/events/landExpansion/buyDecoration.ts
@@ -11,7 +11,7 @@ import {
   ShopDecorationName,
 } from "features/game/types/decorations";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type buyDecorationAction = {
   type: "decoration.bought";
@@ -34,94 +34,95 @@ export function buyDecoration({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
-  const { name } = action;
-  const desiredItem = DECORATIONS[name];
+  return produce(state, (stateCopy) => {
+    const { name } = action;
+    const desiredItem = DECORATIONS[name];
 
-  if (!desiredItem) {
-    throw new Error("This item is not a decoration");
-  }
+    if (!desiredItem) {
+      throw new Error("This item is not a decoration");
+    }
 
-  const { bumpkin } = stateCopy;
+    const { bumpkin } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("Bumpkin not found");
-  }
+    if (!bumpkin) {
+      throw new Error("Bumpkin not found");
+    }
 
-  const price = desiredItem.coins ?? 0;
+    const price = desiredItem.coins ?? 0;
 
-  if (price && stateCopy.coins < price) {
-    throw new Error("Insufficient coins");
-  }
+    if (price && stateCopy.coins < price) {
+      throw new Error("Insufficient coins");
+    }
 
-  const subtractedInventory = getKeys(desiredItem.ingredients)?.reduce(
-    (inventory, ingredient) => {
-      const count = inventory[ingredient] || new Decimal(0);
-      const desiredCount =
-        desiredItem.ingredients[ingredient] || new Decimal(0);
+    const subtractedInventory = getKeys(desiredItem.ingredients)?.reduce(
+      (inventory, ingredient) => {
+        const count = inventory[ingredient] || new Decimal(0);
+        const desiredCount =
+          desiredItem.ingredients[ingredient] || new Decimal(0);
 
-      if (count.lessThan(desiredCount)) {
-        throw new Error(`Insufficient ingredient: ${ingredient}`);
+        if (count.lessThan(desiredCount)) {
+          throw new Error(`Insufficient ingredient: ${ingredient}`);
+        }
+
+        return {
+          ...inventory,
+          [ingredient]: count.sub(desiredCount),
+        };
+      },
+      stateCopy.inventory,
+    );
+
+    const oldAmount = stateCopy.inventory[name] ?? new Decimal(0);
+
+    bumpkin.activity = trackActivity(
+      "Coins Spent",
+      bumpkin?.activity,
+      new Decimal(price),
+    );
+    bumpkin.activity = trackActivity(
+      `${name} Bought`,
+      bumpkin?.activity,
+      new Decimal(1),
+    );
+
+    if (action.coordinates && action.id) {
+      const dimensions = COLLECTIBLES_DIMENSIONS[name];
+      const collides = detectCollision({
+        state: stateCopy,
+        position: {
+          x: action.coordinates.x,
+          y: action.coordinates.y,
+          height: dimensions.height,
+          width: dimensions.width,
+        },
+        location: "farm",
+        name,
+      });
+
+      if (collides) {
+        throw new Error("Decoration collides");
       }
 
-      return {
-        ...inventory,
-        [ingredient]: count.sub(desiredCount),
-      };
-    },
-    stateCopy.inventory,
-  );
+      const previous = stateCopy.collectibles[name] ?? [];
 
-  const oldAmount = stateCopy.inventory[name] ?? new Decimal(0);
+      if (previous.find((item) => item.id === action.id)) {
+        throw new Error("ID already exists");
+      }
 
-  bumpkin.activity = trackActivity(
-    "Coins Spent",
-    bumpkin?.activity,
-    new Decimal(price),
-  );
-  bumpkin.activity = trackActivity(
-    `${name} Bought`,
-    bumpkin?.activity,
-    new Decimal(1),
-  );
-
-  if (action.coordinates && action.id) {
-    const dimensions = COLLECTIBLES_DIMENSIONS[name];
-    const collides = detectCollision({
-      state: stateCopy,
-      position: {
-        x: action.coordinates.x,
-        y: action.coordinates.y,
-        height: dimensions.height,
-        width: dimensions.width,
-      },
-      location: "farm",
-      name,
-    });
-
-    if (collides) {
-      throw new Error("Decoration collides");
+      stateCopy.collectibles[name] = previous.concat({
+        id: action.id,
+        coordinates: { x: action.coordinates.x, y: action.coordinates.y },
+        readyAt: Date.now(),
+        createdAt: Date.now(),
+      });
     }
 
-    const previous = stateCopy.collectibles[name] ?? [];
+    stateCopy.coins = stateCopy.coins - price;
+    stateCopy.inventory = {
+      ...subtractedInventory,
+      [name]: oldAmount.add(1),
+    };
 
-    if (previous.find((item) => item.id === action.id)) {
-      throw new Error("ID already exists");
-    }
-
-    stateCopy.collectibles[name] = previous.concat({
-      id: action.id,
-      coordinates: { x: action.coordinates.x, y: action.coordinates.y },
-      readyAt: Date.now(),
-      createdAt: Date.now(),
-    });
-  }
-
-  stateCopy.coins = stateCopy.coins - price;
-  stateCopy.inventory = {
-    ...subtractedInventory,
-    [name]: oldAmount.add(1),
-  };
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/buyFarmHand.ts
+++ b/src/features/game/events/landExpansion/buyFarmHand.ts
@@ -1,6 +1,6 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState, IslandType, Wardrobe } from "features/game/types/game";
+import { produce } from "immer";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 
 export type BuyFarmHandAction = {
@@ -34,61 +34,61 @@ export function buyFarmhand({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    // TODO
+    const island: IslandType = game.island?.type ?? "basic";
+    const capacity = ISLAND_BUMPKIN_CAPACITY[island];
+    const farmHands = Object.keys(game.farmHands.bumpkins).length;
 
-  // TODO
-  const island: IslandType = game.island?.type ?? "basic";
-  const capacity = ISLAND_BUMPKIN_CAPACITY[island];
-  const farmHands = Object.keys(game.farmHands.bumpkins).length;
-
-  if (farmHands + 1 >= capacity) {
-    throw new Error("No space for a farm hand");
-  }
-
-  const cost = (farmHands + 2) * 5;
-
-  // Use coupon, otherwise Block Bucks
-  const coupons = game.inventory["Farmhand Coupon"];
-  if (coupons?.gte(1)) {
-    game.inventory["Farmhand Coupon"] = coupons.sub(1);
-  } else {
-    const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
-    if (blockBucks.lt(cost)) {
-      throw new Error("Insufficient Block Bucks");
+    if (farmHands + 1 >= capacity) {
+      throw new Error("No space for a farm hand");
     }
 
-    game.inventory["Block Buck"] = blockBucks.sub(cost);
-  }
+    const cost = (farmHands + 2) * 5;
 
-  const id = Object.keys(game.farmHands.bumpkins).length + 1;
-  game.farmHands.bumpkins[id] = {
-    equipped: {
-      background: "Farm Background",
-      body: "Beige Farmer Potion",
-      hair: "Basic Hair",
-      shoes: "Black Farmer Boots",
-      tool: "Farmer Pitchfork",
-      shirt: "Yellow Farmer Shirt",
-      pants: "Farmer Overalls",
-    },
-  };
+    // Use coupon, otherwise Block Bucks
+    const coupons = game.inventory["Farmhand Coupon"];
+    if (coupons?.gte(1)) {
+      game.inventory["Farmhand Coupon"] = coupons.sub(1);
+    } else {
+      const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
+      if (blockBucks.lt(cost)) {
+        throw new Error("Insufficient Block Bucks");
+      }
 
-  // Add wearables to wardrobe
-  game.wardrobe = Object.values(FARM_HAND_PARTS).reduce(
-    (wardrobe, part) => {
-      const total = (wardrobe[part] ?? 0) + 1;
-      return {
-        ...wardrobe,
-        [part]: total,
-      };
-    },
-    game.wardrobe ?? ({} as Wardrobe),
-  );
+      game.inventory["Block Buck"] = blockBucks.sub(cost);
+    }
 
-  const previous = game.inventory.Farmhand ?? new Decimal(0);
-  game.inventory.Farmhand = previous.add(1);
+    const id = Object.keys(game.farmHands.bumpkins).length + 1;
+    game.farmHands.bumpkins[id] = {
+      equipped: {
+        background: "Farm Background",
+        body: "Beige Farmer Potion",
+        hair: "Basic Hair",
+        shoes: "Black Farmer Boots",
+        tool: "Farmer Pitchfork",
+        shirt: "Yellow Farmer Shirt",
+        pants: "Farmer Overalls",
+      },
+    };
 
-  return {
-    ...game,
-  };
+    // Add wearables to wardrobe
+    game.wardrobe = Object.values(FARM_HAND_PARTS).reduce(
+      (wardrobe, part) => {
+        const total = (wardrobe[part] ?? 0) + 1;
+        return {
+          ...wardrobe,
+          [part]: total,
+        };
+      },
+      game.wardrobe ?? ({} as Wardrobe),
+    );
+
+    const previous = game.inventory.Farmhand ?? new Decimal(0);
+    game.inventory.Farmhand = previous.add(1);
+
+    return {
+      ...game,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/buyFarmHand.ts
+++ b/src/features/game/events/landExpansion/buyFarmHand.ts
@@ -87,8 +87,6 @@ export function buyFarmhand({
     const previous = game.inventory.Farmhand ?? new Decimal(0);
     game.inventory.Farmhand = previous.add(1);
 
-    return {
-      ...game,
-    };
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/buyMegaStoreItem.ts
+++ b/src/features/game/events/landExpansion/buyMegaStoreItem.ts
@@ -7,7 +7,7 @@ import {
   MegaStoreItemName,
 } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type BuyMegaStoreItemAction = {
   type: "megastoreItem.bought";
@@ -25,89 +25,90 @@ export function buyMegaStoreItem({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
-  const { name } = action;
+  return produce(state, (stateCopy) => {
+    const { name } = action;
 
-  if (!stateCopy.bumpkin) {
-    throw new Error("Bumpkin not found");
-  }
+    if (!stateCopy.bumpkin) {
+      throw new Error("Bumpkin not found");
+    }
 
-  const { megastore } = stateCopy;
-  const availableItems = [...megastore.collectibles, ...megastore.wearables];
+    const { megastore } = stateCopy;
+    const availableItems = [...megastore.collectibles, ...megastore.wearables];
 
-  const item = availableItems.find((item) => item.name === name);
+    const item = availableItems.find((item) => item.name === name);
 
-  if (!item) {
-    throw new Error("This item is not available");
-  }
+    if (!item) {
+      throw new Error("This item is not available");
+    }
 
-  // Check current balance of item if there is a limit
-  if (item.limit) {
-    if (item.type === "wearable") {
-      const currentAmount = stateCopy.wardrobe[name as BumpkinItem] ?? 0;
+    // Check current balance of item if there is a limit
+    if (item.limit) {
+      if (item.type === "wearable") {
+        const currentAmount = stateCopy.wardrobe[name as BumpkinItem] ?? 0;
 
-      if (currentAmount >= item.limit) {
-        throw new Error(
-          "You already have reached the max allowed for this item",
-        );
+        if (currentAmount >= item.limit) {
+          throw new Error(
+            "You already have reached the max allowed for this item",
+          );
+        }
+      } else {
+        const currentAmount =
+          stateCopy.inventory[name as InventoryItemName] ?? new Decimal(0);
+
+        if (currentAmount.greaterThanOrEqualTo(item.limit)) {
+          throw new Error(
+            "You already have reached the max allowed for this item",
+          );
+        }
       }
+    }
+
+    const currency =
+      item.currency === "Seasonal Ticket" ? getSeasonalTicket() : item.currency;
+
+    // Handle SFL purchase
+    if (currency === "SFL") {
+      if (stateCopy.balance.lessThan(item.price)) {
+        throw new Error("Not enough SFL");
+      }
+
+      stateCopy.balance = stateCopy.balance.sub(item.price);
+
+      stateCopy.bumpkin.activity = trackActivity(
+        "SFL Spent",
+        stateCopy.bumpkin.activity,
+        item.price,
+      );
     } else {
-      const currentAmount =
+      // Handle inventory item purchase
+      const inventoryBalance = stateCopy.inventory[currency] ?? new Decimal(0);
+
+      if (inventoryBalance.lessThan(item.price)) {
+        throw new Error(`Not enough ${currency}`);
+      }
+
+      stateCopy.inventory[currency] = inventoryBalance.sub(item.price);
+    }
+
+    // Wearable
+    if (item.type === "wearable") {
+      const oldAmount = stateCopy.wardrobe[name as BumpkinItem] ?? 0;
+
+      stateCopy.wardrobe[name as BumpkinItem] = oldAmount + 1;
+
+      return stateCopy;
+    }
+
+    // Collectible
+    if (item.type === "collectible") {
+      const oldAmount =
         stateCopy.inventory[name as InventoryItemName] ?? new Decimal(0);
 
-      if (currentAmount.greaterThanOrEqualTo(item.limit)) {
-        throw new Error(
-          "You already have reached the max allowed for this item",
-        );
-      }
+      stateCopy.inventory[name as InventoryItemName] = oldAmount.add(1);
+
+      return stateCopy;
     }
-  }
-
-  const currency =
-    item.currency === "Seasonal Ticket" ? getSeasonalTicket() : item.currency;
-
-  // Handle SFL purchase
-  if (currency === "SFL") {
-    if (stateCopy.balance.lessThan(item.price)) {
-      throw new Error("Not enough SFL");
-    }
-
-    stateCopy.balance = stateCopy.balance.sub(item.price);
-
-    stateCopy.bumpkin.activity = trackActivity(
-      "SFL Spent",
-      stateCopy.bumpkin.activity,
-      item.price,
-    );
-  } else {
-    // Handle inventory item purchase
-    const inventoryBalance = stateCopy.inventory[currency] ?? new Decimal(0);
-
-    if (inventoryBalance.lessThan(item.price)) {
-      throw new Error(`Not enough ${currency}`);
-    }
-
-    stateCopy.inventory[currency] = inventoryBalance.sub(item.price);
-  }
-
-  // Wearable
-  if (item.type === "wearable") {
-    const oldAmount = stateCopy.wardrobe[name as BumpkinItem] ?? 0;
-
-    stateCopy.wardrobe[name as BumpkinItem] = oldAmount + 1;
 
     return stateCopy;
-  }
-
-  // Collectible
-  if (item.type === "collectible") {
-    const oldAmount =
-      stateCopy.inventory[name as InventoryItemName] ?? new Decimal(0);
-
-    stateCopy.inventory[name as InventoryItemName] = oldAmount.add(1);
-
-    return stateCopy;
-  }
-
-  return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/buyMoreDigs.ts
+++ b/src/features/game/events/landExpansion/buyMoreDigs.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+
+import { produce } from "immer";
 
 export type BuyMoreDigsAction = {
   type: "desert.digsBought";
@@ -16,19 +17,21 @@ const EXTRA_DIGS_AMOUNT = 5;
 export const GRID_DIG_SPOTS = 100;
 
 export function buyMoreDigs({ state }: Options) {
-  const game = cloneDeep(state);
+  return produce(state, (game) => {
+    const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
 
-  const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
+    if (blockBucks.lt(1)) {
+      throw new Error(
+        "Player does not have enough block bucks to buy more digs",
+      );
+    }
 
-  if (blockBucks.lt(1)) {
-    throw new Error("Player does not have enough block bucks to buy more digs");
-  }
+    const extraDigs = game.desert.digging.extraDigs ?? 0;
 
-  const extraDigs = game.desert.digging.extraDigs ?? 0;
+    game.inventory["Block Buck"] = blockBucks.sub(1);
 
-  game.inventory["Block Buck"] = blockBucks.sub(1);
+    game.desert.digging.extraDigs = extraDigs + EXTRA_DIGS_AMOUNT;
 
-  game.desert.digging.extraDigs = extraDigs + EXTRA_DIGS_AMOUNT;
-
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/buyWearable.ts
+++ b/src/features/game/events/landExpansion/buyWearable.ts
@@ -7,7 +7,7 @@ import { getKeys } from "features/game/types/craftables";
 
 import { GameState } from "features/game/types/game";
 import { STYLIST_WEARABLES } from "features/game/types/stylist";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type BuyWearableAction = {
   type: "wearable.bought";
@@ -25,71 +25,72 @@ export function buyWearable({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
-  const { name } = action;
-  const wearable = { ...STYLIST_WEARABLES, ...ARTEFACT_SHOP_WEARABLES }[name];
+  return produce(state, (stateCopy) => {
+    const { name } = action;
+    const wearable = { ...STYLIST_WEARABLES, ...ARTEFACT_SHOP_WEARABLES }[name];
 
-  if (!wearable) {
-    throw new Error("This item is not available");
-  }
-
-  const { bumpkin } = stateCopy;
-
-  if (!bumpkin) {
-    throw new Error("Bumpkin not found");
-  }
-
-  if (wearable.from && wearable.from?.getTime() > createdAt) {
-    throw new Error("Too early");
-  }
-
-  if (wearable.to && wearable.to?.getTime() < createdAt) {
-    throw new Error("Too late");
-  }
-
-  if (wearable.hoursPlayed) {
-    const hoursPlayed = (Date.now() - stateCopy.createdAt) / 1000 / 60 / 60;
-
-    if (hoursPlayed < wearable.hoursPlayed) {
-      throw new Error("Not available");
+    if (!wearable) {
+      throw new Error("This item is not available");
     }
-  }
 
-  const price =
-    SFLDiscount(stateCopy, new Decimal(wearable.coins)).toNumber() ?? 0;
+    const { bumpkin } = stateCopy;
 
-  if (price && stateCopy.coins < price) {
-    throw new Error("Insufficient coins");
-  }
+    if (!bumpkin) {
+      throw new Error("Bumpkin not found");
+    }
 
-  const subtractedInventory = getKeys(wearable.ingredients)?.reduce(
-    (inventory, ingredient) => {
-      const count = inventory[ingredient] || new Decimal(0);
-      const desiredCount = wearable.ingredients[ingredient] || new Decimal(0);
+    if (wearable.from && wearable.from?.getTime() > createdAt) {
+      throw new Error("Too early");
+    }
 
-      if (count.lessThan(desiredCount)) {
-        throw new Error(`Insufficient ingredient: ${ingredient}`);
+    if (wearable.to && wearable.to?.getTime() < createdAt) {
+      throw new Error("Too late");
+    }
+
+    if (wearable.hoursPlayed) {
+      const hoursPlayed = (Date.now() - stateCopy.createdAt) / 1000 / 60 / 60;
+
+      if (hoursPlayed < wearable.hoursPlayed) {
+        throw new Error("Not available");
       }
+    }
 
-      return {
-        ...inventory,
-        [ingredient]: count.sub(desiredCount),
-      };
-    },
-    stateCopy.inventory,
-  );
+    const price =
+      SFLDiscount(stateCopy, new Decimal(wearable.coins)).toNumber() ?? 0;
 
-  bumpkin.activity = trackActivity(
-    "Coins Spent",
-    bumpkin?.activity,
-    new Decimal(price),
-  );
+    if (price && stateCopy.coins < price) {
+      throw new Error("Insufficient coins");
+    }
 
-  const oldAmount = stateCopy.wardrobe[name] ?? 0;
+    const subtractedInventory = getKeys(wearable.ingredients)?.reduce(
+      (inventory, ingredient) => {
+        const count = inventory[ingredient] || new Decimal(0);
+        const desiredCount = wearable.ingredients[ingredient] || new Decimal(0);
 
-  stateCopy.coins = stateCopy.coins - price;
-  stateCopy.wardrobe[name] = oldAmount + 1;
-  stateCopy.inventory = subtractedInventory;
+        if (count.lessThan(desiredCount)) {
+          throw new Error(`Insufficient ingredient: ${ingredient}`);
+        }
 
-  return stateCopy;
+        return {
+          ...inventory,
+          [ingredient]: count.sub(desiredCount),
+        };
+      },
+      stateCopy.inventory,
+    );
+
+    bumpkin.activity = trackActivity(
+      "Coins Spent",
+      bumpkin?.activity,
+      new Decimal(price),
+    );
+
+    const oldAmount = stateCopy.wardrobe[name] ?? 0;
+
+    stateCopy.coins = stateCopy.coins - price;
+    stateCopy.wardrobe[name] = oldAmount + 1;
+    stateCopy.inventory = subtractedInventory;
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/cancelTrade.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.ts
@@ -1,7 +1,7 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
+import { produce } from "immer";
 
 export type CancelTradeAction = {
   type: "trade.cancelled";
@@ -19,26 +19,26 @@ export function cancelTrade({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const trade = game.trades.listings?.[action.tradeId];
 
-  const trade = game.trades.listings?.[action.tradeId];
+    if (!trade) {
+      throw new Error(`Trade #${action.tradeId} does not exist`);
+    }
 
-  if (!trade) {
-    throw new Error(`Trade #${action.tradeId} does not exist`);
-  }
+    if (trade.boughtAt) {
+      throw new Error(`Trade #${action.tradeId} already bought`);
+    }
 
-  if (trade.boughtAt) {
-    throw new Error(`Trade #${action.tradeId} already bought`);
-  }
+    // Add items
+    getKeys(trade.items).forEach((name) => {
+      const previous = game.inventory[name] ?? new Decimal(0);
+      game.inventory[name] = previous.add(trade.items[name] ?? 0);
+    });
 
-  // Add items
-  getKeys(trade.items).forEach((name) => {
-    const previous = game.inventory[name] ?? new Decimal(0);
-    game.inventory[name] = previous.add(trade.items[name] ?? 0);
+    // Remove Trade
+    delete game.trades.listings?.[action.tradeId];
+
+    return game;
   });
-
-  // Remove Trade
-  delete game.trades.listings?.[action.tradeId];
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -1,5 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "../../types/game";
 import {
   CHUM_AMOUNTS,
@@ -13,6 +11,7 @@ import Decimal from "decimal.js-light";
 import { isWearableActive } from "features/game/lib/wearables";
 import { translate } from "lib/i18n/translate";
 import { trackActivity } from "features/game/types/bumpkinActivity";
+import { produce } from "immer";
 
 export type CastRodAction = {
   type: "rod.casted";
@@ -32,82 +31,85 @@ export function castRod({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
-  const { bumpkin } = game;
-  const now = new Date(createdAt);
-  const today = new Date(now).toISOString().split("T")[0];
-  const location = action.location;
+  return produce(state, (game) => {
+    const { bumpkin } = game;
+    const now = new Date(createdAt);
+    const today = new Date(now).toISOString().split("T")[0];
+    const location = action.location;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-
-  if (getDailyFishingCount(game) >= getDailyFishingLimit(game)) {
-    throw new Error(translate("error.dailyAttemptsExhausted"));
-  }
-
-  const rodCount = game.inventory.Rod ?? new Decimal(0);
-  // Requires Rod
-  if (rodCount.lt(1) && !isWearableActive({ name: "Ancient Rod", game })) {
-    throw new Error(translate("error.missingRod"));
-  }
-
-  // Requires Bait
-  const baitCount = game.inventory[action.bait] ?? new Decimal(0);
-  if (baitCount.lt(1)) {
-    throw new Error(`Missing ${action.bait}`);
-  }
-
-  if (game.fishing[location].castedAt) {
-    throw new Error(translate("error.alreadyCasted"));
-  }
-
-  // Subtract Chum
-  if (action.chum) {
-    const chumAmount = CHUM_AMOUNTS[action.chum] ?? 0;
-    if (!chumAmount) {
-      throw new Error(`${action.chum} Axe is not a supported chum`);
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
     }
 
-    const inventoryChum = game.inventory[action.chum] ?? new Decimal(0);
-
-    if (inventoryChum.lt(chumAmount)) {
-      throw new Error(`${translate("error.insufficientChum")}: ${action.chum}`);
+    if (getDailyFishingCount(game) >= getDailyFishingLimit(game)) {
+      throw new Error(translate("error.dailyAttemptsExhausted"));
     }
 
-    game.inventory[action.chum] = inventoryChum.sub(chumAmount);
-  }
+    const rodCount = game.inventory.Rod ?? new Decimal(0);
+    // Requires Rod
+    if (rodCount.lt(1) && !isWearableActive({ name: "Ancient Rod", game })) {
+      throw new Error(translate("error.missingRod"));
+    }
 
-  // Subtracts Rod
-  if (!isWearableActive({ name: "Ancient Rod", game })) {
-    game.inventory.Rod = rodCount.sub(1);
-  }
+    // Requires Bait
+    const baitCount = game.inventory[action.bait] ?? new Decimal(0);
+    if (baitCount.lt(1)) {
+      throw new Error(`Missing ${action.bait}`);
+    }
 
-  // Subtracts Bait
-  game.inventory[action.bait] = baitCount.sub(1);
+    if (game.fishing[location].castedAt) {
+      throw new Error(translate("error.alreadyCasted"));
+    }
 
-  // Casts Rod
-  game.fishing = {
-    ...game.fishing,
-    [location]: {
-      castedAt: createdAt,
-      bait: action.bait,
-      chum: action.chum,
-    },
-  };
+    // Subtract Chum
+    if (action.chum) {
+      const chumAmount = CHUM_AMOUNTS[action.chum] ?? 0;
+      if (!chumAmount) {
+        throw new Error(`${action.chum} Axe is not a supported chum`);
+      }
 
-  // Track daily attempts
-  if (game.fishing.dailyAttempts && game.fishing.dailyAttempts[today]) {
-    game.fishing.dailyAttempts[today] += 1;
-  } else {
-    game.fishing.dailyAttempts = {
-      [today]: 1,
+      const inventoryChum = game.inventory[action.chum] ?? new Decimal(0);
+
+      if (inventoryChum.lt(chumAmount)) {
+        throw new Error(
+          `${translate("error.insufficientChum")}: ${action.chum}`,
+        );
+      }
+
+      game.inventory[action.chum] = inventoryChum.sub(chumAmount);
+    }
+
+    // Subtracts Rod
+    if (!isWearableActive({ name: "Ancient Rod", game })) {
+      game.inventory.Rod = rodCount.sub(1);
+    }
+
+    // Subtracts Bait
+    game.inventory[action.bait] = baitCount.sub(1);
+
+    // Casts Rod
+    game.fishing = {
+      ...game.fishing,
+      [location]: {
+        castedAt: createdAt,
+        bait: action.bait,
+        chum: action.chum,
+      },
     };
-  }
 
-  bumpkin.activity = trackActivity("Rod Casted", bumpkin.activity);
+    // Track daily attempts
+    if (game.fishing.dailyAttempts && game.fishing.dailyAttempts[today]) {
+      game.fishing.dailyAttempts[today] += 1;
+    } else {
+      game.fishing.dailyAttempts = {
+        [today]: 1,
+      };
+    }
 
-  return {
-    ...game,
-  };
+    bumpkin.activity = trackActivity("Rod Casted", bumpkin.activity);
+
+    return {
+      ...game,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -108,8 +108,6 @@ export function castRod({
 
     bumpkin.activity = trackActivity("Rod Casted", bumpkin.activity);
 
-    return {
-      ...game,
-    };
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/claimBonus.ts
+++ b/src/features/game/events/landExpansion/claimBonus.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { BONUSES, BonusName } from "features/game/types/bonuses";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type ClaimBonusAction = {
   type: "bonus.claimed";
@@ -20,42 +20,45 @@ export function claimBonus({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  return produce(state, (game) => {
+    const bonus = BONUSES[action.name];
 
-  const bonus = BONUSES[action.name];
+    if (!bonus) {
+      throw new Error("No bonus exists");
+    }
 
-  if (!bonus) {
-    throw new Error("No bonus exists");
-  }
+    if (bonus.isClaimed(game)) {
+      throw new Error("Bonus already claimed");
+    }
 
-  if (bonus.isClaimed(game)) {
-    throw new Error("Bonus already claimed");
-  }
+    const inventory = getKeys(bonus.reward.inventory).reduce(
+      (acc, itemName) => {
+        const previous = acc[itemName] || new Decimal(0);
 
-  const inventory = getKeys(bonus.reward.inventory).reduce((acc, itemName) => {
-    const previous = acc[itemName] || new Decimal(0);
+        return {
+          ...acc,
+          [itemName]: previous.add(bonus.reward.inventory[itemName] || 0),
+        };
+      },
+      game.inventory,
+    );
+
+    const wardrobe = getKeys(bonus.reward.wearables ?? {}).reduce(
+      (acc, itemName) => {
+        const previous = acc[itemName] || 0;
+
+        return {
+          ...acc,
+          [itemName]: previous + (bonus.reward.wearables[itemName] || 0),
+        };
+      },
+      game.wardrobe,
+    );
 
     return {
-      ...acc,
-      [itemName]: previous.add(bonus.reward.inventory[itemName] || 0),
+      ...game,
+      inventory,
+      wardrobe,
     };
-  }, game.inventory);
-
-  const wardrobe = getKeys(bonus.reward.wearables ?? {}).reduce(
-    (acc, itemName) => {
-      const previous = acc[itemName] || 0;
-
-      return {
-        ...acc,
-        [itemName]: previous + (bonus.reward.wearables[itemName] || 0),
-      };
-    },
-    game.wardrobe,
-  );
-
-  return {
-    ...game,
-    inventory,
-    wardrobe,
-  };
+  });
 }

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { BuildingName } from "features/game/types/buildings";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 
 export type CollectRecipeAction = {
@@ -22,41 +22,42 @@ export function collectRecipe({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
-  const { bumpkin } = game;
+  return produce(state, (game) => {
+    const { bumpkin } = game;
 
-  const building = game.buildings[action.building]?.find(
-    (b) => b.id === action.buildingId,
-  );
+    const building = game.buildings[action.building]?.find(
+      (b) => b.id === action.buildingId,
+    );
 
-  if (!building) {
-    throw new Error(translate("error.buildingNotExist"));
-  }
+    if (!building) {
+      throw new Error(translate("error.buildingNotExist"));
+    }
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const recipe = building.crafting;
-  if (!recipe) {
-    throw new Error(translate("error.buildingNotCooking"));
-  }
+    const recipe = building.crafting;
+    if (!recipe) {
+      throw new Error(translate("error.buildingNotCooking"));
+    }
 
-  if (createdAt < recipe.readyAt) {
-    throw new Error(translate("error.recipeNotReady"));
-  }
+    if (createdAt < recipe.readyAt) {
+      throw new Error(translate("error.recipeNotReady"));
+    }
 
-  delete building.crafting;
+    delete building.crafting;
 
-  const consumableCount = game.inventory[recipe.name] || new Decimal(0);
+    const consumableCount = game.inventory[recipe.name] || new Decimal(0);
 
-  bumpkin.activity = trackActivity(`${recipe.name} Cooked`, bumpkin.activity);
+    bumpkin.activity = trackActivity(`${recipe.name} Cooked`, bumpkin.activity);
 
-  return {
-    ...game,
-    inventory: {
-      ...game.inventory,
-      [recipe.name]: consumableCount.add(1),
-    },
-  };
+    return {
+      ...game,
+      inventory: {
+        ...game.inventory,
+        [recipe.name]: consumableCount.add(1),
+      },
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -52,12 +52,8 @@ export function collectRecipe({
 
     bumpkin.activity = trackActivity(`${recipe.name} Cooked`, bumpkin.activity);
 
-    return {
-      ...game,
-      inventory: {
-        ...game.inventory,
-        [recipe.name]: consumableCount.add(1),
-      },
-    };
+    game.inventory[recipe.name] = consumableCount.add(1);
+
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/collectTreeReward.ts
+++ b/src/features/game/events/landExpansion/collectTreeReward.ts
@@ -1,8 +1,8 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 
 import { GameState } from "../../types/game";
 import { canChop, CHOP_ERRORS } from "features/game/events/landExpansion/chop";
+import { produce } from "immer";
 
 export type CollectTreeRewardAction = {
   type: "treeReward.collected";
@@ -20,44 +20,45 @@ export function collectTreeReward({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy = cloneDeep(state);
-  const tree = stateCopy.trees[action.treeIndex];
+  return produce(state, (stateCopy) => {
+    const tree = stateCopy.trees[action.treeIndex];
 
-  if (!tree) {
-    throw new Error("Tree does not exist");
-  }
+    if (!tree) {
+      throw new Error("Tree does not exist");
+    }
 
-  const { wood } = tree;
+    const { wood } = tree;
 
-  if (!wood) {
-    throw new Error("Tree has not been chopped");
-  }
+    if (!wood) {
+      throw new Error("Tree has not been chopped");
+    }
 
-  if (!wood.reward) {
-    throw new Error("Tree does not have a reward");
-  }
+    if (!wood.reward) {
+      throw new Error("Tree does not have a reward");
+    }
 
-  if (!canChop(tree, createdAt)) {
-    throw new Error(CHOP_ERRORS.STILL_GROWING);
-  }
+    if (!canChop(tree, createdAt)) {
+      throw new Error(CHOP_ERRORS.STILL_GROWING);
+    }
 
-  const {
-    reward: { items, coins },
-  } = wood;
+    const {
+      reward: { items, coins },
+    } = wood;
 
-  if (items?.length) {
-    items.forEach(({ name, amount }) => {
-      const itemBalance = stateCopy.inventory[name] || new Decimal(0);
+    if (items?.length) {
+      items.forEach(({ name, amount }) => {
+        const itemBalance = stateCopy.inventory[name] || new Decimal(0);
 
-      stateCopy.inventory[name] = itemBalance.add(new Decimal(amount));
-    });
-  }
+        stateCopy.inventory[name] = itemBalance.add(new Decimal(amount));
+      });
+    }
 
-  if (coins) {
-    stateCopy.coins = stateCopy.coins + coins;
-  }
+    if (coins) {
+      stateCopy.coins = stateCopy.coins + coins;
+    }
 
-  delete wood.reward;
+    delete wood.reward;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/completeBertObsession.ts
+++ b/src/features/game/events/landExpansion/completeBertObsession.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 
 export type CompleteBertObsessionAction = {
@@ -19,61 +19,62 @@ export function completeBertObsession({
   state,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { bumpkin } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-
-  if (!stateCopy.npcs) {
-    throw new Error(translate("error.npcsNotExist"));
-  }
-
-  if (!stateCopy.npcs?.bert) {
-    stateCopy.npcs.bert = { deliveryCount: 0 };
-  }
-
-  const currentObsession = stateCopy.bertObsession;
-  if (!currentObsession) {
-    throw new Error(translate("error.noDiscoveryAvailable"));
-  }
-
-  if (stateCopy.npcs.bert.questCompletedAt) {
-    const obsessionAlreadyCompleted =
-      stateCopy.npcs.bert.questCompletedAt >= currentObsession.startDate &&
-      stateCopy.npcs.bert.questCompletedAt <= currentObsession.endDate;
-
-    if (obsessionAlreadyCompleted) {
-      throw new Error(translate("error.obsessionAlreadyCompleted"));
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
     }
-  }
 
-  if (currentObsession.type === "collectible") {
-    const isItemInInventory =
-      stateCopy.inventory[currentObsession.name as InventoryItemName];
-
-    if (!isItemInInventory) {
-      throw new Error(translate("error.collectibleNotInInventory"));
+    if (!stateCopy.npcs) {
+      throw new Error(translate("error.npcsNotExist"));
     }
-  }
 
-  if (currentObsession.type === "wearable") {
-    const isWearableInWardrobe =
-      stateCopy.wardrobe[currentObsession.name as BumpkinItem];
-
-    if (!isWearableInWardrobe) {
-      throw new Error(translate("error.wearableNotInWardrobe"));
+    if (!stateCopy.npcs?.bert) {
+      stateCopy.npcs.bert = { deliveryCount: 0 };
     }
-  }
 
-  const currentTickets =
-    stateCopy.inventory[getSeasonalTicket()] || new Decimal(0);
-  stateCopy.inventory[getSeasonalTicket()] = currentTickets.add(
-    currentObsession.reward,
-  );
+    const currentObsession = stateCopy.bertObsession;
+    if (!currentObsession) {
+      throw new Error(translate("error.noDiscoveryAvailable"));
+    }
 
-  stateCopy.npcs.bert.questCompletedAt = createdAt;
+    if (stateCopy.npcs.bert.questCompletedAt) {
+      const obsessionAlreadyCompleted =
+        stateCopy.npcs.bert.questCompletedAt >= currentObsession.startDate &&
+        stateCopy.npcs.bert.questCompletedAt <= currentObsession.endDate;
 
-  return stateCopy;
+      if (obsessionAlreadyCompleted) {
+        throw new Error(translate("error.obsessionAlreadyCompleted"));
+      }
+    }
+
+    if (currentObsession.type === "collectible") {
+      const isItemInInventory =
+        stateCopy.inventory[currentObsession.name as InventoryItemName];
+
+      if (!isItemInInventory) {
+        throw new Error(translate("error.collectibleNotInInventory"));
+      }
+    }
+
+    if (currentObsession.type === "wearable") {
+      const isWearableInWardrobe =
+        stateCopy.wardrobe[currentObsession.name as BumpkinItem];
+
+      if (!isWearableInWardrobe) {
+        throw new Error(translate("error.wearableNotInWardrobe"));
+      }
+    }
+
+    const currentTickets =
+      stateCopy.inventory[getSeasonalTicket()] || new Decimal(0);
+    stateCopy.inventory[getSeasonalTicket()] = currentTickets.add(
+      currentObsession.reward,
+    );
+
+    stateCopy.npcs.bert.questCompletedAt = createdAt;
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -1,10 +1,10 @@
 import Decimal from "decimal.js-light";
 import { ChoreV2Name, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import {
   getSeasonalBanner,
   getSeasonalTicket,
 } from "features/game/types/seasons";
+import { produce } from "immer";
 
 const CHORE_TICKETS: Record<ChoreV2Name, number> = {
   "1": 1,
@@ -58,54 +58,60 @@ export function completeChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
-  const { id } = action;
-  const { chores, bumpkin } = game;
+  return produce(state, (game) => {
+    const { id } = action;
+    const { chores, bumpkin } = game;
 
-  if (id === undefined) {
-    throw new Error("Chore ID not supplied");
-  }
+    if (id === undefined) {
+      throw new Error("Chore ID not supplied");
+    }
 
-  if (!chores) {
-    throw new Error("No chores found");
-  }
+    if (!chores) {
+      throw new Error("No chores found");
+    }
 
-  if (!bumpkin) {
-    throw new Error("No bumpkin found");
-  }
+    if (!bumpkin) {
+      throw new Error("No bumpkin found");
+    }
 
-  if (!isChoreId(id)) {
-    throw new Error("Invalid chore ID");
-  }
+    if (!isChoreId(id)) {
+      throw new Error("Invalid chore ID");
+    }
 
-  const chore = chores.chores[id];
+    const chore = chores.chores[id];
 
-  if ((chore.completedAt ?? 0) > 0) {
-    throw new Error("Chore is already completed");
-  }
+    if ((chore.completedAt ?? 0) > 0) {
+      throw new Error("Chore is already completed");
+    }
 
-  if (bumpkin.id !== chore.bumpkinId) {
-    throw new Error("Not the same bumpkin");
-  }
+    if (bumpkin.id !== chore.bumpkinId) {
+      throw new Error("Not the same bumpkin");
+    }
 
-  const progress = bumpkin?.activity?.[chore.activity] ?? 0 - chore.startCount;
+    const progress =
+      bumpkin?.activity?.[chore.activity] ?? 0 - chore.startCount;
 
-  if (progress < chore.requirement) {
-    throw new Error("Chore is not completed");
-  }
+    if (progress < chore.requirement) {
+      throw new Error("Chore is not completed");
+    }
 
-  const tickets = generateChoreTickets({ game, id, now: new Date(createdAt) });
+    const tickets = generateChoreTickets({
+      game,
+      id,
+      now: new Date(createdAt),
+    });
 
-  if (!tickets) {
-    throw new Error("No tickets exist for this chore");
-  }
+    if (!tickets) {
+      throw new Error("No tickets exist for this chore");
+    }
 
-  const ticket = getSeasonalTicket(new Date(createdAt));
-  const previous = game.inventory[ticket] ?? new Decimal(0);
-  game.inventory[ticket] = previous.add(tickets);
+    const ticket = getSeasonalTicket(new Date(createdAt));
+    const previous = game.inventory[ticket] ?? new Decimal(0);
+    game.inventory[ticket] = previous.add(tickets);
 
-  chore.completedAt = createdAt;
-  chores.choresCompleted += 1;
+    chore.completedAt = createdAt;
+    chores.choresCompleted += 1;
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/completeKingdomChore.ts
+++ b/src/features/game/events/landExpansion/completeKingdomChore.ts
@@ -6,6 +6,7 @@ import {
 } from "features/game/lib/factions";
 import { BoostType, BoostValue } from "features/game/types/boosts";
 import { Bumpkin, GameState, KingdomChores } from "features/game/types/game";
+import { produce } from "immer";
 import cloneDeep from "lodash.clonedeep";
 
 export const getKingdomChoreBoost = (
@@ -73,60 +74,65 @@ export function completeKingdomChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
-  const { id } = action;
-  const { kingdomChores, bumpkin, inventory, faction } = game;
+  return produce(state, (game) => {
+    const { id } = action;
+    const { kingdomChores, bumpkin, inventory, faction } = game;
 
-  const chore = kingdomChores.chores[id];
+    const chore = kingdomChores.chores[id];
 
-  if (faction?.name === undefined) {
-    throw new Error("No faction found");
-  }
+    if (faction?.name === undefined) {
+      throw new Error("No faction found");
+    }
 
-  if (chore === undefined) {
-    throw new Error("Chore not found");
-  }
+    if (chore === undefined) {
+      throw new Error("Chore not found");
+    }
 
-  if (!bumpkin) {
-    throw new Error("No bumpkin found");
-  }
+    if (!bumpkin) {
+      throw new Error("No bumpkin found");
+    }
 
-  if (chore.completedAt !== undefined) {
-    throw new Error("Chore is already completed");
-  }
+    if (chore.completedAt !== undefined) {
+      throw new Error("Chore is already completed");
+    }
 
-  if (chore.skippedAt !== undefined) {
-    throw new Error("Chore was already skipped");
-  }
+    if (chore.skippedAt !== undefined) {
+      throw new Error("Chore was already skipped");
+    }
 
-  if (chore.startedAt === undefined) {
-    throw new Error("Chore is not active");
-  }
+    if (chore.startedAt === undefined) {
+      throw new Error("Chore is not active");
+    }
 
-  const progress =
-    (bumpkin?.activity?.[chore.activity] ?? 0) - chore.startCount;
+    const progress =
+      (bumpkin?.activity?.[chore.activity] ?? 0) - chore.startCount;
 
-  if (progress < chore.requirement) {
-    throw new Error("Chore is not completed");
-  }
+    if (progress < chore.requirement) {
+      throw new Error("Chore is not completed");
+    }
 
-  chore.completedAt = createdAt;
+    chore.completedAt = createdAt;
 
-  kingdomChores.choresCompleted += 1;
-  game.kingdomChores = populateKingdomChores(kingdomChores, bumpkin, createdAt);
+    kingdomChores.choresCompleted += 1;
+    game.kingdomChores = populateKingdomChores(
+      kingdomChores,
+      bumpkin,
+      createdAt,
+    );
 
-  const previousMarks = inventory["Mark"] ?? new Decimal(0);
-  const marks = chore.marks + getKingdomChoreBoost(game, chore.marks)[0];
+    const previousMarks = inventory["Mark"] ?? new Decimal(0);
+    const marks = chore.marks + getKingdomChoreBoost(game, chore.marks)[0];
 
-  // Add to inventory
-  inventory["Mark"] = previousMarks.add(marks);
+    // Add to inventory
+    inventory["Mark"] = previousMarks.add(marks);
 
-  // Add to history
-  const week = getFactionWeek({ date: new Date(createdAt) });
-  const factionHistory = faction.history[week] ?? { score: 0, petXP: 0 };
-  factionHistory.score += marks;
+    // Add to history
+    const week = getFactionWeek({ date: new Date(createdAt) });
+    const factionHistory = faction.history[week] ?? { score: 0, petXP: 0 };
+    factionHistory.score += marks;
 
-  faction.history[week] = factionHistory;
+    faction.history[week] = factionHistory;
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
@@ -22,86 +22,89 @@ export function completeSpecialEventTask({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const stateCopy = cloneDeep(state);
+  return produce(state, (stateCopy) => {
+    const event = stateCopy.specialEvents.current[action.event];
+    if (!event) throw new Error("Event does not exist");
 
-  const event = stateCopy.specialEvents.current[action.event];
-  if (!event) throw new Error("Event does not exist");
+    if (!event.isEligible) throw new Error("You are not eligible");
 
-  if (!event.isEligible) throw new Error("You are not eligible");
+    if (createdAt < event.startAt)
+      throw new Error(`${action.event} has not started`);
 
-  if (createdAt < event.startAt)
-    throw new Error(`${action.event} has not started`);
+    if (createdAt > event.endAt)
+      throw new Error(`${action.event} has finished`);
 
-  if (createdAt > event.endAt) throw new Error(`${action.event} has finished`);
+    const taskIndex = action.task - 1;
+    const previousTaskIndex = taskIndex - 1;
 
-  const taskIndex = action.task - 1;
-  const previousTaskIndex = taskIndex - 1;
+    const task = event.tasks[taskIndex];
+    if (!task) throw new Error("Task does not exist");
 
-  const task = event.tasks[taskIndex];
-  if (!task) throw new Error("Task does not exist");
+    if (task.completedAt)
+      throw new Error(`Task ${action.task} already completed`);
 
-  if (task.completedAt)
-    throw new Error(`Task ${action.task} already completed`);
+    const previousTask = event.tasks[previousTaskIndex];
+    if (previousTask) {
+      if (!previousTask.completedAt) {
+        throw new Error(`Task ${previousTaskIndex + 1} not completed`);
+      }
 
-  const previousTask = event.tasks[previousTaskIndex];
-  if (previousTask) {
-    if (!previousTask.completedAt) {
-      throw new Error(`Task ${previousTaskIndex + 1} not completed`);
+      const previousDay = Math.floor(
+        (previousTask.completedAt - event.startAt) / TWENTY_FOUR_HOURS,
+      );
+      const currentDay = Math.floor(
+        (createdAt - event.startAt) / TWENTY_FOUR_HOURS,
+      );
+
+      if (previousDay === currentDay) {
+        throw new Error("Task already completed today");
+      }
     }
 
-    const previousDay = Math.floor(
-      (previousTask.completedAt - event.startAt) / TWENTY_FOUR_HOURS,
+    const { items, sfl } = task.requirements;
+
+    const balance = stateCopy.balance;
+    if (balance.lt(sfl)) throw new Error("SFL requirement not met");
+    stateCopy.balance = balance.minus(sfl);
+
+    stateCopy.inventory = getKeys(items).reduce((inventory, item) => {
+      const inventoryAmount = inventory[item] ?? new Decimal(0);
+      const requirementAmount = items[item] ?? new Decimal(0);
+
+      if (inventoryAmount.lt(requirementAmount)) {
+        throw new Error(`${item} requirements not met`);
+      }
+
+      return { ...inventory, [item]: inventoryAmount.minus(requirementAmount) };
+    }, stateCopy.inventory);
+
+    task.completedAt = createdAt;
+    getKeys(task.reward.items).forEach((item) => {
+      const rewardAmount = task.reward.items[item] ?? new Decimal(0);
+      stateCopy.inventory[item] = (
+        stateCopy.inventory[item] ?? new Decimal(0)
+      ).plus(rewardAmount);
+    });
+    getKeys(task.reward.wearables).forEach((item) => {
+      const rewardAmount = task.reward.wearables[item] ?? 0;
+      stateCopy.wardrobe[item] = (stateCopy.wardrobe[item] ?? 0) + rewardAmount;
+    });
+    stateCopy.balance = (stateCopy.balance ?? new Decimal(0)).plus(
+      task.reward.sfl,
     );
-    const currentDay = Math.floor(
-      (createdAt - event.startAt) / TWENTY_FOUR_HOURS,
+
+    const eventYear = new Date(event.startAt).getUTCFullYear();
+    const completedTasks = event.tasks.filter(
+      (task) => task.completedAt,
+    ).length;
+    const totalTasks = event.tasks.length;
+
+    if (!stateCopy.specialEvents.history[eventYear])
+      stateCopy.specialEvents.history[eventYear] = {};
+    stateCopy.specialEvents.history[eventYear][action.event] = Math.floor(
+      (completedTasks / totalTasks) * 100,
     );
 
-    if (previousDay === currentDay) {
-      throw new Error("Task already completed today");
-    }
-  }
-
-  const { items, sfl } = task.requirements;
-
-  const balance = stateCopy.balance;
-  if (balance.lt(sfl)) throw new Error("SFL requirement not met");
-  stateCopy.balance = balance.minus(sfl);
-
-  stateCopy.inventory = getKeys(items).reduce((inventory, item) => {
-    const inventoryAmount = inventory[item] ?? new Decimal(0);
-    const requirementAmount = items[item] ?? new Decimal(0);
-
-    if (inventoryAmount.lt(requirementAmount)) {
-      throw new Error(`${item} requirements not met`);
-    }
-
-    return { ...inventory, [item]: inventoryAmount.minus(requirementAmount) };
-  }, stateCopy.inventory);
-
-  task.completedAt = createdAt;
-  getKeys(task.reward.items).forEach((item) => {
-    const rewardAmount = task.reward.items[item] ?? new Decimal(0);
-    stateCopy.inventory[item] = (
-      stateCopy.inventory[item] ?? new Decimal(0)
-    ).plus(rewardAmount);
+    return stateCopy;
   });
-  getKeys(task.reward.wearables).forEach((item) => {
-    const rewardAmount = task.reward.wearables[item] ?? 0;
-    stateCopy.wardrobe[item] = (stateCopy.wardrobe[item] ?? 0) + rewardAmount;
-  });
-  stateCopy.balance = (stateCopy.balance ?? new Decimal(0)).plus(
-    task.reward.sfl,
-  );
-
-  const eventYear = new Date(event.startAt).getUTCFullYear();
-  const completedTasks = event.tasks.filter((task) => task.completedAt).length;
-  const totalTasks = event.tasks.length;
-
-  if (!stateCopy.specialEvents.history[eventYear])
-    stateCopy.specialEvents.history[eventYear] = {};
-  stateCopy.specialEvents.history[eventYear][action.event] = Math.floor(
-    (completedTasks / totalTasks) * 100,
-  );
-
-  return stateCopy;
 }

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -8,7 +8,6 @@ import {
   WORKBENCH_TOOLS,
 } from "features/game/types/tools";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 
 import { GameState, Inventory } from "../../types/game";
 import {
@@ -16,6 +15,7 @@ import {
   PurchaseableBait,
 } from "features/game/types/fishing";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+import { produce } from "immer";
 
 type CraftableToolName =
   | WorkbenchToolName
@@ -48,70 +48,73 @@ function getToolPrice(tool: Tool, inventory: Inventory) {
 }
 
 export function craftTool({ state, action }: Options) {
-  const stateCopy: GameState = cloneDeep(state);
-  const bumpkin = stateCopy.bumpkin;
+  return produce(state, (stateCopy) => {
+    const bumpkin = stateCopy.bumpkin;
 
-  const tool = CRAFTABLE_TOOLS[action.tool];
-  const amount = action.amount ?? 1;
+    const tool = CRAFTABLE_TOOLS[action.tool];
+    const amount = action.amount ?? 1;
 
-  if (!tool) {
-    throw new Error("Tool does not exist");
-  }
+    if (!tool) {
+      throw new Error("Tool does not exist");
+    }
 
-  if (!hasRequiredIslandExpansion(stateCopy.island.type, tool.requiredIsland)) {
-    throw new Error("You do not have the required island expansion");
-  }
+    if (
+      !hasRequiredIslandExpansion(stateCopy.island.type, tool.requiredIsland)
+    ) {
+      throw new Error("You do not have the required island expansion");
+    }
 
-  if (stateCopy.stock[action.tool]?.lt(1)) {
-    throw new Error("Not enough stock");
-  }
+    if (stateCopy.stock[action.tool]?.lt(1)) {
+      throw new Error("Not enough stock");
+    }
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-  const price = getToolPrice(tool, stateCopy.inventory) * amount;
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
+    const price = getToolPrice(tool, stateCopy.inventory) * amount;
 
-  if (stateCopy.coins < price) {
-    throw new Error("Insufficient Coins");
-  }
+    if (stateCopy.coins < price) {
+      throw new Error("Insufficient Coins");
+    }
 
-  const subtractedInventory = getKeys(tool.ingredients).reduce(
-    (inventory, ingredientName) => {
-      const count = inventory[ingredientName] || new Decimal(0);
-      const totalAmount =
-        tool.ingredients[ingredientName]?.mul(amount) || new Decimal(0);
+    const subtractedInventory = getKeys(tool.ingredients).reduce(
+      (inventory, ingredientName) => {
+        const count = inventory[ingredientName] || new Decimal(0);
+        const totalAmount =
+          tool.ingredients[ingredientName]?.mul(amount) || new Decimal(0);
 
-      if (count.lessThan(totalAmount)) {
-        throw new Error(`Insufficient ingredient: ${ingredientName}`);
-      }
+        if (count.lessThan(totalAmount)) {
+          throw new Error(`Insufficient ingredient: ${ingredientName}`);
+        }
 
-      return {
-        ...inventory,
-        [ingredientName]: count.sub(totalAmount),
-      };
-    },
-    stateCopy.inventory,
-  );
+        return {
+          ...inventory,
+          [ingredientName]: count.sub(totalAmount),
+        };
+      },
+      stateCopy.inventory,
+    );
 
-  const oldAmount = stateCopy.inventory[action.tool] || new Decimal(0);
+    const oldAmount = stateCopy.inventory[action.tool] || new Decimal(0);
 
-  bumpkin.activity = trackActivity(
-    `${action.tool} Crafted`,
-    bumpkin.activity,
-    new Decimal(amount),
-  );
-  bumpkin.activity = trackActivity(
-    "Coins Spent",
-    bumpkin.activity,
-    new Decimal(price),
-  );
+    bumpkin.activity = trackActivity(
+      `${action.tool} Crafted`,
+      bumpkin.activity,
+      new Decimal(amount),
+    );
+    bumpkin.activity = trackActivity(
+      "Coins Spent",
+      bumpkin.activity,
+      new Decimal(price),
+    );
 
-  stateCopy.coins = stateCopy.coins - price;
-  stateCopy.inventory = {
-    ...subtractedInventory,
-    [action.tool]: oldAmount.add(amount) as Decimal,
-  };
-  stateCopy.stock[action.tool] = stateCopy.stock[action.tool]?.minus(amount);
+    stateCopy.coins = stateCopy.coins - price;
+    stateCopy.inventory = {
+      ...subtractedInventory,
+      [action.tool]: oldAmount.add(amount) as Decimal,
+    };
+    stateCopy.stock[action.tool] = stateCopy.stock[action.tool]?.minus(amount);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -10,9 +10,9 @@ import {
 } from "features/game/types/seasons";
 import { NPCName } from "lib/npcs";
 import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
-import cloneDeep from "lodash.clonedeep";
 import { isWearableActive } from "features/game/lib/wearables";
 import { FACTION_OUTFITS } from "features/game/lib/factions";
+import { produce } from "immer";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   "pumpkin' pete": 1,
@@ -168,10 +168,6 @@ export function populateOrders(
   return orders;
 }
 
-const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
-};
-
 export function getOrderSellPrice<T>(game: GameState, order: Order): T {
   let mul = 1;
 
@@ -213,138 +209,139 @@ export function deliverOrder({
   createdAt = Date.now(),
   farmId = 0,
 }: Options): GameState {
-  const game = clone(state);
-  const bumpkin = game.bumpkin;
+  return produce(state, (game) => {
+    const bumpkin = game.bumpkin;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-
-  const order = game.delivery.orders.find((order) => order.id === action.id);
-
-  if (!order) {
-    throw new Error("Order does not exist");
-  }
-
-  if (order.readyAt > createdAt) {
-    throw new Error("Order has not started");
-  }
-
-  if (order.completedAt) {
-    throw new Error("Order is already completed");
-  }
-
-  const { ticketTasksAreFrozen } = getSeasonChangeover({
-    id: farmId,
-    now: createdAt,
-  });
-
-  const tickets = generateDeliveryTickets({
-    game,
-    npc: order.from,
-    now: new Date(createdAt),
-  });
-  const isTicketOrder = tickets > 0;
-
-  if (isTicketOrder && ticketTasksAreFrozen) {
-    throw new Error("Ticket tasks are frozen");
-  }
-
-  getKeys(order.items).forEach((name) => {
-    if (name === "coins") {
-      const coins = game.coins;
-      const amount = order.items[name] ?? 0;
-
-      if (coins < amount) {
-        throw new Error(`Insufficient ingredient: ${name}`);
-      }
-
-      game.coins = coins - amount;
-    } else if (name === "sfl") {
-      const sfl = game.balance;
-      const amount = order.items[name] || new Decimal(0);
-
-      if (sfl.lessThan(amount)) {
-        throw new Error(`Insufficient ingredient: ${name}`);
-      }
-
-      game.balance = sfl.sub(amount);
-    } else {
-      const count = game.inventory[name] || new Decimal(0);
-      const amount = order.items[name] || new Decimal(0);
-
-      if (count.lessThan(amount)) {
-        throw new Error(`Insufficient ingredient: ${name}`);
-      }
-
-      game.inventory[name] = count.sub(amount);
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
     }
-  });
 
-  if (order.reward.sfl) {
-    const sfl = getOrderSellPrice<Decimal>(game, order);
-    game.balance = game.balance.add(sfl);
+    const order = game.delivery.orders.find((order) => order.id === action.id);
 
-    bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sfl);
-  }
+    if (!order) {
+      throw new Error("Order does not exist");
+    }
 
-  if (order.reward.coins) {
-    const coinsReward = getOrderSellPrice<number>(game, order);
+    if (order.readyAt > createdAt) {
+      throw new Error("Order has not started");
+    }
 
-    game.coins = game.coins + coinsReward;
+    if (order.completedAt) {
+      throw new Error("Order is already completed");
+    }
 
-    bumpkin.activity = trackActivity(
-      "Coins Earned",
-      bumpkin.activity,
-      new Decimal(coinsReward),
-    );
-  }
-
-  if (tickets > 0) {
-    const seasonalTicket = getSeasonalTicket();
-
-    const count = game.inventory[seasonalTicket] || new Decimal(0);
-    const amount = tickets || new Decimal(0);
-
-    game.inventory[seasonalTicket] = count.add(amount);
-  }
-
-  const rewardItems = order.reward.items ?? {};
-
-  if (Object.keys(rewardItems).length > 0) {
-    getKeys(rewardItems).forEach((name) => {
-      const previousAmount = game.inventory[name] || new Decimal(0);
-
-      game.inventory[name] = previousAmount.add(rewardItems[name] || 0);
+    const { ticketTasksAreFrozen } = getSeasonChangeover({
+      id: farmId,
+      now: createdAt,
     });
-  }
 
-  game.delivery.fulfilledCount += 1;
+    const tickets = generateDeliveryTickets({
+      game,
+      npc: order.from,
+      now: new Date(createdAt),
+    });
+    const isTicketOrder = tickets > 0;
 
-  const npcs = game.npcs ?? ({} as Partial<Record<NPCName, NPCData>>);
-  const npc = npcs[order.from] ?? ({} as NPCData);
-  const completedDeliveries = npcs[order.from]?.deliveryCount ?? 0;
+    if (isTicketOrder && ticketTasksAreFrozen) {
+      throw new Error("Ticket tasks are frozen");
+    }
 
-  npc.deliveryCount = completedDeliveries + 1;
+    getKeys(order.items).forEach((name) => {
+      if (name === "coins") {
+        const coins = game.coins;
+        const amount = order.items[name] ?? 0;
 
-  if (action.friendship && BUMPKIN_GIFTS[order.from]) {
-    npc.friendship = {
-      updatedAt: createdAt,
-      points: (npc.friendship?.points ?? 0) + DELIVERY_FRIENDSHIP_POINTS,
-      giftClaimedAtPoints: npc.friendship?.giftClaimedAtPoints ?? 0,
-      giftedAt: npc.friendship?.giftedAt,
+        if (coins < amount) {
+          throw new Error(`Insufficient ingredient: ${name}`);
+        }
+
+        game.coins = coins - amount;
+      } else if (name === "sfl") {
+        const sfl = game.balance;
+        const amount = order.items[name] || new Decimal(0);
+
+        if (sfl.lessThan(amount)) {
+          throw new Error(`Insufficient ingredient: ${name}`);
+        }
+
+        game.balance = sfl.sub(amount);
+      } else {
+        const count = game.inventory[name] || new Decimal(0);
+        const amount = order.items[name] || new Decimal(0);
+
+        if (count.lessThan(amount)) {
+          throw new Error(`Insufficient ingredient: ${name}`);
+        }
+
+        game.inventory[name] = count.sub(amount);
+      }
+    });
+
+    if (order.reward.sfl) {
+      const sfl = getOrderSellPrice<Decimal>(game, order);
+      game.balance = game.balance.add(sfl);
+
+      bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sfl);
+    }
+
+    if (order.reward.coins) {
+      const coinsReward = getOrderSellPrice<number>(game, order);
+
+      game.coins = game.coins + coinsReward;
+
+      bumpkin.activity = trackActivity(
+        "Coins Earned",
+        bumpkin.activity,
+        new Decimal(coinsReward),
+      );
+    }
+
+    if (tickets > 0) {
+      const seasonalTicket = getSeasonalTicket();
+
+      const count = game.inventory[seasonalTicket] || new Decimal(0);
+      const amount = tickets || new Decimal(0);
+
+      game.inventory[seasonalTicket] = count.add(amount);
+    }
+
+    const rewardItems = order.reward.items ?? {};
+
+    if (Object.keys(rewardItems).length > 0) {
+      getKeys(rewardItems).forEach((name) => {
+        const previousAmount = game.inventory[name] || new Decimal(0);
+
+        game.inventory[name] = previousAmount.add(rewardItems[name] || 0);
+      });
+    }
+
+    game.delivery.fulfilledCount += 1;
+
+    const npcs = game.npcs ?? ({} as Partial<Record<NPCName, NPCData>>);
+    const npc = npcs[order.from] ?? ({} as NPCData);
+    const completedDeliveries = npcs[order.from]?.deliveryCount ?? 0;
+
+    npc.deliveryCount = completedDeliveries + 1;
+
+    if (action.friendship && BUMPKIN_GIFTS[order.from]) {
+      npc.friendship = {
+        updatedAt: createdAt,
+        points: (npc.friendship?.points ?? 0) + DELIVERY_FRIENDSHIP_POINTS,
+        giftClaimedAtPoints: npc.friendship?.giftClaimedAtPoints ?? 0,
+        giftedAt: npc.friendship?.giftedAt,
+      };
+    }
+
+    game.npcs = {
+      ...npcs,
+      [order.from]: npc,
     };
-  }
 
-  game.npcs = {
-    ...npcs,
-    [order.from]: npc,
-  };
+    // bumpkin.activity = trackActivity(`${order.from} Delivered`, 1);
 
-  // bumpkin.activity = trackActivity(`${order.from} Delivered`, 1);
+    // Mark as complete
+    order.completedAt = Date.now();
 
-  // Mark as complete
-  order.completedAt = Date.now();
-
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/enterRaffle.ts
+++ b/src/features/game/events/landExpansion/enterRaffle.ts
@@ -42,8 +42,6 @@ export function enterRaffle({
       },
     };
 
-    return {
-      ...game,
-    };
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/enterRaffle.ts
+++ b/src/features/game/events/landExpansion/enterRaffle.ts
@@ -1,6 +1,6 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
+import { produce } from "immer";
 
 export type EnterRaffleAction = {
   type: "raffle.entered";
@@ -19,31 +19,31 @@ export function enterRaffle({
   createdAt = Date.now(),
   randomGenerator = Math.random,
 }: Options): GameState {
-  const game = cloneDeep(state);
+  return produce(state, (game) => {
+    const tickets = game.inventory["Prize Ticket"] ?? new Decimal(0);
 
-  const tickets = game.inventory["Prize Ticket"] ?? new Decimal(0);
+    if (!tickets.gte(1)) {
+      throw new Error("Missing Treasure Key");
+    }
 
-  if (!tickets.gte(1)) {
-    throw new Error("Missing Treasure Key");
-  }
+    game.inventory["Prize Ticket"] = tickets.sub(1);
 
-  game.inventory["Prize Ticket"] = tickets.sub(1);
+    const monthKey = new Date(createdAt).toISOString().slice(0, 7);
 
-  const monthKey = new Date(createdAt).toISOString().slice(0, 7);
+    const raffle = game.pumpkinPlaza.raffle ?? {
+      entries: {},
+    };
 
-  const raffle = game.pumpkinPlaza.raffle ?? {
-    entries: {},
-  };
+    game.pumpkinPlaza.raffle = {
+      ...raffle,
+      entries: {
+        ...raffle.entries,
+        [monthKey]: (raffle.entries[monthKey] ?? 0) + 1,
+      },
+    };
 
-  game.pumpkinPlaza.raffle = {
-    ...raffle,
-    entries: {
-      ...raffle.entries,
-      [monthKey]: (raffle.entries[monthKey] ?? 0) + 1,
-    },
-  };
-
-  return {
-    ...game,
-  };
+    return {
+      ...game,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/equip.ts
+++ b/src/features/game/events/landExpansion/equip.ts
@@ -1,8 +1,8 @@
 import { Equipped } from "features/game/types/bumpkin";
 import { getKeys } from "features/game/types/craftables";
 import { Bumpkin, GameState, Wardrobe } from "features/game/types/game";
+import { produce } from "immer";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
-import cloneDeep from "lodash.clonedeep";
 
 export type EquipBumpkinAction = {
   type: "bumpkin.equipped";
@@ -20,18 +20,19 @@ export function equip({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
-  const { bumpkin } = game;
+  return produce(state, (game) => {
+    const { bumpkin } = game;
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  assertEquipment({ game, equipment: action.equipment, bumpkin });
+    assertEquipment({ game, equipment: action.equipment, bumpkin });
 
-  bumpkin.equipped = action.equipment;
+    bumpkin.equipped = action.equipment;
 
-  return game;
+    return game;
+  });
 }
 
 export function assertEquipment({

--- a/src/features/game/events/landExpansion/equipFarmHand.ts
+++ b/src/features/game/events/landExpansion/equipFarmHand.ts
@@ -1,7 +1,7 @@
-import cloneDeep from "lodash.clonedeep";
 import { assertEquipment } from "./equip";
 import { Equipped } from "features/game/types/bumpkin";
 import { GameState } from "features/game/types/game";
+import { produce } from "immer";
 
 export type EquipFarmHandAction = {
   type: "farmHand.equipped";
@@ -20,16 +20,17 @@ export function equipFarmhand({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
-  const bumpkin = game.farmHands.bumpkins[action.id];
+  return produce(state, (game) => {
+    const bumpkin = game.farmHands.bumpkins[action.id];
 
-  if (bumpkin === undefined) {
-    throw new Error("Farm hand does not exist");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("Farm hand does not exist");
+    }
 
-  assertEquipment({ game, equipment: action.equipment, bumpkin });
+    assertEquipment({ game, equipment: action.equipment, bumpkin });
 
-  bumpkin.equipped = action.equipment;
+    bumpkin.equipped = action.equipment;
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
@@ -1,5 +1,5 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 type ExchangePackage = { sfl: number; coins: number };
 export type PackageId = 1 | 2 | 3;
@@ -29,25 +29,26 @@ export function exchangeSFLtoCoins({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game: GameState = cloneDeep(state);
-  const { bumpkin, balance } = game;
+  return produce(state, (game) => {
+    const { bumpkin, balance } = game;
 
-  if (!SFL_TO_COIN_PACKAGES[action.packageId]) {
-    throw new Error("Invalid packageId");
-  }
+    if (!SFL_TO_COIN_PACKAGES[action.packageId]) {
+      throw new Error("Invalid packageId");
+    }
 
-  const { sfl, coins } = SFL_TO_COIN_PACKAGES[action.packageId];
+    const { sfl, coins } = SFL_TO_COIN_PACKAGES[action.packageId];
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin");
+    }
 
-  if (balance.lt(sfl)) {
-    throw new Error("Not enough SFL");
-  }
+    if (balance.lt(sfl)) {
+      throw new Error("Not enough SFL");
+    }
 
-  game.balance = balance.minus(sfl);
-  game.coins += coins;
+    game.balance = balance.minus(sfl);
+    game.coins += coins;
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -4,8 +4,8 @@ import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 
-import cloneDeep from "lodash.clonedeep";
 import { expansionRequirements } from "./revealLand";
+import { produce } from "immer";
 
 export type ExpandLandAction = {
   type: "land.expanded";
@@ -19,66 +19,67 @@ type Options = {
 };
 
 export function expandLand({ state, action, createdAt = Date.now() }: Options) {
-  const game = cloneDeep(state) as GameState;
-  const bumpkin = game.bumpkin;
+  return produce(state, (game) => {
+    const bumpkin = game.bumpkin;
 
-  const requirements = expansionRequirements({ game });
-  if (!requirements) {
-    throw new Error("No more land expansions available");
-  }
+    const requirements = expansionRequirements({ game });
+    if (!requirements) {
+      throw new Error("No more land expansions available");
+    }
 
-  if (game.expansionConstruction) {
-    throw new Error("Player is expanding");
-  }
+    if (game.expansionConstruction) {
+      throw new Error("Player is expanding");
+    }
 
-  const bumpkinLevel = getBumpkinLevel(bumpkin?.experience ?? 0);
-  if (bumpkinLevel < requirements.bumpkinLevel) {
-    throw new Error("Insufficient Bumpkin Level");
-  }
+    const bumpkinLevel = getBumpkinLevel(bumpkin?.experience ?? 0);
+    if (bumpkinLevel < requirements.bumpkinLevel) {
+      throw new Error("Insufficient Bumpkin Level");
+    }
 
-  const coinRequirement = requirements.coins ?? 0;
-  if (game.coins < coinRequirement) {
-    throw new Error("Insufficient coins");
-  }
-  game.coins -= coinRequirement;
+    const coinRequirement = requirements.coins ?? 0;
+    if (game.coins < coinRequirement) {
+      throw new Error("Insufficient coins");
+    }
+    game.coins -= coinRequirement;
 
-  const inventory = getKeys(requirements.resources).reduce(
-    (inventory, ingredientName) => {
-      const count = game.inventory[ingredientName] || new Decimal(0);
-      const totalAmount =
-        requirements?.resources[ingredientName] || new Decimal(0);
+    const inventory = getKeys(requirements.resources).reduce(
+      (inventory, ingredientName) => {
+        const count = game.inventory[ingredientName] || new Decimal(0);
+        const totalAmount =
+          requirements?.resources[ingredientName] || new Decimal(0);
 
-      if (count.lessThan(totalAmount)) {
-        throw new Error(`Insufficient ingredient: ${ingredientName}`);
-      }
+        if (count.lessThan(totalAmount)) {
+          throw new Error(`Insufficient ingredient: ${ingredientName}`);
+        }
 
-      return {
-        ...inventory,
-        [ingredientName]: count.sub(totalAmount),
-      };
-    },
-    game.inventory,
-  );
+        return {
+          ...inventory,
+          [ingredientName]: count.sub(totalAmount),
+        };
+      },
+      game.inventory,
+    );
 
-  game.expansionConstruction = {
-    createdAt,
-    readyAt: createdAt + requirements.seconds * 1000,
-  };
+    game.expansionConstruction = {
+      createdAt,
+      readyAt: createdAt + requirements.seconds * 1000,
+    };
 
-  // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#tutorial_complete
-  if (game.inventory["Basic Land"]?.eq(3)) {
-    onboardingAnalytics.logEvent("tutorial_complete");
-  }
+    // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#tutorial_complete
+    if (game.inventory["Basic Land"]?.eq(3)) {
+      onboardingAnalytics.logEvent("tutorial_complete");
+    }
 
-  //developers.google.com/analytics/devguides/collection/ga4/reference/events?sjid=11955999175679069053-AP&client_type=gtag#level_up
-  onboardingAnalytics.logEvent("level_up", {
-    level: game.inventory["Basic Land"]?.toNumber() ?? 3,
+    //developers.google.com/analytics/devguides/collection/ga4/reference/events?sjid=11955999175679069053-AP&client_type=gtag#level_up
+    onboardingAnalytics.logEvent("level_up", {
+      level: game.inventory["Basic Land"]?.toNumber() ?? 3,
+    });
+
+    game.expandedAt = createdAt;
+
+    return {
+      ...game,
+      inventory,
+    };
   });
-
-  game.expandedAt = createdAt;
-
-  return {
-    ...game,
-    inventory,
-  };
 }

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -77,9 +77,7 @@ export function expandLand({ state, action, createdAt = Date.now() }: Options) {
 
     game.expandedAt = createdAt;
 
-    return {
-      ...game,
-      inventory,
-    };
+    game.inventory = inventory;
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/feedBumpkin.ts
+++ b/src/features/game/events/landExpansion/feedBumpkin.ts
@@ -2,8 +2,8 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { ConsumableName, CONSUMABLES } from "features/game/types/consumables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getFoodExpBoost } from "features/game/expansion/lib/boosts";
+import { produce } from "immer";
 
 export enum FEED_BUMPKIN_ERRORS {
   MISSING_BUMPKIN = "You do not have a Bumpkin",
@@ -28,52 +28,52 @@ export function feedBumpkin({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  return produce(state, (stateCopy) => {
+    const bumpkin = stateCopy.bumpkin;
+    const buds = stateCopy.buds;
+    const inventory = stateCopy.inventory;
 
-  const bumpkin = stateCopy.bumpkin;
-  const buds = stateCopy.buds;
-  const inventory = stateCopy.inventory;
+    // throws error when player does not have a bumpkin
+    if (bumpkin === undefined) {
+      throw new Error(FEED_BUMPKIN_ERRORS.MISSING_BUMPKIN);
+    }
 
-  // throws error when player does not have a bumpkin
-  if (bumpkin === undefined) {
-    throw new Error(FEED_BUMPKIN_ERRORS.MISSING_BUMPKIN);
-  }
+    // throws error when feeding invalid amount of food (undefined or negative number)
+    const feedAmount = new Decimal(action.amount ?? 1);
+    if (feedAmount.lessThanOrEqualTo(0)) {
+      throw new Error(FEED_BUMPKIN_ERRORS.INVALID_AMOUNT);
+    }
 
-  // throws error when feeding invalid amount of food (undefined or negative number)
-  const feedAmount = new Decimal(action.amount ?? 1);
-  if (feedAmount.lessThanOrEqualTo(0)) {
-    throw new Error(FEED_BUMPKIN_ERRORS.INVALID_AMOUNT);
-  }
+    // throws error if there are not enough in the inventory to feed the bumpkin
+    const inventoryFoodCount = inventory[action.food] ?? new Decimal(0);
+    if (inventoryFoodCount.lessThan(feedAmount)) {
+      throw new Error(FEED_BUMPKIN_ERRORS.NOT_ENOUGH_FOOD);
+    }
 
-  // throws error if there are not enough in the inventory to feed the bumpkin
-  const inventoryFoodCount = inventory[action.food] ?? new Decimal(0);
-  if (inventoryFoodCount.lessThan(feedAmount)) {
-    throw new Error(FEED_BUMPKIN_ERRORS.NOT_ENOUGH_FOOD);
-  }
+    // reduce inventory food amount
+    inventory[action.food] = inventoryFoodCount.sub(feedAmount);
 
-  // reduce inventory food amount
-  inventory[action.food] = inventoryFoodCount.sub(feedAmount);
+    // increaes bumpkin experience
+    const foodExperience = new Decimal(
+      getFoodExpBoost(
+        CONSUMABLES[action.food],
+        bumpkin,
+        stateCopy,
+        buds ?? {},
+        createdAt,
+      ),
+    );
 
-  // increaes bumpkin experience
-  const foodExperience = new Decimal(
-    getFoodExpBoost(
-      CONSUMABLES[action.food],
-      bumpkin,
-      stateCopy,
-      buds ?? {},
-      createdAt,
-    ),
-  );
+    bumpkin.experience += Number(foodExperience.mul(feedAmount));
 
-  bumpkin.experience += Number(foodExperience.mul(feedAmount));
+    // tracks activity
+    bumpkin.activity = trackActivity(
+      `${action.food} Fed`,
+      bumpkin.activity,
+      feedAmount,
+    );
 
-  // tracks activity
-  bumpkin.activity = trackActivity(
-    `${action.food} Fed`,
-    bumpkin.activity,
-    feedAmount,
-  );
-
-  // return new state
-  return stateCopy;
+    // return new state
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -11,7 +11,7 @@ import { isWearableActive } from "features/game/lib/wearables";
 import { BoostType, BoostValue } from "features/game/types/boosts";
 import { CONSUMABLES } from "features/game/types/consumables";
 import { FactionPetRequest, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 const isPawShieldActive = (game: GameState) =>
   isWearableActive({ game, name: "Paw Shield" });
@@ -83,61 +83,61 @@ export function feedFactionPet({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
+  return produce(state, (stateCopy) => {
+    if (createdAt < START_DATE.getTime()) {
+      throw new Error("Faction pet feature is not active yet");
+    }
 
-  if (createdAt < START_DATE.getTime()) {
-    throw new Error("Faction pet feature is not active yet");
-  }
+    if (!stateCopy.faction) {
+      throw new Error("Player has not joined a faction");
+    }
 
-  if (!stateCopy.faction) {
-    throw new Error("Player has not joined a faction");
-  }
+    if (!stateCopy.faction.pet) {
+      throw new Error("No pet data available");
+    }
 
-  if (!stateCopy.faction.pet) {
-    throw new Error("No pet data available");
-  }
+    const { requests } = stateCopy.faction.pet;
 
-  const { requests } = stateCopy.faction.pet;
+    if (!requests[action.requestIndex]) {
+      throw new Error("No requested food found at index");
+    }
 
-  if (!requests[action.requestIndex]) {
-    throw new Error("No requested food found at index");
-  }
+    const request = requests[action.requestIndex];
+    const foodBalance = stateCopy.inventory[request.food] ?? new Decimal(0);
+    const week = getFactionWeek({ date: new Date(createdAt) });
+    const day = getFactionWeekday(createdAt);
 
-  const request = requests[action.requestIndex];
-  const foodBalance = stateCopy.inventory[request.food] ?? new Decimal(0);
-  const week = getFactionWeek({ date: new Date(createdAt) });
-  const day = getFactionWeekday(createdAt);
+    if (foodBalance.lt(request.quantity)) {
+      throw new Error("Insufficient food to fulfill the request");
+    }
 
-  if (foodBalance.lt(request.quantity)) {
-    throw new Error("Insufficient food to fulfill the request");
-  }
+    stateCopy.inventory[request.food] = foodBalance.minus(request.quantity);
 
-  stateCopy.inventory[request.food] = foodBalance.minus(request.quantity);
+    const totalXP = getTotalXPForRequest(stateCopy, request);
+    const leaderboard = stateCopy.faction.history[week] ?? {
+      score: 0,
+      petXP: 0,
+    };
 
-  const totalXP = getTotalXPForRequest(stateCopy, request);
-  const leaderboard = stateCopy.faction.history[week] ?? {
-    score: 0,
-    petXP: 0,
-  };
+    const marksBalance = stateCopy.inventory.Mark ?? new Decimal(0);
+    const fulfilled = request.dailyFulfilled?.[day] ?? 0;
 
-  const marksBalance = stateCopy.inventory.Mark ?? new Decimal(0);
-  const fulfilled = request.dailyFulfilled?.[day] ?? 0;
+    const baseReward = calculatePoints(
+      fulfilled,
+      PET_FED_REWARDS_KEY[action.requestIndex],
+    );
+    const boostAmount = getKingdomPetBoost(stateCopy, baseReward)[0];
+    const totalAmount = baseReward + boostAmount;
 
-  const baseReward = calculatePoints(
-    fulfilled,
-    PET_FED_REWARDS_KEY[action.requestIndex],
-  );
-  const boostAmount = getKingdomPetBoost(stateCopy, baseReward)[0];
-  const totalAmount = baseReward + boostAmount;
+    stateCopy.inventory.Mark = marksBalance.add(totalAmount);
+    request.dailyFulfilled[day] = fulfilled + 1;
 
-  stateCopy.inventory.Mark = marksBalance.add(totalAmount);
-  request.dailyFulfilled[day] = fulfilled + 1;
+    stateCopy.faction.history[week] = {
+      ...leaderboard,
+      score: leaderboard.score + totalAmount,
+      petXP: leaderboard.petXP + totalXP,
+    };
 
-  stateCopy.faction.history[week] = {
-    ...leaderboard,
-    score: leaderboard.score + totalAmount,
-    petXP: leaderboard.petXP + totalXP,
-  };
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -1,11 +1,11 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { CropCompostName } from "features/game/types/composters";
 import { CROPS, Crop } from "features/game/types/crops";
 import { isReadyToHarvest } from "./harvest";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
+import { produce } from "immer";
 
 export type LandExpansionFertiliseCropAction = {
   type: "plot.fertilised";
@@ -50,69 +50,70 @@ export function fertilisePlot({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { crops: plots, inventory, collectibles, bumpkin } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { crops: plots, inventory, collectibles, bumpkin } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("Bumpkin not found");
-  }
-
-  if (!plots[action.plotID]) {
-    throw new Error(FERTILISE_CROP_ERRORS.EMPTY_PLOT);
-  }
-
-  const plot = plots[action.plotID];
-
-  if (plot.fertiliser) {
-    throw new Error(FERTILISE_CROP_ERRORS.CROP_ALREADY_FERTILISED);
-  }
-
-  if (!action.fertiliser) {
-    throw new Error(FERTILISE_CROP_ERRORS.NO_FERTILISER_SELECTED);
-  }
-
-  const fertiliserAmount = inventory[action.fertiliser] || new Decimal(0);
-
-  if (fertiliserAmount.lessThan(1)) {
-    throw new Error(FERTILISE_CROP_ERRORS.NOT_ENOUGH_FERTILISER);
-  }
-
-  // Apply fertiliser
-  plot.fertiliser = {
-    name: action.fertiliser,
-    fertilisedAt: createdAt,
-  };
-
-  // Apply buff if already planted
-  const crop = plot.crop;
-  if (crop) {
-    const cropDetails = crop && CROPS[crop.name];
-    if (cropDetails && isReadyToHarvest(createdAt, crop, cropDetails)) {
-      throw new Error(FERTILISE_CROP_ERRORS.READY_TO_HARVEST);
+    if (!bumpkin) {
+      throw new Error("Bumpkin not found");
     }
 
-    if (cropDetails && action.fertiliser === "Rapid Root") {
-      crop.plantedAt = getPlantedAt(
-        action.fertiliser,
-        crop.plantedAt,
-        createdAt,
-        cropDetails,
-      );
+    if (!plots[action.plotID]) {
+      throw new Error(FERTILISE_CROP_ERRORS.EMPTY_PLOT);
     }
 
-    if (!!crop && action.fertiliser === "Sprout Mix") {
-      if (isCollectibleBuilt({ name: "Knowledge Crab", game: stateCopy })) {
-        crop.amount = (crop.amount ?? 1) + 0.4;
-      } else crop.amount = (crop.amount ?? 1) + 0.2;
+    const plot = plots[action.plotID];
+
+    if (plot.fertiliser) {
+      throw new Error(FERTILISE_CROP_ERRORS.CROP_ALREADY_FERTILISED);
     }
-  }
 
-  inventory[action.fertiliser] = fertiliserAmount.minus(1);
+    if (!action.fertiliser) {
+      throw new Error(FERTILISE_CROP_ERRORS.NO_FERTILISER_SELECTED);
+    }
 
-  bumpkin.activity = trackActivity(
-    `Crop Fertilised`,
-    stateCopy.bumpkin?.activity,
-  );
+    const fertiliserAmount = inventory[action.fertiliser] || new Decimal(0);
 
-  return stateCopy;
+    if (fertiliserAmount.lessThan(1)) {
+      throw new Error(FERTILISE_CROP_ERRORS.NOT_ENOUGH_FERTILISER);
+    }
+
+    // Apply fertiliser
+    plot.fertiliser = {
+      name: action.fertiliser,
+      fertilisedAt: createdAt,
+    };
+
+    // Apply buff if already planted
+    const crop = plot.crop;
+    if (crop) {
+      const cropDetails = crop && CROPS[crop.name];
+      if (cropDetails && isReadyToHarvest(createdAt, crop, cropDetails)) {
+        throw new Error(FERTILISE_CROP_ERRORS.READY_TO_HARVEST);
+      }
+
+      if (cropDetails && action.fertiliser === "Rapid Root") {
+        crop.plantedAt = getPlantedAt(
+          action.fertiliser,
+          crop.plantedAt,
+          createdAt,
+          cropDetails,
+        );
+      }
+
+      if (!!crop && action.fertiliser === "Sprout Mix") {
+        if (isCollectibleBuilt({ name: "Knowledge Crab", game: stateCopy })) {
+          crop.amount = (crop.amount ?? 1) + 0.4;
+        } else crop.amount = (crop.amount ?? 1) + 0.2;
+      }
+    }
+
+    inventory[action.fertiliser] = fertiliserAmount.minus(1);
+
+    bumpkin.activity = trackActivity(
+      `Crop Fertilised`,
+      stateCopy.bumpkin?.activity,
+    );
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -16,7 +16,6 @@ import {
   GreenHouseFruitName,
 } from "features/game/types/fruits";
 import { Bumpkin, GameState, PlantedFruit } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getTimeLeft } from "lib/utils/time";
 import { FruitPatch } from "features/game/types/game";
 import { FruitCompostName } from "features/game/types/composters";
@@ -24,6 +23,7 @@ import { getPlantedAt } from "./fruitPlanted";
 import { isWearableActive } from "features/game/lib/wearables";
 import { isGreenhouseFruit } from "./plantGreenhouse";
 import { FACTION_ITEMS } from "features/game/lib/factions";
+import { produce } from "immer";
 
 export type HarvestFruitAction = {
   type: "fruit.harvested";
@@ -190,60 +190,61 @@ export function harvestFruit({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { fruitPatches, bumpkin, collectibles } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { fruitPatches, bumpkin, collectibles } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const patch = fruitPatches[action.index];
+    const patch = fruitPatches[action.index];
 
-  if (!patch) {
-    throw new Error("Fruit patch does not exist");
-  }
+    if (!patch) {
+      throw new Error("Fruit patch does not exist");
+    }
 
-  if (!patch.fruit) {
-    throw new Error("Nothing was planted");
-  }
+    if (!patch.fruit) {
+      throw new Error("Nothing was planted");
+    }
 
-  const { name, plantedAt, harvestsLeft, harvestedAt, amount } = patch.fruit;
+    const { name, plantedAt, harvestsLeft, harvestedAt, amount } = patch.fruit;
 
-  const { seed } = FRUIT()[name];
-  const { plantSeconds } = FRUIT_SEEDS()[seed];
+    const { seed } = FRUIT()[name];
+    const { plantSeconds } = FRUIT_SEEDS()[seed];
 
-  if (createdAt - plantedAt < plantSeconds * 1000) {
-    throw new Error("Not ready");
-  }
+    if (createdAt - plantedAt < plantSeconds * 1000) {
+      throw new Error("Not ready");
+    }
 
-  if (createdAt - harvestedAt < plantSeconds * 1000) {
-    throw new Error("Fruit is still replenishing");
-  }
+    if (createdAt - harvestedAt < plantSeconds * 1000) {
+      throw new Error("Fruit is still replenishing");
+    }
 
-  if (!harvestsLeft) {
-    throw new Error("No harvest left");
-  }
+    if (!harvestsLeft) {
+      throw new Error("No harvest left");
+    }
 
-  stateCopy.inventory[name] =
-    stateCopy.inventory[name]?.add(amount) ?? new Decimal(amount);
+    stateCopy.inventory[name] =
+      stateCopy.inventory[name]?.add(amount) ?? new Decimal(amount);
 
-  patch.fruit.harvestsLeft = patch.fruit.harvestsLeft - 1;
-  patch.fruit.harvestedAt = getPlantedAt(
-    seed,
-    (stateCopy.bumpkin as Bumpkin).equipped,
-    stateCopy,
-    createdAt,
-  );
+    patch.fruit.harvestsLeft = patch.fruit.harvestsLeft - 1;
+    patch.fruit.harvestedAt = getPlantedAt(
+      seed,
+      (stateCopy.bumpkin as Bumpkin).equipped,
+      stateCopy,
+      createdAt,
+    );
 
-  patch.fruit.amount = getFruitYield({
-    game: stateCopy,
-    name,
-    fertiliser: patch.fertiliser?.name,
+    patch.fruit.amount = getFruitYield({
+      game: stateCopy,
+      name,
+      fertiliser: patch.fertiliser?.name,
+    });
+
+    const activityName: BumpkinActivityName = `${name} Harvested`;
+
+    bumpkin.activity = trackActivity(activityName, bumpkin.activity);
+
+    return stateCopy;
   });
-
-  const activityName: BumpkinActivityName = `${name} Harvested`;
-
-  bumpkin.activity = trackActivity(activityName, bumpkin.activity);
-
-  return stateCopy;
 }

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -12,10 +12,10 @@ import {
 } from "features/game/types/fruits";
 import { Bumpkin, GameState } from "features/game/types/game";
 import { randomInt } from "lib/utils/random";
-import cloneDeep from "lodash.clonedeep";
 import { getFruitYield } from "./fruitHarvested";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import { isWearableActive } from "features/game/lib/wearables";
+import { produce } from "immer";
 
 export type PlantFruitAction = {
   type: "fruit.planted";
@@ -147,71 +147,73 @@ export function plantFruit({
   createdAt = Date.now(),
   harvestsLeft = getHarvestsLeft,
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { fruitPatches, bumpkin } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { fruitPatches, bumpkin } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const patch = fruitPatches[action.index];
+    const patch = fruitPatches[action.index];
 
-  if (!patch) {
-    throw new Error("Fruit patch does not exist");
-  }
+    if (!patch) {
+      throw new Error("Fruit patch does not exist");
+    }
 
-  if (patch.fruit?.plantedAt) {
-    throw new Error("Fruit is already planted");
-  }
+    if (patch.fruit?.plantedAt) {
+      throw new Error("Fruit is already planted");
+    }
 
-  if (!isFruitSeed(action.seed)) {
-    throw new Error("Not a fruit seed");
-  }
+    if (!isFruitSeed(action.seed)) {
+      throw new Error("Not a fruit seed");
+    }
 
-  const seedCount = stateCopy.inventory[action.seed] || new Decimal(0);
+    const seedCount = stateCopy.inventory[action.seed] || new Decimal(0);
 
-  if (seedCount.lessThan(1)) {
-    throw new Error("Not enough seeds");
-  }
+    if (seedCount.lessThan(1)) {
+      throw new Error("Not enough seeds");
+    }
 
-  let harvestCount = harvestsLeft();
-  const invalidAmount = harvestCount > 6 || harvestCount < 3;
+    let harvestCount = harvestsLeft();
+    const invalidAmount = harvestCount > 6 || harvestCount < 3;
 
-  if (invalidAmount) {
-    throw new Error("Invalid harvests left amount");
-  }
+    if (invalidAmount) {
+      throw new Error("Invalid harvests left amount");
+    }
 
-  if (isCollectibleBuilt({ name: "Immortal Pear", game: stateCopy })) {
-    harvestCount += 1;
-  }
+    if (isCollectibleBuilt({ name: "Immortal Pear", game: stateCopy })) {
+      harvestCount += 1;
+    }
 
-  stateCopy.inventory[action.seed] = stateCopy.inventory[action.seed]?.minus(1);
+    stateCopy.inventory[action.seed] =
+      stateCopy.inventory[action.seed]?.minus(1);
 
-  const fruitName = FRUIT_SEEDS()[action.seed].yield;
+    const fruitName = FRUIT_SEEDS()[action.seed].yield;
 
-  patch.fruit = {
-    name: fruitName,
-    plantedAt: getPlantedAt(
-      action.seed,
-      (stateCopy.bumpkin as Bumpkin).equipped,
-      stateCopy,
-      createdAt,
-    ),
-    amount: getFruitYield({
+    patch.fruit = {
       name: fruitName,
-      game: stateCopy,
-      fertiliser: patch.fertiliser?.name,
-    }),
-    harvestedAt: 0,
-    // Value will be overridden by BE
-    harvestsLeft: harvestCount,
-  };
+      plantedAt: getPlantedAt(
+        action.seed,
+        (stateCopy.bumpkin as Bumpkin).equipped,
+        stateCopy,
+        createdAt,
+      ),
+      amount: getFruitYield({
+        name: fruitName,
+        game: stateCopy,
+        fertiliser: patch.fertiliser?.name,
+      }),
+      harvestedAt: 0,
+      // Value will be overridden by BE
+      harvestsLeft: harvestCount,
+    };
 
-  bumpkin.activity = trackActivity(
-    `${action.seed} Planted`,
-    bumpkin?.activity,
-    new Decimal(1),
-  );
+    bumpkin.activity = trackActivity(
+      `${action.seed} Planted`,
+      bumpkin?.activity,
+      new Decimal(1),
+    );
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/fruitTreeRemoved.ts
+++ b/src/features/game/events/landExpansion/fruitTreeRemoved.ts
@@ -6,7 +6,7 @@ import {
   Inventory,
   InventoryItemName,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum FRUIT_TREE_REMOVED_ERRORS {
   MISSING_AXE = "No axe",
@@ -53,50 +53,52 @@ export function removeFruitTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { fruitPatches, bumpkin, inventory, collectibles } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { fruitPatches, bumpkin, inventory, collectibles } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const patch = fruitPatches[action.index];
+    const patch = fruitPatches[action.index];
 
-  if (!patch) {
-    throw new Error("Fruit patch does not exist");
-  }
+    if (!patch) {
+      throw new Error("Fruit patch does not exist");
+    }
 
-  if (!patch.fruit) {
-    throw new Error("Nothing was planted");
-  }
+    if (!patch.fruit) {
+      throw new Error("Nothing was planted");
+    }
 
-  const requiredAxes = getRequiredAxeAmount(
-    patch.fruit.name,
-    inventory,
-    stateCopy,
-  );
+    const requiredAxes = getRequiredAxeAmount(
+      patch.fruit.name,
+      inventory,
+      stateCopy,
+    );
 
-  if (action.selectedItem !== "Axe" && requiredAxes.gt(0)) {
-    throw new Error(FRUIT_TREE_REMOVED_ERRORS.MISSING_AXE);
-  }
+    if (action.selectedItem !== "Axe" && requiredAxes.gt(0)) {
+      throw new Error(FRUIT_TREE_REMOVED_ERRORS.MISSING_AXE);
+    }
 
-  const axeAmount = inventory.Axe || new Decimal(0);
+    const axeAmount = inventory.Axe || new Decimal(0);
 
-  if (axeAmount.lessThan(requiredAxes)) {
-    throw new Error(FRUIT_TREE_REMOVED_ERRORS.NO_AXES);
-  }
+    if (axeAmount.lessThan(requiredAxes)) {
+      throw new Error(FRUIT_TREE_REMOVED_ERRORS.NO_AXES);
+    }
 
-  const { harvestsLeft } = patch.fruit;
+    const { harvestsLeft } = patch.fruit;
 
-  if (harvestsLeft) {
-    throw new Error("Fruit is still available");
-  }
+    if (harvestsLeft) {
+      throw new Error("Fruit is still available");
+    }
 
-  delete patch.fruit;
-  delete patch.fertiliser;
+    delete patch.fruit;
+    delete patch.fertiliser;
 
-  inventory.Axe = axeAmount.sub(requiredAxes);
-  stateCopy.inventory.Wood = stateCopy.inventory.Wood?.add(1) || new Decimal(1);
+    inventory.Axe = axeAmount.sub(requiredAxes);
+    stateCopy.inventory.Wood =
+      stateCopy.inventory.Wood?.add(1) || new Decimal(1);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/garbageSold.ts
+++ b/src/features/game/events/landExpansion/garbageSold.ts
@@ -2,9 +2,9 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
 import { GARBAGE, GarbageName } from "features/game/types/garbage";
+import { produce } from "immer";
 
 import { setPrecision } from "lib/utils/formatNumber";
-import cloneDeep from "lodash.clonedeep";
 
 export type SellGarbageAction = {
   type: "garbage.sold";
@@ -18,44 +18,45 @@ type Options = {
 };
 
 export function sellGarbage({ state, action }: Options) {
-  const game: GameState = cloneDeep(state);
-  const { item, amount } = action;
+  return produce(state, (game) => {
+    const { item, amount } = action;
 
-  const { bumpkin, inventory, coins } = game;
+    const { bumpkin, inventory, coins } = game;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  if (!(item in GARBAGE)) {
-    throw new Error("Not for sale");
-  }
+    if (!(item in GARBAGE)) {
+      throw new Error("Not for sale");
+    }
 
-  if (!new Decimal(amount).isInteger()) {
-    throw new Error("Invalid amount");
-  }
+    if (!new Decimal(amount).isInteger()) {
+      throw new Error("Invalid amount");
+    }
 
-  const count = inventory[item] || new Decimal(0);
+    const count = inventory[item] || new Decimal(0);
 
-  if (count.lessThan(amount)) {
-    throw new Error("Insufficient quantity to sell");
-  }
+    if (count.lessThan(amount)) {
+      throw new Error("Insufficient quantity to sell");
+    }
 
-  const price = GARBAGE[item].sellPrice ?? 0;
-  const coinsEarned = price * amount;
-  bumpkin.activity = trackActivity(
-    "Coins Earned",
-    bumpkin.activity,
-    new Decimal(coinsEarned),
-  );
-  bumpkin.activity = trackActivity(
-    `${item} Sold`,
-    bumpkin?.activity,
-    new Decimal(amount),
-  );
+    const price = GARBAGE[item].sellPrice ?? 0;
+    const coinsEarned = price * amount;
+    bumpkin.activity = trackActivity(
+      "Coins Earned",
+      bumpkin.activity,
+      new Decimal(coinsEarned),
+    );
+    bumpkin.activity = trackActivity(
+      `${item} Sold`,
+      bumpkin?.activity,
+      new Decimal(amount),
+    );
 
-  game.coins = coins + coinsEarned;
-  game.inventory[item] = setPrecision(count.sub(amount));
+    game.coins = coins + coinsEarned;
+    game.inventory[item] = setPrecision(count.sub(amount));
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -1,9 +1,9 @@
 import "lib/__mocks__/configMock";
 import Decimal from "decimal.js-light";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import cloneDeep from "lodash.clonedeep";
 import { GameState, CropPlot } from "../../types/game";
 import { harvest } from "./harvest";
+import cloneDeep from "lodash.clonedeep";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -7,12 +7,12 @@ import {
   GreenHouseCropName,
 } from "../../types/crops";
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import {
   BumpkinActivityName,
   trackActivity,
 } from "features/game/types/bumpkinActivity";
 import { CropPlot } from "features/game/types/game";
+import { produce } from "immer";
 
 export type LandExpansionHarvestAction = {
   type: "crop.harvested";
@@ -80,46 +80,47 @@ export function harvest({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin, crops: plots } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { bumpkin, crops: plots } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const plot = plots[action.index];
+    const plot = plots[action.index];
 
-  if (!plot) {
-    throw new Error("Plot does not exist");
-  }
+    if (!plot) {
+      throw new Error("Plot does not exist");
+    }
 
-  if (!plot.crop) {
-    throw new Error("Nothing was planted");
-  }
+    if (!plot.crop) {
+      throw new Error("Nothing was planted");
+    }
 
-  const { name: cropName, plantedAt, amount = 1, reward } = plot.crop;
+    const { name: cropName, plantedAt, amount = 1, reward } = plot.crop;
 
-  const { harvestSeconds } = CROPS[cropName];
+    const { harvestSeconds } = CROPS[cropName];
 
-  if (createdAt - plantedAt < harvestSeconds * 1000) {
-    throw new Error("Not ready");
-  }
+    if (createdAt - plantedAt < harvestSeconds * 1000) {
+      throw new Error("Not ready");
+    }
 
-  const activityName: BumpkinActivityName = `${cropName} Harvested`;
+    const activityName: BumpkinActivityName = `${cropName} Harvested`;
 
-  bumpkin.activity = trackActivity(activityName, bumpkin.activity);
+    bumpkin.activity = trackActivity(activityName, bumpkin.activity);
 
-  // Remove crop data for plot
-  delete plot.crop;
+    // Remove crop data for plot
+    delete plot.crop;
 
-  delete plot.fertiliser;
+    delete plot.fertiliser;
 
-  const cropCount = stateCopy.inventory[cropName] || new Decimal(0);
+    const cropCount = stateCopy.inventory[cropName] || new Decimal(0);
 
-  stateCopy.inventory = {
-    ...stateCopy.inventory,
-    [cropName]: cropCount.add(amount),
-  };
+    stateCopy.inventory = {
+      ...stateCopy.inventory,
+      [cropName]: cropCount.add(amount),
+    };
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import {
@@ -8,6 +7,7 @@ import {
 import { getKeys } from "features/game/types/craftables";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { isWearableActive } from "features/game/lib/wearables";
+import { produce } from "immer";
 
 export const HARVEST_BEEHIVE_ERRORS = {
   BEEHIVE_NOT_PLACED: "harvestBeeHive.notPlaced",
@@ -76,57 +76,57 @@ export function harvestBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-
-  if (!stateCopy.bumpkin) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-
-  // Update beehives before harvesting to set honey produced
-  const freshBeehives = updateBeehives({ game: stateCopy, createdAt });
-
-  stateCopy.beehives = freshBeehives;
-
-  if (!stateCopy.beehives[action.id]) {
-    throw new Error(HARVEST_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);
-  }
-
-  if (stateCopy.beehives[action.id].honey.produced <= 0) {
-    throw new Error(HARVEST_BEEHIVE_ERRORS.NO_HONEY);
-  }
-
-  const honeyProduced =
-    stateCopy.beehives[action.id].honey.produced /
-    DEFAULT_HONEY_PRODUCTION_TIME;
-  const isFull = honeyProduced >= 1;
-
-  const totalHoneyProduced = getTotalHoneyProduced(stateCopy, honeyProduced);
-
-  stateCopy.beehives[action.id].honey.produced = 0;
-  stateCopy.beehives[action.id].honey.updatedAt = createdAt;
-  stateCopy.inventory.Honey = (stateCopy.inventory.Honey ?? new Decimal(0)).add(
-    new Decimal(totalHoneyProduced),
-  );
-
-  // If the beehive is full, check, apply and update swarm
-  if (isFull) {
-    if (stateCopy.beehives[action.id].swarm) {
-      stateCopy.crops = applySwarmBoostToCrops(stateCopy.crops);
+  return produce(state, (stateCopy) => {
+    if (!stateCopy.bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
     }
 
-    // Actual value updated on the server
-    stateCopy.beehives[action.id].swarm = false;
-  }
+    // Update beehives before harvesting to set honey produced
+    const freshBeehives = updateBeehives({ game: stateCopy, createdAt });
 
-  stateCopy.bumpkin.activity = trackActivity(
-    `Honey Harvested`,
-    stateCopy.bumpkin?.activity,
-    new Decimal(totalHoneyProduced),
-  );
+    stateCopy.beehives = freshBeehives;
 
-  const updatedBeehives = updateBeehives({ game: stateCopy, createdAt });
+    if (!stateCopy.beehives[action.id]) {
+      throw new Error(HARVEST_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);
+    }
 
-  stateCopy.beehives = updatedBeehives;
+    if (stateCopy.beehives[action.id].honey.produced <= 0) {
+      throw new Error(HARVEST_BEEHIVE_ERRORS.NO_HONEY);
+    }
 
-  return stateCopy;
+    const honeyProduced =
+      stateCopy.beehives[action.id].honey.produced /
+      DEFAULT_HONEY_PRODUCTION_TIME;
+    const isFull = honeyProduced >= 1;
+
+    const totalHoneyProduced = getTotalHoneyProduced(stateCopy, honeyProduced);
+
+    stateCopy.beehives[action.id].honey.produced = 0;
+    stateCopy.beehives[action.id].honey.updatedAt = createdAt;
+    stateCopy.inventory.Honey = (
+      stateCopy.inventory.Honey ?? new Decimal(0)
+    ).add(new Decimal(totalHoneyProduced));
+
+    // If the beehive is full, check, apply and update swarm
+    if (isFull) {
+      if (stateCopy.beehives[action.id].swarm) {
+        stateCopy.crops = applySwarmBoostToCrops(stateCopy.crops);
+      }
+
+      // Actual value updated on the server
+      stateCopy.beehives[action.id].swarm = false;
+    }
+
+    stateCopy.bumpkin.activity = trackActivity(
+      `Honey Harvested`,
+      stateCopy.bumpkin?.activity,
+      new Decimal(totalHoneyProduced),
+    );
+
+    const updatedBeehives = updateBeehives({ game: stateCopy, createdAt });
+
+    stateCopy.beehives = updatedBeehives;
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/harvestCropMachine.ts
+++ b/src/features/game/events/landExpansion/harvestCropMachine.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type HarvestCropMachineAction = {
   type: "cropMachine.harvested";
@@ -19,45 +19,46 @@ export function harvestCropMachine({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
-  const machine = stateCopy.buildings["Crop Machine"]?.[0];
-  const { bumpkin } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const machine = stateCopy.buildings["Crop Machine"]?.[0];
+    const { bumpkin } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error("Bumpkin does not exist");
-  }
+    if (!bumpkin) {
+      throw new Error("Bumpkin does not exist");
+    }
 
-  if (!machine) {
-    throw new Error("Crop Machine does not exist");
-  }
+    if (!machine) {
+      throw new Error("Crop Machine does not exist");
+    }
 
-  if (!machine.queue || machine.queue?.length === 0) {
-    throw new Error("Nothing in the queue");
-  }
+    if (!machine.queue || machine.queue?.length === 0) {
+      throw new Error("Nothing in the queue");
+    }
 
-  if (!machine.queue[action.packIndex]) {
-    throw new Error("Pack does not exist");
-  }
+    if (!machine.queue[action.packIndex]) {
+      throw new Error("Pack does not exist");
+    }
 
-  const pack = machine.queue[action.packIndex];
+    const pack = machine.queue[action.packIndex];
 
-  if (!pack.readyAt || (pack.readyAt && pack.readyAt > createdAt)) {
-    throw new Error("The pack is not ready yet");
-  }
+    if (!pack.readyAt || (pack.readyAt && pack.readyAt > createdAt)) {
+      throw new Error("The pack is not ready yet");
+    }
 
-  // Harvest the crops from pack
-  const cropsInInventory = stateCopy.inventory[pack.crop] ?? new Decimal(0);
-  stateCopy.inventory[pack.crop] = cropsInInventory.add(pack.amount);
-  bumpkin.activity = trackActivity(
-    `${pack.crop} Harvested`,
-    bumpkin.activity,
-    new Decimal(pack.seeds),
-  );
+    // Harvest the crops from pack
+    const cropsInInventory = stateCopy.inventory[pack.crop] ?? new Decimal(0);
+    stateCopy.inventory[pack.crop] = cropsInInventory.add(pack.amount);
+    bumpkin.activity = trackActivity(
+      `${pack.crop} Harvested`,
+      bumpkin.activity,
+      new Decimal(pack.seeds),
+    );
 
-  // Filter out the harvested crops and add them to the player's inventory
-  machine.queue = machine.queue.filter(
-    (_, index) => index !== action.packIndex,
-  );
+    // Filter out the harvested crops and add them to the player's inventory
+    machine.queue = machine.queue.filter(
+      (_, index) => index !== action.packIndex,
+    );
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/harvestFlower.ts
+++ b/src/features/game/events/landExpansion/harvestFlower.ts
@@ -1,6 +1,5 @@
 import { FLOWERS, FLOWER_SEEDS } from "features/game/types/flowers";
 import { GameState } from "../../types/game";
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { trackActivity } from "features/game/types/bumpkinActivity";
@@ -8,6 +7,7 @@ import { trackActivity } from "features/game/types/bumpkinActivity";
 import { translate } from "lib/i18n/translate";
 
 import { trackFarmActivity } from "features/game/types/farmActivity";
+import { produce } from "immer";
 
 export type HarvestFlowerAction = {
   type: "flower.harvested";
@@ -25,69 +25,69 @@ export function harvestFlower({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-
-  stateCopy.beehives = updateBeehives({
-    game: state,
-    createdAt,
-  });
-
-  const bumpkin = stateCopy.bumpkin;
-
-  if (!bumpkin) throw new Error("You do not have a Bumpkin!");
-
-  const flowers = stateCopy.flowers;
-  const flowerBed = flowers.flowerBeds[action.id];
-
-  if (!flowerBed) throw new Error(translate("harvestflower.noFlowerBed"));
-
-  const flower = flowerBed.flower;
-
-  if (!flower) throw new Error(translate("harvestflower.noFlower"));
-
-  const isReady =
-    flower.plantedAt +
-      FLOWER_SEEDS()[FLOWERS[flower.name].seed].plantSeconds * 1000 <
-    createdAt;
-
-  if (!isReady) throw new Error(translate("harvestflower.notReady"));
-
-  stateCopy.inventory[flower.name] = (
-    stateCopy.inventory[flower.name] ?? new Decimal(0)
-  ).add(flower.amount);
-
-  const discovered = flowers.discovered[flower.name] ?? [];
-  if (!!flower.crossbreed && !discovered.includes(flower.crossbreed)) {
-    flowers.discovered[flower.name] = [...discovered, flower.crossbreed];
-  }
-
-  const reward = flower.reward;
-  if (reward) {
-    (reward.items ?? []).forEach((item) => {
-      stateCopy.inventory[item.name] = (
-        stateCopy.inventory[item.name] ?? new Decimal(0)
-      ).add(item.amount);
+  return produce(state, (stateCopy) => {
+    stateCopy.beehives = updateBeehives({
+      game: state,
+      createdAt,
     });
-  }
 
-  delete flowerBed.flower;
+    const bumpkin = stateCopy.bumpkin;
 
-  bumpkin.activity = trackActivity(
-    `${flower.name} Harvested`,
-    bumpkin?.activity,
-    new Decimal(1),
-  );
+    if (!bumpkin) throw new Error("You do not have a Bumpkin!");
 
-  stateCopy.farmActivity = trackFarmActivity(
-    `${flower.name} Harvested`,
-    stateCopy.farmActivity,
-    1,
-  );
+    const flowers = stateCopy.flowers;
+    const flowerBed = flowers.flowerBeds[action.id];
 
-  stateCopy.beehives = updateBeehives({
-    game: stateCopy,
-    createdAt,
+    if (!flowerBed) throw new Error(translate("harvestflower.noFlowerBed"));
+
+    const flower = flowerBed.flower;
+
+    if (!flower) throw new Error(translate("harvestflower.noFlower"));
+
+    const isReady =
+      flower.plantedAt +
+        FLOWER_SEEDS()[FLOWERS[flower.name].seed].plantSeconds * 1000 <
+      createdAt;
+
+    if (!isReady) throw new Error(translate("harvestflower.notReady"));
+
+    stateCopy.inventory[flower.name] = (
+      stateCopy.inventory[flower.name] ?? new Decimal(0)
+    ).add(flower.amount);
+
+    const discovered = flowers.discovered[flower.name] ?? [];
+    if (!!flower.crossbreed && !discovered.includes(flower.crossbreed)) {
+      flowers.discovered[flower.name] = [...discovered, flower.crossbreed];
+    }
+
+    const reward = flower.reward;
+    if (reward) {
+      (reward.items ?? []).forEach((item) => {
+        stateCopy.inventory[item.name] = (
+          stateCopy.inventory[item.name] ?? new Decimal(0)
+        ).add(item.amount);
+      });
+    }
+
+    delete flowerBed.flower;
+
+    bumpkin.activity = trackActivity(
+      `${flower.name} Harvested`,
+      bumpkin?.activity,
+      new Decimal(1),
+    );
+
+    stateCopy.farmActivity = trackFarmActivity(
+      `${flower.name} Harvested`,
+      stateCopy.farmActivity,
+      1,
+    );
+
+    stateCopy.beehives = updateBeehives({
+      game: stateCopy,
+      createdAt,
+    });
+
+    return stateCopy;
   });
-
-  return stateCopy;
 }

--- a/src/features/game/events/landExpansion/ironMine.ts
+++ b/src/features/game/events/landExpansion/ironMine.ts
@@ -1,10 +1,10 @@
 import Decimal from "decimal.js-light";
 import { canMine } from "features/game/expansion/lib/utils";
-import cloneDeep from "lodash.clonedeep";
 import { IRON_RECOVERY_TIME } from "../../lib/constants";
 import { trackActivity } from "../../types/bumpkinActivity";
 import { GameState } from "../../types/game";
 import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
+import { produce } from "immer";
 
 export type LandExpansionIronMineAction = {
   type: "ironRock.mined";
@@ -55,40 +55,41 @@ export function mineIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { iron, bumpkin, collectibles } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { iron, bumpkin, collectibles } = stateCopy;
 
-  if (!bumpkin) {
-    throw new Error(MINE_ERRORS.NO_BUMPKIN);
-  }
+    if (!bumpkin) {
+      throw new Error(MINE_ERRORS.NO_BUMPKIN);
+    }
 
-  const ironRock = iron[action.index];
+    const ironRock = iron[action.index];
 
-  if (!ironRock) {
-    throw new Error(MINE_ERRORS.NO_IRON);
-  }
+    if (!ironRock) {
+      throw new Error(MINE_ERRORS.NO_IRON);
+    }
 
-  if (!canMine(ironRock, IRON_RECOVERY_TIME, createdAt)) {
-    throw new Error(MINE_ERRORS.STILL_RECOVERING);
-  }
+    if (!canMine(ironRock, IRON_RECOVERY_TIME, createdAt)) {
+      throw new Error(MINE_ERRORS.STILL_RECOVERING);
+    }
 
-  const toolAmount = stateCopy.inventory["Stone Pickaxe"] || new Decimal(0);
+    const toolAmount = stateCopy.inventory["Stone Pickaxe"] || new Decimal(0);
 
-  if (toolAmount.lessThan(1)) {
-    throw new Error(MINE_ERRORS.NO_PICKAXES);
-  }
+    if (toolAmount.lessThan(1)) {
+      throw new Error(MINE_ERRORS.NO_PICKAXES);
+    }
 
-  const ironMined = ironRock.stone.amount;
-  const amountInInventory = stateCopy.inventory.Iron || new Decimal(0);
+    const ironMined = ironRock.stone.amount;
+    const amountInInventory = stateCopy.inventory.Iron || new Decimal(0);
 
-  ironRock.stone = {
-    minedAt: getMinedAt({ createdAt, game: stateCopy }),
-    amount: 2,
-  };
-  bumpkin.activity = trackActivity("Iron Mined", bumpkin.activity);
+    ironRock.stone = {
+      minedAt: getMinedAt({ createdAt, game: stateCopy }),
+      amount: 2,
+    };
+    bumpkin.activity = trackActivity("Iron Mined", bumpkin.activity);
 
-  stateCopy.inventory["Stone Pickaxe"] = toolAmount.sub(1);
-  stateCopy.inventory.Iron = amountInInventory.add(ironMined);
+    stateCopy.inventory["Stone Pickaxe"] = toolAmount.sub(1);
+    stateCopy.inventory.Iron = amountInInventory.add(ironMined);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/leaveFaction.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.ts
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 import { FACTION_BANNERS, FACTION_EMBLEMS } from "./joinFaction";
 import { GameState } from "features/game/types/game";
 
@@ -17,30 +17,30 @@ export function leaveFaction({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const game: GameState = cloneDeep(state);
+  return produce(state, (game) => {
+    if (!game.faction) {
+      throw new Error("You are not in a faction");
+    }
 
-  if (!game.faction) {
-    throw new Error("You are not in a faction");
-  }
+    const emblem = FACTION_EMBLEMS[game.faction.name];
+    if (game.inventory[emblem]?.gt(0)) {
+      throw new Error("Cannot leave a faction with emblems");
+    }
 
-  const emblem = FACTION_EMBLEMS[game.faction.name];
-  if (game.inventory[emblem]?.gt(0)) {
-    throw new Error("Cannot leave a faction with emblems");
-  }
+    if (createdAt - game.faction.pledgedAt < 1000 * 60 * 60 * 24) {
+      throw new Error("Cannot leave a newly joined faction");
+    }
 
-  if (createdAt - game.faction.pledgedAt < 1000 * 60 * 60 * 24) {
-    throw new Error("Cannot leave a newly joined faction");
-  }
+    delete game.faction;
+    delete game.inventory.Mark;
 
-  delete game.faction;
-  delete game.inventory.Mark;
+    // Clean up the banners
+    Object.values(FACTION_BANNERS).forEach((name) => {
+      delete game.inventory[name];
+      delete game.collectibles[name];
+      delete game.home.collectibles[name];
+    });
 
-  // Clean up the banners
-  Object.values(FACTION_BANNERS).forEach((name) => {
-    delete game.inventory[name];
-    delete game.collectibles[name];
-    delete game.home.collectibles[name];
+    return game;
   });
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/mineCrimstone.ts
+++ b/src/features/game/events/landExpansion/mineCrimstone.ts
@@ -1,9 +1,9 @@
 import Decimal from "decimal.js-light";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import cloneDeep from "lodash.clonedeep";
 import { GameState, Rock } from "../../types/game";
 import { isWearableActive } from "features/game/lib/wearables";
+import { produce } from "immer";
 
 export type MineCrimstoneAction = {
   type: "crimstoneRock.mined";
@@ -41,56 +41,57 @@ export function mineCrimstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { crimstones, bumpkin } = stateCopy;
-  const rock = crimstones?.[action.index];
+  return produce(state, (stateCopy) => {
+    const { crimstones, bumpkin } = stateCopy;
+    const rock = crimstones?.[action.index];
 
-  if (!rock) {
-    throw new Error("Crimstone does not exist");
-  }
+    if (!rock) {
+      throw new Error("Crimstone does not exist");
+    }
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  if (!canMine(rock, createdAt)) {
-    throw new Error("Rock is still recovering");
-  }
+    if (!canMine(rock, createdAt)) {
+      throw new Error("Rock is still recovering");
+    }
 
-  const toolAmount = stateCopy.inventory["Gold Pickaxe"] || new Decimal(0);
+    const toolAmount = stateCopy.inventory["Gold Pickaxe"] || new Decimal(0);
 
-  if (toolAmount.lessThan(1)) {
-    throw new Error("No gold pickaxes left");
-  }
+    if (toolAmount.lessThan(1)) {
+      throw new Error("No gold pickaxes left");
+    }
 
-  // if last minedAt is more than CRIMSTONE_RECOVERY_TIME + 24hrs, reset minesLeft to 5
-  // else, decrement minesLeft by 1
-  const twentyFourHrs = 24 * 60 * 60;
+    // if last minedAt is more than CRIMSTONE_RECOVERY_TIME + 24hrs, reset minesLeft to 5
+    // else, decrement minesLeft by 1
+    const twentyFourHrs = 24 * 60 * 60;
 
-  const timeToReset = (CRIMSTONE_RECOVERY_TIME + twentyFourHrs) * 1000;
+    const timeToReset = (CRIMSTONE_RECOVERY_TIME + twentyFourHrs) * 1000;
 
-  if (createdAt - rock.stone.minedAt > timeToReset) {
-    rock.minesLeft = 5;
-  }
+    if (createdAt - rock.stone.minedAt > timeToReset) {
+      rock.minesLeft = 5;
+    }
 
-  const stoneMined = rock.stone.amount;
-  const amountInInventory = stateCopy.inventory.Crimstone || new Decimal(0);
+    const stoneMined = rock.stone.amount;
+    const amountInInventory = stateCopy.inventory.Crimstone || new Decimal(0);
 
-  rock.stone = {
-    minedAt: getMinedAt({ createdAt, game: stateCopy }),
-    amount: 1,
-  };
+    rock.stone = {
+      minedAt: getMinedAt({ createdAt, game: stateCopy }),
+      amount: 1,
+    };
 
-  rock.minesLeft = rock.minesLeft - 1;
+    rock.minesLeft = rock.minesLeft - 1;
 
-  if (rock.minesLeft === 0) {
-    rock.minesLeft = 5;
-  }
+    if (rock.minesLeft === 0) {
+      rock.minesLeft = 5;
+    }
 
-  stateCopy.inventory["Gold Pickaxe"] = toolAmount.sub(1);
-  stateCopy.inventory.Crimstone = amountInInventory.add(stoneMined);
+    stateCopy.inventory["Gold Pickaxe"] = toolAmount.sub(1);
+    stateCopy.inventory.Crimstone = amountInInventory.add(stoneMined);
 
-  bumpkin.activity = trackActivity("Crimstone Mined", bumpkin.activity);
+    bumpkin.activity = trackActivity("Crimstone Mined", bumpkin.activity);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/missFish.ts
+++ b/src/features/game/events/landExpansion/missFish.ts
@@ -1,5 +1,4 @@
-import cloneDeep from "lodash.clonedeep";
-
+import { produce } from "immer";
 import { GameState } from "../../types/game";
 import { FishingLocation } from "features/game/types/fishing";
 
@@ -19,17 +18,18 @@ export function missFish({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
-  const location = action.location;
-  if (!game.fishing[location].castedAt) {
-    throw new Error("Nothing has been casted");
-  }
+  return produce(state, (game) => {
+    const location = action.location;
+    if (!game.fishing[location].castedAt) {
+      throw new Error("Nothing has been casted");
+    }
 
-  delete game.fishing[location].castedAt;
-  delete game.fishing[location].caught;
-  delete game.fishing[location].chum;
+    delete game.fishing[location].castedAt;
+    delete game.fishing[location].caught;
+    delete game.fishing[location].chum;
 
-  return {
-    ...game,
-  };
+    return {
+      ...game,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/moveBeehive.ts
+++ b/src/features/game/events/landExpansion/moveBeehive.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_BEEHIVE_ERRORS {
   NO_BEEHIVE = "This beehive does not exist.",
@@ -24,14 +24,14 @@ export function moveBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  return produce(state, (stateCopy) => {
+    if (!stateCopy.beehives[action.id]) {
+      throw new Error(MOVE_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);
+    }
 
-  if (!stateCopy.beehives[action.id]) {
-    throw new Error(MOVE_BEEHIVE_ERRORS.BEEHIVE_NOT_PLACED);
-  }
+    stateCopy.beehives[action.id].x = action.coordinates.x;
+    stateCopy.beehives[action.id].y = action.coordinates.y;
 
-  stateCopy.beehives[action.id].x = action.coordinates.x;
-  stateCopy.beehives[action.id].y = action.coordinates.y;
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveBud.ts
+++ b/src/features/game/events/landExpansion/moveBud.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_BUD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -25,19 +25,19 @@ export function moveBud({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  return produce(state, (stateCopy) => {
+    const bud = stateCopy.buds?.[Number(action.id)];
 
-  const bud = stateCopy.buds?.[Number(action.id)];
+    if (!bud) {
+      throw new Error(MOVE_BUD_ERRORS.NO_BUD);
+    }
 
-  if (!bud) {
-    throw new Error(MOVE_BUD_ERRORS.NO_BUD);
-  }
+    if (!bud.coordinates) {
+      throw new Error(MOVE_BUD_ERRORS.BUD_NOT_PLACED);
+    }
 
-  if (!bud.coordinates) {
-    throw new Error(MOVE_BUD_ERRORS.BUD_NOT_PLACED);
-  }
+    bud.coordinates = action.coordinates;
 
-  bud.coordinates = action.coordinates;
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveBuilding.ts
+++ b/src/features/game/events/landExpansion/moveBuilding.ts
@@ -1,7 +1,7 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { BuildingName } from "features/game/types/buildings";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_BUILDING_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -27,26 +27,27 @@ export function moveBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const buildings = stateCopy.buildings[action.name];
+  return produce(state, (stateCopy) => {
+    const buildings = stateCopy.buildings[action.name];
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_BUILDING_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_BUILDING_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!buildings) {
-    throw new Error(MOVE_BUILDING_ERRORS.NO_BUILDINGS);
-  }
+    if (!buildings) {
+      throw new Error(MOVE_BUILDING_ERRORS.NO_BUILDINGS);
+    }
 
-  const collectibleToMoveIndex = buildings.findIndex(
-    (collectible) => collectible.id === action.id,
-  );
+    const collectibleToMoveIndex = buildings.findIndex(
+      (collectible) => collectible.id === action.id,
+    );
 
-  if (collectibleToMoveIndex < 0) {
-    throw new Error(MOVE_BUILDING_ERRORS.BUILDING_NOT_PLACED);
-  }
+    if (collectibleToMoveIndex < 0) {
+      throw new Error(MOVE_BUILDING_ERRORS.BUILDING_NOT_PLACED);
+    }
 
-  buildings[collectibleToMoveIndex].coordinates = action.coordinates;
+    buildings[collectibleToMoveIndex].coordinates = action.coordinates;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveChicken.ts
+++ b/src/features/game/events/landExpansion/moveChicken.ts
@@ -7,8 +7,8 @@ import {
   GameState,
   Position,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { eggIsReady } from "./collectEgg";
+import { produce } from "immer";
 
 export enum MOVE_CHICKEN_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -69,31 +69,32 @@ export function moveChicken({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const chickens = stateCopy.chickens;
-  const collectibles = stateCopy.collectibles;
+  return produce(state, (stateCopy) => {
+    const chickens = stateCopy.chickens;
+    const collectibles = stateCopy.collectibles;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_CHICKEN_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_CHICKEN_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!chickens[action.id]?.coordinates) {
-    throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
-  }
+    if (!chickens[action.id]?.coordinates) {
+      throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
+    }
 
-  const coordinates = chickens[action.id].coordinates;
-  if (!coordinates) {
-    throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
-  }
+    const coordinates = chickens[action.id].coordinates;
+    if (!coordinates) {
+      throw new Error(MOVE_CHICKEN_ERRORS.CHICKEN_NOT_PLACED);
+    }
 
-  if (
-    isLocked(chickens[action.id], collectibles, createdAt, stateCopy.bumpkin)
-  ) {
-    throw new Error(MOVE_CHICKEN_ERRORS.AOE_LOCKED);
-  }
+    if (
+      isLocked(chickens[action.id], collectibles, createdAt, stateCopy.bumpkin)
+    ) {
+      throw new Error(MOVE_CHICKEN_ERRORS.AOE_LOCKED);
+    }
 
-  coordinates.x = action.coordinates.x;
-  coordinates.y = action.coordinates.y;
+    coordinates.x = action.coordinates.x;
+    coordinates.y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveCollectible.ts
+++ b/src/features/game/events/landExpansion/moveCollectible.ts
@@ -3,7 +3,7 @@ import { CollectibleLocation } from "features/game/types/collectibles";
 import { CollectibleName } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
 import { hasMoveRestriction } from "features/game/types/removeables";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_COLLECTIBLE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -30,40 +30,40 @@ export function moveCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
+  return produce(state, (stateCopy) => {
+    const collectibleGroup =
+      action.location === "home"
+        ? stateCopy.home.collectibles[action.name]
+        : stateCopy.collectibles[action.name];
 
-  const collectibleGroup =
-    action.location === "home"
-      ? stateCopy.home.collectibles[action.name]
-      : stateCopy.collectibles[action.name];
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_COLLECTIBLE_ERRORS.NO_BUMPKIN);
+    }
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_COLLECTIBLE_ERRORS.NO_BUMPKIN);
-  }
+    if (!collectibleGroup) {
+      throw new Error(MOVE_COLLECTIBLE_ERRORS.NO_COLLECTIBLES);
+    }
 
-  if (!collectibleGroup) {
-    throw new Error(MOVE_COLLECTIBLE_ERRORS.NO_COLLECTIBLES);
-  }
+    const collectibleToMoveIndex = collectibleGroup.findIndex(
+      (collectible) => collectible.id === action.id,
+    );
 
-  const collectibleToMoveIndex = collectibleGroup.findIndex(
-    (collectible) => collectible.id === action.id,
-  );
+    if (collectibleToMoveIndex < 0) {
+      throw new Error(MOVE_COLLECTIBLE_ERRORS.COLLECTIBLE_NOT_PLACED);
+    }
 
-  if (collectibleToMoveIndex < 0) {
-    throw new Error(MOVE_COLLECTIBLE_ERRORS.COLLECTIBLE_NOT_PLACED);
-  }
+    const [isRestricted, restrictionReason] = hasMoveRestriction(
+      action.name,
+      action.id,
+      stateCopy,
+    );
 
-  const [isRestricted, restrictionReason] = hasMoveRestriction(
-    action.name,
-    action.id,
-    stateCopy,
-  );
+    if (isRestricted) {
+      throw new Error(restrictionReason);
+    }
 
-  if (isRestricted) {
-    throw new Error(restrictionReason);
-  }
+    collectibleGroup[collectibleToMoveIndex].coordinates = action.coordinates;
 
-  collectibleGroup[collectibleToMoveIndex].coordinates = action.coordinates;
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveCrimstone.ts
+++ b/src/features/game/events/landExpansion/moveCrimstone.ts
@@ -1,7 +1,7 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { canMine } from "./stoneMine";
+import { produce } from "immer";
 
 export enum MOVE_CRIMSTONE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -36,23 +36,24 @@ export function moveCrimstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const crimstones = stateCopy.crimstones;
+  return produce(state, (stateCopy) => {
+    const crimstones = stateCopy.crimstones;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_CRIMSTONE_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_CRIMSTONE_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!crimstones[action.id]) {
-    throw new Error(MOVE_CRIMSTONE_ERRORS.CRIMSTONE_NOT_PLACED);
-  }
+    if (!crimstones[action.id]) {
+      throw new Error(MOVE_CRIMSTONE_ERRORS.CRIMSTONE_NOT_PLACED);
+    }
 
-  if (isLocked(crimstones[action.id], createdAt)) {
-    throw new Error(MOVE_CRIMSTONE_ERRORS.AOE_LOCKED);
-  }
+    if (isLocked(crimstones[action.id], createdAt)) {
+      throw new Error(MOVE_CRIMSTONE_ERRORS.AOE_LOCKED);
+    }
 
-  crimstones[action.id].x = action.coordinates.x;
-  crimstones[action.id].y = action.coordinates.y;
+    crimstones[action.id].x = action.coordinates.x;
+    crimstones[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -7,10 +7,10 @@ import {
   GameState,
   Position,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { isReadyToHarvest } from "./harvest";
 import { CROPS } from "features/game/types/crops";
 import { isBasicCrop, isMediumCrop, isAdvancedCrop } from "./harvest";
+import { produce } from "immer";
 
 export enum MOVE_CROP_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -230,24 +230,25 @@ export function moveCrop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const { crops, collectibles } = stateCopy;
-  const plot = crops[action.id];
+  return produce(state, (stateCopy) => {
+    const { crops, collectibles } = stateCopy;
+    const plot = crops[action.id];
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_CROP_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_CROP_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!plot) {
-    throw new Error(MOVE_CROP_ERRORS.CROP_NOT_PLACED);
-  }
+    if (!plot) {
+      throw new Error(MOVE_CROP_ERRORS.CROP_NOT_PLACED);
+    }
 
-  if (isLocked(plot, collectibles, createdAt, stateCopy.bumpkin)) {
-    throw new Error(MOVE_CROP_ERRORS.AOE_LOCKED);
-  }
+    if (isLocked(plot, collectibles, createdAt, stateCopy.bumpkin)) {
+      throw new Error(MOVE_CROP_ERRORS.AOE_LOCKED);
+    }
 
-  crops[action.id].x = action.coordinates.x;
-  crops[action.id].y = action.coordinates.y;
+    crops[action.id].x = action.coordinates.x;
+    crops[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveFruitPatch.ts
+++ b/src/features/game/events/landExpansion/moveFruitPatch.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_FRUIT_PATCH_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,19 +24,20 @@ export function moveFruitPatch({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const fruitPatch = stateCopy.fruitPatches;
+  return produce(state, (stateCopy) => {
+    const fruitPatch = stateCopy.fruitPatches;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_FRUIT_PATCH_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_FRUIT_PATCH_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!fruitPatch[action.id]) {
-    throw new Error(MOVE_FRUIT_PATCH_ERRORS.FRUIT_PATCH_NOT_PLACED);
-  }
+    if (!fruitPatch[action.id]) {
+      throw new Error(MOVE_FRUIT_PATCH_ERRORS.FRUIT_PATCH_NOT_PLACED);
+    }
 
-  fruitPatch[action.id].x = action.coordinates.x;
-  fruitPatch[action.id].y = action.coordinates.y;
+    fruitPatch[action.id].x = action.coordinates.x;
+    fruitPatch[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveGold.ts
+++ b/src/features/game/events/landExpansion/moveGold.ts
@@ -3,7 +3,7 @@ import { canMine } from "features/game/expansion/lib/utils";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
 import { GOLD_RECOVERY_TIME } from "features/game/lib/constants";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_GOLD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -43,30 +43,31 @@ export function moveGold({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const gold = stateCopy.gold;
+  return produce(state, (stateCopy) => {
+    const gold = stateCopy.gold;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_GOLD_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_GOLD_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!gold[action.id]) {
-    throw new Error(MOVE_GOLD_ERRORS.GOLD_NOT_PLACED);
-  }
+    if (!gold[action.id]) {
+      throw new Error(MOVE_GOLD_ERRORS.GOLD_NOT_PLACED);
+    }
 
-  if (
-    isLocked(
-      gold[action.id],
-      stateCopy.collectibles,
-      createdAt,
-      stateCopy.bumpkin,
-    )
-  ) {
-    throw new Error(MOVE_GOLD_ERRORS.AOE_LOCKED);
-  }
+    if (
+      isLocked(
+        gold[action.id],
+        stateCopy.collectibles,
+        createdAt,
+        stateCopy.bumpkin,
+      )
+    ) {
+      throw new Error(MOVE_GOLD_ERRORS.AOE_LOCKED);
+    }
 
-  gold[action.id].x = action.coordinates.x;
-  gold[action.id].y = action.coordinates.y;
+    gold[action.id].x = action.coordinates.x;
+    gold[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveIron.ts
+++ b/src/features/game/events/landExpansion/moveIron.ts
@@ -3,7 +3,7 @@ import { canMine } from "features/game/expansion/lib/utils";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
 import { IRON_RECOVERY_TIME } from "features/game/lib/constants";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_IRON_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -44,30 +44,31 @@ export function moveIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const iron = stateCopy.iron;
+  return produce(state, (stateCopy) => {
+    const iron = stateCopy.iron;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_IRON_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_IRON_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!iron[action.id]) {
-    throw new Error(MOVE_IRON_ERRORS.IRON_NOT_PLACED);
-  }
+    if (!iron[action.id]) {
+      throw new Error(MOVE_IRON_ERRORS.IRON_NOT_PLACED);
+    }
 
-  if (
-    isLocked(
-      iron[action.id],
-      stateCopy.collectibles,
-      createdAt,
-      stateCopy.bumpkin,
-    )
-  ) {
-    throw new Error(MOVE_IRON_ERRORS.AOE_LOCKED);
-  }
+    if (
+      isLocked(
+        iron[action.id],
+        stateCopy.collectibles,
+        createdAt,
+        stateCopy.bumpkin,
+      )
+    ) {
+      throw new Error(MOVE_IRON_ERRORS.AOE_LOCKED);
+    }
 
-  iron[action.id].x = action.coordinates.x;
-  iron[action.id].y = action.coordinates.y;
+    iron[action.id].x = action.coordinates.x;
+    iron[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveOilReserve.ts
+++ b/src/features/game/events/landExpansion/moveOilReserve.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_OIL_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,19 +24,20 @@ export function moveOilReserve({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const oilReserves = stateCopy.oilReserves;
+  return produce(state, (stateCopy) => {
+    const oilReserves = stateCopy.oilReserves;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_OIL_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_OIL_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!oilReserves[action.id]) {
-    throw new Error(MOVE_OIL_ERRORS.OIL_NOT_PLACED);
-  }
+    if (!oilReserves[action.id]) {
+      throw new Error(MOVE_OIL_ERRORS.OIL_NOT_PLACED);
+    }
 
-  oilReserves[action.id].x = action.coordinates.x;
-  oilReserves[action.id].y = action.coordinates.y;
+    oilReserves[action.id].x = action.coordinates.x;
+    oilReserves[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveStone.ts
+++ b/src/features/game/events/landExpansion/moveStone.ts
@@ -1,8 +1,8 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { Collectibles, GameState, Rock } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { canMine } from "./stoneMine";
 import { isAOEImpacted } from "features/game/expansion/placeable/lib/collisionDetection";
+import { produce } from "immer";
 
 export enum MOVE_STONE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -47,30 +47,31 @@ export function moveStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const stones = stateCopy.stones;
+  return produce(state, (stateCopy) => {
+    const stones = stateCopy.stones;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_STONE_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_STONE_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!stones[action.id]) {
-    throw new Error(MOVE_STONE_ERRORS.STONE_NOT_PLACED);
-  }
+    if (!stones[action.id]) {
+      throw new Error(MOVE_STONE_ERRORS.STONE_NOT_PLACED);
+    }
 
-  if (
-    isLocked(
-      stones[action.id],
-      stateCopy.collectibles,
-      createdAt,
-      stateCopy.bumpkin,
-    )
-  ) {
-    throw new Error(MOVE_STONE_ERRORS.AOE_LOCKED);
-  }
+    if (
+      isLocked(
+        stones[action.id],
+        stateCopy.collectibles,
+        createdAt,
+        stateCopy.bumpkin,
+      )
+    ) {
+      throw new Error(MOVE_STONE_ERRORS.AOE_LOCKED);
+    }
 
-  stones[action.id].x = action.coordinates.x;
-  stones[action.id].y = action.coordinates.y;
+    stones[action.id].x = action.coordinates.x;
+    stones[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveSunstone.ts
+++ b/src/features/game/events/landExpansion/moveSunstone.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_GOLD_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,19 +24,20 @@ export function moveSunstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const sunstones = stateCopy.sunstones;
+  return produce(state, (stateCopy) => {
+    const sunstones = stateCopy.sunstones;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_GOLD_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_GOLD_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!sunstones[action.id]) {
-    throw new Error(MOVE_GOLD_ERRORS.SUNSTONE_NOT_PLACED);
-  }
+    if (!sunstones[action.id]) {
+      throw new Error(MOVE_GOLD_ERRORS.SUNSTONE_NOT_PLACED);
+    }
 
-  sunstones[action.id].x = action.coordinates.x;
-  sunstones[action.id].y = action.coordinates.y;
+    sunstones[action.id].x = action.coordinates.x;
+    sunstones[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/moveTree.ts
+++ b/src/features/game/events/landExpansion/moveTree.ts
@@ -1,6 +1,6 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export enum MOVE_TREE_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -24,19 +24,20 @@ export function moveTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state) as GameState;
-  const trees = stateCopy.trees;
+  return produce(state, (stateCopy) => {
+    const trees = stateCopy.trees;
 
-  if (stateCopy.bumpkin === undefined) {
-    throw new Error(MOVE_TREE_ERRORS.NO_BUMPKIN);
-  }
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_TREE_ERRORS.NO_BUMPKIN);
+    }
 
-  if (!trees[action.id]) {
-    throw new Error(MOVE_TREE_ERRORS.TREE_NOT_PLACED);
-  }
+    if (!trees[action.id]) {
+      throw new Error(MOVE_TREE_ERRORS.TREE_NOT_PLACED);
+    }
 
-  trees[action.id].x = action.coordinates.x;
-  trees[action.id].y = action.coordinates.y;
+    trees[action.id].x = action.coordinates.x;
+    trees[action.id].y = action.coordinates.y;
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/pickMushroom.ts
+++ b/src/features/game/events/landExpansion/pickMushroom.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
+import { produce } from "immer";
 
 export type PickMushroomAction = {
   type: "mushroom.picked";
@@ -18,22 +18,23 @@ export function pickMushroom({
   action,
   createdAt = Date.now(),
 }: Options) {
-  const copy = cloneDeep<GameState>(state);
-  const mushrooms = copy.mushrooms?.mushrooms;
+  return produce(state, (copy) => {
+    const mushrooms = copy.mushrooms?.mushrooms;
 
-  if (!mushrooms) {
-    throw new Error("Mushrooms not populated");
-  }
+    if (!mushrooms) {
+      throw new Error("Mushrooms not populated");
+    }
 
-  const mushroom = mushrooms[action.id];
-  if (!mushroom) {
-    throw new Error(`Mushroom not found: ${action.id}`);
-  }
+    const mushroom = mushrooms[action.id];
+    if (!mushroom) {
+      throw new Error(`Mushroom not found: ${action.id}`);
+    }
 
-  delete mushrooms[action.id];
+    delete mushrooms[action.id];
 
-  const inventoryMushrooms = copy.inventory[mushroom.name] ?? new Decimal(0);
-  copy.inventory[mushroom.name] = inventoryMushrooms.add(mushroom.amount);
+    const inventoryMushrooms = copy.inventory[mushroom.name] ?? new Decimal(0);
+    copy.inventory[mushroom.name] = inventoryMushrooms.add(mushroom.amount);
 
-  return copy;
+    return copy;
+  });
 }

--- a/src/features/game/events/landExpansion/pickSkill.ts
+++ b/src/features/game/events/landExpansion/pickSkill.ts
@@ -5,7 +5,7 @@ import {
 } from "features/game/types/bumpkinSkills";
 import { getKeys } from "features/game/types/craftables";
 import { Bumpkin, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type PickSkillAction = {
   type: "skill.picked";
@@ -37,30 +37,31 @@ export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
 };
 
 export function pickSkill({ state, action, createdAt = Date.now() }: Options) {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin } = stateCopy;
-  if (bumpkin == undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+  return produce(state, (stateCopy) => {
+    const { bumpkin } = stateCopy;
+    if (bumpkin == undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+    const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
 
-  const requirements = BUMPKIN_SKILL_TREE[action.skill].requirements;
+    const requirements = BUMPKIN_SKILL_TREE[action.skill].requirements;
 
-  if (availableSkillPoints < requirements.points) {
-    throw new Error("You do not have enough skill points");
-  }
+    if (availableSkillPoints < requirements.points) {
+      throw new Error("You do not have enough skill points");
+    }
 
-  if (requirements.skill && !bumpkin.skills[requirements.skill]) {
-    throw new Error("Missing previous skill requirement");
-  }
-  const bumpkinHasSkill = bumpkin.skills[action.skill];
+    if (requirements.skill && !bumpkin.skills[requirements.skill]) {
+      throw new Error("Missing previous skill requirement");
+    }
+    const bumpkinHasSkill = bumpkin.skills[action.skill];
 
-  if (bumpkinHasSkill) {
-    throw new Error("You already have this skill");
-  }
+    if (bumpkinHasSkill) {
+      throw new Error("You already have this skill");
+    }
 
-  bumpkin.skills = { ...bumpkin.skills, [action.skill]: 1 };
+    bumpkin.skills = { ...bumpkin.skills, [action.skill]: 1 };
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/placeBeehive.ts
+++ b/src/features/game/events/landExpansion/placeBeehive.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import { Beehive, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type PlaceBeehiveAction = {
   type: "beehive.placed";
@@ -23,37 +23,37 @@ export function placeBeehive({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const copy: GameState = cloneDeep(state);
+  return produce(state, (copy) => {
+    const available = (copy.inventory.Beehive || new Decimal(0)).minus(
+      Object.keys(copy.beehives ?? {}).length,
+    );
 
-  const available = (copy.inventory.Beehive || new Decimal(0)).minus(
-    Object.keys(copy.beehives ?? {}).length,
-  );
+    if (available.lte(0)) {
+      throw new Error("You do not have any available beehives");
+    }
 
-  if (available.lte(0)) {
-    throw new Error("You do not have any available beehives");
-  }
+    const beehive: Beehive = {
+      x: action.coordinates.x,
+      y: action.coordinates.y,
+      swarm: false,
+      height: 1,
+      width: 1,
+      honey: {
+        updatedAt: createdAt,
+        produced: 0,
+      },
+      flowers: [],
+    };
 
-  const beehive: Beehive = {
-    x: action.coordinates.x,
-    y: action.coordinates.y,
-    swarm: false,
-    height: 1,
-    width: 1,
-    honey: {
-      updatedAt: createdAt,
-      produced: 0,
-    },
-    flowers: [],
-  };
+    copy.beehives = { ...copy.beehives, [action.id]: beehive };
 
-  copy.beehives = { ...copy.beehives, [action.id]: beehive };
+    const updatedBeehives = updateBeehives({
+      game: copy,
+      createdAt,
+    });
 
-  const updatedBeehives = updateBeehives({
-    game: copy,
-    createdAt,
+    copy.beehives = updatedBeehives;
+
+    return copy;
   });
-
-  copy.beehives = updatedBeehives;
-
-  return copy;
 }

--- a/src/features/game/events/landExpansion/placeBud.ts
+++ b/src/features/game/events/landExpansion/placeBud.ts
@@ -1,6 +1,6 @@
 import { CollectibleLocation } from "features/game/types/collectibles";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type PlaceBudAction = {
   type: "bud.placed";
@@ -23,16 +23,16 @@ export function placeBud({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const copy = cloneDeep(state);
+  return produce(state, (copy) => {
+    const bud = copy.buds?.[Number(action.id)];
 
-  const bud = copy.buds?.[Number(action.id)];
+    if (!bud) throw new Error("This bud does not exist");
 
-  if (!bud) throw new Error("This bud does not exist");
+    if (bud.coordinates) throw new Error("This bud is already placed");
 
-  if (bud.coordinates) throw new Error("This bud is already placed");
+    bud.coordinates = action.coordinates;
+    bud.location = action.location;
 
-  bud.coordinates = action.coordinates;
-  bud.location = action.location;
-
-  return copy;
+    return copy;
+  });
 }

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -1,8 +1,8 @@
 import Decimal from "decimal.js-light";
 // import { randomUUID } from "crypto";
-import cloneDeep from "lodash.clonedeep";
 import { BuildingName } from "../../types/buildings";
 import { GameState, PlacedItem } from "../../types/game";
+import { produce } from "immer";
 
 export enum PLACE_BUILDING_ERRORS {
   NO_BUMPKIN = "You do not have a Bumpkin!",
@@ -31,35 +31,37 @@ export function placeBuilding({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const bumpkin = stateCopy.bumpkin;
+  return produce(state, (stateCopy) => {
+    const bumpkin = stateCopy.bumpkin;
 
-  if (bumpkin === undefined) {
-    throw new Error(PLACE_BUILDING_ERRORS.NO_BUMPKIN);
-  }
+    if (bumpkin === undefined) {
+      throw new Error(PLACE_BUILDING_ERRORS.NO_BUMPKIN);
+    }
 
-  const buildingInventory = stateCopy.inventory[action.name] || new Decimal(0);
-  const placed = stateCopy.buildings[action.name] || [];
-  const hasUnplacedBuildings = buildingInventory
-    .minus(1)
-    .greaterThanOrEqualTo(placed.length);
+    const buildingInventory =
+      stateCopy.inventory[action.name] || new Decimal(0);
+    const placed = stateCopy.buildings[action.name] || [];
+    const hasUnplacedBuildings = buildingInventory
+      .minus(1)
+      .greaterThanOrEqualTo(placed.length);
 
-  if (!hasUnplacedBuildings) {
-    throw new Error(PLACE_BUILDING_ERRORS.NO_UNPLACED_BUILDINGS);
-  }
+    if (!hasUnplacedBuildings) {
+      throw new Error(PLACE_BUILDING_ERRORS.NO_UNPLACED_BUILDINGS);
+    }
 
-  const newBuilding: PlacedItem = {
-    id: action.id,
-    createdAt: createdAt,
-    coordinates: action.coordinates,
-    readyAt: createdAt,
-  };
+    const newBuilding: PlacedItem = {
+      id: action.id,
+      createdAt: createdAt,
+      coordinates: action.coordinates,
+      readyAt: createdAt,
+    };
 
-  return {
-    ...stateCopy,
-    buildings: {
-      ...stateCopy.buildings,
-      [action.name]: [...placed, newBuilding],
-    },
-  };
+    return {
+      ...stateCopy,
+      buildings: {
+        ...stateCopy.buildings,
+        [action.name]: [...placed, newBuilding],
+      },
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/placeChicken.ts
+++ b/src/features/game/events/landExpansion/placeChicken.ts
@@ -1,7 +1,7 @@
 import { getKeys } from "features/game/types/craftables";
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "../../types/game";
 import { getSupportedChickens } from "./utils";
+import { produce } from "immer";
 
 export type PlaceChickenAction = {
   type: "chicken.placed";
@@ -23,37 +23,38 @@ export function placeChicken({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const bumpkin = stateCopy.bumpkin;
+  return produce(state, (stateCopy) => {
+    const bumpkin = stateCopy.bumpkin;
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const placedChickens = getKeys(stateCopy.chickens).filter(
-    (index) => stateCopy.chickens[index].coordinates,
-  ).length;
+    const placedChickens = getKeys(stateCopy.chickens).filter(
+      (index) => stateCopy.chickens[index].coordinates,
+    ).length;
 
-  if (stateCopy.inventory.Chicken?.lte(placedChickens)) {
-    throw new Error("You do not have any available chickens");
-  }
+    if (stateCopy.inventory.Chicken?.lte(placedChickens)) {
+      throw new Error("You do not have any available chickens");
+    }
 
-  const availableSpots = getSupportedChickens(stateCopy);
+    const availableSpots = getSupportedChickens(stateCopy);
 
-  if (placedChickens === availableSpots) {
-    throw new Error("Insufficient space for more chickens");
-  }
+    if (placedChickens === availableSpots) {
+      throw new Error("Insufficient space for more chickens");
+    }
 
-  const chickens: GameState["chickens"] = {
-    ...stateCopy.chickens,
-    [action.id]: {
-      multiplier: 1,
-      coordinates: action.coordinates,
-    },
-  };
+    const chickens: GameState["chickens"] = {
+      ...stateCopy.chickens,
+      [action.id]: {
+        multiplier: 1,
+        coordinates: action.coordinates,
+      },
+    };
 
-  return {
-    ...stateCopy,
-    chickens,
-  };
+    return {
+      ...stateCopy,
+      chickens,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -81,8 +81,6 @@ export function placeCollectible({
       stateCopy.collectibles[action.name] = collectibleItems;
     }
 
-    return {
-      ...stateCopy,
-    };
+    return stateCopy;
   });
 }

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import {
   CollectibleName,
   COLLECTIBLES_DIMENSIONS,
@@ -6,6 +5,7 @@ import {
 import { GameState, PlacedItem } from "features/game/types/game";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { CollectibleLocation } from "features/game/types/collectibles";
+import { produce } from "immer";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -29,59 +29,60 @@ export function placeCollectible({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin } = stateCopy;
-  const collectible = action.name;
+  return produce(state, (stateCopy) => {
+    const { bumpkin } = stateCopy;
+    const collectible = action.name;
 
-  let collectibleItems =
-    action.location === "home"
-      ? stateCopy.home.collectibles[action.name]
-      : stateCopy.collectibles[action.name];
+    let collectibleItems =
+      action.location === "home"
+        ? stateCopy.home.collectibles[action.name]
+        : stateCopy.collectibles[action.name];
 
-  if (!collectibleItems) {
-    collectibleItems = [];
-  }
+    if (!collectibleItems) {
+      collectibleItems = [];
+    }
 
-  const inventoryItemBalance = stateCopy.inventory[collectible];
+    const inventoryItemBalance = stateCopy.inventory[collectible];
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  if (!inventoryItemBalance) {
-    throw new Error("You can't place an item that is not on the inventory");
-  }
+    if (!inventoryItemBalance) {
+      throw new Error("You can't place an item that is not on the inventory");
+    }
 
-  if (
-    collectibleItems &&
-    inventoryItemBalance?.lessThanOrEqualTo(collectibleItems.length)
-  ) {
-    throw new Error("This collectible is already placed");
-  }
+    if (
+      collectibleItems &&
+      inventoryItemBalance?.lessThanOrEqualTo(collectibleItems.length)
+    ) {
+      throw new Error("This collectible is already placed");
+    }
 
-  if (!(collectible in COLLECTIBLES_DIMENSIONS)) {
-    throw new Error("You cannot place this item");
-  }
+    if (!(collectible in COLLECTIBLES_DIMENSIONS)) {
+      throw new Error("You cannot place this item");
+    }
 
-  const newCollectiblePlacement: PlacedItem = {
-    id: action.id,
-    createdAt: createdAt,
-    coordinates: action.coordinates,
-    readyAt: createdAt,
-  };
+    const newCollectiblePlacement: PlacedItem = {
+      id: action.id,
+      createdAt: createdAt,
+      coordinates: action.coordinates,
+      readyAt: createdAt,
+    };
 
-  bumpkin.activity = trackActivity("Collectible Placed", bumpkin.activity);
+    bumpkin.activity = trackActivity("Collectible Placed", bumpkin.activity);
 
-  collectibleItems.push(newCollectiblePlacement);
+    collectibleItems.push(newCollectiblePlacement);
 
-  // Update stateCopy with the new collectibleItems
-  if (action.location === "home") {
-    stateCopy.home.collectibles[action.name] = collectibleItems;
-  } else {
-    stateCopy.collectibles[action.name] = collectibleItems;
-  }
+    // Update stateCopy with the new collectibleItems
+    if (action.location === "home") {
+      stateCopy.home.collectibles[action.name] = collectibleItems;
+    } else {
+      stateCopy.collectibles[action.name] = collectibleItems;
+    }
 
-  return {
-    ...stateCopy,
-  };
+    return {
+      ...stateCopy,
+    };
+  });
 }

--- a/src/features/game/events/landExpansion/placeFlowerBed.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.ts
@@ -1,9 +1,8 @@
-import cloneDeep from "lodash.clonedeep";
-
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
+import { produce } from "immer";
 
 export type PlaceFlowerBedAction = {
   type: "flowerBed.placed";
@@ -25,46 +24,46 @@ export function placeFlowerBed({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Flower Bed"] || new Decimal(0)).minus(
+      Object.keys(game.flowers.flowerBeds).length,
+    );
 
-  const available = (game.inventory["Flower Bed"] || new Decimal(0)).minus(
-    Object.keys(game.flowers.flowerBeds).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No flower beds available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No flower beds available");
-  }
+    const dimensions = RESOURCE_DIMENSIONS["Flower Bed"];
+    const collides = detectCollision({
+      state,
+      name: "Flower Bed",
+      location: "farm",
+      position: {
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        height: dimensions.height,
+        width: dimensions.width,
+      },
+    });
 
-  const dimensions = RESOURCE_DIMENSIONS["Flower Bed"];
-  const collides = detectCollision({
-    state,
-    name: "Flower Bed",
-    location: "farm",
-    position: {
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      height: dimensions.height,
-      width: dimensions.width,
-    },
+    if (collides) {
+      throw new Error("Flower Bed collides");
+    }
+
+    if (game.flowers.flowerBeds[action.id]) {
+      throw new Error("ID exists");
+    }
+
+    game.flowers.flowerBeds = {
+      ...game.flowers.flowerBeds,
+      [action.id]: {
+        createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Flower Bed"],
+      },
+    };
+
+    return game;
   });
-
-  if (collides) {
-    throw new Error("Flower Bed collides");
-  }
-
-  if (game.flowers.flowerBeds[action.id]) {
-    throw new Error("ID exists");
-  }
-
-  game.flowers.flowerBeds = {
-    ...game.flowers.flowerBeds,
-    [action.id]: {
-      createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Flower Bed"],
-    },
-  };
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/placeGold.ts
+++ b/src/features/game/events/landExpansion/placeGold.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlaceGoldAction = {
   type: "gold.placed";
@@ -28,29 +27,29 @@ export function placeGold({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Gold Rock"] || new Decimal(0)).minus(
+      Object.keys(game.gold).length,
+    );
 
-  const available = (game.inventory["Gold Rock"] || new Decimal(0)).minus(
-    Object.keys(game.gold).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No gold available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No gold available");
-  }
-
-  game.gold = {
-    ...game.gold,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Gold Rock"],
-      stone: {
-        amount: 0,
-        minedAt: 0,
+    game.gold = {
+      ...game.gold,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Gold Rock"],
+        stone: {
+          amount: 0,
+          minedAt: 0,
+        },
       },
-    },
-  };
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/placeIron.ts
+++ b/src/features/game/events/landExpansion/placeIron.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlaceIronAction = {
   type: "iron.placed";
@@ -28,29 +27,29 @@ export function placeIron({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Iron Rock"] || new Decimal(0)).minus(
+      Object.keys(game.iron).length,
+    );
 
-  const available = (game.inventory["Iron Rock"] || new Decimal(0)).minus(
-    Object.keys(game.iron).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No iron available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No iron available");
-  }
-
-  game.iron = {
-    ...game.iron,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Iron Rock"],
-      stone: {
-        amount: 0,
-        minedAt: 0,
+    game.iron = {
+      ...game.iron,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Iron Rock"],
+        stone: {
+          amount: 0,
+          minedAt: 0,
+        },
       },
-    },
-  };
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/placePlot.ts
+++ b/src/features/game/events/landExpansion/placePlot.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlacePlotAction = {
   type: "plot.placed";
@@ -28,25 +27,25 @@ export function placePlot({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Crop Plot"] || new Decimal(0)).minus(
+      Object.keys(game.crops).length,
+    );
 
-  const available = (game.inventory["Crop Plot"] || new Decimal(0)).minus(
-    Object.keys(game.crops).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No plots available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No plots available");
-  }
+    game.crops = {
+      ...game.crops,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Crop Plot"],
+      },
+    };
 
-  game.crops = {
-    ...game.crops,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Crop Plot"],
-    },
-  };
-
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/placeStone.ts
+++ b/src/features/game/events/landExpansion/placeStone.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlaceStoneAction = {
   type: "stone.placed";
@@ -28,29 +27,29 @@ export function placeStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Stone Rock"] || new Decimal(0)).minus(
+      Object.keys(game.stones).length,
+    );
 
-  const available = (game.inventory["Stone Rock"] || new Decimal(0)).minus(
-    Object.keys(game.stones).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No stone available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No stone available");
-  }
-
-  game.stones = {
-    ...game.stones,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Stone Rock"],
-      stone: {
-        amount: 0,
-        minedAt: 0,
+    game.stones = {
+      ...game.stones,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Stone Rock"],
+        stone: {
+          amount: 0,
+          minedAt: 0,
+        },
       },
-    },
-  };
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/placeSunstone.ts
+++ b/src/features/game/events/landExpansion/placeSunstone.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlaceSunstoneAction = {
   type: "sunstone.placed";
@@ -28,30 +27,30 @@ export function placeSunstone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const available = (game.inventory["Sunstone Rock"] || new Decimal(0)).minus(
+      Object.keys(game.sunstones).length,
+    );
 
-  const available = (game.inventory["Sunstone Rock"] || new Decimal(0)).minus(
-    Object.keys(game.sunstones).length,
-  );
+    if (available.lt(1)) {
+      throw new Error("No sunstone available");
+    }
 
-  if (available.lt(1)) {
-    throw new Error("No sunstone available");
-  }
-
-  game.sunstones = {
-    ...game.sunstones,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Sunstone Rock"],
-      stone: {
-        amount: 0,
-        minedAt: 0,
+    game.sunstones = {
+      ...game.sunstones,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Sunstone Rock"],
+        stone: {
+          amount: 0,
+          minedAt: 0,
+        },
+        minesLeft: 10,
       },
-      minesLeft: 10,
-    },
-  };
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/placeTree.ts
+++ b/src/features/game/events/landExpansion/placeTree.ts
@@ -1,11 +1,10 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "features/game/types/game";
 import {
   ResourceName,
   RESOURCE_DIMENSIONS,
 } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type PlaceTreeAction = {
   type: "tree.placed";
@@ -28,28 +27,29 @@ export function placeTree({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
-  const available = (game.inventory.Tree || new Decimal(0)).minus(
-    Object.keys(game.trees).length,
-  );
+  return produce(state, (game) => {
+    const available = (game.inventory.Tree || new Decimal(0)).minus(
+      Object.keys(game.trees).length,
+    );
 
-  if (available.lt(1)) {
-    throw new Error("No trees available");
-  }
+    if (available.lt(1)) {
+      throw new Error("No trees available");
+    }
 
-  game.trees = {
-    ...game.trees,
-    [action.id as unknown as number]: {
-      createdAt: createdAt,
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      ...RESOURCE_DIMENSIONS["Tree"],
-      wood: {
-        amount: 1,
-        choppedAt: 0,
+    game.trees = {
+      ...game.trees,
+      [action.id as unknown as number]: {
+        createdAt: createdAt,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        ...RESOURCE_DIMENSIONS["Tree"],
+        wood: {
+          amount: 1,
+          choppedAt: 0,
+        },
       },
-    },
-  };
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/readMessage.ts
+++ b/src/features/game/events/landExpansion/readMessage.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { Announcements } from "features/game/types/announcements";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type MessageRead = {
   id: string;
@@ -16,41 +16,37 @@ type Options = {
   createdAt?: number;
 };
 
-const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
-};
-
 export function readMessage({
   state,
   action,
   announcements,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = clone(state);
+  return produce(state, (game) => {
+    const message = state.mailbox.read.find((mail) => mail.id === action.id);
+    if (message) {
+      throw new Error("Message already read");
+    }
 
-  const message = state.mailbox.read.find((mail) => mail.id === action.id);
-  if (message) {
-    throw new Error("Message already read");
-  }
-
-  game.mailbox.read.push({
-    id: action.id,
-    createdAt,
-  });
-
-  const announcement = announcements?.[action.id];
-
-  const reward = announcement?.reward;
-  if (reward) {
-    getKeys(reward.items).forEach((name) => {
-      const previous = game.inventory[name] ?? new Decimal(0);
-      game.inventory[name] = previous.add(reward.items[name] ?? 0);
+    game.mailbox.read.push({
+      id: action.id,
+      createdAt,
     });
 
-    if (reward.coins) {
-      game.coins = game.coins + reward.coins;
-    }
-  }
+    const announcement = announcements?.[action.id];
 
-  return game;
+    const reward = announcement?.reward;
+    if (reward) {
+      getKeys(reward.items).forEach((name) => {
+        const previous = game.inventory[name] ?? new Decimal(0);
+        game.inventory[name] = previous.add(reward.items[name] ?? 0);
+      });
+
+      if (reward.coins) {
+        game.coins = game.coins + reward.coins;
+      }
+    }
+
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/reelRod.ts
+++ b/src/features/game/events/landExpansion/reelRod.ts
@@ -47,8 +47,6 @@ export function reelRod({
     delete game.fishing[location].caught;
     delete game.fishing[location].chum;
 
-    return {
-      ...game,
-    };
+    return game;
   });
 }

--- a/src/features/game/events/landExpansion/reelRod.ts
+++ b/src/features/game/events/landExpansion/reelRod.ts
@@ -1,10 +1,9 @@
-import cloneDeep from "lodash.clonedeep";
-
 import { GameState } from "../../types/game";
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { FishingLocation } from "features/game/types/fishing";
 import { trackFarmActivity } from "features/game/types/farmActivity";
+import { produce } from "immer";
 
 export type ReelRodAction = {
   type: "rod.reeled";
@@ -22,33 +21,34 @@ export function reelRod({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state) as GameState;
-  const location = action.location;
+  return produce(state, (game) => {
+    const location = action.location;
 
-  if (!game.fishing[location].castedAt) {
-    throw new Error("Nothing has been casted");
-  }
+    if (!game.fishing[location].castedAt) {
+      throw new Error("Nothing has been casted");
+    }
 
-  const caught = game.fishing[location].caught ?? {};
-  getKeys(caught).forEach((name) => {
-    const previous = game.inventory[name] ?? new Decimal(0);
-    game.inventory[name] = previous.add(caught[name] ?? 0);
+    const caught = game.fishing[location].caught ?? {};
+    getKeys(caught).forEach((name) => {
+      const previous = game.inventory[name] ?? new Decimal(0);
+      game.inventory[name] = previous.add(caught[name] ?? 0);
+    });
+
+    // Track farm activity
+    getKeys(caught).forEach((itemName) => {
+      game.farmActivity = trackFarmActivity(
+        `${itemName} Caught`,
+        game.farmActivity,
+        caught[itemName],
+      );
+    });
+
+    delete game.fishing[location].castedAt;
+    delete game.fishing[location].caught;
+    delete game.fishing[location].chum;
+
+    return {
+      ...game,
+    };
   });
-
-  // Track farm activity
-  getKeys(caught).forEach((itemName) => {
-    game.farmActivity = trackFarmActivity(
-      `${itemName} Caught`,
-      game.farmActivity,
-      caught[itemName],
-    );
-  });
-
-  delete game.fishing[location].castedAt;
-  delete game.fishing[location].caught;
-  delete game.fishing[location].chum;
-
-  return {
-    ...game,
-  };
 }

--- a/src/features/game/events/landExpansion/refreshKingdomChores.ts
+++ b/src/features/game/events/landExpansion/refreshKingdomChores.ts
@@ -1,5 +1,5 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type RefreshKingdomChoresAction = {
   type: "kingdomChores.refreshed";
@@ -11,5 +11,7 @@ type Options = {
 };
 
 export function refreshKingdomChores({ state }: Options) {
-  return cloneDeep<GameState>(state);
+  return produce(state, (stateCopy) => {
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/refundBid.ts
+++ b/src/features/game/events/landExpansion/refundBid.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type RefundBidAction = {
   type: "bid.refunded";
@@ -13,23 +13,23 @@ type Options = {
 };
 
 export function refundBid({ state }: Options) {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    const bid = game.auctioneer.bid;
+    if (!bid) {
+      throw new Error("No bid was placed");
+    }
 
-  const bid = game.auctioneer.bid;
-  if (!bid) {
-    throw new Error("No bid was placed");
-  }
+    // Add ingredients back to inventory
+    getKeys(bid.ingredients)?.forEach((name) => {
+      const old = game.inventory[name] || new Decimal(0);
+      game.inventory[name] = old.add(bid.ingredients[name] ?? 0);
+    });
 
-  // Add ingredients back to inventory
-  getKeys(bid.ingredients)?.forEach((name) => {
-    const old = game.inventory[name] || new Decimal(0);
-    game.inventory[name] = old.add(bid.ingredients[name] ?? 0);
+    // Add SFL back to balance
+    game.balance = game.balance.add(bid.sfl);
+
+    delete game.auctioneer.bid;
+
+    return game;
   });
-
-  // Add SFL back to balance
-  game.balance = game.balance.add(bid.sfl);
-
-  delete game.auctioneer.bid;
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { GameState, PlacedLamp } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import {
   areUnsupportedChickensBrewing,
   removeUnsupportedChickens,
@@ -11,6 +10,7 @@ import { REMOVAL_RESTRICTIONS } from "features/game/types/removeables";
 import { SEEDS } from "features/game/types/seeds";
 import { CollectibleLocation } from "features/game/types/collectibles";
 import { FLOWER_SEEDS } from "features/game/types/flowers";
+import { produce } from "immer";
 
 export enum REMOVE_COLLECTIBLE_ERRORS {
   INVALID_COLLECTIBLE = "This collectible does not exist",
@@ -34,101 +34,101 @@ type Options = {
 };
 
 export function removeCollectible({ state, action }: Options) {
-  const stateCopy = cloneDeep(state) as GameState;
+  return produce(state, (stateCopy) => {
+    const { inventory, bumpkin } = stateCopy;
+    let collectibleGroup =
+      action.location === "home"
+        ? stateCopy.home.collectibles[action.name]
+        : stateCopy.collectibles[action.name];
 
-  const { inventory, bumpkin } = stateCopy;
-  let collectibleGroup =
-    action.location === "home"
-      ? stateCopy.home.collectibles[action.name]
-      : stateCopy.collectibles[action.name];
-
-  if (bumpkin === undefined) {
-    throw new Error(REMOVE_COLLECTIBLE_ERRORS.NO_BUMPKIN);
-  }
-
-  if (!collectibleGroup) {
-    throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
-  }
-
-  const collectibleToRemove = collectibleGroup.find(
-    (collectible) => collectible.id === action.id,
-  );
-
-  if (!collectibleToRemove) {
-    throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
-  }
-
-  // TODO - remove once landscaping is launched
-  const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
-  if (shovelAmount.gte(1)) {
-    inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
-  }
-
-  collectibleGroup = collectibleGroup.filter(
-    (collectible) => collectible.id !== collectibleToRemove.id,
-  );
-
-  // Remove collectible key if there are none placed
-  if (collectibleGroup.length === 0) {
-    if (action.location === "home") {
-      delete stateCopy.home.collectibles[action.name];
+    if (bumpkin === undefined) {
+      throw new Error(REMOVE_COLLECTIBLE_ERRORS.NO_BUMPKIN);
     }
 
-    if (action.location === "farm") {
-      delete stateCopy.collectibles[action.name];
-    }
-  } else {
-    if (action.location === "home") {
-      stateCopy.home.collectibles[action.name] = collectibleGroup;
+    if (!collectibleGroup) {
+      throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
     }
 
-    if (action.location === "farm") {
-      stateCopy.collectibles[action.name] = collectibleGroup;
-    }
-  }
+    const collectibleToRemove = collectibleGroup.find(
+      (collectible) => collectible.id === action.id,
+    );
 
-  if (action.name === "Chicken Coop") {
-    if (areUnsupportedChickensBrewing(stateCopy)) {
-      throw new Error(
-        REMOVE_COLLECTIBLE_ERRORS.CHICKEN_COOP_REMOVE_BREWING_CHICKEN,
-      );
+    if (!collectibleToRemove) {
+      throw new Error(REMOVE_COLLECTIBLE_ERRORS.INVALID_COLLECTIBLE);
     }
 
-    stateCopy.chickens = removeUnsupportedChickens(stateCopy);
-  }
-
-  if (action.name === "Genie Lamp") {
-    const collectible: PlacedLamp = collectibleToRemove;
-    const rubbedCount = collectible.rubbedCount ?? 0;
-    if (rubbedCount > 0) {
-      throw new Error(REMOVE_COLLECTIBLE_ERRORS.GENIE_IN_USE);
+    // TODO - remove once landscaping is launched
+    const shovelAmount = inventory["Rusty Shovel"] || new Decimal(0);
+    if (shovelAmount.gte(1)) {
+      inventory["Rusty Shovel"] = inventory["Rusty Shovel"]?.minus(1);
     }
-  }
 
-  const removalRestriction = REMOVAL_RESTRICTIONS[action.name];
-  if (removalRestriction) {
-    const [restricted] = removalRestriction(state);
-    if (restricted)
-      throw new Error(REMOVE_COLLECTIBLE_ERRORS.COLLECTIBLE_IN_USE);
-  }
+    collectibleGroup = collectibleGroup.filter(
+      (collectible) => collectible.id !== collectibleToRemove.id,
+    );
 
-  if (action.name === "Kuebiko") {
-    getKeys(SEEDS()).forEach((seed) => {
-      if (stateCopy.inventory[seed]) {
-        delete stateCopy.inventory[seed];
+    // Remove collectible key if there are none placed
+    if (collectibleGroup.length === 0) {
+      if (action.location === "home") {
+        delete stateCopy.home.collectibles[action.name];
       }
-    });
-  }
 
-  if (action.name === "Hungry Caterpillar") {
-    getKeys(FLOWER_SEEDS()).forEach((seed) => {
-      if (stateCopy.inventory[seed]) {
-        delete stateCopy.inventory[seed];
+      if (action.location === "farm") {
+        delete stateCopy.collectibles[action.name];
       }
-    });
-  }
+    } else {
+      if (action.location === "home") {
+        stateCopy.home.collectibles[action.name] = collectibleGroup;
+      }
 
-  bumpkin.activity = trackActivity("Collectible Removed", bumpkin.activity);
+      if (action.location === "farm") {
+        stateCopy.collectibles[action.name] = collectibleGroup;
+      }
+    }
 
-  return stateCopy;
+    if (action.name === "Chicken Coop") {
+      if (areUnsupportedChickensBrewing(stateCopy)) {
+        throw new Error(
+          REMOVE_COLLECTIBLE_ERRORS.CHICKEN_COOP_REMOVE_BREWING_CHICKEN,
+        );
+      }
+
+      stateCopy.chickens = removeUnsupportedChickens(stateCopy);
+    }
+
+    if (action.name === "Genie Lamp") {
+      const collectible: PlacedLamp = collectibleToRemove;
+      const rubbedCount = collectible.rubbedCount ?? 0;
+      if (rubbedCount > 0) {
+        throw new Error(REMOVE_COLLECTIBLE_ERRORS.GENIE_IN_USE);
+      }
+    }
+
+    const removalRestriction = REMOVAL_RESTRICTIONS[action.name];
+    if (removalRestriction) {
+      const [restricted] = removalRestriction(state);
+      if (restricted)
+        throw new Error(REMOVE_COLLECTIBLE_ERRORS.COLLECTIBLE_IN_USE);
+    }
+
+    if (action.name === "Kuebiko") {
+      getKeys(SEEDS()).forEach((seed) => {
+        if (stateCopy.inventory[seed]) {
+          delete stateCopy.inventory[seed];
+        }
+      });
+    }
+
+    if (action.name === "Hungry Caterpillar") {
+      getKeys(FLOWER_SEEDS()).forEach((seed) => {
+        if (stateCopy.inventory[seed]) {
+          delete stateCopy.inventory[seed];
+        }
+      });
+    }
+
+    bumpkin.activity = trackActivity("Collectible Removed", bumpkin.activity);
+
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -1,9 +1,9 @@
 import Decimal from "decimal.js-light";
 import { screenTracker } from "lib/utils/screen";
-import cloneDeep from "lodash.clonedeep";
 import { CROPS } from "../../types/crops";
 import { GameState, InventoryItemName } from "../../types/game";
 import { isReadyToHarvest } from "./harvest";
+import { produce } from "immer";
 
 export enum REMOVE_CROP_ERRORS {
   EMPTY_EXPANSION = "Expansion does not exist!",
@@ -29,50 +29,51 @@ type Options = {
 };
 
 export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
-  const stateCopy = cloneDeep(state);
-  const { crops: plots, inventory } = stateCopy;
+  return produce(state, (stateCopy) => {
+    const { crops: plots, inventory } = stateCopy;
 
-  if (action.index < 0) {
-    throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
-  }
+    if (action.index < 0) {
+      throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
+    }
 
-  if (!Number.isInteger(action.index)) {
-    throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
-  }
+    if (!Number.isInteger(action.index)) {
+      throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
+    }
 
-  if (action.index >= Object.keys(plots).length) {
-    throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
-  }
+    if (action.index >= Object.keys(plots).length) {
+      throw new Error(REMOVE_CROP_ERRORS.EMPTY_PLOT);
+    }
 
-  const plot = plots[action.index];
-  const crop = plot && plot.crop;
+    const plot = plots[action.index];
+    const crop = plot && plot.crop;
 
-  if (!crop) {
-    throw new Error(REMOVE_CROP_ERRORS.EMPTY_CROP);
-  }
+    if (!crop) {
+      throw new Error(REMOVE_CROP_ERRORS.EMPTY_CROP);
+    }
 
-  if (action.item !== "Shovel") {
-    throw new Error(REMOVE_CROP_ERRORS.NO_VALID_SHOVEL_SELECTED);
-  }
+    if (action.item !== "Shovel") {
+      throw new Error(REMOVE_CROP_ERRORS.NO_VALID_SHOVEL_SELECTED);
+    }
 
-  const shovelAmount = stateCopy.inventory.Shovel || new Decimal(0);
-  if (shovelAmount.lessThan(1)) {
-    throw new Error(REMOVE_CROP_ERRORS.NO_SHOVEL_AVAILABLE);
-  }
+    const shovelAmount = stateCopy.inventory.Shovel || new Decimal(0);
+    if (shovelAmount.lessThan(1)) {
+      throw new Error(REMOVE_CROP_ERRORS.NO_SHOVEL_AVAILABLE);
+    }
 
-  const cropDetails = CROPS[crop.name];
-  if (isReadyToHarvest(createdAt, crop, cropDetails)) {
-    throw new Error(REMOVE_CROP_ERRORS.READY_TO_HARVEST);
-  }
+    const cropDetails = CROPS[crop.name];
+    if (isReadyToHarvest(createdAt, crop, cropDetails)) {
+      throw new Error(REMOVE_CROP_ERRORS.READY_TO_HARVEST);
+    }
 
-  if (!screenTracker.calculate()) {
-    throw new Error(REMOVE_CROP_ERRORS.INVALID_PLANT);
-  }
+    if (!screenTracker.calculate()) {
+      throw new Error(REMOVE_CROP_ERRORS.INVALID_PLANT);
+    }
 
-  delete plot.crop;
+    delete plot.crop;
 
-  return {
-    ...stateCopy,
-    crops: plots,
-  } as GameState;
+    return {
+      ...stateCopy,
+      crops: plots,
+    } as GameState;
+  });
 }

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -71,9 +71,7 @@ export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
 
     delete plot.crop;
 
-    return {
-      ...stateCopy,
-      crops: plots,
-    } as GameState;
+    stateCopy.crops = plots;
+    return stateCopy;
   });
 }

--- a/src/features/game/events/landExpansion/restock.ts
+++ b/src/features/game/events/landExpansion/restock.ts
@@ -1,8 +1,8 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_STOCK } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";
+import { produce } from "immer";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
-import cloneDeep from "lodash.clonedeep";
 
 export type RestockAction = {
   type: "shops.restocked";
@@ -13,27 +13,23 @@ type Options = {
   action: RestockAction;
 };
 
-const clone = (state: GameState): GameState => {
-  return cloneDeep(state);
-};
-
 export function restock({ state }: Options): GameState {
-  const game = clone(state);
+  return produce(state, (game) => {
+    const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
+    if (blockBucks.lt(1)) {
+      throw new Error("You do not have enough Block Bucks");
+    }
 
-  const blockBucks = game.inventory["Block Buck"] ?? new Decimal(0);
-  if (blockBucks.lt(1)) {
-    throw new Error("You do not have enough Block Bucks");
-  }
+    game.stock = INITIAL_STOCK(state);
+    game.inventory["Block Buck"] = blockBucks.sub(1);
 
-  game.stock = INITIAL_STOCK(state);
-  game.inventory["Block Buck"] = blockBucks.sub(1);
+    // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#spend_virtual_currency
+    onboardingAnalytics.logEvent("spend_virtual_currency", {
+      value: 1,
+      virtual_currency_name: "Block Buck",
+      item_name: "Restock",
+    });
 
-  // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#spend_virtual_currency
-  onboardingAnalytics.logEvent("spend_virtual_currency", {
-    value: 1,
-    virtual_currency_name: "Block Buck",
-    item_name: "Restock",
+    return game;
   });
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -10,12 +10,12 @@ import {
 } from "features/game/types/expansions";
 import { Airdrop, GameState } from "features/game/types/game";
 
-import cloneDeep from "lodash.clonedeep";
 import { getKeys } from "features/game/types/craftables";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { CropName } from "features/game/types/crops";
+import { produce } from "immer";
 
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
@@ -50,305 +50,307 @@ export function revealLand({
   farmId = 0,
   promo,
 }: Options) {
-  const game = cloneDeep(state) as GameState;
+  return produce(state, (game) => {
+    if (!game.expansionConstruction) {
+      throw new Error("Land is not in construction");
+    }
 
-  if (!game.expansionConstruction) {
-    throw new Error("Land is not in construction");
-  }
+    const land = getLand({ id: farmId, game });
+    if (!land) {
+      throw new Error("Land Does Not Exists");
+    }
 
-  const land = getLand({ id: farmId, game });
-  if (!land) {
-    throw new Error("Land Does Not Exists");
-  }
+    const { inventory } = game;
 
-  const { inventory } = game;
+    inventory["Basic Land"] = (inventory["Basic Land"] ?? new Decimal(0)).add(
+      1,
+    );
 
-  inventory["Basic Land"] = (inventory["Basic Land"] ?? new Decimal(0)).add(1);
+    const landCount = inventory["Basic Land"].toNumber();
+    const origin = EXPANSION_ORIGINS[landCount - 1];
 
-  const landCount = inventory["Basic Land"].toNumber();
-  const origin = EXPANSION_ORIGINS[landCount - 1];
+    delete game.expansionConstruction;
 
-  delete game.expansionConstruction;
+    // Add Trees
+    land.trees?.forEach((coords) => {
+      game.trees[randomUUID().slice(0, 8)] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        wood: { amount: 1, choppedAt: 0 },
+      };
+    });
+    inventory.Tree = (inventory.Tree || new Decimal(0)).add(land.trees.length);
 
-  // Add Trees
-  land.trees?.forEach((coords) => {
-    game.trees[randomUUID().slice(0, 8)] = {
-      height: 2,
-      width: 2,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      wood: { amount: 1, choppedAt: 0 },
-    };
-  });
-  inventory.Tree = (inventory.Tree || new Decimal(0)).add(land.trees.length);
+    // Add Stones
+    land.stones?.forEach((coords) => {
+      game.stones[randomUUID().slice(0, 8)] = {
+        height: 1,
+        width: 1,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        stone: { amount: 1, minedAt: 0 },
+      };
+    });
+    inventory["Stone Rock"] = (inventory["Stone Rock"] || new Decimal(0)).add(
+      land.stones.length,
+    );
 
-  // Add Stones
-  land.stones?.forEach((coords) => {
-    game.stones[randomUUID().slice(0, 8)] = {
-      height: 1,
-      width: 1,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      stone: { amount: 1, minedAt: 0 },
-    };
-  });
-  inventory["Stone Rock"] = (inventory["Stone Rock"] || new Decimal(0)).add(
-    land.stones.length,
-  );
+    // Add Iron
+    land.iron?.forEach((coords) => {
+      game.iron[randomUUID().slice(0, 8)] = {
+        height: 1,
+        width: 1,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        stone: { amount: 1, minedAt: 0 },
+      };
+    });
+    inventory["Iron Rock"] = (inventory["Iron Rock"] || new Decimal(0)).add(
+      land.iron?.length ?? 0,
+    );
 
-  // Add Iron
-  land.iron?.forEach((coords) => {
-    game.iron[randomUUID().slice(0, 8)] = {
-      height: 1,
-      width: 1,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      stone: { amount: 1, minedAt: 0 },
-    };
-  });
-  inventory["Iron Rock"] = (inventory["Iron Rock"] || new Decimal(0)).add(
-    land.iron?.length ?? 0,
-  );
+    // Add Gold
+    land.gold?.forEach((coords) => {
+      game.gold[randomUUID().slice(0, 8)] = {
+        height: 1,
+        width: 1,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        stone: { amount: 1, minedAt: 0 },
+      };
+    });
+    inventory["Gold Rock"] = (inventory["Gold Rock"] || new Decimal(0)).add(
+      land.gold?.length ?? 0,
+    );
 
-  // Add Gold
-  land.gold?.forEach((coords) => {
-    game.gold[randomUUID().slice(0, 8)] = {
-      height: 1,
-      width: 1,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      stone: { amount: 1, minedAt: 0 },
-    };
-  });
-  inventory["Gold Rock"] = (inventory["Gold Rock"] || new Decimal(0)).add(
-    land.gold?.length ?? 0,
-  );
+    // Add Crimstone
+    land.crimstones?.forEach((coords) => {
+      game.crimstones[randomUUID().slice(0, 8)] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        stone: { amount: 1, minedAt: 0 },
+        minesLeft: 5,
+      };
+    });
+    inventory["Crimstone Rock"] = (
+      inventory["Crimstone Rock"] || new Decimal(0)
+    ).add(land.crimstones?.length ?? 0);
 
-  // Add Crimstone
-  land.crimstones?.forEach((coords) => {
-    game.crimstones[randomUUID().slice(0, 8)] = {
-      height: 2,
-      width: 2,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      stone: { amount: 1, minedAt: 0 },
-      minesLeft: 5,
-    };
-  });
-  inventory["Crimstone Rock"] = (
-    inventory["Crimstone Rock"] || new Decimal(0)
-  ).add(land.crimstones?.length ?? 0);
-
-  // Add Plots
-  land.plots?.forEach((coords) => {
-    game.crops[randomUUID().slice(0, 8)] = {
-      createdAt: Date.now(),
-      height: 1,
-      width: 1,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      crop: {
-        name: EXPANSION_CROPS[landCount] ?? "Sunflower",
-        amount: 1,
-        plantedAt: 0,
-      },
-    };
-  });
-
-  inventory["Crop Plot"] = (inventory["Crop Plot"] || new Decimal(0)).add(
-    land.plots?.length ?? 0,
-  );
-
-  // Add Fruit patches
-  land.fruitPatches?.forEach((coords) => {
-    game.fruitPatches[randomUUID().slice(0, 8)] = {
-      height: 2,
-      width: 2,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      fruit: {
-        amount: 1,
-        harvestedAt: 0,
-        harvestsLeft: 3,
-        name: "Apple",
-        plantedAt: 0,
-      },
-    };
-  });
-  inventory["Fruit Patch"] = (inventory["Fruit Patch"] || new Decimal(0)).add(
-    land.fruitPatches?.length ?? 0,
-  );
-
-  // Add sun stones
-  land.sunstones?.forEach((coords) => {
-    const id = randomUUID();
-    game.sunstones[id] = {
-      height: 2,
-      width: 2,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      stone: { amount: 1, minedAt: 0 },
-      minesLeft: 10,
-    };
-  });
-  inventory["Sunstone Rock"] = (
-    inventory["Sunstone Rock"] || new Decimal(0)
-  ).add(land.sunstones?.length ?? 0);
-
-  // Add bee hives
-  land.beehives?.forEach((coords) => {
-    const id = randomUUID();
-    game.beehives[id] = {
-      height: 1,
-      width: 1,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      honey: { produced: 0, updatedAt: Date.now() },
-      flowers: [],
-      swarm: false,
-    };
-  });
-  inventory.Beehive = (inventory.Beehive || new Decimal(0)).add(
-    land.beehives?.length ?? 0,
-  );
-
-  // Add flower beds
-  land.flowerBeds?.forEach((coords) => {
-    const id = randomUUID();
-    game.flowers.flowerBeds[id] = {
-      height: 1,
-      width: 3,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      createdAt,
-    };
-  });
-  inventory["Flower Bed"] = (inventory["Flower Bed"] || new Decimal(0)).add(
-    land.flowerBeds?.length ?? 0,
-  );
-
-  land.oilReserves?.forEach((coords) => {
-    const id = randomUUID();
-    game.oilReserves[id] = {
-      height: 2,
-      width: 2,
-      x: coords.x + origin.x,
-      y: coords.y + origin.y,
-      createdAt,
-      drilled: 0,
-      oil: {
-        amount: 10,
-        drilledAt: 0,
-      },
-    };
-  });
-  inventory["Oil Reserve"] = (inventory["Oil Reserve"] || new Decimal(0)).add(
-    land.oilReserves?.length ?? 0,
-  );
-
-  // Refresh all basic resources
-  game.trees = getKeys(game.trees).reduce(
-    (acc, id) => {
-      return {
-        ...acc,
-        [id]: {
-          ...game.trees[id],
-          wood: {
-            ...game.trees[id].wood,
-            choppedAt: createdAt - 4 * 60 * 60 * 1000,
-          },
+    // Add Plots
+    land.plots?.forEach((coords) => {
+      game.crops[randomUUID().slice(0, 8)] = {
+        createdAt: Date.now(),
+        height: 1,
+        width: 1,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        crop: {
+          name: EXPANSION_CROPS[landCount] ?? "Sunflower",
+          amount: 1,
+          plantedAt: 0,
         },
       };
-    },
-    {} as GameState["trees"],
-  );
+    });
 
-  game.stones = getKeys(game.stones).reduce(
-    (acc, id) => {
-      return {
-        ...acc,
-        [id]: {
-          ...game.stones[id],
-          stone: {
-            ...game.stones[id].stone,
-            minedAt: createdAt - 12 * 60 * 60 * 1000,
-          },
+    inventory["Crop Plot"] = (inventory["Crop Plot"] || new Decimal(0)).add(
+      land.plots?.length ?? 0,
+    );
+
+    // Add Fruit patches
+    land.fruitPatches?.forEach((coords) => {
+      game.fruitPatches[randomUUID().slice(0, 8)] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        fruit: {
+          amount: 1,
+          harvestedAt: 0,
+          harvestsLeft: 3,
+          name: "Apple",
+          plantedAt: 0,
         },
       };
-    },
-    {} as GameState["stones"],
-  );
+    });
+    inventory["Fruit Patch"] = (inventory["Fruit Patch"] || new Decimal(0)).add(
+      land.fruitPatches?.length ?? 0,
+    );
 
-  game.iron = getKeys(game.iron).reduce(
-    (acc, id) => {
-      return {
-        ...acc,
-        [id]: {
-          ...game.iron[id],
-          stone: {
-            ...game.iron[id].stone,
-            minedAt: createdAt - 24 * 60 * 60 * 1000,
-          },
-        },
+    // Add sun stones
+    land.sunstones?.forEach((coords) => {
+      const id = randomUUID();
+      game.sunstones[id] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        stone: { amount: 1, minedAt: 0 },
+        minesLeft: 10,
       };
-    },
-    {} as GameState["iron"],
-  );
+    });
+    inventory["Sunstone Rock"] = (
+      inventory["Sunstone Rock"] || new Decimal(0)
+    ).add(land.sunstones?.length ?? 0);
 
-  game.gold = getKeys(game.gold).reduce(
-    (acc, id) => {
-      return {
-        ...acc,
-        [id]: {
-          ...game.gold[id],
-          stone: {
-            ...game.gold[id].stone,
-            minedAt: createdAt - 48 * 60 * 60 * 1000,
-          },
-        },
+    // Add bee hives
+    land.beehives?.forEach((coords) => {
+      const id = randomUUID();
+      game.beehives[id] = {
+        height: 1,
+        width: 1,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        honey: { produced: 0, updatedAt: Date.now() },
+        flowers: [],
+        swarm: false,
       };
-    },
-    {} as GameState["gold"],
-  );
+    });
+    inventory.Beehive = (inventory.Beehive || new Decimal(0)).add(
+      land.beehives?.length ?? 0,
+    );
 
-  game.crimstones = getKeys(game.crimstones).reduce(
-    (acc, id) => {
-      return {
-        ...acc,
-        [id]: {
-          ...game.crimstones[id],
-          stone: {
-            ...game.crimstones[id].stone,
-            minedAt: createdAt - CRIMSTONE_RECOVERY_TIME * 1000,
-          },
-        },
-      };
-    },
-    {} as GameState["crimstones"],
-  );
-
-  // Add fire pit on expansion 5
-  if (landCount >= 5 && !game.inventory["Fire Pit"]) {
-    game.inventory["Fire Pit"] = new Decimal(1);
-    game.buildings["Fire Pit"] = [
-      {
-        coordinates: { x: -6, y: 8 },
+    // Add flower beds
+    land.flowerBeds?.forEach((coords) => {
+      const id = randomUUID();
+      game.flowers.flowerBeds[id] = {
+        height: 1,
+        width: 3,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
         createdAt,
-        id: "123",
-        readyAt: createdAt,
+      };
+    });
+    inventory["Flower Bed"] = (inventory["Flower Bed"] || new Decimal(0)).add(
+      land.flowerBeds?.length ?? 0,
+    );
+
+    land.oilReserves?.forEach((coords) => {
+      const id = randomUUID();
+      game.oilReserves[id] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        createdAt,
+        drilled: 0,
+        oil: {
+          amount: 10,
+          drilledAt: 0,
+        },
+      };
+    });
+    inventory["Oil Reserve"] = (inventory["Oil Reserve"] || new Decimal(0)).add(
+      land.oilReserves?.length ?? 0,
+    );
+
+    // Refresh all basic resources
+    game.trees = getKeys(game.trees).reduce(
+      (acc, id) => {
+        return {
+          ...acc,
+          [id]: {
+            ...game.trees[id],
+            wood: {
+              ...game.trees[id].wood,
+              choppedAt: createdAt - 4 * 60 * 60 * 1000,
+            },
+          },
+        };
       },
-    ];
-  }
+      {} as GameState["trees"],
+    );
 
-  // Add any rewards
-  const rewards = getRewards({ game, createdAt });
-  const previous = game.airdrops ?? [];
-  game.airdrops = [...previous, ...rewards];
+    game.stones = getKeys(game.stones).reduce(
+      (acc, id) => {
+        return {
+          ...acc,
+          [id]: {
+            ...game.stones[id],
+            stone: {
+              ...game.stones[id].stone,
+              minedAt: createdAt - 12 * 60 * 60 * 1000,
+            },
+          },
+        };
+      },
+      {} as GameState["stones"],
+    );
 
-  return {
-    ...game,
-    inventory,
-  };
+    game.iron = getKeys(game.iron).reduce(
+      (acc, id) => {
+        return {
+          ...acc,
+          [id]: {
+            ...game.iron[id],
+            stone: {
+              ...game.iron[id].stone,
+              minedAt: createdAt - 24 * 60 * 60 * 1000,
+            },
+          },
+        };
+      },
+      {} as GameState["iron"],
+    );
+
+    game.gold = getKeys(game.gold).reduce(
+      (acc, id) => {
+        return {
+          ...acc,
+          [id]: {
+            ...game.gold[id],
+            stone: {
+              ...game.gold[id].stone,
+              minedAt: createdAt - 48 * 60 * 60 * 1000,
+            },
+          },
+        };
+      },
+      {} as GameState["gold"],
+    );
+
+    game.crimstones = getKeys(game.crimstones).reduce(
+      (acc, id) => {
+        return {
+          ...acc,
+          [id]: {
+            ...game.crimstones[id],
+            stone: {
+              ...game.crimstones[id].stone,
+              minedAt: createdAt - CRIMSTONE_RECOVERY_TIME * 1000,
+            },
+          },
+        };
+      },
+      {} as GameState["crimstones"],
+    );
+
+    // Add fire pit on expansion 5
+    if (landCount >= 5 && !game.inventory["Fire Pit"]) {
+      game.inventory["Fire Pit"] = new Decimal(1);
+      game.buildings["Fire Pit"] = [
+        {
+          coordinates: { x: -6, y: 8 },
+          createdAt,
+          id: "123",
+          readyAt: createdAt,
+        },
+      ];
+    }
+
+    // Add any rewards
+    const rewards = getRewards({ game, createdAt });
+    const previous = game.airdrops ?? [];
+    game.airdrops = [...previous, ...rewards];
+
+    return {
+      ...game,
+      inventory,
+    };
+  });
 }
 
 export const expansionRequirements = ({ game }: { game: GameState }) => {

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -346,10 +346,8 @@ export function revealLand({
     const previous = game.airdrops ?? [];
     game.airdrops = [...previous, ...rewards];
 
-    return {
-      ...game,
-      inventory,
-    };
+    game.inventory = inventory;
+    return game;
   });
 }
 

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { Crop, CropName, CROPS, GREENHOUSE_CROPS } from "../../types/crops";
 import { GameState } from "../../types/game";
-import cloneDeep from "lodash.clonedeep";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { setPrecision } from "lib/utils/formatNumber";
@@ -11,6 +10,7 @@ import {
   FruitName,
   GREENHOUSE_FRUIT,
 } from "features/game/types/fruits";
+import { produce } from "immer";
 
 export type SellableName = CropName | FruitName;
 export type SellableItem = Crop | Fruit;
@@ -39,51 +39,51 @@ export function sellCrop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
+  return produce(state, (game) => {
+    const { bumpkin } = game;
 
-  const { bumpkin } = game;
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!(action.crop in SELLABLE)) {
+      throw new Error("Not for sale");
+    }
 
-  if (!(action.crop in SELLABLE)) {
-    throw new Error("Not for sale");
-  }
+    const amount = new Decimal(action.amount);
+    if (amount.lessThanOrEqualTo(0)) {
+      throw new Error("Invalid amount");
+    }
 
-  const amount = new Decimal(action.amount);
-  if (amount.lessThanOrEqualTo(0)) {
-    throw new Error("Invalid amount");
-  }
+    const sellables = SELLABLE[action.crop];
 
-  const sellables = SELLABLE[action.crop];
+    const count = game.inventory[action.crop] || new Decimal(0);
 
-  const count = game.inventory[action.crop] || new Decimal(0);
+    if (count.lessThan(action.amount)) {
+      throw new Error("Insufficient quantity to sell");
+    }
 
-  if (count.lessThan(action.amount)) {
-    throw new Error("Insufficient quantity to sell");
-  }
+    const price = getSellPrice({
+      item: sellables,
+      game,
+      now: new Date(createdAt),
+    });
 
-  const price = getSellPrice({
-    item: sellables,
-    game,
-    now: new Date(createdAt),
+    const coinsEarned = price * action.amount;
+    bumpkin.activity = trackActivity(
+      "Coins Earned",
+      bumpkin.activity,
+      new Decimal(coinsEarned),
+    );
+    bumpkin.activity = trackActivity(
+      `${action.crop} Sold`,
+      bumpkin?.activity,
+      new Decimal(amount),
+    );
+
+    game.coins = game.coins + coinsEarned;
+    game.inventory[action.crop] = setPrecision(count.sub(amount));
+
+    return game;
   });
-
-  const coinsEarned = price * action.amount;
-  bumpkin.activity = trackActivity(
-    "Coins Earned",
-    bumpkin.activity,
-    new Decimal(coinsEarned),
-  );
-  bumpkin.activity = trackActivity(
-    `${action.crop} Sold`,
-    bumpkin?.activity,
-    new Decimal(amount),
-  );
-
-  game.coins = game.coins + coinsEarned;
-  game.inventory[action.crop] = setPrecision(count.sub(amount));
-
-  return game;
 }

--- a/src/features/game/events/landExpansion/skipChore.ts
+++ b/src/features/game/events/landExpansion/skipChore.ts
@@ -1,6 +1,6 @@
-import cloneDeep from "lodash.clonedeep";
 import { GameState } from "features/game/types/game";
 import { isChoreId } from "./completeChore";
+import { produce } from "immer";
 
 export type SkipChoreAction = {
   type: "chore.skipped";
@@ -25,43 +25,44 @@ export function skipChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep(state);
-  const { id } = action;
-  const { chores, bumpkin } = game;
+  return produce(state, (game) => {
+    const { id } = action;
+    const { chores, bumpkin } = game;
 
-  if (id === undefined) {
-    throw new Error("Chore ID not supplied");
-  }
+    if (id === undefined) {
+      throw new Error("Chore ID not supplied");
+    }
 
-  if (!chores) {
-    throw new Error("No chores found");
-  }
+    if (!chores) {
+      throw new Error("No chores found");
+    }
 
-  if (!bumpkin) {
-    throw new Error("No bumpkin found");
-  }
-  if (!isChoreId(id)) {
-    throw new Error("Invalid chore ID");
-  }
+    if (!bumpkin) {
+      throw new Error("No bumpkin found");
+    }
+    if (!isChoreId(id)) {
+      throw new Error("Invalid chore ID");
+    }
 
-  const chore = chores.chores[id];
+    const chore = chores.chores[id];
 
-  if ((chore.completedAt ?? 0) > 0) {
-    throw new Error("Chore is already completed");
-  }
+    if ((chore.completedAt ?? 0) > 0) {
+      throw new Error("Chore is already completed");
+    }
 
-  if (bumpkin.id !== chore.bumpkinId) {
-    throw new Error("Not the same bumpkin");
-  }
+    if (bumpkin.id !== chore.bumpkinId) {
+      throw new Error("Not the same bumpkin");
+    }
 
-  const dayOfYear = getDayOfYear(new Date(createdAt));
-  const choreDayOfYear = getDayOfYear(new Date(chore.createdAt ?? 0));
+    const dayOfYear = getDayOfYear(new Date(createdAt));
+    const choreDayOfYear = getDayOfYear(new Date(chore.createdAt ?? 0));
 
-  if (dayOfYear <= choreDayOfYear) {
+    if (dayOfYear <= choreDayOfYear) {
+      return game;
+    }
+
+    // Skip chore
+
     return game;
-  }
-
-  // Skip chore
-
-  return game;
+  });
 }

--- a/src/features/game/events/landExpansion/skipKingdomChore.ts
+++ b/src/features/game/events/landExpansion/skipKingdomChore.ts
@@ -1,6 +1,6 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { populateKingdomChores } from "./completeKingdomChore";
+import { produce } from "immer";
 
 export type SkipKingdomChoreAction = {
   type: "kingdomChore.skipped";
@@ -18,41 +18,46 @@ export function skipKingdomChore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
-  const { id } = action;
-  const { kingdomChores, bumpkin } = game;
+  return produce(state, (game) => {
+    const { id } = action;
+    const { kingdomChores, bumpkin } = game;
 
-  const chore = kingdomChores.chores[id];
+    const chore = kingdomChores.chores[id];
 
-  if (!bumpkin) {
-    throw new Error("No bumpkin found");
-  }
+    if (!bumpkin) {
+      throw new Error("No bumpkin found");
+    }
 
-  if (chore === undefined) {
-    throw new Error("Chore not found");
-  }
+    if (chore === undefined) {
+      throw new Error("Chore not found");
+    }
 
-  if ((kingdomChores.skipAvailableAt ?? 0) > createdAt) {
-    throw new Error("Skip is not available");
-  }
+    if ((kingdomChores.skipAvailableAt ?? 0) > createdAt) {
+      throw new Error("Skip is not available");
+    }
 
-  if (chore.startedAt === undefined) {
-    throw new Error("Chore is not active");
-  }
+    if (chore.startedAt === undefined) {
+      throw new Error("Chore is not active");
+    }
 
-  if (chore.completedAt !== undefined) {
-    throw new Error("Chore is already completed");
-  }
+    if (chore.completedAt !== undefined) {
+      throw new Error("Chore is already completed");
+    }
 
-  if (chore.skippedAt !== undefined) {
-    throw new Error("Chore was already skipped");
-  }
+    if (chore.skippedAt !== undefined) {
+      throw new Error("Chore was already skipped");
+    }
 
-  chore.skippedAt = createdAt;
-  kingdomChores.skipAvailableAt = createdAt + 24 * 60 * 60 * 1000;
-  kingdomChores.choresSkipped += 1;
+    chore.skippedAt = createdAt;
+    kingdomChores.skipAvailableAt = createdAt + 24 * 60 * 60 * 1000;
+    kingdomChores.choresSkipped += 1;
 
-  game.kingdomChores = populateKingdomChores(kingdomChores, bumpkin, createdAt);
+    game.kingdomChores = populateKingdomChores(
+      kingdomChores,
+      bumpkin,
+      createdAt,
+    );
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -10,8 +10,8 @@ import {
   GameState,
   InventoryItemName,
 } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
+import { produce } from "immer";
 
 export type StartComposterAction = {
   type: "composter.started";
@@ -39,64 +39,64 @@ export function startComposter({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
-
-  const buildings = stateCopy.buildings[action.building] as CompostBuilding[];
-  if (!buildings) {
-    throw new Error(translate("error.composterNotExist"));
-  }
-
-  const { skills } = stateCopy.bumpkin;
-  const composter = buildings[0];
-  const isProducing = composter.producing;
-
-  if (isProducing && isProducing.readyAt > createdAt) {
-    throw new Error(translate("error.alr.composter"));
-  }
-
-  if (!composter.requires) {
-    throw new Error(translate("error.alr.composter"));
-  }
-
-  // remove the requirements from the player's inventory
-  getKeys(composter.requires ?? {}).forEach((name) => {
-    const previous =
-      stateCopy.inventory[name as InventoryItemName] || new Decimal(0);
-
-    if (previous.lt(composter.requires?.[name] ?? 0)) {
-      throw new Error(translate("error.missing"));
-      ("Missing requirements");
+  return produce(state, (stateCopy) => {
+    const buildings = stateCopy.buildings[action.building] as CompostBuilding[];
+    if (!buildings) {
+      throw new Error(translate("error.composterNotExist"));
     }
 
-    stateCopy.inventory[name as InventoryItemName] = previous.minus(
-      composter.requires?.[name] ?? 0,
-    );
+    const { skills } = stateCopy.bumpkin;
+    const composter = buildings[0];
+    const isProducing = composter.producing;
+
+    if (isProducing && isProducing.readyAt > createdAt) {
+      throw new Error(translate("error.alr.composter"));
+    }
+
+    if (!composter.requires) {
+      throw new Error(translate("error.alr.composter"));
+    }
+
+    // remove the requirements from the player's inventory
+    getKeys(composter.requires ?? {}).forEach((name) => {
+      const previous =
+        stateCopy.inventory[name as InventoryItemName] || new Decimal(0);
+
+      if (previous.lt(composter.requires?.[name] ?? 0)) {
+        throw new Error(translate("error.missing"));
+        ("Missing requirements");
+      }
+
+      stateCopy.inventory[name as InventoryItemName] = previous.minus(
+        composter.requires?.[name] ?? 0,
+      );
+    });
+
+    let produceAmount = composterDetails[action.building].produceAmount;
+
+    if (skills["Efficient Bin"] && action.building === "Compost Bin") {
+      produceAmount += 5;
+    }
+
+    if (skills["Turbo Charged"] && action.building === "Turbo Composter") {
+      produceAmount += 3;
+    }
+
+    if (skills["Premium Worms"] && action.building === "Premium Composter") {
+      produceAmount += 10;
+    }
+
+    // start the production
+    buildings[0].producing = {
+      items: {
+        [composterDetails[action.building].produce]: produceAmount,
+        // Set on backend
+        [composterDetails[action.building].worm]: 1,
+      },
+      startedAt: createdAt,
+      readyAt: createdAt + getReadyAt(stateCopy, action.building),
+    };
+
+    return stateCopy;
   });
-
-  let produceAmount = composterDetails[action.building].produceAmount;
-
-  if (skills["Efficient Bin"] && action.building === "Compost Bin") {
-    produceAmount += 5;
-  }
-
-  if (skills["Turbo Charged"] && action.building === "Turbo Composter") {
-    produceAmount += 3;
-  }
-
-  if (skills["Premium Worms"] && action.building === "Premium Composter") {
-    produceAmount += 10;
-  }
-
-  // start the production
-  buildings[0].producing = {
-    items: {
-      [composterDetails[action.building].produce]: produceAmount,
-      // Set on backend
-      [composterDetails[action.building].worm]: 1,
-    },
-    startedAt: createdAt,
-    readyAt: createdAt + getReadyAt(stateCopy, action.building),
-  };
-
-  return stateCopy;
 }

--- a/src/features/game/events/landExpansion/stoneMine.ts
+++ b/src/features/game/events/landExpansion/stoneMine.ts
@@ -2,9 +2,9 @@ import Decimal from "decimal.js-light";
 import { STONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { BumpkinSkillName } from "features/game/types/bumpkinSkills";
-import cloneDeep from "lodash.clonedeep";
 import { GameState, Rock } from "../../types/game";
 import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
+import { produce } from "immer";
 
 export type LandExpansionStoneMineAction = {
   type: "stoneRock.mined";
@@ -60,44 +60,45 @@ export function mineStone({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep(state);
-  const { stones, bumpkin, collectibles } = stateCopy;
-  const rock = stones?.[action.index];
+  return produce(state, (stateCopy) => {
+    const { stones, bumpkin, collectibles } = stateCopy;
+    const rock = stones?.[action.index];
 
-  if (!rock) {
-    throw new Error("Stone does not exist");
-  }
+    if (!rock) {
+      throw new Error("Stone does not exist");
+    }
 
-  if (bumpkin === undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (bumpkin === undefined) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  if (!canMine(rock, createdAt)) {
-    throw new Error("Rock is still recovering");
-  }
+    if (!canMine(rock, createdAt)) {
+      throw new Error("Rock is still recovering");
+    }
 
-  const toolAmount = stateCopy.inventory["Pickaxe"] || new Decimal(0);
+    const toolAmount = stateCopy.inventory["Pickaxe"] || new Decimal(0);
 
-  if (toolAmount.lessThan(1)) {
-    throw new Error("No pickaxes left");
-  }
+    if (toolAmount.lessThan(1)) {
+      throw new Error("No pickaxes left");
+    }
 
-  const stoneMined = rock.stone.amount;
-  const amountInInventory = stateCopy.inventory.Stone || new Decimal(0);
+    const stoneMined = rock.stone.amount;
+    const amountInInventory = stateCopy.inventory.Stone || new Decimal(0);
 
-  rock.stone = {
-    minedAt: getMinedAt({
-      skills: bumpkin.skills,
-      createdAt: Date.now(),
-      game: stateCopy,
-    }),
-    amount: 2,
-  };
+    rock.stone = {
+      minedAt: getMinedAt({
+        skills: bumpkin.skills,
+        createdAt: Date.now(),
+        game: stateCopy,
+      }),
+      amount: 2,
+    };
 
-  stateCopy.inventory.Pickaxe = toolAmount.sub(1);
-  stateCopy.inventory.Stone = amountInInventory.add(stoneMined);
+    stateCopy.inventory.Pickaxe = toolAmount.sub(1);
+    stateCopy.inventory.Stone = amountInInventory.add(stoneMined);
 
-  bumpkin.activity = trackActivity("Stone Mined", bumpkin.activity);
+    bumpkin.activity = trackActivity("Stone Mined", bumpkin.activity);
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/supplyCookingOil.ts
+++ b/src/features/game/events/landExpansion/supplyCookingOil.ts
@@ -1,8 +1,8 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 import { CookingBuildingName } from "features/game/types/buildings";
 import Decimal from "decimal.js-light";
+import { produce } from "immer";
 
 export type SupplyCookingOilAction = {
   type: "cookingOil.supplied";
@@ -31,34 +31,34 @@ export function supplyCookingOil({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const stateCopy = cloneDeep<GameState>(state);
+  return produce(state, (stateCopy) => {
+    const buildings = stateCopy.buildings[action.building];
+    if (!buildings) {
+      throw new Error(translate("error.buildingNotExist"));
+    }
 
-  const buildings = stateCopy.buildings[action.building];
-  if (!buildings) {
-    throw new Error(translate("error.buildingNotExist"));
-  }
+    const building = buildings.find((b) => b.id === action.buildingId);
+    if (!building) {
+      throw new Error(translate("error.buildingNotExist"));
+    }
 
-  const building = buildings.find((b) => b.id === action.buildingId);
-  if (!building) {
-    throw new Error(translate("error.buildingNotExist"));
-  }
+    const oilInInventory = stateCopy.inventory["Oil"] || new Decimal(0);
 
-  const oilInInventory = stateCopy.inventory["Oil"] || new Decimal(0);
+    if (oilInInventory.lessThan(action.oilQuantity)) {
+      throw new Error(translate("error.notEnoughOil"));
+    }
 
-  if (oilInInventory.lessThan(action.oilQuantity)) {
-    throw new Error(translate("error.notEnoughOil"));
-  }
+    const oilCapacity = BUILDING_DAILY_OIL_CAPACITY[action.building];
+    const oilInBuilding = building.oil || 0;
 
-  const oilCapacity = BUILDING_DAILY_OIL_CAPACITY[action.building];
-  const oilInBuilding = building.oil || 0;
+    if (oilInBuilding + action.oilQuantity > oilCapacity) {
+      throw new Error(translate("error.oilCapacityExceeded"));
+    }
 
-  if (oilInBuilding + action.oilQuantity > oilCapacity) {
-    throw new Error(translate("error.oilCapacityExceeded"));
-  }
+    stateCopy.inventory["Oil"] = oilInInventory.sub(action.oilQuantity);
 
-  stateCopy.inventory["Oil"] = oilInInventory.sub(action.oilQuantity);
+    building.oil = oilInBuilding + action.oilQuantity;
 
-  building.oil = oilInBuilding + action.oilQuantity;
-
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { CROPS, CropName, CropSeedName } from "features/game/types/crops";
 import {
@@ -8,6 +7,7 @@ import {
 } from "features/game/types/game";
 import { getCropYieldAmount } from "./plant";
 import { isBasicCrop } from "./harvest";
+import cloneDeep from "lodash.clonedeep";
 
 export type AddSeedsInput = { type: CropSeedName; amount: number };
 

--- a/src/features/game/events/landExpansion/tradeFlowerShop.ts
+++ b/src/features/game/events/landExpansion/tradeFlowerShop.ts
@@ -1,8 +1,8 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { FlowerName } from "features/game/types/flowers";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { produce } from "immer";
 
 export type FlowerShopTradedAction = {
   type: "flowerShop.traded";
@@ -22,41 +22,41 @@ export function tradeFlowerShop({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game: GameState = cloneDeep(state);
+  return produce(state, (game) => {
+    const flowerShop = game.flowerShop;
+    if (!flowerShop) {
+      throw new Error("Flower shop is not open");
+    }
 
-  const flowerShop = game.flowerShop;
-  if (!flowerShop) {
-    throw new Error("Flower shop is not open");
-  }
+    if (
+      createdAt < flowerShop.week ||
+      createdAt > flowerShop.week + 7 * 24 * 60 * 60 * 1000
+    ) {
+      throw new Error("Flower shop has not been updated");
+    }
 
-  if (
-    createdAt < flowerShop.week ||
-    createdAt > flowerShop.week + 7 * 24 * 60 * 60 * 1000
-  ) {
-    throw new Error("Flower shop has not been updated");
-  }
+    const weeklyFlower = flowerShop.weeklyFlower;
+    if (action.flower !== weeklyFlower) {
+      throw new Error("Flower is not the current weeks flower");
+    }
 
-  const weeklyFlower = flowerShop.weeklyFlower;
-  if (action.flower !== weeklyFlower) {
-    throw new Error("Flower is not the current weeks flower");
-  }
+    if (flowerShop.tradedFlowerShop) {
+      throw new Error("Already claimed reward");
+    }
 
-  if (flowerShop.tradedFlowerShop) {
-    throw new Error("Already claimed reward");
-  }
+    flowerShop.tradedFlowerShop = true;
+    game.flowerShop = flowerShop;
 
-  flowerShop.tradedFlowerShop = true;
-  game.flowerShop = flowerShop;
+    const flowerCount = game.inventory[weeklyFlower] ?? new Decimal(0);
+    if (flowerCount.lessThan(1)) {
+      throw new Error("Not enough flowers");
+    }
+    game.inventory[weeklyFlower] = flowerCount.minus(1);
 
-  const flowerCount = game.inventory[weeklyFlower] ?? new Decimal(0);
-  if (flowerCount.lessThan(1)) {
-    throw new Error("Not enough flowers");
-  }
-  game.inventory[weeklyFlower] = flowerCount.minus(1);
+    const seasonTicket = getSeasonalTicket(new Date(createdAt));
+    const ticketCount = game.inventory[seasonTicket] ?? new Decimal(0);
+    game.inventory[seasonTicket] = ticketCount.plus(TICKETS_REWARDED);
 
-  const seasonTicket = getSeasonalTicket(new Date(createdAt));
-  const ticketCount = game.inventory[seasonTicket] ?? new Decimal(0);
-  game.inventory[seasonTicket] = ticketCount.plus(TICKETS_REWARDED);
-
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -9,9 +9,9 @@ import {
   IslandType,
 } from "features/game/types/game";
 
-import cloneDeep from "lodash.clonedeep";
 import { translate } from "lib/i18n/translate";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
+import cloneDeep from "lodash.clonedeep";
 
 export type UpgradeFarmAction = {
   type: "farm.upgraded";

--- a/src/features/game/events/minigames/claimMinigamePrize.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import {
   MinigameName,
@@ -7,6 +6,7 @@ import {
 import { GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
 import { getFactionWeek } from "features/game/lib/factions";
+import { produce } from "immer";
 
 export function isMinigameComplete({
   game,
@@ -56,80 +56,81 @@ export function claimMinigamePrize({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  return produce(state, (game) => {
+    if (!SUPPORTED_MINIGAMES.includes(action.id)) {
+      throw new Error(`${action.id} is not a valid minigame`);
+    }
 
-  if (!SUPPORTED_MINIGAMES.includes(action.id)) {
-    throw new Error(`${action.id} is not a valid minigame`);
-  }
+    const minigames = (game.minigames ??
+      {}) as Required<GameState>["minigames"];
+    const { games, prizes } = minigames;
 
-  const minigames = (game.minigames ?? {}) as Required<GameState>["minigames"];
-  const { games, prizes } = minigames;
+    const todayKey = new Date(createdAt).toISOString().slice(0, 10);
 
-  const todayKey = new Date(createdAt).toISOString().slice(0, 10);
+    // Get todays prize
+    const prize = prizes[action.id];
 
-  // Get todays prize
-  const prize = prizes[action.id];
+    if (!prize) {
+      throw new Error(`No prize found for ${action.id}`);
+    }
 
-  if (!prize) {
-    throw new Error(`No prize found for ${action.id}`);
-  }
+    if (createdAt < prize.startAt || createdAt > prize.endAt) {
+      throw new Error("Prize is no longer available");
+    }
 
-  if (createdAt < prize.startAt || createdAt > prize.endAt) {
-    throw new Error("Prize is no longer available");
-  }
+    const minigame = games[action.id];
+    const history = minigame?.history[todayKey];
 
-  const minigame = games[action.id];
-  const history = minigame?.history[todayKey];
+    // has not played
+    if (!history) {
+      throw new Error(`No history found for ${action.id}`);
+    }
 
-  // has not played
-  if (!history) {
-    throw new Error(`No history found for ${action.id}`);
-  }
+    // Has reached score
+    if (history.highscore < prize.score) {
+      throw new Error(`Score ${history.highscore} is less than ${prize.score}`);
+    }
 
-  // Has reached score
-  if (history.highscore < prize.score) {
-    throw new Error(`Score ${history.highscore} is less than ${prize.score}`);
-  }
+    // Has already claimed
+    if (history.prizeClaimedAt) {
+      throw new Error(`Already claimed ${action.id} prize`);
+    }
 
-  // Has already claimed
-  if (history.prizeClaimedAt) {
-    throw new Error(`Already claimed ${action.id} prize`);
-  }
+    // Claim prize
+    history.prizeClaimedAt = createdAt;
 
-  // Claim prize
-  history.prizeClaimedAt = createdAt;
+    // Claim coins
+    if (prize.coins) {
+      game.coins += prize.coins;
+    }
 
-  // Claim coins
-  if (prize.coins) {
-    game.coins += prize.coins;
-  }
+    // Claims items
+    getKeys(prize.items).forEach((name) => {
+      const count = game.inventory[name] ?? new Decimal(0);
 
-  // Claims items
-  getKeys(prize.items).forEach((name) => {
-    const count = game.inventory[name] ?? new Decimal(0);
+      game.inventory[name] = count.add(prize.items[name] ?? 0);
+    });
 
-    game.inventory[name] = count.add(prize.items[name] ?? 0);
+    // Claims wearables
+    getKeys(prize.wearables).forEach((name) => {
+      const count = game.wardrobe[name] ?? 0;
+
+      game.wardrobe[name] = count + (prize.wearables[name] ?? 0);
+    });
+
+    if (game.faction && prize.items.Mark) {
+      const week = getFactionWeek({ date: new Date(createdAt) });
+      const leaderboard = game.faction.history[week] ?? {
+        score: 0,
+        petXP: 0,
+      };
+
+      game.faction.history[week] = {
+        ...leaderboard,
+        score: leaderboard.score + prize.items.Mark,
+      };
+    }
+
+    return game;
   });
-
-  // Claims wearables
-  getKeys(prize.wearables).forEach((name) => {
-    const count = game.wardrobe[name] ?? 0;
-
-    game.wardrobe[name] = count + (prize.wearables[name] ?? 0);
-  });
-
-  if (game.faction && prize.items.Mark) {
-    const week = getFactionWeek({ date: new Date(createdAt) });
-    const leaderboard = game.faction.history[week] ?? {
-      score: 0,
-      petXP: 0,
-    };
-
-    game.faction.history[week] = {
-      ...leaderboard,
-      score: leaderboard.score + prize.items.Mark,
-    };
-  }
-
-  return game;
 }

--- a/src/features/game/events/minigames/submitMinigameScore.ts
+++ b/src/features/game/events/minigames/submitMinigameScore.ts
@@ -3,8 +3,7 @@ import {
   MinigameName,
   SUPPORTED_MINIGAMES,
 } from "features/game/types/minigames";
-
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type SubmitMinigameScoreAction = {
   type: "minigame.scoreSubmitted";
@@ -23,37 +22,38 @@ export function submitMinigameScore({
   action,
   createdAt = Date.now(),
 }: Options): GameState {
-  const game = cloneDeep<GameState>(state);
+  return produce(state, (game) => {
+    if (!SUPPORTED_MINIGAMES.includes(action.id)) {
+      throw new Error(`${action.id} is not a valid minigame`);
+    }
 
-  if (!SUPPORTED_MINIGAMES.includes(action.id)) {
-    throw new Error(`${action.id} is not a valid minigame`);
-  }
+    const minigames = (game.minigames ??
+      {}) as Required<GameState>["minigames"];
 
-  const minigames = (game.minigames ?? {}) as Required<GameState>["minigames"];
+    const minigame = minigames.games[action.id] ?? {
+      history: {},
+      highscore: 0,
+    };
 
-  const minigame = minigames.games[action.id] ?? {
-    history: {},
-    highscore: 0,
-  };
+    const todayKey = new Date(createdAt).toISOString().slice(0, 10);
 
-  const todayKey = new Date(createdAt).toISOString().slice(0, 10);
+    const daily = minigame.history[todayKey] ?? {
+      attempts: 0,
+      highscore: 0,
+    };
 
-  const daily = minigame.history[todayKey] ?? {
-    attempts: 0,
-    highscore: 0,
-  };
-
-  minigames.games[action.id] = {
-    ...minigame,
-    history: {
-      ...minigame.history,
-      [todayKey]: {
-        ...daily,
-        highscore: Math.max(daily.highscore, action.score),
+    minigames.games[action.id] = {
+      ...minigame,
+      history: {
+        ...minigame.history,
+        [todayKey]: {
+          ...daily,
+          highscore: Math.max(daily.highscore, action.score),
+        },
       },
-    },
-    highscore: Math.max(daily.highscore, action.score),
-  };
+      highscore: Math.max(daily.highscore, action.score),
+    };
 
-  return game;
+    return game;
+  });
 }

--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -1,13 +1,13 @@
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "features/game/lib/constants";
 import { GameState, Position } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
 import {
   detectCollision,
   isOverlapping,
   isWithinAOE,
 } from "./collisionDetection";
 import { Dimensions } from "features/game/types/buildings";
+import cloneDeep from "lodash.clonedeep";
 
 describe("isOverlapping", () => {
   it("returns false if there is no overlap between two positions", () => {

--- a/src/features/game/lib/updateBeehives.ts
+++ b/src/features/game/lib/updateBeehives.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
-import cloneDeep from "lodash.clonedeep";
 import { Beehive, Beehives, FlowerBeds, GameState } from "../types/game";
 import { isCollectibleBuilt } from "./collectibleBuilt";
 import { getKeys } from "../types/craftables";
 import { FLOWERS, FLOWER_SEEDS } from "../types/flowers";
 import { isWearableActive } from "./wearables";
+import cloneDeep from "lodash.clonedeep";
 
 /**
  * updateBeehives runs on any event that changes the state for bees or flowers

--- a/yarn.lock
+++ b/yarn.lock
@@ -8303,6 +8303,11 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"


### PR DESCRIPTION
# Description

This PR is a follow on from: https://github.com/sunflower-land/sunflower-land/pull/4196


Instead of doing a single `produce` call, this new version introduces `produce` into each domain function. This is to make the change less magic, reduce the chance invisible errors in the future.

In each function the following has been changed:

```ts
const stateCopy = cloneDeep(state)
domainLogic()
return stateCopy
```

to 

```ts
return produce(state, (stateCopy) => {
    domainLogic()
    return stateCopy
})
```

The test steps are the same as in: https://github.com/sunflower-land/sunflower-land/pull/4196

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]