### PR TITLE
[FEAT] Separate Crops into Categories

### DIFF
--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,19 +1,32 @@
 import Decimal from "decimal.js-light";
-import { Crop, CropName, CROPS, GREENHOUSE_CROPS } from "../../types/crops";
+import {
+  Crop,
+  CropName,
+  CROPS,
+  GREENHOUSE_CROPS,
+  GreenHouseCrop,
+} from "../../types/crops";
 import { GameState } from "../../types/game";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { setPrecision } from "lib/utils/formatNumber";
 import {
   GREENHOUSE_FRUIT,
+  GreenHouseFruit,
   PATCH_FRUIT,
   PatchFruit,
   PatchFruitName,
 } from "features/game/types/fruits";
 import { produce } from "immer";
+import { ExoticCrop } from "features/game/types/beans";
 
 export type SellableName = CropName | PatchFruitName;
-export type SellableItem = Crop | PatchFruit;
+export type SellableItem =
+  | Crop
+  | PatchFruit
+  | ExoticCrop
+  | GreenHouseFruit
+  | GreenHouseCrop;
 
 export type SellCropAction = {
   type: "crop.sold";

--- a/src/features/game/types/beans.ts
+++ b/src/features/game/types/beans.ts
@@ -39,6 +39,7 @@ export type ExoticCrop = {
   description: string;
   sellPrice: number;
   name: ExoticCropName;
+  disabled: boolean;
 };
 
 export const EXOTIC_CROPS: Record<ExoticCropName, ExoticCrop> = {
@@ -46,35 +47,42 @@ export const EXOTIC_CROPS: Record<ExoticCropName, ExoticCrop> = {
     name: "Black Magic",
     description: translate("description.black.magic"),
     sellPrice: 32000,
+    disabled: false,
   },
   "Golden Helios": {
     name: "Golden Helios",
     description: translate("description.golden.helios"),
     sellPrice: 16000,
+    disabled: false,
   },
   Chiogga: {
     name: "Chiogga",
     description: translate("description.chiogga"),
     sellPrice: 8000,
+    disabled: false,
   },
   "Purple Cauliflower": {
     name: "Purple Cauliflower",
     description: translate("description.purple.cauliflower"),
     sellPrice: 3200,
+    disabled: false,
   },
   "Adirondack Potato": {
     name: "Adirondack Potato",
     description: translate("description.adirondack.potato"),
     sellPrice: 2400,
+    disabled: false,
   },
   "Warty Goblin Pumpkin": {
     name: "Warty Goblin Pumpkin",
     description: translate("description.warty.goblin.pumpkin"),
     sellPrice: 1600,
+    disabled: false,
   },
   "White Carrot": {
     name: "White Carrot",
     description: translate("description.white.carrot"),
     sellPrice: 800,
+    disabled: false,
   },
 };

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -3,13 +3,20 @@ import Decimal from "decimal.js-light";
 import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
-import { Crop, CROPS, GREENHOUSE_CROPS } from "features/game/types/crops";
+import {
+  Crop,
+  CropName,
+  CROPS,
+  GREENHOUSE_CROPS,
+  GreenHouseCrop,
+} from "features/game/types/crops";
 import { useActor } from "@xstate/react";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
 import { setPrecision } from "lib/utils/formatNumber";
 import {
   GREENHOUSE_FRUIT,
+  GreenHouseFruit,
   PATCH_FRUIT,
   PatchFruit,
 } from "features/game/types/fruits";
@@ -32,17 +39,22 @@ import { NPC_WEARABLES } from "lib/npcs";
 import { BulkSellModal } from "components/ui/BulkSellModal";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { hasFeatureAccess } from "lib/flags";
+import {
+  isAdvancedCrop,
+  isBasicCrop,
+  isMediumCrop,
+} from "features/game/events/landExpansion/harvest";
 
 export const isExoticCrop = (
-  item: Crop | PatchFruit | ExoticCrop,
+  item: Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
 ): item is ExoticCrop => {
   return item.name in EXOTIC_CROPS;
 };
 
 export const Crops: React.FC = () => {
-  const [selected, setSelected] = useState<Crop | PatchFruit | ExoticCrop>(
-    CROPS.Sunflower,
-  );
+  const [selected, setSelected] = useState<
+    Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
+  >(CROPS.Sunflower);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
   const [customAmount, setCustomAmount] = useState(new Decimal(0));
@@ -80,7 +92,9 @@ export const Crops: React.FC = () => {
     }
   };
 
-  const displaySellPrice = (crop: Crop | PatchFruit | ExoticCrop) =>
+  const displaySellPrice = (
+    crop: Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
+  ) =>
     isExoticCrop(crop)
       ? crop.sellPrice
       : getSellPrice({ item: crop, game: state });
@@ -122,9 +136,9 @@ export const Crops: React.FC = () => {
     .reduce(
       (acc, key) => ({
         ...acc,
-        [key]: { ...EXOTIC_CROPS[key], disabled: false },
+        [key]: EXOTIC_CROPS[key],
       }),
-      {} as Record<ExoticCropName, ExoticCrop & { disabled: false }>,
+      {} as Record<ExoticCropName, ExoticCrop>,
     );
 
   const cropsAndFruits = Object.values({
@@ -133,7 +147,7 @@ export const Crops: React.FC = () => {
     ...exotics,
     ...GREENHOUSE_FRUIT(),
     ...GREENHOUSE_CROPS,
-  }) as Crop[];
+  });
 
   return (
     <>
@@ -212,12 +226,61 @@ export const Crops: React.FC = () => {
                 icon={CROP_LIFECYCLE.Sunflower.crop}
                 type="default"
               >
-                {t("crops")}
+                {`Basic Crops`}
               </Label>
             </div>
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
                 .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => isBasicCrop(crop.name as CropName))
+                .map((item) => (
+                  <Box
+                    isSelected={selected.name === item.name}
+                    key={item.name}
+                    onClick={() => setSelected(item)}
+                    image={ITEM_DETAILS[item.name].image}
+                    count={inventory[item.name]}
+                    parentDivRef={divRef}
+                  />
+                ))}
+            </div>
+            <div className="flex">
+              <Label
+                className="mr-3 ml-2 mb-1"
+                icon={CROP_LIFECYCLE.Carrot.crop}
+                type="default"
+              >
+                {`Medium Crops`}
+              </Label>
+            </div>
+            <div className="flex flex-wrap mb-2">
+              {cropsAndFruits
+                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => isMediumCrop(crop.name as CropName))
+                .map((item) => (
+                  <Box
+                    isSelected={selected.name === item.name}
+                    key={item.name}
+                    onClick={() => setSelected(item)}
+                    image={ITEM_DETAILS[item.name].image}
+                    count={inventory[item.name]}
+                    parentDivRef={divRef}
+                  />
+                ))}
+            </div>
+            <div className="flex">
+              <Label
+                className="mr-3 ml-2 mb-1"
+                icon={CROP_LIFECYCLE.Kale.crop}
+                type="default"
+              >
+                {`Advanced Crops`}
+              </Label>
+            </div>
+            <div className="flex flex-wrap mb-2">
+              {cropsAndFruits
+                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => isAdvancedCrop(crop.name as CropName))
                 .filter(
                   (crop) =>
                     crop.name !== "Barley" || hasFeatureAccess(state, "BARLEY"),
@@ -241,7 +304,7 @@ export const Crops: React.FC = () => {
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
                 .filter(
-                  (crop) => !!crop.sellPrice && crop.name in PATCH_FRUIT(),
+                  (fruit) => !!fruit.sellPrice && fruit.name in PATCH_FRUIT(),
                 )
                 .map((item) => (
                   <Box

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -46,6 +46,11 @@ import { NPC_WEARABLES } from "lib/npcs";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
 import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
+import {
+  isAdvancedCrop,
+  isBasicCrop,
+  isMediumCrop,
+} from "features/game/events/landExpansion/harvest";
 
 interface Props {
   onClose: () => void;
@@ -289,11 +294,66 @@ export const Seeds: React.FC<Props> = ({ onClose }) => {
             type="default"
             className="ml-2 mb-1"
           >
-            {t("crops")}
+            {`Basic Crops`}
           </Label>
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in CROP_SEEDS)
+              .filter((name) => isBasicCrop(name.split(" ")[0] as CropName))
+              .filter(
+                (name) =>
+                  name !== "Barley Seed" || hasFeatureAccess(state, "BARLEY"),
+              )
+              .map((name: SeedName) => (
+                <Box
+                  isSelected={selectedName === name}
+                  key={name}
+                  onClick={() => onSeedClick(name)}
+                  image={ITEM_DETAILS[name].image}
+                  showOverlay={isSeedLocked(name)}
+                  secondaryImage={
+                    isSeedLocked(name) ? SUNNYSIDE.icons.lock : undefined
+                  }
+                  count={inventory[name]}
+                />
+              ))}
+          </div>
+          <Label
+            icon={CROP_LIFECYCLE.Carrot.crop}
+            type="default"
+            className="ml-2 mb-1"
+          >
+            {`Medium Crops`}
+          </Label>
+          <div className="flex flex-wrap mb-2">
+            {seeds
+              .filter((name) => name in CROP_SEEDS)
+              .filter((name) => isMediumCrop(name.split(" ")[0] as CropName))
+              .map((name: SeedName) => (
+                <Box
+                  isSelected={selectedName === name}
+                  key={name}
+                  onClick={() => onSeedClick(name)}
+                  image={ITEM_DETAILS[name].image}
+                  showOverlay={isSeedLocked(name)}
+                  secondaryImage={
+                    isSeedLocked(name) ? SUNNYSIDE.icons.lock : undefined
+                  }
+                  count={inventory[name]}
+                />
+              ))}
+          </div>
+          <Label
+            icon={CROP_LIFECYCLE.Kale.crop}
+            type="default"
+            className="ml-2 mb-1"
+          >
+            {`Advanced Crops`}
+          </Label>
+          <div className="flex flex-wrap mb-2">
+            {seeds
+              .filter((name) => name in CROP_SEEDS)
+              .filter((name) => isAdvancedCrop(name.split(" ")[0] as CropName))
               .filter(
                 (name) =>
                   name !== "Barley Seed" || hasFeatureAccess(state, "BARLEY"),


### PR DESCRIPTION
# Description

This change is to make it clear for buffs that are for specific categories of crops, separating them into groups will make it clear what kind of crop it is

![image](https://github.com/user-attachments/assets/0a4d0cd3-1bd3-4103-8226-ab91d08e9047)
![image](https://github.com/user-attachments/assets/022c471f-084c-454e-aec1-f7be0e49f493)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
