### PR TITLE
[FIX] shipmentRestocked test

### DIFF
--- a/src/features/game/events/landExpansion/shipmentRestocked.test.ts
+++ b/src/features/game/events/landExpansion/shipmentRestocked.test.ts
@@ -19,6 +19,7 @@ describe("shipmentRestocked", () => {
           restockedAt: new Date("2023-04-04").getTime(),
         },
       },
+      createdAt: now,
     });
 
     expect(state.shipments.restockedAt).toEqual(now);
@@ -43,6 +44,7 @@ describe("shipmentRestocked", () => {
           restockedAt: new Date("2023-04-04").getTime(),
         },
       },
+      createdAt: now,
     });
 
     expect(state.shipments.restockedAt).toEqual(now);


### PR DESCRIPTION
Fix for
```
FAIL src/features/game/events/landExpansion/shipmentRestocked.test.ts
  ● shipmentRestocked › restocks a shipment

    expect(received).toEqual(expected) // deep equality

    Expected: 1728416225842
    Received: 1728416225843
```
Seen here:
<https://github.com/sunflower-land/sunflower-land/actions/runs/11242461660/job/31256183043?pr=4502>