### PR TITLE
[CHORE] Allow withdrawals of expired items

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -800,8 +800,8 @@ const goblinPirate: Record<GoblinPirateItemName, () => boolean> = {
   Karkinos: () => true,
   "Emerald Turtle": () => true,
   "Tin Turtle": () => true, // Mint ended
-  "Golden Bear Head": () => false,
-  "Parasaur Skull": () => false,
+  "Golden Bear Head": () => true, // Mint ended
+  "Parasaur Skull": () => true, // Mint ended
 };
 
 const treasureDecoration: Record<DecorationTreasure, () => boolean> = {
@@ -1306,8 +1306,8 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Mushroom Lamp": () => false, // Not Launched
   "Mushroom Lights Background": () => false, // Not Launched
   "Mushroom Pants": () => false, // Not Launched
-  "Mushroom Shield": () => false, // Not Launched
-  "Mushroom Shoes": () => false, // Not Launched
+  "Mushroom Shield": () => true,
+  "Mushroom Shoes": () => true,
   "Mushroom Sweater": () => true,
   "Rash Vest": () => false, // Not Launched
   "Squid Hat": () => true,
@@ -1460,7 +1460,7 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Beekeeper Hat": (state) =>
     canWithdrawBoostedWearable("Beekeeper Hat", state),
   "Beekeeper Suit": () => true,
-  "Crimstone Boots": () => false,
+  "Crimstone Boots": () => true,
   "Crimstone Pants": () => true,
   "Crimstone Armor": (state) =>
     canWithdrawBoostedWearable("Crimstone Armor", state),


### PR DESCRIPTION
# Description

Allow Withdrawals of the following items:

### Old Treasure Island Craftables
- Golden Bear Head
- Parasaur Skull

### Clash of Factions Megastore Items
- Mushroom Shield
- Mushroom Shoes
- Crimstone Boots

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
