### PR TITLE
[FEAT] Track produce claimed activity

### DIFF
--- a/src/features/game/events/landExpansion/claimProduce.test.ts
+++ b/src/features/game/events/landExpansion/claimProduce.test.ts
@@ -943,4 +943,67 @@ describe("claimProduce", () => {
 
     expect(state.barn.animals["0"].asleepAt).toEqual(boostedAsleepAt);
   });
+
+  it("tracks the bumpkin activity when a resource is collected", () => {
+    const chickenId = "123";
+
+    const newState = claimProduce({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Barn Manager": new Decimal(1),
+          "Rich Chicken": new Decimal(1),
+          "Chicken Coop": new Decimal(1),
+          Bale: new Decimal(1),
+        },
+        collectibles: {
+          "Rich Chicken": [
+            {
+              id: "rich",
+              createdAt: now,
+              coordinates: { x: 0, y: 0 },
+              readyAt: now,
+            },
+          ],
+          "Chicken Coop": [
+            {
+              id: "coop",
+              createdAt: now,
+              coordinates: { x: 0, y: 0 },
+              readyAt: now,
+            },
+          ],
+          Bale: [
+            {
+              id: "bale",
+              createdAt: now,
+              coordinates: { x: 0, y: 0 },
+              readyAt: now,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            [chickenId]: {
+              coordinates: { x: 0, y: 0 },
+              id: chickenId,
+              type: "Chicken",
+              createdAt: 0,
+              state: "ready",
+              experience: 120,
+              asleepAt: 0,
+              lovedAt: 0,
+              item: "Petting Hand",
+            },
+          },
+        },
+      },
+      action: { type: "produce.claimed", animal: "Chicken", id: chickenId },
+      createdAt: now,
+    });
+
+    expect(newState.bumpkin.activity["Egg Collected"]).toEqual(1);
+    expect(newState.bumpkin.activity["Feather Collected"]).toEqual(1);
+  });
 });

--- a/src/features/game/events/landExpansion/claimProduce.ts
+++ b/src/features/game/events/landExpansion/claimProduce.ts
@@ -13,6 +13,7 @@ import {
 } from "features/game/lib/animals";
 import { makeAnimalBuildingKey } from "features/game/lib/animals";
 import { getKeys } from "features/game/types/craftables";
+import { trackActivity } from "features/game/types/bumpkinActivity";
 
 export type ClaimProduceAction = {
   type: "produce.claimed";
@@ -63,6 +64,11 @@ export function claimProduce({
       copy.inventory[resource] = (
         copy.inventory[resource] ?? new Decimal(0)
       ).add(boostedAmount ?? new Decimal(0));
+
+      copy.bumpkin.activity = trackActivity(
+        `${resource} Collected`,
+        copy.bumpkin.activity,
+      );
     });
 
     animal.asleepAt = getBoostedAsleepAt({

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -5,6 +5,7 @@ import { CropName, GreenHouseCropName, GreenHouseCropSeedName } from "./crops";
 import {
   AnimalFoodName,
   AnimalMedicineName,
+  AnimalResource,
   Bumpkin,
   Keys,
   LanternName,
@@ -91,6 +92,7 @@ export type AnimalFeedMixedEvent =
   `${AnimalFoodName | AnimalMedicineName} Mixed`;
 export type AnimalFeedEvent = `${Animal} Fed`;
 export type AnimalCuredEvent = `${Animal} Cured`;
+export type AnimalResourceEvent = `${AnimalResource} Collected`;
 
 export type BumpkinActivityName =
   | PlantGreenHouseFruitEvent
@@ -110,6 +112,7 @@ export type BumpkinActivityName =
   | AnimalFeedMixedEvent
   | AnimalFeedEvent
   | AnimalCuredEvent
+  | AnimalResourceEvent
   // Resources
   | "Tree Chopped"
   | "Stone Mined"


### PR DESCRIPTION
# Description

Track produce collected on bumpkin activity.

Fixes #issue

# What needs to be tested by the reviewer?

Bumpkin activity is updated when produce is collected.

Please describe how this can be tested.

Level up an animal and check the `{Animal Resource} Collected` activity was incremented

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
