### PR TITLE
[CHORE] Improve cannot trade screen layout

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -33,12 +33,19 @@ import {
   getListingsFloorPrices,
 } from "features/game/actions/getListingsFloorPrices";
 import { Context as AuthContext } from "features/auth/lib/Provider";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { Loading } from "features/auth/components";
 import { formatNumber } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+import { MachineState } from "features/game/lib/gameMachine";
 
 type ViewState = "home" | "achievements" | "skills" | "skills2";
+
+const _rawToken = (state: AuthMachineState) => state.context.user.rawToken;
+
+const _experience = (state: MachineState) =>
+  state.context.state.bumpkin?.experience ?? 0;
 
 export const BumpkinLevel: React.FC<{ experience?: number }> = ({
   experience = 0,
@@ -99,8 +106,13 @@ export const BumpkinModal: React.FC<Props> = ({
   gameState,
 }) => {
   const { gameService } = useContext(Context);
+  const experience = useSelector(gameService, _experience);
+  const level = getBumpkinLevel(experience);
+  const maxLevel = isMaxLevel(experience);
+  const canTrade = level >= 10;
+
   const { authService } = useContext(AuthContext);
-  const [authState] = useActor(authService);
+  const rawToken = useSelector(authService, _rawToken);
   const [floorPrices, setFloorPrices] = useState<FloorPrices>({});
   const [isLoading, setIsLoading] = useState(false);
   const [view, setView] = useState<ViewState>(initialView);
@@ -126,21 +138,19 @@ export const BumpkinModal: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    if (tab === 2) {
-      const load = async () => {
-        setIsLoading(true);
-        const floorPrices = await getListingsFloorPrices(
-          authState.context.user.rawToken,
-        );
-        setFloorPrices((prevFloorPrices) => ({
-          ...prevFloorPrices,
-          ...floorPrices,
-        }));
+    if (tab !== 2 || !canTrade) return;
 
-        setIsLoading(false);
-      };
-      load();
-    }
+    const load = async () => {
+      setIsLoading(true);
+      const floorPrices = await getListingsFloorPrices(rawToken);
+      setFloorPrices((prevFloorPrices) => ({
+        ...prevFloorPrices,
+        ...floorPrices,
+      }));
+
+      setIsLoading(false);
+    };
+    load();
   }, [tab]);
 
   if (view === "achievements") {
@@ -172,10 +182,6 @@ export const BumpkinModal: React.FC<Props> = ({
       />
     );
   }
-
-  const experience = bumpkin?.experience ?? 0;
-  const level = getBumpkinLevel(experience);
-  const maxLevel = isMaxLevel(experience);
 
   const hasAvailableSP = getAvailableBumpkinSkillPoints(bumpkin) > 0;
 

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -38,6 +38,7 @@ import {
   TRADE_MINIMUMS,
 } from "features/game/actions/tradeLimits";
 import { PIXEL_SCALE } from "features/game/lib/constants";
+import { CannotTrade } from "features/world/ui/CannotTrade";
 
 const MAX_SFL = 150;
 
@@ -500,18 +501,7 @@ export const Trade: React.FC<{
   };
 
   if (level < 10) {
-    return (
-      <div className="relative">
-        <div className="p-1 flex flex-col items-center">
-          <img
-            src={SUNNYSIDE.icons.lock}
-            className="w-1/5 mx-auto my-2 img-highlight-heavy"
-          />
-          <p className="text-sm">{t("bumpkinTrade.minLevel")}</p>
-          <p className="text-xs mb-2">{t("statements.lvlUp")}</p>
-        </div>
-      </div>
-    );
+    return <CannotTrade />;
   }
 
   if (showListing) {

--- a/src/features/world/ui/CannotTrade.tsx
+++ b/src/features/world/ui/CannotTrade.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+export const CannotTrade: React.FC = () => {
+  const { t } = useAppTranslation();
+
+  return (
+    <div className="flex flex-col items-center p-2">
+      <img
+        src={SUNNYSIDE.icons.lock}
+        className="my-2"
+        style={{
+          width: `${PIXEL_SCALE * 12}px`,
+        }}
+      />
+      <p className="text-sm">{t("bumpkinTrade.minLevel")}</p>
+      <p className="text-xs">{t("statements.lvlUp")}</p>
+    </div>
+  );
+};

--- a/src/features/world/ui/PlayerTrade.tsx
+++ b/src/features/world/ui/PlayerTrade.tsx
@@ -7,7 +7,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import React, { useContext, useEffect, useState } from "react";
 import { Context } from "features/game/GameProvider";
 import { Button } from "components/ui/Button";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import * as AuthProvider from "features/auth/lib/Provider";
@@ -18,16 +18,36 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { makeListingType } from "lib/utils/makeTradeListingType";
 import { Loading } from "features/auth/components";
 import token from "assets/icons/sfl.webp";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+import { MachineState } from "features/game/lib/gameMachine";
+import { CannotTrade } from "./CannotTrade";
+
+const _rawToken = (state: AuthMachineState) => state.context.user.rawToken;
+
+const _experience = (state: MachineState) =>
+  state.context.state.bumpkin?.experience ?? 0;
+const _inventory = (state: MachineState) => state.context.state.inventory;
+const _previousInventory = (state: MachineState) =>
+  state.context.state.previousInventory;
+const _balance = (state: MachineState) => state.context.state.balance;
+const _transactionExpiresAt = (state: MachineState) =>
+  state.context.transaction?.expiresAt;
 
 interface Props {
   farmId: number;
   onClose: () => void;
 }
+
 export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
   const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
+  const experience = useSelector(gameService, _experience);
+  const inventory = useSelector(gameService, _inventory);
+  const previousInventory = useSelector(gameService, _previousInventory);
+  const balance = useSelector(gameService, _balance);
+  const transactionExpiresAt = useSelector(gameService, _transactionExpiresAt);
+
   const { authService } = useContext(AuthProvider.Context);
-  const [authState] = useActor(authService);
+  const rawToken = useSelector(authService, _rawToken);
 
   const [warning, setWarning] = useState<"pendingTransaction" | "hoarding">();
   const [isLoading, setIsLoading] = useState(true);
@@ -38,12 +58,15 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
 
   const { t } = useAppTranslation();
 
+  const level = getBumpkinLevel(experience);
+  const canTrade = level >= 10;
+
+  // load listings if the player can trade
   useEffect(() => {
+    if (!canTrade) return;
+
     const load = async () => {
-      const farm = await loadGameStateForVisit(
-        farmId,
-        authState.context.user.rawToken,
-      );
+      const farm = await loadGameStateForVisit(farmId, rawToken);
 
       const listings = farm.state.trades?.listings;
       setListings(listings);
@@ -54,26 +77,8 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
     load();
   }, []);
 
-  const level = getBumpkinLevel(
-    gameState.context.state.bumpkin?.experience ?? 0,
-  );
-
-  if (level < 10) {
-    return (
-      <div className="relative">
-        <Label type="info" className="absolute top-2 right-2">
-          {t("beta")}
-        </Label>
-        <div className="p-1 flex flex-col items-center">
-          <img
-            src={SUNNYSIDE.icons.lock}
-            className="w-1/5 mx-auto my-2 img-highlight-heavy"
-          />
-          <p className="text-sm">{t("bumpkinTrade.minLevel")}</p>
-          <p className="text-xs mb-2">{t("statements.lvlUp")}</p>
-        </div>
-      </div>
-    );
+  if (!canTrade) {
+    return <CannotTrade />;
   }
 
   if (isLoading) {
@@ -111,8 +116,7 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
   }
 
   const confirm = (listingId: string) => {
-    // Check hoard
-    const inventory = gameState.context.state.inventory;
+    // Check hoarding
     const updatedInventory = getKeys(listings[listingId].items).reduce(
       (acc, name) => ({
         ...acc,
@@ -125,7 +129,7 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
 
     const hasMaxedOut = hasMaxItems({
       current: updatedInventory,
-      old: gameState.context.state.previousInventory,
+      old: previousInventory,
     });
 
     if (hasMaxedOut) {
@@ -133,10 +137,7 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
       return;
     }
 
-    if (
-      gameState.context.transaction &&
-      gameState.context.transaction.expiresAt > Date.now()
-    ) {
+    if (transactionExpiresAt && transactionExpiresAt > Date.now()) {
       setWarning("pendingTransaction");
       return;
     }
@@ -175,7 +176,7 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
       );
     }
 
-    const hasSFL = gameState.context.state.balance.gte(listings[listingId].sfl);
+    const hasSFL = balance.gte(listings[listingId].sfl);
     const disabled = !hasSFL;
 
     return (

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -32,6 +32,7 @@ import {
   EMBLEM_TRADE_LIMITS,
 } from "features/game/actions/tradeLimits";
 import { PIXEL_SCALE } from "features/game/lib/constants";
+import { CannotTrade } from "../../CannotTrade";
 
 const MAX_NON_VIP_LISTINGS = 1;
 const MAX_SFL = 150;
@@ -431,18 +432,7 @@ export const Trade: React.FC<{
   };
 
   if (level < 10) {
-    return (
-      <div className="relative">
-        <div className="p-1 flex flex-col items-center">
-          <img
-            src={SUNNYSIDE.icons.lock}
-            className="w-1/5 mx-auto my-2 img-highlight-heavy"
-          />
-          <p className="text-sm">{t("bumpkinTrade.minLevel")}</p>
-          <p className="text-xs mb-2">{t("statements.lvlUp")}</p>
-        </div>
-      </div>
-    );
+    return <CannotTrade />;
   }
 
   if (showListing) {

--- a/src/features/world/ui/npcs/TradingBoard.tsx
+++ b/src/features/world/ui/npcs/TradingBoard.tsx
@@ -6,7 +6,7 @@ import { BuyPanel } from "../trader/BuyPanel";
 import { Trade } from "features/bumpkins/components/Trade";
 import { Context } from "features/game/GameProvider";
 import { Context as AuthContext } from "features/auth/lib/Provider";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 
 import tradeIcon from "assets/icons/trade.png";
 import {
@@ -16,6 +16,9 @@ import {
 import { Label } from "components/ui/Label";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { getRelativeTime } from "lib/utils/time";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+
+const _rawToken = (state: AuthMachineState) => state.context.user.rawToken;
 
 interface Props {
   onClose: () => void;
@@ -27,7 +30,7 @@ export const TradingBoard: React.FC<Props> = ({ onClose }) => {
 
   const { gameService } = useContext(Context);
   const { authService } = useContext(AuthContext);
-  const [authState] = useActor(authService);
+  const rawToken = useSelector(authService, _rawToken);
 
   const [floorPrices, setFloorPrices] = useState<FloorPrices>({});
 
@@ -36,9 +39,7 @@ export const TradingBoard: React.FC<Props> = ({ onClose }) => {
 
   useEffect(() => {
     const load = async () => {
-      const floorPrices = await getListingsFloorPrices(
-        authState.context.user.rawToken,
-      );
+      const floorPrices = await getListingsFloorPrices(rawToken);
       setFloorPrices((prevFloorPrices) => ({
         ...prevFloorPrices,
         ...floorPrices,


### PR DESCRIPTION
# Description

- improve layout for cannot trade
- use useSelector instead of useActor for some components
- do not load floor prices when player cannot trade due to low level when opening bumpkin modal

Before|After
---|---
![image](https://github.com/user-attachments/assets/a33d76c6-adf6-4179-9072-4e97a2490ee9)|![image](https://github.com/user-attachments/assets/d4b2ab04-8aa6-4f98-837a-175d2f9a299b)

Fixes #issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- trade when below level 10
- trade when above level 10

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
