### PR TITLE
[FEAT] Add raft coordinates for expansions past max expansions

### DIFF
--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -234,11 +234,54 @@ export const IslandUpgrader: React.FC<Props> = ({ gameState, offset }) => {
     (gameState.inventory["Basic Land"]?.toNumber() ?? 3) + 1;
 
   const getPosition = () => {
-    if (island === "basic" && nextExpansion === 10) {
-      return { x: 1, y: -5 };
+    if (island === "basic") {
+      switch (nextExpansion) {
+        case 10:
+          return { x: 1, y: -5 };
+        case 11:
+          return { x: 0, y: 2 };
+        case 12:
+          return { x: 0, y: 8 };
+        case 13:
+          return { x: -1, y: 14 };
+        case 14:
+          return { x: -7, y: 14 };
+        case 15:
+          return { x: -14, y: 14 };
+        case 16:
+          return { x: -20, y: 14 };
+        case 17:
+          return { x: -26, y: 14 };
+        case 18:
+          return { x: -27, y: 8 };
+        case 19:
+          return { x: -27, y: 2 };
+        case 20:
+          return { x: -28, y: -4 };
+        case 21:
+          return { x: -28, y: -10 };
+        case 22:
+          return { x: -22, y: -10 };
+        case 23:
+          return { x: -17, y: -10 };
+        case 24:
+          return { x: -11, y: -10 };
+      }
     }
-    if (island === "spring" && nextExpansion === 17) {
-      return { x: -26, y: 14 };
+
+    if (island === "spring") {
+      switch (nextExpansion) {
+        case 17:
+          return { x: -26, y: 14 };
+        case 18:
+          return { x: -27, y: 8 };
+        case 19:
+          return { x: -27, y: 2 };
+        case 20:
+          return { x: -28, y: -4 };
+        case 21:
+          return { x: -28, y: -10 };
+      }
     }
 
     return { x: 7, y: 0 };


### PR DESCRIPTION
# Description

This PR adds coordinates for the upgrade raft for expansions past the current max expansions.


The aim here is for returning players who reached the later expansions from earlier iterations of the game but have no idea how to continue to progress. Having the rafts at the next expansions slot will make it clear that they need to upgrade to continue.

Currently returning players have to click on the raft at the right to upgrade to next island, which isn't really that obvious to the average player

example:
![image](https://github.com/user-attachments/assets/05f00a63-4026-4d24-89dd-d55ef52a1da0)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Change island type to basic and the edit the number of basic lands to check the location of the raft at the space after each land

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
