### PR TITLE
[FEAT] Revert transactions

### DIFF
--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -23,10 +23,7 @@ type Response = {
   isBlacklisted?: boolean;
   deviceTrackerId: string;
   announcements: Announcements;
-  transaction?: {
-    type: "withdraw_bumpkin";
-    expiresAt: number;
-  };
+
   verified: boolean;
   promoCode?: string;
   moderation: Moderation;
@@ -93,7 +90,6 @@ export async function loadSession(request: Request): Promise<Response> {
     isBlacklisted,
     deviceTrackerId,
     announcements,
-    transaction,
     verified,
     moderation,
     promoCode: promo,
@@ -112,7 +108,6 @@ export async function loadSession(request: Request): Promise<Response> {
     deviceTrackerId: string;
     status?: "COOL_DOWN";
     announcements: Announcements;
-    transaction: { type: "withdraw_bumpkin"; expiresAt: number };
     verified: boolean;
     moderation: Moderation;
     promoCode?: string;
@@ -136,7 +131,6 @@ export async function loadSession(request: Request): Promise<Response> {
     isBlacklisted,
     deviceTrackerId,
     announcements,
-    transaction,
     verified,
     moderation,
     promoCode: promo,

--- a/src/features/game/actions/mintAuctionItem.ts
+++ b/src/features/game/actions/mintAuctionItem.ts
@@ -54,7 +54,7 @@ export async function mintAuctionItem(request: Request) {
   } else {
     sessionId = await mintAuctionWearable({
       ...transaction,
-      account: wallet.getAccount(),
+      sender: wallet.getAccount(),
     });
   }
 

--- a/src/features/game/actions/mintAuctionItem.ts
+++ b/src/features/game/actions/mintAuctionItem.ts
@@ -1,13 +1,6 @@
-import {
-  mintAuctionCollectible,
-  mintAuctionWearable,
-} from "lib/blockchain/Auction";
-import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
-import { Bid, GameState, InventoryItemName } from "../types/game";
-import { gameAnalytics } from "lib/gameAnalytics";
-import { getSeasonalTicket } from "../types/seasons";
+import { Bid, GameState } from "../types/game";
 import { makeGame } from "../lib/transforms";
 
 type Request = {

--- a/src/features/game/actions/sync.ts
+++ b/src/features/game/actions/sync.ts
@@ -1,5 +1,3 @@
-import { syncProgress, SyncProgressParams } from "lib/blockchain/Game";
-import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { GameState } from "../types/game";
@@ -18,11 +16,6 @@ export async function sync({
   token,
   transactionId,
 }: SyncSignatureRequest): Promise<{ game: GameState }> {
-  console.log({
-    farmId,
-    token,
-    transactionId,
-  });
   const response = await window.fetch(`${API_URL}/sync-progress/${farmId}`, {
     method: "POST",
     headers: {

--- a/src/features/game/actions/sync.ts
+++ b/src/features/game/actions/sync.ts
@@ -51,11 +51,9 @@ export async function sync({
     throw new Error(ERRORS.SYNC_SERVER_ERROR);
   }
 
-  // TODO
   const newSessionId = await syncProgress({
     ...transaction,
-    account: wallet.getAccount(),
-    blockBucks,
+    sender: wallet.getAccount(),
   });
 
   return { verified: true, sessionId: newSessionId };

--- a/src/features/game/actions/sync.ts
+++ b/src/features/game/actions/sync.ts
@@ -1,27 +1,28 @@
-import { syncProgress } from "lib/blockchain/Game";
+import { syncProgress, SyncProgressParams } from "lib/blockchain/Game";
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
+import { GameState } from "../types/game";
+import { makeGame } from "../lib/transforms";
 
 const API_URL = CONFIG.API_URL;
 
-type Options = {
+export type SyncSignatureRequest = {
   farmId: number;
-  sessionId: string;
   token: string;
-  captcha?: string;
   transactionId: string;
-  blockBucks: number;
 };
 
 export async function sync({
   farmId,
-  sessionId,
   token,
-  captcha,
   transactionId,
-  blockBucks,
-}: Options) {
+}: SyncSignatureRequest): Promise<{ game: GameState }> {
+  console.log({
+    farmId,
+    token,
+    transactionId,
+  });
   const response = await window.fetch(`${API_URL}/sync-progress/${farmId}`, {
     method: "POST",
     headers: {
@@ -29,11 +30,7 @@ export async function sync({
       Authorization: `Bearer ${token}`,
       "X-Transaction-ID": transactionId,
     },
-    body: JSON.stringify({
-      sessionId: sessionId,
-      captcha,
-      blockBucks,
-    }),
+    body: JSON.stringify({}),
   });
 
   if (response.status === 429) {
@@ -51,10 +48,14 @@ export async function sync({
     throw new Error(ERRORS.SYNC_SERVER_ERROR);
   }
 
-  const newSessionId = await syncProgress({
-    ...transaction,
-    sender: wallet.getAccount(),
-  });
+  // const newSessionId = await syncProgress({
+  //   ...transaction,
+  //   sender: wallet.getAccount(),
+  // });
 
-  return { verified: true, sessionId: newSessionId };
+  // return { verified: true, sessionId: newSessionId };
+
+  return {
+    game: makeGame(transaction.farm),
+  };
 }

--- a/src/features/game/actions/withdraw.ts
+++ b/src/features/game/actions/withdraw.ts
@@ -1,10 +1,3 @@
-import {
-  withdrawBudsTransaction,
-  withdrawItemsTransaction,
-  withdrawSFLTransaction,
-  withdrawWearablesTransaction,
-} from "lib/blockchain/Withdrawals";
-import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { makeGame } from "../lib/transforms";

--- a/src/features/game/actions/withdraw.ts
+++ b/src/features/game/actions/withdraw.ts
@@ -7,6 +7,8 @@ import {
 import { wallet } from "lib/blockchain/wallet";
 import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
+import { makeGame } from "../lib/transforms";
+import { GameState } from "../types/game";
 
 const API_URL = CONFIG.API_URL;
 
@@ -19,13 +21,13 @@ type SFLOptions = {
   transactionId: string;
 };
 
-export async function withdrawSFL({
+export async function withdrawSFLRequest({
   farmId,
   sessionId,
   sfl,
   token,
   transactionId,
-}: SFLOptions) {
+}: SFLOptions): Promise<{ game: GameState }> {
   const response = await window.fetch(`${API_URL}/withdraw-sfl/${farmId}`, {
     method: "POST",
     headers: {
@@ -48,12 +50,9 @@ export async function withdrawSFL({
 
   const transaction = await response.json();
 
-  const newSessionId = await withdrawSFLTransaction({
-    ...transaction,
-    sender: wallet.getAccount(),
-  });
-
-  return { sessionId: newSessionId, verified: true };
+  return {
+    game: makeGame(transaction.farm),
+  };
 }
 
 type ItemsOptions = {
@@ -66,14 +65,14 @@ type ItemsOptions = {
   transactionId: string;
 };
 
-export async function withdrawItems({
+export async function withdrawItemsRequest({
   farmId,
   sessionId,
   ids,
   amounts,
   token,
   transactionId,
-}: ItemsOptions) {
+}: ItemsOptions): Promise<{ game: GameState }> {
   const response = await window.fetch(`${API_URL}/withdraw-items/${farmId}`, {
     method: "POST",
     headers: {
@@ -97,12 +96,9 @@ export async function withdrawItems({
 
   const transaction = await response.json();
 
-  const newSessionId = await withdrawItemsTransaction({
-    ...transaction,
-    sender: wallet.getAccount(),
-  });
-
-  return { sessionId: newSessionId, verified: true };
+  return {
+    game: makeGame(transaction.farm),
+  };
 }
 
 type WearableOptions = {
@@ -115,13 +111,13 @@ type WearableOptions = {
   transactionId: string;
 };
 
-export async function withdrawWearables({
+export async function withdrawWearablesRequest({
   farmId,
   ids,
   amounts,
   token,
   transactionId,
-}: WearableOptions) {
+}: WearableOptions): Promise<{ game: GameState }> {
   const response = await window.fetch(
     `${API_URL}/withdraw-wearables/${farmId}`,
     {
@@ -148,12 +144,9 @@ export async function withdrawWearables({
 
   const transaction = await response.json();
 
-  const newSessionId = await withdrawWearablesTransaction({
-    ...transaction,
-    sender: wallet.getAccount(),
-  });
-
-  return { sessionId: newSessionId, verified: true };
+  return {
+    game: makeGame(transaction.farm),
+  };
 }
 
 type BudOptions = {
@@ -163,12 +156,12 @@ type BudOptions = {
   token: string;
 };
 
-export async function withdrawBuds({
+export async function withdrawBudsRequest({
   farmId,
   budIds,
   transactionId,
   token,
-}: BudOptions) {
+}: BudOptions): Promise<{ game: GameState }> {
   const response = await window.fetch(`${API_URL}/withdraw-buds/${farmId}`, {
     method: "POST",
     headers: {
@@ -191,10 +184,7 @@ export async function withdrawBuds({
 
   const transaction = await response.json();
 
-  const newSessionId = await withdrawBudsTransaction({
-    ...transaction,
-    sender: wallet.getAccount(),
-  });
-
-  return { sessionId: newSessionId, verified: true };
+  return {
+    game: makeGame(transaction.farm),
+  };
 }

--- a/src/features/game/actions/withdraw.ts
+++ b/src/features/game/actions/withdraw.ts
@@ -50,7 +50,7 @@ export async function withdrawSFL({
 
   const newSessionId = await withdrawSFLTransaction({
     ...transaction,
-    account: wallet.getAccount(),
+    sender: wallet.getAccount(),
   });
 
   return { sessionId: newSessionId, verified: true };
@@ -99,7 +99,7 @@ export async function withdrawItems({
 
   const newSessionId = await withdrawItemsTransaction({
     ...transaction,
-    account: wallet.getAccount(),
+    sender: wallet.getAccount(),
   });
 
   return { sessionId: newSessionId, verified: true };
@@ -150,7 +150,7 @@ export async function withdrawWearables({
 
   const newSessionId = await withdrawWearablesTransaction({
     ...transaction,
-    account: wallet.getAccount(),
+    sender: wallet.getAccount(),
   });
 
   return { sessionId: newSessionId, verified: true };
@@ -193,7 +193,7 @@ export async function withdrawBuds({
 
   const newSessionId = await withdrawBudsTransaction({
     ...transaction,
-    account: wallet.getAccount(),
+    sender: wallet.getAccount(),
   });
 
   return { sessionId: newSessionId, verified: true };

--- a/src/features/game/components/auctionResults/ClaimAuction.tsx
+++ b/src/features/game/components/auctionResults/ClaimAuction.tsx
@@ -39,7 +39,7 @@ export const ClaimAuction: React.FC = () => {
         <Winner
           onMint={() =>
             gameService.send("TRANSACT", {
-              transaction: "transaction.wearablesWithdrawn",
+              transaction: "transaction.bidMinted",
               request: {
                 auctionId: bid.auctionId,
               },

--- a/src/features/game/components/auctionResults/ClaimAuction.tsx
+++ b/src/features/game/components/auctionResults/ClaimAuction.tsx
@@ -9,6 +9,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ITEM_IDS } from "features/game/types/bumpkin";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getImageUrl } from "lib/utils/getImageURLS";
+import { Transaction } from "features/island/hud/Transaction";
 
 export const ClaimAuction: React.FC = () => {
   const { gameService } = useContext(GameContext);
@@ -23,6 +24,11 @@ export const ClaimAuction: React.FC = () => {
   const onClose = () => {
     gameService.send("CLOSE");
   };
+
+  const transaction = gameService.state.context.state.transaction;
+  if (transaction) {
+    return <Transaction onClose={onClose} />;
+  }
 
   return (
     <Modal show={true} onHide={onClose}>

--- a/src/features/game/components/auctionResults/ClaimAuction.tsx
+++ b/src/features/game/components/auctionResults/ClaimAuction.tsx
@@ -27,7 +27,7 @@ export const ClaimAuction: React.FC = () => {
 
   const transaction = gameService.state.context.state.transaction;
   if (transaction) {
-    return <Transaction onClose={onClose} />;
+    return <Transaction isBlocked onClose={onClose} />;
   }
 
   return (

--- a/src/features/game/components/auctionResults/ClaimAuction.tsx
+++ b/src/features/game/components/auctionResults/ClaimAuction.tsx
@@ -38,8 +38,11 @@ export const ClaimAuction: React.FC = () => {
         </div>
         <Winner
           onMint={() =>
-            gameService.send("MINT", {
-              auctionId: bid.auctionId,
+            gameService.send("TRANSACT", {
+              transaction: "transaction.wearablesWithdrawn",
+              request: {
+                auctionId: bid.auctionId,
+              },
             })
           }
           bid={gameService.state.context.state.auctioneer.bid!}

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -191,7 +191,7 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
 
   const transaction = gameService.state.context.state.transaction;
   if (transaction) {
-    return <Transaction onClose={onClose} />;
+    return <Transaction isBlocked onClose={onClose} />;
   }
 
   if (!verified) {

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -18,6 +18,7 @@ import { Label } from "components/ui/Label";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { MachineState } from "features/game/lib/gameMachine";
 import { translate } from "lib/i18n/translate";
+import { Transaction } from "features/island/hud/Transaction";
 
 const getPageIcon = (page: Page) => {
   switch (page) {
@@ -212,6 +213,11 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
     gameService.send("PROVE_PERSONHOOD");
     onClose();
   };
+
+  const transaction = gameService.state.context.state.transaction;
+  if (transaction) {
+    return <Transaction onClose={onClose} />;
+  }
 
   if (!verified) {
     return (

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -1,7 +1,5 @@
-import React, { useContext, useRef, useState } from "react";
-import ReCAPTCHA from "react-google-recaptcha";
+import React, { useContext, useState } from "react";
 import { useSelector } from "@xstate/react";
-import { CONFIG } from "lib/config";
 
 import { Button } from "components/ui/Button";
 import { WithdrawTokens } from "./WithdrawTokens";

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -137,74 +137,51 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
 
   const [page, setPage] = useState<Page>("main");
 
-  const withdrawAmount = useRef({
-    ids: [] as number[],
-    amounts: [] as string[],
-    sfl: "0",
-    wearableIds: [] as number[],
-    wearableAmounts: [] as number[],
-    budIds: [] as number[],
-  });
-
-  const [showCaptcha, setShowCaptcha] = useState(false);
-
   const onWithdrawTokens = async (sfl: string) => {
-    withdrawAmount.current = {
-      ids: [],
-      amounts: [],
-      sfl,
-      wearableAmounts: [],
-      wearableIds: [],
-      budIds: [],
-    };
-    setShowCaptcha(true);
+    gameService.send("TRANSACT", {
+      transaction: "transaction.sflWithdrawn",
+      request: {
+        captcha: token,
+        sfl: sfl,
+      },
+    });
+    onClose();
   };
 
   const onWithdrawItems = async (ids: number[], amounts: string[]) => {
-    withdrawAmount.current = {
-      ids,
-      amounts,
-      sfl: "0",
-      wearableAmounts: [],
-      wearableIds: [],
-      budIds: [],
-    };
-    setShowCaptcha(true);
+    gameService.send("TRANSACT", {
+      transaction: "transaction.itemsWithdrawn",
+      request: {
+        captcha: token,
+        amounts: amounts,
+        ids: ids,
+      },
+    });
+    onClose();
   };
 
   const onWithdrawWearables = async (
     wearableIds: number[],
     wearableAmounts: number[],
   ) => {
-    withdrawAmount.current = {
-      ids: [],
-      amounts: [],
-      sfl: "0",
-      wearableAmounts,
-      wearableIds,
-      budIds: [],
-    };
-    setShowCaptcha(true);
+    gameService.send("TRANSACT", {
+      transaction: "transaction.wearablesWithdrawn",
+      request: {
+        captcha: token,
+        amounts: wearableAmounts,
+        ids: wearableIds,
+      },
+    });
+    onClose();
   };
 
   const onWithdrawBuds = async (ids: number[]) => {
-    withdrawAmount.current = {
-      ids: [],
-      amounts: [],
-      sfl: "0",
-      wearableAmounts: [],
-      wearableIds: [],
-      budIds: ids,
-    };
-    setShowCaptcha(true);
-  };
-
-  const onCaptchaSolved = async (token: string | null) => {
-    await new Promise((res) => setTimeout(res, 1000));
-
-    gameService.send("WITHDRAW", {
-      ...withdrawAmount.current,
-      captcha: token,
+    gameService.send("TRANSACT", {
+      transaction: "transaction.budsWithdrawn",
+      request: {
+        captcha: token,
+        budIds: ids,
+      },
     });
     onClose();
   };
@@ -224,20 +201,6 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
       <>
         <p className="p-1 m-1">{t("withdraw.proof")}</p>
         <Button onClick={provePersonhood}>{t("withdraw.verification")}</Button>
-      </>
-    );
-  }
-
-  if (showCaptcha) {
-    return (
-      <>
-        <ReCAPTCHA
-          sitekey={CONFIG.RECAPTCHA_SITEKEY}
-          onChange={onCaptchaSolved}
-          onExpired={() => setShowCaptcha(false)}
-          className="w-full m-4 flex items-center justify-center"
-        />
-        <p className="text-xs p-1 m-1 text-center">{t("withdraw.unsave")}</p>
       </>
     );
   }

--- a/src/features/game/components/bank/components/WithdrawResources.tsx
+++ b/src/features/game/components/bank/components/WithdrawResources.tsx
@@ -74,11 +74,13 @@ export const WithdrawResources: React.FC<Props> = ({ onWithdraw }) => {
       toWei(selected[item]?.toString() as string, getItemUnit(item)),
     );
 
-    gameService.send("WITHDRAW", {
-      ids,
-      amounts,
-      sfl: 0,
-      captcha: "0x",
+    gameService.send("TRANSACT", {
+      transaction: "transaction.itemsWithdrawn",
+      request: {
+        captcha: "0x",
+        amounts: amounts,
+        ids: ids,
+      },
     });
 
     onWithdraw();

--- a/src/features/game/components/modal/components/StoreOnChainModal.tsx
+++ b/src/features/game/components/modal/components/StoreOnChainModal.tsx
@@ -5,6 +5,8 @@ import { Context } from "features/game/GameProvider";
 import { Button } from "components/ui/Button";
 import { GameWallet } from "features/wallet/Wallet";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { Transaction } from "features/island/hud/Transaction";
+import { Panel } from "components/ui/Panel";
 
 interface Props {
   onClose: () => void;
@@ -12,6 +14,7 @@ interface Props {
 export const StoreOnChainModal: React.FC<Props> = ({ onClose }) => {
   const { gameService } = useContext(Context);
   const { t } = useAppTranslation();
+
   const storeData = () => {
     gameService.send("SYNC", {
       captcha: "",
@@ -20,6 +23,16 @@ export const StoreOnChainModal: React.FC<Props> = ({ onClose }) => {
 
     onClose();
   };
+
+  // Transaction already in progress
+  const transaction = gameService.state.context.state.transaction;
+  if (transaction) {
+    return (
+      <Panel>
+        <Transaction onClose={onClose} />
+      </Panel>
+    );
+  }
 
   return (
     <CloseButtonPanel

--- a/src/features/game/components/modal/components/StoreOnChainModal.tsx
+++ b/src/features/game/components/modal/components/StoreOnChainModal.tsx
@@ -16,11 +16,6 @@ export const StoreOnChainModal: React.FC<Props> = ({ onClose }) => {
   const { t } = useAppTranslation();
 
   const storeData = () => {
-    // gameService.send("SYNC", {
-    //   captcha: "",
-    //   blockBucks: 0,
-    // });
-
     gameService.send("TRANSACT", {
       transaction: "transaction.progressSynced",
       request: {

--- a/src/features/game/components/modal/components/StoreOnChainModal.tsx
+++ b/src/features/game/components/modal/components/StoreOnChainModal.tsx
@@ -16,11 +16,17 @@ export const StoreOnChainModal: React.FC<Props> = ({ onClose }) => {
   const { t } = useAppTranslation();
 
   const storeData = () => {
-    gameService.send("SYNC", {
-      captcha: "",
-      blockBucks: 0,
-    });
+    // gameService.send("SYNC", {
+    //   captcha: "",
+    //   blockBucks: 0,
+    // });
 
+    gameService.send("TRANSACT", {
+      transaction: "transaction.progressSynced",
+      request: {
+        captcha: "",
+      },
+    });
     onClose();
   };
 

--- a/src/features/game/components/modal/components/StoreOnChainModal.tsx
+++ b/src/features/game/components/modal/components/StoreOnChainModal.tsx
@@ -35,7 +35,7 @@ export const StoreOnChainModal: React.FC<Props> = ({ onClose }) => {
   if (transaction) {
     return (
       <Panel>
-        <Transaction onClose={onClose} />
+        <Transaction isBlocked onClose={onClose} />
       </Panel>
     );
   }

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -15,8 +15,6 @@ import { INITIAL_SESSION, MachineState, StateValues } from "../lib/gameMachine";
 import { ToastProvider } from "../toast/ToastProvider";
 import { ToastPanel } from "../toast/ToastPanel";
 import { Panel } from "components/ui/Panel";
-import { Success } from "../components/Success";
-import { Syncing } from "../components/Syncing";
 
 import { Hoarding } from "../components/Hoarding";
 import { Swarming } from "../components/Swarming";
@@ -31,7 +29,6 @@ import { IslandNotFound } from "./components/IslandNotFound";
 import { Rules } from "../components/Rules";
 import { Introduction } from "./components/Introduction";
 import { Purchasing } from "../components/Purchasing";
-import { Minting } from "../components/Minting";
 import { ClaimAuction } from "../components/auctionResults/ClaimAuction";
 import { RefundAuction } from "../components/auctionResults/RefundAuction";
 import { Promo } from "./components/Promo";
@@ -51,8 +48,6 @@ import { ListingDeleted } from "../components/listingDeleted";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import { usePWAInstall } from "features/pwa/PWAInstallProvider";
 import { fixInstallPromptTextStyles } from "features/pwa/lib/fixInstallPromptStyles";
-import { Withdrawing } from "../components/Withdrawing";
-import { Withdrawn } from "../components/Withdrawn";
 import { PersonhoodContent } from "features/retreat/components/personhood/PersonhoodContent";
 import { hasFeatureAccess } from "lib/flags";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -72,8 +67,6 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   loading: true,
   playing: false,
   autosaving: false,
-  syncing: true,
-  synced: true,
   error: true,
   buyingBlockBucks: true,
   refreshing: true,
@@ -95,7 +88,6 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   introduction: false,
   specialOffer: true,
   transacting: true,
-  minting: true,
   auctionResults: false,
   claimAuction: false,
   refundAuction: false,
@@ -115,8 +107,6 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   airdrop: true,
   portalling: true,
   provingPersonhood: false,
-  // withdrawing: true,
-  // withdrawn: true,
   sellMarketResource: false,
   somethingArrived: true,
 };
@@ -143,8 +133,6 @@ const hasMarketPriceChanged = (state: MachineState) =>
 const isRefreshing = (state: MachineState) => state.matches("refreshing");
 const isBuyingSFL = (state: MachineState) => state.matches("buyingSFL");
 const isError = (state: MachineState) => state.matches("error");
-const isSynced = (state: MachineState) => state.matches("synced");
-const isSyncing = (state: MachineState) => state.matches("syncing");
 const isHoarding = (state: MachineState) => state.matches("hoarding");
 const isVisiting = (state: MachineState) => state.matches("visiting");
 const isSwarming = (state: MachineState) => state.matches("swarming");
@@ -154,7 +142,6 @@ const isPurchasing = (state: MachineState) =>
 const isCoolingDown = (state: MachineState) => state.matches("coolingDown");
 const isGameRules = (state: MachineState) => state.matches("gameRules");
 const isDepositing = (state: MachineState) => state.matches("depositing");
-const isMinting = (state: MachineState) => state.matches("minting");
 const isLoadingLandToVisit = (state: MachineState) =>
   state.matches("loadLandToVisit");
 const isLoadingSession = (state: MachineState) =>
@@ -165,8 +152,6 @@ const currentState = (state: MachineState) => state.value;
 const getErrorCode = (state: MachineState) => state.context.errorCode;
 const getActions = (state: MachineState) => state.context.actions;
 
-const isWithdrawing = (state: MachineState) => state.matches("withdrawing");
-const isWithdrawn = (state: MachineState) => state.matches("withdrawn");
 const isTransacting = (state: MachineState) => state.matches("transacting");
 const isClaimAuction = (state: MachineState) => state.matches("claimAuction");
 const isRefundingAuction = (state: MachineState) =>
@@ -269,8 +254,6 @@ export const GameWrapper: React.FC = ({ children }) => {
 
   const loading = useSelector(gameService, isLoading);
   const provingPersonhood = useSelector(gameService, isProvingPersonhood);
-  const withdrawing = useSelector(gameService, isWithdrawing);
-  const withdrawn = useSelector(gameService, isWithdrawn);
   const portalling = useSelector(gameService, isPortalling);
   const trading = useSelector(gameService, isTrading);
   const traded = useSelector(gameService, isTraded);
@@ -287,8 +270,6 @@ export const GameWrapper: React.FC = ({ children }) => {
   const refreshing = useSelector(gameService, isRefreshing);
   const buyingSFL = useSelector(gameService, isBuyingSFL);
   const error = useSelector(gameService, isError);
-  const synced = useSelector(gameService, isSynced);
-  const syncing = useSelector(gameService, isSyncing);
   const purchasing = useSelector(gameService, isPurchasing);
   const hoarding = useSelector(gameService, isHoarding);
   const swarming = useSelector(gameService, isSwarming);
@@ -301,7 +282,6 @@ export const GameWrapper: React.FC = ({ children }) => {
   const errorCode = useSelector(gameService, getErrorCode);
   const actions = useSelector(gameService, getActions);
   const transacting = useSelector(gameService, isTransacting);
-  const minting = useSelector(gameService, isMinting);
   const claimingAuction = useSelector(gameService, isClaimAuction);
   const refundAuction = useSelector(gameService, isRefundingAuction);
   const promo = useSelector(gameService, isPromoing);
@@ -467,8 +447,6 @@ export const GameWrapper: React.FC = ({ children }) => {
             {refreshing && <Refreshing />}
             {buyingSFL && <AddingSFL />}
             {error && <ErrorMessage errorCode={errorCode as ErrorCode} />}
-            {synced && <Success />}
-            {syncing && <Syncing />}
             {purchasing && <Purchasing />}
             {hoarding && <Hoarding />}
             {swarming && <Swarming />}
@@ -486,12 +464,9 @@ export const GameWrapper: React.FC = ({ children }) => {
             {sniped && <Sniped />}
             {tradeAlreadyFulfilled && <TradeAlreadyFulfilled />}
             {marketPriceChanged && <PriceChange />}
-            {minting && <Minting />}
             {promo && <Promo />}
             {airdrop && <AirdropPopup />}
             {specialOffer && <VIPOffer />}
-            {withdrawing && <Withdrawing />}
-            {withdrawn && <Withdrawn />}
             {hasSomethingArrived && <SomethingArrived />}
           </Panel>
         </Modal>

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -31,7 +31,6 @@ import { IslandNotFound } from "./components/IslandNotFound";
 import { Rules } from "../components/Rules";
 import { Introduction } from "./components/Introduction";
 import { Purchasing } from "../components/Purchasing";
-import { Transacting } from "../components/Transacting";
 import { Minting } from "../components/Minting";
 import { ClaimAuction } from "../components/auctionResults/ClaimAuction";
 import { RefundAuction } from "../components/auctionResults/RefundAuction";
@@ -64,6 +63,7 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { SomethingArrived } from "./components/SomethingArrived";
 import { TradeAlreadyFulfilled } from "../components/TradeAlreadyFulfilled";
 import { NPC_WEARABLES } from "lib/npcs";
+import { Transaction } from "features/island/hud/Transaction";
 
 const land = SUNNYSIDE.land.island;
 
@@ -115,8 +115,8 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   airdrop: true,
   portalling: true,
   provingPersonhood: false,
-  withdrawing: true,
-  withdrawn: true,
+  // withdrawing: true,
+  // withdrawn: true,
   sellMarketResource: false,
   somethingArrived: true,
 };
@@ -475,7 +475,7 @@ export const GameWrapper: React.FC = ({ children }) => {
 
             {coolingDown && <Cooldown />}
             {gameRules && <Rules />}
-            {transacting && <Transacting />}
+            {transacting && <Transaction />}
             {depositing && <Loading text="Depositing" />}
             {trading && <Loading text="Trading" />}
             {traded && <Traded />}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -148,29 +148,6 @@ export type Moderation = {
   }[];
 };
 
-// type MintEvent = {
-//   type: "MINT";
-//   auctionId: string;
-// };
-
-// type WithdrawEvent = {
-//   type: "WITHDRAW";
-//   sfl: number;
-//   ids: number[];
-//   amounts: string[];
-//   bumpkinId?: number;
-//   wearableIds: number[];
-//   wearableAmounts: number[];
-//   captcha: string;
-//   budIds: number[];
-// };
-
-// type SyncEvent = {
-//   captcha: string;
-//   type: "SYNC";
-//   blockBucks: number;
-// };
-
 type CommunityEvent = {
   type: "COMMUNITY_UPDATE";
   game: GameState;
@@ -283,7 +260,6 @@ export type BlockchainEvent =
     }
   | TransactEvent
   | WalletUpdatedEvent
-  // | SyncEvent
   | CommunityEvent
   | ListingEvent
   | DeleteTradeListingEvent
@@ -331,9 +307,7 @@ export type BlockchainEvent =
   | {
       type: "PERSONHOOD_CANCELLED";
     }
-  // | WithdrawEvent
   | GameEvent
-  // | MintEvent
   | LandscapeEvent
   | VisitEvent
   | BuySFLEvent
@@ -433,9 +407,6 @@ export type BlockchainState = {
     | "introduction"
     | "playing"
     | "autosaving"
-    | "syncing"
-    | "synced"
-    | "minting"
     | "buyingSFL"
     | "revealing"
     | "revealed"
@@ -447,7 +418,6 @@ export type BlockchainState = {
     | "hoarding"
     | "mailbox"
     | "transacting"
-    // | "transacted"
     | "depositing"
     | "landscaping"
     | "specialOffer"
@@ -470,8 +440,6 @@ export type BlockchainState = {
     | "claimAuction"
     | "refundAuction"
     | "blacklisted"
-    // | "withdrawing"
-    // | "withdrawn"
     | "provingPersonhood"
     | "somethingArrived"
     | "randomising"; // TEST ONLY
@@ -728,11 +696,6 @@ export function startGame(authContext: AuthContext) {
         },
         notifying: {
           always: [
-            // {
-            //   target: "transacting",
-            //   cond: (context: Context) => !!context.state.transaction,
-            // },
-
             {
               target: "gameRules",
               cond: () => {
@@ -916,9 +879,6 @@ export function startGame(authContext: AuthContext) {
         },
         claimAuction: {
           on: {
-            // MINT: {
-            //   target: "minting",
-            // },
             TRANSACT: {
               target: "transacting",
             },
@@ -983,15 +943,6 @@ export function startGame(authContext: AuthContext) {
             SAVE: {
               target: "autosaving",
             },
-            // SYNC: {
-            //   target: "syncing",
-            // },
-            // MINT: {
-            //   target: "minting",
-            // },
-            // WITHDRAW: {
-            //   target: "withdrawing",
-            // },
             TRANSACT: {
               target: "transacting",
             },
@@ -1159,12 +1110,9 @@ export function startGame(authContext: AuthContext) {
               };
             },
             onDone: {
-              // target: "transacted",
               target: "playing",
               actions: [
                 assign((_, event) => ({
-                  // sessionId: event.data.sessionId,
-                  // Store the transaction
                   state: event.data.farm,
                   actions: [],
                 })),
@@ -1186,99 +1134,7 @@ export function startGame(authContext: AuthContext) {
             ],
           },
         },
-        // syncing: {
-        //   entry: "setTransactionId",
-        //   invoke: {
-        //     src: async (context, event) => {
-        //       // Autosave just in case
-        //       if (context.actions.length > 0) {
-        //         await autosave({
-        //           farmId: Number(context.farmId),
-        //           sessionId: context.sessionId as string,
-        //           actions: context.actions,
-        //           token: authContext.user.rawToken as string,
-        //           fingerprint: context.fingerprint as string,
-        //           deviceTrackerId: context.deviceTrackerId as string,
-        //           transactionId: context.transactionId as string,
-        //         });
-        //       }
 
-        //       const { sessionId } = await sync({
-        //         farmId: Number(context.farmId),
-        //         sessionId: context.sessionId as string,
-        //         token: authContext.user.rawToken as string,
-        //         captcha: (event as SyncEvent).captcha,
-        //         transactionId: context.transactionId as string,
-        //         blockBucks: (event as SyncEvent).blockBucks,
-        //       });
-
-        //       return {
-        //         sessionId: sessionId,
-        //       };
-        //     },
-        //     onDone: {
-        //       target: "synced",
-        //       actions: assign((_, event) => ({
-        //         sessionId: event.data.sessionId,
-        //         actions: [],
-        //       })),
-        //     },
-        //     onError: [
-        //       {
-        //         target: "playing",
-        //         cond: (_, event: any) =>
-        //           event.data.message === ERRORS.REJECTED_TRANSACTION,
-        //         actions: assign((_) => ({
-        //           actions: [],
-        //         })),
-        //       },
-        //       {
-        //         target: "error",
-        //         actions: "assignErrorMessage",
-        //       },
-        //     ],
-        //   },
-        // },
-        // minting: {
-        //   entry: "setTransactionId",
-        //   invoke: {
-        //     src: async (context, event) => {
-        //       const { auctionId } = event as MintEvent;
-
-        //       const { sessionId } = await mintAuctionItem({
-        //         farmId: Number(context.farmId),
-        //         token: authContext.user.rawToken as string,
-        //         auctionId,
-        //         transactionId: context.transactionId as string,
-        //         bid: context.state.auctioneer.bid,
-        //       });
-
-        //       return {
-        //         sessionId: sessionId,
-        //       };
-        //     },
-        //     onDone: {
-        //       target: "synced",
-        //       actions: assign((_, event) => ({
-        //         sessionId: event.data.sessionId,
-        //       })),
-        //     },
-        //     onError: [
-        //       {
-        //         target: "playing",
-        //         cond: (_, event: any) =>
-        //           event.data.message === ERRORS.REJECTED_TRANSACTION,
-        //         actions: assign((_) => ({
-        //           actions: [],
-        //         })),
-        //       },
-        //       {
-        //         target: "error",
-        //         actions: "assignErrorMessage",
-        //       },
-        //     ],
-        //   },
-        // },
         buyingBlockBucks: {
           entry: "setTransactionId",
           invoke: {
@@ -1871,25 +1727,8 @@ export function startGame(authContext: AuthContext) {
             },
           },
         },
-        // transacted: {
-        //   on: {
-        //     REFRESH: {
-        //       target: "loading",
-        //     },
-        //   },
-        // },
-        // synced: {
-        //   on: {
-        //     REFRESH: {
-        //       target: "loading",
-        //     },
-        //   },
-        // },
         hoarding: {
           on: {
-            // SYNC: {
-            //   target: "syncing",
-            // },
             TRANSACT: {
               target: "transacting",
             },
@@ -1964,108 +1803,7 @@ export function startGame(authContext: AuthContext) {
             },
           },
         },
-        // withdrawing: {
-        //   entry: "setTransactionId",
-        //   invoke: {
-        //     src: async (context, event) => {
-        //       const {
-        //         amounts,
-        //         ids,
-        //         sfl,
-        //         captcha,
-        //         type,
-        //         wearableAmounts,
-        //         wearableIds,
-        //         bumpkinId,
-        //         budIds,
-        //       } = event as WithdrawEvent;
 
-        //       if (Number(sfl) > 0) {
-        //         const { sessionId } = await withdrawSFL({
-        //           farmId: Number(context.farmId),
-        //           sessionId: context.sessionId as string,
-        //           token: authContext.user.rawToken as string,
-        //           sfl,
-        //           captcha,
-        //           transactionId: context.transactionId as string,
-        //         });
-
-        //         return {
-        //           sessionId,
-        //         };
-        //       }
-
-        //       if (ids.length > 0) {
-        //         const { sessionId } = await withdrawItems({
-        //           farmId: Number(context.farmId),
-        //           sessionId: context.sessionId as string,
-        //           token: authContext.user.rawToken as string,
-        //           amounts,
-        //           ids,
-        //           captcha,
-        //           transactionId: context.transactionId as string,
-        //         });
-
-        //         return {
-        //           sessionId,
-        //         };
-        //       }
-
-        //       if (wearableIds.length > 0) {
-        //         const { sessionId } = await withdrawWearables({
-        //           farmId: Number(context.farmId),
-        //           sessionId: context.sessionId as string,
-        //           token: authContext.user.rawToken as string,
-        //           amounts: wearableAmounts,
-        //           ids: wearableIds,
-        //           captcha,
-        //           transactionId: context.transactionId as string,
-        //         });
-
-        //         return {
-        //           sessionId,
-        //         };
-        //       }
-
-        //       if (budIds.length > 0) {
-        //         const { sessionId } = await withdrawBuds({
-        //           farmId: Number(context.farmId),
-        //           token: authContext.user.rawToken as string,
-        //           transactionId: context.transactionId as string,
-        //           budIds,
-        //         });
-
-        //         return {
-        //           sessionId,
-        //         };
-        //       }
-        //     },
-        //     onDone: {
-        //       target: "withdrawn",
-        //       actions: assign({
-        //         sessionId: (_, event) => event.data.sessionId,
-        //       }),
-        //     },
-        //     onError: [
-        //       {
-        //         target: "playing",
-        //         cond: (_, event: any) =>
-        //           event.data.message === ERRORS.REJECTED_TRANSACTION,
-        //       },
-        //       {
-        //         target: "error",
-        //         actions: "assignErrorMessage",
-        //       },
-        //     ],
-        //   },
-        // },
-        // withdrawn: {
-        //   on: {
-        //     REFRESH: {
-        //       target: "loading",
-        //     },
-        //   },
-        // },
         provingPersonhood: {
           on: {
             PERSONHOOD_FINISHED: {

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -128,7 +128,6 @@ export interface Context {
     wardrobe: Record<BumpkinItem, number>;
   };
   announcements: Announcements;
-  transaction?: { type: "withdraw_bumpkin"; expiresAt: number };
   auctionResults?: AuctionResults;
   promoCode?: string;
   moderation: Moderation;
@@ -611,7 +610,6 @@ export function startGame(authContext: AuthContext) {
                 fingerprint,
                 deviceTrackerId: response.deviceTrackerId,
                 announcements: response.announcements,
-                transaction: response.transaction,
                 moderation: response.moderation,
                 promoCode: response.promoCode,
                 farmAddress: response.farmAddress,
@@ -730,10 +728,7 @@ export function startGame(authContext: AuthContext) {
           always: [
             {
               target: "transacting",
-              cond: (context: Context) =>
-                !!context.transaction &&
-                context.transaction.type === "withdraw_bumpkin" &&
-                context.transaction.expiresAt > Date.now(),
+              cond: (context: Context) => !!context.state.transaction,
             },
 
             {
@@ -2101,7 +2096,6 @@ export function startGame(authContext: AuthContext) {
           fingerprint: (_, event) => event.data.fingerprint,
           deviceTrackerId: (_, event) => event.data.deviceTrackerId,
           announcements: (_, event) => event.data.announcements,
-          transaction: (_, event) => event.data.transaction,
           moderation: (_, event) => event.data.moderation,
           promoCode: (_, event) => event.data.promoCode,
           farmAddress: (_, event) => event.data.farmAddress,

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -726,10 +726,10 @@ export function startGame(authContext: AuthContext) {
         },
         notifying: {
           always: [
-            {
-              target: "transacting",
-              cond: (context: Context) => !!context.state.transaction,
-            },
+            // {
+            //   target: "transacting",
+            //   cond: (context: Context) => !!context.state.transaction,
+            // },
 
             {
               target: "gameRules",

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -32,7 +32,6 @@ import { getPromoCode, loadSession } from "../actions/loadSession";
 import { EMPTY } from "./constants";
 import { autosave } from "../actions/autosave";
 import { CollectibleName } from "../types/craftables";
-import { sync } from "../actions/sync";
 import { ErrorCode, ERRORS } from "lib/errors";
 import { makeGame } from "./transforms";
 import { reset } from "features/farming/hud/actions/reset";
@@ -89,11 +88,7 @@ import { MinigameName } from "../types/minigames";
 import { OFFLINE_FARM } from "./landData";
 import { isValidRedirect } from "features/portal/lib/portalUtil";
 import { Effect, postEffect } from "../actions/effect";
-import {
-  ONCHAIN_TRANSACTIONS,
-  TRANSACTION_SIGNATURES,
-  TransactionName,
-} from "../types/transactions";
+import { TRANSACTION_SIGNATURES, TransactionName } from "../types/transactions";
 
 // Run at startup in case removed from query params
 const portalName = new URLSearchParams(window.location.search).get("portal");
@@ -1151,7 +1146,6 @@ export function startGame(authContext: AuthContext) {
 
               const { transaction, request } = event as TransactEvent;
 
-              console.log({ request });
               const { game } = await TRANSACTION_SIGNATURES[transaction]({
                 ...request,
                 farmId: Number(context.farmId),

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -111,5 +111,6 @@ export function makeGame(farm: any): GameState {
         }
       : undefined,
     desert: farm.desert,
+    transaction: farm.transaction,
   };
 }

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1133,6 +1133,11 @@ export interface GameState {
 
   rewards: Rewards;
 
+  // There are more fields but unused
+  transaction?: {
+    createdAt: number;
+  };
+
   island: {
     type: IslandType;
     upgradedAt?: number;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -74,6 +74,7 @@ import { DiggingFormationName } from "./desert";
 import { Rewards } from "./rewards";
 import { ExperimentName } from "lib/flags";
 import { CollectionName, MarketplaceTradeableName } from "./marketplace";
+import { GameTransaction } from "./transactions";
 
 export type Reward = {
   coins?: number;
@@ -1134,9 +1135,7 @@ export interface GameState {
   rewards: Rewards;
 
   // There are more fields but unused
-  transaction?: {
-    createdAt: number;
-  };
+  transaction?: GameTransaction;
 
   island: {
     type: IslandType;

--- a/src/features/game/types/transactions.ts
+++ b/src/features/game/types/transactions.ts
@@ -1,0 +1,132 @@
+import { SyncProgressParams } from "lib/blockchain/Game";
+import { GameState, InventoryItemName, Wardrobe } from "./game";
+import { MintBidParams } from "lib/blockchain/Auction";
+import {
+  WithdrawBudsParams,
+  WithdrawItemsParams,
+  WithdrawSFLParams,
+  WithdrawWearablesParams,
+} from "lib/blockchain/Withdrawals";
+
+export type BidMintedTransaction = {
+  event: "transaction.bidMinted";
+  createdAt: number;
+  data: {
+    bid: GameState["auctioneer"]["bid"];
+    params: MintBidParams;
+  };
+};
+
+export type SFLWithdrawnTransaction = {
+  event: "transaction.sflWithdrawn";
+  createdAt: number;
+  data: {
+    sfl: number;
+    params: WithdrawSFLParams;
+  };
+};
+
+export type BudWithdrawnTransaction = {
+  event: "transaction.budWithdrawn";
+  createdAt: number;
+  data: {
+    buds: GameState["buds"];
+    params: WithdrawBudsParams;
+  };
+};
+
+export type ItemsWithdrawnTransaction = {
+  event: "transaction.itemsWithdrawn";
+  createdAt: number;
+  data: {
+    items: Partial<Record<InventoryItemName, number>>;
+    params: WithdrawItemsParams;
+  };
+};
+
+export type WearablesWithdrawnTransaction = {
+  event: "transaction.wearablesWithdrawn";
+  createdAt: number;
+  data: {
+    wearables: Wardrobe;
+    params: WithdrawWearablesParams;
+  };
+};
+
+export type ProgressSyncedTransaction = {
+  event: "transaction.progressSynced";
+  createdAt: number;
+  data: {
+    params: SyncProgressParams;
+  };
+};
+
+export type GameTransaction =
+  | ProgressSyncedTransaction
+  | WearablesWithdrawnTransaction
+  | ItemsWithdrawnTransaction
+  | BudWithdrawnTransaction
+  | SFLWithdrawnTransaction
+  | BidMintedTransaction;
+
+export type TransactionName = Extract<
+  GameTransaction,
+  { event: string }
+>["event"];
+
+type TransactionHash = {
+  // deadline: number;
+  sessionId: string;
+  hash: string;
+  event: TransactionName;
+};
+
+export const DEADLINE_MS = 5 * 60 * 1000;
+
+const host = window.location.host.replace(/^www\./, "");
+const LOCAL_STORAGE_KEY = `sb_wiz.hash.v.${host}-${window.location.pathname}`;
+
+export function saveTxHash({
+  hash,
+  event,
+  // deadline,
+  sessionId,
+}: {
+  hash: string;
+  sessionId: string;
+  event: TransactionName;
+  // deadline: number;
+}) {
+  const txHash: TransactionHash = {
+    hash,
+    event,
+    sessionId,
+    // deadline,
+  };
+
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(txHash));
+}
+
+export function loadActiveTxHash({
+  event,
+  sessionId,
+}: {
+  event: TransactionName;
+  sessionId: string;
+}) {
+  const item = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  if (!item) return null;
+
+  const txHash = JSON.parse(item) as TransactionHash;
+
+  if (txHash.event !== event) return null;
+
+  if (txHash.sessionId !== sessionId) return null;
+
+  // const hasExpired = txHash.deadline * 1000 + DEADLINE_MS < Date.now();
+
+  // if (hasExpired) return null;
+
+  return txHash;
+}

--- a/src/features/game/types/transactions.ts
+++ b/src/features/game/types/transactions.ts
@@ -1,6 +1,10 @@
 import { syncProgress, SyncProgressParams } from "lib/blockchain/Game";
 import { GameState, InventoryItemName, Wardrobe } from "./game";
-import { mintAuctionCollectible, MintBidParams } from "lib/blockchain/Auction";
+import {
+  mintAuctionCollectible,
+  mintAuctionWearable,
+  MintBidParams,
+} from "lib/blockchain/Auction";
 import {
   WithdrawBudsParams,
   withdrawBudsTransaction,
@@ -161,7 +165,7 @@ export const ONCHAIN_TRANSACTIONS: TransactionHandler = {
       return mintAuctionCollectible(data.params);
     }
 
-    return mintAuctionCollectible(data.params);
+    return mintAuctionWearable(data.params);
   },
 };
 

--- a/src/features/game/types/transactions.ts
+++ b/src/features/game/types/transactions.ts
@@ -162,7 +162,7 @@ export const ONCHAIN_TRANSACTIONS: TransactionHandler = {
 
   // Minting a bid has 2 separate contract methods
   "transaction.bidMinted": (data) => {
-    if (!!data.bid?.collectible) {
+    if (data.bid?.collectible) {
       return mintAuctionCollectible(data.params);
     }
 
@@ -178,7 +178,7 @@ export type SignatureHandler = {
 
 type TransactionRequest = Record<
   TransactionName,
-  ({}: any) => Promise<{ game: GameState }>
+  (_: any) => Promise<{ game: GameState }>
 >;
 
 export const TRANSACTION_SIGNATURES: TransactionRequest = {

--- a/src/features/game/types/transactions.ts
+++ b/src/features/game/types/transactions.ts
@@ -98,6 +98,7 @@ type TransactionHash = {
 };
 
 export const DEADLINE_MS = 5 * 60 * 1000;
+export const DEADLINE_BUFFER_MS = 1 * 60 * 1000;
 
 const host = window.location.host.replace(/^www\./, "");
 const LOCAL_STORAGE_KEY = `sb_wiz.hash.v.${host}-${window.location.pathname}`;

--- a/src/features/helios/components/heliosAuction/HeliosAuction.tsx
+++ b/src/features/helios/components/heliosAuction/HeliosAuction.tsx
@@ -58,7 +58,12 @@ export const HeliosAuction: React.FC = () => {
         }}
         onMint={(id) => {
           setIsOpen(false);
-          gameService.send("MINT", { auctionId: id });
+          gameService.send("TRANSACT", {
+            transaction: "transaction.wearablesWithdrawn",
+            request: {
+              auctionId: id,
+            },
+          });
         }}
         deviceTrackerId={gameState.context.deviceTrackerId as string}
         linkedAddress={gameState.context.linkedWallet}

--- a/src/features/helios/components/heliosAuction/HeliosAuction.tsx
+++ b/src/features/helios/components/heliosAuction/HeliosAuction.tsx
@@ -59,7 +59,7 @@ export const HeliosAuction: React.FC = () => {
         onMint={(id) => {
           setIsOpen(false);
           gameService.send("TRANSACT", {
-            transaction: "transaction.wearablesWithdrawn",
+            transaction: "transaction.bidMinted",
             request: {
               auctionId: id,
             },

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -26,6 +26,7 @@ import { SeasonBannerCountdown } from "./SeasonBannerCountdown";
 import marketplaceIcon from "assets/icons/shop_disc.png";
 import { hasFeatureAccess } from "lib/flags";
 import { useNavigate } from "react-router-dom";
+import { TransactionCountdown } from "./Transaction";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _showMarketplace = (state: MachineState) =>
@@ -169,6 +170,7 @@ const HudComponent: React.FC<{
             left: `${PIXEL_SCALE * 28}px`,
           }}
         >
+          <TransactionCountdown />
           <AuctionCountdown />
           <SpecialEventCountdown />
           <SeasonBannerCountdown />

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -174,11 +174,7 @@ const HudComponent: React.FC<{
             left: `${PIXEL_SCALE * 28}px`,
           }}
         >
-          <WagmiProvider config={config}>
-            <QueryClientProvider client={queryClient}>
-              <TransactionCountdown />
-            </QueryClientProvider>
-          </WagmiProvider>
+          <TransactionCountdown />
           <AuctionCountdown />
           <SpecialEventCountdown />
           <SeasonBannerCountdown />

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -27,10 +27,6 @@ import marketplaceIcon from "assets/icons/shop_disc.png";
 import { hasFeatureAccess } from "lib/flags";
 import { useNavigate } from "react-router-dom";
 import { TransactionCountdown } from "./Transaction";
-import { WagmiProvider } from "wagmi";
-import { config } from "features/wallet/WalletProvider";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "features/wallet/Wallet";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _showMarketplace = (state: MachineState) =>

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -27,6 +27,10 @@ import marketplaceIcon from "assets/icons/shop_disc.png";
 import { hasFeatureAccess } from "lib/flags";
 import { useNavigate } from "react-router-dom";
 import { TransactionCountdown } from "./Transaction";
+import { WagmiProvider } from "wagmi";
+import { config } from "features/wallet/WalletProvider";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "features/wallet/Wallet";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _showMarketplace = (state: MachineState) =>
@@ -170,7 +174,11 @@ const HudComponent: React.FC<{
             left: `${PIXEL_SCALE * 28}px`,
           }}
         >
-          <TransactionCountdown />
+          <WagmiProvider config={config}>
+            <QueryClientProvider client={queryClient}>
+              <TransactionCountdown />
+            </QueryClientProvider>
+          </WagmiProvider>
           <AuctionCountdown />
           <SpecialEventCountdown />
           <SeasonBannerCountdown />

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -1,0 +1,221 @@
+import React, { useContext, useState } from "react";
+import { ButtonPanel, Panel } from "components/ui/Panel";
+import { Label } from "components/ui/Label";
+import { SUNNYSIDE } from "assets/sunnyside";
+
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import { MachineState } from "features/game/lib/gameMachine";
+
+import {
+  getCurrentSeason,
+  getSeasonalBanner,
+  SEASONS,
+} from "features/game/types/seasons";
+import { getSeasonWeek } from "lib/utils/getSeasonWeek";
+import { getBumpkinLevel } from "features/game/lib/level";
+import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
+import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { Modal } from "components/ui/Modal";
+import { Button } from "components/ui/Button";
+import { syncProgress } from "lib/blockchain/Game";
+import { useWaitForTransactionReceipt } from "wagmi";
+import {
+  DEADLINE_MS,
+  loadActiveTxHash,
+  TransactionName,
+} from "features/game/types/transactions";
+import { GameWallet } from "features/wallet/Wallet";
+import { ResizableBar } from "components/ui/ProgressBar";
+
+import walletIcon from "assets/icons/wallet.png";
+import lockIcon from "assets/icons/lock.png";
+
+import { Loading } from "features/auth/components";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+export const TransactionCountdown: React.FC = () => {
+  const { gameService } = useContext(Context);
+
+  const [showTransaction, setShowTransaction] = useState(false);
+
+  const transaction = gameService.state.context.state.transaction;
+
+  // Show expired = Button to refresh
+
+  const tx = loadActiveTxHash({
+    event: transaction?.event as TransactionName,
+    sessionId: gameService.state.context.sessionId as string,
+  });
+
+  if (!transaction) return null;
+
+  return (
+    <>
+      <Modal show={showTransaction} onHide={() => setShowTransaction(false)}>
+        <Panel>
+          <Transaction onClose={() => setShowTransaction(false)} />
+        </Panel>
+      </Modal>
+      <ButtonPanel
+        onClick={() => setShowTransaction(true)}
+        className="flex justify-center"
+        id="emblem-airdrop"
+      >
+        <div>
+          <div className="h-6 flex justify-between">
+            <Label
+              type={!tx ? "danger" : "default"}
+              className="ml-1 mr-1"
+              icon={walletIcon}
+            >
+              {`Transaction`}
+            </Label>
+          </div>
+          {!tx && <span className="text-sm">Not submitted</span>}
+          {tx && <Loading />}
+        </div>
+      </ButtonPanel>
+    </>
+  );
+};
+
+interface Props {
+  onClose: () => void;
+}
+
+export const Transaction: React.FC<Props> = ({ onClose }) => {
+  return (
+    <>
+      <GameWallet action="sync">
+        <TransactionProgress onClose={onClose} />
+      </GameWallet>
+    </>
+  );
+};
+
+export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
+  const { gameService } = useContext(Context);
+  const { t } = useAppTranslation();
+
+  const transaction = gameService.state.context.state.transaction;
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const tx = loadActiveTxHash({
+    event: transaction?.event as TransactionName,
+    sessionId: gameService.state.context.sessionId as string,
+  });
+
+  const { isLoading, isSuccess, isError } = useWaitForTransactionReceipt({
+    hash: tx?.hash as `0x${string}`,
+  });
+
+  const end = useCountdown((transaction?.createdAt ?? 0) + DEADLINE_MS);
+
+  if (!transaction) return null;
+
+  const submit = async () => {
+    setIsSubmitting(true);
+
+    try {
+      if (transaction.event === "transaction.progressSynced") {
+        await syncProgress(transaction.data.params);
+      }
+    } catch (e) {
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const reload = () => {
+    gameService.send("REFRESH");
+    onClose();
+  };
+
+  if (isSuccess) {
+    return (
+      <>
+        <div className="p-2">
+          <div className="flex items-center justify-between mb-2">
+            <Label icon={walletIcon} type="success" className="-ml-1">
+              Success
+            </Label>
+          </div>
+          <p className="text-sm mb-2">
+            Congratulations, your transaction was secured
+          </p>
+        </div>
+        <Button onClick={reload}>Continue</Button>
+      </>
+    );
+  }
+
+  if (tx || isSubmitting) {
+    return (
+      <>
+        <div className="p-2">
+          <Label icon={lockIcon} type="default" className="mb-2">
+            Transaction in progress
+          </Label>
+          <Loading />
+          {/* <p>{tx?.hash}</p>
+          <p>
+            {JSON.stringify({
+              isLoading,
+              isSuccess,
+              isError,
+            })}
+          </p> */}
+          {/* <Button onClick={submit}>Submit</Button> */}
+        </div>
+      </>
+    );
+  }
+
+  if (Date.now() > (transaction?.createdAt ?? 0) + DEADLINE_MS) {
+    return (
+      <>
+        <div className="p-2">
+          <div className="flex items-center justify-between mb-2">
+            <Label icon={lockIcon} type="danger" className="-ml-1">
+              Transaction failed
+            </Label>
+          </div>
+          <p className="text-sm mb-2">
+            Looks like there was an issue with your previous transaction.
+          </p>
+        </div>
+        <Button onClick={reload}>Continue</Button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center justify-between mb-2">
+          <Label icon={lockIcon} type="danger" className="-ml-1">
+            Transaction in progress
+          </Label>
+          <TimerDisplay time={end} />
+        </div>
+        <p className="text-sm mb-2">
+          You have a transaction which was already initiated. It looks like
+          there was an issue.
+        </p>
+        <p>{transaction.event}</p>
+      </div>
+      <div className="flex">
+        <Button className="mr-1" onClick={onClose}>
+          Close
+        </Button>
+        <Button onClick={submit} className="relative">
+          <span>{t("retry")}</span>
+          <img src={walletIcon} className="absolute right-1 top-0.5 h-7" />
+        </Button>
+      </div>
+    </>
+  );
+};

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -8,7 +8,7 @@ import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDeta
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { Modal } from "components/ui/Modal";
 import { Button } from "components/ui/Button";
-import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useWaitForTransactionReceipt, WagmiProvider } from "wagmi";
 import {
   DEADLINE_MS,
   GameTransaction,
@@ -16,7 +16,7 @@ import {
   ONCHAIN_TRANSACTIONS,
   TransactionName,
 } from "features/game/types/transactions";
-import { GameWallet } from "features/wallet/Wallet";
+import { GameWallet, queryClient } from "features/wallet/Wallet";
 
 import walletIcon from "assets/icons/wallet.png";
 import lockIcon from "assets/icons/lock.png";
@@ -26,6 +26,8 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { wallet } from "lib/blockchain/wallet";
+import { config } from "features/wallet/WalletProvider";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 const _transaction = (state: MachineState) => state.context.state.transaction;
 
@@ -54,10 +56,14 @@ export const TransactionCountdown: React.FC = () => {
         className="flex justify-center"
         id="emblem-airdrop"
       >
-        <TransactionWidget
-          transaction={transaction}
-          onOpen={() => setShowTransaction(true)}
-        />
+        <WagmiProvider config={config}>
+          <QueryClientProvider client={queryClient}>
+            <TransactionWidget
+              transaction={transaction}
+              onOpen={() => setShowTransaction(true)}
+            />
+          </QueryClientProvider>
+        </WagmiProvider>
       </ButtonPanel>
     </>
   );

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -1,61 +1,44 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { ButtonPanel, Panel } from "components/ui/Panel";
 import { Label } from "components/ui/Label";
-import { SUNNYSIDE } from "assets/sunnyside";
 
 import { Context } from "features/game/GameProvider";
-import { useSelector } from "@xstate/react";
-import { MachineState } from "features/game/lib/gameMachine";
 
-import {
-  getCurrentSeason,
-  getSeasonalBanner,
-  SEASONS,
-} from "features/game/types/seasons";
-import { getSeasonWeek } from "lib/utils/getSeasonWeek";
-import { getBumpkinLevel } from "features/game/lib/level";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
-import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { Modal } from "components/ui/Modal";
 import { Button } from "components/ui/Button";
-import { syncProgress } from "lib/blockchain/Game";
-import { useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useWaitForTransactionReceipt } from "wagmi";
 import {
   DEADLINE_MS,
   GameTransaction,
   loadActiveTxHash,
-  TRANSACTION_HANDLERS,
-  TransactionHandler,
+  ONCHAIN_TRANSACTIONS,
   TransactionName,
 } from "features/game/types/transactions";
 import { GameWallet } from "features/wallet/Wallet";
-import { ResizableBar } from "components/ui/ProgressBar";
 
 import walletIcon from "assets/icons/wallet.png";
 import lockIcon from "assets/icons/lock.png";
 
 import { Loading } from "features/auth/components";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import {
-  mintAuctionCollectible,
-  mintAuctionWearable,
-} from "lib/blockchain/Auction";
-import { withdrawItemsTransaction } from "lib/blockchain/Withdrawals";
+import { MachineState } from "features/game/lib/gameMachine";
+import { useSelector } from "@xstate/react";
+import { wallet } from "lib/blockchain/wallet";
+
+const _transaction = (state: MachineState) => state.context.state.transaction;
 
 export const TransactionCountdown: React.FC = () => {
   const { gameService } = useContext(Context);
-
   const [showTransaction, setShowTransaction] = useState(false);
 
-  const transaction = gameService.state.context.state.transaction;
+  const transaction = useSelector(gameService, _transaction);
 
-  // Show expired = Button to refresh
-
-  const tx = loadActiveTxHash({
-    event: transaction?.event as TransactionName,
-    sessionId: gameService.state.context.sessionId as string,
-  });
+  useEffect(() => {
+    // Whenever something with transaction changes - pop up
+    setShowTransaction(true);
+  }, [transaction]);
 
   if (!transaction) return null;
 
@@ -71,29 +54,144 @@ export const TransactionCountdown: React.FC = () => {
         className="flex justify-center"
         id="emblem-airdrop"
       >
-        <div>
-          <div className="h-6 flex justify-between">
-            <Label
-              type={!tx ? "danger" : "default"}
-              className="ml-1 mr-1"
-              icon={walletIcon}
-            >
-              {`Transaction`}
-            </Label>
-          </div>
-          {!tx && <span className="text-sm">Not submitted</span>}
-          {tx && <Loading />}
-        </div>
+        <TransactionWidget
+          transaction={transaction}
+          onOpen={() => setShowTransaction(true)}
+        />
       </ButtonPanel>
     </>
   );
 };
 
+const TransactionWidget: React.FC<{
+  transaction: GameTransaction;
+  onOpen: () => void;
+}> = ({ transaction, onOpen }) => {
+  const { gameService } = useContext(Context);
+  const { isConnected, address } = useAccount();
+
+  console.log({ isConnected });
+  const tx = loadActiveTxHash({
+    event: transaction?.event as TransactionName,
+    sessionId: gameService.state.context.sessionId as string,
+  });
+
+  const { isSuccess, isError, isLoading } = useWaitForTransactionReceipt({
+    hash: tx?.hash as `0x${string}`,
+  });
+
+  useEffect(() => {
+    if (isSuccess) {
+      onOpen();
+    }
+  }, [isSuccess]);
+
+  console.log({ isSuccess, isError, isLoading });
+
+  const timedOut = Date.now() > (transaction.createdAt ?? 0) + DEADLINE_MS;
+
+  if (timedOut) {
+    return (
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label type={"danger"} className="ml-1 mr-1" icon={walletIcon}>
+            {`Transaction`}
+          </Label>
+        </div>
+        <span className="text-sm">Timed out</span>
+      </div>
+    );
+  }
+
+  if (!tx) {
+    return (
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
+            {`Transaction`}
+          </Label>
+        </div>
+        <span className="text-sm">Not submitted</span>
+      </div>
+    );
+  }
+
+  // Is not connected to game wallet?
+  const test = wallet.getAccount();
+  console.log({ isConnected, address, test });
+
+  if (!isConnected) {
+    return (
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
+            {`Transaction`}
+          </Label>
+        </div>
+        <Loading />
+      </div>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label type={"success"} className="ml-1 mr-1" icon={walletIcon}>
+            {`Transaction`}
+          </Label>
+        </div>
+        <span>Success</span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div>
+        <div className="h-6 flex justify-between">
+          <Label type={"danger"} className="ml-1 mr-1" icon={walletIcon}>
+            {`Transaction`}
+          </Label>
+        </div>
+        <span className="text-sm">Error</span>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="h-6 flex justify-between">
+        <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
+          {`Transaction`}
+        </Label>
+      </div>
+      <Loading />
+    </div>
+  );
+};
+
 interface Props {
-  onClose: () => void;
+  onClose?: () => void;
 }
 
+const _isTransacting = (state: MachineState) => state.matches("transacting");
+
 export const Transaction: React.FC<Props> = ({ onClose }) => {
+  const { gameService } = useContext(Context);
+  const isTransacting = useSelector(gameService, _isTransacting);
+
+  if (isTransacting) {
+    return (
+      <div className="p-2">
+        <Label type="default" className="mb-2" icon={walletIcon}>
+          Transaction in progress
+        </Label>
+        <Loading text="Preparing transaction" />
+      </div>
+    );
+  }
+
   return (
     <>
       <GameWallet action="sync">
@@ -125,7 +223,7 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
     sessionId: gameService.state.context.sessionId as string,
   });
 
-  const { isLoading, isSuccess, isError } = useWaitForTransactionReceipt({
+  const { isSuccess, isError, isLoading } = useWaitForTransactionReceipt({
     hash: tx?.hash as `0x${string}`,
   });
 
@@ -137,7 +235,7 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
     setIsSubmitting(true);
 
     try {
-      const handler = TRANSACTION_HANDLERS[transaction.event];
+      const handler = ONCHAIN_TRANSACTIONS[transaction.event];
       await handler(transaction.data as any);
     } catch (e) {
       console.log({ error: e });
@@ -148,7 +246,9 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
 
   const reload = () => {
     gameService.send("REFRESH");
-    onClose();
+    if (onClose) {
+      onClose();
+    }
   };
 
   if (isSuccess) {
@@ -165,6 +265,50 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
           </p>
         </div>
         <Button onClick={reload}>Continue</Button>
+      </>
+    );
+  }
+
+  if (Date.now() > (transaction?.createdAt ?? 0) + DEADLINE_MS) {
+    return (
+      <>
+        <div className="p-2">
+          <div className="flex items-center justify-between mb-2">
+            <Label icon={lockIcon} type="danger" className="-ml-1">
+              Transaction timed out
+            </Label>
+          </div>
+          <p className="text-sm mb-2">Looks like your transaction timed out.</p>
+        </div>
+        <Button onClick={reload}>Continue</Button>
+      </>
+    );
+  }
+
+  if (isError) {
+    return (
+      <>
+        <div className="p-2">
+          <div className="flex items-center justify-between mb-2 flex-wrap">
+            <Label icon={lockIcon} type="danger" className="-ml-1">
+              {EVENT_TO_NAME[transaction.event]} error
+            </Label>
+            <TimerDisplay time={end} />
+          </div>
+          <p className="text-sm mb-2">Looks like something went wrong.</p>
+        </div>
+        <div className="flex">
+          {onClose && (
+            <Button className="mr-1" onClick={onClose}>
+              Close
+            </Button>
+          )}
+
+          <Button onClick={submit} className="relative">
+            <span>{t("retry")}</span>
+            <img src={walletIcon} className="absolute right-1 top-0.5 h-7" />
+          </Button>
+        </div>
       </>
     );
   }
@@ -187,24 +331,7 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
           </p> */}
           {/* <Button onClick={submit}>Submit</Button> */}
         </div>
-      </>
-    );
-  }
-
-  if (Date.now() > (transaction?.createdAt ?? 0) + DEADLINE_MS) {
-    return (
-      <>
-        <div className="p-2">
-          <div className="flex items-center justify-between mb-2">
-            <Label icon={lockIcon} type="danger" className="-ml-1">
-              Transaction failed
-            </Label>
-          </div>
-          <p className="text-sm mb-2">
-            Looks like there was an issue with your previous transaction.
-          </p>
-        </div>
-        <Button onClick={reload}>Continue</Button>
+        <Button onClick={onClose}>Close</Button>
       </>
     );
   }
@@ -212,29 +339,23 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
   return (
     <>
       <div className="p-2">
-        <div className="flex items-center justify-between mb-2">
-          <Label icon={lockIcon} type="danger" className="-ml-1">
-            Transaction in progress
+        <div className="flex items-center justify-between mb-2 flex-wrap">
+          <Label icon={lockIcon} type="default" className="-ml-1">
+            {EVENT_TO_NAME[transaction.event]} in progress
           </Label>
           <TimerDisplay time={end} />
         </div>
-        <p className="text-sm mb-2">
-          You have a transaction in progress. You can wait for it to timeout or
-          submit it again.
-        </p>
-        <div className="flex items-center">
-          <Label type="formula" className="-ml-1 mr-2">
-            Transaction: {EVENT_TO_NAME[transaction.event]}
-          </Label>
-          <span className="text-xs italic"></span>
-        </div>
+        <p className="text-sm mb-2">You have a transaction ready to submit.</p>
       </div>
       <div className="flex">
-        <Button className="mr-1" onClick={onClose}>
-          Close
-        </Button>
+        {onClose && (
+          <Button className="mr-1" onClick={onClose}>
+            Close
+          </Button>
+        )}
+
         <Button onClick={submit} className="relative">
-          <span>{t("retry")}</span>
+          <span>{t("submit")}</span>
           <img src={walletIcon} className="absolute right-1 top-0.5 h-7" />
         </Button>
       </div>

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -55,7 +55,6 @@ export const TransactionCountdown: React.FC = () => {
       <ButtonPanel
         onClick={() => setShowTransaction(true)}
         className="flex justify-center"
-        id="emblem-airdrop"
       >
         <WagmiProvider config={config}>
           <QueryClientProvider client={queryClient}>
@@ -76,8 +75,8 @@ const TransactionWidget: React.FC<{
 }> = ({ transaction, onOpen }) => {
   const { gameService } = useContext(Context);
   const { isConnected, address } = useAccount();
+  const { t } = useAppTranslation();
 
-  console.log({ isConnected });
   const tx = loadActiveTxHash({
     event: transaction?.event as TransactionName,
     sessionId: gameService.state.context.sessionId as string,
@@ -93,8 +92,6 @@ const TransactionWidget: React.FC<{
     }
   }, [isSuccess]);
 
-  console.log({ isSuccess, isError, isLoading });
-
   const timedOut =
     Date.now() >
     (transaction.createdAt ?? 0) + DEADLINE_MS + DEADLINE_BUFFER_MS;
@@ -104,10 +101,10 @@ const TransactionWidget: React.FC<{
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"danger"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
-        <span className="text-sm">Timed out</span>
+        <span className="text-sm">{t("transaction.timedOut")}</span>
       </div>
     );
   }
@@ -121,10 +118,10 @@ const TransactionWidget: React.FC<{
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"danger"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
-        <span className="text-sm">Expired</span>
+        <span className="text-sm">{t("transaction.expired")}</span>
       </div>
     );
   }
@@ -134,24 +131,23 @@ const TransactionWidget: React.FC<{
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
-        <span className="text-sm">Not submitted</span>
+        <span className="text-sm">{t("transaction.notSubmitted")}</span>
       </div>
     );
   }
 
   // Is not connected to game wallet?
   const test = wallet.getAccount();
-  console.log({ isConnected, address, test });
 
   if (!isConnected) {
     return (
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
         <Loading />
@@ -164,10 +160,10 @@ const TransactionWidget: React.FC<{
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"success"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
-        <span>Success</span>
+        <span>{t("transaction.success")}</span>
       </div>
     );
   }
@@ -177,10 +173,10 @@ const TransactionWidget: React.FC<{
       <div>
         <div className="h-6 flex justify-between">
           <Label type={"danger"} className="ml-1 mr-1" icon={walletIcon}>
-            {`Transaction`}
+            {t("transaction")}
           </Label>
         </div>
-        <span className="text-sm">Error</span>
+        <span className="text-sm">{t("transaction.error")}</span>
       </div>
     );
   }
@@ -189,7 +185,7 @@ const TransactionWidget: React.FC<{
     <div>
       <div className="h-6 flex justify-between">
         <Label type={"default"} className="ml-1 mr-1" icon={walletIcon}>
-          {`Transaction`}
+          {t("transaction")}
         </Label>
       </div>
       <Loading />
@@ -206,14 +202,15 @@ const _isTransacting = (state: MachineState) => state.matches("transacting");
 export const Transaction: React.FC<Props> = ({ onClose }) => {
   const { gameService } = useContext(Context);
   const isTransacting = useSelector(gameService, _isTransacting);
+  const { t } = useAppTranslation();
 
   if (isTransacting) {
     return (
       <div className="p-2">
         <Label type="default" className="mb-2" icon={walletIcon}>
-          Transaction in progress
+          {t("transaction.inProgress")}
         </Label>
-        <Loading text="Preparing transaction" />
+        <Loading text={t("transaction.preparing")} />
       </div>
     );
   }
@@ -263,14 +260,9 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
   const submit = async () => {
     setIsSubmitting(true);
 
-    try {
-      const handler = ONCHAIN_TRANSACTIONS[transaction.event];
-      await handler(transaction.data as any);
-    } catch (e) {
-      console.log({ error: e });
-    } finally {
-      setIsSubmitting(false);
-    }
+    const handler = ONCHAIN_TRANSACTIONS[transaction.event];
+    await handler(transaction.data as any);
+    setIsSubmitting(false);
   };
 
   const reload = () => {
@@ -286,14 +278,12 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
         <div className="p-2">
           <div className="flex items-center justify-between mb-2">
             <Label icon={walletIcon} type="success" className="-ml-1">
-              Success
+              {t("transaction.success")}
             </Label>
           </div>
-          <p className="text-sm mb-2">
-            Congratulations, your transaction was secured
-          </p>
+          <p className="text-sm mb-2">{t("transaction.success.message")}</p>
         </div>
-        <Button onClick={reload}>Continue</Button>
+        <Button onClick={reload}>{t("continue")}</Button>
       </>
     );
   }
@@ -307,14 +297,12 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
         <div className="p-2">
           <div className="flex items-center justify-between mb-2">
             <Label icon={lockIcon} type="danger" className="-ml-1">
-              Transaction cleared
+              {t("transaction.cleared")}
             </Label>
           </div>
-          <p className="text-sm mb-2">
-            Your transaction was unable to go through. Please try again.
-          </p>
+          <p className="text-sm mb-2">{t("transaction.cleared.message")}</p>
         </div>
-        <Button onClick={reload}>Continue</Button>
+        <Button onClick={reload}> {t("continue")}</Button>
       </>
     );
   }
@@ -326,14 +314,11 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
         <div className="p-2">
           <div className="flex items-center justify-between mb-2">
             <Label icon={lockIcon} type="danger" className="-ml-1">
-              Transaction expired
+              {t("transaction.expired")}
             </Label>
             <TimerDisplay time={timedOut} />
           </div>
-          <p className="text-sm mb-2">
-            Looks like your transaction expired. Sit tight while we clear the
-            transaction for you.
-          </p>
+          <p className="text-sm mb-2">{t("transaction.expired.message")}</p>
         </div>
       </>
     );
@@ -345,16 +330,16 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
         <div className="p-2">
           <div className="flex items-center justify-between mb-2 flex-wrap">
             <Label icon={lockIcon} type="danger" className="-ml-1">
-              {EVENT_TO_NAME[transaction.event]} error
+              {EVENT_TO_NAME[transaction.event]} {t("error")}
             </Label>
             <TimerDisplay time={expired} />
           </div>
-          <p className="text-sm mb-2">Looks like something went wrong.</p>
+          <p className="text-sm mb-2">{t("transaction.error.message")}</p>
         </div>
         <div className="flex">
           {onClose && (
             <Button className="mr-1" onClick={onClose}>
-              Close
+              {t("close")}
             </Button>
           )}
 
@@ -372,20 +357,11 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
       <>
         <div className="p-2">
           <Label icon={lockIcon} type="default" className="mb-2">
-            Transaction in progress
+            {t("transaction.inProgress")}
           </Label>
           <Loading />
-          {/* <p>{tx?.hash}</p>
-          <p>
-            {JSON.stringify({
-              isLoading,
-              isSuccess,
-              isError,
-            })}
-          </p> */}
-          {/* <Button onClick={submit}>Submit</Button> */}
         </div>
-        <Button onClick={onClose}>Close</Button>
+        <Button onClick={onClose}>{t("close")}</Button>
       </>
     );
   }
@@ -395,16 +371,18 @@ export const TransactionProgress: React.FC<Props> = ({ onClose }) => {
       <div className="p-2">
         <div className="flex items-center justify-between mb-2 flex-wrap">
           <Label icon={lockIcon} type="default" className="-ml-1">
-            {EVENT_TO_NAME[transaction.event]} in progress
+            {t("transaction.waiting", {
+              name: EVENT_TO_NAME[transaction.event],
+            })}
           </Label>
           <TimerDisplay time={expired} />
         </div>
-        <p className="text-sm mb-2">You have a transaction ready to submit.</p>
+        <p className="text-sm mb-2">{t("transaction.ready")}</p>
       </div>
       <div className="flex">
         {onClose && (
           <Button className="mr-1" onClick={onClose}>
-            Close
+            {t("close")}
           </Button>
         )}
 

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -22,6 +22,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useLocation } from "react-router-dom";
 import { SpecialEventCountdown } from "./SpecialEventCountdown";
 import { DesertDiggingDisplay } from "./components/DesertDiggingDisplay";
+import { TransactionCountdown } from "./Transaction";
 
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.
@@ -108,6 +109,8 @@ const HudComponent: React.FC = () => {
           left: `${PIXEL_SCALE * 28}px`,
         }}
       >
+        <TransactionCountdown />
+
         <AuctionCountdown />
         <SpecialEventCountdown />
       </div>

--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -44,6 +44,7 @@ import { AppearanceSettings } from "./general-settings/AppearanceSettings";
 import { FontSettings } from "./general-settings/FontSettings";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
 import ticket from "assets/icons/ticket.png";
+import lockIcon from "assets/icons/lock.png";
 import { DEV_HoarderCheck } from "./amoy-actions/DEV_HoardingCheck";
 import { WalletAddressLabel } from "components/ui/WalletAddressLabel";
 import { PickServer } from "./plaza-settings/PickServer";
@@ -97,6 +98,8 @@ const GameOptions: React.FC<ContentComponentProps> = ({
     walletService.send("RESET");
   };
 
+  const canRefresh = !gameService.state.context.state.transaction;
+
   return (
     <>
       {/* Root menu */}
@@ -149,8 +152,16 @@ const GameOptions: React.FC<ContentComponentProps> = ({
           <span>{t("install.app")}</span>
         </Button>
       )}
-      <Button className="p-1 mb-1" onClick={refreshSession}>
+      <Button
+        disabled={!canRefresh}
+        className="p-1 mb-1 relative"
+        onClick={refreshSession}
+      >
         {t("gameOptions.blockchainSettings.refreshChain")}
+
+        {!canRefresh && (
+          <img src={lockIcon} className="absolute right-1 top-0.5 h-7" />
+        )}
       </Button>
       {CONFIG.NETWORK === "amoy" && (
         <Button className="p-1 mb-1" onClick={() => onSubMenuClick("amoy")}>

--- a/src/features/retreat/components/auctioneer/AuctionDetails.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionDetails.tsx
@@ -28,8 +28,8 @@ type Props = {
 
 type TimeObject = {
   time: {
-    days: number;
-    hours: number;
+    days?: number;
+    hours?: number;
     minutes: number;
     seconds: number;
   };
@@ -41,7 +41,9 @@ export const TimerDisplay = ({ time, fontSize = 40, color }: TimeObject) => {
   const timeKeys = getKeys(time);
 
   const times = timeKeys.map((key) => {
-    const value = time[key].toString().padStart(2, "0");
+    const value = time[key as keyof TimeObject["time"]]
+      ?.toString()
+      .padStart(2, "0");
 
     return value;
   });

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -304,7 +304,7 @@ const WrappedWallet: React.FC<Props> = ({
   );
 };
 
-const queryClient = new QueryClient();
+export const queryClient = new QueryClient();
 
 export const Wallet: React.FC<Props> = (props) => (
   <WagmiProvider config={config}>

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -36,7 +36,12 @@ export const AuctionHouseModal: React.FC<Props> = ({
       }}
       onMint={(id) => {
         closeModal();
-        gameService.send("MINT", { auctionId: id });
+        gameService.send("TRANSACT", {
+          transaction: "transaction.wearablesWithdrawn",
+          request: {
+            auctionId: id,
+          },
+        });
       }}
       deviceTrackerId={gameState.context.deviceTrackerId as string}
       linkedAddress={linkedWallet}

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -1,5 +1,6 @@
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
+import { Transaction } from "features/island/hud/Transaction";
 import { AuctioneerModal } from "features/retreat/components/auctioneer/AuctioneerModal";
 import React, { useContext } from "react";
 
@@ -18,6 +19,11 @@ export const AuctionHouseModal: React.FC<Props> = ({
   const {
     context: { state, linkedWallet },
   } = gameState;
+
+  const transaction = state.transaction;
+  if (transaction) {
+    return <Transaction onClose={closeModal} />;
+  }
 
   return (
     <AuctioneerModal

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -21,9 +21,6 @@ export const AuctionHouseModal: React.FC<Props> = ({
   } = gameState;
 
   const transaction = state.transaction;
-  if (transaction) {
-    return <Transaction onClose={closeModal} />;
-  }
 
   return (
     <AuctioneerModal

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -33,7 +33,7 @@ export const AuctionHouseModal: React.FC<Props> = ({
       onMint={(id) => {
         closeModal();
         gameService.send("TRANSACT", {
-          transaction: "transaction.wearablesWithdrawn",
+          transaction: "transaction.bidMinted",
           request: {
             auctionId: id,
           },

--- a/src/features/world/ui/AuctionHouseModal.tsx
+++ b/src/features/world/ui/AuctionHouseModal.tsx
@@ -1,6 +1,5 @@
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { Transaction } from "features/island/hud/Transaction";
 import { AuctioneerModal } from "features/retreat/components/auctioneer/AuctioneerModal";
 import React, { useContext } from "react";
 

--- a/src/features/world/ui/PlayerTrade.tsx
+++ b/src/features/world/ui/PlayerTrade.tsx
@@ -30,8 +30,6 @@ const _inventory = (state: MachineState) => state.context.state.inventory;
 const _previousInventory = (state: MachineState) =>
   state.context.state.previousInventory;
 const _balance = (state: MachineState) => state.context.state.balance;
-const _transactionExpiresAt = (state: MachineState) =>
-  state.context.transaction?.expiresAt;
 
 interface Props {
   farmId: number;
@@ -44,12 +42,11 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
   const inventory = useSelector(gameService, _inventory);
   const previousInventory = useSelector(gameService, _previousInventory);
   const balance = useSelector(gameService, _balance);
-  const transactionExpiresAt = useSelector(gameService, _transactionExpiresAt);
 
   const { authService } = useContext(AuthProvider.Context);
   const rawToken = useSelector(authService, _rawToken);
 
-  const [warning, setWarning] = useState<"pendingTransaction" | "hoarding">();
+  const [warning, setWarning] = useState<"hoarding">();
   const [isLoading, setIsLoading] = useState(true);
   const [listings, setListings] = useState<
     Record<string, TradeListing> | undefined
@@ -103,18 +100,6 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
     );
   }
 
-  if (warning === "pendingTransaction") {
-    return (
-      <div className="p-1 flex flex-col items-center">
-        <img src={SUNNYSIDE.icons.timer} className="w-1/6 mb-2" />
-        <p className="text-sm mb-1 text-center">
-          {t("playerTrade.transaction")}
-        </p>
-        <p className="text-xs mb-1 text-center">{t("playerTrade.Please")}</p>
-      </div>
-    );
-  }
-
   const confirm = (listingId: string) => {
     // Check hoarding
     const updatedInventory = getKeys(listings[listingId].items).reduce(
@@ -134,11 +119,6 @@ export const PlayerTrade: React.FC<Props> = ({ farmId, onClose }) => {
 
     if (hasMaxedOut) {
       setWarning("hoarding");
-      return;
-    }
-
-    if (transactionExpiresAt && transactionExpiresAt > Date.now()) {
-      setWarning("pendingTransaction");
       return;
     }
 

--- a/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
+++ b/src/features/world/ui/factions/emblemTrading/BuyPanel.tsx
@@ -111,7 +111,7 @@ const ListView: React.FC<ListViewProps> = ({
 }) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
-  const [warning, setWarning] = useState<"pendingTransaction" | "hoarding">();
+  const [warning, setWarning] = useState<"hoarding">();
   const [loading, setLoading] = useState(false);
   const [listings, setListings] = useState<Listing[]>([]);
   const [selectedListing, setSelectedListing] = useState<Listing>();
@@ -120,7 +120,7 @@ const ListView: React.FC<ListViewProps> = ({
   const [fulfillListing, setfulfillListing] = useState(false);
   const [
     {
-      context: { state, transaction, farmId },
+      context: { state, farmId },
     },
   ] = useActor(gameService);
   const inventory = state.inventory;
@@ -191,11 +191,6 @@ const ListView: React.FC<ListViewProps> = ({
       return;
     }
 
-    if (transaction && transaction.expiresAt > Date.now()) {
-      setWarning("pendingTransaction");
-      return;
-    }
-
     setSelectedListing(listing);
   };
 
@@ -240,18 +235,6 @@ const ListView: React.FC<ListViewProps> = ({
         >
           {t("back")}
         </Button>
-      </div>
-    );
-  }
-
-  if (warning === "pendingTransaction") {
-    return (
-      <div className="p-1 flex flex-col items-center">
-        <img src={SUNNYSIDE.icons.timer} className="w-1/6 mb-2" />
-        <p className="text-sm mb-1 text-center">
-          {t("playerTrade.transaction")}
-        </p>
-        <p className="text-xs mb-1 text-center">{t("playerTrade.Please")}</p>
       </div>
     );
   }

--- a/src/features/world/ui/trader/BuyPanel.tsx
+++ b/src/features/world/ui/trader/BuyPanel.tsx
@@ -174,7 +174,7 @@ const ListView: React.FC<ListViewProps> = ({
   const [warning, setWarning] = useState<"pendingTransaction" | "hoarding">();
   const [
     {
-      context: { state, transaction, farmId },
+      context: { state, farmId },
     },
   ] = useActor(gameService);
   const inventory = state.inventory;
@@ -243,11 +243,6 @@ const ListView: React.FC<ListViewProps> = ({
       return;
     }
 
-    if (transaction && transaction.expiresAt > Date.now()) {
-      setWarning("pendingTransaction");
-      return;
-    }
-
     setSelectedListing(listing);
   };
 
@@ -308,18 +303,6 @@ const ListView: React.FC<ListViewProps> = ({
         >
           {t("back")}
         </Button>
-      </div>
-    );
-  }
-
-  if (warning === "pendingTransaction") {
-    return (
-      <div className="p-1 flex flex-col items-center">
-        <img src={SUNNYSIDE.icons.timer} className="w-1/6 mb-2" />
-        <p className="text-sm mb-1 text-center">
-          {t("playerTrade.transaction")}
-        </p>
-        <p className="text-xs mb-1 text-center">{t("playerTrade.Please")}</p>
       </div>
     );
   }

--- a/src/lib/blockchain/Auction.ts
+++ b/src/lib/blockchain/Auction.ts
@@ -3,11 +3,24 @@ import ABI from "./abis/Auction";
 import { getNextSessionId, getSessionId } from "./Session";
 import { waitForTransactionReceipt, writeContract } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
+import { saveTxHash } from "features/game/types/transactions";
 
 const address = CONFIG.AUCTION_CONTRACT;
 
+export type MintBidParams = {
+  signature: string;
+  deadline: number;
+  farmId: string | number;
+  sender: string;
+  sessionId: string;
+  nextSessionId: string;
+  mintId: string | number;
+  supply: string | number;
+  fee: string;
+};
+
 export async function mintAuctionCollectible({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
@@ -16,28 +29,17 @@ export async function mintAuctionCollectible({
   mintId,
   supply,
   fee,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  mintId: number;
-  supply: number;
-  fee: number;
-}): Promise<string> {
-  const oldSessionId = await getSessionId(farmId);
+}: MintBidParams): Promise<string> {
+  const oldSessionId = await getSessionId(farmId as number);
 
   const hash = await writeContract(config, {
     abi: ABI,
     address: address as `0x${string}`,
     functionName: "mintCollectible",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       BigInt(fee),
@@ -45,11 +47,13 @@ export async function mintAuctionCollectible({
       BigInt(supply),
     ],
     value: BigInt(fee),
-    account,
+    account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.bidMinted", hash });
+
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId as number, oldSessionId);
 }
 
 export async function mintAuctionWearable({

--- a/src/lib/blockchain/Auction.ts
+++ b/src/lib/blockchain/Auction.ts
@@ -85,6 +85,7 @@ export async function mintAuctionWearable({
     ],
     account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.bidMinted", hash, sessionId, deadline });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId as number, oldSessionId);

--- a/src/lib/blockchain/Auction.ts
+++ b/src/lib/blockchain/Auction.ts
@@ -49,7 +49,7 @@ export async function mintAuctionCollectible({
     value: BigInt(fee),
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.bidMinted", hash });
+  saveTxHash({ event: "transaction.bidMinted", hash, sessionId });
 
   await waitForTransactionReceipt(config, { hash });
 
@@ -57,7 +57,7 @@ export async function mintAuctionCollectible({
 }
 
 export async function mintAuctionWearable({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
@@ -66,37 +66,26 @@ export async function mintAuctionWearable({
   mintId,
   supply,
   fee,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  mintId: number;
-  supply: number;
-  fee: number;
-}): Promise<string> {
-  const oldSessionId = await getSessionId(farmId);
+}: MintBidParams): Promise<string> {
+  const oldSessionId = await getSessionId(farmId as number);
 
   const hash = await writeContract(config, {
     abi: ABI,
     address: address as `0x${string}`,
     functionName: "mintWearable",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       BigInt(fee),
       BigInt(mintId),
       BigInt(supply),
     ],
-    account,
+    account: sender as `0x${string}`,
   });
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId as number, oldSessionId);
 }

--- a/src/lib/blockchain/Auction.ts
+++ b/src/lib/blockchain/Auction.ts
@@ -49,7 +49,7 @@ export async function mintAuctionCollectible({
     value: BigInt(fee),
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.bidMinted", hash, sessionId });
+  saveTxHash({ event: "transaction.bidMinted", hash, sessionId, deadline });
 
   await waitForTransactionReceipt(config, { hash });
 

--- a/src/lib/blockchain/Game.ts
+++ b/src/lib/blockchain/Game.ts
@@ -1,7 +1,5 @@
 import { CONFIG } from "lib/config";
-import { fromWei } from "web3-utils";
 import GameABI from "./abis/SunflowerLandGame";
-import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { getNextSessionId, getSessionId } from "./Session";
 import { waitForTransactionReceipt, writeContract } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
@@ -73,7 +71,7 @@ export async function syncProgress({
   saveTxHash({
     event: "transaction.progressSynced",
     hash,
-    // deadline,
+    deadline,
     sessionId,
   });
 

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -28,7 +28,6 @@ export async function withdrawSFLTransaction({
   tax,
   sfl,
 }: WithdrawSFLParams): Promise<string> {
-  console.log("Withdraw SFL");
   const oldSessionId = sessionId;
 
   const hash = await writeContract(config, {
@@ -75,17 +74,6 @@ export async function withdrawItemsTransaction({
   amounts,
 }: WithdrawItemsParams): Promise<string> {
   const oldSessionId = sessionId;
-
-  console.log({
-    sender,
-    signature,
-    sessionId,
-    nextSessionId,
-    deadline,
-    farmId,
-    ids,
-    amounts,
-  });
 
   const hash = await writeContract(config, {
     abi: WithdrawalABI,

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -46,7 +46,7 @@ export async function withdrawSFLTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.sflWithdrawn", hash, sessionId });
+  saveTxHash({ event: "transaction.sflWithdrawn", hash, sessionId, deadline });
 
   await waitForTransactionReceipt(config, { hash });
 
@@ -91,7 +91,12 @@ export async function withdrawItemsTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.itemsWithdrawn", hash, sessionId });
+  saveTxHash({
+    event: "transaction.itemsWithdrawn",
+    hash,
+    sessionId,
+    deadline,
+  });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);
@@ -135,7 +140,12 @@ export async function withdrawWearablesTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.wearablesWithdrawn", hash, sessionId });
+  saveTxHash({
+    event: "transaction.wearablesWithdrawn",
+    hash,
+    sessionId,
+    deadline,
+  });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);
@@ -176,7 +186,7 @@ export async function withdrawBudsTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.budWithdrawn", hash, sessionId });
+  saveTxHash({ event: "transaction.budWithdrawn", hash, sessionId, deadline });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -76,6 +76,17 @@ export async function withdrawItemsTransaction({
 }: WithdrawItemsParams): Promise<string> {
   const oldSessionId = sessionId;
 
+  console.log({
+    sender,
+    signature,
+    sessionId,
+    nextSessionId,
+    deadline,
+    farmId,
+    ids,
+    amounts,
+  });
+
   const hash = await writeContract(config, {
     abi: WithdrawalABI,
     address: address as `0x${string}`,

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -28,6 +28,7 @@ export async function withdrawSFLTransaction({
   tax,
   sfl,
 }: WithdrawSFLParams): Promise<string> {
+  console.log("Withdraw SFL");
   const oldSessionId = sessionId;
 
   const hash = await writeContract(config, {
@@ -45,7 +46,7 @@ export async function withdrawSFLTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.sflWithdrawn", hash });
+  saveTxHash({ event: "transaction.sflWithdrawn", hash, sessionId });
 
   await waitForTransactionReceipt(config, { hash });
 
@@ -90,7 +91,7 @@ export async function withdrawItemsTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.itemsWithdrawn", hash });
+  saveTxHash({ event: "transaction.itemsWithdrawn", hash, sessionId });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);
@@ -134,7 +135,7 @@ export async function withdrawWearablesTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.wearablesWithdrawn", hash });
+  saveTxHash({ event: "transaction.wearablesWithdrawn", hash, sessionId });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);
@@ -175,7 +176,7 @@ export async function withdrawBudsTransaction({
     ],
     account: sender as `0x${string}`,
   });
-  saveTxHash({ event: "transaction.budWithdrawn", hash });
+  saveTxHash({ event: "transaction.budWithdrawn", hash, sessionId });
   await waitForTransactionReceipt(config, { hash });
 
   return await getNextSessionId(sender, farmId, oldSessionId);

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -3,11 +3,23 @@ import WithdrawalABI from "./abis/Withdrawals";
 import { getNextSessionId, getSessionId } from "./Session";
 import { waitForTransactionReceipt, writeContract } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
+import { saveTxHash } from "features/game/types/transactions";
 
 const address = CONFIG.WITHDRAWAL_CONTRACT;
 
+export type WithdrawSFLParams = {
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  farmId: number;
+  sender: string;
+  sfl: string;
+  deadline: number;
+  tax: number;
+};
+
 export async function withdrawSFLTransaction({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
@@ -15,17 +27,7 @@ export async function withdrawSFLTransaction({
   farmId,
   tax,
   sfl,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  sfl: number;
-  tax: number;
-}): Promise<string> {
+}: WithdrawSFLParams): Promise<string> {
   const oldSessionId = sessionId;
 
   const hash = await writeContract(config, {
@@ -33,23 +35,36 @@ export async function withdrawSFLTransaction({
     address: address as `0x${string}`,
     functionName: "withdrawSFL",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       BigInt(sfl),
       BigInt(tax),
     ],
-    account,
+    account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.sflWithdrawn", hash });
+
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId, oldSessionId);
 }
 
+export type WithdrawItemsParams = {
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  farmId: number;
+  sender: string;
+  deadline: number;
+  ids: number[];
+  amounts: string[];
+};
+
 export async function withdrawItemsTransaction({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
@@ -57,17 +72,7 @@ export async function withdrawItemsTransaction({
   farmId,
   ids,
   amounts,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  ids: number[];
-  amounts: number[];
-}): Promise<string> {
+}: WithdrawItemsParams): Promise<string> {
   const oldSessionId = sessionId;
 
   const hash = await writeContract(config, {
@@ -75,23 +80,35 @@ export async function withdrawItemsTransaction({
     address: address as `0x${string}`,
     functionName: "withdrawItems",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       ids.map(BigInt),
       amounts.map(BigInt),
     ],
-    account,
+    account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.itemsWithdrawn", hash });
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId, oldSessionId);
 }
 
+export type WithdrawWearablesParams = {
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  farmId: number;
+  ids: number[];
+  amounts: number[];
+  sender: string;
+  deadline: number;
+};
+
 export async function withdrawWearablesTransaction({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
@@ -99,17 +116,7 @@ export async function withdrawWearablesTransaction({
   farmId,
   ids,
   amounts,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  ids: number[];
-  amounts: number[];
-}): Promise<string> {
+}: WithdrawWearablesParams): Promise<string> {
   const oldSessionId = await getSessionId(farmId);
 
   const hash = await writeContract(config, {
@@ -117,39 +124,41 @@ export async function withdrawWearablesTransaction({
     address: address as `0x${string}`,
     functionName: "withdrawWearables",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       ids.map(BigInt),
       amounts.map(BigInt),
     ],
-    account,
+    account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.wearablesWithdrawn", hash });
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId, oldSessionId);
 }
 
+export type WithdrawBudsParams = {
+  signature: string;
+  sessionId: string;
+  nextSessionId: string;
+  farmId: number;
+  sender: string;
+  deadline: number;
+  budIds: number[];
+};
+
 export async function withdrawBudsTransaction({
-  account,
+  sender,
   signature,
   sessionId,
   nextSessionId,
   deadline,
   farmId,
   budIds,
-}: {
-  account: `0x${string}`;
-  signature: `0x${string}`;
-  sessionId: `0x${string}`;
-  nextSessionId: `0x${string}`;
-  deadline: number;
-  // Data
-  farmId: number;
-  budIds: number[];
-}): Promise<string> {
+}: WithdrawBudsParams): Promise<string> {
   const oldSessionId = await getSessionId(farmId);
 
   const hash = await writeContract(config, {
@@ -157,16 +166,17 @@ export async function withdrawBudsTransaction({
     address: address as `0x${string}`,
     functionName: "withdrawBuds",
     args: [
-      signature,
-      sessionId,
-      nextSessionId,
+      signature as `0x${string}`,
+      sessionId as `0x${string}`,
+      nextSessionId as `0x${string}`,
       BigInt(deadline),
       BigInt(farmId),
       budIds.map(BigInt),
     ],
-    account,
+    account: sender as `0x${string}`,
   });
+  saveTxHash({ event: "transaction.budWithdrawn", hash });
   await waitForTransactionReceipt(config, { hash });
 
-  return await getNextSessionId(account, farmId, oldSessionId);
+  return await getNextSessionId(sender, farmId, oldSessionId);
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3574,6 +3574,7 @@
   "transaction.preparing": "Preparing transaction",
   "transaction.success.message": "Congratulations, your transaction was secured.",
   "transaction.ready": "You have a transaction ready to submit.",
+  "transaction.blocked": "Hold up, you already have a transaction that has been initiated.",
   "transaction.cleared": "Transaction cleared",
   "transaction.cleared.message": "Your transaction was unable to go through. Please try again.",
   "transaction.waiting": "{{name}} in progress",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3562,5 +3562,20 @@
   "merkl.introducing": "Introducing Merkl rewards!",
   "merkl.introducing.two": "A new and improved way to earn SFL for supporting the ecosystem.",
   "merkl.quickswapPool": "Quickswap V3 USDC Pool",
-  "merkl.leaving": "Leaving Sunflower Land"
+  "merkl.leaving": "Leaving Sunflower Land",
+  "transaction": "Transaction",
+  "transaction.expired": "Expired",
+  "transaction.expired.message": "Looks like your transaction expired. Please wait while we clear the transaction for you.",
+  "transaction.notSubmitted": "Not submitted",
+  "transaction.success": "Success",
+  "transaction.error": "Error",
+  "transaction.error.message": "Looks like something went wrong.",
+  "transaction.inProgress": "Transaction in progress",
+  "transaction.preparing": "Preparing transaction",
+  "transaction.success.message": "Congratulations, your transaction was secured.",
+  "transaction.ready": "You have a transaction ready to submit.",
+  "transaction.cleared": "Transaction cleared",
+  "transaction.cleared.message": "Your transaction was unable to go through. Please try again.",
+  "transaction.waiting": "{{name}} in progress",
+  "transaction.timedOut": "Timed out"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3578,5 +3578,6 @@
   "transaction.cleared": "Transaction cleared",
   "transaction.cleared.message": "Your transaction was unable to go through. Please try again.",
   "transaction.waiting": "{{name}} in progress",
+  "transaction.somethingWentWrong": "Hmmm, something went wrong. Please try again.",
   "transaction.timedOut": "Timed out"
 }


### PR DESCRIPTION
# Description

A more seamless session management and transaction flow. Now supports:

1. Non-blocking transactions. You can keep playing while a transaction is in progress without fear of rollbacks
2. Instant transaction retries. Persists the latest signature to allow players to instantly retry
3. Can sync while you have an active auction bid
4. Can buy resources off P2P market from someone with in-flight transaction.

<img width="562" alt="Screenshot 2024-09-10 at 8 52 56 AM" src="https://github.com/user-attachments/assets/f7f5a57a-e904-4e36-a764-a0711a28c856">
<img width="537" alt="Screenshot 2024-09-10 at 8 53 12 AM" src="https://github.com/user-attachments/assets/fe5d9d24-8ace-4b8e-a18e-5021a6a2d199">
<img width="253" alt="Screenshot 2024-09-10 at 8 53 17 AM" src="https://github.com/user-attachments/assets/8ac3cc44-85ff-47cd-b47e-06e7879b692f">
<img width="558" alt="Screenshot 2024-09-10 at 8 53 23 AM" src="https://github.com/user-attachments/assets/87b3ef22-0f36-4813-9b31-ebea23b4bc07">


## How to test?

We will want to test the following flows:
- Store on chain
- Withdrawing (all items)
- Mint Auction item
- Refreshing on chain

1. Point at local API
2. Fire transactions and ensure flow is correct after transaction finishes
3. Start transaction and wait for timeout (revert should occur)