### PR TITLE
[FEAT] Chest Reward verification improvement

### DIFF
--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -53,7 +53,7 @@ export const ChestReward: React.FC<Props> = ({
   const [opened, setOpened] = useState(isNew);
   const [loading, setLoading] = useState(false);
   const challenge = useRef<Challenge>(
-    (isSeasoned || (Math.random() > 0.3)) ? "chest" : "goblins",
+    isSeasoned || Math.random() > 0.3 ? "chest" : "goblins",
   );
 
   useEffect(() => {

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -49,7 +49,7 @@ export const ChestReward: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const isNew = useSelector(gameService, isNewGame);
   const isSeasoned = useSelector(gameService, isSeasonedPlayer);
-  const [opened, setOpened] = useState(isNew);
+  const [opened, setOpened] = useState(isNew || isSeasoned);
   const [loading, setLoading] = useState(false);
   const challenge = useRef<Challenge>(
     Math.random() > 0.3 ? "chest" : "goblins",

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -34,7 +34,7 @@ const isNewGame = (state: MachineState) =>
 // A player that has been vetted and is engaged in the season.
 const isSeasonedPlayer = (state: MachineState) =>
   // - level 60+
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) &&
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) >= 60 &&
   // - verified (personhood verification)
   state.context.verified &&
   // - has active seasonal banner

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -35,8 +35,8 @@ const isNewGame = (state: MachineState) =>
 const isSeasonedPlayer = (state: MachineState) =>
   // - level 60+
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) &&
-  // - TODO: is verified (personhood verification)
-  true &&
+  // - verified (personhood verification)
+  state.context.verified &&
   // - has active seasonal banner
   hasActiveSeasonBanner({ game: state.context.state });
 

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -31,8 +31,7 @@ type Challenge = "goblins" | "chest";
 const isNewGame = (state: MachineState) =>
   state.context.state.createdAt + 24 * 60 * 60 * 1000 > Date.now();
 
-// A player that should not have to do the goblins
-// challenge or be timed out for misclicking the chest.
+// A player that has been vetted and is engaged in the season.
 const isSeasonedPlayer = (state: MachineState) =>
   // - level 60+
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) &&
@@ -53,11 +52,11 @@ export const ChestReward: React.FC<Props> = ({
   const [opened, setOpened] = useState(isNew);
   const [loading, setLoading] = useState(false);
   const challenge = useRef<Challenge>(
-    isSeasoned || Math.random() > 0.3 ? "chest" : "goblins",
+    Math.random() > 0.3 ? "chest" : "goblins",
   );
 
   useEffect(() => {
-    if (reward && !isNew) {
+    if (reward && !isNew && !isSeasoned) {
       setLoading(true);
       setTimeout(() => setLoading(false), 500);
     }
@@ -74,10 +73,8 @@ export const ChestReward: React.FC<Props> = ({
 
   const fail = () => {
     close(false);
-    if (!isSeasoned) {
-      gameService.send("bot.detected");
-      gameService.send("REFRESH");
-    }
+    gameService.send("bot.detected");
+    gameService.send("REFRESH");
   };
 
   const close = (success: boolean) => {


### PR DESCRIPTION
# Issue

For random drops from nodes, the is a "Chest Reward" UX presented to the player.

This can either be a chest or a goblin/moonseeker "challenge".

In both cases, incorrect response results in:
1. the reward is not received (requiring future challenge success)
2. the player's farm is put in "time out" for a few minutes

Many players, especially veterans, find this frustrating especially after weeks, months, or years of gameplay.

# Change

"New" is already defined as farms created less than a day ago.

"Seasoned players" are now defined as:
- level 60+
- verified (personhood)
- have active seasonal banner placed (includes `Lifetime Farmer Banner`)

"New" players already bypass the Chest Reward UX.

Now "Seasoned" players also bypass the Chest Reward UX.

# Acknowledgements

Kudos to Dcol for formally raising this proposal and getting community feedback.
