### PR TITLE
[FIX] Additive boosts for selling crops to coins

### DIFF
--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -89,4 +89,115 @@ describe("boosts", () => {
       }),
     ).toEqual(FRUIT().Tomato.sellPrice);
   });
+
+  it("applies Green Thumb boost to crop", () => {
+    const now = new Date();
+    expect(
+      getSellPrice({
+        item: CROPS.Sunflower,
+        game: {
+          ...TEST_FARM,
+          inventory: {
+            "Basic Land": new Decimal(3),
+            "Green Thumb": new Decimal(1),
+          },
+          // Game started over 2 hours ago
+          createdAt: now.getTime() - 2 * 60 * 60 * 1000 - 1,
+        },
+        now,
+      }),
+    ).toEqual(CROPS.Sunflower.sellPrice * 1.05);
+  });
+
+  it("does not apply Green Thumb boost to non crops", () => {
+    const now = new Date();
+    expect(
+      getSellPrice({
+        item: FRUIT().Tomato,
+        game: {
+          ...TEST_FARM,
+          inventory: {
+            "Basic Land": new Decimal(3),
+            "Green Thumb": new Decimal(1),
+          },
+          // Game started over 2 hours ago
+          createdAt: now.getTime() - 2 * 60 * 60 * 1000 - 1,
+        },
+        now,
+      }),
+    ).toEqual(FRUIT().Tomato.sellPrice);
+  });
+
+  it("applies Coin Swindler boost to crop", () => {
+    const now = new Date();
+    expect(
+      getSellPrice({
+        item: CROPS.Sunflower,
+        game: {
+          ...TEST_FARM,
+          bumpkin: {
+            ...TEST_FARM.bumpkin,
+            skills: {
+              "Coin Swindler": 1,
+            },
+          },
+          inventory: {
+            "Basic Land": new Decimal(3),
+          },
+          // Game started over 2 hours ago
+          createdAt: now.getTime() - 2 * 60 * 60 * 1000 - 1,
+        },
+        now,
+      }),
+    ).toEqual(CROPS.Sunflower.sellPrice * 1.1);
+  });
+
+  it("applies Coin Swindler boost to crop", () => {
+    const now = new Date();
+    expect(
+      getSellPrice({
+        item: FRUIT().Tomato,
+        game: {
+          ...TEST_FARM,
+          bumpkin: {
+            ...TEST_FARM.bumpkin,
+            skills: {
+              "Coin Swindler": 1,
+            },
+          },
+          inventory: {
+            "Basic Land": new Decimal(3),
+          },
+          // Game started over 2 hours ago
+          createdAt: now.getTime() - 2 * 60 * 60 * 1000 - 1,
+        },
+        now,
+      }),
+    ).toEqual(FRUIT().Tomato.sellPrice);
+  });
+
+  it("boosts are additive", () => {
+    const now = new Date();
+    expect(
+      getSellPrice({
+        item: CROPS.Sunflower,
+        game: {
+          ...TEST_FARM,
+          bumpkin: {
+            ...TEST_FARM.bumpkin,
+            skills: {
+              "Coin Swindler": 1,
+            },
+          },
+          inventory: {
+            "Basic Land": new Decimal(3),
+            "Green Thumb": new Decimal(1),
+          },
+          // Game started now
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+        },
+        now,
+      }),
+    ).toEqual(CROPS.Sunflower.sellPrice * 2.15);
+  });
 });

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -57,7 +57,7 @@ export const getSellPrice = ({
   game: GameState;
   now?: Date;
 }) => {
-  let price = item.sellPrice;
+  const price = item.sellPrice;
 
   const { inventory, bumpkin } = game;
 
@@ -67,9 +67,11 @@ export const getSellPrice = ({
 
   if (!price) return 0;
 
+  let multiplier = 1;
+
   // apply Green Thumb boost to crop LEGACY SKILL!
   if (item.name in crops && inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
-    price = price * 1.05;
+    multiplier += 0.05;
   }
 
   // Crop Shortage during initial gameplay
@@ -77,7 +79,7 @@ export const getSellPrice = ({
     game.createdAt + CROP_SHORTAGE_HOURS * 60 * 60 * 1000 > now.getTime();
 
   if (item.name in CROPS && isCropShortage) {
-    price = price * 2;
+    multiplier += 1;
   }
 
   // Special Events
@@ -90,14 +92,14 @@ export const getSellPrice = ({
   ]?.saleMultiplier;
 
   if (specialEventMultiplier) {
-    price = price * specialEventMultiplier;
+    multiplier += specialEventMultiplier - 1;
   }
 
   if (bumpkin.skills["Coin Swindler"] && item.name in CROPS) {
-    price = price * 1.1;
+    multiplier += 0.1;
   }
 
-  return price;
+  return price * multiplier;
 };
 
 /**


### PR DESCRIPTION
# Description

- make crop sell price additive before we add more skills/boosts to it
  - backend changes needed

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- yarn test

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
