### PR TITLE
[FIX] Split attempt and score events for portals

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -342,6 +342,14 @@ import {
   completeDailyChallenge,
   CompleteDailyChallengeAction,
 } from "./landExpansion/completeDailyChallenge";
+import {
+  startMinigameAttempt,
+  StartMinigameAttemptAction,
+} from "./minigames/startMinigameAttempt";
+import {
+  submitMinigameScore,
+  SubmitMinigameScoreAction,
+} from "./minigames/submitMinigameScore";
 
 export type PlayingEvent =
   | CompleteDailyChallengeAction
@@ -430,6 +438,8 @@ export type PlayingEvent =
   | DrillOilReserveAction
   | ClaimMinigamePrizeAction
   | PurchaseMinigameAction
+  | StartMinigameAttemptAction
+  | SubmitMinigameScoreAction
   | PlayMinigameAction
   | SupplyCropMachineAction
   | HarvestCropMachineAction
@@ -517,6 +527,8 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "greenhouse.planted": plantGreenhouse,
   "minigame.itemPurchased": purchaseMinigameItem,
   "minigame.prizeClaimed": claimMinigamePrize,
+  "minigame.attemptStarted": startMinigameAttempt,
+  "minigame.scoreSubmitted": submitMinigameScore,
   "minigame.played": playMinigame,
   "airdrop.claimed": claimAirdrop,
   "bot.detected": detectBot,

--- a/src/features/game/events/minigames/startMinigameAttempt.test.ts
+++ b/src/features/game/events/minigames/startMinigameAttempt.test.ts
@@ -1,0 +1,82 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { startMinigameAttempt } from "./startMinigameAttempt";
+
+describe("minigame.attemptStarted", () => {
+  it("requires minigame exists", () => {
+    expect(() =>
+      startMinigameAttempt({
+        state: TEST_FARM,
+        action: {
+          id: "not-a-game" as any,
+          type: "minigame.attemptStarted",
+        },
+      }),
+    ).toThrow("not-a-game is not a valid minigame");
+  });
+
+  it("updates the first attempt", () => {
+    const date = new Date("2024-05-04T00:00:00Z");
+    const state = startMinigameAttempt({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {},
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        type: "minigame.attemptStarted",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 0,
+      history: {
+        [date.toISOString().substring(0, 10)]: {
+          highscore: 0,
+          attempts: 1,
+        },
+      },
+    });
+  });
+
+  it("updates more attempts", () => {
+    const date = new Date("2024-05-04T00:00:00Z");
+    const state = startMinigameAttempt({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {
+                [date.toISOString().substring(0, 10)]: {
+                  highscore: 10,
+                  attempts: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        type: "minigame.attemptStarted",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {
+        [date.toISOString().substring(0, 10)]: {
+          highscore: 10,
+          attempts: 3,
+        },
+      },
+    });
+  });
+});

--- a/src/features/game/events/minigames/startMinigameAttempt.ts
+++ b/src/features/game/events/minigames/startMinigameAttempt.ts
@@ -6,27 +6,18 @@ import {
 
 import cloneDeep from "lodash.clonedeep";
 
-/**
- * @deprecated This function is obsolete and should not be used.
- * Use `StartMinigameAttemptAction` and `SubmitMinigameScoreAction` instead.
- */
-export type PlayMinigameAction = {
-  type: "minigame.played";
+export type StartMinigameAttemptAction = {
+  type: "minigame.attemptStarted";
   id: MinigameName;
-  score: number;
 };
 
 type Options = {
   state: Readonly<GameState>;
-  action: PlayMinigameAction;
+  action: StartMinigameAttemptAction;
   createdAt?: number;
 };
 
-/**
- * @deprecated This function is obsolete and should not be used.
- * Use `startMinigameAttempt` and `recordMinigameScore` instead.
- */
-export function playMinigame({
+export function startMinigameAttempt({
   state,
   action,
   createdAt = Date.now(),
@@ -58,10 +49,8 @@ export function playMinigame({
       [todayKey]: {
         ...daily,
         attempts: daily.attempts + 1,
-        highscore: Math.max(daily.highscore, action.score),
       },
     },
-    highscore: Math.max(daily.highscore, action.score),
   };
 
   return game;

--- a/src/features/game/events/minigames/submitMinigameScore.test.ts
+++ b/src/features/game/events/minigames/submitMinigameScore.test.ts
@@ -1,0 +1,124 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { submitMinigameScore } from "./submitMinigameScore";
+
+describe("minigame.scoreSubmitted", () => {
+  it("requires minigame exists", () => {
+    expect(() =>
+      submitMinigameScore({
+        state: TEST_FARM,
+        action: {
+          id: "not-a-game" as any,
+          score: 10,
+          type: "minigame.scoreSubmitted",
+        },
+      }),
+    ).toThrow("not-a-game is not a valid minigame");
+  });
+
+  it("updates the first score", () => {
+    const date = new Date("2024-05-04T00:00:00Z");
+    const state = submitMinigameScore({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {},
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        score: 10,
+        type: "minigame.scoreSubmitted",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {
+        [date.toISOString().substring(0, 10)]: {
+          highscore: 10,
+          attempts: 0,
+        },
+      },
+    });
+  });
+
+  it("updates a highscore", () => {
+    const date = new Date("2024-05-04T00:00:00Z");
+    const state = submitMinigameScore({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {
+                [date.toISOString().substring(0, 10)]: {
+                  highscore: 10,
+                  attempts: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        score: 15,
+        type: "minigame.scoreSubmitted",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 15,
+      history: {
+        [date.toISOString().substring(0, 10)]: {
+          highscore: 15,
+          attempts: 2,
+        },
+      },
+    });
+  });
+
+  it("does not update a highscore", () => {
+    const date = new Date("2024-05-04T00:00:00Z");
+    const state = submitMinigameScore({
+      state: {
+        ...TEST_FARM,
+        minigames: {
+          prizes: {},
+          games: {
+            "chicken-rescue": {
+              highscore: 10,
+              history: {
+                [date.toISOString().substring(0, 10)]: {
+                  highscore: 10,
+                  attempts: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        score: 5,
+        type: "minigame.scoreSubmitted",
+      },
+      createdAt: date.getTime(),
+    });
+
+    expect(state.minigames.games["chicken-rescue"]).toEqual({
+      highscore: 10,
+      history: {
+        [date.toISOString().substring(0, 10)]: {
+          highscore: 10,
+          attempts: 2,
+        },
+      },
+    });
+  });
+});

--- a/src/features/game/events/minigames/submitMinigameScore.ts
+++ b/src/features/game/events/minigames/submitMinigameScore.ts
@@ -6,27 +6,19 @@ import {
 
 import cloneDeep from "lodash.clonedeep";
 
-/**
- * @deprecated This function is obsolete and should not be used.
- * Use `StartMinigameAttemptAction` and `SubmitMinigameScoreAction` instead.
- */
-export type PlayMinigameAction = {
-  type: "minigame.played";
+export type SubmitMinigameScoreAction = {
+  type: "minigame.scoreSubmitted";
   id: MinigameName;
   score: number;
 };
 
 type Options = {
   state: Readonly<GameState>;
-  action: PlayMinigameAction;
+  action: SubmitMinigameScoreAction;
   createdAt?: number;
 };
 
-/**
- * @deprecated This function is obsolete and should not be used.
- * Use `startMinigameAttempt` and `recordMinigameScore` instead.
- */
-export function playMinigame({
+export function submitMinigameScore({
   state,
   action,
   createdAt = Date.now(),
@@ -57,7 +49,6 @@ export function playMinigame({
       ...minigame.history,
       [todayKey]: {
         ...daily,
-        attempts: daily.attempts + 1,
         highscore: Math.max(daily.highscore, action.score),
       },
     },

--- a/src/features/portal/lib/portalUtil.ts
+++ b/src/features/portal/lib/portalUtil.ts
@@ -15,7 +15,7 @@ export function claimPrize() {
 }
 
 /**
- * Exit the portal
+ * Exits the portal
  */
 export function goHome() {
   if (isInIframe) {
@@ -72,11 +72,34 @@ export function donate({ matic, address }: { matic: number; address: string }) {
 }
 
 /**
+ * Starts a minigame attempt
+ */
+export function startAttempt() {
+  if (!isInIframe) {
+    alert(`Sunflower Land running in test mode - attempt started`);
+  } else {
+    window.parent.postMessage({ event: "attemptStarted" }, "*");
+  }
+}
+
+/**
+ * Submits a minigame score
+ */
+export function submitScore({ score }: { score: number }) {
+  if (!isInIframe) {
+    alert(`Sunflower Land running in test mode - score submitted`);
+  } else {
+    window.parent.postMessage({ event: "scoreSubmitted", score }, "*");
+  }
+}
+
+/**
+ * @deprecated Use `attemptStarted` and `scoreSubmitted` instead
  * When to want to store the score
  */
 export function played({ score }: { score: number }) {
   if (!isInIframe) {
-    alert(`Sunflower Land running in test mode - score submitted`);
+    alert(`Sunflower Land running in test mode - played`);
   } else {
     window.parent.postMessage({ event: "played", score }, "*");
   }

--- a/src/features/portal/portal.md
+++ b/src/features/portal/portal.md
@@ -20,9 +20,13 @@ https://docs.sunflower-land.com/contributing/portals/portal-apis
 
 Call `purchase` in `./lib/portalUtil.ts` to spend a players SFL or items.
 
-## Store score
+## Start attempt
 
-Call `played` in `./lib/portalUtil.ts` to record a players progress, attempts and score.
+Call `startAttempt` in `./lib/portalUtil.ts` to start an attempt of a play.
+
+## Submit score
+
+Call `submitScore` in `./lib/portalUtil.ts` to submit the player score.
 
 ## Claim Prize
 

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -111,6 +111,25 @@ export const Portal: React.FC<Props> = ({ portalName, onClose }) => {
       return;
     }
 
+    if (event.data.event === "attemptStarted") {
+      // Start the minigame attempt
+      gameService.send("minigame.attemptStarted", {
+        id: portalName,
+      });
+      gameService.send("SAVE");
+      return;
+    }
+
+    if (event.data.event === "scoreSubmitted") {
+      // Submit the minigame score
+      gameService.send("minigame.scoreSubmitted", {
+        score: event.data.score,
+        id: portalName,
+      });
+      gameService.send("SAVE");
+      return;
+    }
+
     if (event.data.event === "played") {
       // Purchase the item
       gameService.send("minigame.played", {


### PR DESCRIPTION
# Description

- split up attempt and score events for portals
   - `minigame.attemptStarted` and `minigame.scoreSubmitted` events need to be added to the backend, or else autosave API call will fail with 500 error
- deprecate the played function for portals

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- use these new methods from a portal

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
