### PR TITLE
[FEAT] Pirate Chest Improvements

### DIFF
--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -135,6 +135,7 @@ export const PIRATE_CHEST_REWARDS: ChestReward[] = [
   { items: { "Orange Cake": 1 }, weighting: 10 },
   { items: { Sand: 20 }, weighting: 10 },
   { items: { Hieroglyph: 1 }, weighting: 10 },
+  { items: { "Pirate Cake": 1 }, weighting: 5 },
 ];
 
 // 1-3 days

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -322,6 +322,15 @@ function hasShakenManeki(game: GameState): Restriction {
   return [hasShakenRecently, translate("restrictionReason.pawShaken")];
 }
 
+export function hasOpenedPirateChest(game: GameState): Restriction {
+  function pirateChestOpened() {
+    const piratePotionOpened = game.pumpkinPlaza.pirateChest?.openedAt || 0;
+    return !canShake(piratePotionOpened);
+  }
+
+  return [pirateChestOpened(), "Pirate Chest Opened"];
+}
+
 function hasShakenTree(game: GameState): Restriction {
   const trees = game.collectibles["Festive Tree"] ?? [];
   const hasShakenRecently = trees.some((tree) => {

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -15,6 +15,7 @@ import {
   hasFishedToday,
   areBonusTreasureHolesDug,
   areAnyCropsOrGreenhouseCropsGrowing,
+  hasOpenedPirateChest,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -75,6 +76,7 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
   "Oil Overalls": (state) => !areAnyOilReservesDrilled(state)[0],
   "Hornet Mask": (state) => isBeehivesFull(state)[0],
   "Ancient Shovel": (state) => areBonusTreasureHolesDug(state)[0],
+  "Pirate Potion": (state) => !hasOpenedPirateChest(state)[0],
 };
 
 export const canWithdrawBoostedWearable = (

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1255,7 +1255,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Fruit Bowl": () => true,
   "Striped Blue Shirt": () => true,
   "Peg Leg": () => true,
-  "Pirate Potion": () => true,
+  "Pirate Potion": (state) =>
+    canWithdrawBoostedWearable("Pirate Potion", state),
   "Pirate Hat": () => true,
   "Pirate General Coat": () => true,
   "Pirate Pants": () => true,

--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -36,7 +36,7 @@ import { KingdomNoticeboard } from "./kingdom/KingdomNoticeboard";
 import { FactionNoticeboard } from "./factions/FactionNoticeboard";
 import { CropsAndChickens } from "./portals/CropsAndChickens";
 import { DesertNoticeboard } from "./beach/DesertNoticeboard";
-import { PirateChest } from "./chests/PirateChest";
+import { PirateChestModal } from "./chests/PirateChest";
 
 type InteractableName =
   | "desert_noticeboard"
@@ -316,9 +316,11 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
           setIsLoading={setIsLoading}
         />
       </Modal>
-      <Modal show={interactable === "pirate_chest"} onHide={closeModal}>
-        <PirateChest onClose={closeModal} setIsLoading={setIsLoading} />
-      </Modal>
+      <PirateChestModal
+        show={interactable === "pirate_chest"}
+        onClose={closeModal}
+        setIsLoading={setIsLoading}
+      />
       <Modal show={interactable === "plaza_orange_book"} onHide={closeModal}>
         <SpeakingModal
           onClose={closeModal}

--- a/src/features/world/ui/chests/PirateChest.tsx
+++ b/src/features/world/ui/chests/PirateChest.tsx
@@ -15,16 +15,26 @@ import { isWearableActive } from "features/game/lib/wearables";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { NPC_WEARABLES } from "lib/npcs";
+import { Modal } from "components/ui/Modal";
 
-const PirateChestContent: React.FC<{
+interface PirateChestContentProps {
   setIsLoading?: (isLoading: boolean) => void;
-}> = ({ setIsLoading }) => {
+  isPicking: boolean;
+  setIsPicking: (picking: boolean) => void;
+  isRevealing: boolean;
+  setIsRevealing: (revealing: boolean) => void;
+}
+const PirateChestContent: React.FC<PirateChestContentProps> = ({
+  setIsLoading,
+  isPicking,
+  setIsPicking,
+  isRevealing,
+  setIsRevealing,
+}) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const { state } = gameState.context;
-  const [isPicking, setIsPicking] = useState(false);
-  const [isRevealing, setIsRevealing] = useState(false);
 
   const piratePotionEquipped = isWearableActive({
     game: state,
@@ -91,16 +101,16 @@ const PirateChestContent: React.FC<{
     return (
       <>
         <div className="p-1">
-          <div className="justify-between flex">
+          <div className="flex gap-1 mb-1 flex-col md:justify-between md:flex-row">
             <Label
               type="success"
-              className="mb-1"
+              className="md:mb-0"
               secondaryIcon={SUNNYSIDE.icons.confirm}
             >
               {t("pirate.chest.opened")}
             </Label>
             <Label
-              className="text-right mb-1"
+              className="text-right"
               type="info"
               icon={SUNNYSIDE.icons.stopwatch}
             >
@@ -152,21 +162,57 @@ const PirateChestContent: React.FC<{
 interface Props {
   onClose: () => void;
   setIsLoading?: (isLoading: boolean) => void;
+  show: boolean;
 }
 
-export const PirateChest: React.FC<Props> = ({ onClose, setIsLoading }) => {
+export const PirateChestModal: React.FC<Props> = ({
+  show,
+  onClose,
+  setIsLoading,
+}) => {
   const { t } = useAppTranslation();
 
+  const [isPicking, setIsPicking] = useState(false);
+  const [isRevealing, setIsRevealing] = useState(false);
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+
   return (
-    <CloseButtonPanel
-      onClose={onClose}
-      bumpkinParts={NPC_WEARABLES["old salty"]}
-      tabs={[
-        { icon: ITEM_DETAILS["Pirate Bounty"].image, name: t("pirate.chest") },
-      ]}
-      className="pt-1"
+    <Modal
+      show={show}
+      onHide={
+        isPicking ||
+        (isRevealing &&
+          (gameState.matches("revealing") || gameState.matches("revealed")))
+          ? undefined
+          : onClose
+      }
     >
-      <PirateChestContent setIsLoading={setIsLoading} />
-    </CloseButtonPanel>
+      <CloseButtonPanel
+        onClose={
+          isPicking ||
+          (isRevealing &&
+            (gameState.matches("revealing") || gameState.matches("revealed")))
+            ? undefined
+            : onClose
+        }
+        bumpkinParts={NPC_WEARABLES["old salty"]}
+        tabs={[
+          {
+            icon: ITEM_DETAILS["Pirate Bounty"].image,
+            name: t("pirate.chest"),
+          },
+        ]}
+        className="pt-1"
+      >
+        <PirateChestContent
+          setIsLoading={setIsLoading}
+          isPicking={isPicking}
+          setIsPicking={setIsPicking}
+          isRevealing={isRevealing}
+          setIsRevealing={setIsRevealing}
+        />
+      </CloseButtonPanel>
+    </Modal>
   );
 };


### PR DESCRIPTION
# Description

- Improve Labels for isOpened styling for mobile devices
- Added Pirate Cake to the pool rewards with a weightage of 5
- Added Withdrawal Restriction

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/2856cf96-d810-4663-af68-d6af782cb689)|![image](https://github.com/user-attachments/assets/84759540-4819-4029-a5ad-2b9511fb0d3b)|


Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
