### PR TITLE
[FIX] CropName sorted by base duration

### DIFF
--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -7,6 +7,7 @@ export type CropName =
   | "Pumpkin"
   | "Carrot"
   | "Cabbage"
+  | "Soybean"
   | "Beetroot"
   | "Cauliflower"
   | "Parsnip"
@@ -15,7 +16,6 @@ export type CropName =
   | "Radish"
   | "Wheat"
   | "Kale"
-  | "Soybean"
   | "Barley";
 
 export type Crop = {


### PR DESCRIPTION
Moves `Soybean` to the proper location in the `CropName` order (matching the `CROPS` order).