### PR TITLE
[CHORE] Enable settings for retreat

### DIFF
--- a/src/features/island/hud/components/Settings.tsx
+++ b/src/features/island/hud/components/Settings.tsx
@@ -34,9 +34,8 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
 
   const button = useSound("button");
 
-  // The actions included in this more buttons should not be shown if the player is in goblin retreat or visiting another farm
-  const showLimitedButtons =
-    pathname.includes("retreat") || pathname.includes("visit");
+  // The actions included in this more buttons should not be shown if the player is visiting another farm
+  const showLimitedButtons = pathname.includes("visit");
 
   const cogRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
# Description

- enable settings for retreat
  - no need to limit settings anymore because the retreat is not using the old goblin state machine anymore

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- go to retreat and change settings

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
