### PR TITLE
[FIX] Chunky Font Word Spacing in Bert and Poppy Modals

### DIFF
--- a/src/features/world/ui/flowerShop/FlowerTrade.tsx
+++ b/src/features/world/ui/flowerShop/FlowerTrade.tsx
@@ -86,11 +86,7 @@ export const FlowerTrade: React.FC<Props> = ({ flowerShop, flowerCount }) => {
             />
           </div>
         </div>
-        <Label
-          type="info"
-          className="font-secondary mb-2"
-          icon={SUNNYSIDE.icons.stopwatch}
-        >
+        <Label type="info" className="mb-2" icon={SUNNYSIDE.icons.stopwatch}>
           {`${t("offer.end")} ${secondsToString(remainingSecondsInWeek, {
             length: "medium",
             removeTrailingZeros: true,

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -117,7 +117,7 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
             reward > 1 ? "s" : ""
           }`}
         </Button>
-        <span className="text-xs font-secondary text-center">
+        <span className="text-xs text-center">
           {t("bert.day", { seasonalTicket: getSeasonalTicket() })}
         </span>
       </>
@@ -191,7 +191,7 @@ export const Bert: React.FC<Props> = ({ onClose }) => {
               </div>
               <Label
                 type="info"
-                className="font-secondary mb-2"
+                className="mb-2"
                 icon={SUNNYSIDE.icons.stopwatch}
               >
                 {`${t("offer.end")} ${secondsToString(resetSeconds, {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/18f43732-59ce-4cde-84b9-5b283befd66b) | ![image](https://github.com/user-attachments/assets/80ec09e3-b445-498b-a494-d8d759fb8aa5) | 

Fixes #issue

# How Has This Been Tested?

Choose Chunky font then click Bert and Poppy