### PR TITLE
[FEAT] Megastore Key Restrictions

### DIFF
--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -3,7 +3,7 @@ import { getKeys } from "features/game/types/craftables";
 import { GameState, InventoryItemName, Keys } from "features/game/types/game";
 
 import { produce } from "immer";
-import { getCurrentSeason } from "features/game/types/seasons";
+import { getCurrentSeason, SEASONS } from "features/game/types/seasons";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import {
   MEGASTORE,
@@ -60,40 +60,37 @@ export function buySeasonalItem({
       throw new Error("Item not found in the seasonal store");
     }
 
-    const tierData =
-      tier === "basic"
-        ? seasonalStore["basic"].items
-        : tier === "rare"
-          ? seasonalStore["basic"].items
-          : tier === "epic"
-            ? seasonalStore["rare"].items
-            : seasonalStore["basic"].items;
-    const seasonalCollectiblesCrafted = getKeys(stateCopy.inventory).filter(
-      (itemName) =>
-        tierData.some((item) =>
-          "wearable" in item
-            ? item.wearable === itemName
-            : item.collectible === itemName,
-        ),
-    ).length;
-
-    const seasonalWearablesCrafted = getKeys(stateCopy.wardrobe).filter(
-      (itemName) =>
-        tierData.some((item) =>
-          "wearable" in item
-            ? item.wearable === itemName
-            : item.collectible === itemName,
-        ),
-    ).length;
-
+    const seasonalCollectiblesCrafted = getSeasonalItemsCrafted(
+      state,
+      "inventory",
+      seasonalStore,
+      "collectible",
+      tier,
+      true,
+    );
+    const seasonalWearablesCrafted = getSeasonalItemsCrafted(
+      state,
+      "wardrobe",
+      seasonalStore,
+      "wearable",
+      tier,
+      true,
+    );
     const seasonalItemsCrafted =
       seasonalCollectiblesCrafted + seasonalWearablesCrafted;
+
+    const isKey = (name: InventoryItemName): name is Keys =>
+      name in ARTEFACT_SHOP_KEYS;
+    const keyBoughtAt =
+      stateCopy.pumpkinPlaza.keysBought?.megastore[name as Keys]?.boughtAt;
+
+    const reduction = isKeyBoughtWithinSeason(state, tier, true) ? 0 : 1;
 
     // Check if player meets the tier requirement
     if (tier !== "basic") {
       if (
         tier === "rare" &&
-        seasonalItemsCrafted < seasonalStore.rare.requirement
+        seasonalItemsCrafted - reduction < seasonalStore.rare.requirement
       ) {
         throw new Error(
           "You need to buy more basic items to unlock rare items",
@@ -102,10 +99,10 @@ export function buySeasonalItem({
 
       if (
         tier === "epic" &&
-        seasonalItemsCrafted < seasonalStore.epic.requirement
+        seasonalItemsCrafted - reduction < seasonalStore.rare.requirement
       ) {
         throw new Error(
-          "You need to buy more basic items to unlock epic items",
+          "You need to buy more basic and rare items to unlock epic items",
         );
       }
     }
@@ -146,14 +143,8 @@ export function buySeasonalItem({
       stateCopy.wardrobe[item.wearable] = current + 1;
     }
 
-    const isKey = (name: InventoryItemName): name is Keys =>
-      name in ARTEFACT_SHOP_KEYS;
-
     // This is where the key is bought
-
     if (isKey(name as InventoryItemName)) {
-      const keyBoughtAt =
-        stateCopy.pumpkinPlaza.keysBought?.megastore[name as Keys]?.boughtAt;
       if (keyBoughtAt) {
         const currentTime = new Date(createdAt).toISOString().slice(0, 10);
         const lastBoughtTime = new Date(keyBoughtAt).toISOString().slice(0, 10);
@@ -175,7 +166,98 @@ export function buySeasonalItem({
         boughtAt: createdAt,
       };
     }
-
     return stateCopy;
   });
+}
+
+// Function to assess if key is bought within the current season
+export function isKeyBoughtWithinSeason(
+  game: GameState,
+  tier: keyof SeasonalStore,
+  isLowerTier = false,
+) {
+  const tierKey =
+    isLowerTier && tier === "rare"
+      ? "Treasure Key"
+      : isLowerTier && tier === "epic"
+        ? "Rare Key"
+        : tier === "basic"
+          ? "Treasure Key"
+          : tier === "rare"
+            ? "Rare Key"
+            : "Luxury Key";
+
+  const keyBoughtAt =
+    game.pumpkinPlaza.keysBought?.megastore[tierKey as Keys]?.boughtAt;
+  const seasonTime = SEASONS[getCurrentSeason()];
+
+  if (keyBoughtAt) {
+    const isWithinSeason =
+      new Date(keyBoughtAt) >= seasonTime.startDate &&
+      new Date(keyBoughtAt) <= seasonTime.endDate;
+
+    return isWithinSeason;
+  }
+
+  return false;
+}
+
+const tierMapping: Record<keyof SeasonalStore, keyof SeasonalStore> = {
+  basic: "basic",
+  rare: "basic",
+  epic: "rare",
+};
+
+//Gets lower Tier
+export function getLowerTier(tiers: keyof SeasonalStore, isLowerTier = true) {
+  const selectedTier = isLowerTier ? tierMapping[tiers] : tiers;
+  return selectedTier;
+}
+
+export function getStore(
+  seasonalStore: SeasonalStore,
+  tiers: keyof SeasonalStore,
+  isLowerTier = false,
+) {
+  // Select lower tier if isLowerTier is true, otherwise select the provided tier
+  const selectedTier = isLowerTier ? tierMapping[tiers] : tiers;
+  return seasonalStore[selectedTier];
+}
+
+export function getTierItems(
+  seasonalStore: SeasonalStore,
+  tiers: keyof SeasonalStore,
+  isLowerTier = false,
+): SeasonalStoreItem[] {
+  // Select lower tier if isLowerTier is true, otherwise select the provided tier
+  const selectedTier = isLowerTier ? tierMapping[tiers] : tiers;
+  return seasonalStore[selectedTier].items;
+}
+
+export function getSeasonalItemsCrafted(
+  game: GameState,
+  items: "wardrobe" | "inventory",
+  seasonalStore: SeasonalStore,
+  itemType: "collectible" | "wearable",
+  tier: keyof SeasonalStore,
+  isLowerTier = false,
+) {
+  const tierItems = getTierItems(seasonalStore, tier, isLowerTier);
+  if (!tierItems) return 0;
+
+  const craftedItems = getKeys(game[items]).filter((itemName) =>
+    tierItems.some(
+      (tierItem: SeasonalStoreItem) =>
+        (itemType === "collectible" &&
+          "collectible" in tierItem &&
+          tierItem.collectible === itemName) ||
+        (itemType === "wearable" &&
+          "wearable" in tierItem &&
+          tierItem.wearable === itemName) ||
+        0,
+    ),
+  );
+  if (!craftedItems) return 0;
+
+  return craftedItems.length > 0 ? craftedItems.length : 0;
 }

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
@@ -33,6 +33,10 @@ import { getItemDescription } from "../SeasonalStore";
 import { getKeys } from "features/game/types/craftables";
 import { ARTEFACT_SHOP_KEYS } from "features/game/types/collectibles";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
+import {
+  getSeasonalItemsCrafted,
+  isKeyBoughtWithinSeason,
+} from "features/game/events/landExpansion/buySeasonalItem";
 
 interface ItemOverlayProps {
   item: SeasonalStoreItem | null;
@@ -47,7 +51,6 @@ interface ItemOverlayProps {
 
 const _sflBalance = (state: MachineState) => state.context.state.balance;
 const _inventory = (state: MachineState) => state.context.state.inventory;
-const _wardrobe = (state: MachineState) => state.context.state.wardrobe;
 const _keysBought = (state: MachineState) =>
   state.context.state.pumpkinPlaza.keysBought;
 
@@ -64,7 +67,6 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
   const { shortcutItem, gameService, showAnimations } = useContext(Context);
   const sflBalance = useSelector(gameService, _sflBalance);
   const inventory = useSelector(gameService, _inventory);
-  const wardrobe = useSelector(gameService, _wardrobe);
   const keysBought = useSelector(gameService, _keysBought);
 
   const [imageWidth, setImageWidth] = useState<number>(0);
@@ -83,36 +85,30 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
   const tiers =
     tier === "basic"
       ? "basic"
-      : tier === "epic"
-        ? "epic"
-        : tier === "rare"
-          ? "rare"
+      : tier === "rare"
+        ? "rare"
+        : tier === "epic"
+          ? "epic"
           : "basic";
 
-  const tierItems =
-    tiers === "basic"
-      ? seasonalStore["basic"].items
-      : tiers === "rare"
-        ? seasonalStore["basic"].items
-        : tiers === "epic"
-          ? seasonalStore["rare"].items
-          : seasonalStore["basic"].items;
-  const seasonalCollectiblesCrafted = getKeys(inventory).filter((itemName) =>
-    tierItems.some((items: SeasonalStoreItem) =>
-      "collectible" in items ? items.collectible === itemName : false,
-    ),
-  ).length;
-  const seasonalWearablesCrafted = getKeys(wardrobe).filter((itemName) =>
-    tierItems.some((items: SeasonalStoreItem) =>
-      "wearable" in items ? items.wearable === itemName : false,
-    ),
-  ).length;
-
+  const seasonalCollectiblesCrafted = getSeasonalItemsCrafted(
+    state,
+    "inventory",
+    seasonalStore,
+    "collectible",
+    tiers,
+    true,
+  );
+  const seasonalWearablesCrafted = getSeasonalItemsCrafted(
+    state,
+    "wardrobe",
+    seasonalStore,
+    "wearable",
+    tiers,
+    true,
+  );
   const seasonalItemsCrafted =
     seasonalCollectiblesCrafted + seasonalWearablesCrafted;
-
-  const isRareUnlocked = seasonalItemsCrafted >= seasonalStore.rare.requirement;
-  const isEpicUnlocked = seasonalItemsCrafted >= seasonalStore.epic.requirement;
 
   const itemName = item
     ? isWearable
@@ -122,6 +118,15 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
 
   const isKey = (name: InventoryItemName): name is Keys =>
     name in ARTEFACT_SHOP_KEYS;
+
+  const reduction = isKeyBoughtWithinSeason(state, tiers, true) ? 0 : 1;
+  const isRareUnlocked =
+    tiers === "rare" &&
+    seasonalItemsCrafted - reduction >= seasonalStore.rare.requirement;
+  const isEpicUnlocked =
+    tiers === "epic" &&
+    seasonalItemsCrafted - reduction >= seasonalStore.epic.requirement;
+
   const keysBoughtAt = keysBought?.megastore[itemName as Keys]?.boughtAt;
   const keysBoughtToday =
     !!keysBoughtAt &&
@@ -156,6 +161,7 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
     if (!item) return false;
 
     if (keysBoughtToday) return false;
+
     if (tier !== "basic") {
       if (tier === "rare" && !isRareUnlocked) return false;
       if (tier === "epic" && !isEpicUnlocked) return false;

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -17,7 +17,7 @@ import lightning from "assets/icons/lightning.png";
 import lock from "assets/icons/lock.png";
 
 import { ITEM_DETAILS } from "features/game/types/images";
-import { InventoryItemName } from "features/game/types/game";
+import { InventoryItemName, Keys } from "features/game/types/game";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useActor, useSelector } from "@xstate/react";
@@ -30,10 +30,15 @@ import {
   SeasonalStoreItem,
   SeasonalStoreWearable,
 } from "features/game/types/megastore";
-import { getKeys } from "features/game/types/craftables";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ResizableBar } from "components/ui/ProgressBar";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
+import {
+  getSeasonalItemsCrafted,
+  getStore,
+  isKeyBoughtWithinSeason,
+} from "features/game/events/landExpansion/buySeasonalItem";
+import { ARTEFACT_SHOP_KEYS } from "features/game/types/collectibles";
 
 interface Props {
   itemsLabel?: string;
@@ -156,41 +161,54 @@ export const ItemsList: React.FC<Props> = ({
         : tier === "rare"
           ? "rare"
           : "basic";
-  const tierItems =
-    tiers === "basic"
-      ? seasonalStore["basic"].items
-      : tiers === "rare"
-        ? seasonalStore["basic"].items
-        : tiers === "epic"
-          ? seasonalStore["rare"].items
-          : seasonalStore["basic"].items;
 
-  const seasonalCollectiblesCrafted = getKeys(inventory).filter((itemName) =>
-    tierItems.some((items: SeasonalStoreItem) =>
-      "collectible" in items ? items.collectible === itemName : false,
-    ),
-  ).length;
-  const seasonalWearablesCrafted = getKeys(wardrobe).filter((itemName) =>
-    tierItems.some((items: SeasonalStoreItem) =>
-      "wearable" in items ? items.wearable === itemName : false,
-    ),
-  ).length;
-
+  const seasonalCollectiblesCrafted = getSeasonalItemsCrafted(
+    state,
+    "inventory",
+    seasonalStore,
+    "collectible",
+    tier,
+    true,
+  );
+  const seasonalWearablesCrafted = getSeasonalItemsCrafted(
+    state,
+    "wardrobe",
+    seasonalStore,
+    "wearable",
+    tier,
+    true,
+  );
   const seasonalItemsCrafted =
     seasonalCollectiblesCrafted + seasonalWearablesCrafted;
 
+  // Type guard if the requirement exists
   const hasRequirement = (
     tier: any,
   ): tier is { items: SeasonalStoreItem[]; requirement: number } => {
     return "requirement" in tier;
   };
 
-  const tierData = seasonalStore[tier];
-  // Type guard if the requirement exists
+  const tierData = getStore(seasonalStore, tier);
+
+  const isKey = (name: InventoryItemName): name is Keys =>
+    name in ARTEFACT_SHOP_KEYS;
+
+  const isKeyCounted = isKeyBoughtWithinSeason(state, tiers) ? 0 : 1;
+  const isAllKeyBought =
+    isKeyBoughtWithinSeason(state, "basic") &&
+    isKeyBoughtWithinSeason(state, "rare") &&
+    isKeyBoughtWithinSeason(state, "epic");
+
+  const reduction = isKeyBoughtWithinSeason(state, tiers, true) ? 0 : 1;
+
   const requirements = hasRequirement(tierData) ? tierData.requirement : 0;
-  const isRareUnlocked = seasonalItemsCrafted >= seasonalStore.rare.requirement;
-  const isEpicUnlocked = seasonalItemsCrafted >= seasonalStore.epic.requirement;
-  const tierpercentage = seasonalItemsCrafted;
+
+  const isRareUnlocked =
+    tier === "rare" && seasonalItemsCrafted - reduction >= requirements;
+  const isEpicUnlocked =
+    tier === "epic" && seasonalItemsCrafted - reduction >= requirements;
+  const tierpercentage = seasonalItemsCrafted - reduction;
+
   const percentage = Math.round((tierpercentage / requirements) * 100);
 
   const sortedItems = filteredItems
@@ -262,6 +280,9 @@ export const ItemsList: React.FC<Props> = ({
         ) : (
           sortedItems.map((item) => {
             const buff = getItemBuffLabel(item);
+            const isItemKey = isKey(
+              getItemName(item) as unknown as InventoryItemName,
+            );
             const balanceOfItem = getBalanceOfItem(item);
 
             return (
@@ -289,7 +310,24 @@ export const ItemsList: React.FC<Props> = ({
                         alt="crop"
                       />
                     )}
+                    {/* Confirm Icon for non-key items */}
                     {balanceOfItem > 0 &&
+                      !isItemKey &&
+                      (tier === "basic" ||
+                        (tier === "rare" && isRareUnlocked) ||
+                        (tier === "epic" && isEpicUnlocked)) && (
+                        <img
+                          src={SUNNYSIDE.icons.confirm}
+                          className="absolute -right-2 -top-3"
+                          style={{
+                            width: `${PIXEL_SCALE * 9}px`,
+                          }}
+                          alt="crop"
+                        />
+                      )}
+
+                    {isItemKey &&
+                      isKeyCounted === 0 &&
                       (tier === "basic" ||
                         (tier === "rare" && isRareUnlocked) ||
                         (tier === "epic" && isEpicUnlocked)) && (


### PR DESCRIPTION
# Description

This PR adds guard for keys for Megastore. If the key is lastbought outside the season, it will not be counted when checking items crafted by tier.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
