### PR TITLE
[FEAT] Update chests and treasure shop keys prices

### DIFF
--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -77,9 +77,9 @@ const SEASONAL_REWARDS: (weight: number) => ChestReward[] = (weight) => {
 };
 
 export const BASIC_REWARDS: () => ChestReward[] = () => [
-  { sfl: 5, weighting: 100 * multiplier },
-  { sfl: 10, weighting: 50 * multiplier },
-  { sfl: 25, weighting: 20 * multiplier },
+  { coins: 1440, weighting: 100 * multiplier },
+  { coins: 2880, weighting: 50 * multiplier },
+  { coins: 7200, weighting: 20 * multiplier },
   { items: { "Block Buck": 1 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 2 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 20 * multiplier },
@@ -104,10 +104,10 @@ export const BASIC_REWARDS: () => ChestReward[] = () => [
 ];
 
 export const RARE_REWARDS: () => ChestReward[] = () => [
-  { sfl: 5, weighting: 50 * multiplier },
-  { sfl: 10, weighting: 100 * multiplier },
-  { sfl: 25, weighting: 50 * multiplier },
-  { sfl: 50, weighting: 20 * multiplier },
+  { coins: 1440, weighting: 50 * multiplier },
+  { coins: 2880, weighting: 100 * multiplier },
+  { coins: 7200, weighting: 50 * multiplier },
+  { coins: 14400, weighting: 20 * multiplier },
   { items: { "Block Buck": 1 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 2 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 50 * multiplier },
@@ -134,9 +134,9 @@ export const RARE_REWARDS: () => ChestReward[] = () => [
 ];
 
 export const LUXURY_REWARDS: () => ChestReward[] = () => [
-  { sfl: 10, weighting: 50 * multiplier },
-  { sfl: 25, weighting: 100 * multiplier },
-  { sfl: 50, weighting: 50 * multiplier },
+  { coins: 2880, weighting: 50 * multiplier },
+  { coins: 7200, weighting: 100 * multiplier },
+  { coins: 14400, weighting: 50 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 10 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 25 }, weighting: 25 * multiplier },

--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -77,9 +77,9 @@ const SEASONAL_REWARDS: (weight: number) => ChestReward[] = (weight) => {
 };
 
 export const BASIC_REWARDS: () => ChestReward[] = () => [
-  { coins: 1440, weighting: 100 * multiplier },
-  { coins: 2880, weighting: 50 * multiplier },
-  { coins: 7200, weighting: 20 * multiplier },
+  { coins: 1600, weighting: 100 * multiplier },
+  { coins: 3200, weighting: 50 * multiplier },
+  { coins: 8000, weighting: 20 * multiplier },
   { items: { "Block Buck": 1 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 2 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 20 * multiplier },
@@ -104,10 +104,10 @@ export const BASIC_REWARDS: () => ChestReward[] = () => [
 ];
 
 export const RARE_REWARDS: () => ChestReward[] = () => [
-  { coins: 1440, weighting: 50 * multiplier },
-  { coins: 2880, weighting: 100 * multiplier },
-  { coins: 7200, weighting: 50 * multiplier },
-  { coins: 14400, weighting: 20 * multiplier },
+  { coins: 1600, weighting: 50 * multiplier },
+  { coins: 3200, weighting: 100 * multiplier },
+  { coins: 8000, weighting: 50 * multiplier },
+  { coins: 16000, weighting: 20 * multiplier },
   { items: { "Block Buck": 1 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 2 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 50 * multiplier },
@@ -134,9 +134,9 @@ export const RARE_REWARDS: () => ChestReward[] = () => [
 ];
 
 export const LUXURY_REWARDS: () => ChestReward[] = () => [
-  { coins: 2880, weighting: 50 * multiplier },
-  { coins: 7200, weighting: 100 * multiplier },
-  { coins: 14400, weighting: 50 * multiplier },
+  { coins: 3200, weighting: 50 * multiplier },
+  { coins: 8000, weighting: 100 * multiplier },
+  { coins: 16000, weighting: 50 * multiplier },
   { items: { "Block Buck": 5 }, weighting: 50 * multiplier },
   { items: { "Block Buck": 10 }, weighting: 100 * multiplier },
   { items: { "Block Buck": 25 }, weighting: 25 * multiplier },

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -292,22 +292,22 @@ export const HELIOS_BLACKSMITH_ITEMS: (
 export const ARTEFACT_SHOP_KEYS: Record<Keys, CraftableCollectible> = {
   "Treasure Key": {
     ingredients: {
-      Sand: new Decimal(10),
-      Hieroglyph: new Decimal(2),
+      Sand: new Decimal(25),
+      Hieroglyph: new Decimal(5),
     },
     description: translate("description.treasure.key"),
   },
   "Rare Key": {
     ingredients: {
-      Sand: new Decimal(30),
-      Hieroglyph: new Decimal(10),
+      Sand: new Decimal(75),
+      Hieroglyph: new Decimal(15),
     },
     description: translate("description.rare.key"),
   },
   "Luxury Key": {
     ingredients: {
-      Sand: new Decimal(100),
-      Hieroglyph: new Decimal(20),
+      Sand: new Decimal(250),
+      Hieroglyph: new Decimal(50),
     },
     description: translate("description.luxury.key"),
   },

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -292,22 +292,22 @@ export const HELIOS_BLACKSMITH_ITEMS: (
 export const ARTEFACT_SHOP_KEYS: Record<Keys, CraftableCollectible> = {
   "Treasure Key": {
     ingredients: {
-      Sand: new Decimal(25),
-      Hieroglyph: new Decimal(5),
+      Sand: new Decimal(10),
+      Hieroglyph: new Decimal(3),
     },
     description: translate("description.treasure.key"),
   },
   "Rare Key": {
     ingredients: {
-      Sand: new Decimal(75),
-      Hieroglyph: new Decimal(15),
+      Sand: new Decimal(30),
+      Hieroglyph: new Decimal(10),
     },
     description: translate("description.rare.key"),
   },
   "Luxury Key": {
     ingredients: {
-      Sand: new Decimal(250),
-      Hieroglyph: new Decimal(50),
+      Sand: new Decimal(100),
+      Hieroglyph: new Decimal(30),
     },
     description: translate("description.luxury.key"),
   },

--- a/src/features/game/types/factionShop.ts
+++ b/src/features/game/types/factionShop.ts
@@ -825,7 +825,7 @@ const NIGHTSHADE_FACTION_ITEMS: Record<
 export const FACTION_SHOP_KEYS: Record<Keys, FactionShopKeys> = {
   "Treasure Key": {
     name: "Treasure Key",
-    price: new Decimal(500),
+    price: new Decimal(1000),
     limit: null,
     currency: "Mark",
     shortDescription: translate("description.treasure.key"),
@@ -833,7 +833,7 @@ export const FACTION_SHOP_KEYS: Record<Keys, FactionShopKeys> = {
   },
   "Rare Key": {
     name: "Rare Key",
-    price: new Decimal(1500),
+    price: new Decimal(3000),
     limit: null,
     currency: "Mark",
     shortDescription: translate("description.rare.key"),
@@ -841,7 +841,7 @@ export const FACTION_SHOP_KEYS: Record<Keys, FactionShopKeys> = {
   },
   "Luxury Key": {
     name: "Luxury Key",
-    price: new Decimal(5000),
+    price: new Decimal(10000),
     limit: null,
     currency: "Mark",
     shortDescription: translate("description.luxury.key"),


### PR DESCRIPTION
# Description

Doubled the prices of keys in Megastore and Faction shop

Increased price of keys in treasure shop

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
