### PR TITLE
[CHORE] Add Singular Form to 'entries' in Raffle Modal

### DIFF
--- a/src/features/world/ui/chests/Raffle.tsx
+++ b/src/features/world/ui/chests/Raffle.tsx
@@ -67,7 +67,7 @@ export const Raffle: React.FC<Props> = ({ onClose }) => {
           </Label>
           {entries > 0 && (
             <Label icon={ITEM_DETAILS["Prize Ticket"].image} type="success">
-              {entries} {t("raffle.entries")}
+              {entries} {entries > 1 ? t("raffle.entries") : t("raffle.entry")}
             </Label>
           )}
         </div>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -106,6 +106,7 @@
   "budBox.today": "Today - {{timeLeft}} left",
   "raffle.title": "Goblin Raffle",
   "raffle.description": "Each month, you have a chance to win rewards. Winners will be announced on Discord.",
+  "raffle.entry": "entry",
   "raffle.entries": "entries",
   "raffle.noTicket": "Missing Prize Ticket",
   "raffle.how": "You can collect Prize Tickets for free through special events and Bumpkin deliveries.",


### PR DESCRIPTION
The image below shows the singular form of 'entries' in the Raffle Modal.

![image](https://github.com/user-attachments/assets/5c8ee14f-90ef-4eb6-bca2-82a9d3ff9321)
