### PR TITLE
[FEAT] Seasonal Codex

### DIFF
--- a/src/assets/sunnyside.ts
+++ b/src/assets/sunnyside.ts
@@ -58,6 +58,7 @@ export const SUNNYSIDE = {
     desertPrestige: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/desert_prestige.png`,
     desert_digging: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/desert.webp`,
     factions: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/factions.png`,
+    desertSeason: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/desert_season.png`,
   },
   //Badges(Pre-LandExpansion Skills)
   badges: {

--- a/src/assets/sunnyside.ts
+++ b/src/assets/sunnyside.ts
@@ -59,6 +59,7 @@ export const SUNNYSIDE = {
     desert_digging: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/desert.webp`,
     factions: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/factions.png`,
     desertSeason: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/desert_season.png`,
+    pharaohSeasonRares: `${CONFIG.PROTECTED_IMAGE_URL}/announcements/pharaoh_seasonal_rares.png`,
   },
   //Badges(Pre-LandExpansion Skills)
   badges: {

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -22,13 +22,14 @@ import { Label } from "components/ui/Label";
 import classNames from "classnames";
 import { useSound } from "lib/utils/hooks/useSound";
 
-import trophy from "assets/icons/trophy.png";
 import factions from "assets/icons/factions.webp";
 import chores from "assets/icons/chores.webp";
+import gift from "assets/icons/gift.png";
 import { TicketsLeaderboard } from "./pages/TicketsLeaderboard";
 import { Leaderboards } from "features/game/expansion/components/leaderboard/actions/cache";
 import { fetchLeaderboardData } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import { FactionLeaderboard } from "./pages/FactionLeaderboard";
+import { Season } from "./pages/Season";
 
 interface Props {
   show: boolean;
@@ -131,7 +132,7 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
 
     {
       name: "Leaderboard" as const,
-      icon: trophy,
+      icon: gift,
       count: 0,
     },
     ...(state.faction
@@ -220,17 +221,17 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
               <Flowers onMilestoneReached={handleMilestoneReached} />
             )}
             {currentTab === 4 && (
-              <InnerPanel
+              <div
                 className={classNames(
                   "flex flex-col h-full overflow-hidden overflow-y-auto scrollable",
                 )}
               >
-                <TicketsLeaderboard
+                <Season
                   id={id}
                   isLoading={data?.tickets === undefined}
                   data={data?.tickets ?? null}
                 />
-              </InnerPanel>
+              </div>
             )}
 
             {currentTab === 5 && state.faction && (

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -120,6 +120,11 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
       count: incompleteChores + inCompleteKingdomChores,
     },
     {
+      name: "Leaderboard" as const,
+      icon: gift,
+      count: 0,
+    },
+    {
       name: "Fish",
       icon: SUNNYSIDE.icons.fish,
       count: 0,
@@ -130,11 +135,6 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
       count: 0,
     },
 
-    {
-      name: "Leaderboard" as const,
-      icon: gift,
-      count: 0,
-    },
     ...(state.faction
       ? [
           {
@@ -215,23 +215,17 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
             {currentTab === 0 && <Deliveries onClose={onHide} />}
             {currentTab === 1 && <Chores farmId={farmId} />}
             {currentTab === 2 && (
-              <Fish onMilestoneReached={handleMilestoneReached} />
+              <Season
+                id={id}
+                isLoading={data?.tickets === undefined}
+                data={data?.tickets ?? null}
+              />
             )}
             {currentTab === 3 && (
-              <Flowers onMilestoneReached={handleMilestoneReached} />
+              <Fish onMilestoneReached={handleMilestoneReached} />
             )}
             {currentTab === 4 && (
-              <div
-                className={classNames(
-                  "flex flex-col h-full overflow-hidden overflow-y-auto scrollable",
-                )}
-              >
-                <Season
-                  id={id}
-                  isLoading={data?.tickets === undefined}
-                  data={data?.tickets ?? null}
-                />
-              </div>
+              <Flowers onMilestoneReached={handleMilestoneReached} />
             )}
 
             {currentTab === 5 && state.faction && (

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { InnerPanel, OuterPanel } from "components/ui/Panel";
+import { OuterPanel } from "components/ui/Panel";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 import { Modal } from "components/ui/Modal";
@@ -25,7 +25,6 @@ import { useSound } from "lib/utils/hooks/useSound";
 import factions from "assets/icons/factions.webp";
 import chores from "assets/icons/chores.webp";
 import gift from "assets/icons/gift.png";
-import { TicketsLeaderboard } from "./pages/TicketsLeaderboard";
 import { Leaderboards } from "features/game/expansion/components/leaderboard/actions/cache";
 import { fetchLeaderboardData } from "features/game/expansion/components/leaderboard/actions/leaderboard";
 import { FactionLeaderboard } from "./pages/FactionLeaderboard";

--- a/src/features/island/hud/components/codex/components/AuctionSummary.tsx
+++ b/src/features/island/hud/components/codex/components/AuctionSummary.tsx
@@ -1,13 +1,14 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Modal } from "components/ui/Modal";
 
 import { useActor, useInterpret } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import {
+  Auction,
   MachineInterpreter,
   createAuctioneerMachine,
 } from "features/game/lib/auctionMachine";
-import { GameState } from "features/game/types/game";
+import { GameState, InventoryItemName } from "features/game/types/game";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -16,6 +17,237 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { VIPAccess } from "features/game/components/VipAccess";
 import { Loading } from "features/auth/components";
+import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
+import { getKeys } from "features/game/types/decorations";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
+import { getCurrentSeason, SEASONS } from "features/game/types/seasons";
+import { ButtonPanel, InnerPanel, OuterPanel } from "components/ui/Panel";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { getImageUrl } from "lib/utils/getImageURLS";
+import { CollectibleName } from "features/game/types/craftables";
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
+import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
+
+import lightning from "assets/icons/lightning.png";
+import sfl from "assets/icons/sfl.webp";
+
+import { Label } from "components/ui/Label";
+import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
+import { ModalOverlay } from "components/ui/ModalOverlay";
+
+type AuctionDetail = {
+  supply: number;
+  type: "collectible" | "wearable";
+  auctions: Auction[];
+};
+
+type AuctionItems = Record<BumpkinItem | InventoryItemName, AuctionDetail>;
+
+/**
+ * Aggregates the seasonal auction items
+ */
+function getSeasonalAuctions({ auctions }: { auctions: Auction[] }) {
+  const season = getCurrentSeason();
+  const { startDate, endDate } = SEASONS[season];
+
+  // Aggregate supplies
+  let details: AuctionItems = auctions.reduce((acc, auction) => {
+    const type = auction.type;
+    const name =
+      auction.type === "wearable" ? auction.wearable : auction.collectible;
+
+    const existing = acc[name];
+
+    if (existing) {
+      existing.auctions.push(auction);
+      existing.supply += auction.supply;
+    } else {
+      acc[name] = {
+        type,
+        supply: auction.supply,
+        auctions: [auction],
+      };
+    }
+
+    return acc;
+  }, {} as AuctionItems);
+
+  // Filter out any not in this season
+  details = getKeys(details).reduce((acc, name) => {
+    const hasNoSeasonAuctions = details[name].auctions.every((auction) => {
+      auction.startAt < startDate.getTime() ||
+        auction.startAt > endDate.getTime();
+    });
+
+    if (hasNoSeasonAuctions) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [name]: details[name],
+    };
+  }, {} as AuctionItems);
+
+  return details;
+}
+
+const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
+  let drops = getKeys(auctions).reduce((acc, name) => {
+    return [...acc, ...auctions[name].auctions];
+  }, [] as Auction[]);
+
+  drops = drops.sort((a, b) => (a.startAt > b.startAt ? 1 : -1));
+
+  const nextDrop = drops.find((drop) => drop.startAt > Date.now());
+
+  const starts = useCountdown(nextDrop?.startAt ?? 0);
+
+  if (!nextDrop) {
+    return null;
+  }
+
+  const image =
+    nextDrop.type === "collectible"
+      ? ITEM_DETAILS[nextDrop.collectible as CollectibleName].image
+      : getImageUrl(ITEM_IDS[nextDrop.wearable as BumpkinItem]);
+
+  const buffLabel =
+    nextDrop.type === "collectible"
+      ? COLLECTIBLE_BUFF_LABELS[nextDrop.collectible as CollectibleName]
+      : BUMPKIN_ITEM_BUFF_LABELS[nextDrop.wearable as BumpkinItem];
+
+  return (
+    <InnerPanel className="mb-1">
+      <div className="p-1">
+        <div className="flex justify-between mb-2">
+          <Label className="-ml-1" type="default">
+            Next drop
+          </Label>
+          <Label type="warning">{`${nextDrop.supply} available`}</Label>
+        </div>
+        <div className="flex justify-between items-start">
+          <div className="flex w-full">
+            <div className="w-12 h-12  mr-1">
+              <img src={image} className="h-full mx-auto" />
+            </div>
+            <div className="flex justify-between flex-1 flex-wrap">
+              <div>
+                <p className="text-sm mb-1">
+                  {nextDrop.type === "collectible"
+                    ? nextDrop.collectible
+                    : nextDrop.wearable}
+                </p>
+                {buffLabel ? (
+                  <div className="flex">
+                    <img src={lightning} className="h-4 mr-0.5" />
+                    <p className="text-xs">{buffLabel.shortDescription}</p>
+                  </div>
+                ) : (
+                  <div className="flex">
+                    <img src={SUNNYSIDE.icons.heart} className="h-4 mr-0.5" />
+                    <p className="text-xs">Collectible</p>
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col items-end">
+                <TimerDisplay fontSize={10} time={starts} />
+                <span className="text-xs">
+                  {new Date(nextDrop.startAt).toLocaleString().slice(0, -3)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </InnerPanel>
+  );
+};
+
+const Drops: React.FC<{
+  detail: AuctionDetail;
+  name: BumpkinItem | InventoryItemName;
+}> = ({ detail, name }) => {
+  const image =
+    detail.type === "collectible"
+      ? ITEM_DETAILS[name as CollectibleName].image
+      : getImageUrl(ITEM_IDS[name as BumpkinItem]);
+
+  const buffLabel =
+    detail.type === "collectible"
+      ? COLLECTIBLE_BUFF_LABELS[name as CollectibleName]
+      : BUMPKIN_ITEM_BUFF_LABELS[name as BumpkinItem];
+
+  return (
+    <>
+      <div className="p-1">
+        <p className="text-sm mb-1">{name}</p>
+        {buffLabel ? (
+          <div className="flex">
+            <img src={lightning} className="h-4 mr-0.5" />
+            <p className="text-xs">{buffLabel.shortDescription}</p>
+          </div>
+        ) : (
+          <div className="flex">
+            <img src={SUNNYSIDE.icons.heart} className="h-4 mr-0.5" />
+            <p className="text-xs">Collectible</p>
+          </div>
+        )}
+      </div>
+      <div
+        style={{ maxHeight: "300px" }}
+        className="overflow-y-auto divide-brown-600 pb-0 scrollable pr-1"
+      >
+        {detail.auctions.map((drop) => {
+          return (
+            <InnerPanel className="mb-1">
+              <div className="p-1">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <div className="flex items-center">
+                      <img
+                        src={SUNNYSIDE.icons.stopwatch}
+                        className="h-4 mr-1"
+                      />
+                      <span className="text-xs">
+                        {new Date(drop.startAt).toLocaleString().slice(0, -3)}
+                      </span>
+                    </div>
+                    <div className="flex items-center">
+                      <span className="text-xs mb-1">Requires:</span>
+                      <div className="flex items-center justify-center">
+                        {drop.sfl > 0 && (
+                          <div className="flex items-center">
+                            <img src={sfl} className="h-4" />
+                          </div>
+                        )}
+                        {getKeys(drop.ingredients).map((name) => (
+                          <div className="flex items-center ml-1" key={name}>
+                            <img
+                              src={ITEM_DETAILS[name].image}
+                              className="h-4"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  {drop.startAt > Date.now() ? (
+                    <Label type="warning">{`${drop.supply} available`}</Label>
+                  ) : (
+                    <Label type="danger">Sold out</Label>
+                  )}
+                </div>
+              </div>
+            </InnerPanel>
+          );
+        })}
+      </div>
+    </>
+  );
+};
 
 interface Props {
   gameState: GameState;
@@ -26,6 +258,8 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
   const { t } = useAppTranslation();
   const { authService } = useContext(AuthProvider.Context);
   const [authState] = useActor(authService);
+
+  const [selected, setSelected] = useState<InventoryItemName | BumpkinItem>();
 
   const auctionService = useInterpret(
     createAuctioneerMachine({ onUpdate: console.log }),
@@ -55,9 +289,106 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
     return <Loading />;
   }
 
+  const auctionItems = getSeasonalAuctions({
+    auctions: auctioneerState.context.auctions,
+  });
+
   return (
-    <div className="flex flex-col">
-      {JSON.stringify({ auctions: auctioneerState.context.auctions })}
-    </div>
+    <>
+      <ModalOverlay
+        show={!!selected}
+        onBackdropClick={() => setSelected(undefined)}
+      >
+        <CloseButtonPanel
+          container={OuterPanel}
+          onClose={() => setSelected(undefined)}
+        >
+          {selected && (
+            <Drops name={selected} detail={auctionItems[selected]} />
+          )}
+        </CloseButtonPanel>
+      </ModalOverlay>
+
+      <NextDrop auctions={auctionItems} />
+
+      <InnerPanel className="mb-1">
+        <div className="p-1">
+          <div className="flex justify-between mb-2">
+            <Label className="-ml-1" type="default">
+              Seasonal Drops
+            </Label>
+          </div>
+          <p className="text-xs mb-2">
+            Compete with others for the rarest items!
+          </p>
+
+          <div className="flex flex-col -mx-1">
+            {getKeys(auctionItems).map((name) => {
+              const details = auctionItems[name];
+
+              const image =
+                details.type === "collectible"
+                  ? ITEM_DETAILS[name as CollectibleName].image
+                  : getImageUrl(ITEM_IDS[name as BumpkinItem]);
+
+              const buffLabel =
+                details.type === "collectible"
+                  ? COLLECTIBLE_BUFF_LABELS[name as CollectibleName]
+                  : BUMPKIN_ITEM_BUFF_LABELS[name as BumpkinItem];
+
+              const remainingAuctions = details.auctions.filter(
+                (auction) => auction.startAt > Date.now(),
+              );
+              const remainingLeft = remainingAuctions.reduce(
+                (total, auction) => total + auction.supply,
+                0,
+              );
+
+              return (
+                <ButtonPanel
+                  onClick={() => setSelected(name)}
+                  key={name}
+                  className="relative"
+                >
+                  <div className="flex">
+                    <div className="w-12 h-12  mr-1">
+                      <img src={image} className="h-full mx-auto" />
+                    </div>
+                    <div>
+                      <p className="text-sm mb-1">{name}</p>
+                      {buffLabel ? (
+                        <div className="flex">
+                          <img src={lightning} className="h-4 mr-0.5" />
+                          <p className="text-xs">
+                            {buffLabel.shortDescription}
+                          </p>
+                        </div>
+                      ) : (
+                        <div className="flex">
+                          <img
+                            src={SUNNYSIDE.icons.heart}
+                            className="h-4 mr-0.5"
+                          />
+                          <p className="text-xs">Collectible</p>
+                        </div>
+                      )}
+                    </div>
+                    <div className="absolute top-0 right-0">
+                      {remainingLeft === 0 ? (
+                        <Label type="danger">Sold out</Label>
+                      ) : remainingLeft <= 50 ? (
+                        <Label type="warning">{`${remainingLeft} left`}</Label>
+                      ) : (
+                        <Label type="default">{`${remainingLeft} left`}</Label>
+                      )}
+                    </div>
+                  </div>
+                </ButtonPanel>
+              );
+            })}
+          </div>
+        </div>
+      </InnerPanel>
+    </>
   );
 };

--- a/src/features/island/hud/components/codex/components/AuctionSummary.tsx
+++ b/src/features/island/hud/components/codex/components/AuctionSummary.tsx
@@ -1,0 +1,63 @@
+import React, { useContext, useEffect } from "react";
+import { Modal } from "components/ui/Modal";
+
+import { useActor, useInterpret } from "@xstate/react";
+import { SUNNYSIDE } from "assets/sunnyside";
+import {
+  MachineInterpreter,
+  createAuctioneerMachine,
+} from "features/game/lib/auctionMachine";
+import { GameState } from "features/game/types/game";
+import * as AuthProvider from "features/auth/lib/Provider";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { NPC_WEARABLES } from "lib/npcs";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { hasVipAccess } from "features/game/lib/vipAccess";
+import { VIPAccess } from "features/game/components/VipAccess";
+import { Loading } from "features/auth/components";
+
+interface Props {
+  gameState: GameState;
+  farmId: number;
+}
+
+export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
+  const { t } = useAppTranslation();
+  const { authService } = useContext(AuthProvider.Context);
+  const [authState] = useActor(authService);
+
+  const auctionService = useInterpret(
+    createAuctioneerMachine({ onUpdate: console.log }),
+    {
+      context: {
+        farmId: farmId,
+        token: authState.context.user.rawToken,
+        bid: gameState.auctioneer.bid,
+        deviceTrackerId: "0x",
+        canAccess: true,
+        linkedAddress: "0x",
+      },
+    },
+  ) as unknown as MachineInterpreter;
+
+  const [auctioneerState] = useActor(auctionService);
+
+  useEffect(() => {
+    auctionService.send("OPEN", { gameState });
+  }, []);
+
+  if (auctioneerState.matches("idle")) {
+    return null;
+  }
+
+  if (auctioneerState.matches("loading")) {
+    return <Loading />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {JSON.stringify({ auctions: auctioneerState.context.auctions })}
+    </div>
+  );
+};

--- a/src/features/island/hud/components/codex/components/AuctionSummary.tsx
+++ b/src/features/island/hud/components/codex/components/AuctionSummary.tsx
@@ -125,7 +125,7 @@ const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
           <Label className="-ml-1" type="default">
             Next drop
           </Label>
-          <Label type="warning">{`${nextDrop.supply} available`}</Label>
+          <Label type="info">{`${nextDrop.supply} available`}</Label>
         </div>
         <div className="flex justify-between items-start">
           <div className="flex w-full">
@@ -235,7 +235,7 @@ const Drops: React.FC<{
                   </div>
 
                   {drop.startAt > Date.now() ? (
-                    <Label type="warning">{`${drop.supply} available`}</Label>
+                    <Label type="info">{`${drop.supply} available`}</Label>
                   ) : (
                     <Label type="danger">Sold out</Label>
                   )}
@@ -319,7 +319,8 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
             </Label>
           </div>
           <p className="text-xs mb-2">
-            Compete with others for the rarest items!
+            Compete with others for the rarest items! Visit the Auctioneer in
+            the plaza for more details.
           </p>
 
           <div className="flex flex-col -mx-1">
@@ -377,7 +378,7 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
                       {remainingLeft === 0 ? (
                         <Label type="danger">Sold out</Label>
                       ) : remainingLeft <= 50 ? (
-                        <Label type="warning">{`${remainingLeft} left`}</Label>
+                        <Label type="info">{`${remainingLeft} left`}</Label>
                       ) : (
                         <Label type="default">{`${remainingLeft} left`}</Label>
                       )}

--- a/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
@@ -94,6 +94,8 @@ function getSeasonalAuctions({ auctions }: { auctions: Auction[] }) {
 }
 
 const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
+  const { t } = useAppTranslation();
+
   let drops = getKeys(auctions).reduce((acc, name) => {
     return [...acc, ...auctions[name].auctions];
   }, [] as Auction[]);
@@ -123,7 +125,7 @@ const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
       <div className="p-1">
         <div className="flex justify-between mb-2">
           <Label className="-ml-1" type="default">
-            Next drop
+            {t("season.codex.nextDrop")}
           </Label>
           <Label type="info">{`${nextDrop.supply} available`}</Label>
         </div>
@@ -147,7 +149,7 @@ const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
                 ) : (
                   <div className="flex">
                     <img src={SUNNYSIDE.icons.heart} className="h-4 mr-0.5" />
-                    <p className="text-xs">Collectible</p>
+                    <p className="text-xs">{t("collectibles")}</p>
                   </div>
                 )}
               </div>
@@ -169,11 +171,7 @@ const Drops: React.FC<{
   detail: AuctionDetail;
   name: BumpkinItem | InventoryItemName;
 }> = ({ detail, name }) => {
-  const image =
-    detail.type === "collectible"
-      ? ITEM_DETAILS[name as CollectibleName].image
-      : getImageUrl(ITEM_IDS[name as BumpkinItem]);
-
+  const { t } = useAppTranslation();
   const buffLabel =
     detail.type === "collectible"
       ? COLLECTIBLE_BUFF_LABELS[name as CollectibleName]
@@ -191,7 +189,7 @@ const Drops: React.FC<{
         ) : (
           <div className="flex">
             <img src={SUNNYSIDE.icons.heart} className="h-4 mr-0.5" />
-            <p className="text-xs">Collectible</p>
+            <p className="text-xs">{t("collectibles")}</p>
           </div>
         )}
       </div>
@@ -215,7 +213,7 @@ const Drops: React.FC<{
                       </span>
                     </div>
                     <div className="flex items-center">
-                      <span className="text-xs mb-1">Requires:</span>
+                      <span className="text-xs mb-1">{`Requires:`}</span>
                       <div className="flex items-center justify-center">
                         {drop.sfl > 0 && (
                           <div className="flex items-center">
@@ -237,7 +235,7 @@ const Drops: React.FC<{
                   {drop.startAt > Date.now() ? (
                     <Label type="info">{`${drop.supply} available`}</Label>
                   ) : (
-                    <Label type="danger">Sold out</Label>
+                    <Label type="danger">{t("statements.soldOut")}</Label>
                   )}
                 </div>
               </div>
@@ -254,7 +252,7 @@ interface Props {
   farmId: number;
 }
 
-export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
+export const SeasonalAuctions: React.FC<Props> = ({ farmId, gameState }) => {
   const { t } = useAppTranslation();
   const { authService } = useContext(AuthProvider.Context);
   const [authState] = useActor(authService);
@@ -315,12 +313,11 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
         <div className="p-1">
           <div className="flex justify-between mb-2">
             <Label className="-ml-1" type="default">
-              Seasonal Drops
+              {t("season.codex.seasonalDrops")}
             </Label>
           </div>
           <p className="text-xs mb-2">
-            Compete with others for the rarest items! Visit the Auctioneer in
-            the plaza for more details.
+            {t("season.codex.seasonalDrops.description")}
           </p>
 
           <div className="flex flex-col -mx-1">
@@ -370,13 +367,13 @@ export const AuctionSummary: React.FC<Props> = ({ farmId, gameState }) => {
                             src={SUNNYSIDE.icons.heart}
                             className="h-4 mr-0.5"
                           />
-                          <p className="text-xs">Collectible</p>
+                          <p className="text-xs">{t("collectibles")}</p>
                         </div>
                       )}
                     </div>
                     <div className="absolute top-0 right-0">
                       {remainingLeft === 0 ? (
-                        <Label type="danger">Sold out</Label>
+                        <Label type="danger">{t("season.codex.soldOut")}</Label>
                       ) : remainingLeft <= 50 ? (
                         <Label type="info">{`${remainingLeft} left`}</Label>
                       ) : (

--- a/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Modal } from "components/ui/Modal";
 
 import { useActor, useInterpret } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -11,15 +10,10 @@ import {
 import { GameState, InventoryItemName } from "features/game/types/game";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { NPC_WEARABLES } from "lib/npcs";
-import { PIXEL_SCALE } from "features/game/lib/constants";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { hasVipAccess } from "features/game/lib/vipAccess";
-import { VIPAccess } from "features/game/components/VipAccess";
 import { Loading } from "features/auth/components";
 import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { getKeys } from "features/game/types/decorations";
-import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 import { getCurrentSeason, SEASONS } from "features/game/types/seasons";
 import { ButtonPanel, InnerPanel, OuterPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -199,7 +193,7 @@ const Drops: React.FC<{
       >
         {detail.auctions.map((drop) => {
           return (
-            <InnerPanel className="mb-1">
+            <InnerPanel className="mb-1" key={drop.auctionId}>
               <div className="p-1">
                 <div className="flex justify-between items-center">
                   <div>
@@ -260,7 +254,11 @@ export const SeasonalAuctions: React.FC<Props> = ({ farmId, gameState }) => {
   const [selected, setSelected] = useState<InventoryItemName | BumpkinItem>();
 
   const auctionService = useInterpret(
-    createAuctioneerMachine({ onUpdate: console.log }),
+    createAuctioneerMachine({
+      onUpdate: () => {
+        // No op
+      },
+    }),
     {
       context: {
         farmId: farmId,

--- a/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
@@ -123,11 +123,11 @@ const NextDrop: React.FC<{ auctions: AuctionItems }> = ({ auctions }) => {
   return (
     <InnerPanel className="mb-1">
       <div className="p-1">
-        <div className="flex justify-between mb-2">
-          <Label className="-ml-1" type="default">
+        <div className="flex justify-between mb-1 flex-wrap wrap">
+          <Label className="-ml-1 mb-1" type="default">
             {t("season.codex.nextDrop")}
           </Label>
-          <Label type="info">{`${nextDrop.supply} available`}</Label>
+          <Label type="formula">{`${nextDrop.supply} available`}</Label>
         </div>
         <div className="flex justify-between items-start">
           <div className="flex w-full">
@@ -233,7 +233,7 @@ const Drops: React.FC<{
                   </div>
 
                   {drop.startAt > Date.now() ? (
-                    <Label type="info">{`${drop.supply} available`}</Label>
+                    <Label type="formula">{`${drop.supply} available`}</Label>
                   ) : (
                     <Label type="danger">{t("statements.soldOut")}</Label>
                   )}
@@ -375,7 +375,7 @@ export const SeasonalAuctions: React.FC<Props> = ({ farmId, gameState }) => {
                       {remainingLeft === 0 ? (
                         <Label type="danger">{t("season.codex.soldOut")}</Label>
                       ) : remainingLeft <= 50 ? (
-                        <Label type="info">{`${remainingLeft} left`}</Label>
+                        <Label type="formula">{`${remainingLeft} left`}</Label>
                       ) : (
                         <Label type="default">{`${remainingLeft} left`}</Label>
                       )}

--- a/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
@@ -1,7 +1,6 @@
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { InnerPanel } from "components/ui/Panel";
-import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getCurrentSeason, SeasonName } from "features/game/types/seasons";

--- a/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
@@ -1,0 +1,72 @@
+import { SUNNYSIDE } from "assets/sunnyside";
+import { Label } from "components/ui/Label";
+import { InnerPanel } from "components/ui/Panel";
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
+import { InventoryItemName } from "features/game/types/game";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { getCurrentSeason, SeasonName } from "features/game/types/seasons";
+import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+import React from "react";
+
+type SeasonalMutants = {
+  banner: string;
+  chicken: InventoryItemName;
+  flower: InventoryItemName;
+  fish: InventoryItemName;
+};
+
+const DEFAULT: SeasonalMutants = {
+  chicken: "Fat Chicken",
+  flower: "Red Pansy",
+  fish: "Anchovy",
+  banner: "?",
+};
+
+const SEASONAL_MUTANTS: Partial<Record<SeasonName, SeasonalMutants>> = {
+  "Pharaoh's Treasure": {
+    chicken: "Pharaoh Chicken",
+    flower: "Desert Rose",
+    fish: "Lemon Shark",
+    banner: SUNNYSIDE.announcement.pharaohSeasonRares,
+  },
+};
+
+export const SeasonalMutants: React.FC = () => {
+  const mutants = SEASONAL_MUTANTS[getCurrentSeason()];
+
+  if (!mutants) {
+    return null;
+  }
+  return (
+    <InnerPanel className="mb-1">
+      <div className="p-1">
+        <div className="flex justify-between mb-2">
+          <Label className="-ml-1" type="default">
+            Mutants
+          </Label>
+        </div>
+        <p className="text-xs">Discover the seasonal mutants!</p>
+        <img className="my-1 w-full rounded-md" src={mutants.banner} />
+
+        <NoticeboardItems
+          iconWidth={8}
+          items={[
+            {
+              text: `Collect eggs to discover the ${mutants.chicken}.`,
+              icon: ITEM_DETAILS.Chicken.image,
+            },
+            {
+              text: `Fish in the depths for the ${mutants.fish}.`,
+
+              icon: ITEM_DETAILS.Rod.image,
+            },
+            {
+              text: `Experiment with flowers to discover the ${mutants.flower}.`,
+              icon: ITEM_DETAILS["Red Pansy"].image,
+            },
+          ]}
+        />
+      </div>
+    </InnerPanel>
+  );
+};

--- a/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalMutants.tsx
@@ -6,6 +6,7 @@ import { InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getCurrentSeason, SeasonName } from "features/game/types/seasons";
 import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import React from "react";
 
 type SeasonalMutants = {
@@ -34,6 +35,8 @@ const SEASONAL_MUTANTS: Partial<Record<SeasonName, SeasonalMutants>> = {
 export const SeasonalMutants: React.FC = () => {
   const mutants = SEASONAL_MUTANTS[getCurrentSeason()];
 
+  const { t } = useAppTranslation();
+
   if (!mutants) {
     return null;
   }
@@ -42,26 +45,32 @@ export const SeasonalMutants: React.FC = () => {
       <div className="p-1">
         <div className="flex justify-between mb-2">
           <Label className="-ml-1" type="default">
-            Mutants
+            {t("season.codex.mutants")}
           </Label>
         </div>
-        <p className="text-xs">Discover the seasonal mutants!</p>
+        <p className="text-xs">{t("season.codex.mutants.discover")}</p>
         <img className="my-1 w-full rounded-md" src={mutants.banner} />
 
         <NoticeboardItems
           iconWidth={8}
           items={[
             {
-              text: `Collect eggs to discover the ${mutants.chicken}.`,
+              text: t("season.codex.mutants.one", {
+                item: mutants.chicken,
+              }),
               icon: ITEM_DETAILS.Chicken.image,
             },
             {
-              text: `Fish in the depths for the ${mutants.fish}.`,
+              text: t("season.codex.mutants.two", {
+                item: mutants.fish,
+              }),
 
               icon: ITEM_DETAILS.Rod.image,
             },
             {
-              text: `Experiment with flowers to discover the ${mutants.flower}.`,
+              text: t("season.codex.mutants.three", {
+                item: mutants.flower,
+              }),
               icon: ITEM_DETAILS["Red Pansy"].image,
             },
           ]}

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -43,8 +43,8 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
     >
       <InnerPanel className="mb-1">
         <div className="p-1">
-          <div className="flex justify-between mb-2">
-            <Label className="-ml-1" type="default">
+          <div className="flex justify-between mb-1 flex-wrap">
+            <Label className="-ml-1 mb-1" type="default">
               {getCurrentSeason()}
             </Label>
             <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -4,6 +4,7 @@ import { TicketLeaderboard } from "features/game/expansion/components/leaderboar
 import { InnerPanel } from "components/ui/Panel";
 import {
   getCurrentSeason,
+  getSeasonalTicket,
   secondsLeftInSeason,
 } from "features/game/types/seasons";
 import { Label } from "components/ui/Label";
@@ -18,6 +19,9 @@ import { MegaStoreContent } from "features/world/ui/megastore/MegaStore";
 import { AuctionSummary } from "../components/AuctionSummary";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
+import classNames from "classnames";
+import { SeasonalMutants } from "../components/SeasonalMutants";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 interface Props {
   id: string;
@@ -29,9 +33,15 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
+  const { t } = useAppTranslation();
+
   const { state, farmId } = gameState.context;
   return (
-    <>
+    <div
+      className={classNames(
+        "flex flex-col h-full overflow-hidden overflow-y-auto scrollable",
+      )}
+    >
       <InnerPanel className="mb-1">
         <div className="p-1">
           <div className="flex justify-between mb-2">
@@ -43,8 +53,7 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
             </Label>
           </div>
           <p className="text-xs">
-            Earn Amber Fossils to craft limited edition collectibles & wearables
-            for your farm! Hurry before time runs out!
+            {t("season.codex.intro", { ticket: getSeasonalTicket() })}
           </p>
         </div>
       </InnerPanel>
@@ -66,22 +75,22 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
         <div className="p-1">
           <div className="flex justify-between mb-2">
             <Label className="-ml-1" type="default">
-              How to earn Amber Fossils?
+              {t("season.codex.howToEarn", { ticket: getSeasonalTicket() })}
             </Label>
           </div>
           <NoticeboardItems
             iconWidth={8}
             items={[
               {
-                text: "Deliver resources to Bumpkins",
+                text: "Deliver resources to Bumpkins.",
                 icon: SUNNYSIDE.icons.player,
               },
               {
-                text: "Complete Hank's chores",
+                text: "Complete Hank's chores.",
                 icon: chores,
               },
               {
-                text: "Compete in the faction competition",
+                text: "Compete in the faction competition.",
                 icon: factions,
               },
             ]}
@@ -95,20 +104,11 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
 
       <AuctionSummary gameState={state} farmId={farmId} />
 
-      <InnerPanel className="mb-1">
-        <div className="p-1">
-          <div className="flex justify-between mb-2">
-            <Label className="-ml-1" type="default">
-              Mutants
-            </Label>
-          </div>
-          <p className="text-xs">Discover the following seasonal rares:</p>
-        </div>
-      </InnerPanel>
+      <SeasonalMutants />
 
       <InnerPanel className="mb-1">
         <TicketsLeaderboard id={id} isLoading={isLoading} data={data} />
       </InnerPanel>
-    </>
+    </div>
   );
 };

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -50,6 +50,19 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
       </InnerPanel>
 
       <InnerPanel className="mb-1">
+        <div
+          style={{
+            backgroundImage: `url(${SUNNYSIDE.announcement.desertSeason})`,
+            imageRendering: "pixelated",
+            height: "125px",
+            backgroundSize: "600px",
+            backgroundPosition: "center",
+            margin: "-3px",
+          }}
+        ></div>
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
         <div className="p-1">
           <div className="flex justify-between mb-2">
             <Label className="-ml-1" type="default">
@@ -77,20 +90,10 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
       </InnerPanel>
 
       <InnerPanel className="mb-1">
-        <MegaStoreContent />
+        <MegaStoreContent readonly />
       </InnerPanel>
 
-      <InnerPanel className="mb-1">
-        <div className="p-1">
-          <div className="flex justify-between mb-2">
-            <Label className="-ml-1" type="default">
-              Auctions
-            </Label>
-          </div>
-          <p className="text-xs">Compete with others for the rarest items!</p>
-          <AuctionSummary gameState={state} farmId={farmId} />
-        </div>
-      </InnerPanel>
+      <AuctionSummary gameState={state} farmId={farmId} />
 
       <InnerPanel className="mb-1">
         <div className="p-1">

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -14,9 +14,8 @@ import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
 
 import factions from "assets/icons/factions.webp";
 import chores from "assets/icons/chores.webp";
-import trophy from "assets/icons/trophy.png";
 import { MegaStoreContent } from "features/world/ui/megastore/MegaStore";
-import { AuctionSummary } from "../components/AuctionSummary";
+import { SeasonalAuctions } from "../components/SeasonalAuctions";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import classNames from "classnames";
@@ -82,15 +81,15 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
             iconWidth={8}
             items={[
               {
-                text: "Deliver resources to Bumpkins.",
+                text: t("season.codex.howToEarn.one"),
                 icon: SUNNYSIDE.icons.player,
               },
               {
-                text: "Complete Hank's chores.",
+                text: t("season.codex.howToEarn.two"),
                 icon: chores,
               },
               {
-                text: "Compete in the faction competition.",
+                text: t("season.codex.howToEarn.three"),
                 icon: factions,
               },
             ]}
@@ -102,7 +101,7 @@ export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
         <MegaStoreContent readonly />
       </InnerPanel>
 
-      <AuctionSummary gameState={state} farmId={farmId} />
+      <SeasonalAuctions gameState={state} farmId={farmId} />
 
       <SeasonalMutants />
 

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -1,0 +1,111 @@
+import React, { useContext } from "react";
+import { TicketsLeaderboard } from "./TicketsLeaderboard";
+import { TicketLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
+import { InnerPanel } from "components/ui/Panel";
+import {
+  getCurrentSeason,
+  secondsLeftInSeason,
+} from "features/game/types/seasons";
+import { Label } from "components/ui/Label";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { secondsToString } from "lib/utils/time";
+import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+
+import factions from "assets/icons/factions.webp";
+import chores from "assets/icons/chores.webp";
+import trophy from "assets/icons/trophy.png";
+import { MegaStoreContent } from "features/world/ui/megastore/MegaStore";
+import { AuctionSummary } from "../components/AuctionSummary";
+import { Context } from "features/game/GameProvider";
+import { useActor } from "@xstate/react";
+
+interface Props {
+  id: string;
+  isLoading: boolean;
+  data: TicketLeaderboard | null;
+}
+
+export const Season: React.FC<Props> = ({ id, isLoading, data }) => {
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+
+  const { state, farmId } = gameState.context;
+  return (
+    <>
+      <InnerPanel className="mb-1">
+        <div className="p-1">
+          <div className="flex justify-between mb-2">
+            <Label className="-ml-1" type="default">
+              {getCurrentSeason()}
+            </Label>
+            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+              {`${secondsToString(secondsLeftInSeason(), { length: "short" })} left`}
+            </Label>
+          </div>
+          <p className="text-xs">
+            Earn Amber Fossils to craft limited edition collectibles & wearables
+            for your farm! Hurry before time runs out!
+          </p>
+        </div>
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
+        <div className="p-1">
+          <div className="flex justify-between mb-2">
+            <Label className="-ml-1" type="default">
+              How to earn Amber Fossils?
+            </Label>
+          </div>
+          <NoticeboardItems
+            iconWidth={8}
+            items={[
+              {
+                text: "Deliver resources to Bumpkins",
+                icon: SUNNYSIDE.icons.player,
+              },
+              {
+                text: "Complete Hank's chores",
+                icon: chores,
+              },
+              {
+                text: "Compete in the faction competition",
+                icon: factions,
+              },
+            ]}
+          />
+        </div>
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
+        <MegaStoreContent />
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
+        <div className="p-1">
+          <div className="flex justify-between mb-2">
+            <Label className="-ml-1" type="default">
+              Auctions
+            </Label>
+          </div>
+          <p className="text-xs">Compete with others for the rarest items!</p>
+          <AuctionSummary gameState={state} farmId={farmId} />
+        </div>
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
+        <div className="p-1">
+          <div className="flex justify-between mb-2">
+            <Label className="-ml-1" type="default">
+              Mutants
+            </Label>
+          </div>
+          <p className="text-xs">Discover the following seasonal rares:</p>
+        </div>
+      </InnerPanel>
+
+      <InnerPanel className="mb-1">
+        <TicketsLeaderboard id={id} isLoading={isLoading} data={data} />
+      </InnerPanel>
+    </>
+  );
+};

--- a/src/features/world/ui/kingdom/KingdomNoticeboard.tsx
+++ b/src/features/world/ui/kingdom/KingdomNoticeboard.tsx
@@ -10,13 +10,17 @@ import trophy from "assets/icons/trophy.png";
 import gift from "assets/icons/gift.png";
 interface NoticeboardItemProps {
   items: { text: string; icon: string }[];
+  iconWidth?: number;
 }
-export const NoticeboardItems: React.FC<NoticeboardItemProps> = ({ items }) => {
+export const NoticeboardItems: React.FC<NoticeboardItemProps> = ({
+  items,
+  iconWidth = 12,
+}) => {
   return (
     <>
       {items.map((item, index) => (
-        <div className="flex mb-2" key={index}>
-          <div className="w-12 flex justify-center">
+        <div className="flex mb-2 items-center" key={index}>
+          <div className={`w-${iconWidth} flex justify-center`}>
             <img src={item.icon} className="h-6 mr-2 object-contain" />
           </div>
           <p className="text-xs  flex-1">{item.text}</p>

--- a/src/features/world/ui/kingdom/KingdomNoticeboard.tsx
+++ b/src/features/world/ui/kingdom/KingdomNoticeboard.tsx
@@ -8,8 +8,10 @@ import shop from "assets/icons/shop.png";
 import factions from "assets/icons/factions.webp";
 import trophy from "assets/icons/trophy.png";
 import gift from "assets/icons/gift.png";
+import { BuffLabel } from "features/game/types";
+import { Label } from "components/ui/Label";
 interface NoticeboardItemProps {
-  items: { text: string; icon: string }[];
+  items: { text: string; icon: string; label?: BuffLabel }[];
   iconWidth?: number;
 }
 export const NoticeboardItems: React.FC<NoticeboardItemProps> = ({
@@ -23,7 +25,14 @@ export const NoticeboardItems: React.FC<NoticeboardItemProps> = ({
           <div className={`w-${iconWidth} flex justify-center`}>
             <img src={item.icon} className="h-6 mr-2 object-contain" />
           </div>
-          <p className="text-xs  flex-1">{item.text}</p>
+          <div>
+            <p className="text-xs  flex-1">{item.text}</p>
+            {item.label && (
+              <Label type={item.label.labelType}>
+                {item.label.shortDescription}
+              </Label>
+            )}
+          </div>
         </div>
       ))}
     </>

--- a/src/features/world/ui/megastore/MegaStore.tsx
+++ b/src/features/world/ui/megastore/MegaStore.tsx
@@ -22,6 +22,7 @@ import shopIcon from "assets/icons/shop.png";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getImageUrl } from "lib/utils/getImageURLS";
 import { ModalOverlay } from "components/ui/ModalOverlay";
+import classNames from "classnames";
 
 interface Props {
   onClose: () => void;
@@ -72,7 +73,9 @@ export const MegaStore: React.FC<Props> = ({ onClose }) => {
   );
 };
 
-export const MegaStoreContent: React.FC = () => {
+export const MegaStoreContent: React.FC<{ readonly?: boolean }> = ({
+  readonly,
+}) => {
   const { gameService } = useContext(Context);
   const megastore = useSelector(gameService, _megastore);
 
@@ -118,8 +121,14 @@ export const MegaStoreContent: React.FC = () => {
           })}
         </Label>
       </div>
-      <div className="flex flex-col p-2 pt-1 space-y-3 overflow-y-auto scrollable max-h-[300px]">
-        <span className="text-xs pb-2">{t("megaStore.message")}</span>
+      <div
+        className={classNames("flex flex-col p-2 pt-1 space-y-3 ", {
+          ["max-h-[300px] overflow-y-auto scrollable "]: !readonly,
+        })}
+      >
+        <span className="text-xs pb-2">
+          {readonly ? t("megaStore.visit") : t("megaStore.message")}
+        </span>
         {/* Wearables */}
         <ItemsList
           itemsLabel="Wearables"
@@ -147,6 +156,7 @@ export const MegaStoreContent: React.FC = () => {
           buff={getItemBuffLabel(selectedItem)}
           isWearable={selectedItem ? isWearablesItem(selectedItem) : false}
           onClose={() => setSelectedItem(null)}
+          readonly={readonly}
         />
       </ModalOverlay>
     </div>

--- a/src/features/world/ui/megastore/MegaStore.tsx
+++ b/src/features/world/ui/megastore/MegaStore.tsx
@@ -61,6 +61,18 @@ export const getItemBuffLabel = (
 const _megastore = (state: MachineState) => state.context.state.megastore;
 
 export const MegaStore: React.FC<Props> = ({ onClose }) => {
+  return (
+    <CloseButtonPanel
+      bumpkinParts={NPC_WEARABLES.stella}
+      tabs={[{ icon: shopIcon, name: "Mega Store" }]}
+      onClose={onClose}
+    >
+      <MegaStoreContent />
+    </CloseButtonPanel>
+  );
+};
+
+export const MegaStoreContent: React.FC = () => {
   const { gameService } = useContext(Context);
   const megastore = useSelector(gameService, _megastore);
 
@@ -92,57 +104,51 @@ export const MegaStore: React.FC<Props> = ({ onClose }) => {
 
   const { t } = useAppTranslation();
   return (
-    <CloseButtonPanel
-      bumpkinParts={NPC_WEARABLES.stella}
-      tabs={[{ icon: shopIcon, name: "Mega Store" }]}
-      onClose={onClose}
-    >
-      <div className="relative h-full w-full">
-        <div className="flex justify-between px-2 pb-2">
-          <Label type="vibrant" icon={lightning}>
-            {t("megaStore.month.sale")}
-          </Label>
-          <Label icon={SUNNYSIDE.icons.stopwatch} type="danger">
-            {t("megaStore.timeRemaining", {
-              timeRemaining: secondsToString(timeRemaining, {
-                length: "medium",
-                removeTrailingZeros: true,
-              }),
-            })}
-          </Label>
-        </div>
-        <div className="flex flex-col p-2 pt-1 space-y-3 overflow-y-auto scrollable max-h-[300px]">
-          <span className="text-xs pb-2">{t("megaStore.message")}</span>
-          {/* Wearables */}
-          <ItemsList
-            itemsLabel="Wearables"
-            type="wearables"
-            items={megastore.wearables}
-            onItemClick={handleClickItem}
-          />
-          {/* Collectibles */}
-          <ItemsList
-            itemsLabel="Collectibles"
-            type="collectibles"
-            items={megastore.collectibles}
-            onItemClick={handleClickItem}
-          />
-        </div>
-
-        <ModalOverlay
-          show={!!selectedItem}
-          onBackdropClick={() => setSelectedItem(null)}
-        >
-          <ItemDetail
-            isVisible={isVisible}
-            item={selectedItem}
-            image={getItemImage(selectedItem)}
-            buff={getItemBuffLabel(selectedItem)}
-            isWearable={selectedItem ? isWearablesItem(selectedItem) : false}
-            onClose={() => setSelectedItem(null)}
-          />
-        </ModalOverlay>
+    <div className="relative h-full w-full">
+      <div className="flex justify-between px-2 pb-2">
+        <Label type="vibrant" icon={lightning}>
+          {t("megaStore.month.sale")}
+        </Label>
+        <Label icon={SUNNYSIDE.icons.stopwatch} type="danger">
+          {t("megaStore.timeRemaining", {
+            timeRemaining: secondsToString(timeRemaining, {
+              length: "medium",
+              removeTrailingZeros: true,
+            }),
+          })}
+        </Label>
       </div>
-    </CloseButtonPanel>
+      <div className="flex flex-col p-2 pt-1 space-y-3 overflow-y-auto scrollable max-h-[300px]">
+        <span className="text-xs pb-2">{t("megaStore.message")}</span>
+        {/* Wearables */}
+        <ItemsList
+          itemsLabel="Wearables"
+          type="wearables"
+          items={megastore.wearables}
+          onItemClick={handleClickItem}
+        />
+        {/* Collectibles */}
+        <ItemsList
+          itemsLabel="Collectibles"
+          type="collectibles"
+          items={megastore.collectibles}
+          onItemClick={handleClickItem}
+        />
+      </div>
+
+      <ModalOverlay
+        show={!!selectedItem}
+        onBackdropClick={() => setSelectedItem(null)}
+      >
+        <ItemDetail
+          isVisible={isVisible}
+          item={selectedItem}
+          image={getItemImage(selectedItem)}
+          buff={getItemBuffLabel(selectedItem)}
+          isWearable={selectedItem ? isWearablesItem(selectedItem) : false}
+          onClose={() => setSelectedItem(null)}
+        />
+      </ModalOverlay>
+    </div>
   );
 };

--- a/src/features/world/ui/megastore/MegaStore.tsx
+++ b/src/features/world/ui/megastore/MegaStore.tsx
@@ -108,8 +108,8 @@ export const MegaStoreContent: React.FC<{ readonly?: boolean }> = ({
   const { t } = useAppTranslation();
   return (
     <div className="relative h-full w-full">
-      <div className="flex justify-between px-2 pb-2">
-        <Label type="vibrant" icon={lightning}>
+      <div className="flex justify-between px-2 flex-wrap pb-1">
+        <Label type="vibrant" icon={lightning} className="mb-1">
           {t("megaStore.month.sale")}
         </Label>
         <Label icon={SUNNYSIDE.icons.stopwatch} type="danger">

--- a/src/features/world/ui/megastore/components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/components/ItemDetail.tsx
@@ -30,6 +30,7 @@ interface ItemOverlayProps {
   buff?: BuffLabel;
   isVisible: boolean;
   onClose: () => void;
+  readonly?: boolean;
 }
 
 const _sflBalance = (state: MachineState) => state.context.state.balance;
@@ -43,6 +44,7 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
   isWearable,
   isVisible,
   onClose,
+  readonly,
 }) => {
   const { shortcutItem, gameService, showAnimations } = useContext(Context);
   const sflBalance = useSelector(gameService, _sflBalance);
@@ -268,27 +270,31 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
               </div>
             )}
           </div>
-          {!showSuccess && (
-            <div
-              className={classNames("flex", {
-                "space-x-1": confirmBuy,
-              })}
-            >
-              {confirmBuy && (
-                <Button onClick={() => setConfirmBuy(false)}>
-                  {t("cancel")}
-                </Button>
+          {!readonly && (
+            <>
+              {!showSuccess && (
+                <div
+                  className={classNames("flex", {
+                    "space-x-1": confirmBuy,
+                  })}
+                >
+                  {confirmBuy && (
+                    <Button onClick={() => setConfirmBuy(false)}>
+                      {t("cancel")}
+                    </Button>
+                  )}
+                  <Button disabled={!canBuy()} onClick={buttonHandler}>
+                    {getButtonLabel()}
+                  </Button>
+                </div>
               )}
-              <Button disabled={!canBuy()} onClick={buttonHandler}>
-                {getButtonLabel()}
-              </Button>
-            </div>
-          )}
-          {showSuccess && (
-            <div className="flex flex-col space-y-1">
-              <span className="p-2 text-xs">{getSuccessCopy()}</span>
-              <Button onClick={onClose}>{t("ok")}</Button>
-            </div>
+              {showSuccess && (
+                <div className="flex flex-col space-y-1">
+                  <span className="p-2 text-xs">{getSuccessCopy()}</span>
+                  <Button onClick={onClose}>{t("ok")}</Button>
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4292,6 +4292,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
   "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
   "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
+  "season.codex.intro": ENGLISH_TERMS["season.codex.intro"],
+  "season.codex.howToEarn": ENGLISH_TERMS["season.codex.howToEarn"],
+  "season.codex.howToEarn.one": ENGLISH_TERMS["season.codex.howToEarn.one"],
+  "season.codex.howToEarn.two": ENGLISH_TERMS["season.codex.howToEarn.two"],
+  "season.codex.howToEarn.three": ENGLISH_TERMS["season.codex.howToEarn.three"],
+  "season.codex.nextDrop": ENGLISH_TERMS["season.codex.nextDrop"],
+  "season.codex.seasonalDrops": ENGLISH_TERMS["season.codex.seasonalDrops"],
+  "season.codex.seasonalDrops.description":
+    ENGLISH_TERMS["season.codex.seasonalDrops.description"],
+  "season.codex.soldOut": ENGLISH_TERMS["season.codex.soldOut"],
+  "season.codex.mutants": ENGLISH_TERMS["season.codex.mutants"],
+  "season.codex.mutants.discover":
+    ENGLISH_TERMS["season.codex.mutants.discover"],
+  "season.codex.mutants.one": ENGLISH_TERMS["season.codex.mutants.one"],
+  "season.codex.mutants.two": ENGLISH_TERMS["season.codex.mutants.two"],
+  "season.codex.mutants.three": ENGLISH_TERMS["season.codex.mutants.three"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -3035,6 +3035,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": ENGLISH_TERMS["megaStore.visit"],
   "megaStore.message": ENGLISH_TERMS["megaStore.message"],
   "megaStore.month.sale": ENGLISH_TERMS["megaStore.month.sale"],
   "megaStore.wearable": ENGLISH_TERMS["megaStore.wearable"],

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4920,8 +4920,8 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.pharaohs.gift": "5 Extra Desert Digs",
   "season.ticket.bonus": "+2 {{item}}s (deliveries & chores)",
   "season.codex.intro":
-    "Earn {{tickets}}s to craft exclusive collectibles & wearables for your farm in this limited season...Hurry before time runs out!",
-  "season.codex.howToEarn": "How to earn {{tickets}}s?",
+    "Earn {{ticket}}s to craft exclusive collectibles & wearables for your farm in this limited season...Hurry before time runs out!",
+  "season.codex.howToEarn": "How to earn {{ticket}}s?",
   "season.codex.howToEarn.one":
     "Visit the plaza & deliver resources to Bumpkins.",
   "season.codex.howToEarn.two": "Complete Hank's chores.",
@@ -4937,7 +4937,6 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.codex.mutants.two": "Fish in the depths for the {{item}}.",
   "season.codex.mutants.three":
     "Experiment with flowers to discover the {{item}}.",
-  "season.codex.discoverMutants": "?",
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -3409,6 +3409,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": "Visit the Megastore in the plaza before time runs out!",
   "megaStore.message":
     "Welcome to the Mega Store! Check out this month's limited items. If you like something, be sure to grab it before it vanishes into the realms of time.",
   "megaStore.month.sale": "This month's sales",
@@ -4918,6 +4919,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.free.with.lifetime": "Free with Lifetime Farmer",
   "season.pharaohs.gift": "5 Extra Desert Digs",
   "season.ticket.bonus": "+2 {{item}}s (deliveries & chores)",
+  "season.codex.intro":
+    "Earn {{tickets}}s to craft exclusive collectibles & wearables for your farm in this limited season...Hurry before time runs out!",
+  "season.codex.howToEarn": "How to earn {{tickets}}s?",
+  "season.codex.howToEarn.one": "?",
+  "season.codex.howToEarn.two": "?",
+  "season.codex.howToEarn.three": "?",
+  "season.codex.nextDrop": "?",
+  "season.codex.seasonalDrops": "?",
+  "season.codex.seasonalDrops.description": "?",
+  "season.codex.soldOut": "?",
+  "season.codex.mutants": "?",
+  "season.codex.mutants.discover": "?",
+  "season.codex.mutants.one": "?",
+  "season.codex.mutants.two": "?",
+  "season.codex.mutants.three": "?",
+  "season.codex.discoverMutants": "?",
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -4922,18 +4922,21 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.codex.intro":
     "Earn {{tickets}}s to craft exclusive collectibles & wearables for your farm in this limited season...Hurry before time runs out!",
   "season.codex.howToEarn": "How to earn {{tickets}}s?",
-  "season.codex.howToEarn.one": "?",
-  "season.codex.howToEarn.two": "?",
-  "season.codex.howToEarn.three": "?",
-  "season.codex.nextDrop": "?",
-  "season.codex.seasonalDrops": "?",
-  "season.codex.seasonalDrops.description": "?",
-  "season.codex.soldOut": "?",
-  "season.codex.mutants": "?",
-  "season.codex.mutants.discover": "?",
-  "season.codex.mutants.one": "?",
-  "season.codex.mutants.two": "?",
-  "season.codex.mutants.three": "?",
+  "season.codex.howToEarn.one":
+    "Visit the plaza & deliver resources to Bumpkins.",
+  "season.codex.howToEarn.two": "Complete Hank's chores.",
+  "season.codex.howToEarn.three": "Compete in the faction competition.",
+  "season.codex.nextDrop": "Next Drop",
+  "season.codex.seasonalDrops": "Seasonal Drops",
+  "season.codex.seasonalDrops.description":
+    "Compete with others for the rarest items! Visit the Auctioneer in the plaza for more details.",
+  "season.codex.soldOut": "Sold out",
+  "season.codex.mutants": "Mutants",
+  "season.codex.mutants.discover": "Discover the seasonal mutants!",
+  "season.codex.mutants.one": "Collect eggs to discover the {{item}}.",
+  "season.codex.mutants.two": "Fish in the depths for the {{item}}.",
+  "season.codex.mutants.three":
+    "Experiment with flowers to discover the {{item}}.",
   "season.codex.discoverMutants": "?",
 };
 

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -3558,6 +3558,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": ENGLISH_TERMS["megaStore.visit"],
   "megaStore.message":
     "Bienvenue dans le Mega Store ! Découvrez les articles limités du mois. Si vous aimez quelque chose, assurez-vous de le prendre avant qu'il ne disparaisse dans les méandres du temps.",
   "megaStore.month.sale": "Les soldes du mois en cours",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -4988,6 +4988,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
   "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
   "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
+  "season.codex.intro": ENGLISH_TERMS["season.codex.intro"],
+  "season.codex.howToEarn": ENGLISH_TERMS["season.codex.howToEarn"],
+  "season.codex.howToEarn.one": ENGLISH_TERMS["season.codex.howToEarn.one"],
+  "season.codex.howToEarn.two": ENGLISH_TERMS["season.codex.howToEarn.two"],
+  "season.codex.howToEarn.three": ENGLISH_TERMS["season.codex.howToEarn.three"],
+  "season.codex.nextDrop": ENGLISH_TERMS["season.codex.nextDrop"],
+  "season.codex.seasonalDrops": ENGLISH_TERMS["season.codex.seasonalDrops"],
+  "season.codex.seasonalDrops.description":
+    ENGLISH_TERMS["season.codex.seasonalDrops.description"],
+  "season.codex.soldOut": ENGLISH_TERMS["season.codex.soldOut"],
+  "season.codex.mutants": ENGLISH_TERMS["season.codex.mutants"],
+  "season.codex.mutants.discover":
+    ENGLISH_TERMS["season.codex.mutants.discover"],
+  "season.codex.mutants.one": ENGLISH_TERMS["season.codex.mutants.one"],
+  "season.codex.mutants.two": ENGLISH_TERMS["season.codex.mutants.two"],
+  "season.codex.mutants.three": ENGLISH_TERMS["season.codex.mutants.three"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -4839,6 +4839,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
   "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
   "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
+  "season.codex.intro": ENGLISH_TERMS["season.codex.intro"],
+  "season.codex.howToEarn": ENGLISH_TERMS["season.codex.howToEarn"],
+  "season.codex.howToEarn.one": ENGLISH_TERMS["season.codex.howToEarn.one"],
+  "season.codex.howToEarn.two": ENGLISH_TERMS["season.codex.howToEarn.two"],
+  "season.codex.howToEarn.three": ENGLISH_TERMS["season.codex.howToEarn.three"],
+  "season.codex.nextDrop": ENGLISH_TERMS["season.codex.nextDrop"],
+  "season.codex.seasonalDrops": ENGLISH_TERMS["season.codex.seasonalDrops"],
+  "season.codex.seasonalDrops.description":
+    ENGLISH_TERMS["season.codex.seasonalDrops.description"],
+  "season.codex.soldOut": ENGLISH_TERMS["season.codex.soldOut"],
+  "season.codex.mutants": ENGLISH_TERMS["season.codex.mutants"],
+  "season.codex.mutants.discover":
+    ENGLISH_TERMS["season.codex.mutants.discover"],
+  "season.codex.mutants.one": ENGLISH_TERMS["season.codex.mutants.one"],
+  "season.codex.mutants.two": ENGLISH_TERMS["season.codex.mutants.two"],
+  "season.codex.mutants.three": ENGLISH_TERMS["season.codex.mutants.three"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -3461,6 +3461,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": ENGLISH_TERMS["megaStore.visit"],
   "megaStore.message":
     "Bem-vindo à Mega Loja! Confira os itens limitados deste mês. Se você gostar de algo, certifique-se de pegá-lo antes que desapareça nos reinos do tempo.",
   "megaStore.month.sale": "Vendas deste mês",

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -4880,6 +4880,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.free.with.lifetime": "Free with Lifetime Farmer",
   "season.pharaohs.gift": "5 Extra Desert Digs",
   "season.ticket.bonus": "+2 {{item}}s (deliveries & chores)",
+  "season.codex.intro": ENGLISH_TERMS["season.codex.intro"],
+  "season.codex.howToEarn": ENGLISH_TERMS["season.codex.howToEarn"],
+  "season.codex.howToEarn.one": ENGLISH_TERMS["season.codex.howToEarn.one"],
+  "season.codex.howToEarn.two": ENGLISH_TERMS["season.codex.howToEarn.two"],
+  "season.codex.howToEarn.three": ENGLISH_TERMS["season.codex.howToEarn.three"],
+  "season.codex.nextDrop": ENGLISH_TERMS["season.codex.nextDrop"],
+  "season.codex.seasonalDrops": ENGLISH_TERMS["season.codex.seasonalDrops"],
+  "season.codex.seasonalDrops.description":
+    ENGLISH_TERMS["season.codex.seasonalDrops.description"],
+  "season.codex.soldOut": ENGLISH_TERMS["season.codex.soldOut"],
+  "season.codex.mutants": ENGLISH_TERMS["season.codex.mutants"],
+  "season.codex.mutants.discover":
+    ENGLISH_TERMS["season.codex.mutants.discover"],
+  "season.codex.mutants.one": ENGLISH_TERMS["season.codex.mutants.one"],
+  "season.codex.mutants.two": ENGLISH_TERMS["season.codex.mutants.two"],
+  "season.codex.mutants.three": ENGLISH_TERMS["season.codex.mutants.three"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -3419,6 +3419,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": ENGLISH_TERMS["megaStore.visit"],
   "megaStore.message":
     "Добро пожаловать в Мегамагазин! Ознакомься с лимитированными товарами этого месяца. Если тебе что-то понравится, успей купить это, пока оно не исчезло в царстве времени.",
   "megaStore.month.sale": "Распродажи этого месяца",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -3428,6 +3428,7 @@ const lostSunflorian: Record<LostSunflorian, string> = {
 };
 
 const megaStore: Record<MegaStore, string> = {
+  "megaStore.visit": ENGLISH_TERMS["megaStore.visit"],
   "megaStore.message":
     "Mega Mağaza'ya hoş geldiniz! Bu ayın sınırlı ürünlerine göz atın. Bir şeyden hoşlanırsanız, zamanın derinliklerinde kaybolmadan önce onu yakaladığınızdan emin olun.",
   "megaStore.month.sale": "Bu ayın satışları",

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -4843,6 +4843,22 @@ const seasonTerms: Record<SeasonTerms, string> = {
   "season.vip.claim": ENGLISH_TERMS["season.vip.claim"],
   "season.pharaohs.gift": ENGLISH_TERMS["season.pharaohs.gift"],
   "season.ticket.bonus": ENGLISH_TERMS["season.ticket.bonus"],
+  "season.codex.intro": ENGLISH_TERMS["season.codex.intro"],
+  "season.codex.howToEarn": ENGLISH_TERMS["season.codex.howToEarn"],
+  "season.codex.howToEarn.one": ENGLISH_TERMS["season.codex.howToEarn.one"],
+  "season.codex.howToEarn.two": ENGLISH_TERMS["season.codex.howToEarn.two"],
+  "season.codex.howToEarn.three": ENGLISH_TERMS["season.codex.howToEarn.three"],
+  "season.codex.nextDrop": ENGLISH_TERMS["season.codex.nextDrop"],
+  "season.codex.seasonalDrops": ENGLISH_TERMS["season.codex.seasonalDrops"],
+  "season.codex.seasonalDrops.description":
+    ENGLISH_TERMS["season.codex.seasonalDrops.description"],
+  "season.codex.soldOut": ENGLISH_TERMS["season.codex.soldOut"],
+  "season.codex.mutants": ENGLISH_TERMS["season.codex.mutants"],
+  "season.codex.mutants.discover":
+    ENGLISH_TERMS["season.codex.mutants.discover"],
+  "season.codex.mutants.one": ENGLISH_TERMS["season.codex.mutants.one"],
+  "season.codex.mutants.two": ENGLISH_TERMS["season.codex.mutants.two"],
+  "season.codex.mutants.three": ENGLISH_TERMS["season.codex.mutants.three"],
 };
 
 const share: Record<Share, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3295,8 +3295,7 @@ export type SeasonTerms =
   | "season.codex.mutants.discover"
   | "season.codex.mutants.one"
   | "season.codex.mutants.two"
-  | "season.codex.mutants.three"
-  | "season.codex.discoverMutants";
+  | "season.codex.mutants.three";
 
 export type Share =
   | "share.TweetText"

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -2412,6 +2412,7 @@ export type LostSunflorian =
 
 export type MegaStore =
   | "megaStore.message"
+  | "megaStore.visit"
   | "megaStore.month.sale"
   | "megaStore.wearable"
   | "megaStore.collectible"
@@ -3280,7 +3281,22 @@ export type SeasonTerms =
   | "season.xp.boost"
   | "season.free.season.passes.description"
   | "season.lifetime.farmer"
-  | "season.free.with.lifetime";
+  | "season.free.with.lifetime"
+  | "season.codex.intro"
+  | "season.codex.howToEarn"
+  | "season.codex.howToEarn.one"
+  | "season.codex.howToEarn.two"
+  | "season.codex.howToEarn.three"
+  | "season.codex.nextDrop"
+  | "season.codex.seasonalDrops"
+  | "season.codex.seasonalDrops.description"
+  | "season.codex.soldOut"
+  | "season.codex.mutants"
+  | "season.codex.mutants.discover"
+  | "season.codex.mutants.one"
+  | "season.codex.mutants.two"
+  | "season.codex.mutants.three"
+  | "season.codex.discoverMutants";
 
 export type Share =
   | "share.TweetText"


### PR DESCRIPTION
# Description

Adds more information + docs into the game around the seasonal content. Includes:

- Countdown
- How to earn Tickets
- Megastore Items
- Auction Overview
- Seasonal Mutants
- Leaderboards

## How to test?

1. Point API to testnet
2. Open the codex

<img width="782" alt="Screenshot 2024-08-14 at 1 05 14 PM" src="https://github.com/user-attachments/assets/723e38d0-75e4-43cb-9444-c9546e4c7e3c">
<img width="818" alt="Screenshot 2024-08-14 at 1 05 38 PM" src="https://github.com/user-attachments/assets/9e5b2afb-59d6-43ec-8b34-557ffeeb5fb7">
<img width="796" alt="Screenshot 2024-08-14 at 1 05 34 PM" src="https://github.com/user-attachments/assets/dbacab99-7ca4-4ff1-a6be-60e3d06e0559">
<img width="821" alt="Screenshot 2024-08-14 at 1 05 25 PM" src="https://github.com/user-attachments/assets/0e1c9e41-b39e-42ff-8f0c-872dbd2886a8">
<img width="814" alt="Screenshot 2024-08-14 at 1 05 20 PM" src="https://github.com/user-attachments/assets/bc1225d8-0f21-4610-a242-901316dfa866">
