### PR TITLE
[FIX] Remove Default Caching Policy

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,9 +3,9 @@
 
 import "workbox-core";
 import { googleFontsCache, offlineFallback } from "workbox-recipes";
-import { registerRoute, setDefaultHandler } from "workbox-routing";
+import { registerRoute } from "workbox-routing";
 import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
-import { StaleWhileRevalidate, NetworkOnly } from "workbox-strategies";
+import { StaleWhileRevalidate } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
 import { CONFIG } from "./lib/config";
 
@@ -50,9 +50,6 @@ if (import.meta.env.PROD) {
   // Google Fonts
   googleFontsCache();
 }
-
-// Network only default handler for all other fetch requests
-setDefaultHandler(new NetworkOnly());
 
 // Offline fallback html page
 offlineFallback();


### PR DESCRIPTION
This PR attempts to improve plaza performance by removing the default handler in the service worker.

The hope is that requests for non service worker assets cached assets will go via the standard browser HTTP cache.