### PR TITLE
[FIX] Bert's Obsession & Poppy Labels

### DIFF
--- a/src/features/world/ui/flowerShop/FlowerTrade.tsx
+++ b/src/features/world/ui/flowerShop/FlowerTrade.tsx
@@ -26,7 +26,11 @@ const Complete: React.FC<CompleteProps> = ({
   const { t } = useAppTranslation();
 
   if (alreadyComplete) {
-    return <Label type="info">{t("alr.completed")}</Label>;
+    return (
+      <Label type="success" icon={SUNNYSIDE.icons.confirm}>
+        {t("alr.completed")}
+      </Label>
+    );
   }
 
   return (
@@ -38,7 +42,7 @@ const Complete: React.FC<CompleteProps> = ({
         }
       >
         {`Trade for ${TICKETS_REWARDED} ${getSeasonalTicket()}${
-          TICKETS_REWARDED > 0 ? "s" : ""
+          TICKETS_REWARDED > 1 ? "s" : ""
         }`}
       </Button>
     </>
@@ -82,16 +86,15 @@ export const FlowerTrade: React.FC<Props> = ({ flowerShop, flowerCount }) => {
             />
           </div>
         </div>
-        <Label type="warning" className="my-1 mx-auto">
-          <div className="flex items-center">
-            <img src={SUNNYSIDE.icons.stopwatch} className="h-5 mr-1" />
-            <span>
-              {`${t("offer.end")} ${secondsToString(remainingSecondsInWeek, {
-                length: "medium",
-                removeTrailingZeros: true,
-              })}`}
-            </span>
-          </div>
+        <Label
+          type="info"
+          className="font-secondary mb-2"
+          icon={SUNNYSIDE.icons.stopwatch}
+        >
+          {`${t("offer.end")} ${secondsToString(remainingSecondsInWeek, {
+            length: "medium",
+            removeTrailingZeros: true,
+          })}`}
         </Label>
       </div>
       <Complete

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -100,7 +100,11 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
       obsessionCompletedAt >= currentObsession.startDate &&
       obsessionCompletedAt <= currentObsession.endDate
     ) {
-      return <Label type="info">{t("alr.completed")}</Label>;
+      return (
+        <Label type="success" icon={SUNNYSIDE.icons.confirm}>
+          {t("alr.completed")}
+        </Label>
+      );
     }
 
     return (
@@ -110,7 +114,7 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
           onClick={() => gameService.send("bertObsession.completed")}
         >
           {`${t("claim")} ${reward} ${getSeasonalTicket()}${
-            reward > 0 ? "s" : ""
+            reward > 1 ? "s" : ""
           }`}
         </Button>
         <span className="text-xs font-secondary text-center">
@@ -190,11 +194,10 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
                 className="font-secondary mb-2"
                 icon={SUNNYSIDE.icons.stopwatch}
               >
-                {"Resets in "}
-                {secondsToString(resetSeconds, {
+                {`${t("offer.end")} ${secondsToString(resetSeconds, {
                   length: "medium",
                   removeTrailingZeros: true,
-                })}
+                })}`}
               </Label>
             </div>
           )}


### PR DESCRIPTION
Updating the labels for Poppy and Bert's Obsession modals to match those in other places (NPCs Deliveries, Mini-Games, etc) and addressing minor fixes.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/fcefd522-c9c8-4fa9-8a44-c6459f7f6da9) | ![image](https://github.com/user-attachments/assets/cc68b5b1-1874-4955-a6b1-4fc086aba4e3) | 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f470fdd8-b8f1-49a5-9017-c577a4b8d984) | ![image](https://github.com/user-attachments/assets/17310bc0-fa12-47cb-8b53-599f21de7306) | 