### PR TITLE
[FIX] another instantCook test

### DIFF
--- a/src/features/game/events/landExpansion/speedUpRecipe.test.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.test.ts
@@ -193,6 +193,7 @@ describe("instantCook", () => {
     expect(state.inventory.Gem).toEqual(new Decimal(86));
   });
   it("gives the player the food", () => {
+    const now = Date.now();
     const state = speedUpRecipe({
       action: {
         buildingId: "123",
@@ -211,11 +212,12 @@ describe("instantCook", () => {
               readyAt: 0,
               crafting: {
                 name: "Mashed Potato",
-                readyAt: Date.now(),
+                readyAt: now + 30000,
               },
             },
           ],
         },
+        createdAt: now,
       },
     });
 


### PR DESCRIPTION
Fix for
```
FAIL src/features/game/events/landExpansion/speedUpRecipe.test.ts
  ● instantCook › gives the player the food
    Already cooked
```
<https://github.com/sunflower-land/sunflower-land/actions/runs/11288520443/job/31396452829?pr=4522>