### PR TITLE
[FEAT] Chore Board

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -391,6 +391,10 @@ import {
   collectCrafting,
   CollectCraftingAction,
 } from "./landExpansion/collectCrafting";
+import {
+  completeNPCChore,
+  CompleteNPCChoreAction,
+} from "./landExpansion/completeNPCChore";
 
 export type PlayingEvent =
   | SellAnimalAction
@@ -508,7 +512,8 @@ export type PlayingEvent =
   | LoveAnimalAction
   | UpgradeBuildingAction
   | StartCraftingAction
-  | CollectCraftingAction;
+  | CollectCraftingAction
+  | CompleteNPCChoreAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -691,6 +696,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "building.upgraded": upgradeBuilding,
   "crafting.started": startCrafting,
   "crafting.collected": collectCrafting,
+  "chore.fulfilled": completeNPCChore,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/completeKingdomChore.test.ts
+++ b/src/features/game/events/landExpansion/completeKingdomChore.test.ts
@@ -1,7 +1,7 @@
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { completeKingdomChore } from "./completeKingdomChore";
 import Decimal from "decimal.js-light";
-import { getFactionWeek } from "features/game/lib/factions";
+import { getWeekKey } from "features/game/lib/factions";
 import { GameState } from "features/game/types/game";
 
 const state: GameState = {
@@ -501,7 +501,7 @@ describe("kingdomChore.completed", () => {
       },
     });
 
-    const week = getFactionWeek({ date: new Date(now) });
+    const week = getWeekKey({ date: new Date(now) });
     expect(result.faction?.history[week].score).toBe(
       new Decimal(3).mul(5.05).toNumber(),
     );

--- a/src/features/game/events/landExpansion/completeKingdomChore.ts
+++ b/src/features/game/events/landExpansion/completeKingdomChore.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { getFactionRankBoostAmount } from "features/game/lib/factionRanks";
 import {
   getFactionWearableBoostAmount,
-  getFactionWeek,
+  getWeekKey,
 } from "features/game/lib/factions";
 import { BoostType, BoostValue } from "features/game/types/boosts";
 import { Bumpkin, GameState, KingdomChores } from "features/game/types/game";
@@ -127,7 +127,7 @@ export function completeKingdomChore({
     inventory["Mark"] = previousMarks.add(marks);
 
     // Add to history
-    const week = getFactionWeek({ date: new Date(createdAt) });
+    const week = getWeekKey({ date: new Date(createdAt) });
     const factionHistory = faction.history[week] ?? { score: 0, petXP: 0 };
     factionHistory.score += marks;
 

--- a/src/features/game/events/landExpansion/completeNPCChore.test.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.test.ts
@@ -1,0 +1,162 @@
+import { GameState } from "features/game/types/game";
+import { completeNPCChore } from "./completeNPCChore";
+import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+import Decimal from "decimal.js-light";
+import { NpcChore } from "features/game/types/choreBoard";
+
+describe("completeNPCChore", () => {
+  const CHORE: NpcChore = {
+    name: "CHOP_1_TREE",
+    reward: { items: { Wood: 1 } },
+    initialProgress: 0,
+    startedAt: Date.now(),
+  };
+
+  it("throws an error if no chore exists for the NPC", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      choreBoard: {
+        chores: {},
+      },
+    };
+
+    expect(() =>
+      completeNPCChore({
+        state,
+        action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      }),
+    ).toThrow("No chore exists for this NPC");
+  });
+
+  it("throws an error if the chore is already completed", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": { ...CHORE, completedAt: Date.now() },
+        },
+      },
+    };
+
+    expect(() =>
+      completeNPCChore({
+        state,
+        action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      }),
+    ).toThrow("Chore is already completed");
+  });
+
+  it("throws an error if chore requirements are not met", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: {},
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": CHORE,
+        },
+      },
+    };
+
+    expect(() =>
+      completeNPCChore({
+        state,
+        action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      }),
+    ).toThrow("Chore requirements not met");
+  });
+
+  it("completes the chore when requirements are met", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": CHORE,
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+    });
+
+    expect(
+      newState.choreBoard.chores["pumpkin' pete"]?.completedAt,
+    ).toBeDefined();
+  });
+
+  it("completes the chore when requirements are met with initial progress", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 2 },
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": { ...CHORE, initialProgress: 1 },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+    });
+
+    expect(
+      newState.choreBoard.chores["pumpkin' pete"]?.completedAt,
+    ).toBeDefined();
+  });
+
+  it("provides rewards when completing the chore", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": CHORE,
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+    });
+
+    expect(newState.inventory.Wood).toEqual(new Decimal(1));
+  });
+
+  it("increases NPC friendship points when completing the chore", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": CHORE,
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+    });
+
+    expect(newState.npcs?.["pumpkin' pete"]?.friendship?.points).toBe(1);
+  });
+});

--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -1,0 +1,73 @@
+import Decimal from "decimal.js-light";
+import { GameState, InventoryItemName } from "features/game/types/game";
+import {
+  getChoreProgress,
+  NPC_CHORES,
+  NpcChore,
+} from "features/game/types/choreBoard";
+import { produce } from "immer";
+import { NPCName } from "lib/npcs";
+
+export type CompleteNPCChoreAction = {
+  type: "chore.fulfilled";
+  npcName: NPCName;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: CompleteNPCChoreAction;
+  createdAt?: number;
+};
+
+export function completeNPCChore({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (draft) => {
+    const { npcName } = action;
+    const { choreBoard, bumpkin, npcs } = draft;
+
+    if (!choreBoard.chores[npcName]) {
+      throw new Error("No chore exists for this NPC");
+    }
+
+    const chore = choreBoard.chores[npcName] as NpcChore;
+
+    if (chore.completedAt) {
+      throw new Error("Chore is already completed");
+    }
+
+    const progress = getChoreProgress({ chore, game: draft });
+
+    if (progress < NPC_CHORES[chore.name].requirement) {
+      throw new Error("Chore requirements not met");
+    }
+
+    // Mark chore as completed
+    chore.completedAt = createdAt;
+
+    // Add rewards to inventory
+    Object.entries(chore.reward.items).forEach(([itemName, amount]) => {
+      draft.inventory[itemName as InventoryItemName] = (
+        draft.inventory[itemName as InventoryItemName] || new Decimal(0)
+      ).add(amount);
+    });
+
+    // Increase NPC friendship points
+    if (!draft.npcs) {
+      draft.npcs = {};
+    }
+    if (!draft.npcs[npcName]) {
+      draft.npcs[npcName] = { deliveryCount: 0 };
+    }
+    if (!draft.npcs[npcName].friendship) {
+      draft.npcs[npcName].friendship = { points: 0, updatedAt: createdAt };
+    }
+
+    draft.npcs[npcName].friendship.points += 1;
+    draft.npcs[npcName].friendship.updatedAt = createdAt;
+
+    return draft;
+  });
+}

--- a/src/features/game/events/landExpansion/deliverFactionKitchen.ts
+++ b/src/features/game/events/landExpansion/deliverFactionKitchen.ts
@@ -4,7 +4,7 @@ import {
   START_DATE,
   calculatePoints,
   getFactionWearableBoostAmount,
-  getFactionWeek,
+  getWeekKey,
   getFactionWeekday,
 } from "features/game/lib/factions";
 import { BoostType, BoostValue } from "features/game/types/boosts";
@@ -84,7 +84,7 @@ export function deliverFactionKitchen({
 
     inventory[request.item] = resourceBalance.minus(request.amount);
 
-    const week = getFactionWeek({ date: new Date(createdAt) });
+    const week = getWeekKey({ date: new Date(createdAt) });
     const day = getFactionWeekday(createdAt);
     const marksBalance = inventory["Mark"] ?? new Decimal(0);
     const fulfilledToday = request.dailyFulfilled[day] ?? 0;

--- a/src/features/game/events/landExpansion/feedFactionPet.test.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.test.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import {
   START_DATE,
-  getFactionWeek,
+  getWeekKey,
   getFactionWeekday,
 } from "features/game/lib/factions";
 import { Faction, GameState } from "features/game/types/game";
@@ -23,7 +23,7 @@ describe("feedFactionPet", () => {
   afterEach(() => jest.useRealTimers());
 
   const startTime = START_DATE.getTime();
-  const week = getFactionWeek({ date: START_DATE });
+  const week = getWeekKey({ date: START_DATE });
 
   it("throws an error if the faction pet feature is not active yet", () => {
     expect(() => {

--- a/src/features/game/events/landExpansion/feedFactionPet.ts
+++ b/src/features/game/events/landExpansion/feedFactionPet.ts
@@ -4,7 +4,7 @@ import {
   START_DATE,
   calculatePoints,
   getFactionWearableBoostAmount,
-  getFactionWeek,
+  getWeekKey,
   getFactionWeekday,
 } from "features/game/lib/factions";
 import { isWearableActive } from "features/game/lib/wearables";
@@ -104,7 +104,7 @@ export function feedFactionPet({
 
     const request = requests[action.requestIndex];
     const foodBalance = stateCopy.inventory[request.food] ?? new Decimal(0);
-    const week = getFactionWeek({ date: new Date(createdAt) });
+    const week = getWeekKey({ date: new Date(createdAt) });
     const day = getFactionWeekday(createdAt);
 
     if (foodBalance.lt(request.quantity)) {

--- a/src/features/game/events/minigames/claimMinigamePrize.ts
+++ b/src/features/game/events/minigames/claimMinigamePrize.ts
@@ -5,7 +5,7 @@ import {
 } from "features/game/types/minigames";
 import { GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
-import { getFactionWeek } from "features/game/lib/factions";
+import { getWeekKey } from "features/game/lib/factions";
 import { produce } from "immer";
 
 export function isMinigameComplete({
@@ -119,7 +119,7 @@ export function claimMinigamePrize({
     });
 
     if (game.faction && prize.items.Mark) {
-      const week = getFactionWeek({ date: new Date(createdAt) });
+      const week = getWeekKey({ date: new Date(createdAt) });
       const leaderboard = game.faction.history[week] ?? {
         score: 0,
         petXP: 0,

--- a/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
+++ b/src/features/game/expansion/components/leaderboard/actions/leaderboard.ts
@@ -6,7 +6,7 @@ import {
   getCachedLeaderboardData,
 } from "./cache";
 import { FactionName, MazeAttempt } from "features/game/types/game";
-import { getFactionWeek } from "features/game/lib/factions";
+import { getWeekKey } from "features/game/lib/factions";
 import { CompetitionName } from "features/game/types/competitions";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 
@@ -168,8 +168,7 @@ export async function getChampionsLeaderboard<T>({
     duration: KINGDOM_LEADERBOARD_CACHE,
   });
 
-  const isCorrectWeek =
-    cache?.week === getFactionWeek({ date: new Date(date) });
+  const isCorrectWeek = cache?.week === getWeekKey({ date: new Date(date) });
 
   if (cache && isCorrectWeek) {
     return cache;

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -15,6 +15,7 @@ import { Equipped } from "../types/bumpkin";
 import { SeedName } from "../types/seeds";
 import { INITIAL_REWARDS } from "../types/rewards";
 import { makeAnimalBuilding } from "./animals";
+import { ChoreBoard } from "../types/choreBoard";
 
 // Our "zoom" factor
 export const PIXEL_SCALE = 2.625;
@@ -387,6 +388,17 @@ export const INITIAL_BUMPKIN: Bumpkin = {
   activity: {},
 };
 
+export const INITIAL_CHORE_BOARD: ChoreBoard = {
+  chores: {
+    "pumpkin' pete": {
+      name: "CHOP_1_TREE",
+      reward: { items: { Wood: 1 } },
+      initialProgress: 0,
+      startedAt: Date.now(),
+    },
+  },
+};
+
 export const INITIAL_FARM: GameState = {
   coins: 0,
   balance: new Decimal(0),
@@ -413,6 +425,8 @@ export const INITIAL_FARM: GameState = {
   previousInventory: {},
   wardrobe: {},
   previousWardrobe: {},
+
+  choreBoard: INITIAL_CHORE_BOARD,
 
   competitions: {
     progress: {},
@@ -703,6 +717,8 @@ export const TEST_FARM: GameState = {
     completed: [],
     requests: [],
   },
+  choreBoard: INITIAL_CHORE_BOARD,
+
   rewards: INITIAL_REWARDS,
   minigames: {
     games: {},
@@ -1020,6 +1036,8 @@ export const EMPTY: GameState = {
   shipments: {},
   previousInventory: {},
   chickens: {},
+  choreBoard: INITIAL_CHORE_BOARD,
+
   stock: {},
   stockExpiry: {},
   wardrobe: {},

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -16,6 +16,7 @@ import { SeedName } from "../types/seeds";
 import { INITIAL_REWARDS } from "../types/rewards";
 import { makeAnimalBuilding } from "./animals";
 import { ChoreBoard } from "../types/choreBoard";
+import { getSeasonalTicket } from "../types/seasons";
 
 // Our "zoom" factor
 export const PIXEL_SCALE = 2.625;
@@ -392,7 +393,19 @@ export const INITIAL_CHORE_BOARD: ChoreBoard = {
   chores: {
     "pumpkin' pete": {
       name: "CHOP_1_TREE",
-      reward: { items: { Wood: 1 } },
+      reward: { items: { [getSeasonalTicket()]: 1 } },
+      initialProgress: 0,
+      startedAt: Date.now(),
+    },
+    betty: {
+      name: "CHOP_2_TREE",
+      reward: { items: { [getSeasonalTicket()]: 2 } },
+      initialProgress: 0,
+      startedAt: Date.now(),
+    },
+    finley: {
+      name: "CHOP_1_TREE",
+      reward: { items: { [getSeasonalTicket()]: 2 } },
       initialProgress: 0,
       startedAt: Date.now(),
     },

--- a/src/features/game/lib/factions.ts
+++ b/src/features/game/lib/factions.ts
@@ -20,7 +20,7 @@ export const START_DATE = new Date("2024-06-24T00:00:00Z");
  * Begins on Monday 24th June
  * E.g returns start of the week - "2024-06-24"
  */
-export function getFactionWeek({
+export function getWeekKey({
   date = new Date(),
 }: { date?: Date } = {}): string {
   const proposedDate = new Date(date);
@@ -48,9 +48,9 @@ export function getFactionWeek({
 }
 
 export function getPreviousWeek() {
-  const current = getFactionWeek();
+  const current = getWeekKey();
 
-  return getFactionWeek({
+  return getWeekKey({
     date: new Date(new Date(current).getTime() - 7 * 24 * 60 * 60 * 1000),
   });
 }
@@ -78,7 +78,7 @@ export function getWeekNumber({
 }
 
 export function weekResetsAt(): number {
-  const weekStart = getFactionWeek();
+  const weekStart = getWeekKey();
   const weekEnd = new Date(
     new Date(weekStart).getTime() + 7 * 24 * 60 * 60 * 1000,
   );
@@ -107,7 +107,7 @@ export function secondsTillWeekReset(): number {
 export function getFactionWeekEndTime({
   date = new Date(),
 }: { date?: Date } = {}): number {
-  const start = new Date(getFactionWeek({ date }));
+  const start = new Date(getWeekKey({ date }));
   start.setUTCDate(start.getUTCDate() + 7);
 
   return start.getTime();
@@ -609,8 +609,8 @@ export function getFactionPetBoostMultiplier(game: GameState) {
 
   if (!faction) return 1;
 
-  const week = getFactionWeek({ date: new Date() });
-  const lastWeek = getFactionWeek({
+  const week = getWeekKey({ date: new Date() });
+  const lastWeek = getWeekKey({
     date: new Date(new Date(week).getTime() - 7 * 24 * 60 * 60 * 1000),
   });
 

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -49,6 +49,7 @@ export function makeGame(farm: any): GameState {
     expansionConstruction: farm.expansionConstruction,
     expandedAt: farm.expandedAt,
     greenhouse: farm.greenhouse,
+    choreBoard: farm.choreBoard,
 
     shipments: farm.shipments,
 

--- a/src/features/game/types/choreBoard.ts
+++ b/src/features/game/types/choreBoard.ts
@@ -2,8 +2,9 @@ import { NPCName } from "lib/npcs";
 import { GameState, InventoryItemName } from "./game";
 import { getWeekKey } from "../lib/factions";
 import { getKeys } from "./decorations";
+import { ITEM_DETAILS } from "./images";
 
-type ChoreNPCName = Extract<
+export type ChoreNPCName = Extract<
   NPCName,
   | "pumpkin' pete"
   | "bert"
@@ -34,21 +35,39 @@ type ChoreTask = {
   progress: (game: GameState) => number;
 };
 
-const CHORES = {
+export const NPC_CHORES = {
   CHOP_1_TREE: {
     requirement: 1,
     progress: (game: GameState) => game.bumpkin.activity["Tree Chopped"] ?? 0,
   },
+  CHOP_2_TREE: {
+    requirement: 2,
+    progress: (game: GameState) => game.bumpkin.activity["Tree Chopped"] ?? 0,
+  },
 } satisfies Record<string, ChoreTask>;
 
-type ChoreName = keyof typeof CHORES;
+export const CHORE_DETAILS: Record<
+  ChoreName,
+  { icon: string; description: string }
+> = {
+  CHOP_1_TREE: {
+    description: "Chop 1 Tree",
+    icon: ITEM_DETAILS.Axe.image,
+  },
+  CHOP_2_TREE: {
+    description: "Chop 2 Trees",
+    icon: ITEM_DETAILS.Axe.image,
+  },
+};
+
+type ChoreName = keyof typeof NPC_CHORES;
 
 type ChoreDetails = {
   name: ChoreName;
   reward: { items: Partial<Record<InventoryItemName, number>> };
 };
 
-type NpcChore = ChoreDetails & {
+export type NpcChore = ChoreDetails & {
   initialProgress: number;
   startedAt: number;
   completedAt?: number;
@@ -107,7 +126,7 @@ function makeChoreBoard({
       ) {
         existing = {
           ...chores[name],
-          initialProgress: CHORES[chores[name].name].progress(game),
+          initialProgress: NPC_CHORES[chores[name].name].progress(game),
           startedAt: now,
         };
       }
@@ -124,3 +143,40 @@ function makeChoreBoard({
     chores: progress,
   };
 }
+
+export function getChoreProgress({
+  chore,
+  game,
+}: {
+  chore: NpcChore;
+  game: GameState;
+}) {
+  const progress = NPC_CHORES[chore.name].progress(game);
+
+  return progress - chore.initialProgress;
+}
+
+export const NPC_CHORE_UNLOCKS: Record<ChoreNPCName, number> = {
+  "pumpkin' pete": 1,
+  betty: 1,
+  blacksmith: 1,
+  peggy: 3,
+  corale: 7,
+  tango: 13,
+  "old salty": 15,
+  victoria: 30,
+  grimbly: 10,
+  grimtooth: 10,
+  gambit: 10,
+  jester: 10,
+  pharaoh: 10,
+  timmy: 10,
+  tywin: 10,
+  cornwell: 10,
+  finn: 10,
+  finley: 10,
+  miranda: 10,
+  raven: 10,
+  grubnuk: 10,
+  bert: 10,
+};

--- a/src/features/game/types/choreBoard.ts
+++ b/src/features/game/types/choreBoard.ts
@@ -2,8 +2,6 @@ import { NPCName } from "lib/npcs";
 import { GameState, InventoryItemName } from "./game";
 import { getWeekKey } from "../lib/factions";
 import { getKeys } from "./decorations";
-import { ITEM_DETAILS } from "./images";
-import { translate } from "lib/i18n/translate";
 
 export type ChoreNPCName = Extract<
   NPCName,
@@ -47,21 +45,7 @@ export const NPC_CHORES = {
   },
 } satisfies Record<string, ChoreTask>;
 
-export const CHORE_DETAILS: Record<
-  ChoreName,
-  { icon: string; description: string }
-> = {
-  CHOP_1_TREE: {
-    description: translate("chore.chop.1.tree"),
-    icon: ITEM_DETAILS.Axe.image,
-  },
-  CHOP_2_TREE: {
-    description: translate("chore.chop.2.trees"),
-    icon: ITEM_DETAILS.Axe.image,
-  },
-};
-
-type ChoreName = keyof typeof NPC_CHORES;
+export type ChoreName = keyof typeof NPC_CHORES;
 
 type ChoreDetails = {
   name: ChoreName;

--- a/src/features/game/types/choreBoard.ts
+++ b/src/features/game/types/choreBoard.ts
@@ -1,0 +1,126 @@
+import { NPCName } from "lib/npcs";
+import { GameState, InventoryItemName } from "./game";
+import { getWeekKey } from "../lib/factions";
+import { getKeys } from "./decorations";
+
+type ChoreNPCName = Extract<
+  NPCName,
+  | "pumpkin' pete"
+  | "bert"
+  | "raven"
+  | "timmy"
+  | "tywin"
+  | "cornwell"
+  | "finn"
+  | "finley"
+  | "miranda"
+  | "jester"
+  | "pharaoh"
+  | "betty"
+  | "peggy"
+  | "tango"
+  | "corale"
+  | "blacksmith"
+  | "victoria"
+  | "old salty"
+  | "grimbly"
+  | "grimtooth"
+  | "grubnuk"
+  | "gambit"
+>;
+
+type ChoreTask = {
+  requirement: number;
+  progress: (game: GameState) => number;
+};
+
+const CHORES = {
+  CHOP_1_TREE: {
+    requirement: 1,
+    progress: (game: GameState) => game.bumpkin.activity["Tree Chopped"] ?? 0,
+  },
+} satisfies Record<string, ChoreTask>;
+
+type ChoreName = keyof typeof CHORES;
+
+type ChoreDetails = {
+  name: ChoreName;
+  reward: { items: Partial<Record<InventoryItemName, number>> };
+};
+
+type NpcChore = ChoreDetails & {
+  initialProgress: number;
+  startedAt: number;
+  completedAt?: number;
+};
+
+export type ChoreBoard = {
+  chores: Partial<Record<NPCName, NpcChore>>;
+};
+
+const WEEKLY_CHORES: Record<string, Record<ChoreNPCName, ChoreDetails>> = {
+  "2024-10-14": {
+    "pumpkin' pete": { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    bert: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    raven: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    timmy: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    tywin: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    cornwell: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    finn: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    finley: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    miranda: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    jester: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    pharaoh: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    betty: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    peggy: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    tango: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    corale: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    blacksmith: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    victoria: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    "old salty": { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    grimbly: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    grimtooth: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    grubnuk: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+    gambit: { name: "CHOP_1_TREE", reward: { items: { Wood: 1 } } },
+  },
+};
+
+function makeChoreBoard({
+  now = Date.now(),
+  game,
+}: {
+  now?: number;
+  game: GameState;
+}): ChoreBoard {
+  const weekKey = getWeekKey({ date: new Date(now) });
+
+  const chores = WEEKLY_CHORES[weekKey];
+
+  const progress = getKeys(chores).reduce(
+    (acc, name) => {
+      let existing = game.choreBoard.chores[name];
+
+      // No progress exists or progress is from a previous week
+      if (
+        !existing ||
+        getWeekKey({ date: new Date(existing.startedAt) }) !== weekKey
+      ) {
+        existing = {
+          ...chores[name],
+          initialProgress: CHORES[chores[name].name].progress(game),
+          startedAt: now,
+        };
+      }
+
+      return {
+        ...acc,
+        [name]: existing,
+      };
+    },
+    {} as Record<ChoreNPCName, NpcChore>,
+  );
+
+  return {
+    chores: progress,
+  };
+}

--- a/src/features/game/types/choreBoard.ts
+++ b/src/features/game/types/choreBoard.ts
@@ -3,6 +3,7 @@ import { GameState, InventoryItemName } from "./game";
 import { getWeekKey } from "../lib/factions";
 import { getKeys } from "./decorations";
 import { ITEM_DETAILS } from "./images";
+import { translate } from "lib/i18n/translate";
 
 export type ChoreNPCName = Extract<
   NPCName,
@@ -51,11 +52,11 @@ export const CHORE_DETAILS: Record<
   { icon: string; description: string }
 > = {
   CHOP_1_TREE: {
-    description: "Chop 1 Tree",
+    description: translate("chore.chop.1.tree"),
     icon: ITEM_DETAILS.Axe.image,
   },
   CHOP_2_TREE: {
-    description: "Chop 2 Trees",
+    description: translate("chore.chop.2.trees"),
     icon: ITEM_DETAILS.Axe.image,
   },
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -77,6 +77,7 @@ import { CollectionName, MarketplaceTradeableName } from "./marketplace";
 import { GameTransaction } from "./transactions";
 import { CompetitionName, CompetitionProgress } from "./competitions";
 import { AnimalType } from "./animals";
+import { ChoreBoard } from "./choreBoard";
 
 export type Reward = {
   coins?: number;
@@ -1194,6 +1195,8 @@ export interface GameState {
   home: Home;
 
   rewards: Rewards;
+
+  choreBoard: ChoreBoard;
 
   competitions: {
     progress: Partial<Record<CompetitionName, CompetitionProgress>>;

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -29,6 +29,8 @@ import { fetchLeaderboardData } from "features/game/expansion/components/leaderb
 import { FactionLeaderboard } from "./pages/FactionLeaderboard";
 import { Season } from "./pages/Season";
 import { getSeasonalTicket } from "features/game/types/seasons";
+import { hasFeatureAccess } from "lib/flags";
+import { ChoreBoard } from "./pages/ChoreBoard";
 
 interface Props {
   show: boolean;
@@ -211,7 +213,18 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
               })}
             > */}
             {currentTab === 0 && <Deliveries onClose={onHide} />}
-            {currentTab === 1 && <Chores farmId={farmId} />}
+            {currentTab === 1 && (
+              <>
+                {hasFeatureAccess(
+                  gameService.getSnapshot().context.state,
+                  "CHORE_BOARD",
+                ) ? (
+                  <ChoreBoard />
+                ) : (
+                  <Chores farmId={farmId} />
+                )}
+              </>
+            )}
             {currentTab === 2 && (
               <Season
                 id={id}

--- a/src/features/island/hud/components/codex/lib/choreDetails.ts
+++ b/src/features/island/hud/components/codex/lib/choreDetails.ts
@@ -1,0 +1,17 @@
+import { ChoreName } from "features/game/types/choreBoard";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { translate } from "lib/i18n/translate";
+
+export const CHORE_DETAILS: Record<
+  ChoreName,
+  { icon: string; description: string }
+> = {
+  CHOP_1_TREE: {
+    description: translate("chore.chop.1.tree"),
+    icon: ITEM_DETAILS.Axe.image,
+  },
+  CHOP_2_TREE: {
+    description: translate("chore.chop.2.trees"),
+    icon: ITEM_DETAILS.Axe.image,
+  },
+};

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -25,7 +25,6 @@ import React, { useContext, useState } from "react";
 import { getSeasonalTicket } from "features/game/types/seasons";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
-  CHORE_DETAILS,
   ChoreNPCName,
   getChoreProgress,
   NPC_CHORE_UNLOCKS,
@@ -40,6 +39,7 @@ import lockIcon from "assets/icons/lock.png";
 import giftIcon from "assets/icons/gift.png";
 
 import { GameState } from "features/game/types/game";
+import { CHORE_DETAILS } from "../lib/choreDetails";
 export const ChoreBoard: React.FC = () => {
   const { gameService } = useContext(Context);
 

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -1,0 +1,15 @@
+import classNames from "classnames";
+import { InnerPanel } from "components/ui/Panel";
+import React from "react";
+
+export const ChoreBoard: React.FC = () => {
+  return (
+    <div
+      className={classNames(
+        "flex flex-col h-full overflow-y-auto scrollable pr-1",
+      )}
+    >
+      <InnerPanel className="space-y-2 mt-1 mb-1"></InnerPanel>
+    </div>
+  );
+};

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -1,15 +1,387 @@
+import { useSelector } from "@xstate/react";
+import { SUNNYSIDE } from "assets/sunnyside";
 import classNames from "classnames";
-import { InnerPanel } from "components/ui/Panel";
-import React from "react";
+import { Label } from "components/ui/Label";
+import { ButtonPanel, InnerPanel } from "components/ui/Panel";
+import { DynamicNFT } from "features/bumpkins/components/DynamicNFT";
+import { Context } from "features/game/GameProvider";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { weekResetsAt } from "features/game/lib/factions";
+import { ITEM_IDS } from "features/game/types/bumpkin";
+import { getKeys } from "features/game/types/decorations";
+import {
+  BEACH_BUMPKINS,
+  KINGDOM_BUMPKINS,
+  RETREAT_BUMPKINS,
+} from "features/island/delivery/components/Orders";
+import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { NPC_WEARABLES, NPCName } from "lib/npcs";
+import { getImageUrl } from "lib/utils/getImageURLS";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
+import { useCountdown } from "lib/utils/hooks/useCountdown";
+import React, { useContext, useState } from "react";
 
+import { getSeasonalTicket } from "features/game/types/seasons";
+import { ITEM_DETAILS } from "features/game/types/images";
+import {
+  CHORE_DETAILS,
+  ChoreNPCName,
+  getChoreProgress,
+  NPC_CHORE_UNLOCKS,
+  NPC_CHORES,
+  NpcChore,
+} from "features/game/types/choreBoard";
+import { NPCIcon } from "features/island/bumpkin/components/NPC";
+import { ResizableBar } from "components/ui/ProgressBar";
+import { Button } from "components/ui/Button";
+import { getBumpkinLevel } from "features/game/lib/level";
+import lockIcon from "assets/icons/lock.png";
+import giftIcon from "assets/icons/gift.png";
+
+import { GameState } from "features/game/types/game";
 export const ChoreBoard: React.FC = () => {
+  const { gameService } = useContext(Context);
+
+  const { t } = useAppTranslation();
+
+  const [selectedId, setSelectedId] = useState<NPCName>();
+
+  const chores = useSelector(
+    gameService,
+    (state) => state.context.state.choreBoard.chores,
+  );
+  const inventory = useSelector(
+    gameService,
+    (state) => state.context.state.inventory,
+  );
+
+  const end = useCountdown(weekResetsAt());
+
+  const previewNpc = selectedId ?? getKeys(chores)[0];
+  const previewChore = chores[previewNpc];
+
+  const getLocationName = (npcName: NPCName) => {
+    if (RETREAT_BUMPKINS.includes(npcName)) return t("island.goblin.retreat");
+    if (BEACH_BUMPKINS.includes(npcName)) return t("island.beach");
+    if (KINGDOM_BUMPKINS.includes(npcName)) return t("island.kingdom");
+    return t("island.pumpkin.plaza");
+  };
+
+  const {
+    tasksStartAt,
+    tasksCloseAt,
+    ticketTasksAreFrozen,
+    ticketTasksAreClosing,
+  } = getSeasonChangeover({ id: gameService.state.context.farmId });
+
+  const level = getBumpkinLevel(
+    gameService.state.context.state.bumpkin.experience ?? 0,
+  );
+
+  const nextUnlock = getKeys(NPC_CHORE_UNLOCKS)
+    .filter((name) => name in chores)
+    .sort((a, b) => (NPC_CHORE_UNLOCKS[a] > NPC_CHORE_UNLOCKS[b] ? 1 : -1))
+    .find((npc) => level < (NPC_CHORE_UNLOCKS?.[npc] ?? 0));
+
+  const handleCompleteChore = (npcName: NPCName) => {
+    gameService.send({
+      type: "chore.fulfilled",
+      npcName,
+    });
+  };
+
   return (
-    <div
-      className={classNames(
-        "flex flex-col h-full overflow-y-auto scrollable pr-1",
+    <div className="flex md:flex-row flex-col-reverse md:mr-1 items-start h-full">
+      <InnerPanel
+        className={classNames(
+          "flex flex-col h-full overflow-hidden scrollable overflow-y-auto pl-1 md:flex w-full md:w-2/3",
+          {
+            hidden: selectedId,
+          },
+        )}
+      >
+        <div className="p-1">
+          <div className="flex items-center justify-between mb-2">
+            <Label type="default">{t("chores.weeklyChores")}</Label>
+            <Label
+              type={end.days < 1 ? "danger" : "info"}
+              icon={SUNNYSIDE.icons.stopwatch}
+            >
+              <TimerDisplay fontSize={24} time={end} />
+            </Label>
+          </div>
+        </div>
+
+        <p className="text-xs mb-2 px-2">
+          {t("chores.completeChoresToEarn", {
+            seasonalTicket: getSeasonalTicket(),
+          })}
+        </p>
+
+        <div className="grid grid-cols-3 sm:grid-cols-4 w-full ">
+          {getKeys(chores)
+            .filter((npc) => level >= NPC_CHORE_UNLOCKS[npc as ChoreNPCName])
+            .map((chore) => (
+              <ChoreCard
+                key={chore}
+                chore={chores[chore] as NpcChore}
+                npc={chore}
+                selected={selectedId}
+                onClick={setSelectedId}
+                game={gameService.state.context.state}
+              />
+            ))}
+          {nextUnlock && (
+            <LockedChoreCard
+              chore={chores[nextUnlock] as NpcChore}
+              npc={nextUnlock}
+            />
+          )}
+        </div>
+      </InnerPanel>
+      {previewChore && (
+        <InnerPanel
+          className={classNames(
+            "md:ml-1 md:flex md:flex-col items-center flex-1 relative h-auto w-full",
+            {
+              hidden: !selectedId,
+            },
+          )}
+        >
+          <img
+            src={SUNNYSIDE.icons.arrow_left}
+            className={classNames(
+              "absolute top-2 left-2 cursor-pointer md:hidden z-10",
+              {
+                hidden: !selectedId,
+                block: !!selectedId,
+              },
+            )}
+            style={{ width: `${PIXEL_SCALE * 11}px` }}
+            onClick={() => setSelectedId(undefined)}
+          />
+          <div
+            className="mb-1 mx-auto w-full col-start-1 row-start-1 overflow-hidden z-0 rounded-lg relative"
+            style={{
+              height: `${PIXEL_SCALE * 50}px`,
+              background:
+                "linear-gradient(0deg, rgba(4,159,224,1) 0%, rgba(31,109,213,1) 100%)",
+            }}
+          >
+            <p
+              className="z-10 absolute bottom-1 right-1.5 capitalize text-xs"
+              style={{
+                background: "#ffffffaf",
+                padding: "2px",
+                borderRadius: "3px",
+              }}
+            >
+              {selectedId}
+            </p>
+
+            <div
+              className="absolute -inset-2 bg-repeat"
+              style={{
+                height: `${PIXEL_SCALE * 50}px`,
+                backgroundImage: `url(${SUNNYSIDE.ui.heartBg})`,
+                backgroundSize: `${32 * PIXEL_SCALE}px`,
+              }}
+            />
+
+            <div
+              className="absolute -inset-2 bg-repeat"
+              style={{
+                height: `${PIXEL_SCALE * 80}px`,
+                backgroundImage: `url(${getImageUrl(ITEM_IDS[NPC_WEARABLES[previewNpc].background])})`,
+                backgroundSize: "100%",
+              }}
+            />
+            <div key={selectedId} className="w-9/12 md:w-full md:-ml-8">
+              <DynamicNFT
+                key={selectedId}
+                bumpkinParts={NPC_WEARABLES[previewNpc]}
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 space-y-2 p-1 w-full">
+            <div className="text-xs flex justify-between flex-wrap items-center mb-2">
+              <Label type="default">
+                {CHORE_DETAILS[previewChore.name].description}
+              </Label>
+              <p>{`${Math.min(
+                getChoreProgress({
+                  chore: previewChore,
+                  game: gameService.state.context.state,
+                }),
+                NPC_CHORES[previewChore.name].requirement,
+              )}/${NPC_CHORES[previewChore.name].requirement}`}</p>
+            </div>
+
+            {!previewChore.completedAt && (
+              <Button
+                className="h-12 relative !mt-4"
+                disabled={
+                  ticketTasksAreFrozen ||
+                  ticketTasksAreClosing ||
+                  !!previewChore.completedAt ||
+                  getChoreProgress({
+                    chore: previewChore,
+                    game: gameService.state.context.state,
+                  }) < NPC_CHORES[previewChore.name].requirement
+                }
+                onClick={() => handleCompleteChore(previewNpc)}
+              >
+                {t("chores.complete")}
+                <Label
+                  type={"warning"}
+                  icon={ITEM_DETAILS[getSeasonalTicket()].image}
+                  className="flex absolute right-0 -top-5"
+                >
+                  {previewChore.reward.items[getSeasonalTicket()] ?? 0}
+                </Label>
+              </Button>
+            )}
+
+            {previewChore.completedAt && (
+              <div className="flex">
+                <img src={SUNNYSIDE.icons.confirm} className="mr-2 h-4" />
+                <p className="text-xxs">{t("chores.completed")}</p>
+              </div>
+            )}
+          </div>
+          {ticketTasksAreFrozen && (
+            <Label
+              type="danger"
+              className="mb-1"
+              icon={SUNNYSIDE.icons.stopwatch}
+            >
+              {t("deliveries.closed")}
+            </Label>
+          )}
+        </InnerPanel>
       )}
-    >
-      <InnerPanel className="space-y-2 mt-1 mb-1"></InnerPanel>
+    </div>
+  );
+};
+
+export const ChoreCard: React.FC<{
+  chore: NpcChore;
+  npc: NPCName;
+  selected?: NPCName;
+  onClick: (npc: NPCName) => void;
+  game: GameState;
+}> = ({ npc, chore, selected, onClick, game }) => {
+  const tickets = chore.reward.items[getSeasonalTicket()];
+
+  return (
+    <div className="py-1 px-1" key={npc}>
+      <ButtonPanel
+        onClick={() => onClick(npc)}
+        className={classNames("w-full relative", {
+          "sm:!bg-brown-200": npc === selected,
+        })}
+        style={{ paddingBottom: "10px" }}
+      >
+        <Label type={"warning"} className="flex absolute -right-2 -top-4">
+          {chore.reward.items[getSeasonalTicket()] ?? 0}
+        </Label>
+        <div className="flex flex-col">
+          <div className="flex items-center">
+            <div className="relative mb-2 mr-0.5 ">
+              <NPCIcon parts={NPC_WEARABLES[npc]} />
+            </div>
+            <div className="flex flex-col items-center flex-1">
+              <img className="h-8" src={CHORE_DETAILS[chore.name].icon} />
+            </div>
+          </div>
+        </div>
+
+        {chore.completedAt && (
+          <Label
+            type="success"
+            className="absolute -bottom-2 text-center mt-1 p-1 left-[-8px] z-10 h-6"
+            style={{ width: "calc(100% + 15px)" }}
+          >
+            <img src={SUNNYSIDE.icons.confirm} className="h-4" />
+          </Label>
+        )}
+
+        <div className="w-full flex justify-center">
+          <span className="text-xs line-clamp-2 text-center truncate">
+            {CHORE_DETAILS[chore.name].description}
+          </span>
+        </div>
+
+        {!chore.completedAt && (
+          <div className="absolute -bottom-4 left-0 w-full flex justify-center">
+            <ResizableBar
+              percentage={
+                (getChoreProgress({
+                  chore,
+                  game,
+                }) /
+                  NPC_CHORES[chore.name].requirement) *
+                100
+              }
+              type="progress"
+              outerDimensions={{ width: 16, height: 7.5 }}
+            />
+            {getChoreProgress({
+              chore,
+              game,
+            }) >= NPC_CHORES[chore.name].requirement && (
+              <img src={giftIcon} className="h-6 absolute -top-1 right-1.5" />
+            )}
+          </div>
+        )}
+      </ButtonPanel>
+    </div>
+  );
+};
+
+export const LockedChoreCard: React.FC<{
+  chore: NpcChore;
+  npc: NPCName;
+}> = ({ npc, chore }) => {
+  const { t } = useAppTranslation();
+
+  return (
+    <div className="py-1 px-1" key={npc}>
+      <ButtonPanel
+        className={classNames("w-full relative", {})}
+        style={{ paddingBottom: "10px" }}
+        disabled
+      >
+        <div className="flex justify-center">
+          <div className="relative mb-2 mr-0.5 ">
+            <NPCIcon parts={NPC_WEARABLES[npc]} />
+          </div>
+        </div>
+
+        <div className="w-full flex justify-center">
+          <span className="text-xs line-clamp-2 text-center truncate">
+            {`?`}
+          </span>
+        </div>
+
+        <Label
+          icon={lockIcon}
+          type={"formula"}
+          className="absolute -bottom-4 text-center p-1"
+          style={{
+            left: `${PIXEL_SCALE * -3}px`,
+            right: `${PIXEL_SCALE * -3}px`,
+            width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+            height: "25px",
+          }}
+        >
+          {t("chores.lockedChore", {
+            level: NPC_CHORE_UNLOCKS[npc as ChoreNPCName],
+          })}
+        </Label>
+      </ButtonPanel>
     </div>
   );
 };

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -245,9 +245,9 @@ export const ChoreBoard: React.FC = () => {
             )}
 
             {previewChore.completedAt && (
-              <div className="flex">
-                <img src={SUNNYSIDE.icons.confirm} className="mr-2 h-4" />
-                <p className="text-xxs">{t("chores.completed")}</p>
+              <div className="flex items-center">
+                <img src={SUNNYSIDE.icons.confirm} className="mr-2 h-6" />
+                <p className="text-sm">{t("chores.completed")}</p>
               </div>
             )}
           </div>
@@ -287,6 +287,12 @@ export const ChoreCard: React.FC<{
         <Label type={"warning"} className="flex absolute -right-2 -top-4">
           {chore.reward.items[getSeasonalTicket()] ?? 0}
         </Label>
+
+        {chore.completedAt && (
+          <div className="absolute -bottom-4 left-0 w-full flex justify-center">
+            <img src={SUNNYSIDE.icons.confirm} className="h-6" />
+          </div>
+        )}
         <div className="flex flex-col">
           <div className="flex items-center">
             <div className="relative mb-2 mr-0.5 ">
@@ -297,16 +303,6 @@ export const ChoreCard: React.FC<{
             </div>
           </div>
         </div>
-
-        {chore.completedAt && (
-          <Label
-            type="success"
-            className="absolute -bottom-2 text-center mt-1 p-1 left-[-8px] z-10 h-6"
-            style={{ width: "calc(100% + 15px)" }}
-          >
-            <img src={SUNNYSIDE.icons.confirm} className="h-4" />
-          </Label>
-        )}
 
         <div className="w-full flex justify-center">
           <span className="text-xs line-clamp-2 text-center truncate">
@@ -373,7 +369,7 @@ export const LockedChoreCard: React.FC<{
           style={{
             left: `${PIXEL_SCALE * -3}px`,
             right: `${PIXEL_SCALE * -3}px`,
-            width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
+            width: `calc(100% + 16px)`,
             height: "25px",
           }}
         >

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -288,6 +288,14 @@ export const ChoreCard: React.FC<{
           {chore.reward.items[getSeasonalTicket()] ?? 0}
         </Label>
 
+        {!chore.completedAt &&
+          getChoreProgress({
+            chore,
+            game,
+          }) >= NPC_CHORES[chore.name].requirement && (
+            <img src={giftIcon} className="h-6 absolute -top-4 -left-3" />
+          )}
+
         {chore.completedAt && (
           <div className="absolute -bottom-4 left-0 w-full flex justify-center">
             <img src={SUNNYSIDE.icons.confirm} className="h-6" />
@@ -324,12 +332,6 @@ export const ChoreCard: React.FC<{
               type="progress"
               outerDimensions={{ width: 16, height: 7.5 }}
             />
-            {getChoreProgress({
-              chore,
-              game,
-            }) >= NPC_CHORES[chore.name].requirement && (
-              <img src={giftIcon} className="h-6 absolute -top-1 right-1.5" />
-            )}
           </div>
         )}
       </ButtonPanel>

--- a/src/features/world/scenes/FactionHouseScene.ts
+++ b/src/features/world/scenes/FactionHouseScene.ts
@@ -3,7 +3,7 @@ import { interactableModalManager } from "../ui/InteractableModals";
 import { translate } from "lib/i18n/translate";
 import { getFactionPrize } from "../ui/factions/weeklyPrize/FactionWeeklyPrize";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { getFactionWeek } from "features/game/lib/factions";
+import { getWeekKey } from "features/game/lib/factions";
 import { CollectivePet, Faction, FactionName } from "features/game/types/game";
 import { FACTION_PET_REFRESH_INTERVAL } from "../ui/factions/FactionPetPanel";
 import { getFactionPetUpdate } from "../ui/factions/actions/getFactionPetUpdate";
@@ -115,7 +115,7 @@ export abstract class FactionHouseScene extends BaseScene {
     this.load.image("empty_progress_bar", "world/empty_bar.png");
     this.load.image("boost_icon", "world/lightning.png");
 
-    const week = getFactionWeek({ date: new Date() });
+    const week = getWeekKey({ date: new Date() });
     const faction = this.gameService.state.context.state.faction;
     this.factionName = faction?.name;
 
@@ -178,8 +178,8 @@ export abstract class FactionHouseScene extends BaseScene {
       4,
     );
 
-    const thisWeek = getFactionWeek({ date: new Date() });
-    const lastWeek = getFactionWeek({
+    const thisWeek = getWeekKey({ date: new Date() });
+    const lastWeek = getWeekKey({
       date: new Date(new Date(thisWeek).getTime() - 7 * 24 * 60 * 60 * 1000),
     });
     const faction = this.gameService.state.context.state.faction as Faction;

--- a/src/features/world/ui/factions/Champions.tsx
+++ b/src/features/world/ui/factions/Champions.tsx
@@ -13,7 +13,7 @@ import {
   BONUS_FACTION_PRIZES,
   FACTION_PRIZES,
   getFactionScores,
-  getFactionWeek,
+  getWeekKey,
   getPreviousWeek,
   getWeekNumber,
 } from "features/game/lib/factions";
@@ -223,7 +223,7 @@ export const ChampionsPrizes: React.FC = () => {
   ] = useActor(gameService);
   const currentFaction = state.faction?.name;
 
-  const week = getFactionWeek();
+  const week = getWeekKey();
   const ticket = getSeasonalTicket(new Date(week));
 
   const { startDate, endDate } = SEASONS["Pharaoh's Treasure"];

--- a/src/features/world/ui/factions/FactionPetPanel.tsx
+++ b/src/features/world/ui/factions/FactionPetPanel.tsx
@@ -21,7 +21,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { TypingMessage } from "../TypingMessage";
 import {
   calculatePoints,
-  getFactionWeek,
+  getWeekKey,
   getFactionWeekEndTime,
   getFactionWeekday,
 } from "features/game/lib/factions";
@@ -63,7 +63,7 @@ export const PET_SLEEP_DURATION = 7 * 24 * 60 * 60 * 1000;
 
 const PetSleeping = ({ onWake }: { onWake: () => void }) => {
   const { t } = useAppTranslation();
-  const week = getFactionWeek({ date: new Date() });
+  const week = getWeekKey({ date: new Date() });
   const beginningOfWeek = new Date(week).getTime();
   const wakeTime = beginningOfWeek + PET_SLEEP_DURATION;
   const [secondsTillWakeUp, setSecondsTillWakeUp] = useState(
@@ -148,7 +148,7 @@ export const FactionPetPanel: React.FC<Props> = ({ onClose }) => {
   const inventory = useSelector(gameService, _inventory);
   const autosaving = useSelector(gameService, _autosaving);
 
-  const week = getFactionWeek({ date: new Date() });
+  const week = getWeekKey({ date: new Date() });
   const pet = faction.pet as FactionPet;
   const collectivePet = faction.history[week].collectivePet as CollectivePet;
   const now = Date.now();
@@ -247,7 +247,7 @@ export const FactionPetPanel: React.FC<Props> = ({ onClose }) => {
     (request) => getKeys(request.dailyFulfilled).length > 0,
   );
 
-  const lastWeek = getFactionWeek({
+  const lastWeek = getWeekKey({
     date: new Date(new Date(week).getTime() - 7 * 24 * 60 * 60 * 1000),
   });
   const isStreakWeek =

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -15,30 +15,6 @@ const betaTimeBasedFeatureFlag = (date: Date) => (game: GameState) => {
   return defaultFeatureFlag(game) || Date.now() > date.getTime();
 };
 
-/*
- * How to Use:
- * Add the feature name to this list when working on a new feature.
- * When the feature is ready for public release, delete the feature from this list.
- *
- * Do not delete JEST_TEST.
- */
-export type FeatureName =
-  | "JEST_TEST"
-  | "PORTALS"
-  | "EASTER"
-  | "CROP_QUICK_SELECT"
-  | "SKILLS_REVAMP"
-  | "MARKETPLACE"
-  | "ONBOARDING_REWARDS"
-  | "NEW_RESOURCES_GE"
-  | "FSL"
-  | "ANIMAL_BUILDINGS"
-  | "BARLEY"
-  | "GEM_BOOSTS"
-  | "CHICKEN_GARBO"
-  | "SEASONAL_TIERS"
-  | "CRAFTING_BOX";
-
 // Used for testing production features
 export const ADMIN_IDS = [1, 3, 51, 39488, 128727];
 /**
@@ -53,8 +29,16 @@ type FeatureFlag = (game: GameState) => boolean;
 
 export type ExperimentName = "ONBOARDING_CHALLENGES" | "GEM_BOOSTS";
 
-const featureFlags: Record<FeatureName, FeatureFlag> = {
-  ONBOARDING_REWARDS: (game) =>
+/*
+ * How to Use:
+ * Add the feature name to this list when working on a new feature.
+ * When the feature is ready for public release, delete the feature from this list.
+ *
+ * Do not delete JEST_TEST.
+ */
+const featureFlags = {
+  CHORE_BOARD: timeBasedFeatureFlag(new Date("2024-11-01T00:00:00Z")),
+  ONBOARDING_REWARDS: (game: GameState) =>
     game.experiments.includes("ONBOARDING_CHALLENGES"),
   SEASONAL_TIERS: testnetFeatureFlag,
   MARKETPLACE: testnetFeatureFlag,
@@ -67,10 +51,12 @@ const featureFlags: Record<FeatureName, FeatureFlag> = {
   NEW_RESOURCES_GE: defaultFeatureFlag,
   ANIMAL_BUILDINGS: testnetFeatureFlag,
   BARLEY: testnetFeatureFlag,
-  GEM_BOOSTS: (game) => game.experiments.includes("GEM_BOOSTS"),
+  GEM_BOOSTS: (game: GameState) => game.experiments.includes("GEM_BOOSTS"),
   CHICKEN_GARBO: timeBasedFeatureFlag(SEASONS["Pharaoh's Treasure"].endDate),
   CRAFTING_BOX: timeBasedFeatureFlag(new Date("2024-11-01T00:00:00Z")),
-};
+} satisfies Record<string, FeatureFlag>;
+
+export type FeatureName = keyof typeof featureFlags;
 
 export const hasFeatureAccess = (game: GameState, featureName: FeatureName) => {
   return featureFlags[featureName](game);

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3734,5 +3734,7 @@
   "chores.completeChoresToEarn": "Complete chores for Bumpkins to earn {{seasonalTicket}}s.",
   "chores.lockedChore": "Lvl {{level}}",
   "chores.completed": "Completed",
-  "chores.complete": "Complete"
+  "chores.complete": "Complete",
+  "chore.chop.1.tree": "Chop 1 Tree",
+  "chore.chop.2.trees": "Chop 2 Trees"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3729,5 +3729,10 @@
   "npcDialogues.chase.intro2": "However I'm in a bit of a pickle. My herd has mysteriously gone missing - it's like they disappeared out of thin air!",
   "npcDialogues.sheep.intro1": "Thanks for finding me! One moment I was pretending to be a sheep with the Cowboy and the next moment I was here.",
   "npcDialogues.sheep.intro2": "All I remember is flashing lights and strange noises...",
-  "teaser.intro": "Animals are coming to Sunflower Land. Prepare your resources for November 1st!"
+  "teaser.intro": "Animals are coming to Sunflower Land. Prepare your resources for November 1st!",
+  "chores.weeklyChores": "Weekly Chores",
+  "chores.completeChoresToEarn": "Complete chores for Bumpkins to earn {{seasonalTicket}}s.",
+  "chores.lockedChore": "Lvl {{level}}",
+  "chores.completed": "Completed",
+  "chores.complete": "Complete"
 }


### PR DESCRIPTION
# Description

This PR includes the initial functionality for the Chore Board Mechanic.

1. Chore Board appears in Codex
2. List of NPCs are shown with their chores
3. Fire "chore.fulfilled" event once complete.

<img width="790" alt="Screenshot 2024-10-17 at 9 34 20 AM" src="https://github.com/user-attachments/assets/a91cccd8-85c9-476f-8d85-79603c499d8b">

**Excludes**

1. I've created some placeholder chores in the front-end. These will be generated on the backend.
2. The levels NPCs are unlocked are currently placeholder and need balancing
3. Custom messaging for each NPC

## How to test?

1. Run the game in Art Mode
2. Chop a tree
3. Complete a chore in the Codex