### PR TITLE
[FIX] Upgrade Warning Description

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2142,7 +2142,7 @@
   "islandNotFound.message": "You have landed in the middle of nowhere!",
   "islandNotFound.takeMeHome": "Take me home",
   "islandupgrade.confirmUpgrade": "Are you sure you want to upgrade to a new island.",
-  "islandupgrade.warning": "Make sure you do not have any crops, fruit, buildings, chickens, mushrooms, crimstone, flowers or honey in progress. These will not be able to be harvested and will be returned to your inventory. Sunstones will remain placed on your land.",
+  "islandupgrade.warning": "Make sure you do not have any crops, fruit, buildings, chickens, crimstone, flowers or honey in progress. These will not be able to be harvested and will be returned to your inventory. Sunstones, House, Market, Fire Pit and Workbench will remain placed on your land.",
   "islandupgrade.upgradeIsland": "Upgrade Island",
   "islandupgrade.newOpportunities": "An exotic island awaits you with new resources and opportunities to grow your farm.",
   "islandupgrade.confirmation": "Would you like to upgrade? You will start on a small island with all of your items.",


### PR DESCRIPTION
# Description

This PR updates the warning message for the Island Upgrade to point out the removal restriction for some buildings.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ce17da75-7ff3-43d8-a9ed-d5e0fe347a5a)| ![image](https://github.com/user-attachments/assets/96994668-f7ca-4d27-8cb7-a44351689aae)|

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
