### PR TITLE
[FIX] MMO Server Loading State

### DIFF
--- a/src/features/world/World.tsx
+++ b/src/features/world/World.tsx
@@ -44,8 +44,13 @@ export const World: React.FC<Props> = ({ isCommunity = false }) => {
 const _isLoading = (state: MachineState) => state.matches("loading");
 
 // MMO Machine
+const _isConnecting = (state: MMOMachineState) => state.matches("connecting");
 const _isConnected = (state: MMOMachineState) => state.matches("connected");
+const _isJoining = (state: MMOMachineState) => state.matches("joining");
+const _isJoined = (state: MMOMachineState) => state.matches("joined");
 const _isKicked = (state: MMOMachineState) => state.matches("kicked");
+const _isMMOInitialising = (state: MMOMachineState) =>
+  state.matches("initialising");
 const _isIntroducing = (state: MMOMachineState) =>
   state.matches("introduction");
 
@@ -102,11 +107,17 @@ export const MMO: React.FC<MMOProps> = ({ isCommunity }) => {
     };
   }, []);
 
+  const isInitialising = useSelector(mmoService, _isMMOInitialising);
+  const isConnecting = useSelector(mmoService, _isConnecting);
+  const isJoining = useSelector(mmoService, _isJoining);
   const isKicked = useSelector(mmoService, _isKicked);
   const isConnected = useSelector(mmoService, _isConnected);
   const isIntroducting = useSelector(mmoService, _isIntroducing);
 
-  if (isKicked || isConnected) {
+  const isTraveling =
+    isInitialising || isConnecting || isConnected || isKicked || isJoining;
+
+  if (isTraveling) {
     return <TravelScreen mmoService={mmoService} />;
   }
 


### PR DESCRIPTION
# Description

This PR is fixing an issue with MMO Server loading state, server connection was done after MMO load, we need to wait before a connection is made to ensure nothing breaks (speech bubble, reactions, ect..)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

locally

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
