### PR TITLE
[CHORE] Consolidate seed levels

### DIFF
--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -95,14 +95,14 @@ export const CROPS: Record<CropName, Crop> = {
     name: "Pumpkin",
     description: translate("description.pumpkin"),
     sellPrice: 0.4,
-    bumpkinLevel: 3,
+    bumpkinLevel: 2,
     harvestSeconds: 30 * 60,
   },
   Carrot: {
     name: "Carrot",
     description: translate("description.carrot"),
     sellPrice: 0.8,
-    bumpkinLevel: 3,
+    bumpkinLevel: 2,
     harvestSeconds: 60 * 60,
   },
   Cabbage: {
@@ -113,11 +113,11 @@ export const CROPS: Record<CropName, Crop> = {
     harvestSeconds: 2 * 60 * 60,
   },
   Soybean: {
-    sellPrice: 2.3,
-    harvestSeconds: 3 * 60 * 60,
     name: "Soybean",
     description: translate("description.soybean"),
-    bumpkinLevel: 10,
+    sellPrice: 2.3,
+    bumpkinLevel: 3,
+    harvestSeconds: 3 * 60 * 60,
   },
   Beetroot: {
     name: "Beetroot",
@@ -181,16 +181,16 @@ export type CropSeedName = `${CropName} Seed`;
 
 export const CROP_SEEDS: Record<CropSeedName, Seed> = {
   "Sunflower Seed": {
-    price: 0.01,
     description: translate("description.sunflower"),
+    price: 0.01,
     plantSeconds: 60,
     bumpkinLevel: 1,
     yield: "Sunflower",
     plantingSpot: "Crop Plot",
   },
   "Potato Seed": {
-    price: 0.1,
     description: translate("description.potato"),
+    price: 0.1,
     plantSeconds: 5 * 60,
     bumpkinLevel: 1,
     yield: "Potato",
@@ -221,9 +221,9 @@ export const CROP_SEEDS: Record<CropSeedName, Seed> = {
     plantingSpot: "Crop Plot",
   },
   "Soybean Seed": {
-    price: 1.5,
     description: translate("description.soybean"),
-    bumpkinLevel: 10,
+    price: 1.5,
+    bumpkinLevel: 3,
     plantSeconds: 3 * 60 * 60,
     yield: "Soybean",
     plantingSpot: "Crop Plot",
@@ -285,8 +285,8 @@ export const CROP_SEEDS: Record<CropSeedName, Seed> = {
     plantingSpot: "Crop Plot",
   },
   "Kale Seed": {
-    price: 7,
     description: translate("description.kale"),
+    price: 7,
     bumpkinLevel: 7,
     plantSeconds: 36 * 60 * 60,
     yield: "Kale",

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -22,7 +22,6 @@ export type Crop = {
   harvestSeconds: number;
   name: CropName;
   description: string;
-  bumpkinLevel: number;
   disabled?: boolean;
 };
 
@@ -33,7 +32,6 @@ export type GreenHouseCrop = {
   harvestSeconds: number;
   name: GreenHouseCropName;
   description: string;
-  bumpkinLevel: number;
   disabled?: boolean;
 };
 
@@ -43,14 +41,12 @@ export const GREENHOUSE_CROPS: Record<GreenHouseCropName, GreenHouseCrop> = {
     harvestSeconds: 32 * 60 * 60,
     name: "Rice",
     description: "A staple food for many.",
-    bumpkinLevel: 10,
   },
   Olive: {
     sellPrice: 400,
     harvestSeconds: 44 * 60 * 60,
     name: "Olive",
     description: "Zesty with a rich history.",
-    bumpkinLevel: 10,
   },
 };
 
@@ -81,98 +77,84 @@ export const CROPS: Record<CropName, Crop> = {
     name: "Sunflower",
     description: translate("description.sunflower"),
     sellPrice: 0.02,
-    bumpkinLevel: 1,
     harvestSeconds: 1 * 60,
   },
   Potato: {
     name: "Potato",
     description: translate("description.potato"),
     sellPrice: 0.14,
-    bumpkinLevel: 1,
     harvestSeconds: 5 * 60,
   },
   Pumpkin: {
     name: "Pumpkin",
     description: translate("description.pumpkin"),
     sellPrice: 0.4,
-    bumpkinLevel: 2,
     harvestSeconds: 30 * 60,
   },
   Carrot: {
     name: "Carrot",
     description: translate("description.carrot"),
     sellPrice: 0.8,
-    bumpkinLevel: 2,
     harvestSeconds: 60 * 60,
   },
   Cabbage: {
     name: "Cabbage",
     description: translate("description.cabbage"),
     sellPrice: 1.5,
-    bumpkinLevel: 3,
     harvestSeconds: 2 * 60 * 60,
   },
   Soybean: {
     name: "Soybean",
     description: translate("description.soybean"),
     sellPrice: 2.3,
-    bumpkinLevel: 3,
     harvestSeconds: 3 * 60 * 60,
   },
   Beetroot: {
     name: "Beetroot",
     description: translate("description.beetroot"),
     sellPrice: 2.8,
-    bumpkinLevel: 3,
     harvestSeconds: 4 * 60 * 60,
   },
   Cauliflower: {
     name: "Cauliflower",
     description: translate("description.cauliflower"),
     sellPrice: 4.25,
-    bumpkinLevel: 4,
     harvestSeconds: 8 * 60 * 60,
   },
   Parsnip: {
     name: "Parsnip",
     description: translate("description.parsnip"),
     sellPrice: 6.5,
-    bumpkinLevel: 4,
     harvestSeconds: 12 * 60 * 60,
   },
   Eggplant: {
     name: "Eggplant",
     description: translate("description.eggplant"),
     sellPrice: 8,
-    bumpkinLevel: 5,
     harvestSeconds: 16 * 60 * 60,
   },
   Corn: {
     name: "Corn",
     description: translate("description.corn"),
     sellPrice: 9,
-    bumpkinLevel: 5,
     harvestSeconds: 20 * 60 * 60,
   },
   Radish: {
     name: "Radish",
     description: translate("description.radish"),
     sellPrice: 9.5,
-    bumpkinLevel: 5,
     harvestSeconds: 24 * 60 * 60,
   },
   Wheat: {
     name: "Wheat",
     description: translate("description.wheat"),
     sellPrice: 7,
-    bumpkinLevel: 5,
     harvestSeconds: 24 * 60 * 60,
   },
   Kale: {
     name: "Kale",
     description: translate("description.kale"),
     sellPrice: 10,
-    bumpkinLevel: 7,
     harvestSeconds: 36 * 60 * 60,
   },
 };

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -57,6 +57,7 @@ export const GREENHOUSE_SEEDS: Record<GreenHouseCropSeedName, Seed> = {
     bumpkinLevel: 40,
     plantSeconds: 32 * 60 * 60,
     plantingSpot: "Greenhouse",
+    yield: "Rice",
   },
   "Olive Seed": {
     price: 320,
@@ -64,6 +65,7 @@ export const GREENHOUSE_SEEDS: Record<GreenHouseCropSeedName, Seed> = {
     bumpkinLevel: 40,
     plantSeconds: 44 * 60 * 60,
     plantingSpot: "Greenhouse",
+    yield: "Olive",
   },
 };
 

--- a/src/features/game/types/fruits.ts
+++ b/src/features/game/types/fruits.ts
@@ -96,7 +96,6 @@ export type Fruit = {
   isBush?: boolean;
   sellPrice: number;
   seed: FruitSeedName;
-  bumpkinLevel: number;
   disabled?: boolean;
 };
 
@@ -107,14 +106,12 @@ export const FRUIT: () => Record<FruitName, Fruit> = () => ({
     sellPrice: 2,
     seed: "Tomato Seed",
     isBush: true,
-    bumpkinLevel: 10,
   },
   Lemon: {
     description: "Because sometimes, you just can't squeeze an orange!",
     name: "Lemon",
     sellPrice: 6,
     seed: "Lemon Seed",
-    bumpkinLevel: 12,
   },
   Blueberry: {
     description: translate("description.blueberry"),
@@ -122,21 +119,18 @@ export const FRUIT: () => Record<FruitName, Fruit> = () => ({
     sellPrice: 12,
     isBush: true,
     seed: "Blueberry Seed",
-    bumpkinLevel: 13,
   },
   Orange: {
     description: translate("description.orange"),
     name: "Orange",
     sellPrice: 18,
     seed: "Orange Seed",
-    bumpkinLevel: 14,
   },
   Apple: {
     description: translate("description.apple"),
     name: "Apple",
     sellPrice: 25,
     seed: "Apple Seed",
-    bumpkinLevel: 15,
   },
   Banana: {
     description: translate("description.banana"),
@@ -144,7 +138,6 @@ export const FRUIT: () => Record<FruitName, Fruit> = () => ({
     sellPrice: 25,
     isBush: true,
     seed: "Banana Plant",
-    bumpkinLevel: 16,
   },
 });
 

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -11,7 +11,6 @@ import { setPrecision } from "lib/utils/formatNumber";
 import { Fruit, FRUIT, GREENHOUSE_FRUIT } from "features/game/types/fruits";
 import { SplitScreenView } from "components/ui/SplitScreenView";
 import { ShopSellDetails } from "components/ui/layouts/ShopSellDetails";
-import { getBumpkinLevel } from "features/game/lib/level";
 import lightning from "assets/icons/lightning.png";
 import orange from "assets/resources/orange.png";
 import {
@@ -81,7 +80,6 @@ export const Crops: React.FC = () => {
       ? crop.sellPrice
       : getSellPrice({ item: crop, game: state });
 
-  const bumpkinLevel = getBumpkinLevel(state.bumpkin?.experience ?? 0);
   const cropAmount = setPrecision(inventory[selected.name] ?? 0, 2);
   const coinAmount = setPrecision(
     new Decimal(displaySellPrice(selected)).mul(
@@ -119,12 +117,9 @@ export const Crops: React.FC = () => {
     .reduce(
       (acc, key) => ({
         ...acc,
-        [key]: { ...EXOTIC_CROPS[key], disabled: false, bumpkinLevel: 0 },
+        [key]: { ...EXOTIC_CROPS[key], disabled: false },
       }),
-      {} as Record<
-        ExoticCropName,
-        ExoticCrop & { disabled: false; bumpkinLevel: 0 }
-      >,
+      {} as Record<ExoticCropName, ExoticCrop & { disabled: false }>,
     );
 
   const cropsAndFruits = Object.values({
@@ -226,12 +221,6 @@ export const Crops: React.FC = () => {
                     image={ITEM_DETAILS[item.name].image}
                     count={inventory[item.name]}
                     parentDivRef={divRef}
-                    secondaryImage={
-                      bumpkinLevel < item.bumpkinLevel
-                        ? SUNNYSIDE.icons.lock
-                        : undefined
-                    }
-                    showOverlay={bumpkinLevel < item.bumpkinLevel}
                   />
                 ))}
             </div>
@@ -251,12 +240,6 @@ export const Crops: React.FC = () => {
                     image={ITEM_DETAILS[item.name].image}
                     count={inventory[item.name]}
                     parentDivRef={divRef}
-                    secondaryImage={
-                      bumpkinLevel < item.bumpkinLevel
-                        ? SUNNYSIDE.icons.lock
-                        : undefined
-                    }
-                    showOverlay={bumpkinLevel < item.bumpkinLevel}
                   />
                 ))}
             </div>
@@ -276,12 +259,6 @@ export const Crops: React.FC = () => {
                     image={ITEM_DETAILS[item.name].image}
                     count={inventory[item.name]}
                     parentDivRef={divRef}
-                    secondaryImage={
-                      bumpkinLevel < item.bumpkinLevel
-                        ? SUNNYSIDE.icons.lock
-                        : undefined
-                    }
-                    showOverlay={bumpkinLevel < item.bumpkinLevel}
                   />
                 ))}
             </div>
@@ -312,12 +289,6 @@ export const Crops: React.FC = () => {
                       image={ITEM_DETAILS[item.name].image}
                       count={inventory[item.name]}
                       parentDivRef={divRef}
-                      secondaryImage={
-                        bumpkinLevel < item.bumpkinLevel
-                          ? SUNNYSIDE.icons.lock
-                          : undefined
-                      }
-                      showOverlay={bumpkinLevel < item.bumpkinLevel}
                     />
                   ))}
               </div>

--- a/src/features/island/bumpkin/components/LevelUp.tsx
+++ b/src/features/island/bumpkin/components/LevelUp.tsx
@@ -17,33 +17,18 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { getKeys } from "features/game/types/craftables";
 import { LEVEL_EXPERIENCE } from "features/game/lib/level";
-import { CROPS } from "features/game/types/crops";
 import { BUILDINGS } from "features/game/types/buildings";
 import { ITEM_DETAILS } from "features/game/types/images";
 import worldIcon from "assets/icons/world_small.png";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { translate } from "lib/i18n/translate";
 import {
   EXPANSION_REQUIREMENTS,
   Land,
 } from "features/game/expansion/lib/expansionRequirements";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SEEDS } from "features/game/types/seeds";
 
 const BONUS_UNLOCKS: Record<number, { text: string; icon: string }[]> = {
-  2: [
-    {
-      text: "Crops",
-      icon: SUNNYSIDE.tools.shovel,
-    },
-    {
-      text: "Sunflower",
-      icon: CROP_LIFECYCLE.Sunflower.crop,
-    },
-    {
-      text: "Potato",
-      icon: CROP_LIFECYCLE.Potato.crop,
-    },
-  ],
   3: [
     {
       text: "Travel",
@@ -69,13 +54,20 @@ function generateUnlockLabels(): Record<
   { text: string; icon: string }[]
 > {
   const levels = getKeys(LEVEL_EXPERIENCE);
+  const seeds = SEEDS();
 
   const unlocks = levels.reduce(
     (acc, id) => {
       const level = Number(id);
-      const crops = getKeys(CROPS)
-        .filter((name) => CROPS[name].bumpkinLevel === level)
-        .map((name) => ({ text: name, icon: ITEM_DETAILS[name].image }));
+      const crops = getKeys(seeds)
+        .filter((seedName) => seeds[seedName].bumpkinLevel === level)
+        .map((seedName) => {
+          const name = seeds[seedName].yield ?? seedName;
+          return {
+            text: name,
+            icon: ITEM_DETAILS[name].image,
+          };
+        });
 
       const buildings = getKeys(BUILDINGS)
         .filter((name) =>


### PR DESCRIPTION
# Description

- lower soybean level requirements to 3
- remove bumpkin levels for all produces (crops, fruits etc.)  The lock icons were showing on the crops sell page but players are still able to sell the crop.  They serve no purpose and were confusing to players
- backend changes might be needed if checks are in place for buying seeds

Before|After
---|---
![image](https://github.com/user-attachments/assets/5c3e9da8-6b75-439a-89c7-6b5dbb204e1f)|![image](https://github.com/user-attachments/assets/788b6bad-ee0f-40db-9a03-0a9ffe0a44e9)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- buy and sell crops at different bumpkin levels

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
