### PR TITLE
[FIX] Dismiss Alert when opening delivery modal

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -17,7 +17,7 @@ const NAME_ALIASES: Partial<Record<NPCName, string>> = {
   "pumpkin' pete": "pete",
   "hammerin harry": "auctioneer",
 };
-const NPCS_WITH_ALERTS: Partial<Record<NPCName, boolean>> = {
+export const NPCS_WITH_ALERTS: Partial<Record<NPCName, boolean>> = {
   "pumpkin' pete": true,
   hank: true,
   santa: true,

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -1,6 +1,6 @@
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
-import { NPCName, NPC_WEARABLES } from "lib/npcs";
+import { NPCName, NPC_WEARABLES, acknowledgeNPC } from "lib/npcs";
 import React, { useContext, useEffect, useState } from "react";
 import { Modal } from "components/ui/Modal";
 import { DeliveryPanel } from "./deliveries/DeliveryPanel";
@@ -36,6 +36,7 @@ import { Context } from "features/game/GameProvider";
 import { Digby } from "./beach/Digby";
 import { CropsAndChickens } from "./portals/CropsAndChickens";
 import { ExampleDonations } from "./donations/ExampleDonations";
+import { NPCS_WITH_ALERTS } from "../containers/BumpkinContainer";
 
 class NpcModalManager {
   private listener?: (npc: NPCName, isOpen: boolean) => void;
@@ -76,6 +77,9 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
   }, []);
 
   const closeModal = () => {
+    if (npc && !!NPCS_WITH_ALERTS[npc]) {
+      acknowledgeNPC(npc);
+    }
     setNpc(undefined);
   };
 


### PR DESCRIPTION
# Description

Updates the NPC Modals to dismiss the alerts when talking to NPCS

Before:

![before](https://github.com/user-attachments/assets/13d2ad50-ee9d-441b-81ed-ce16884a1e0a)

After:

![after](https://github.com/user-attachments/assets/dce8a223-49c6-494d-8373-cc92c6967001)

## How to Test

1. Log into game
2. Talk to Pumpkin Pete
3. Ensure alert is hidden after reload

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

localhost

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes