### PR TITLE
Chest Reward verification improvement - Second Edition

### DIFF
--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -192,16 +192,18 @@ export const Tree: React.FC<Props> = ({ id }) => {
       {chopped && <DepletedTree timeLeft={timeLeft} island={island} />}
 
       {/* Chest reward */}
-      <ChestReward
-        collectedItem={"Wood"}
-        reward={reward}
-        onCollected={onCollectChest}
-        onOpen={() =>
-          gameService.send("treeReward.collected", {
-            treeIndex: id,
-          })
-        }
-      />
+      {reward && (
+        <ChestReward
+          collectedItem={"Wood"}
+          reward={reward}
+          onCollected={onCollectChest}
+          onOpen={() =>
+            gameService.send("treeReward.collected", {
+              treeIndex: id,
+            })
+          }
+        />
+      )}
     </div>
   );
 };

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -127,7 +127,6 @@ export const Tree: React.FC<Props> = ({ id }) => {
     // need to hit enough times to collect resource
     if (touchCount < HITS - 1) return;
 
-    // increase touch count if there is a reward
     if (resource.wood.reward) {
       // they have touched enough!
       setReward(resource.wood.reward);

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -15,8 +15,6 @@ import { translate } from "lib/i18n/translate";
 import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
-import { getBumpkinLevel } from "features/game/lib/level";
-import { hasActiveSeasonBanner } from "features/game/lib/collectibleBuilt";
 
 interface Props {
   collectedItem?: InventoryItemName;
@@ -31,15 +29,6 @@ type Challenge = "goblins" | "chest";
 const isNewGame = (state: MachineState) =>
   state.context.state.createdAt + 24 * 60 * 60 * 1000 > Date.now();
 
-// A player that has been vetted and is engaged in the season.
-const isSeasonedPlayer = (state: MachineState) =>
-  // - level 60+
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0) >= 60 &&
-  // - verified (personhood verification)
-  state.context.verified &&
-  // - has active seasonal banner
-  hasActiveSeasonBanner({ game: state.context.state });
-
 export const ChestReward: React.FC<Props> = ({
   collectedItem,
   reward,
@@ -48,15 +37,14 @@ export const ChestReward: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
   const isNew = useSelector(gameService, isNewGame);
-  const isSeasoned = useSelector(gameService, isSeasonedPlayer);
-  const [opened, setOpened] = useState(isNew || isSeasoned);
+  const [opened, setOpened] = useState(isNew);
   const [loading, setLoading] = useState(false);
   const challenge = useRef<Challenge>(
     Math.random() > 0.3 ? "chest" : "goblins",
   );
 
   useEffect(() => {
-    if (reward && !isNew && !isSeasoned) {
+    if (reward && !isNew) {
       setLoading(true);
       setTimeout(() => setLoading(false), 500);
     }

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -232,6 +232,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
         gameService.send("cropReward.collected", {
           plotIndex: id,
         });
+        harvestCrop(crop);
       } else {
         setReward(crop.reward);
       }

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -366,16 +366,18 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
           pulsating={showQuickSelect && pulsating}
         />
       </div>
-      <ChestReward
-        collectedItem={crop?.name}
-        reward={reward}
-        onCollected={onCollectReward}
-        onOpen={() =>
-          gameService.send("cropReward.collected", {
-            plotIndex: id,
-          })
-        }
-      />
+      {reward && (
+        <ChestReward
+          collectedItem={crop?.name}
+          reward={reward}
+          onCollected={onCollectReward}
+          onOpen={() =>
+            gameService.send("cropReward.collected", {
+              plotIndex: id,
+            })
+          }
+        />
+      )}
 
       {/* Harvest Animation */}
       {showAnimations && (


### PR DESCRIPTION
The first edition attempted to use the new player experience, but there seem to be bugs in that implementation.  Additionally, for seasoned players the experience should be improved to remove the extra clicks entirely.  More specifically, the "click again after discovering a reward is present on the plot" (for crops only) and "click on the woohoo UI" (for both crops and trees).