### PR TITLE
[FIX] Fix order of super.create() for scenes

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -1621,7 +1621,6 @@ export class BeachScene extends BaseScene {
     if (this.isPlayerInDigArea(this.currentPlayer.x, this.currentPlayer.y)) {
       this.updatePlayer();
       this.updateOtherPlayers();
-      this.updateShaders();
       this.handleDigbyWarnings();
     } else {
       // this.noToolHoverBox?.setVisible(false);

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -198,6 +198,7 @@ export class BeachScene extends BaseScene {
     this.map = this.make.tilemap({
       key: "beach",
     });
+
     super.create();
     //To use when there are bumpkins under testing
     // const filteredBumpkins = BUMPKINS.filter((bumpkin) => {
@@ -1620,6 +1621,7 @@ export class BeachScene extends BaseScene {
     if (this.isPlayerInDigArea(this.currentPlayer.x, this.currentPlayer.y)) {
       this.updatePlayer();
       this.updateOtherPlayers();
+      this.updateShaders();
       this.handleDigbyWarnings();
     } else {
       // this.noToolHoverBox?.setVisible(false);

--- a/src/features/world/scenes/BumpkinHouseScene.ts
+++ b/src/features/world/scenes/BumpkinHouseScene.ts
@@ -45,10 +45,11 @@ export class BumpkinHouseScene extends FactionHouseScene {
   }
 
   create() {
-    super.create();
     this.map = this.make.tilemap({
       key: "faction_house",
     });
+
+    super.create();
 
     this.initialiseNPCs(BUMPKIN_HOUSE_NPCS);
 

--- a/src/features/world/scenes/GoblinHouseScene.ts
+++ b/src/features/world/scenes/GoblinHouseScene.ts
@@ -45,10 +45,11 @@ export class GoblinHouseScene extends FactionHouseScene {
   }
 
   create() {
-    super.create();
     this.map = this.make.tilemap({
       key: "faction_house",
     });
+
+    super.create();
 
     this.initialiseNPCs(GOBLIN_HOUSE_NPCS);
 

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -167,10 +167,11 @@ export class KingdomScene extends BaseScene {
   }
 
   create() {
-    super.create();
     this.map = this.make.tilemap({
       key: "kingdom",
     });
+
+    super.create();
 
     this.initialiseNPCs(KINGDOM_NPCS);
     this.addShopDisplayItems();

--- a/src/features/world/scenes/NightshadeHouseScene.ts
+++ b/src/features/world/scenes/NightshadeHouseScene.ts
@@ -51,10 +51,11 @@ export class NightshadeHouseScene extends FactionHouseScene {
   }
 
   create() {
-    super.create();
     this.map = this.make.tilemap({
       key: "faction_house",
     });
+
+    super.create();
 
     this.initialiseNPCs(NIGHTSHADE_HOUSE_NPCS);
 

--- a/src/features/world/scenes/SunflorianHouseScene.ts
+++ b/src/features/world/scenes/SunflorianHouseScene.ts
@@ -47,10 +47,11 @@ export class SunflorianHouseScene extends FactionHouseScene {
   }
 
   create() {
-    super.create();
     this.map = this.make.tilemap({
       key: "faction_house",
     });
+
+    super.create();
 
     this.initialiseNPCs(SUNFLORIAN_HOUSE_NPCS);
     this.setupPrize({ x: 240, y: 384 });

--- a/src/lib/utils/hooks/useIsDarkMode.ts
+++ b/src/lib/utils/hooks/useIsDarkMode.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 const LOCAL_STORAGE_KEY = "settings.darkMode";
-const DARK_MODE_EVENT = "darkModeChanged";
+export const DARK_MODE_EVENT = "darkModeChanged";
 
 export function cacheDarkModeSetting(value: boolean) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(value));

--- a/src/lib/utils/hooks/useIsDarkMode.ts
+++ b/src/lib/utils/hooks/useIsDarkMode.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 const LOCAL_STORAGE_KEY = "settings.darkMode";
-export const DARK_MODE_EVENT = "darkModeChanged";
+const DARK_MODE_EVENT = "darkModeChanged";
 
 export function cacheDarkModeSetting(value: boolean) {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(value));


### PR DESCRIPTION
# Description

- call super.create() after creating this.map, or else the map dimensions will not be set up correctly for scenes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- regression tests

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
