### PR TITLE
[FIX] Settings Icon z-index on Login page

### DIFF
--- a/src/features/auth/components/LoginSettings.tsx
+++ b/src/features/auth/components/LoginSettings.tsx
@@ -68,7 +68,7 @@ export const LoginSettings: React.FC = () => {
       {createPortal(
         <img
           onClick={() => setShowModal(true)}
-          className="absolute bottom-2 right-2 z-[10000] cursor-pointer"
+          className="absolute bottom-2 right-2 z-[50] cursor-pointer"
           src={settingsIcon}
           style={{
             width: `${PIXEL_SCALE * 24}px`,


### PR DESCRIPTION
# Description

Previously the settings button/icon on login page was overlapping above Wallet Connect UI, this was leading to issues with QR Code login.

![image](https://github.com/user-attachments/assets/18ac2a50-bc4d-4644-9d2f-fce434d0bca3)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
