### PR TITLE
[FEAT] Bull Run Megastore Item Boost

### DIFF
--- a/metadata/metadata.ts
+++ b/metadata/metadata.ts
@@ -15033,11 +15033,16 @@ export const OPEN_SEA_WEARABLES: Record<BumpkinItem, Metadata> = {
   },
   "Cowboy Hat": {
     description:
-      "A classic wide-brimmed hat with a rugged charm, perfect for life on the open plains. Protects from the sun while adding a touch of cowboy style.",
+      "A classic wide-brimmed hat with a rugged charm, perfect for life on the open plains. Protects from the sun while adding a touch of cowboy style. +1 Horseshoe from Deliveries during Bull Run Season.",
     decimals: 0,
     attributes: [
       { trait_type: "Part", value: "Hat" },
       { trait_type: "Tradable", value: "No" },
+      {
+        display_type: "boost_number",
+        trait_type: "Extra Horseshoe from Deliveries",
+        value: 1,
+      },
     ],
     external_url: "https://docs.sunflower-land.com/getting-started/about",
     image: "../public/wearables/images/396.png",
@@ -15045,11 +15050,16 @@ export const OPEN_SEA_WEARABLES: Record<BumpkinItem, Metadata> = {
   },
   "Cowboy Shirt": {
     description:
-      "This durable, checked shirt is made for the hardworking cowpoke.",
+      "This durable, checked shirt is made for the hardworking cowpoke. +1 Horseshoe from Bounties during Bull Run Season.",
     decimals: 0,
     attributes: [
       { trait_type: "Part", value: "Shirt" },
       { trait_type: "Tradable", value: "No" },
+      {
+        display_type: "boost_number",
+        trait_type: "Extra Horseshoe from Bounties",
+        value: 1,
+      },
     ],
     external_url: "https://docs.sunflower-land.com/getting-started/about",
     image: "../public/wearables/images/397.png",
@@ -15057,11 +15067,16 @@ export const OPEN_SEA_WEARABLES: Record<BumpkinItem, Metadata> = {
   },
   "Cowboy Trouser": {
     description:
-      "These sturdy trousers are built to withstand the wear and tear of ranch life, complete with a touch of style fit for a true cowboy.",
+      "These sturdy trousers are built to withstand the wear and tear of ranch life, complete with a touch of style fit for a true cowboy.  +1 Horseshoe from Chores during Bull Run Season.",
     decimals: 0,
     attributes: [
       { trait_type: "Part", value: "Pants" },
       { trait_type: "Tradable", value: "No" },
+      {
+        display_type: "boost_number",
+        trait_type: "Extra Horseshoe from Chores",
+        value: 1,
+      },
     ],
     external_url: "https://docs.sunflower-land.com/getting-started/about",
     image: "../public/wearables/images/398.png",

--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -5,6 +5,7 @@ import { Button } from "components/ui/Button";
 import { HudContainer } from "components/ui/HudContainer";
 import { Label } from "components/ui/Label";
 import { ButtonPanel, InnerPanel, Panel } from "components/ui/Panel";
+import { generateBountyTicket } from "features/game/events/landExpansion/sellBounty";
 import { Context } from "features/game/GameProvider";
 import { getAnimalLevel } from "features/game/lib/animals";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -18,6 +19,7 @@ import {
   InventoryItemName,
 } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { getSeasonalTicket } from "features/game/types/seasons";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
@@ -137,7 +139,12 @@ export const AnimalBounties: React.FC<Props> = ({ type, onExchanging }) => {
                           height: "25px",
                         }}
                       >
-                        {deal.items?.[name]}
+                        {name !== getSeasonalTicket()
+                          ? deal.items?.[name]
+                          : generateBountyTicket({
+                              game: state,
+                              bounty: deal,
+                            })}
                       </Label>
                     );
                   })}
@@ -158,6 +165,7 @@ export const AnimalDeal: React.FC<{
   onSold: () => void;
 }> = ({ deal, animal, onClose, onSold }) => {
   const { gameService } = useContext(Context);
+  const state = gameService.getSnapshot().context.state;
 
   const { t } = useAppTranslation();
   const sell = () => {
@@ -192,7 +200,12 @@ export const AnimalDeal: React.FC<{
 
           {getKeys(deal.items ?? {}).map((name) => {
             <Label key={name} type="warning" icon={ITEM_DETAILS[name].image}>
-              {deal.items?.[name]}
+              {name !== getSeasonalTicket()
+                ? deal.items?.[name]
+                : generateBountyTicket({
+                    game: state,
+                    bounty: deal,
+                  })}
             </Label>;
           })}
         </div>
@@ -202,7 +215,17 @@ export const AnimalDeal: React.FC<{
             ? t("bounties.sell.coins", { amount: deal.coins })
             : t("bounties.sell.items", {
                 amount: getKeys(deal.items ?? {})
-                  .map((name) => `${deal.items?.[name]} x ${name}`)
+                  .map(
+                    (name) =>
+                      `${
+                        name !== getSeasonalTicket()
+                          ? deal.items?.[name]
+                          : generateBountyTicket({
+                              game: state,
+                              bounty: deal,
+                            })
+                      } x ${name}`,
+                  )
                   .join(" - "),
               })}
         </p>

--- a/src/features/game/events/landExpansion/claimProduce.test.ts
+++ b/src/features/game/events/landExpansion/claimProduce.test.ts
@@ -349,6 +349,44 @@ describe("claimProduce", () => {
     expect(newState.inventory.Leather).toEqual(new Decimal(1.25));
   });
 
+  it("gives +0.5 yield for Milk for cows when a Milk Apron is being worn", () => {
+    const cowId = "123";
+
+    const newState = claimProduce({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin?.equipped,
+            coat: "Milk Apron",
+          },
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            [cowId]: {
+              coordinates: { x: 0, y: 0 },
+              id: cowId,
+              type: "Cow",
+              createdAt: 0,
+              state: "ready",
+              experience: 360,
+              asleepAt: 0,
+              lovedAt: 0,
+              item: "Petting Hand",
+            },
+          },
+        },
+      },
+      action: { type: "produce.claimed", animal: "Cow", id: cowId },
+      createdAt: now,
+    });
+
+    expect(newState.inventory.Milk).toEqual(new Decimal(1.5));
+    expect(newState.inventory.Leather).toEqual(new Decimal(1));
+  });
+
   it("gives +0.25 yield for all produce for sheep when a Cattlegrim is being worn", () => {
     const sheepId = "123";
 
@@ -837,6 +875,42 @@ describe("claimProduce", () => {
     expect(state.henHouse.animals["0"].asleepAt).toEqual(boostedAsleepAt);
   });
 
+  it("reduces the sleep time by 20% if Dream Scarf is worn and ready", () => {
+    const state = claimProduce({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin?.equipped,
+            necklace: "Dream Scarf",
+          },
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              state: "ready",
+              type: "Sheep",
+              experience: 60,
+            },
+          },
+        },
+      },
+      action: {
+        type: "produce.claimed",
+        animal: "Sheep",
+        id: "0",
+      },
+    });
+
+    const boostedAsleepAt = now - ANIMAL_SLEEP_DURATION * 0.2;
+
+    expect(state.barn.animals["0"].asleepAt).toEqual(boostedAsleepAt);
+  });
+
   it("reduces the sleep time by 10% for a Cow if player has Wrangler skill", () => {
     const state = claimProduce({
       createdAt: now,
@@ -851,6 +925,7 @@ describe("claimProduce", () => {
             "0": {
               ...INITIAL_FARM.barn.animals["0"],
               state: "ready",
+              type: "Cow",
               experience: 60,
             },
           },

--- a/src/features/game/events/landExpansion/completeChore.test.ts
+++ b/src/features/game/events/landExpansion/completeChore.test.ts
@@ -4,7 +4,7 @@ import "lib/__mocks__/configMock";
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { completeChore } from "./completeChore";
 import { ChoreV2 } from "features/game/types/game";
-import { SEASONS } from "features/game/types/seasons";
+import { getSeasonalTicket, SEASONS } from "features/game/types/seasons";
 import cloneDeep from "lodash.clonedeep";
 
 describe("chore.completed", () => {
@@ -560,5 +560,117 @@ describe("chore.completed", () => {
     });
 
     expect(state.inventory["Scroll"]).toEqual(new Decimal(6));
+  });
+
+  it("provides +1 tickets when Cowboy Hat is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            pants: "Cowboy Trouser",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
+  });
+
+  it("does not provide +1 tickets when Cowboy Hat is worn outside Bull Run Season", () => {
+    const mockDate = new Date("2024-10-30T15:00:00Z").getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            pants: "Cowboy Trouser",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
   });
 });

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -1,6 +1,8 @@
 import Decimal from "decimal.js-light";
+import { isWearableActive } from "features/game/lib/wearables";
 import { ChoreV2Name, GameState } from "features/game/types/game";
 import {
+  getCurrentSeason,
   getSeasonalBanner,
   getSeasonalTicket,
 } from "features/game/types/seasons";
@@ -34,6 +36,13 @@ export function generateChoreTickets({
     !!game.inventory["Lifetime Farmer Banner"]
   ) {
     amount += 2;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Trouser" })
+  ) {
+    amount += 1;
   }
 
   return amount;

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -935,6 +935,94 @@ describe("deliver", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(3));
   });
 
+  it("provides +1 tickets when Cowboy Hat is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...TEST_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2024-11-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("does not provide +1 tickets when Cowboy Hat is worn outside Bull Run Season", () => {
+    const mockDate = new Date("2024-10-30T15:00:00Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...TEST_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2024-10-29T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
+  });
+
   it("add 20% coins bonus if has Betty's Friend skill on Betty's orders with Coins reward", () => {
     const state = deliverOrder({
       state: {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -5,6 +5,7 @@ import { getKeys } from "features/game/types/craftables";
 import { GameState, Inventory, NPCData, Order } from "features/game/types/game";
 import { BUMPKIN_GIFTS } from "features/game/types/gifts";
 import {
+  getCurrentSeason,
   getSeasonalBanner,
   getSeasonalTicket,
 } from "features/game/types/seasons";
@@ -51,6 +52,13 @@ export function generateDeliveryTickets({
     !!game.inventory["Lifetime Farmer Banner"]
   ) {
     amount += 2;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Hat" })
+  ) {
+    amount += 1;
   }
 
   const completedAt = game.npcs?.[npc]?.deliveryCompletedAt;

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1979,6 +1979,45 @@ describe("getCropTime", () => {
     );
   });
 
+  it("adds +2 barley with Sheaf of Plenty placed", () => {
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Barley Seed": new Decimal(1),
+        },
+        collectibles: {
+          "Sheaf of Plenty": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: dateNow - 10000,
+              readyAt: dateNow - 10000,
+              id: "123",
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "seed.planted",
+        cropId: "123",
+        index: "0",
+        item: "Barley Seed",
+      },
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+    expect((plots as Record<number, CropPlot>)[0].crop).toEqual(
+      expect.objectContaining({
+        name: "Barley",
+        plantedAt: expect.any(Number),
+        amount: 3,
+      }),
+    );
+  });
+
   it("applies a +5% speed boost with Green Thumb 2 skill", () => {
     const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -457,6 +457,13 @@ export function getCropYieldAmount({
     amount += 0.1;
   }
 
+  if (
+    crop === "Barley" &&
+    isCollectibleBuilt({ name: "Sheaf of Plenty", game })
+  ) {
+    amount += 2;
+  }
+
   const collectibles = game.collectibles;
 
   if (

--- a/src/features/game/events/landExpansion/sellBounty.test.ts
+++ b/src/features/game/events/landExpansion/sellBounty.test.ts
@@ -1,11 +1,13 @@
 import Decimal from "decimal.js-light";
+import "lib/__mocks__/configMock";
 import { GameState } from "features/game/types/game";
 import { sellBounty, SellBountyAction } from "./sellBounty";
-import { INITIAL_FARM } from "features/game/lib/constants";
+import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+import { getSeasonalTicket } from "features/game/types/seasons";
 
 describe("sellBounty", () => {
   const GAME_STATE: GameState = {
-    ...INITIAL_FARM,
+    ...TEST_FARM,
     inventory: {
       "Blue Balloon Flower": new Decimal(1),
     },
@@ -17,6 +19,20 @@ describe("sellBounty", () => {
           coins: 100,
           items: {
             "Sunflower Seed": 10,
+          },
+        },
+        {
+          id: "2",
+          name: "Blue Balloon Flower",
+          items: {
+            "Amber Fossil": 1,
+          },
+        },
+        {
+          id: "3",
+          name: "Blue Balloon Flower",
+          items: {
+            Horseshoe: 1,
           },
         },
       ],
@@ -93,6 +109,58 @@ describe("sellBounty", () => {
     const result = sellBounty({ state: GAME_STATE, action });
 
     expect(result.inventory["Sunflower Seed"]).toEqual(new Decimal(10));
+  });
+
+  it("rewards Amber Fossil", () => {
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "2",
+    };
+
+    const result = sellBounty({ state: GAME_STATE, action });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
+  });
+
+  it("rewards Horseshoe at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "3",
+    };
+
+    const result = sellBounty({ state: GAME_STATE, action });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
+  });
+
+  it("rewards +1 Horseshoe when Cowboy Shirt is worn during Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "3",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            shirt: "Cowboy Shirt",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
   });
 
   it("subtracts the item", () => {

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -1,8 +1,14 @@
 import Decimal from "decimal.js-light";
+import { isWearableActive } from "features/game/lib/wearables";
 import { getKeys } from "features/game/types/decorations";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { GameState } from "features/game/types/game";
+import { BountyRequest, GameState } from "features/game/types/game";
+import {
+  getCurrentSeason,
+  getSeasonalTicket,
+} from "features/game/types/seasons";
 import { produce } from "immer";
+import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 
 export type SellBountyAction = {
   type: "bounty.sold";
@@ -13,12 +19,37 @@ type Options = {
   state: GameState;
   action: SellBountyAction;
   createdAt?: number;
+  farmId?: number;
 };
+
+export function generateBountyTicket({
+  game,
+  bounty,
+}: {
+  game: GameState;
+  bounty: BountyRequest;
+}) {
+  let amount = bounty.items?.[getSeasonalTicket()] ?? 0;
+
+  if (!amount) {
+    return 0;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Shirt" })
+  ) {
+    amount += 1;
+  }
+
+  return amount;
+}
 
 export function sellBounty({
   state,
   action,
   createdAt = Date.now(),
+  farmId = 0,
 }: Options): GameState {
   return produce(state, (draft) => {
     const request = draft.bounties.requests.find(
@@ -36,6 +67,22 @@ export function sellBounty({
       throw new Error("Bounty already completed");
     }
 
+    const { ticketTasksAreFrozen } = getSeasonChangeover({
+      now: createdAt,
+      id: farmId as number,
+    });
+
+    const tickets = generateBountyTicket({
+      game: draft,
+      bounty: request,
+    });
+
+    const isTicketOrder = tickets > 0;
+
+    if (isTicketOrder && ticketTasksAreFrozen) {
+      throw new Error("Ticket tasks are frozen");
+    }
+
     // Remove the item from the inventory
     const item = draft.inventory[request.name];
     if (!item || item.lte(0)) {
@@ -50,7 +97,10 @@ export function sellBounty({
 
     getKeys(request.items ?? {}).forEach((name) => {
       const previous = draft.inventory[name] ?? new Decimal(0);
-      draft.inventory[name] = previous.add(request.items?.[name] ?? 0);
+      const seasonalTicket = getSeasonalTicket();
+      if (tickets > 0 && seasonalTicket === name) {
+        draft.inventory[name] = previous.add(tickets ?? 0);
+      } else draft.inventory[name] = previous.add(request.items?.[name] ?? 0);
     });
 
     // Mark bounty as completed

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -158,6 +158,16 @@ function getEggYieldBoosts(game: GameState) {
   return boost;
 }
 
+function getMilkYieldBoosts(game: GameState) {
+  let boost = 0;
+
+  if (isWearableActive({ name: "Milk Apron", game })) {
+    boost += 0.5;
+  }
+
+  return boost;
+}
+
 export function getResourceDropAmount({
   game,
   animalType,
@@ -170,10 +180,16 @@ export function getResourceDropAmount({
   const { bumpkin, buds = {} } = game;
 
   const isChicken = animalType === "Chicken";
+  const isCow = animalType === "Cow";
 
   // Egg yield boosts
   if (isChicken && resource === "Egg") {
     amount += getEggYieldBoosts(game);
+  }
+
+  // Milk Yield Boost
+  if (isCow && resource === "Milk") {
+    amount += getMilkYieldBoosts(game);
   }
 
   // Cattlegrim boosts all produce
@@ -231,6 +247,7 @@ export function getBoostedAsleepAt({
   const { bumpkin } = game;
 
   const isChicken = animalType === "Chicken";
+  const isSheep = animalType === "Sheep";
 
   if (isChicken) {
     if (isCollectibleBuilt({ name: "Speed Chicken", game })) {
@@ -239,6 +256,12 @@ export function getBoostedAsleepAt({
 
     if (isCollectibleBuilt({ name: "El Pollo Veloz", game })) {
       asleepAt -= 2 * 60 * 60 * 1000;
+    }
+  }
+
+  if (isSheep) {
+    if (isWearableActive({ name: "Dream Scarf", game })) {
+      asleepAt -= sleepDuration * 0.2;
     }
   }
 

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -530,6 +530,24 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: chefHat,
     },
+    "Cowboy Hat": {
+      shortDescription: translate("description.cowboyHat.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Horseshoe.image,
+    },
+    "Cowboy Shirt": {
+      shortDescription: translate("description.cowboyShirt.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Horseshoe.image,
+    },
+    "Cowboy Trouser": {
+      shortDescription: translate("description.cowboyTrouser.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Horseshoe.image,
+    },
     "Milk Apron": {
       shortDescription: translate("description.milkApron.boost"),
       labelType: "info",

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -530,5 +530,18 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: chefHat,
     },
+    "Milk Apron": {
+      shortDescription: translate("description.milkApron.boost"),
+      labelType: "info",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.milk,
+    },
+    "Dream Scarf": {
+      shortDescription: translate("description.dreamScarf.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
+    },
+
     ...SPECIAL_ITEM_LABELS,
   };

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -738,4 +738,11 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     labelType: "success",
     boostTypeIcon: powerup,
   },
+  // Bull Run
+  "Sheaf of Plenty": {
+    shortDescription: translate("description.sheafOfPlenty.boost"),
+    labelType: "success",
+    boostTypeIcon: powerup,
+    boostedItemIcon: CROP_LIFECYCLE.Barley.crop,
+  },
 };

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -39,6 +39,7 @@ import { translate } from "lib/i18n/translate";
 import { canDrillOilReserve } from "../events/landExpansion/drillOilReserve";
 import { getKeys } from "./decorations";
 import { BED_FARMHAND_COUNT } from "./beds";
+import { ANIMAL_SLEEP_DURATION } from "../events/landExpansion/feedAnimal";
 
 export type Restriction = [boolean, string];
 type RemoveCondition = (gameState: GameState) => Restriction;
@@ -242,6 +243,28 @@ export function areAnyChickensFed(game: GameState): Restriction {
   );
 
   return [chickensAreFed, translate("restrictionReason.chickensFed")];
+}
+
+export function areAnySheepsFed(game: GameState): Restriction {
+  const sheepAreFed = Object.values(game.barn.animals).some(
+    (animal) =>
+      animal.asleepAt &&
+      animal.type === "Sheep" &&
+      Date.now() - animal.asleepAt < ANIMAL_SLEEP_DURATION,
+  );
+
+  return [sheepAreFed, translate("restrictionReason.sheepFed")];
+}
+
+export function areAnyCowsFed(game: GameState): Restriction {
+  const cowAreFed = Object.values(game.barn.animals).some(
+    (animal) =>
+      animal.asleepAt &&
+      animal.type === "Cow" &&
+      Date.now() - animal.asleepAt < ANIMAL_SLEEP_DURATION,
+  );
+
+  return [cowAreFed, translate("restrictionReason.cowFed")];
 }
 
 const MAX_DIGS = 25;
@@ -560,6 +583,9 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Cow Bed": (game) => isFarmhandUsingBed("Cow Bed", game),
   "Pirate Bed": (game) => isFarmhandUsingBed("Pirate Bed", game),
   "Royal Bed": (game) => isFarmhandUsingBed("Royal Bed", game),
+
+  // Bull Run
+  "Sheaf of Plenty": (game) => cropIsGrowing({ item: "Barley", game }),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -16,6 +16,8 @@ import {
   areBonusTreasureHolesDug,
   areAnyCropsOrGreenhouseCropsGrowing,
   hasOpenedPirateChest,
+  areAnySheepsFed,
+  areAnyCowsFed,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -77,6 +79,8 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
   "Hornet Mask": (state) => isBeehivesFull(state)[0],
   "Ancient Shovel": (state) => areBonusTreasureHolesDug(state)[0],
   "Pirate Potion": (state) => !hasOpenedPirateChest(state)[0],
+  "Dream Scarf": (state) => !areAnySheepsFed(state)[0],
+  "Milk Apron": (state) => !areAnyCowsFed(state)[0],
 };
 
 export const canWithdrawBoostedWearable = (

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1706,9 +1706,13 @@ export const BUMPKIN_WITHDRAWABLES: Record<
   "Chicken Suit": () => false,
   "Cowgirl Skirt": () => hasSeasonEnded("Bull Run"),
   "Merino Jumper": () => false,
-  "Dream Scarf": () => hasSeasonEnded("Bull Run"),
+  "Dream Scarf": (state) =>
+    canWithdrawBoostedWearable("Dream Scarf", state) &&
+    hasSeasonEnded("Bull Run"),
   "Cowbell Necklace": () => false,
-  "Milk Apron": () => hasSeasonEnded("Bull Run"),
+  "Milk Apron": (state) =>
+    canWithdrawBoostedWearable("Milk Apron", state) &&
+    hasSeasonEnded("Bull Run"),
   "Shepherd Staff": () => false,
   "Sol & Luna": () => false,
   "Fossil Armor": () => false,

--- a/src/features/world/ui/flowerShop/FlowerBounties.tsx
+++ b/src/features/world/ui/flowerShop/FlowerBounties.tsx
@@ -6,6 +6,7 @@ import { Label } from "components/ui/Label";
 import { ButtonPanel, Panel } from "components/ui/Panel";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
+import { generateBountyTicket } from "features/game/events/landExpansion/sellBounty";
 import { Context } from "features/game/GameProvider";
 import { weekResetsAt } from "features/game/lib/factions";
 import { MachineState } from "features/game/lib/gameMachine";
@@ -13,6 +14,7 @@ import { getKeys } from "features/game/types/decorations";
 import { FLOWERS } from "features/game/types/flowers";
 import { BountyRequest } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { getSeasonalTicket } from "features/game/types/seasons";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -149,7 +151,12 @@ export const FlowerBounties: React.FC<Props> = ({ onClose }) => {
                               type="warning"
                               icon={ITEM_DETAILS[name].image}
                             >
-                              {deal.items?.[name]}
+                              {name !== getSeasonalTicket()
+                                ? deal.items?.[name]
+                                : generateBountyTicket({
+                                    game: state,
+                                    bounty: deal,
+                                  })}
                             </Label>
                           );
                         })}
@@ -175,6 +182,7 @@ const Deal: React.FC<{
   onSold: () => void;
 }> = ({ deal, onClose, onSold }) => {
   const { gameService } = useContext(Context);
+  const state = gameService.getSnapshot().context.state;
 
   const { t } = useAppTranslation();
   const sell = () => {
@@ -208,7 +216,12 @@ const Deal: React.FC<{
 
           {getKeys(deal.items ?? {}).map((name) => (
             <Label key={name} type="warning" icon={ITEM_DETAILS[name].image}>
-              {deal.items?.[name]}
+              {name !== getSeasonalTicket()
+                ? deal.items?.[name]
+                : generateBountyTicket({
+                    game: state,
+                    bounty: deal,
+                  })}
             </Label>
           ))}
         </div>
@@ -218,7 +231,17 @@ const Deal: React.FC<{
             ? t("bounties.sell.coins", { amount: deal.coins })
             : t("bounties.sell.items", {
                 amount: getKeys(deal.items ?? {})
-                  .map((name) => `${deal.items?.[name]} x ${name}`)
+                  .map(
+                    (name) =>
+                      `${
+                        name !== getSeasonalTicket()
+                          ? deal.items?.[name]
+                          : generateBountyTicket({
+                              game: state,
+                              bounty: deal,
+                            })
+                      } x ${name}`,
+                  )
                   .join(" - "),
               })}
         </p>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4087,5 +4087,13 @@
   "description.sleepyRug": "Cozy and inviting, this soft rug is perfect for an afternoon nap. It adds warmth and charm to any space.",
   "description.meteorite": "A rare and mysterious fragment from the stars, the meteorite is rumored to hold cosmic power.",
   "description.sheafOfPlenty": "A bundle of barley harvested at peak ripeness, symbolizing abundance and the hard work of the season. +2 Barley",
-  "description.mechanicalBull": "A lively attraction and test of endurance! Hop on the Mechanical Bull and see if you can hold on."
+  "description.mechanicalBull": "A lively attraction and test of endurance! Hop on the Mechanical Bull and see if you can hold on.",
+  "description.dreamScarf.boost": "-20% Sheep Production Time",
+  "description.cowboyHat.boost": " +1 Horseshoe from Deliveries",
+  "description.cowboyShirt.boost": " +1 Horseshoe from Bounties",
+  "description.cowboyTrouser.boost": " +1 Horseshoe from Chores",
+  "description.milkApron.boost": "+0.5 Milk",
+  "description.sheafOfPlenty.boost": "+2 Barley",
+  "restrictionReason.sheepFed": "Sheeps are fed",
+  "restrictionReason.cowFed": "Cows are fed"
 }


### PR DESCRIPTION
# Description
This PR adds Boosts for the Auction Items in Pharaoh's Treasure:
- "Cowboy Hat": +1 Horseshoes from Deliveries
- "Cowboy Shirt": +1 Horseshoes from Bounties
- "Cowboy Trouser": +1 Horseshoes from Chores
- "Dream Scarf":  Time boost (20% reduction in Sheep sleep time)
- "Milk Apron": +0.5 Milk
- "Sheaf of Plenty":  +2 Barley

The follwing features/fixes is also added in this PR:
Old Megastore Modal/UI will be hidden next Season
Withdrawal + Removable Restriction for Megastore Items
Bounty Ticket Boost added for Bounties.
UI logic for Ticket Boost.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
