### PR TITLE
[FIX] Crop Removal Restriction

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -8,7 +8,11 @@ import {
 } from "features/game/lib/constants";
 import { FruitName, GreenHouseFruitName } from "features/game/types/fruits";
 import { GameState, InventoryItemName } from "features/game/types/game";
-import { CropName, GreenHouseCropName } from "features/game/types/crops";
+import {
+  CropName,
+  GREENHOUSE_CROPS,
+  GreenHouseCropName,
+} from "features/game/types/crops";
 import { canMine } from "../expansion/lib/utils";
 import { areUnsupportedChickensBrewing } from "features/game/events/landExpansion/removeBuilding";
 import { Bud, StemTrait, TypeTrait } from "./buds";
@@ -26,6 +30,7 @@ import { getCurrentHoneyProduced } from "../expansion/components/resources/beehi
 import { DEFAULT_HONEY_PRODUCTION_TIME } from "../lib/updateBeehives";
 import { translate } from "lib/i18n/translate";
 import { canDrillOilReserve } from "../events/landExpansion/drillOilReserve";
+import { getKeys } from "./decorations";
 
 export type Restriction = [boolean, string];
 type RemoveCondition = (gameState: GameState) => Restriction;
@@ -70,7 +75,7 @@ function areAnyGreenhouseCropGrowing(game: GameState): Restriction {
 export function areAnyCropsOrGreenhouseCropsGrowing(
   game: GameState,
 ): Restriction {
-  const cropsToCheck: GreenHouseCropName[] = ["Olive", "Rice"];
+  const cropsToCheck = getKeys(GREENHOUSE_CROPS);
   const greenhouseCropsGrowing = cropsToCheck.some(
     (crop) => greenhouseCropIsGrowing({ crop, game })[0],
   );

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -70,7 +70,11 @@ function areAnyGreenhouseCropGrowing(game: GameState): Restriction {
 export function areAnyCropsOrGreenhouseCropsGrowing(
   game: GameState,
 ): Restriction {
-  const [greenhouseCropsGrowing] = areAnyGreenhouseCropGrowing(game);
+  const cropsToCheck: GreenHouseCropName[] = ["Olive", "Rice"];
+  const greenhouseCropsGrowing = cropsToCheck.some(
+    (crop) => greenhouseCropIsGrowing({ crop, game })[0],
+  );
+
   const [cropsGrowing] = areAnyCropsGrowing(game);
 
   const anyCropsGrowing = greenhouseCropsGrowing || cropsGrowing;


### PR DESCRIPTION
# Description

Fix an issue where you would be restricted from removing any crop boost items when you have grapes (which is not a crop) planted. Fixed in this PR

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
