### PR TITLE
[FIX] Trading screen styles and crash

### DIFF
--- a/src/components/ui/ListingCategoryCard.tsx
+++ b/src/components/ui/ListingCategoryCard.tsx
@@ -12,6 +12,7 @@ import decrease_arrow from "assets/icons/decrease_arrow.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SquareIcon } from "./SquareIcon";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { useSound } from "lib/utils/hooks/useSound";
 
 interface Props {
   itemName: InventoryItemName;
@@ -36,6 +37,13 @@ export const ListingCategoryCard: React.FC<Props> = ({
 }) => {
   const { t } = useAppTranslation();
 
+  const button = useSound("button");
+
+  const onClickWithSound = () => {
+    button.play();
+    onClick?.();
+  };
+
   return (
     <OuterPanel
       className={classNames(
@@ -55,7 +63,7 @@ export const ListingCategoryCard: React.FC<Props> = ({
         borderRadius: `${PIXEL_SCALE * 5}px`,
         color: "#674544",
       }}
-      onClick={onClick}
+      onClick={onClickWithSound}
     >
       {inventoryAmount && (
         <Label

--- a/src/components/ui/ListingCategoryCard.tsx
+++ b/src/components/ui/ListingCategoryCard.tsx
@@ -11,6 +11,7 @@ import increase_arrow from "assets/icons/increase_arrow.png";
 import decrease_arrow from "assets/icons/decrease_arrow.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SquareIcon } from "./SquareIcon";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 interface Props {
   itemName: InventoryItemName;
@@ -40,10 +41,20 @@ export const ListingCategoryCard: React.FC<Props> = ({
       className={classNames(
         "w-full relative flex flex-col items-center justify-center",
         {
-          "cursor-not-allowed opacity-75": disabled,
-          "cursor-pointer hover:bg-brown-200": !disabled,
+          "cursor-not-allowed opacity-50": disabled,
+          "cursor-pointer hover:brightness-90": !disabled,
         },
       )}
+      style={{
+        borderImage: `url(${SUNNYSIDE.ui.primaryButton})`,
+        borderStyle: "solid",
+        borderWidth: `8px 8px 10px 8px`,
+        borderImageSlice: "3 3 4 3 fill",
+        imageRendering: "pixelated",
+        borderImageRepeat: "stretch",
+        borderRadius: `${PIXEL_SCALE * 5}px`,
+        color: "#674544",
+      }}
       onClick={onClick}
     >
       {inventoryAmount && (
@@ -51,8 +62,8 @@ export const ListingCategoryCard: React.FC<Props> = ({
           type="default"
           className="absolute"
           style={{
-            top: `${PIXEL_SCALE * -5}px`,
-            right: `${PIXEL_SCALE * -3}px`,
+            top: `${PIXEL_SCALE * -6}px`,
+            right: `${PIXEL_SCALE * -4}px`,
           }}
         >
           {formatNumber(inventoryAmount, { decimalPlaces: 0 })}
@@ -70,8 +81,8 @@ export const ListingCategoryCard: React.FC<Props> = ({
         type="warning"
         className="w-full text-center p-1"
         style={{
-          width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
-          marginBottom: `${PIXEL_SCALE * -3}px`,
+          width: `calc(100% + ${PIXEL_SCALE * 8}px)`,
+          marginBottom: `${PIXEL_SCALE * -4}px`,
         }}
       >
         <span
@@ -94,8 +105,8 @@ export const ListingCategoryCard: React.FC<Props> = ({
             className="absolute"
             style={{
               width: `${PIXEL_SCALE * 10}px`,
-              right: `${PIXEL_SCALE * -2}px`,
-              top: `${PIXEL_SCALE * -10}px`,
+              right: `${PIXEL_SCALE * -3}px`,
+              top: `${PIXEL_SCALE * -11}px`,
             }}
           />
         )}
@@ -105,8 +116,8 @@ export const ListingCategoryCard: React.FC<Props> = ({
             className="absolute"
             style={{
               width: `${PIXEL_SCALE * 10}px`,
-              right: `${PIXEL_SCALE * -2}px`,
-              top: `${PIXEL_SCALE * -10}px`,
+              right: `${PIXEL_SCALE * -3}px`,
+              top: `${PIXEL_SCALE * -11}px`,
             }}
           />
         )}

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -100,7 +100,7 @@ const ListTrade: React.FC<{
   if (!selected) {
     return (
       <div className="space-y-2">
-        <div className="pl-2 pt-2">
+        <div className="pl-2 py-2">
           <Label icon={SUNNYSIDE.icons.basket} type="default">
             {t("bumpkinTrade.like.list")}
           </Label>
@@ -125,7 +125,9 @@ const ListTrade: React.FC<{
     );
   }
 
-  const unitPrice = sfl.dividedBy(quantity);
+  const unitPrice = quantity.equals(0)
+    ? new Decimal(0)
+    : sfl.dividedBy(quantity);
   const tooLittle =
     !!quantity && quantity.lessThan(TRADE_MINIMUMS[selected] ?? 0);
 
@@ -304,7 +306,7 @@ const ListTrade: React.FC<{
         <p className="text-xs font-secondary">
           {quantity.equals(0)
             ? "0.0000 SFL"
-            : `${formatNumber(sfl.dividedBy(quantity), {
+            : `${formatNumber(unitPrice, {
                 decimalPlaces: 4,
                 showTrailingZeros: true,
               })} SFL`}
@@ -431,15 +433,17 @@ const TradeDetails: React.FC<{
               />
             ))}
             <div>
-              <Label type="default" className="ml-1 mt-0.5">{`Listed`}</Label>
+              <Label type="default" className="ml-1 mt-0.5">
+                {t("bumpkinTrade.listed")}
+              </Label>
               <div className="flex items-center mr-0.5 mt-1">
                 <img src={token} className="h-6 mr-1" />
                 <p className="text-xs">{`${trade.sfl} SFL`}</p>
               </div>
             </div>
           </div>
-          <div className="flex flex-col justify-between h-full">
-            <Button className="mb-1" onClick={onCancel}>
+          <div className="flex items-center">
+            <Button onClick={onCancel}>
               {isOldListing ? "Cancel old" : t("cancel")}
             </Button>
           </div>

--- a/src/features/game/components/Listed.tsx
+++ b/src/features/game/components/Listed.tsx
@@ -4,6 +4,7 @@ import { Context } from "../GameProvider";
 import { Button } from "components/ui/Button";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { PIXEL_SCALE } from "../lib/constants";
 
 export const Listed: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -15,7 +16,13 @@ export const Listed: React.FC = () => {
   return (
     <>
       <div className="p-2">
-        <img src={SUNNYSIDE.icons.confirm} className="mx-auto h-12 my-2" />
+        <img
+          src={SUNNYSIDE.icons.confirm}
+          className="mx-auto my-2"
+          style={{
+            width: `${PIXEL_SCALE * 12}px`,
+          }}
+        />
         <p className="text-sm mb-2 text-center">
           {t("trading.listing.congrats")}
         </p>

--- a/src/features/game/components/listingDeleted.tsx
+++ b/src/features/game/components/listingDeleted.tsx
@@ -4,6 +4,7 @@ import { Context } from "../GameProvider";
 import { Button } from "components/ui/Button";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { PIXEL_SCALE } from "../lib/constants";
 
 export const ListingDeleted: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -15,7 +16,13 @@ export const ListingDeleted: React.FC = () => {
   return (
     <>
       <div className="p-2">
-        <img src={SUNNYSIDE.icons.confirm} className="mx-auto h-12 my-2" />
+        <img
+          src={SUNNYSIDE.icons.confirm}
+          className="mx-auto my-2"
+          style={{
+            width: `${PIXEL_SCALE * 12}px`,
+          }}
+        />
         <p className="text-sm mb-2 text-center">
           {t("trading.listing.deleted")}
         </p>

--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -27,6 +27,7 @@ import { getKeys } from "features/game/types/decorations";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { formatNumber } from "lib/utils/formatNumber";
 import token from "assets/icons/sfl.webp";
+import { PIXEL_SCALE } from "features/game/lib/constants";
 
 const MAX_NON_VIP_PURCHASES = 3;
 
@@ -194,9 +195,15 @@ const ListView: React.FC<ListViewProps> = ({
 
   if (listings.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full w-full">
-        <div className="flex flex-col items-center justify-center pb-4">
-          <img src={SUNNYSIDE.icons.search} className="w-16 mx-auto my-2" />
+      <div className="flex flex-col items-center justify-center w-full">
+        <div className="flex flex-col items-center justify-center pb-2">
+          <img
+            src={SUNNYSIDE.icons.search}
+            className="mx-auto my-2"
+            style={{
+              width: `${PIXEL_SCALE * 13}px`,
+            }}
+          />
           <p className="text-sm">{t("trading.no.listings")}</p>
         </div>
       </div>

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -61,7 +61,9 @@ const ListTrade: React.FC<{
 
   const maxSFL = sfl.greaterThan(MAX_SFL);
 
-  const unitPrice = sfl.dividedBy(quantity);
+  const unitPrice = quantity.equals(0)
+    ? new Decimal(0)
+    : sfl.dividedBy(quantity);
   const tooLittle =
     !!quantity && quantity.lessThan(EMBLEM_TRADE_MINIMUMS[emblem] ?? 0);
 
@@ -244,7 +246,7 @@ const ListTrade: React.FC<{
         <p className="text-xs">
           {quantity.equals(0)
             ? "0.0000 SFL"
-            : `${formatNumber(sfl.dividedBy(quantity), {
+            : `${formatNumber(unitPrice, {
                 decimalPlaces: 4,
                 showTrailingZeros: true,
               })} SFL`}
@@ -360,15 +362,17 @@ const TradeDetails: React.FC<{
               />
             ))}
             <div>
-              <Label type="default" className="ml-1 mt-0.5">{`Listed`}</Label>
+              <Label type="default" className="ml-1 mt-0.5">
+                {t("bumpkinTrade.listed")}
+              </Label>
               <div className="flex items-center mr-0.5 mt-1">
                 <img src={token} className="h-6 mr-1" />
                 <p className="text-xs">{`${trade.sfl} SFL`}</p>
               </div>
             </div>
           </div>
-          <div className="flex flex-col justify-between h-full">
-            <Button className="mb-1" onClick={onCancel}>
+          <div className="flex items-center">
+            <Button onClick={onCancel}>
               {isOldListing ? "Cancel old" : t("cancel")}
             </Button>
           </div>

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -70,7 +70,6 @@ export const BuyPanel: React.FC<
   const dailyPurchases = state.trades.dailyPurchases ?? { count: 0, date: 0 };
   const remainingFreePurchases = getRemainingFreePurchases(dailyPurchases);
   const hasPurchasesRemaining = isVIP || remainingFreePurchases > 0;
-  // console.log(`${selected} asdfasd`);
 
   const onSearch = async (resource: Partial<InventoryItemName>) => {
     setSelected(resource);
@@ -246,8 +245,8 @@ const ListView: React.FC<ListViewProps> = ({
 
   if (listings.length === 0) {
     return (
-      <div>
-        <div className="flex items-center">
+      <div className="flex flex-col items-center w-full">
+        <div className="flex items-center w-full">
           <img
             src={SUNNYSIDE.icons.arrow_left}
             className="self-start cursor-pointer mr-3"
@@ -263,8 +262,14 @@ const ListView: React.FC<ListViewProps> = ({
             {selected}
           </Label>
         </div>
-        <div className="flex flex-col items-center justify-center pb-4">
-          <img src={SUNNYSIDE.icons.search} className="w-16 mx-auto my-2" />
+        <div className="flex flex-col items-center justify-center pb-2">
+          <img
+            src={SUNNYSIDE.icons.search}
+            className="mx-auto my-2"
+            style={{
+              width: `${PIXEL_SCALE * 13}px`,
+            }}
+          />
           <p className="text-sm">{t("trading.no.listings")}</p>
         </div>
       </div>

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -1133,6 +1133,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.sellConfirmation":
     "确认卖出 {{quantity}} {{resource}} 以赚 {{price}} SFL？",
   "bumpkinTrade.cant.sell.all": "无法出售全部",
+  "bumpkinTrade.listed": ENGLISH_TERMS["bumpkinTrade.listed"],
 };
 
 const buyFarmHand: Record<BuyFarmHand, string> = {

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -1187,6 +1187,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
     "Sell {{quantity}} {{resource}} for {{price}} SFL?",
   "bumpkinTrade.cant.sell.all": "Can't sell all",
   "bumpkinTrade.price/unit": "{{price}}/unit",
+  "bumpkinTrade.listed": "Listed",
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -1271,6 +1271,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
   "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
+  "bumpkinTrade.listed": ENGLISH_TERMS["bumpkinTrade.listed"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -1257,6 +1257,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
   "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
+  "bumpkinTrade.listed": ENGLISH_TERMS["bumpkinTrade.listed"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/russianDictionary.ts
+++ b/src/lib/i18n/dictionaries/russianDictionary.ts
@@ -1205,6 +1205,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
     "Продать {{quantity}} {{resource}} за {{price}} SFL?",
   "bumpkinTrade.cant.sell.all": "Нельзя продать все",
   "bumpkinTrade.price/unit": "{{price}}/шт",
+  "bumpkinTrade.listed": ENGLISH_TERMS["bumpkinTrade.listed"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -1242,6 +1242,7 @@ const bumpkinTrade: Record<BumpkinTrade, string> = {
   "bumpkinTrade.sellConfirmation":
     ENGLISH_TERMS["bumpkinTrade.sellConfirmation"],
   "bumpkinTrade.cant.sell.all": ENGLISH_TERMS["bumpkinTrade.cant.sell.all"],
+  "bumpkinTrade.listed": ENGLISH_TERMS["bumpkinTrade.listed"],
 };
 
 const goblinTrade: Record<GoblinTrade, string> = {

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -868,7 +868,8 @@ export type BumpkinTrade =
   | "bumpkinTrade.maximumFloor"
   | "bumpkinTrade.floorPrice"
   | "bumpkinTrade.sellConfirmation"
-  | "bumpkinTrade.cant.sell.all";
+  | "bumpkinTrade.cant.sell.all"
+  | "bumpkinTrade.listed";
 
 export type GoblinTrade =
   | "goblinTrade.select"


### PR DESCRIPTION
# Description

- change listing card to button style because it is clickable
- add sound to listing card click
- other minor style fixes including standardizing pixel scale
- fix crash when reverting listing quantity to 0

![image](https://github.com/user-attachments/assets/97910fc0-e298-4414-8c93-4682a76a83f2)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- trade, list and cancel plaza market and emblems market

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
