### PR TITLE
[FIX] Random Farm ID showing on Session Error Modal

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -629,7 +629,8 @@ export function startGame(authContext: AuthContext) {
       initial: "loading",
       context: {
         fslId: "123",
-        farmId: Math.floor(Math.random() * 1000),
+        farmId:
+          CONFIG.NETWORK === "mainnet" ? 0 : Math.floor(Math.random() * 1000),
         actions: [],
         state: EMPTY,
         sessionId: INITIAL_SESSION,


### PR DESCRIPTION
# Description

If there is an error in `loadSession` before the farm ID is loaded it will show a random ID. This PR sets it to zero in prod to clearly indicate an error.