### PR TITLE
[FIX] Round down number for bumpkin reaction

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -12,6 +12,7 @@ import { FactionName, InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ITEM_IDS } from "features/game/types/bumpkin";
 import { CONFIG } from "lib/config";
+import { formatNumber } from "lib/utils/formatNumber";
 
 const NAME_ALIASES: Partial<Record<NPCName, string>> = {
   "pumpkin' pete": "pete",
@@ -670,7 +671,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         0,
         -16,
         "Teeny Tiny Pixls",
-        `+${quantity}`,
+        `+${formatNumber(quantity)}`,
         5,
         1,
       );


### PR DESCRIPTION
# Description

- Round down number to 2 decimal places on top of bumpkin heads when bumpkin gets items in plaza

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
