### PR TITLE
[FEAT] Double Delivery hint

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1314,7 +1314,7 @@ describe("deliver", () => {
             {
               id: "123",
               createdAt: 0,
-              readyAt: Date.now(),
+              readyAt: new Date("2024-09-10").getTime(),
               from: "tango",
               items: {
                 Orange: 5,
@@ -1323,13 +1323,14 @@ describe("deliver", () => {
               reward: { coins: 320 },
             },
           ],
-          doubleDelivery: true,
+          doubleDelivery: "2024-09-10",
         },
       },
       action: {
         id: "123",
         type: "order.delivered",
       },
+      createdAt: new Date("2024-09-10").getTime(),
     });
 
     expect(state.coins).toEqual(640);
@@ -1350,7 +1351,7 @@ describe("deliver", () => {
             {
               id: "123",
               createdAt: 0,
-              readyAt: Date.now(),
+              readyAt: new Date("2024-09-10").getTime(),
               from: "guria",
               items: {
                 Orange: 5,
@@ -1359,13 +1360,14 @@ describe("deliver", () => {
               reward: { sfl: 1 },
             },
           ],
-          doubleDelivery: true,
+          doubleDelivery: "2024-09-10",
         },
       },
       action: {
         id: "123",
         type: "order.delivered",
       },
+      createdAt: new Date("2024-09-10").getTime(),
     });
 
     expect(state.balance).toEqual(new Decimal(2));
@@ -1383,19 +1385,20 @@ describe("deliver", () => {
             {
               id: "123",
               createdAt: 0,
-              readyAt: Date.now(),
+              readyAt: new Date("2024-09-10").getTime(),
               from: "tywin",
               items: { coins: 6400 },
               reward: {},
             },
           ],
-          doubleDelivery: true,
+          doubleDelivery: "2024-09-10",
         },
       },
       action: {
         id: "123",
         type: "order.delivered",
       },
+      createdAt: new Date("2024-09-10").getTime(),
     });
 
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(10));

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -63,12 +63,14 @@ export function generateDeliveryTickets({
 
   const completedAt = game.npcs?.[npc]?.deliveryCompletedAt;
 
+  const dateKey = new Date(now).toISOString().substring(0, 10);
+
   const hasClaimedBonus =
     !!completedAt &&
-    new Date(completedAt).toISOString().substring(0, 10) ===
-      new Date().toISOString().substring(0, 10);
+    new Date(completedAt).toISOString().substring(0, 10) === dateKey;
+
   // Leave this at the end as it will multiply the whole amount by 2
-  if (game.delivery.doubleDelivery === true && !hasClaimedBonus) {
+  if (game.delivery.doubleDelivery === dateKey && !hasClaimedBonus) {
     amount *= 2;
   }
 
@@ -262,12 +264,13 @@ export function getOrderSellPrice<T>(game: GameState, order: Order): T {
 
   const completedAt = game.npcs?.[order.from]?.deliveryCompletedAt;
 
+  const dateKey = new Date().toISOString().substring(0, 10);
   const hasClaimedBonus =
     !!completedAt &&
-    new Date(completedAt).toISOString().substring(0, 10) ===
-      new Date().toISOString().substring(0, 10);
+    new Date(completedAt).toISOString().substring(0, 10) === dateKey;
+
   // Leave this at the end as it will multiply the whole amount by 2
-  if (game.delivery.doubleDelivery === true && !hasClaimedBonus) {
+  if (game.delivery.doubleDelivery === dateKey && !hasClaimedBonus) {
     mul *= 2;
   }
 

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -192,7 +192,11 @@ export function populateOrders(
   return orders;
 }
 
-export function getOrderSellPrice<T>(game: GameState, order: Order): T {
+export function getOrderSellPrice<T>(
+  game: GameState,
+  order: Order,
+  now: Date = new Date(),
+): T {
   let mul = 1;
 
   // Michelin Stars - 5% bonus
@@ -264,7 +268,7 @@ export function getOrderSellPrice<T>(game: GameState, order: Order): T {
 
   const completedAt = game.npcs?.[order.from]?.deliveryCompletedAt;
 
-  const dateKey = new Date().toISOString().substring(0, 10);
+  const dateKey = new Date(now).toISOString().substring(0, 10);
   const hasClaimedBonus =
     !!completedAt &&
     new Date(completedAt).toISOString().substring(0, 10) === dateKey;
@@ -356,14 +360,18 @@ export function deliverOrder({
     });
 
     if (order.reward.sfl) {
-      const sfl = getOrderSellPrice<Decimal>(game, order);
+      const sfl = getOrderSellPrice<Decimal>(game, order, new Date(createdAt));
       game.balance = game.balance.add(sfl);
 
       bumpkin.activity = trackActivity("SFL Earned", bumpkin.activity, sfl);
     }
 
     if (order.reward.coins) {
-      const coinsReward = getOrderSellPrice<number>(game, order);
+      const coinsReward = getOrderSellPrice<number>(
+        game,
+        order,
+        new Date(createdAt),
+      );
 
       game.coins = game.coins + coinsReward;
 

--- a/src/features/game/events/landExpansion/startCompetition.test.ts
+++ b/src/features/game/events/landExpansion/startCompetition.test.ts
@@ -86,7 +86,6 @@ describe("startCompetition", () => {
           fulfilledCount: 177,
           milestone: {} as any,
           orders: [],
-          doubleDelivery: false,
         },
         island: {
           type: "spring",

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -671,7 +671,6 @@ export const INITIAL_FARM: GameState = {
       goal: 10,
       total: 10,
     },
-    doubleDelivery: false,
   },
   farmActivity: {},
   milestones: {},
@@ -864,7 +863,6 @@ export const TEST_FARM: GameState = {
       goal: 10,
       total: 10,
     },
-    doubleDelivery: false,
   },
   auctioneer: {},
   buildings: {
@@ -1085,7 +1083,6 @@ export const EMPTY: GameState = {
       goal: 10,
       total: 10,
     },
-    doubleDelivery: false,
   },
   home: { collectibles: {} },
   island: { type: "basic" },

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -1006,7 +1006,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
       total: 10,
       claimedAt: new Date("2024-02-15").getTime(),
     },
-    doubleDelivery: false,
   },
 
   ...INITIAL_RESOURCES,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -844,7 +844,7 @@ export type Delivery = {
     total: number;
     claimedAt?: number;
   };
-  doubleDelivery: boolean;
+  doubleDelivery?: string;
 };
 
 export type DailyRewards = {

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -441,7 +441,8 @@ export const DeliveryOrders: React.FC<Props> = ({
         <div className="p-1">
           <div className="flex justify-between gap-1 flex-row w-full">
             <Label type="default">{t("deliveries")}</Label>
-            {state.delivery.doubleDelivery === true && (
+            {state.delivery.doubleDelivery ===
+              new Date().toISOString().substring(0, 10) && (
               <Label type="vibrant" icon={lightning}>
                 {t("double.rewards.deliveries")}
               </Label>
@@ -780,11 +781,13 @@ export const DeliveryOrders: React.FC<Props> = ({
                 </Label>
               </div>
               <div className="mb-1">
-                {state.delivery.doubleDelivery === true && !hasClaimedBonus && (
-                  <Label type="vibrant" icon={lightning}>
-                    {t("2x.rewards")}
-                  </Label>
-                )}
+                {state.delivery.doubleDelivery ===
+                  new Date().toISOString().substring(0, 10) &&
+                  !hasClaimedBonus && (
+                    <Label type="vibrant" icon={lightning}>
+                      {t("2x.rewards")}
+                    </Label>
+                  )}
               </div>
               <div>
                 {!previewOrder.completedAt &&

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -616,6 +616,16 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
 
   if (delivery?.completedAt) {
     message = t("bumpkin.delivery.waiting");
+
+    if (
+      npc === "pumpkin' pete" &&
+      (game.npcs?.[npc]?.friendship?.points ?? 0) > 2 &&
+      game.delivery.doubleDelivery !== new Date().toISOString().substring(0, 10)
+    ) {
+      message = t("double.delivery.hint", {
+        date: game.delivery.doubleDelivery ?? "",
+      });
+    }
   }
 
   if (!delivery || (!!tickets && ticketTasksAreFrozen)) {

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -706,7 +706,9 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
             <div className="px-2 ">
               <div className="flex flex-col justify-between items-stretch mb-2 gap-1">
                 <div className="flex flex-row justify-between w-full">
-                  {game.delivery.doubleDelivery === true && !hasClaimedBonus ? (
+                  {game.delivery.doubleDelivery ===
+                    new Date().toISOString().substring(0, 10) &&
+                  !hasClaimedBonus ? (
                     <Label type="vibrant" icon={lightning}>
                       {t("double.rewards.delivery")}
                     </Label>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4095,5 +4095,6 @@
   "description.milkApron.boost": "+0.5 Milk",
   "description.sheafOfPlenty.boost": "+2 Barley",
   "restrictionReason.sheepFed": "Sheeps are fed",
-  "restrictionReason.cowFed": "Cows are fed"
+  "restrictionReason.cowFed": "Cows are fed",
+  "double.delivery.hint": "Pssssst...there will be double rewards for deliveries on {{date}}."
 }


### PR DESCRIPTION
# Description

To help players plan during the season (and remove RNG), give them a hint when the Double Delivery day will be.

This will only show if:

1. You are friends with Pumpkin Pete (friendship points > 50)
2. You have completed his delivery

<img width="567" alt="Screenshot 2024-10-30 at 2 38 00 PM" src="https://github.com/user-attachments/assets/bca32cbd-bb9f-4137-9d6e-e33ab59330af">
