### PR TITLE
[FIX] Wrong Icon on Ancient Shovel

### DIFF
--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -402,7 +402,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       shortDescription: translate("bumpkinItemBuff.ancient.shovel.boost"),
       labelType: "vibrant",
       boostTypeIcon: lightning,
-      boostedItemIcon: ITEM_DETAILS.Oil.image,
+      boostedItemIcon: ITEM_DETAILS["Sand Shovel"].image,
     },
     "Oil Overalls": {
       shortDescription: translate("bumpkinItemBuff.oil.overalls.boost"),


### PR DESCRIPTION
# Description

Ancient Shovel icon currently uses Oil icon, it should be the sand shovel icon instead

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
