### PR TITLE
[FIX] instantCook test

### DIFF
--- a/src/features/game/events/landExpansion/speedUpRecipe.test.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.test.ts
@@ -89,7 +89,7 @@ describe("instantCook", () => {
                 readyAt: 0,
                 crafting: {
                   name: "Mashed Potato",
-                  readyAt: Date.now(),
+                  readyAt: Date.now() + 30000,
                 },
               },
             ],
@@ -118,7 +118,7 @@ describe("instantCook", () => {
               readyAt: 0,
               crafting: {
                 name: "Mashed Potato",
-                readyAt: Date.now(),
+                readyAt: Date.now() + 30000,
               },
             },
           ],


### PR DESCRIPTION
Fix for
```
FAIL src/features/game/events/landExpansion/speedUpRecipe.test.ts
  ● instantCook › requires player has the gems
    expect(received).toThrow(expected)
    Expected substring: "Insufficient gems"
    Received message:   "Already cooked"
```
<https://github.com/sunflower-land/sunflower-land/actions/runs/11242518033/job/31256361218?pr=4503>