### PR TITLE
[FEAT] Replace Animation Flow for NPC and Bumpkin Container to use: /idle_small and /walking_small Animation Endpoint

### DIFF
--- a/src/features/bumpkins/actions/buildNPCSheets.ts
+++ b/src/features/bumpkins/actions/buildNPCSheets.ts
@@ -69,30 +69,7 @@ const getImage = async (url: string) => {
   return image;
 };
 
-export async function buildNPCSheets(request: Request): Promise<Response> {
+export async function buildNPCSheets(request: Request) {
   const tokenUri = tokenUriBuilder(request.parts);
-
-  const idleUrl = `${URL}/idle/${tokenUri}.webp`;
-  const walkingUrl = `${URL}/walking/${tokenUri}.webp`;
-
-  try {
-    const [idle, walking] = await Promise.all([
-      getImage(idleUrl),
-      getImage(walkingUrl),
-    ]);
-
-    return {
-      sheets: {
-        idle,
-        walking,
-      },
-    };
-  } catch {
-    // Since these are not real NFTs, prepend fake ID and version
-    const validName = `0_v1_${tokenUri}`;
-    const sheets = await buildNPCSheetsRequest(validName);
-    return {
-      sheets,
-    };
-  }
+  return tokenUri;
 }

--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -17,7 +17,7 @@ export const TEST_BUMPKIN: Bumpkin = {
   equipped: {
     body: "Beige Farmer Potion",
     hair: "Basic Hair",
-    shirt: "Blue Farmer Shirt",
+    shirt: "Gift Giver",
     pants: "Brown Suspenders",
 
     shoes: "Black Farmer Boots",
@@ -25,6 +25,8 @@ export const TEST_BUMPKIN: Bumpkin = {
     background: "Farm Background",
     beard: "Santa Beard",
     hat: "Deep Sea Helm",
+
+    aura: "Coin Aura",
   },
   skills: {},
   achievements: {},

--- a/src/features/game/lib/bumpkinData.ts
+++ b/src/features/game/lib/bumpkinData.ts
@@ -17,7 +17,7 @@ export const TEST_BUMPKIN: Bumpkin = {
   equipped: {
     body: "Beige Farmer Potion",
     hair: "Basic Hair",
-    shirt: "Gift Giver",
+    shirt: "Blue Farmer Shirt",
     pants: "Brown Suspenders",
 
     shoes: "Black Farmer Boots",
@@ -25,8 +25,6 @@ export const TEST_BUMPKIN: Bumpkin = {
     background: "Farm Background",
     beard: "Santa Beard",
     hat: "Deep Sea Helm",
-
-    aura: "Coin Aura",
   },
   skills: {},
   achievements: {},

--- a/src/features/island/bumpkin/components/NPC.tsx
+++ b/src/features/island/bumpkin/components/NPC.tsx
@@ -12,7 +12,6 @@ import {
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import shadow from "assets/npcs/shadow.png";
-import { SUNNYSIDE } from "assets/sunnyside";
 import { ZoomContext } from "components/ZoomProvider";
 import { SpringValue } from "react-spring";
 import { ITEM_IDS } from "features/game/types/bumpkin";
@@ -52,32 +51,23 @@ export const NPC: React.FC<NPCProps & { onClick?: () => void }> = ({
   preventZoom,
 }) => {
   const { scale } = useContext(ZoomContext);
-  const [sheetSrc, setSheetSrc] = useState<string>();
-  const [backsheet, setBackSheet] = useState<string>();
-  const [frontsheet, setFrontSheet] = useState<string>();
 
-  // make sure all body parts are synchronized
+  const [show, setShow] = useState(false);
+
   useEffect(() => {
-    const load = () => {
-      const sheets_idle = getAnimationUrl(parts, "idle_small");
-      setSheetSrc(sheets_idle);
-    };
-    // load aura equipped
-    const loadAura = () => {
-      if (parts.aura !== undefined) {
-        const auraName = parts.aura;
-        setBackSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[auraName]}.png`,
-        );
-        setFrontSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[auraName]}.png`,
-        );
-      }
-    };
-
-    load();
-    loadAura();
+    setShow(true);
   }, []);
+  const idle = getAnimationUrl(parts, "idle_small");
+  const auraBack =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[parts.aura]}.png`;
+  const auraFront =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[parts.aura]}.png`;
+
+  if (!show) {
+    return null;
+  }
 
   return (
     <>
@@ -92,209 +82,165 @@ export const NPC: React.FC<NPCProps & { onClick?: () => void }> = ({
           height: `${PIXEL_SCALE * 32}px`,
         }}
       >
-        {!sheetSrc && (
-          <img
-            src={SUNNYSIDE.npcs.silhouette}
-            style={{
-              width: `${PIXEL_SCALE * 15}px`,
-              top: `${PIXEL_SCALE * 8}px`,
-              left: `${PIXEL_SCALE * 1}px`,
-            }}
-            className="absolute pointer-events-none npc-loading"
-          />
-        )}
-
-        {sheetSrc && (
-          <>
-            {!hideShadow && (
-              <img
-                src={shadow}
-                style={{
-                  width: `${PIXEL_SCALE * 15}px`,
-                  top: `${PIXEL_SCALE * 20}px`,
-                  left: `${PIXEL_SCALE * 1}px`,
-                }}
-                className="absolute pointer-events-none"
-              />
-            )}
-            {backsheet && (
-              <Spritesheet
-                className="absolute w-full inset-0 pointer-events-none"
-                style={{
-                  width: `${PIXEL_SCALE * 20}px`,
-                  top: `${PIXEL_SCALE * 2}px`,
-                  left: `${PIXEL_SCALE * -2}px`,
-                  imageRendering: "pixelated" as const,
-                }}
-                image={backsheet}
-                widthFrame={AURA_WIDTH}
-                heightFrame={FRAME_HEIGHT}
-                zoomScale={preventZoom ? new SpringValue(1) : scale}
-                steps={AURA_STEPS}
-                fps={14}
-                autoplay={true}
-                loop={true}
-              />
-            )}
+        <>
+          {!hideShadow && (
+            <img
+              src={shadow}
+              style={{
+                width: `${PIXEL_SCALE * 15}px`,
+                top: `${PIXEL_SCALE * 20}px`,
+                left: `${PIXEL_SCALE * 1}px`,
+              }}
+              className="absolute pointer-events-none"
+            />
+          )}
+          {auraBack && (
             <Spritesheet
               className="absolute w-full inset-0 pointer-events-none"
               style={{
                 width: `${PIXEL_SCALE * 20}px`,
-                top: `${PIXEL_SCALE * 5}px`,
+                top: `${PIXEL_SCALE * 2}px`,
                 left: `${PIXEL_SCALE * -2}px`,
                 imageRendering: "pixelated" as const,
               }}
-              image={sheetSrc}
-              widthFrame={FRAME_WIDTH}
+              image={auraBack}
+              widthFrame={AURA_WIDTH}
               heightFrame={FRAME_HEIGHT}
               zoomScale={preventZoom ? new SpringValue(1) : scale}
-              steps={STEPS}
+              steps={AURA_STEPS}
               fps={14}
               autoplay={true}
               loop={true}
             />
-            {frontsheet && (
-              <Spritesheet
-                className="absolute w-full inset-0 pointer-events-none"
-                style={{
-                  width: `${PIXEL_SCALE * 20}px`,
-                  top: `${PIXEL_SCALE * 7}px`,
-                  left: `${PIXEL_SCALE * -2}px`,
-                  imageRendering: "pixelated" as const,
-                }}
-                image={frontsheet}
-                widthFrame={AURA_WIDTH}
-                heightFrame={FRAME_HEIGHT}
-                zoomScale={preventZoom ? new SpringValue(1) : scale}
-                steps={AURA_STEPS}
-                fps={14}
-                autoplay={true}
-                loop={true}
-              />
-            )}
-          </>
-        )}
+          )}
+          <Spritesheet
+            className="absolute w-full inset-0 pointer-events-none"
+            style={{
+              width: `${PIXEL_SCALE * 20}px`,
+              top: `${PIXEL_SCALE * 5}px`,
+              left: `${PIXEL_SCALE * -2}px`,
+              imageRendering: "pixelated" as const,
+            }}
+            image={idle}
+            widthFrame={FRAME_WIDTH}
+            heightFrame={FRAME_HEIGHT}
+            zoomScale={preventZoom ? new SpringValue(1) : scale}
+            steps={STEPS}
+            fps={14}
+            autoplay={true}
+            loop={true}
+          />
+          {auraFront && (
+            <Spritesheet
+              className="absolute w-full inset-0 pointer-events-none"
+              style={{
+                width: `${PIXEL_SCALE * 20}px`,
+                top: `${PIXEL_SCALE * 7}px`,
+                left: `${PIXEL_SCALE * -2}px`,
+                imageRendering: "pixelated" as const,
+              }}
+              image={auraFront}
+              widthFrame={AURA_WIDTH}
+              heightFrame={FRAME_HEIGHT}
+              zoomScale={preventZoom ? new SpringValue(1) : scale}
+              steps={AURA_STEPS}
+              fps={14}
+              autoplay={true}
+              loop={true}
+            />
+          )}
+        </>
       </div>
     </>
   );
 };
 
 export const NPCIcon: React.FC<NPCProps> = ({ parts, hideShadow }) => {
-  const [sheetSrc, setSheetSrc] = useState<string>();
-  const [backsheet, setBackSheet] = useState<string>();
-  const [frontsheet, setFrontSheet] = useState<string>();
+  const [show, setShow] = useState(false);
 
-  // make sure all body parts are synchronized
   useEffect(() => {
-    const load = () => {
-      const sheets_idle = getAnimationUrl(parts, "idle_small");
-      setSheetSrc(sheets_idle);
-    };
-    // load aura equipped
-    const loadAura = () => {
-      if (parts.aura !== undefined) {
-        const auraName = parts.aura;
-        setBackSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[auraName]}.png`,
-        );
-        setFrontSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[auraName]}.png`,
-        );
-      }
-    };
-
-    load();
-    loadAura();
+    setShow(true);
   }, []);
+
+  const idle = getAnimationUrl(parts, "idle_small");
+  const auraBack =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[parts.aura]}.png`;
+  const auraFront =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[parts.aura]}.png`;
+
+  if (!show) {
+    return null;
+  }
 
   return (
     <>
       <div>
-        {!sheetSrc && (
-          <div
-            style={{
-              width: `${PIXEL_SCALE * 14}px`,
-              height: `${PIXEL_SCALE * 19 * (14 / 20)}px`,
-            }}
-          >
+        <>
+          {!hideShadow && (
             <img
-              src={SUNNYSIDE.npcs.silhouette}
+              src={shadow}
               style={{
-                width: `${PIXEL_SCALE * 11}px`,
-                top: `${PIXEL_SCALE * 3}px`,
-                left: `${PIXEL_SCALE * 1}px`,
+                width: `${PIXEL_SCALE * 9}px`,
+                top: `${PIXEL_SCALE * 11}px`,
+                left: `${PIXEL_SCALE * 2.3}px`,
               }}
-              className="absolute pointer-events-none npc-loading pl-1"
+              className="absolute pointer-events-none"
             />
-          </div>
-        )}
-
-        {sheetSrc && (
-          <>
-            {!hideShadow && (
-              <img
-                src={shadow}
-                style={{
-                  width: `${PIXEL_SCALE * 9}px`,
-                  top: `${PIXEL_SCALE * 11}px`,
-                  left: `${PIXEL_SCALE * 2.3}px`,
-                }}
-                className="absolute pointer-events-none"
-              />
-            )}
-            {backsheet && (
-              <Spritesheet
-                className="absolute w-full inset-0 pointer-events-none"
-                style={{
-                  width: `${PIXEL_SCALE * 14}px`,
-                  top: `${PIXEL_SCALE * -3}px`,
-                  imageRendering: "pixelated" as const,
-                }}
-                image={backsheet}
-                widthFrame={AURA_WIDTH}
-                heightFrame={FRAME_HEIGHT}
-                zoomScale={new SpringValue(1)}
-                steps={AURA_STEPS}
-                fps={14}
-                autoplay={true}
-                loop={true}
-              />
-            )}
+          )}
+          {auraBack && (
             <Spritesheet
-              className="w-full inset-0 pointer-events-none"
+              className="absolute w-full inset-0 pointer-events-none"
               style={{
                 width: `${PIXEL_SCALE * 14}px`,
+                top: `${PIXEL_SCALE * -3}px`,
                 imageRendering: "pixelated" as const,
               }}
-              image={sheetSrc}
-              widthFrame={FRAME_WIDTH}
+              image={auraBack}
+              widthFrame={AURA_WIDTH}
               heightFrame={FRAME_HEIGHT}
               zoomScale={new SpringValue(1)}
-              steps={STEPS}
+              steps={AURA_STEPS}
               fps={14}
               autoplay={true}
               loop={true}
             />
-            {frontsheet && (
-              <Spritesheet
-                className="absolute w-full inset-0 pointer-events-none"
-                style={{
-                  width: `${PIXEL_SCALE * 14}px`,
-                  top: `${PIXEL_SCALE * 2}px`,
-                  imageRendering: "pixelated" as const,
-                }}
-                image={frontsheet}
-                widthFrame={AURA_WIDTH}
-                heightFrame={FRAME_HEIGHT}
-                zoomScale={new SpringValue(1)}
-                steps={AURA_STEPS}
-                fps={14}
-                autoplay={true}
-                loop={true}
-              />
-            )}
-          </>
-        )}
+          )}
+          <Spritesheet
+            className="w-full inset-0 pointer-events-none"
+            style={{
+              width: `${PIXEL_SCALE * 14}px`,
+              imageRendering: "pixelated" as const,
+            }}
+            image={idle}
+            widthFrame={FRAME_WIDTH}
+            heightFrame={FRAME_HEIGHT}
+            zoomScale={new SpringValue(1)}
+            steps={STEPS}
+            fps={14}
+            autoplay={true}
+            loop={true}
+          />
+          {auraFront && (
+            <Spritesheet
+              className="absolute w-full inset-0 pointer-events-none"
+              style={{
+                width: `${PIXEL_SCALE * 14}px`,
+                top: `${PIXEL_SCALE * 2}px`,
+                imageRendering: "pixelated" as const,
+              }}
+              image={auraFront}
+              widthFrame={AURA_WIDTH}
+              heightFrame={FRAME_HEIGHT}
+              zoomScale={new SpringValue(1)}
+              steps={AURA_STEPS}
+              fps={14}
+              autoplay={true}
+              loop={true}
+            />
+          )}
+        </>
       </div>
     </>
   );
@@ -304,31 +250,13 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
   parts,
   width,
 }) => {
-  const [sheetSrc, setSheetSrc] = useState<string>();
-  const [backsheet, setBackSheet] = useState<string>();
-  const [frontsheet, setFrontSheet] = useState<string>();
-
-  useEffect(() => {
-    const load = () => {
-      const sheets_idle = getAnimationUrl(parts, "idle_small");
-      setSheetSrc(sheets_idle);
-    };
-    // load aura equipped
-    const loadAura = () => {
-      if (parts.aura !== undefined) {
-        const auraName = parts.aura;
-        setBackSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[auraName]}.png`,
-        );
-        setFrontSheet(
-          `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[auraName]}.png`,
-        );
-      }
-    };
-
-    load();
-    loadAura();
-  }, []);
+  const idle = getAnimationUrl(parts, "idle_small");
+  const auraBack =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/back/${ITEM_IDS[parts.aura]}.png`;
+  const auraFront =
+    parts.aura &&
+    `${CONFIG.PROTECTED_IMAGE_URL}/aura/front/${ITEM_IDS[parts.aura]}.png`;
 
   return (
     <div
@@ -340,7 +268,7 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
       }}
     >
       <img
-        src={backsheet}
+        src={auraBack}
         className="block absolute"
         style={{
           transform: "scale(9)",
@@ -349,7 +277,7 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
         }}
       />
       <img
-        src={sheetSrc}
+        src={idle}
         className="block absolute"
         style={{
           transform: "scale(9)",
@@ -358,7 +286,7 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
         }}
       />
       <img
-        src={frontsheet}
+        src={auraFront}
         className="block absolute"
         style={{
           transform: "scale(9)",

--- a/src/features/island/bumpkin/components/NPC.tsx
+++ b/src/features/island/bumpkin/components/NPC.tsx
@@ -10,7 +10,6 @@ import {
   BumpkinAura,
 } from "features/game/types/bumpkin";
 import { PIXEL_SCALE } from "features/game/lib/constants";
-import { buildNPCSheets } from "features/bumpkins/actions/buildNPCSheets";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import shadow from "assets/npcs/shadow.png";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -18,6 +17,7 @@ import { ZoomContext } from "components/ZoomProvider";
 import { SpringValue } from "react-spring";
 import { ITEM_IDS } from "features/game/types/bumpkin";
 import { CONFIG } from "lib/config";
+import { getAnimationUrl } from "features/world/lib/animations";
 
 const FRAME_WIDTH = 180 / 9;
 const FRAME_HEIGHT = 19;
@@ -34,7 +34,7 @@ export type NPCParts = Omit<
   body: BumpkinBody;
   shoes: BumpkinShoe;
   tool: BumpkinTool;
-  aura: BumpkinAura;
+  aura?: BumpkinAura;
 };
 
 export interface NPCProps {
@@ -58,11 +58,9 @@ export const NPC: React.FC<NPCProps & { onClick?: () => void }> = ({
 
   // make sure all body parts are synchronized
   useEffect(() => {
-    const load = async () => {
-      const { sheets } = await buildNPCSheets({
-        parts,
-      });
-      setSheetSrc(sheets.idle);
+    const load = () => {
+      const sheets_idle = getAnimationUrl(parts, "idle_small");
+      setSheetSrc(sheets_idle);
     };
     // load aura equipped
     const loadAura = () => {
@@ -188,12 +186,9 @@ export const NPCIcon: React.FC<NPCProps> = ({ parts, hideShadow }) => {
 
   // make sure all body parts are synchronized
   useEffect(() => {
-    const load = async () => {
-      const { sheets } = await buildNPCSheets({
-        parts,
-      });
-
-      setSheetSrc(sheets.idle);
+    const load = () => {
+      const sheets_idle = getAnimationUrl(parts, "idle_small");
+      setSheetSrc(sheets_idle);
     };
     // load aura equipped
     const loadAura = () => {
@@ -314,12 +309,9 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
   const [frontsheet, setFrontSheet] = useState<string>();
 
   useEffect(() => {
-    const load = async () => {
-      const { sheets } = await buildNPCSheets({
-        parts,
-      });
-
-      setSheetSrc(sheets.idle);
+    const load = () => {
+      const sheets_idle = getAnimationUrl(parts, "idle_small");
+      setSheetSrc(sheets_idle);
     };
     // load aura equipped
     const loadAura = () => {

--- a/src/features/island/bumpkin/components/NPC.tsx
+++ b/src/features/island/bumpkin/components/NPC.tsx
@@ -267,15 +267,17 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
         height: `${width}px`,
       }}
     >
-      <img
-        src={auraBack}
-        className="block absolute"
-        style={{
-          transform: "scale(9)",
-          top: `${PIXEL_SCALE * 6}px`,
-          left: "400%",
-        }}
-      />
+      {auraBack && (
+        <img
+          src={auraBack}
+          className="block absolute"
+          style={{
+            transform: "scale(9)",
+            top: `${PIXEL_SCALE * 6}px`,
+            left: "400%",
+          }}
+        />
+      )}
       <img
         src={idle}
         className="block absolute"
@@ -285,15 +287,17 @@ export const NPCFixed: React.FC<NPCProps & { width: number }> = ({
           left: "400%",
         }}
       />
-      <img
-        src={auraFront}
-        className="block absolute"
-        style={{
-          transform: "scale(9)",
-          top: `${PIXEL_SCALE * 6}px`,
-          left: "400%",
-        }}
-      />
+      {auraFront && (
+        <img
+          src={auraFront}
+          className="block absolute"
+          style={{
+            transform: "scale(9)",
+            top: `${PIXEL_SCALE * 6}px`,
+            left: "400%",
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -161,9 +161,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     this.digAnimationKey = `${keyName}-bumpkin-dig`;
     this.drillAnimationKey = `${keyName}-bumpkin-drilling`;
 
-    const { sheets } = await buildNPCSheets({
+    await buildNPCSheets({
       parts: this.clothing,
-    });
+    }); //Removing this causes Aura to not show onload
 
     if (scene.textures.exists(this.idleSpriteKey)) {
       // If we have idle sheet then we can create the idle animation and set the sprite up straight away
@@ -188,14 +188,11 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
       this.ready = true;
     } else {
-      const idleLoader = scene.load.spritesheet(
-        this.idleSpriteKey,
-        sheets.idle,
-        {
-          frameWidth: 20,
-          frameHeight: 19,
-        },
-      );
+      const url = getAnimationUrl(this.clothing, "idle_small");
+      const idleLoader = scene.load.spritesheet(this.idleSpriteKey, url, {
+        frameWidth: 20,
+        frameHeight: 19,
+      });
 
       idleLoader.once(Phaser.Loader.Events.COMPLETE, () => {
         if (
@@ -236,14 +233,11 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     if (scene.textures.exists(this.walkingSpriteKey)) {
       this.createWalkingAnimation();
     } else {
-      const walkingLoader = scene.load.spritesheet(
-        this.walkingSpriteKey,
-        sheets.walking,
-        {
-          frameWidth: 20,
-          frameHeight: 19,
-        },
-      );
+      const url = getAnimationUrl(this.clothing, "walking_small");
+      const walkingLoader = scene.load.spritesheet(this.walkingSpriteKey, url, {
+        frameWidth: 20,
+        frameHeight: 19,
+      });
 
       walkingLoader.on(Phaser.Loader.Events.COMPLETE, () => {
         this.createWalkingAnimation();
@@ -410,7 +404,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     this.clothing = clothing;
 
     this.loadSprites(this.scene);
-    this.showAura();
+    if (clothing.aura !== undefined) {
+      this.showAura();
+    }
 
     this.showSmoke();
   }
@@ -457,7 +453,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
   public showAura() {
     //If Bumpkin has an Aura equipped
-    if (this.clothing.aura) {
+    if (this.frontfx && this.backfx) {
       this.removeAura();
     }
     if (this.clothing.aura !== undefined) {
@@ -479,6 +475,8 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         this.add(backaura);
         this.moveTo(backaura, 1);
         this.backfx = backaura;
+
+        this.createBackAuraAnimation();
         this.backfx.play(this.backAuraAnimationKey as string, true);
       } else {
         const backauraLoader = container.scene.load.spritesheet(
@@ -517,6 +515,8 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         this.add(frontaura);
         this.moveTo(frontaura, 3);
         this.frontfx = frontaura;
+
+        this.createFrontAuraAnimation();
         this.frontfx.play(this.frontAuraAnimationKey as string, true);
       } else {
         const frontauraLoader = container.scene.load.spritesheet(

--- a/src/features/world/lib/animations.ts
+++ b/src/features/world/lib/animations.ts
@@ -17,6 +17,7 @@ export enum ANIMATION {
   hammering = "hammering",
   hurt = "hurt",
   idle = "idle",
+  idle_small = "idle_small",
   jump = "jump",
   mining = "mining",
   reeling = "reeling",
@@ -25,6 +26,7 @@ export enum ANIMATION {
   swimming = "swimming",
   waiting = "waiting",
   walking = "walking",
+  walking_small = "walking_small",
   watering = "watering",
 }
 

--- a/src/features/world/scenes/examples/AnimationScene.ts
+++ b/src/features/world/scenes/examples/AnimationScene.ts
@@ -17,7 +17,7 @@ export class ExampleAnimationScene extends Phaser.Scene {
 
   preload() {
     const bumpkin: BumpkinParts = {
-      ...NPC_WEARABLES["phantom face"],
+      ...NPC_WEARABLES["raven"],
     };
 
     getKeys(ANIMATION).forEach((animationName) => {
@@ -27,8 +27,14 @@ export class ExampleAnimationScene extends Phaser.Scene {
        */
       const url = getAnimationUrl(bumpkin, animationName);
       this.load.spritesheet(animationName, url, {
-        frameWidth: 96,
-        frameHeight: 64,
+        frameWidth:
+          animationName === "idle_small" || animationName === "walking_small"
+            ? 20
+            : 96,
+        frameHeight:
+          animationName === "idle_small" || animationName === "walking_small"
+            ? 19
+            : 64,
       });
     });
   }


### PR DESCRIPTION
# Description

This PR replaces the animation flow for NPC.tsx and BumpkinContainer.ts to load idle and walking spritesheet of Bumpkins directly from the animation endpoint: idle_small and walking_small. This should help the browser to cache the images correctly.
Fixes #issue

## Type of change
Before:
We get idle and walking Spritesheets thru buildNPCSheets
After:
We load idle and walking Spritesheets directly from the animation endpoint.
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Requires backend changes to add animation endpoint for idle_small and walking_small. 
# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
