### PR TITLE
[FEAT] Oraganise animal positions

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect, useState } from "react";
+import React, { useContext, useLayoutEffect, useState, useMemo } from "react";
 
 import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -10,7 +10,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/decorations";
-import { MapPlacement } from "features/game/expansion/components/MapPlacement";
+// import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { ANIMALS, AnimalType } from "features/game/types/animals";
 import { Cow } from "./components/Cow";
 import { Sheep } from "./components/Sheep";
@@ -28,6 +28,8 @@ import { AnimalDeal, ExchangeHud } from "./components/AnimalBounties";
 import { Modal } from "components/ui/Modal";
 import classNames from "classnames";
 import { isValidDeal } from "features/game/events/landExpansion/sellAnimal";
+import { MapPlacement } from "features/game/expansion/components/MapPlacement";
+import { ANIMAL_HOUSE_BOUNDS } from "features/game/expansion/placeable/lib/collisionDetection";
 
 export const EXTERIOR_ISLAND_BG: Record<IslandType, string> = {
   basic: SUNNYSIDE.land.basic_building_bg,
@@ -67,6 +69,35 @@ export const BarnInside: React.FC = () => {
   }, []);
 
   const nextLevel = Math.min(level + 1, 3) as Exclude<AnimalBuildingLevel, 1>;
+
+  const {
+    x: floorX,
+    y: floorY,
+    height: floorHeight,
+    width: floorWidth,
+  } = ANIMAL_HOUSE_BOUNDS.barn[level];
+
+  // Organise the animals neatly in the barn
+  const organizedAnimals = useMemo(() => {
+    const animals = getKeys(barn.animals).map((id) => ({
+      ...barn.animals[id],
+    }));
+
+    const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Cow.width);
+    const verticalGap = 0.5; // Add a 0.5 grid unit gap between rows
+
+    return animals.map((animal, index) => {
+      const row = Math.floor(index / maxAnimalsPerRow);
+      const col = index % maxAnimalsPerRow;
+      return {
+        ...animal,
+        coordinates: {
+          x: col * ANIMALS.Cow.width,
+          y: row * (ANIMALS.Cow.height + verticalGap),
+        },
+      };
+    });
+  }, [barn.animals, floorWidth]);
 
   return (
     <>
@@ -140,45 +171,51 @@ export const BarnInside: React.FC = () => {
                 <FeederMachine />
               </div>
 
-              {getKeys(barn.animals)
-                .map((id) => {
-                  const animal = barn.animals[id];
-                  const isValid = deal && isValidDeal({ animal, deal });
-                  const Component =
-                    BARN_ANIMAL_COMPONENTS[animal.type as BarnAnimal];
+              <MapPlacement
+                x={floorX}
+                y={floorY}
+                height={floorHeight}
+                width={floorWidth}
+              >
+                <div className="flex flex-wrap w-full h-full">
+                  {organizedAnimals.map((animal) => {
+                    const isValid = deal && isValidDeal({ animal, deal });
+                    const Component =
+                      BARN_ANIMAL_COMPONENTS[animal.type as BarnAnimal];
+                    const { width, height } = ANIMALS[animal.type];
 
-                  return (
-                    <MapPlacement
-                      key={`${animal.type.toLowerCase()}-${id}`}
-                      x={animal.coordinates.x}
-                      y={animal.coordinates.y}
-                      height={ANIMALS.Chicken.height}
-                      width={ANIMALS.Chicken.width}
-                    >
+                    return (
                       <div
-                        className={classNames({
+                        id={`${animal.type.toLowerCase()}-${animal.id}`}
+                        key={`${animal.type.toLowerCase()}-${animal.id}`}
+                        className={classNames("relative", {
                           "opacity-50": deal && !isValid,
                           "cursor-pointer": deal && isValid,
                           "pointer-events-none": deal && !isValid,
                         })}
+                        style={{
+                          position: "absolute",
+                          left: `${animal.coordinates.x * GRID_WIDTH_PX}px`,
+                          top: `${animal.coordinates.y * GRID_WIDTH_PX}px`,
+                          width: `${width * GRID_WIDTH_PX}px`,
+                          height: `${height * GRID_WIDTH_PX}px`,
+                        }}
                         onClick={(e) => {
                           if (deal) {
-                            // Stop other clicks
                             e.stopPropagation();
                             e.preventDefault();
-
                             if (!isValid) return;
-
                             setSelected(animal);
                           }
                         }}
                       >
-                        <Component id={id} disabled={!!deal} />
+                        <Component id={animal.id} disabled={!!deal} />
                       </div>
-                    </MapPlacement>
-                  );
-                })
-                .sort((a, b) => a.props.y - b.props.y)}
+                    );
+                  })}
+                </div>
+              </MapPlacement>
+
               {!deal && (
                 <>
                   <img

--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -10,7 +10,6 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/decorations";
-// import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { ANIMALS, AnimalType } from "features/game/types/animals";
 import { Cow } from "./components/Cow";
 import { Sheep } from "./components/Sheep";
@@ -79,9 +78,19 @@ export const BarnInside: React.FC = () => {
 
   // Organise the animals neatly in the barn
   const organizedAnimals = useMemo(() => {
-    const animals = getKeys(barn.animals).map((id) => ({
-      ...barn.animals[id],
-    }));
+    // First, group animals by type and sort within each group
+    const animals = getKeys(barn.animals)
+      .map((id) => ({
+        ...barn.animals[id],
+      }))
+      // Group by type first (Cow, then Sheep)
+      .sort((a, b) => b.experience - a.experience)
+      .sort((a, b) => {
+        if (a.type === b.type) {
+          return a.experience - b.experience;
+        }
+        return a.type === "Cow" ? -1 : 1;
+      });
 
     const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Cow.width);
     const verticalGap = 0.5; // Add a 0.5 grid unit gap between rows
@@ -97,7 +106,7 @@ export const BarnInside: React.FC = () => {
         },
       };
     });
-  }, [barn.animals, floorWidth]);
+  }, [getKeys(barn.animals).length, floorWidth]);
 
   return (
     <>

--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -48,6 +48,7 @@ describe("animal.sold", () => {
       }),
     ).toThrow("Bounty already completed");
   });
+
   it("requires player has a chicken", () => {
     expect(() =>
       sellAnimal({
@@ -109,6 +110,16 @@ describe("animal.sold", () => {
     const state = sellAnimal({
       state: {
         ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            ...INITIAL_FARM.henHouse.animals,
+            [animalId]: {
+              ...INITIAL_FARM.henHouse.animals[animalId],
+              experience: 1000,
+            },
+          },
+        },
         bounties: {
           completed: [],
           requests: [
@@ -139,6 +150,16 @@ describe("animal.sold", () => {
     const state = sellAnimal({
       state: {
         ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            ...INITIAL_FARM.henHouse.animals,
+            [animalId]: {
+              ...INITIAL_FARM.henHouse.animals[animalId],
+              experience: 1000,
+            },
+          },
+        },
         bounties: {
           completed: [],
           requests: [
@@ -162,11 +183,22 @@ describe("animal.sold", () => {
 
     expect(state.coins).toEqual(100);
   });
+
   it("exchanges tickets", () => {
     const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
     const state = sellAnimal({
       state: {
         ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            ...INITIAL_FARM.henHouse.animals,
+            [animalId]: {
+              ...INITIAL_FARM.henHouse.animals[animalId],
+              experience: 1000,
+            },
+          },
+        },
         bounties: {
           completed: [],
           requests: [
@@ -198,6 +230,16 @@ describe("animal.sold", () => {
     const state = sellAnimal({
       state: {
         ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            ...INITIAL_FARM.henHouse.animals,
+            [animalId]: {
+              ...INITIAL_FARM.henHouse.animals[animalId],
+              experience: 1000,
+            },
+          },
+        },
         bounties: {
           completed: [],
           requests: [

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -203,7 +203,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
               </div>
               <Label
                 type={atMaxCapacity ? "danger" : "info"}
-                className="absolute bottom-3 left-2"
+                className="absolute bottom-3 sm:bottom-2 left-2"
               >
                 {`${getTotalAnimalsInBuilding()}/${getAnimalCapacity(
                   buildingKey,

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -205,7 +205,7 @@ export const HOME_BOUNDS: Record<IslandType, BoundingBox> = {
   },
 };
 
-const ANIMAL_HOUSE_BOUNDS: Record<
+export const ANIMAL_HOUSE_BOUNDS: Record<
   AnimalBuildingKey,
   Record<number, BoundingBox>
 > = {

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -61,7 +61,7 @@ export function makeAnimalBuilding(
           state: "idle",
           coordinates: positions[index],
           asleepAt: 0,
-          experience: 1000,
+          experience: 0,
           createdAt: Date.now(),
           item: "Petting Hand",
           lovedAt: 0,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -390,6 +390,8 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   inventory: {
+    Hay: new Decimal(100),
+    "Kernel Blend": new Decimal(100),
     "Rich Chicken": new Decimal(1),
     Wrangler: new Decimal(1),
     "Bull Run Banner": new Decimal(1),
@@ -466,7 +468,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Pickaxe: new Decimal(100),
     Warehouse: new Decimal(1),
     Wheat: new Decimal(100),
-    Oil: new Decimal(100),
+    Oil: new Decimal(250),
     "Sand Shovel": new Decimal(1),
     "Sand Drill": new Decimal(1),
     Manor: new Decimal(1),
@@ -562,7 +564,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Egg: new Decimal(12),
     Beehive: new Decimal(1),
     Banana: new Decimal(12),
-    Crimstone: new Decimal(100),
+    Crimstone: new Decimal(50),
     Gem: new Decimal(200),
     Gold: new Decimal("400"),
     Iron: new Decimal("800"),
@@ -763,13 +765,13 @@ export const STATIC_OFFLINE_FARM: GameState = {
       {
         id: "1",
         name: "Cow",
-        level: 2,
+        level: 3,
         coins: 100,
       },
       {
         id: "1",
         name: "Sheep",
-        level: 2,
+        level: 3,
         coins: 100,
       },
       {

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useLayoutEffect, useState } from "react";
+import React, { useContext, useLayoutEffect, useMemo, useState } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -26,9 +26,8 @@ import {
 import { Animal, AnimalBounty } from "features/game/types/game";
 import { isValidDeal } from "features/game/events/landExpansion/sellAnimal";
 import classNames from "classnames";
-import { NPC } from "features/island/bumpkin/components/NPC";
-import { NPC_WEARABLES } from "lib/npcs";
 import { EXTERIOR_ISLAND_BG } from "features/barn/BarnInside";
+import { ANIMAL_HOUSE_BOUNDS } from "features/game/expansion/placeable/lib/collisionDetection";
 
 const _henHouse = (state: MachineState) => state.context.state.henHouse;
 
@@ -60,6 +59,33 @@ export const HenHouseInside: React.FC = () => {
   }, []);
 
   const nextLevel = Math.min(level + 1, 3) as Exclude<AnimalBuildingLevel, 1>;
+
+  const {
+    x: floorX,
+    y: floorY,
+    height: floorHeight,
+    width: floorWidth,
+  } = ANIMAL_HOUSE_BOUNDS.henHouse[level];
+
+  const organizedAnimals = useMemo(() => {
+    const animals = getKeys(henHouse.animals).map((id) => ({
+      ...henHouse.animals[id],
+    }));
+
+    const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Chicken.width);
+
+    return animals.map((animal, index) => {
+      const row = Math.floor(index / maxAnimalsPerRow);
+      const col = index % maxAnimalsPerRow;
+      return {
+        ...animal,
+        coordinates: {
+          x: col * ANIMALS.Chicken.width,
+          y: row * ANIMALS.Chicken.height,
+        },
+      };
+    });
+  }, [henHouse.animals, floorWidth]);
 
   return (
     <>
@@ -161,25 +187,33 @@ export const HenHouseInside: React.FC = () => {
                 <FeederMachine />
               </div>
 
-              {getKeys(henHouse.animals)
-                .map((id) => {
-                  const animal = henHouse.animals[id];
-                  const isValid = deal && isValidDeal({ animal, deal });
+              <MapPlacement
+                x={floorX}
+                y={floorY}
+                height={floorHeight}
+                width={floorWidth}
+              >
+                <div className="flex flex-wrap w-full h-full">
+                  {organizedAnimals.map((animal) => {
+                    const isValid = deal && isValidDeal({ animal, deal });
+                    const { width, height } = ANIMALS[animal.type];
 
-                  return (
-                    <MapPlacement
-                      key={`chicken-${id}`}
-                      x={animal.coordinates.x}
-                      y={animal.coordinates.y}
-                      height={ANIMALS.Chicken.height}
-                      width={ANIMALS.Chicken.width}
-                    >
+                    return (
                       <div
+                        id={`${animal.type.toLowerCase()}-${animal.id}`}
+                        key={`${animal.type.toLowerCase()}-${animal.id}`}
                         className={classNames({
                           "opacity-50": deal && !isValid,
                           "cursor-pointer": deal && isValid,
                           "pointer-events-none": deal && !isValid,
                         })}
+                        style={{
+                          position: "absolute",
+                          left: `${animal.coordinates.x * GRID_WIDTH_PX}px`,
+                          top: `${animal.coordinates.y * GRID_WIDTH_PX}px`,
+                          width: `${width * GRID_WIDTH_PX}px`,
+                          height: `${height * GRID_WIDTH_PX}px`,
+                        }}
                         onClick={(e) => {
                           if (deal) {
                             // Stop other clicks
@@ -192,12 +226,12 @@ export const HenHouseInside: React.FC = () => {
                           }
                         }}
                       >
-                        <Chicken disabled={!!deal} id={id} />
+                        <Chicken disabled={!!deal} id={animal.id} />
                       </div>
-                    </MapPlacement>
-                  );
-                })
-                .sort((a, b) => a.props.y - b.props.y)}
+                    );
+                  })}
+                </div>
+              </MapPlacement>
             </div>
           </div>
         </div>
@@ -213,100 +247,6 @@ export const HenHouseInside: React.FC = () => {
           }}
         />
       )}
-    </>
-  );
-};
-
-const message = () => {
-  if (Math.random() < 0.05) return "Feast";
-
-  if (Math.random() < 0.2) return "Gobble";
-  if (Math.random() < 0.5) return "Crunch";
-  return "Tasty...";
-};
-
-const GrabNab: React.FC = () => {
-  const [hint, _] = useState(message());
-  const [state, setState] = useState<"idle" | "typing">("idle");
-
-  useEffect(() => {
-    const speak = async () => {
-      setState("typing");
-
-      await new Promise((res) => setTimeout(() => setState("idle"), 1000));
-    };
-
-    speak();
-  }, [hint]);
-
-  return (
-    <>
-      <div>
-        {hint && (
-          <div
-            className={"absolute uppercase"}
-            style={{
-              fontFamily: "Teeny",
-              color: "black",
-              textShadow: "none",
-              top: `${PIXEL_SCALE * -4}px`,
-              left: `${PIXEL_SCALE * 12}px`,
-
-              borderImage: `url(${SUNNYSIDE.ui.speechBorder})`,
-              borderStyle: "solid",
-              borderTopWidth: `${PIXEL_SCALE * 2}px`,
-              borderRightWidth: `${PIXEL_SCALE * 2}px`,
-              borderBottomWidth: `${PIXEL_SCALE * 4}px`,
-              borderLeftWidth: `${PIXEL_SCALE * 5}px`,
-
-              borderImageSlice: "2 2 4 5 fill",
-              imageRendering: "pixelated",
-              borderImageRepeat: "stretch",
-              fontSize: "8px",
-            }}
-          >
-            <div
-              style={{
-                height: "12px",
-                minWidth: "30px",
-              }}
-            >
-              {state === "idle" && (
-                <span
-                  className="whitespace-nowrap"
-                  style={{
-                    fontSize: "10px",
-                    position: "relative",
-                    bottom: "4px",
-                    left: "-2px",
-                    wordSpacing: "-4px",
-                    color: "#262b45",
-                  }}
-                >
-                  {hint}
-                </span>
-              )}
-
-              {state === "typing" && (
-                <span
-                  style={{
-                    fontSize: "10px",
-                    position: "relative",
-                    bottom: "4px",
-                    left: "-2px",
-                    wordSpacing: "-4px",
-                    color: "#262b45",
-                  }}
-                >
-                  {"..."}
-                </span>
-              )}
-            </div>
-          </div>
-        )}
-
-        <NPC parts={NPC_WEARABLES["grabnab"]} />
-      </div>
     </>
   );
 };


### PR DESCRIPTION
# Description

This change organises the animals in the barn from top left. This means they always just run from this position so if you level up the building they don't trigger OCD panic in the user which was happening when they were picking an empty position themselves 😄 

**NOTE: I will leave the coordinates on the animal type even though they're not used anymore. This may not be the final solution**

<img width="461" alt="Screenshot 2024-10-27 at 10 40 29 PM" src="https://github.com/user-attachments/assets/f7cb765f-7d31-4725-b232-04ec68a05f3f">


Fixes #issue

# What needs to be tested by the reviewer?
Rendering of the animals in their building in a organised fashion from top left.

Please describe how this can be tested.
- Open the animal building
- Purchase animals
- Sell animals
- Level up building

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
