### PR TITLE
[CHORE] Daily Chest Streak Bonus Label

### DIFF
--- a/src/features/game/components/Revealed.tsx
+++ b/src/features/game/components/Revealed.tsx
@@ -8,6 +8,8 @@ import { getKeys } from "../types/craftables";
 import { Label } from "components/ui/Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ClaimReward } from "../expansion/components/ClaimReward";
+import Gift from "assets/icons/gift.png";
+import Lightning from "assets/icons/lightning.png";
 
 export const Revealed: React.FC<{
   onAcknowledged?: () => void;
@@ -51,8 +53,14 @@ export const Revealed: React.FC<{
       />
       {streaks && streakBonus && (
         <div className="flex flex-col items-center p-2">
-          <Label type="info" className="px-0.5 text-sm">
-            {t("reward.streakBonus")}
+          <Label
+            type="vibrant"
+            icon={currentStreaks === 365 ? Gift : Lightning}
+            className="px-0.5 text-sm"
+          >
+            {currentStreaks === 365
+              ? t("reward.streak.oneYear")
+              : t("reward.streakBonus")}
           </Label>
         </div>
       )}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3031,6 +3031,7 @@
   "reward.lvlRequirement": "You must be level 3 to claim daily rewards.",
   "reward.whatCouldItBe": "What could it be?",
   "reward.streakBonus": "3x streak bonus",
+  "reward.streak.oneYear": "365 day streak reward",
   "reward.found": "You found",
   "reward.spendWisely": "Spend it wisely.",
   "reward.wearable": "A wearable for your Bumpkin",


### PR DESCRIPTION
#### This PR updates the daily chest streak bonus label to look better. Photos are edited and provided for better visibility.

### For 3x streak bonus:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1aad13f8-3d46-4147-990f-4c3c9eb8e58e) | ![image](https://github.com/user-attachments/assets/785dfbac-0433-433c-8c45-598e81955814) | 

### For 365 day streak reward:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6cc9e296-5821-48c5-80ec-708796c3413c) | ![image](https://github.com/user-attachments/assets/4d25a9ff-dbc3-4ffa-b230-3209901b0910) | 