### PR TITLE
[FIX] Separate emblem listings from resource listings

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -47,7 +47,7 @@ const ISLAND_LIMITS: Record<IslandType, number> = {
   desert: 20,
 };
 
-function getRemainingListings({ game }: { game: GameState }) {
+export function getRemainingListings({ game }: { game: GameState }) {
   let remaining = ISLAND_LIMITS[game.island?.type] ?? 0;
 
   if (!hasVipAccess(game.inventory)) {
@@ -468,6 +468,13 @@ export const Trade: React.FC<{
     gameState.context.state.bumpkin?.experience ?? 0,
   );
 
+  const resourceListings = getKeys(trades).filter((listingId) => {
+    const items = Object.keys(trades[listingId].items);
+    return !items.some((item) =>
+      Object.values(FACTION_EMBLEMS).includes(item as FactionEmblem),
+    );
+  });
+
   const onList = (items: Items, sfl: number) => {
     gameService.send("LIST_TRADE", {
       sellerId: gameState.context.farmId,
@@ -506,7 +513,7 @@ export const Trade: React.FC<{
     );
   }
 
-  if (getKeys(trades).length === 0) {
+  if (resourceListings.length === 0) {
     return (
       <div className="relative">
         <div className="pl-2 pt-2 space-y-1 sm:space-y-0 sm:flex items-center justify-between ml-1.5">
@@ -573,34 +580,27 @@ export const Trade: React.FC<{
               })}`}
         </Label>
       </div>
-      {getKeys(trades)
-        .filter((listingId) => {
-          const items = Object.keys(trades[listingId].items);
-          return !items.some((item) =>
-            Object.values(FACTION_EMBLEMS).includes(item as FactionEmblem),
-          );
-        })
-        .map((listingId, index) => {
-          return (
-            <div className="mt-2" key={index}>
-              <TradeDetails
-                onCancel={() =>
-                  onCancel(listingId, makeListingType(trades[listingId].items))
-                }
-                onClaim={() => {
-                  gameService.send("trade.received", {
-                    tradeId: listingId,
-                  });
-                  gameService.send("SAVE");
-                }}
-                trade={trades[listingId]}
-                isOldListing={listingId.length < 38}
-              />
-            </div>
-          );
-        })}
+      {resourceListings.map((listingId, index) => {
+        return (
+          <div className="mt-2" key={index}>
+            <TradeDetails
+              onCancel={() =>
+                onCancel(listingId, makeListingType(trades[listingId].items))
+              }
+              onClaim={() => {
+                gameService.send("trade.received", {
+                  tradeId: listingId,
+                });
+                gameService.send("SAVE");
+              }}
+              trade={trades[listingId]}
+              isOldListing={listingId.length < 38}
+            />
+          </div>
+        );
+      })}
 
-      {!hideButton && getKeys(trades).length < 3 && (
+      {!hideButton && resourceListings.length < 3 && (
         <div className="relative mt-2">
           <Button
             onClick={() => setShowListing(true)}
@@ -618,7 +618,7 @@ export const Trade: React.FC<{
         </div>
       )}
 
-      {getKeys(trades).length >= 3 && (
+      {resourceListings.length >= 3 && (
         <div className="relative my-2">
           <Label type="danger" icon={SUNNYSIDE.icons.lock} className="mx-auto">
             {t("bumpkinTrade.maxListings")}

--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -370,8 +370,6 @@ const TradeDetails: React.FC<{
 }> = ({ trade, onCancel, onClaim, isOldListing }) => {
   const { t } = useAppTranslation();
 
-  const { gameService } = useContext(Context); // To remove after testing ends
-
   if (trade.boughtAt) {
     return (
       <div>

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -25,7 +25,6 @@ import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { VIPAccess } from "features/game/components/VipAccess";
-import { getDayOfYear } from "lib/utils/time";
 import { NumberInput } from "components/ui/NumberInput";
 import {
   EMBLEM_TRADE_MINIMUMS,
@@ -35,19 +34,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { CannotTrade } from "../../CannotTrade";
 import { getRemainingListings } from "features/bumpkins/components/Trade";
 
-const MAX_NON_VIP_LISTINGS = 1;
 const MAX_SFL = 150;
-
-function getRemainingFreeListings(dailyListings: {
-  count: number;
-  date: number;
-}) {
-  if (dailyListings.date !== getDayOfYear(new Date())) {
-    return MAX_NON_VIP_LISTINGS;
-  }
-  return MAX_NON_VIP_LISTINGS - dailyListings.count;
-}
-
 type Items = Partial<Record<InventoryItemName, number>>;
 
 const ListTrade: React.FC<{
@@ -397,10 +384,6 @@ export const Trade: React.FC<{
   const [showListing, setShowListing] = useState(false);
 
   const isVIP = hasVipAccess(gameState.context.state.inventory);
-  const dailyListings = gameState.context.state.trades.dailyListings ?? {
-    count: 0,
-    date: 0,
-  };
   const remainingListings = getRemainingListings({
     game: gameState.context.state,
   });

--- a/src/features/world/ui/factions/emblemTrading/Trade.tsx
+++ b/src/features/world/ui/factions/emblemTrading/Trade.tsx
@@ -33,6 +33,7 @@ import {
 } from "features/game/actions/tradeLimits";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { CannotTrade } from "../../CannotTrade";
+import { getRemainingListings } from "features/bumpkins/components/Trade";
 
 const MAX_NON_VIP_LISTINGS = 1;
 const MAX_SFL = 150;
@@ -400,7 +401,9 @@ export const Trade: React.FC<{
     count: 0,
     date: 0,
   };
-  const remainingListings = getRemainingFreeListings(dailyListings);
+  const remainingListings = getRemainingListings({
+    game: gameState.context.state,
+  });
   const hasListingsRemaining = isVIP || remainingListings > 0;
   // Show listings
   const trades = gameState.context.state.trades?.listings ?? {};
@@ -408,6 +411,13 @@ export const Trade: React.FC<{
   const level = getBumpkinLevel(
     gameState.context.state.bumpkin?.experience ?? 0,
   );
+
+  const emblemListings = getKeys(trades).filter((listingId) => {
+    return (
+      makeListingType(trades[listingId].items) ===
+      makeListingType({ [emblem]: 0 })
+    );
+  });
 
   const onList = (items: Items, sfl: number) => {
     gameService.send("LIST_TRADE", {
@@ -448,7 +458,7 @@ export const Trade: React.FC<{
     );
   }
 
-  if (getKeys(trades).length === 0) {
+  if (emblemListings.length === 0) {
     return (
       <div className="relative">
         <div className="pl-2 pt-2 space-y-1 sm:space-y-0 sm:flex items-center justify-between ml-1.5">
@@ -517,33 +527,26 @@ export const Trade: React.FC<{
           </Label>
         )}
       </div>
-      {getKeys(trades)
-        .filter((listingId) => {
-          return (
-            makeListingType(trades[listingId].items) ===
-            makeListingType({ [emblem]: 0 })
-          );
-        })
-        .map((listingId, index) => {
-          return (
-            <div className="mt-2" key={index}>
-              <TradeDetails
-                onCancel={() =>
-                  onCancel(listingId, makeListingType(trades[listingId].items))
-                }
-                onClaim={() => {
-                  gameService.send("trade.received", {
-                    tradeId: listingId,
-                  });
-                  gameService.send("SAVE");
-                }}
-                trade={trades[listingId]}
-                isOldListing={listingId.length < 38}
-              />
-            </div>
-          );
-        })}
-      {getKeys(trades).length < 3 && (
+      {emblemListings.map((listingId, index) => {
+        return (
+          <div className="mt-2" key={index}>
+            <TradeDetails
+              onCancel={() =>
+                onCancel(listingId, makeListingType(trades[listingId].items))
+              }
+              onClaim={() => {
+                gameService.send("trade.received", {
+                  tradeId: listingId,
+                });
+                gameService.send("SAVE");
+              }}
+              trade={trades[listingId]}
+              isOldListing={listingId.length < 38}
+            />
+          </div>
+        );
+      })}
+      {emblemListings.length < 3 && (
         <div className="relative mt-2">
           <Button
             onClick={() => setShowListing(true)}
@@ -553,7 +556,7 @@ export const Trade: React.FC<{
           </Button>
         </div>
       )}
-      {getKeys(trades).length >= 3 && (
+      {emblemListings.length >= 3 && (
         <div className="relative my-2">
           <Label type="danger" icon={SUNNYSIDE.icons.lock} className="mx-auto">
             {t("bumpkinTrade.maxListings")}


### PR DESCRIPTION
# Description

This PR fixes the issue where emblem listings count towards the total trade limit

Separated emblem listings from resource trade listings

Am able to list 3 resource and 3 emblem listings
```typescript
      "listings": {
        "0002000000#2lpp2Umf5OaXj24974oj0I0kET9": {
          "createdAt": 1725886657196,
          "items": {
            "Gold": 3
          },
          "sfl": 6
        },
        "0002000000#2lpp5MybPHfY6Zzy9SPvoiXn9I6": {
          "createdAt": 1725886691032,
          "items": {
            "Gold": 3
          },
          "sfl": 6
        },
        "0002000000#2lpp7pAo9W0vVvD0tYsjYe15tU1": {
          "createdAt": 1725886711265,
          "items": {
            "Gold": 3
          },
          "sfl": 6
        },
        "0000500000#2lpqoNX3c2bC6hCeGR1hE6tCkHG": {
          "createdAt": 1725887535200,
          "items": {
            "Sunflorian Emblem": 100
          },
          "sfl": 50
        },
        "0000500000#2lpqqrK184AIKVEffEBAOOXwYTY": {
          "createdAt": 1725887562502,
          "items": {
            "Sunflorian Emblem": 100
          },
          "sfl": 50
        },
        "0000500000#2lpqtuXyUaaxcEXbaIRTXwAISHt": {
          "createdAt": 1725887587590,
          "items": {
            "Sunflorian Emblem": 100
          },
          "sfl": 50
        }
      },
```

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run FE and BE

- list 3 resources
- you should be able to list 3 additional emblem trades

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
