### PR TITLE
[FIX] Incorrect bulk buy amount for fractional seeds

### DIFF
--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -44,7 +44,7 @@ import {
 } from "features/game/events/landExpansion/plantGreenhouse";
 import { NPC_WEARABLES } from "lib/npcs";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
-import { formatNumber } from "lib/utils/formatNumber";
+import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
 
 interface Props {
@@ -96,7 +96,10 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
 
   const stock = state.stock[selectedName] || new Decimal(0);
   const inventoryLimit = INVENTORY_LIMIT(state)[selectedName] ?? new Decimal(0);
-  const inventoryAmount = inventory[selectedName] ?? new Decimal(0);
+  const inventoryAmount = setPrecision(
+    inventory[selectedName] ?? new Decimal(0),
+    2,
+  );
   const bulkBuyLimit = inventoryLimit.minus(inventoryAmount);
   // Calculates the difference between amount in inventory and the inventory limit
   const bulkSeedBuyAmount = makeBulkBuySeeds(stock, bulkBuyLimit);


### PR DESCRIPTION
# Description

- fix bulk buy amount if players has fractional seeds (eg. player has 28.0000000000000000001 apple seeds)

Before|After
---|---
![image](https://github.com/user-attachments/assets/8fb07457-5590-4e54-83f1-2449070b86e5)|![image](https://github.com/user-attachments/assets/ca25143b-c924-415b-b176-9f26ddc6f5bd)

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- bulk buy seeds

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
