### PR TITLE
[FEAT] Barn Bounties

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -22,10 +22,9 @@ import { AnimalBuildingLevel } from "features/game/events/landExpansion/upgradeB
 import { SUNNYSIDE } from "assets/sunnyside";
 import { UpgradeBuildingModal } from "features/game/expansion/components/UpgradeBuildingModal";
 import { ANIMAL_HOUSE_IMAGES } from "features/henHouse/HenHouseInside";
-import { Animal, AnimalBounty, BountyRequest } from "features/game/types/game";
+import { Animal, AnimalBounty } from "features/game/types/game";
 import { AnimalDeal, ExchangeHud } from "./components/AnimalBounties";
 import { Modal } from "components/ui/Modal";
-import { AnimalBounties } from "./components/AnimalBounties";
 import classNames from "classnames";
 import { isValidDeal } from "features/game/events/landExpansion/sellAnimal";
 
@@ -110,24 +109,6 @@ export const BarnInside: React.FC = () => {
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
             <div className="relative w-full h-full">
               <img
-                src={shopDisc}
-                alt="Buy Animals"
-                className="absolute top-[18px] right-[18px] cursor-pointer z-10"
-                style={{
-                  width: `${PIXEL_SCALE * 18}px`,
-                }}
-                onClick={() => setShowModal(true)}
-              />
-              <img
-                src={SUNNYSIDE.icons.upgradeBuildingIcon}
-                alt="Upgrade Building"
-                className="absolute bottom-[44px] right-[18px] cursor-pointer z-10"
-                style={{
-                  width: `${PIXEL_SCALE * 16}px`,
-                }}
-                onClick={() => setShowUpgradeModal(true)}
-              />
-              <img
                 src={ANIMAL_HOUSE_IMAGES[level].src}
                 id={Section.GenesisBlock}
                 className="relative z-0"
@@ -155,8 +136,6 @@ export const BarnInside: React.FC = () => {
                   const isValid = deal && isValidDeal({ animal, deal });
                   const Component =
                     BARN_ANIMAL_COMPONENTS[animal.type as BarnAnimal];
-
-                  console.log({ id, isValid, deal });
 
                   return (
                     <MapPlacement
@@ -190,13 +169,35 @@ export const BarnInside: React.FC = () => {
                   );
                 })
                 .sort((a, b) => a.props.y - b.props.y)}
+              {!deal && (
+                <>
+                  <img
+                    src={shopDisc}
+                    alt="Buy Animals"
+                    className="absolute top-[18px] right-[18px] cursor-pointer z-10"
+                    style={{
+                      width: `${PIXEL_SCALE * 18}px`,
+                    }}
+                    onClick={() => setShowModal(true)}
+                  />
+                  <img
+                    src={SUNNYSIDE.icons.upgradeBuildingIcon}
+                    alt="Upgrade Building"
+                    className="absolute bottom-[44px] right-[18px] cursor-pointer z-10"
+                    style={{
+                      width: `${PIXEL_SCALE * 16}px`,
+                    }}
+                    onClick={() => setShowUpgradeModal(true)}
+                  />
 
-              <Button
-                className="absolute -bottom-16"
-                onClick={() => navigate("/")}
-              >
-                {t("exit")}
-              </Button>
+                  <Button
+                    className="absolute -bottom-16"
+                    onClick={() => navigate("/")}
+                  >
+                    {t("exit")}
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -10,7 +10,6 @@ import { getAnimalLevel } from "features/game/lib/animals";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { weekResetsAt } from "features/game/lib/factions";
 import { MachineState } from "features/game/lib/gameMachine";
-import { AnimalType } from "features/game/types/animals";
 import { getKeys } from "features/game/types/decorations";
 import {
   Animal,
@@ -21,9 +20,8 @@ import {
 import { ITEM_DETAILS } from "features/game/types/images";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { NPC_WEARABLES } from "lib/npcs";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 
 const _exchange = (state: MachineState) => state.context.state.bounties;
 
@@ -43,8 +41,6 @@ export const AnimalBounties: React.FC<Props> = ({ type, onExchanging }) => {
   const deals = exchange.requests.filter((deal) =>
     type.includes(deal.name),
   ) as AnimalBounty[];
-
-  console.log({ type, deals, exchange });
 
   const expiresAt = useCountdown(weekResetsAt());
 

--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -5,16 +5,19 @@ import { Button } from "components/ui/Button";
 import { HudContainer } from "components/ui/HudContainer";
 import { Label } from "components/ui/Label";
 import { ButtonPanel, InnerPanel, Panel } from "components/ui/Panel";
-import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { SpeakingModal } from "features/game/components/SpeakingModal";
-import { getAnimalLevel } from "features/game/events/landExpansion/sellAnimal";
 import { Context } from "features/game/GameProvider";
+import { getAnimalLevel } from "features/game/lib/animals";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { weekResetsAt } from "features/game/lib/factions";
 import { MachineState } from "features/game/lib/gameMachine";
 import { AnimalType } from "features/game/types/animals";
 import { getKeys } from "features/game/types/decorations";
-import { Animal, AnimalBounty, BountyRequest } from "features/game/types/game";
+import {
+  Animal,
+  AnimalBounty,
+  BountyRequest,
+  InventoryItemName,
+} from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -25,61 +28,28 @@ import React, { useContext, useState } from "react";
 const _exchange = (state: MachineState) => state.context.state.bounties;
 
 interface Props {
-  type: AnimalType;
+  type: InventoryItemName[];
   onExchanging: (deal: AnimalBounty) => void;
 }
 
-function acknowledgeIntro() {
-  localStorage.setItem(
-    "animal.bounties.acknowledged",
-    new Date().toISOString(),
-  );
-}
-
-function hasReadIntro() {
-  return !!localStorage.getItem("animal.bounties.acknowledged");
-}
 export const AnimalBounties: React.FC<Props> = ({ type, onExchanging }) => {
   const { gameService } = useContext(Context);
   const exchange = useSelector(gameService, _exchange);
 
   const { t } = useAppTranslation();
 
-  const [showIntro, setShowIntro] = useState(!hasReadIntro());
-
   const state = gameService.getSnapshot().context.state;
 
-  const deals = exchange.requests.filter(
-    (deal) => deal.name === type,
+  const deals = exchange.requests.filter((deal) =>
+    type.includes(deal.name),
   ) as AnimalBounty[];
+
+  console.log({ type, deals, exchange });
 
   const expiresAt = useCountdown(weekResetsAt());
 
-  if (showIntro) {
-    return (
-      <SpeakingModal
-        message={[
-          {
-            text: t("bounties.animal.intro.one"),
-          },
-          {
-            text: t("bounties.animal.intro.two"),
-          },
-          {
-            text: t("bounties.animal.intro.three"),
-          },
-        ]}
-        bumpkinParts={NPC_WEARABLES.grabnab}
-        onClose={() => {
-          acknowledgeIntro();
-          setShowIntro(false);
-        }}
-      />
-    );
-  }
-
   return (
-    <CloseButtonPanel bumpkinParts={NPC_WEARABLES.grabnab}>
+    <InnerPanel>
       <div className="p-1">
         <div className="flex justify-between items-center mb-2">
           <Label type="default">{t("bounties.board")}</Label>
@@ -94,9 +64,6 @@ export const AnimalBounties: React.FC<Props> = ({ type, onExchanging }) => {
             <p className="text-sm">{t("bounties.board.empty")}</p>
           )}
           {deals.map((deal) => {
-            const animals =
-              type === "Chicken" ? state.henHouse.animals : state.barn.animals;
-
             const isSold = !!state.bounties.completed.find(
               (request) => request.id === deal.id,
             );
@@ -187,7 +154,7 @@ export const AnimalBounties: React.FC<Props> = ({ type, onExchanging }) => {
           })}
         </div>
       </div>
-    </CloseButtonPanel>
+    </InnerPanel>
   );
 };
 
@@ -222,7 +189,7 @@ export const AnimalDeal: React.FC<{
             icon={ITEM_DETAILS[animal.type].image}
             className="mr-2"
           >
-            {`Lvl ${getAnimalLevel({ animal })} ${animal.type}`}
+            {`Lvl ${getAnimalLevel(animal.experience, animal.type)} ${animal.type}`}
           </Label>
           {!!deal.coins && (
             <Label type="warning" icon={SUNNYSIDE.ui.coinsImg}>

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -1,15 +1,9 @@
 import Decimal from "decimal.js-light";
+import { getAnimalLevel } from "features/game/lib/animals";
 import { getKeys } from "features/game/types/decorations";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { Animal, BountyRequest, GameState } from "features/game/types/game";
 import { produce } from "immer";
-
-// TEMP level function
-export function getAnimalLevel({ animal }: { animal: Animal }) {
-  if (animal.experience < 5) return 1;
-
-  return 2;
-}
 
 export function isValidDeal({
   animal,
@@ -22,7 +16,7 @@ export function isValidDeal({
     return false;
   }
 
-  if (getAnimalLevel({ animal }) < deal.level) {
+  if (getAnimalLevel(animal.experience, animal.type) < deal.level) {
     return false;
   }
 

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SplitScreenView } from "components/ui/SplitScreenView";
 import { Context } from "features/game/GameProvider";

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -17,7 +17,7 @@ import {
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { AnimalBuildingKey } from "features/game/types/game";
+import { AnimalBounty, AnimalBuildingKey } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { getAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
@@ -27,11 +27,27 @@ import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeab
 import coinsIcon from "assets/icons/coins.webp";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { makeAnimalBuildingKey } from "features/game/lib/animals";
+import { AnimalBounties } from "features/barn/components/AnimalBounties";
+import { SpeakingModal } from "features/game/components/SpeakingModal";
+import { NPC_WEARABLES } from "lib/npcs";
+import { OuterPanel } from "components/ui/Panel";
+
+function acknowledgeIntro() {
+  localStorage.setItem(
+    "animal.bounties.acknowledged",
+    new Date().toISOString(),
+  );
+}
+
+function hasReadIntro() {
+  return !!localStorage.getItem("animal.bounties.acknowledged");
+}
 
 type Props = {
   show: boolean;
   buildingName: AnimalBuildingType;
   onClose: () => void;
+  onExchanging: (deal: AnimalBounty) => void;
 };
 
 const _state = (state: MachineState) => state.context.state;
@@ -43,8 +59,10 @@ export const AnimalBuildingModal: React.FC<Props> = ({
   show,
   buildingName,
   onClose,
+  onExchanging,
 }) => {
   const { gameService } = useContext(Context);
+  const [showIntro, setShowIntro] = useState(!hasReadIntro());
 
   const state = useSelector(gameService, _state);
   const bumpkin = useSelector(gameService, _bumpkin);
@@ -107,15 +125,42 @@ export const AnimalBuildingModal: React.FC<Props> = ({
   const atMaxCapacity =
     getTotalAnimalsInBuilding() >= getAnimalCapacity(buildingKey, state);
 
+  if (showIntro) {
+    return (
+      <SpeakingModal
+        message={[
+          {
+            text: t("bounties.animal.intro.one"),
+          },
+          {
+            text: t("bounties.animal.intro.two"),
+          },
+          {
+            text: t("bounties.animal.intro.three"),
+          },
+        ]}
+        bumpkinParts={NPC_WEARABLES.grabnab}
+        onClose={() => {
+          acknowledgeIntro();
+          setShowIntro(false);
+        }}
+      />
+    );
+  }
+
   return (
-    <Modal show={show} onHide={onClose}>
-      <CloseButtonPanel
-        onClose={onClose}
-        tabs={[{ name: t("animals.buyAnimal"), icon: coinsIcon }]}
-        currentTab={currentTab}
-        setCurrentTab={setCurrentTab}
-        className="relative"
-      >
+    <CloseButtonPanel
+      onClose={onClose}
+      tabs={[
+        { name: t("buy"), icon: coinsIcon },
+        { name: t("sell"), icon: SUNNYSIDE.icons.death },
+      ]}
+      currentTab={currentTab}
+      setCurrentTab={setCurrentTab}
+      className="relative"
+      container={OuterPanel}
+    >
+      {currentTab === 0 && (
         <SplitScreenView
           panel={
             <CraftingRequirements
@@ -175,7 +220,14 @@ export const AnimalBuildingModal: React.FC<Props> = ({
             </div>
           }
         />
-      </CloseButtonPanel>
-    </Modal>
+      )}
+
+      {currentTab === 1 && (
+        <AnimalBounties
+          type={buildingName === "Barn" ? ["Cow", "Sheep"] : ["Chicken"]}
+          onExchanging={onExchanging}
+        />
+      )}
+    </CloseButtonPanel>
   );
 };

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -55,7 +55,7 @@ export function makeAnimalBuilding(
           state: "idle",
           coordinates: positions[index],
           asleepAt: 0,
-          experience: 0,
+          experience: 1000,
           createdAt: Date.now(),
           item: "Petting Hand",
           lovedAt: 0,

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -475,7 +475,7 @@ export const INITIAL_FARM: GameState = {
     requests: [
       {
         id: "1",
-        name: "Chicken",
+        name: "Cow",
         level: 1,
         coins: 100,
       },

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -760,9 +760,33 @@ export const STATIC_OFFLINE_FARM: GameState = {
     requests: [
       {
         id: "1",
-        name: "Chicken",
+        name: "Cow",
         level: 2,
         coins: 100,
+      },
+      {
+        id: "1",
+        name: "Sheep",
+        level: 2,
+        coins: 100,
+      },
+      {
+        id: "1c",
+        name: "Cow",
+        level: 1,
+        coins: 100,
+      },
+      {
+        id: "1e",
+        name: "Chicken",
+        level: 1,
+        coins: 100,
+      },
+      {
+        id: "1ef",
+        name: "Chicken",
+        level: 1,
+        coins: 150,
       },
       {
         id: "2",

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -21,7 +21,6 @@ import { UpgradeBuildingModal } from "features/game/expansion/components/Upgrade
 import { Modal } from "components/ui/Modal";
 import {
   AnimalDeal,
-  AnimalBounties,
   ExchangeHud,
 } from "features/barn/components/AnimalBounties";
 import { Animal, AnimalBounty } from "features/game/types/game";

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -45,7 +45,6 @@ export const HenHouseInside: React.FC = () => {
   const { gameService } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-  const [showExchange, setShowExchange] = useState(false);
   const [deal, setDeal] = useState<AnimalBounty>();
   const [selected, setSelected] = useState<Animal>();
   const henHouse = useSelector(gameService, _henHouse);
@@ -64,11 +63,17 @@ export const HenHouseInside: React.FC = () => {
 
   return (
     <>
-      <AnimalBuildingModal
-        buildingName="Hen House"
-        show={showModal}
-        onClose={() => setShowModal(false)}
-      />
+      <Modal show={showModal} onHide={() => setShowModal(false)}>
+        <AnimalBuildingModal
+          buildingName="Hen House"
+          show={showModal}
+          onClose={() => setShowModal(false)}
+          onExchanging={(deal) => {
+            setShowModal(false);
+            setDeal(deal);
+          }}
+        />
+      </Modal>
       <UpgradeBuildingModal
         buildingName="Hen House"
         currentLevel={level}
@@ -76,15 +81,6 @@ export const HenHouseInside: React.FC = () => {
         show={showUpgradeModal}
         onClose={() => setShowUpgradeModal(false)}
       />
-      <Modal show={showExchange} onHide={() => setShowExchange(false)}>
-        <AnimalBounties
-          onExchanging={(deal) => {
-            setShowExchange(false);
-            setDeal(deal);
-          }}
-          type="Chicken"
-        />
-      </Modal>
 
       <Modal show={!!selected} onHide={() => setSelected(undefined)}>
         <AnimalDeal
@@ -121,15 +117,6 @@ export const HenHouseInside: React.FC = () => {
                     }}
                     onClick={() => setShowModal(true)}
                   />
-                  <div
-                    className="absolute bottom-32 left-8 cursor-pointer z-10"
-                    style={{
-                      width: `${PIXEL_SCALE * 18}px`,
-                    }}
-                    onClick={() => setShowExchange(true)}
-                  >
-                    <GrabNab />
-                  </div>
 
                   <Button
                     className="absolute -bottom-16"


### PR DESCRIPTION
# Description

This PR adds support for barn bounties. Includes:

1. Moved the sell animals UI into the shop modal
2. Sell Sheep + Cow

**Excludes**

Selling sick animal restrictions

<img width="542" alt="Screenshot 2024-10-24 at 3 13 18 PM" src="https://github.com/user-attachments/assets/cc05cf35-0158-4f6f-8366-eb0554e26c09">

## How to test?

1. Connect to local API
2. Level up an animal
4. Sell it 🚀 