### PR TITLE
[FEAT] Allow mod tools to appear when Halo is in wardrobe

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { Game, AUTO } from "phaser";
-import { useSelector } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import NinePatchPlugin from "phaser3-rex-plugins/plugins/ninepatch-plugin.js";
 import VirtualJoystickPlugin from "phaser3-rex-plugins/plugins/virtualjoystick-plugin.js";
 import { PhaserNavMeshPlugin } from "phaser-navmesh";
@@ -106,6 +106,12 @@ export const PhaserComponent: React.FC<Props> = ({
   const { authService } = useContext(AuthProvider.Context);
   const { gameService, selectedItem, shortcutItem } = useContext(Context);
 
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
+
   const { toastsList } = useContext(ToastContext);
 
   const [messages, setMessages] = useState<Message[]>([]);
@@ -152,12 +158,10 @@ export const PhaserComponent: React.FC<Props> = ({
     });
 
     // Set up moderator by looking if bumpkin has Halo hat equipped and Beta Pass in inventory
-    const bumpkin = gameService.state.context.state.bumpkin;
-    const hasBetaPass = !!inventory["Beta Pass"];
+    const { wardrobe } = state;
+    const isModerator = !!inventory["Beta Pass"] && !!wardrobe.Halo;
 
-    bumpkin?.equipped?.hat === "Halo" && hasBetaPass
-      ? setIsModerator(true)
-      : setIsModerator(false); // I know i know this is a bit useless but useful for debugging rofl
+    isModerator ? setIsModerator(true) : setIsModerator(false); // I know i know this is a bit useless but useful for debugging rofl
 
     // Check if user is muted and if so, apply mute details to isMuted state
     const userModLogs = gameService.state.context.moderation;


### PR DESCRIPTION
# Description

Currently you need to equip the Halo to access the Mod tools, this update allows you to access mod tools as long as you have Halo in your wardrobe

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
