### PR TITLE
[FIX] Label Styling for Deliveries on Widescreen

### DIFF
--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -50,6 +50,7 @@ import { useNavigate } from "react-router-dom";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { formatNumber } from "lib/utils/formatNumber";
+import { isMobile } from "mobile-device-detect";
 
 // Bumpkins
 export const BEACH_BUMPKINS: NPCName[] = [
@@ -744,19 +745,21 @@ export const DeliveryOrders: React.FC<Props> = ({
                   />
                   <span className="text-xs ml-1">{t("reward")}</span>
                 </div>
-                <Label type="warning">
-                  <span>{`${
-                    generateDeliveryTickets({
-                      game: gameState,
-                      npc: previewOrder.from,
-                    }) || makeRewardAmountForLabel(previewOrder)
-                  } ${
-                    previewOrder.reward.coins
-                      ? t("coins")
-                      : previewOrder.reward.sfl
-                        ? "SFL"
-                        : `${getSeasonalTicket()}s`
-                  }`}</span>
+                <Label type="warning" className="whitespace-nowrap">
+                  <span className={!isMobile ? "text-xxs" : ""}>
+                    {`${
+                      generateDeliveryTickets({
+                        game: gameState,
+                        npc: previewOrder.from,
+                      }) || makeRewardAmountForLabel(previewOrder)
+                    } ${
+                      previewOrder.reward.coins
+                        ? t("coins")
+                        : previewOrder.reward.sfl
+                          ? "SFL"
+                          : `${getSeasonalTicket()}s`
+                    }`}
+                  </span>
                 </Label>
               </div>
               {!previewOrder.completedAt &&


### PR DESCRIPTION
# Description

Adjusted the styling for delivery labels on widescreen devices
- Forced text to be text-xxs
- added whitespace-nowrap

Mobile Styling remains unchanged

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/35206737-cce2-47d4-a4ae-ced272848c20)|![image](https://github.com/user-attachments/assets/037cecef-a133-4053-b010-e1455363f4c7)|

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
