### PR TITLE
[FIX] Sync the Required Level for the Plaza in the Tutorial Modal with the Map

### DIFF
--- a/src/features/game/expansion/components/PeteHelp.tsx
+++ b/src/features/game/expansion/components/PeteHelp.tsx
@@ -11,7 +11,7 @@ import { useSelector } from "@xstate/react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 const isLocked = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) < 3;
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) < 2;
 
 export const PeteHelp: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -38,7 +38,7 @@ export const PeteHelp: React.FC = () => {
             className="mb-2 ml-1"
             icon={SUNNYSIDE.icons.lock}
           >
-            {t("warning.level.required", { lvl: 3 })}
+            {t("warning.level.required", { lvl: 2 })}
           </Label>
         </>
       )}


### PR DESCRIPTION
# Description
The required lvl for the plaza is different on the world map.
https://github.com/sunflower-land/sunflower-land/blob/7f76e6a894f0d2b1f21e44a2ce3a6642d9762693/src/features/island/hud/components/deliveries/WorldMap.tsx#L110

Fixes #issue

# What needs to be tested by the reviewer?

Click Pete at the south of a new farm with lvl 1 bumpkin and try to travel.
