### PR TITLE
[FIX] Special Event Popup keeps Appearing

### DIFF
--- a/src/features/announcements/announcementsStorage.ts
+++ b/src/features/announcements/announcementsStorage.ts
@@ -86,3 +86,14 @@ export function hasUnreadMail(
 
   return hasAnnouncement;
 }
+
+export function acknowledgeSpecialEvent() {
+  localStorage.setItem("specialEventRead", new Date().toISOString());
+}
+
+export function specialEventLastAcknowledged(): Date | null {
+  const value = localStorage.getItem("specialEventRead");
+  if (!value) return null;
+
+  return new Date(value);
+}


### PR DESCRIPTION
# Description

Fixes two issue with the Special Event Popup

**Issue 1: Panel overflows on mobile in some languages**

The max width has been updated to be 60% of the view width, to squash the panel on smaller phones.

![fix](https://github.com/user-attachments/assets/0d88a866-9775-454b-8ba8-03f9de20a0e3)

**Issue 2: The Popup is annoying reappearing**

Added one item on local storage, `specialEventRead` which will hide the popup from being seen multiple times.

## How to Test

1. Load the game
2. Dismiss the popup
3. Reload and ensure it dissapears
4. Modify `specialEventRead` to be in the past and ensure the pop up reappears

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
