### PR TITLE
[FIX] Remove redundant sentence in pet guide

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2012,7 +2012,7 @@
   "guide.factionPet.one": "Each week the pet will request 3 foods. When fed, the XP from the food will go to the total XP tally for the faction.",
   "guide.factionPet.two": "Your faction will have a goal xp they need to reach each week. If the faction reaches the goal, the next week goal will be 25% more than the previous week's goal! If the goal isn't reached, it will be reset back to 1000 x faction members.",
   "guide.factionPet.three": "If the faction doesn't reach the goal then the pet will go to sleep for 1 week.",
-  "guide.factionPet.four": "Once the faction reaches a streak of 2 or more weeks, an XP bonus will be given to each contributing faction member when their bumpkin eats! To be a contributing member you will need to have fed the pet at least 1 of each request during the week prior.",
+  "guide.factionPet.four": "Once the faction reaches a streak of 2 or more weeks, an XP bonus will be given to each contributing faction member when their bumpkin eats!",
   "guide.factionPet.five": "Contributing member: To be eligible for potential streak boosts in the following week, a player needs to fulfill one of each pet's requests.",
   "guide.factionPet.six": "You will be awared marks for each food delivered. Every time you deliver the reward will be reduced. These rewards will reset daily. Players with an emblem bonus will get an additional bonus based on their faction bonus rank.",
   "guide.streak.one": "Week 2 streak achieved = 10% XP during week 3 & week 4*",


### PR DESCRIPTION
The 4th paragraph defines contributing member.  The 3rd paragraph's second sentence is thus redundant and potentially confusing or at least distracting.