### PR TITLE
[FEAT] Show availability Date of Seasonal Artefact on Treasure Shop Sell

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -316,7 +316,7 @@ export const CraftingRequirements: React.FC<Props> = ({
           <Label
             icon={SUNNYSIDE.icons.stopwatch}
             type="warning"
-            className="my-1 mx-auto"
+            className="my-1 mx-auto whitespace-nowrap"
           >
             {formatDateRange(details.from, details.to as Date)}
           </Label>

--- a/src/components/ui/layouts/ShopSellDetails.tsx
+++ b/src/components/ui/layouts/ShopSellDetails.tsx
@@ -5,6 +5,9 @@ import { RequirementLabel } from "../RequirementsLabel";
 import { SquareIcon } from "../SquareIcon";
 import Decimal from "decimal.js-light";
 import { translateTerms } from "lib/i18n/translate";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { formatDateRange } from "lib/utils/time";
+import { Label } from "../Label";
 
 /**
  * The props for the details for items.
@@ -12,6 +15,8 @@ import { translateTerms } from "lib/i18n/translate";
  */
 interface ItemDetailsProps {
   item: InventoryItemName;
+  from?: Date;
+  to?: Date;
 }
 
 /**
@@ -89,6 +94,15 @@ export const ShopSellDetails: React.FC<Props> = ({
   return (
     <div className="flex flex-col h-full justify-center">
       <div className="flex flex-col h-full px-1 py-0">
+        {details.from && (
+          <Label
+            icon={SUNNYSIDE.icons.stopwatch}
+            type="warning"
+            className="my-1 mx-auto whitespace-nowrap"
+          >
+            {formatDateRange(details.from, details.to as Date)}
+          </Label>
+        )}
         {getItemDetail()}
         {getProperties()}
       </div>

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -6,7 +6,7 @@ import catchTheKrakenBanner from "assets/decorations/banners/catch_the_kraken_ba
 import springBlossomBanner from "assets/decorations/banners/spring_banner.gif";
 import clashOfFactionsBanner from "assets/decorations/banners/clash_of_factions_banner.webp";
 import pharaohsTreasureBanner from "assets/decorations/banners/pharaohs_treasure_banner.webp";
-import { InventoryItemName } from "./game";
+import { BeachBountySeasonalArtefact } from "./treasure";
 
 export type SeasonName =
   | "Solar Flare"
@@ -90,7 +90,10 @@ export const SEASON_TICKET_NAME: Record<SeasonName, SeasonalTicket> = {
   "Pharaoh's Treasure": "Amber Fossil",
 };
 
-export const SEASON_ARTEFACT_NAME: Record<SeasonName, InventoryItemName> = {
+export const SEASON_ARTEFACT_NAME: Record<
+  SeasonName,
+  BeachBountySeasonalArtefact
+> = {
   "Solar Flare": "Scarab",
   "Dawn Breaker": "Scarab",
   "Witches' Eve": "Scarab",

--- a/src/features/game/types/treasure.ts
+++ b/src/features/game/types/treasure.ts
@@ -1,3 +1,5 @@
+import { SEASONS } from "./seasons";
+
 export type BeachBountyTreasure =
   | "Pirate Bounty"
   | "Pearl"
@@ -72,6 +74,8 @@ export interface Treasure {
 
 export type SellableTreasure = {
   sellPrice: number;
+  from?: Date;
+  to?: Date;
 };
 
 export const SEASONAL_ARTEFACT: Record<
@@ -80,6 +84,8 @@ export const SEASONAL_ARTEFACT: Record<
 > = {
   Scarab: {
     sellPrice: 200,
+    from: SEASONS["Pharaoh's Treasure"].startDate,
+    to: SEASONS["Pharaoh's Treasure"].endDate,
   },
 };
 

--- a/src/features/world/ui/beach/treasure_shop/TreasureShopSell.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopSell.tsx
@@ -65,6 +65,8 @@ export const TreasureShopSell: React.FC = () => {
           <ShopSellDetails
             details={{
               item: selectedName,
+              from: selected.from,
+              to: selected.to,
             }}
             properties={{
               coins: price,

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -824,7 +824,7 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
   "description.laurie.chuckle.crow.boost": "+0.2 Advanced Crops",
   "description.bale.boost": "+0.2 Eggs",
   "description.immortal.pear.boost": "+1 Fruit Harvest per seed",
-  "description.treasure.map.boost": "+20% Coins on Treasure Bounty Sales",
+  "description.treasure.map.boost": "+20% Coins Treasure Bounty Sale Price",
   "description.poppy.boost": "+0.1 Corn",
   "description.kernaldo.boost": "-25% Corn Growth Time",
   "description.grain.grinder.boost": "+20% Cake XP",
@@ -944,7 +944,7 @@ const boostEffectDescriptions: Record<BoostEffectDescriptions, string> = {
   "description.tomato.clown.boost": "-50% Tomato Growth Time",
   "description.cannonball.boost": "-25% Tomato Growth Time",
   "description.tomato.bombard.boost": "+1 Tomato",
-  "description.camel.boost": "+1 Sand and +30% Artefact Shop Bounty Sell Price",
+  "description.camel.boost": "+1 Sand and +30% Treasure Bounty Sale Price",
   "description.reveling.lemon.boost": "+0.25 Lemon",
   "description.lemon.frog.boost": "-25% Lemon Growth Time",
 };
@@ -5672,7 +5672,7 @@ export const desertTerms: Record<DesertKeys, string> = {
   "desert.notice.one":
     "Welcome to the Desert. Can you solve the Pharaoh's puzzle and find the hidden treasures?",
   "desert.notice.two":
-    "Discover {{ticket}}s & exchange them for rewards before time runs out.",
+    "Discover {{ticket}}s & exchange them for rewards before it goes away!",
   "desert.notice.three": "Use hieroglyphs to upgrade your digging.",
   "desert.notice.four": "Sell resources at the shop for coins.",
   "desert.notice.five":

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -5729,8 +5729,7 @@ export const desertTerms: Record<DesertKeys, string> = {
     "Each day a desert storm resets the puzzle with new patterns and resources.",
   "desert.notice.one":
     "Welcome to the Desert. Can you solve the Pharaoh's puzzle and find the hidden treasures?",
-  "desert.notice.two":
-    "Discover {{ticket}}s & exchange them for rewards before time runs out.",
+  "desert.notice.two": ENGLISH_TERMS["desert.notice.two"],
   "desert.notice.three": "Use hieroglyphs to upgrade your digging.",
   "desert.notice.four": "Sell resources at the shop for coins.",
   "desert.notice.five":


### PR DESCRIPTION
# Description

Show the availbility date of Seasonal Artefacts in Treasure Shop Sell

Additional Changes:
- Improve styles of availability labels
- Use `BeachBountySeasonalArtefact` type instead of InventoryItemName in SEASON_ARTEFACT_NAME
- Edit Camel and Treasure Map description to be more uniformed
- Edit Noticeboard for season artefact

![image](https://github.com/user-attachments/assets/39a2c63a-46a0-4102-b6bd-1b80ae98234e)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
