### PR TITLE
[FIX] Optimize Faction Shop General Item Details Layout for Small Screens

### DIFF
--- a/src/features/world/ui/factionShop/components/ItemDetail.tsx
+++ b/src/features/world/ui/factionShop/components/ItemDetail.tsx
@@ -288,7 +288,7 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
                         item.faction !== pledgedFaction &&
                         getFactionOnlyLabel(item.faction)}
                       {!faction && !item?.faction && (
-                        <Label type="warning" className="whitespace-nowrap">
+                        <Label type="warning" className="sm:whitespace-nowrap">
                           {t("faction.shop.membersOnly")}
                         </Label>
                       )}


### PR DESCRIPTION
# Description
The condition happens when players haven't joined a faction yet and try to see general item details on a small screen, so "Faction member exclusive" label causes the issue.
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7c5c7932-87fc-4852-81b9-1b7c8f6b81f7) | ![image](https://github.com/user-attachments/assets/f0c2d3a5-7c3e-4322-ae9e-68a1c4aa55cd) | 

Fixes #issue

# What needs to be tested by the reviewer?

Click Eldric at kingdom and choose a general item.


