### PR TITLE
[FIX] Showing German Terms

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.ts
+++ b/src/lib/i18n/dictionaries/dictionary.ts
@@ -6,6 +6,7 @@ import FRENCH_TERMS from "./fr.json";
 import RUSSIAN_TERMS from "./ru.json";
 import ITALIAN_TERMS from "./it.json";
 import SPANISH_TERMS from "./es.json";
+import GERMAN_TERMS from "./de.json";
 import { TranslationKeys } from "./types";
 
 import britishFlag from "assets/sfts/flags/british_flag.gif";
@@ -98,4 +99,5 @@ export const resources: Partial<
   "zh-CN": { translation: CHINESE_SIMPLIFIED_TERMS },
   ru: { translation: RUSSIAN_TERMS },
   it: { translation: ITALIAN_TERMS },
+  de: { translation: GERMAN_TERMS },
 };


### PR DESCRIPTION
This PR fixes the German language configuration to show the terms inside the game.
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b549676c-290c-40e0-801d-27ce5aead73f) | ![image](https://github.com/user-attachments/assets/72211901-28d0-4df7-8636-18317f68389d) | 