### PR TITLE
[FEAT] Add Default Animal Buildings to GameState

### DIFF
--- a/src/features/game/events/landExpansion/buyAnimal.test.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.test.ts
@@ -1,24 +1,6 @@
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { AnimalType } from "features/game/types/animals";
-import { AnimalState } from "features/game/types/game";
 import { buyAnimal } from "./buyAnimal";
-
-function makeAnimals(count: number, type: AnimalType) {
-  return new Array(count).fill(0).reduce(
-    (animals, _, index) => {
-      return {
-        ...animals,
-        [index]: {
-          id: index.toString(),
-          type,
-          state: "idle",
-          coordinates: { x: index, y: index },
-        },
-      };
-    },
-    {} as Record<string, AnimalState>,
-  );
-}
+import { makeAnimals } from "features/game/lib/animals";
 
 describe("buyAnimal", () => {
   const leveledUpBumpkin = { ...INITIAL_BUMPKIN, experience: 300000 };
@@ -152,7 +134,7 @@ describe("buyAnimal", () => {
           },
           henHouse: {
             level: 0,
-            animals: makeAnimals(1, "Chicken"),
+            animals: makeAnimals(3, "Chicken"),
           },
         },
         action: {

--- a/src/features/game/events/landExpansion/buyAnimal.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.ts
@@ -1,17 +1,17 @@
 import Decimal from "decimal.js-light";
 import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
+import { makeAnimalBuildingKey } from "features/game/lib/animals";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { ANIMALS, AnimalType } from "features/game/types/animals";
+import {
+  AnimalBuildingType,
+  ANIMALS,
+  AnimalType,
+} from "features/game/types/animals";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/decorations";
-import {
-  AnimalBuilding,
-  AnimalBuildingKey,
-  GameState,
-} from "features/game/types/game";
+import { AnimalBuilding, GameState } from "features/game/types/game";
 import { produce } from "immer";
-import { toCamelCase } from "lib/utils/toCamelCase";
 
 export type BuyAnimalAction = {
   type: "animal.bought";
@@ -86,18 +86,12 @@ export function buyAnimal({
       );
     }
 
-    const buildingKey = toCamelCase(buildingRequired) as AnimalBuildingKey;
-    const building = copy[buildingKey] as AnimalBuilding;
-
-    // This should not happen as this field will be added when a building is placed but just in case
-    if (!building) {
-      throw new Error(
-        `You do not have a ${buildingRequired} on your gameState`,
-      );
-    }
+    const buildingKey = makeAnimalBuildingKey(
+      buildingRequired as AnimalBuildingType,
+    );
 
     const capacity = getAnimalCapacity(buildingKey, copy);
-    const totalAnimalsInBuilding = getKeys(building.animals).length;
+    const totalAnimalsInBuilding = getKeys(copy[buildingKey].animals).length;
 
     if (totalAnimalsInBuilding >= capacity) {
       throw new Error("You do not have the capacity for this animal");
@@ -121,7 +115,7 @@ export function buyAnimal({
 
     copy.coins -= price;
 
-    building.animals[action.id] = {
+    copy[buildingKey].animals[action.id] = {
       id: action.id,
       state: "idle",
       type: action.animal,

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -1,0 +1,35 @@
+import { AnimalType } from "../types/animals";
+import { BuildingName } from "../types/buildings";
+import { Animal, AnimalBuildingKey } from "../types/game";
+
+export const makeAnimalBuildingKey = (
+  buildingName: Extract<BuildingName, "Hen House" | "Barn">,
+): AnimalBuildingKey => {
+  return buildingName
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, "") as AnimalBuildingKey;
+};
+
+export function makeAnimals(count: number, type: AnimalType) {
+  const positions = [
+    { x: -1, y: 0 },
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ];
+  return new Array(count).fill(0).reduce(
+    (animals, _, index) => {
+      return {
+        ...animals,
+        [index]: {
+          id: index.toString(),
+          type,
+          state: "idle",
+          coordinates: positions[index],
+        },
+      };
+    },
+    {} as Record<string, Animal>,
+  );
+}

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -14,6 +14,7 @@ import { BumpkinParts, tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import { Equipped } from "../types/bumpkin";
 import { SeedName } from "../types/seeds";
 import { INITIAL_REWARDS } from "../types/rewards";
+import { makeAnimals } from "./animals";
 
 // Our "zoom" factor
 export const PIXEL_SCALE = 2.625;
@@ -611,6 +612,14 @@ export const INITIAL_FARM: GameState = {
       patterns: [],
     },
   },
+  henHouse: {
+    level: 0,
+    animals: makeAnimals(3, "Chicken"),
+  },
+  barn: {
+    level: 0,
+    animals: makeAnimals(3, "Cow"),
+  },
 };
 
 export const TEST_FARM: GameState = {
@@ -911,6 +920,14 @@ export const TEST_FARM: GameState = {
       grid: [],
     },
   },
+  henHouse: {
+    level: 0,
+    animals: makeAnimals(3, "Chicken"),
+  },
+  barn: {
+    level: 0,
+    animals: makeAnimals(3, "Cow"),
+  },
 };
 
 export const INITIAL_EQUIPPED: Equipped = {
@@ -1028,5 +1045,13 @@ export const EMPTY: GameState = {
       patterns: [],
       grid: [],
     },
+  },
+  henHouse: {
+    level: 0,
+    animals: makeAnimals(3, "Chicken"),
+  },
+  barn: {
+    level: 0,
+    animals: makeAnimals(3, "Cow"),
   },
 };

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -115,5 +115,7 @@ export function makeGame(farm: any): GameState {
       : undefined,
     desert: farm.desert,
     transaction: farm.transaction,
+    henHouse: farm.henHouse,
+    barn: farm.barn,
   };
 }

--- a/src/features/game/types/animals.ts
+++ b/src/features/game/types/animals.ts
@@ -1,16 +1,16 @@
 import { BuildingName } from "./buildings";
 
+export type AnimalBuildingType = Extract<BuildingName, "Barn" | "Hen House">;
+
 export type AnimalType = "Chicken" | "Cow" | "Sheep";
-export const ANIMAL_BUILDINGS: BuildingName[] = ["Hen House", "Barn"] as const;
 
 type AnimalDetail = {
   coins: number;
   levelRequired: number;
-  buildingRequired: BuildingName;
+  buildingRequired: AnimalBuildingType;
   height: number;
   width: number;
 };
-
 export const ANIMALS: Record<AnimalType, AnimalDetail> = {
   Chicken: {
     coins: 50,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1140,18 +1140,19 @@ type Stores = "factionShop" | "treasureShop" | "megastore";
 export type KeysBought = Record<Stores, KeysBoughtAt>;
 
 export type AnimalBuildingKey = "henHouse" | "barn";
+type AnimalState = "idle";
 
-export type AnimalState = {
+export type Animal = {
   id: string;
   type: AnimalType;
-  state: "idle";
+  state: AnimalState;
   createdAt: number;
   coordinates: Coordinates;
 };
 
 export type AnimalBuilding = {
   level: number;
-  animals: Record<string, AnimalState>;
+  animals: Record<string, Animal>;
 };
 
 export interface GameState {
@@ -1323,8 +1324,8 @@ export interface GameState {
   desert: Desert;
 
   experiments: ExperimentName[];
-  henHouse?: AnimalBuilding;
-  barn?: AnimalBuilding;
+  henHouse: AnimalBuilding;
+  barn: AnimalBuilding;
 }
 
 export interface Context {

--- a/src/lib/utils/toCamelCase.ts
+++ b/src/lib/utils/toCamelCase.ts
@@ -1,7 +1,0 @@
-export const toCamelCase = (str: string) => {
-  return str
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => {
-      return index === 0 ? word.toLowerCase() : word.toUpperCase();
-    })
-    .replace(/\s+/g, "");
-};


### PR DESCRIPTION
# Description

Adds animals buildings as default values on `GameState`.

Fixes #issue

# What needs to be tested by the reviewer?

- Code review
- Run a session and check for `henHouse` and `barn` on `gameState`. Each building should have 3 animals on them by default.

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
