### PR TITLE
[FIX] Clear Crafting Details on Gem Boost

### DIFF
--- a/src/features/island/buildings/lib/craftingMachine.ts
+++ b/src/features/island/buildings/lib/craftingMachine.ts
@@ -109,6 +109,7 @@ export const craftingMachine = createMachine<
           },
           INSTANT: {
             target: "idle",
+            actions: ["clearCraftingDetails"],
           },
         },
       },


### PR DESCRIPTION
# Description

Small UI bug on smoothie shack after instant craft. In progress section would have out of date data in machine.

Before:
<img width="500" alt="1" src="https://github.com/user-attachments/assets/6732aae0-1ee4-4ecc-8304-a33d534d82e0">

After:
<img width="496" alt="2" src="https://github.com/user-attachments/assets/48cd1bbc-520d-4a94-ad9c-e3dacf97b0db">
