### PR TITLE
[FEAT] Update Faction Pet Guide

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1983,7 +1983,7 @@
   "guide.compost.useEggs": "Tired of waiting? Use Eggs to speed up the compost production",
   "guide.compost.addEggs.confirmation": "Are you sure you want to add {{noEggs}} Eggs to reduce compost production time by {{time}}?",
   "guide.factionPet.one": "Each week the pet will request 3 foods. When fed, the XP from the food will go to the total XP tally for the faction.",
-  "guide.factionPet.two": "Your faction will have a goal xp they need to reach each week. If the faction reaches the goal, the next week goal will be 15% harder than the total xp achieved for the week! If the goal isn't reached, it will be reset back to 1000 x faction members.",
+  "guide.factionPet.two": "Your faction will have a goal xp they need to reach each week. If the faction reaches the goal, the next week goal will be 25% more than the previous week's goal! If the goal isn't reached, it will be reset back to 1000 x faction members.",
   "guide.factionPet.three": "If the faction doesn't reach the goal then the pet will go to sleep for 1 week.",
   "guide.factionPet.four": "Once the faction reaches a streak of 2 or more weeks, an XP bonus will be given to each contributing faction member when their bumpkin eats! To be a contributing member you will need to have fed the pet at least 1 of each request during the week prior.",
   "guide.factionPet.five": "Contributing member: To be eligible for potential streak boosts in the following week, a player needs to fulfill one of each pet's requests.",


### PR DESCRIPTION
# Description

This PR updates the guide for faction pet:
- Faction Pet increment will be based on the previous week's goal XP instead of the total XP gained from the previous week
- Faction Pet increment will be 25% instead of 15% to ensure difficulty of streak bonus

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
