### PR TITLE
[FIX] Fix text color for transitioning text when upgrading island

### DIFF
--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -312,7 +312,7 @@ export const IslandUpgrader: React.FC<Props> = ({ gameState, offset }) => {
         >
           <div
             style={{ zIndex: 9999999 }}
-            className="bg-black absolute z-10 inset-0 pointer-events-none flex justify-center items-center"
+            className="bg-black text-white absolute inset-0 pointer-events-none flex justify-center items-center"
           >
             <Loading text={t("islandupgrade.exploring")} />
           </div>


### PR DESCRIPTION
# Description

- fix text color for transitioning text when upgrading island from dark to white

Before|After
---|---
![image](https://github.com/user-attachments/assets/27aabf4d-965f-4bf6-baa8-60182b7171b0)|![image](https://github.com/user-attachments/assets/4907e83d-9e30-40ca-a529-593886b33905)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- upgrade/prestige your island

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
