### PR TITLE
[FIX] Tree Rewards Outside Modal

### DIFF
--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -125,6 +125,14 @@ export const Tree: React.FC<Props> = ({ id }) => {
 
   useUiRefresher({ active: chopped });
 
+  const claimAnyReward = () => {
+    if (resource.wood.reward) {
+      gameService.send("treeReward.collected", {
+        treeIndex: id,
+      });
+    }
+  };
+
   const shake = () => {
     if (!hasTool) return;
 
@@ -134,6 +142,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
 
     if (game.bumpkin.skills["Insta-Chop"]) {
       // insta-chop the tree
+      claimAnyReward();
       chop();
     }
 
@@ -143,9 +152,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
     if (resource.wood.reward) {
       // they have touched enough!
       if (isSeasoned) {
-        gameService.send("treeReward.collected", {
-          treeIndex: id,
-        });
+        claimAnyReward();
       } else {
         setReward(resource.wood.reward);
         return;
@@ -216,11 +223,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
           collectedItem={"Wood"}
           reward={reward}
           onCollected={onCollectChest}
-          onOpen={() =>
-            gameService.send("treeReward.collected", {
-              treeIndex: id,
-            })
-          }
+          onOpen={claimAnyReward}
         />
       )}
     </div>

--- a/src/features/island/common/chest-reward/ChestReward.tsx
+++ b/src/features/island/common/chest-reward/ChestReward.tsx
@@ -69,10 +69,15 @@ export const ChestReward: React.FC<Props> = ({
     setOpened(false);
   };
 
+  const claimAndClose = () => {
+    onOpen();
+    close(true);
+  };
+
   const { items, sfl, coins } = reward;
 
   return (
-    <Modal show={true} onHide={opened ? () => close(true) : undefined}>
+    <Modal show={true} onHide={opened ? () => claimAndClose() : undefined}>
       <Panel>
         {loading && <Loading />}
         {opened ? (
@@ -92,10 +97,7 @@ export const ChestReward: React.FC<Props> = ({
               coins: coins ?? 0,
               message: translate("reward.woohoo"),
             }}
-            onClose={() => {
-              onOpen();
-              close(true);
-            }}
+            onClose={claimAndClose}
           />
         ) : (
           <div


### PR DESCRIPTION
# Description

Fixes a bug where dismissing the reward modal will skip the tree reward.
