### PR TITLE
[FEAT] Update crop types to clearly indicate plot-specific crops

### DIFF
--- a/src/features/builder/components/ResourcePlacer.tsx
+++ b/src/features/builder/components/ResourcePlacer.tsx
@@ -20,7 +20,7 @@ import { Layout } from "../lib/layouts";
 import { Boulder } from "features/island/boulder/Boulder";
 import { Beehive } from "features/game/expansion/components/resources/beehive/Beehive";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { ZoomContext } from "components/ZoomProvider";
 import { Sunstone } from "features/game/expansion/components/resources/sunstone/Sunstone";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -100,7 +100,7 @@ export const RESOURCES: Record<
       height: 1,
       width: 1,
     },
-    icon: CROP_LIFECYCLE.Sunflower.seedling,
+    icon: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
   },
   boulder: {
     component: () => <Boulder />,

--- a/src/features/game/events/landExpansion/collectCropReward.ts
+++ b/src/features/game/events/landExpansion/collectCropReward.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 
-import { CROPS } from "../../types/crops";
+import { PLOT_CROPS } from "../../types/crops";
 import { GameState } from "../../types/game";
 import { produce } from "immer";
 
@@ -37,7 +37,7 @@ export function collectCropReward({
       throw new Error("Crop does not have a reward");
     }
 
-    const crop = CROPS[plantedCrop.name];
+    const crop = PLOT_CROPS[plantedCrop.name];
 
     if (createdAt - plantedCrop.plantedAt < crop.harvestSeconds * 1000) {
       throw new Error("Not ready");

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "../../types/game";
 import { CropCompostName } from "features/game/types/composters";
-import { CROPS, Crop } from "features/game/types/crops";
+import { PLOT_CROPS, Crop } from "features/game/types/crops";
 import { isReadyToHarvest } from "./harvest";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
@@ -86,7 +86,7 @@ export function fertilisePlot({
     // Apply buff if already planted
     const crop = plot.crop;
     if (crop) {
-      const cropDetails = crop && CROPS[crop.name];
+      const cropDetails = crop && PLOT_CROPS[crop.name];
       if (cropDetails && isReadyToHarvest(createdAt, crop, cropDetails)) {
         throw new Error(FERTILISE_CROP_ERRORS.READY_TO_HARVEST);
       }

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "../../types/game";
 import { CropCompostName } from "features/game/types/composters";
-import { PLOT_CROPS, Crop } from "features/game/types/crops";
+import { PLOT_CROPS, PlotCrop } from "features/game/types/crops";
 import { isReadyToHarvest } from "./harvest";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
@@ -34,7 +34,7 @@ const getPlantedAt = (
   fertiliser: CropCompostName,
   plantedAt: number,
   fertilisedAt: number,
-  cropDetails: Crop,
+  cropDetails: PlotCrop,
 ) => {
   const timeToHarvest = cropDetails.harvestSeconds * 1000;
   const harvestTime = plantedAt + timeToHarvest;

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -2,9 +2,9 @@ import { GameState, PlantedCrop } from "../../types/game";
 import {
   Crop,
   CropName,
-  CROPS,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
+  PLOT_CROPS,
 } from "../../types/crops";
 import Decimal from "decimal.js-light";
 import {
@@ -27,8 +27,8 @@ type Options = {
 
 export const isBasicCrop = (cropName: CropName | GreenHouseCropName) => {
   if (!isCrop(cropName)) return false;
-  const cropDetails = CROPS[cropName];
-  return cropDetails.harvestSeconds <= CROPS["Pumpkin"].harvestSeconds;
+  const cropDetails = PLOT_CROPS[cropName];
+  return cropDetails.harvestSeconds <= PLOT_CROPS["Pumpkin"].harvestSeconds;
 };
 
 export const isMediumCrop = (cropName: CropName | GreenHouseCropName) => {
@@ -38,18 +38,18 @@ export const isMediumCrop = (cropName: CropName | GreenHouseCropName) => {
 
 export const isAdvancedCrop = (cropName: CropName | GreenHouseCropName) => {
   if (!isCrop(cropName)) return false;
-  const cropDetails = CROPS[cropName];
-  return cropDetails.harvestSeconds >= CROPS["Eggplant"].harvestSeconds;
+  const cropDetails = PLOT_CROPS[cropName];
+  return cropDetails.harvestSeconds >= PLOT_CROPS["Eggplant"].harvestSeconds;
 };
 
 function isCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in CROPS;
+  return (plant as CropName) in PLOT_CROPS;
 }
 
 export const isOvernightCrop = (cropName: CropName | GreenHouseCropName) => {
   if (isCrop(cropName)) {
-    const cropDetails = CROPS[cropName];
-    return cropDetails.harvestSeconds >= CROPS["Radish"].harvestSeconds;
+    const cropDetails = PLOT_CROPS[cropName];
+    return cropDetails.harvestSeconds >= PLOT_CROPS["Radish"].harvestSeconds;
   }
 
   const details = GREENHOUSE_CROPS[cropName];
@@ -71,7 +71,7 @@ export function isCropGrowing(plot: CropPlot) {
   const crop = plot.crop;
   if (!crop) return false;
 
-  const cropDetails = CROPS[crop.name];
+  const cropDetails = PLOT_CROPS[crop.name];
   return !isReadyToHarvest(Date.now(), crop, cropDetails);
 }
 
@@ -99,7 +99,7 @@ export function harvest({
 
     const { name: cropName, plantedAt, amount = 1, reward } = plot.crop;
 
-    const { harvestSeconds } = CROPS[cropName];
+    const { harvestSeconds } = PLOT_CROPS[cropName];
 
     if (createdAt - plantedAt < harvestSeconds * 1000) {
       throw new Error("Not ready");

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -1,9 +1,9 @@
 import { GameState, PlantedCrop } from "../../types/game";
 import {
-  Crop,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
   PLOT_CROPS,
+  PlotCrop,
   PlotCropName,
 } from "../../types/crops";
 import Decimal from "decimal.js-light";
@@ -62,7 +62,7 @@ export const isOvernightCrop = (cropName: PlotCropName | GreenHouseCropName) => 
 export const isReadyToHarvest = (
   createdAt: number,
   plantedCrop: PlantedCrop,
-  cropDetails: Crop,
+  cropDetails: PlotCrop,
 ) => {
   return createdAt - plantedCrop.plantedAt >= cropDetails.harvestSeconds * 1000;
 };

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -26,28 +26,28 @@ type Options = {
 };
 
 export const isBasicCrop = (cropName: PlotCropName | GreenHouseCropName) => {
-  if (!isCrop(cropName)) return false;
+  if (!isPlotCrop(cropName)) return false;
   const cropDetails = PLOT_CROPS[cropName];
   return cropDetails.harvestSeconds <= PLOT_CROPS["Pumpkin"].harvestSeconds;
 };
 
 export const isMediumCrop = (cropName: PlotCropName | GreenHouseCropName) => {
-  if (!isCrop(cropName)) return false;
+  if (!isPlotCrop(cropName)) return false;
   return !(isBasicCrop(cropName) || isAdvancedCrop(cropName));
 };
 
 export const isAdvancedCrop = (cropName: PlotCropName | GreenHouseCropName) => {
-  if (!isCrop(cropName)) return false;
+  if (!isPlotCrop(cropName)) return false;
   const cropDetails = PLOT_CROPS[cropName];
   return cropDetails.harvestSeconds >= PLOT_CROPS["Eggplant"].harvestSeconds;
 };
 
-function isCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
+function isPlotCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
   return (plant as PlotCropName) in PLOT_CROPS;
 }
 
 export const isOvernightCrop = (cropName: PlotCropName | GreenHouseCropName) => {
-  if (isCrop(cropName)) {
+  if (isPlotCrop(cropName)) {
     const cropDetails = PLOT_CROPS[cropName];
     return cropDetails.harvestSeconds >= PLOT_CROPS["Radish"].harvestSeconds;
   }

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -42,11 +42,15 @@ export const isAdvancedCrop = (cropName: PlotCropName | GreenHouseCropName) => {
   return cropDetails.harvestSeconds >= PLOT_CROPS["Eggplant"].harvestSeconds;
 };
 
-function isPlotCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
+function isPlotCrop(
+  plant: GreenHouseCropName | PlotCropName,
+): plant is PlotCropName {
   return (plant as PlotCropName) in PLOT_CROPS;
 }
 
-export const isOvernightCrop = (cropName: PlotCropName | GreenHouseCropName) => {
+export const isOvernightCrop = (
+  cropName: PlotCropName | GreenHouseCropName,
+) => {
   if (isPlotCrop(cropName)) {
     const cropDetails = PLOT_CROPS[cropName];
     return cropDetails.harvestSeconds >= PLOT_CROPS["Radish"].harvestSeconds;

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -1,10 +1,10 @@
 import { GameState, PlantedCrop } from "../../types/game";
 import {
   Crop,
-  CropName,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
   PLOT_CROPS,
+  PlotCropName,
 } from "../../types/crops";
 import Decimal from "decimal.js-light";
 import {
@@ -25,28 +25,28 @@ type Options = {
   createdAt?: number;
 };
 
-export const isBasicCrop = (cropName: CropName | GreenHouseCropName) => {
+export const isBasicCrop = (cropName: PlotCropName | GreenHouseCropName) => {
   if (!isCrop(cropName)) return false;
   const cropDetails = PLOT_CROPS[cropName];
   return cropDetails.harvestSeconds <= PLOT_CROPS["Pumpkin"].harvestSeconds;
 };
 
-export const isMediumCrop = (cropName: CropName | GreenHouseCropName) => {
+export const isMediumCrop = (cropName: PlotCropName | GreenHouseCropName) => {
   if (!isCrop(cropName)) return false;
   return !(isBasicCrop(cropName) || isAdvancedCrop(cropName));
 };
 
-export const isAdvancedCrop = (cropName: CropName | GreenHouseCropName) => {
+export const isAdvancedCrop = (cropName: PlotCropName | GreenHouseCropName) => {
   if (!isCrop(cropName)) return false;
   const cropDetails = PLOT_CROPS[cropName];
   return cropDetails.harvestSeconds >= PLOT_CROPS["Eggplant"].harvestSeconds;
 };
 
-function isCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in PLOT_CROPS;
+function isCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
+  return (plant as PlotCropName) in PLOT_CROPS;
 }
 
-export const isOvernightCrop = (cropName: CropName | GreenHouseCropName) => {
+export const isOvernightCrop = (cropName: PlotCropName | GreenHouseCropName) => {
   if (isCrop(cropName)) {
     const cropDetails = PLOT_CROPS[cropName];
     return cropDetails.harvestSeconds >= PLOT_CROPS["Radish"].harvestSeconds;

--- a/src/features/game/events/landExpansion/moveCrop.ts
+++ b/src/features/game/events/landExpansion/moveCrop.ts
@@ -8,7 +8,7 @@ import {
   Position,
 } from "features/game/types/game";
 import { isReadyToHarvest } from "./harvest";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { isBasicCrop, isMediumCrop, isAdvancedCrop } from "./harvest";
 import { produce } from "immer";
 
@@ -44,7 +44,7 @@ export function isLocked(
   if (!crop || !plantedAt) return false;
 
   const cropName = crop.name;
-  const cropDetails = CROPS[cropName];
+  const cropDetails = PLOT_CROPS[cropName];
 
   if (isReadyToHarvest(createdAt, crop, cropDetails)) return false;
 

--- a/src/features/game/events/landExpansion/npcRestock.ts
+++ b/src/features/game/events/landExpansion/npcRestock.ts
@@ -5,7 +5,7 @@ import { getKeys } from "features/game/types/decorations";
 import { GameState } from "features/game/types/game";
 import { SEEDS } from "features/game/types/seeds";
 import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 import { NPCName } from "lib/npcs";
@@ -40,7 +40,7 @@ export const RestockItems: Record<RestockNPC, Restock> = {
     shopName: translate("market"),
     categoryLabel: {
       labelText: translate("seeds"),
-      icon: CROP_LIFECYCLE.Sunflower.seed,
+      icon: PLOT_CROP_LIFECYCLE.Sunflower.seed,
     },
   },
   blacksmith: {

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { GameState, CropPlot } from "../../types/game";
 import {
@@ -366,7 +366,7 @@ describe("plant", () => {
     });
 
     // Should be twice as fast! (Planted in the past)
-    const parsnipTime = CROPS.Parsnip.harvestSeconds * 1000;
+    const parsnipTime = PLOT_CROPS.Parsnip.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -495,7 +495,7 @@ describe("plant", () => {
     });
 
     // Should be twice as fast! (Planted in the past)
-    const carrotTime = CROPS.Carrot.harvestSeconds * 1000;
+    const carrotTime = PLOT_CROPS.Carrot.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -535,7 +535,7 @@ describe("plant", () => {
       },
     });
 
-    const sunflowerTime = CROPS.Sunflower.harvestSeconds * 1000;
+    const sunflowerTime = PLOT_CROPS.Sunflower.harvestSeconds * 1000;
 
     const plots = state.crops;
 
@@ -1569,7 +1569,7 @@ describe("plant", () => {
     expect(plots).toBeDefined();
 
     expect((plots as Record<number, CropPlot>)[0].crop?.plantedAt).toEqual(
-      dateNow - 0.1 * CROPS.Parsnip.harvestSeconds * 1000,
+      dateNow - 0.1 * PLOT_CROPS.Parsnip.harvestSeconds * 1000,
     );
   });
 });
@@ -1611,7 +1611,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 10% speed boost with Lunar Calendar placed.", () => {
-    const carrotHarvestSeconds = CROPS["Carrot"].harvestSeconds;
+    const carrotHarvestSeconds = PLOT_CROPS["Carrot"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Carrot",
       inventory: {},
@@ -1636,7 +1636,7 @@ describe("getCropTime", () => {
   });
 
   it("grows cabbage twice as fast with Cabbage Girl placed.", () => {
-    const cabbageHarvestSeconds = CROPS["Cabbage"].harvestSeconds;
+    const cabbageHarvestSeconds = PLOT_CROPS["Cabbage"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Cabbage",
       buds: {},
@@ -1661,7 +1661,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 25% speed boost with Obie placed", () => {
-    const baseHarvestSeconds = CROPS["Eggplant"].harvestSeconds;
+    const baseHarvestSeconds = PLOT_CROPS["Eggplant"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Eggplant",
       inventory: {},
@@ -1724,7 +1724,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 25% speed boost with Kernaldo placed", () => {
-    const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
+    const baseHarvestSeconds = PLOT_CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Corn",
       inventory: {},
@@ -1749,7 +1749,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Sunflower", () => {
-    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = PLOT_CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -1775,7 +1775,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Potato", () => {
-    const potatoHarvestSeconds = CROPS["Potato"].harvestSeconds;
+    const potatoHarvestSeconds = PLOT_CROPS["Potato"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Potato",
@@ -1801,7 +1801,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Pumpkin", () => {
-    const pumpkinHarvestSeconds = CROPS["Pumpkin"].harvestSeconds;
+    const pumpkinHarvestSeconds = PLOT_CROPS["Pumpkin"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Pumpkin",
@@ -1827,7 +1827,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow if not basic crop", () => {
-    const beetrootHarvestSeconds = CROPS["Beetroot"].harvestSeconds;
+    const beetrootHarvestSeconds = PLOT_CROPS["Beetroot"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Beetroot",
@@ -1853,7 +1853,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow placed, if plot is outside AOE", () => {
-    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = PLOT_CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -1879,7 +1879,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply boost with Basic Scarecrow placed, if it was moved within 10min", () => {
-    const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
+    const sunflowerHarvestSeconds = PLOT_CROPS["Sunflower"].harvestSeconds;
 
     const time = getCropPlotTime({
       crop: "Sunflower",
@@ -2018,7 +2018,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a +5% speed boost with Green Thumb 2 skill", () => {
-    const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
+    const baseHarvestSeconds = PLOT_CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Corn",
       inventory: {},
@@ -2040,7 +2040,7 @@ describe("getCropTime", () => {
   });
 
   it("applies a +10% speed boost on Radish, Wheat and Kale with Strong Roots skill", () => {
-    const baseHarvestSeconds = CROPS["Radish"].harvestSeconds;
+    const baseHarvestSeconds = PLOT_CROPS["Radish"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Radish",
       inventory: {},
@@ -2062,7 +2062,7 @@ describe("getCropTime", () => {
   });
 
   it("does not apply a +10% speed boost on Sunflower with Strong Roots skill", () => {
-    const baseHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
+    const baseHarvestSeconds = PLOT_CROPS["Sunflower"].harvestSeconds;
     const time = getCropPlotTime({
       crop: "Sunflower",
       inventory: {},
@@ -3383,7 +3383,7 @@ describe("getCropYield", () => {
 
     it("applies the harvest hourglass boost of -25% crop growth time for 6 hours", () => {
       const now = Date.now();
-      const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
+      const baseHarvestSeconds = PLOT_CROPS["Corn"].harvestSeconds;
 
       const time = getPlantedAt({
         crop: "Corn",

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 
-import { CropName, CROPS, GreenHouseCropName } from "../../types/crops";
+import { CropName, GreenHouseCropName, PLOT_CROPS } from "../../types/crops";
 import {
   Bumpkin,
   CropPlot,
@@ -206,7 +206,7 @@ export const getCropPlotTime = ({
   plot?: CropPlot;
   fertiliser?: CropCompostName;
 }) => {
-  let seconds = CROPS[crop]?.harvestSeconds ?? 0;
+  let seconds = PLOT_CROPS[crop]?.harvestSeconds ?? 0;
 
   if (game.bumpkin === undefined) return seconds;
 
@@ -317,7 +317,7 @@ export function getPlantedAt({
 }: GetPlantedAtArgs): number {
   if (!crop) return 0;
 
-  const cropTime = CROPS[crop].harvestSeconds;
+  const cropTime = PLOT_CROPS[crop].harvestSeconds;
   const boostedTime = getCropPlotTime({
     crop,
     inventory,
@@ -333,7 +333,7 @@ export function getPlantedAt({
 }
 
 function isPlotCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in CROPS;
+  return (plant as CropName) in PLOT_CROPS;
 }
 
 /**

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 
-import { CropName, GreenHouseCropName, PLOT_CROPS } from "../../types/crops";
+import { GreenHouseCropName, PLOT_CROPS, PlotCropName } from "../../types/crops";
 import {
   Bumpkin,
   CropPlot,
@@ -125,7 +125,7 @@ export function getCropTime({
   crop,
 }: {
   game: GameState;
-  crop: CropName | GreenHouseCropName;
+  crop: PlotCropName | GreenHouseCropName;
 }) {
   let seconds = 1;
 
@@ -199,7 +199,7 @@ export const getCropPlotTime = ({
   plot,
   fertiliser,
 }: {
-  crop: CropName;
+  crop: PlotCropName;
   inventory: Inventory;
   game: GameState;
   buds: NonNullable<GameState["buds"]>;
@@ -294,7 +294,7 @@ export const getCropPlotTime = ({
 };
 
 type GetPlantedAtArgs = {
-  crop: CropName;
+  crop: PlotCropName;
   inventory: Inventory;
   game: GameState;
   createdAt: number;
@@ -332,8 +332,8 @@ export function getPlantedAt({
   return createdAt - offset * 1000;
 }
 
-function isPlotCrop(plant: GreenHouseCropName | CropName): plant is CropName {
-  return (plant as CropName) in PLOT_CROPS;
+function isPlotCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
+  return (plant as PlotCropName) in PLOT_CROPS;
 }
 
 /**
@@ -345,7 +345,7 @@ export function getCropYieldAmount({
   game,
   fertiliser,
 }: {
-  crop: CropName | GreenHouseCropName;
+  crop: PlotCropName | GreenHouseCropName;
   plot?: CropPlot;
   game: GameState;
   fertiliser?: CropCompostName;
@@ -750,7 +750,7 @@ export function plant({
       throw new Error("Not enough seeds");
     }
 
-    const cropName = action.item.split(" ")[0] as CropName;
+    const cropName = action.item.split(" ")[0] as PlotCropName;
 
     const activityName: BumpkinActivityName = `${cropName} Planted`;
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -1,6 +1,10 @@
 import Decimal from "decimal.js-light";
 
-import { GreenHouseCropName, PLOT_CROPS, PlotCropName } from "../../types/crops";
+import {
+  GreenHouseCropName,
+  PLOT_CROPS,
+  PlotCropName,
+} from "../../types/crops";
 import {
   Bumpkin,
   CropPlot,
@@ -332,7 +336,9 @@ export function getPlantedAt({
   return createdAt - offset * 1000;
 }
 
-function isPlotCrop(plant: GreenHouseCropName | PlotCropName): plant is PlotCropName {
+function isPlotCrop(
+  plant: GreenHouseCropName | PlotCropName,
+): plant is PlotCropName {
   return (plant as PlotCropName) in PLOT_CROPS;
 }
 

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { screenTracker } from "lib/utils/screen";
-import { CROPS } from "../../types/crops";
+import { PLOT_CROPS } from "../../types/crops";
 import { GameState, InventoryItemName } from "../../types/game";
 import { isReadyToHarvest } from "./harvest";
 import { produce } from "immer";
@@ -60,7 +60,7 @@ export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
       throw new Error(REMOVE_CROP_ERRORS.NO_SHOVEL_AVAILABLE);
     }
 
-    const cropDetails = CROPS[crop.name];
+    const cropDetails = PLOT_CROPS[crop.name];
     if (isReadyToHarvest(createdAt, crop, cropDetails)) {
       throw new Error(REMOVE_CROP_ERRORS.READY_TO_HARVEST);
     }

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -14,11 +14,11 @@ import { getKeys } from "features/game/types/craftables";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
-import { CropName } from "features/game/types/crops";
+import { PlotCropName } from "features/game/types/crops";
 import { produce } from "immer";
 
 // Preloaded crops that will appear on plots when they reveal
-const EXPANSION_CROPS: Record<number, CropName> = {
+const EXPANSION_CROPS: Record<number, PlotCropName> = {
   4: "Sunflower",
   5: "Potato", // We need Potatos at expansion 5 for cooking
   6: "Pumpkin",

--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -110,7 +110,9 @@ describe("seedBought", () => {
     });
 
     expect(state.balance).toEqual(balance);
-    expect(state.coins).toEqual(coins - PLOT_CROP_SEEDS["Sunflower Seed"].price);
+    expect(state.coins).toEqual(
+      coins - PLOT_CROP_SEEDS["Sunflower Seed"].price,
+    );
   });
 
   it("adds the newly bought seed to a players inventory", () => {

--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { CropSeedName, PLOT_CROP_SEEDS } from "features/game/types/crops";
+import { PLOT_CROP_SEEDS, PlotCropSeedName } from "features/game/types/crops";
 import { GameState } from "features/game/types/game";
 
 import { seedBought } from "./seedBought";
@@ -17,7 +17,7 @@ describe("seedBought", () => {
         state: GAME_STATE,
         action: {
           type: "seed.bought",
-          item: "Goblin Key" as CropSeedName,
+          item: "Goblin Key" as PlotCropSeedName,
           amount: 1,
         },
       }),

--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { CropSeedName, CROP_SEEDS } from "features/game/types/crops";
+import { CropSeedName, PLOT_CROP_SEEDS } from "features/game/types/crops";
 import { GameState } from "features/game/types/game";
 
 import { seedBought } from "./seedBought";
@@ -110,7 +110,7 @@ describe("seedBought", () => {
     });
 
     expect(state.balance).toEqual(balance);
-    expect(state.coins).toEqual(coins - CROP_SEEDS["Sunflower Seed"].price);
+    expect(state.coins).toEqual(coins - PLOT_CROP_SEEDS["Sunflower Seed"].price);
   });
 
   it("adds the newly bought seed to a players inventory", () => {
@@ -156,7 +156,7 @@ describe("seedBought", () => {
 
     const oldAmount = GAME_STATE.inventory[item] ?? new Decimal(0);
 
-    expect(state.coins).toEqual(coins - CROP_SEEDS[item].price);
+    expect(state.coins).toEqual(coins - PLOT_CROP_SEEDS[item].price);
     expect(state.inventory[item]).toEqual(oldAmount.add(amount));
   });
 
@@ -182,7 +182,7 @@ describe("seedBought", () => {
 
     const oldAmount = GAME_STATE.inventory[item] ?? new Decimal(0);
 
-    expect(state.coins).toEqual(coins - CROP_SEEDS[item].price * amount);
+    expect(state.coins).toEqual(coins - PLOT_CROP_SEEDS[item].price * amount);
     expect(state.inventory[item]).toEqual(oldAmount.add(amount));
   });
 
@@ -199,7 +199,7 @@ describe("seedBought", () => {
       },
     });
     expect(state.bumpkin?.activity?.["Coins Spent"]).toEqual(
-      CROP_SEEDS["Sunflower Seed"].price,
+      PLOT_CROP_SEEDS["Sunflower Seed"].price,
     );
   });
 

--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -75,7 +75,9 @@ describe("sell", () => {
     });
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(4));
-    expect(state.coins).toEqual(GAME_STATE.coins + PLOT_CROPS.Sunflower.sellPrice);
+    expect(state.coins).toEqual(
+      GAME_STATE.coins + PLOT_CROPS.Sunflower.sellPrice,
+    );
   });
 
   it("sell an item in bulk given sufficient quantity", () => {

--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "../../types/game";
-import { CropName, PLOT_CROPS } from "../../types/crops";
+import { PLOT_CROPS, PlotCropName } from "../../types/crops";
 import { sellCrop } from "./sellCrop";
 import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { PATCH_FRUIT } from "features/game/types/fruits";
@@ -20,7 +20,7 @@ describe("sell", () => {
         state: GAME_STATE,
         action: {
           type: "crop.sold",
-          crop: "Axe" as CropName,
+          crop: "Axe" as PlotCropName,
           amount: 1,
         },
       }),

--- a/src/features/game/events/landExpansion/sellCrop.test.ts
+++ b/src/features/game/events/landExpansion/sellCrop.test.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "../../types/game";
-import { CropName, CROPS } from "../../types/crops";
+import { CropName, PLOT_CROPS } from "../../types/crops";
 import { sellCrop } from "./sellCrop";
 import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { PATCH_FRUIT } from "features/game/types/fruits";
@@ -75,7 +75,7 @@ describe("sell", () => {
     });
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(4));
-    expect(state.coins).toEqual(GAME_STATE.coins + CROPS.Sunflower.sellPrice);
+    expect(state.coins).toEqual(GAME_STATE.coins + PLOT_CROPS.Sunflower.sellPrice);
   });
 
   it("sell an item in bulk given sufficient quantity", () => {
@@ -96,7 +96,7 @@ describe("sell", () => {
 
     expect(state.inventory.Sunflower).toEqual(new Decimal(1));
     expect(state.coins).toEqual(
-      GAME_STATE.coins + CROPS.Sunflower.sellPrice * 10,
+      GAME_STATE.coins + PLOT_CROPS.Sunflower.sellPrice * 10,
     );
   });
 
@@ -134,7 +134,7 @@ describe("sell", () => {
       },
     });
 
-    expect(state.coins).toEqual(CROPS.Cauliflower.sellPrice);
+    expect(state.coins).toEqual(PLOT_CROPS.Cauliflower.sellPrice);
   });
 
   it("increments coins earned when cauliflower is sold", () => {
@@ -153,7 +153,7 @@ describe("sell", () => {
     });
 
     expect(state.bumpkin?.activity?.["Coins Earned"]).toEqual(
-      CROPS.Cauliflower.sellPrice,
+      PLOT_CROPS.Cauliflower.sellPrice,
     );
   });
 
@@ -257,7 +257,7 @@ describe("sell", () => {
       },
     });
 
-    expect(state.coins).toEqual(coins + CROPS.Sunflower.sellPrice * 1.1);
+    expect(state.coins).toEqual(coins + PLOT_CROPS.Sunflower.sellPrice * 1.1);
   });
 
   it("does not add 10% more profit if it is not a crop", () => {
@@ -307,6 +307,6 @@ describe("sell", () => {
       },
     });
 
-    expect(state.coins).toEqual(coins + CROPS.Sunflower.sellPrice);
+    expect(state.coins).toEqual(coins + PLOT_CROPS.Sunflower.sellPrice);
   });
 });

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,9 +1,9 @@
 import Decimal from "decimal.js-light";
 import {
-  Crop,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
   PLOT_CROPS,
+  PlotCrop,
   PlotCropName,
 } from "../../types/crops";
 import { GameState } from "../../types/game";
@@ -22,7 +22,7 @@ import { ExoticCrop } from "features/game/types/beans";
 
 export type SellableName = PlotCropName | PatchFruitName;
 export type SellableItem =
-  | Crop
+  | PlotCrop
   | PatchFruit
   | ExoticCrop
   | GreenHouseFruit

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -2,9 +2,9 @@ import Decimal from "decimal.js-light";
 import {
   Crop,
   CropName,
-  CROPS,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
+  PLOT_CROPS,
 } from "../../types/crops";
 import { GameState } from "../../types/game";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
@@ -35,7 +35,7 @@ export type SellCropAction = {
 };
 
 export const SELLABLE = {
-  ...CROPS,
+  ...PLOT_CROPS,
   ...PATCH_FRUIT(),
   ...GREENHOUSE_CROPS,
   ...GREENHOUSE_FRUIT(),

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -1,10 +1,10 @@
 import Decimal from "decimal.js-light";
 import {
   Crop,
-  CropName,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
   PLOT_CROPS,
+  PlotCropName,
 } from "../../types/crops";
 import { GameState } from "../../types/game";
 import { getSellPrice } from "features/game/expansion/lib/boosts";
@@ -20,7 +20,7 @@ import {
 import { produce } from "immer";
 import { ExoticCrop } from "features/game/types/beans";
 
-export type SellableName = CropName | PatchFruitName;
+export type SellableName = PlotCropName | PatchFruitName;
 export type SellableItem =
   | Crop
   | PatchFruit

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CropName, CropSeedName, PLOT_CROPS } from "features/game/types/crops";
+import { CropSeedName, PLOT_CROPS, PlotCropName } from "features/game/types/crops";
 import {
   CropMachineBuilding,
   CropMachineQueueItem,
@@ -105,7 +105,7 @@ export function calculateCropTime(
     return 0; // Or some default value if state or bumpkin is undefined
   }
 
-  const cropName = seeds.type.split(" ")[0] as CropName;
+  const cropName = seeds.type.split(" ")[0] as PlotCropName;
 
   let milliSeconds = PLOT_CROPS[cropName].harvestSeconds * 1000;
 
@@ -127,7 +127,7 @@ export function getOilTimeInMillis(oil: number, state: GameState) {
 
 export function getPackYieldAmount(
   amount: number,
-  crop: CropName,
+  crop: PlotCropName,
   state: GameState,
 ): number {
   if (!state.bumpkin) {
@@ -311,7 +311,7 @@ export function supplyCropMachine({
     throw new Error("Crop Machine does not exist");
   }
 
-  const cropName = seedsAdded.type.split(" ")[0] as CropName;
+  const cropName = seedsAdded.type.split(" ")[0] as PlotCropName;
 
   if (
     !state.bumpkin.skills["Crop Extension Module"] &&
@@ -374,7 +374,7 @@ export function supplyCropMachine({
       getOilTimeInMillis(oilAdded, state);
   }
 
-  const crop = seedsAdded.type.split(" ")[0] as CropName;
+  const crop = seedsAdded.type.split(" ")[0] as PlotCropName;
 
   if (seedsAdded.amount > 0) {
     queue.push({

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CropSeedName, PLOT_CROPS, PlotCropName } from "features/game/types/crops";
+import { PLOT_CROPS, PlotCropName, PlotCropSeedName } from "features/game/types/crops";
 import {
   CropMachineBuilding,
   CropMachineQueueItem,
@@ -9,7 +9,7 @@ import { getCropYieldAmount } from "./plant";
 import { isBasicCrop } from "./harvest";
 import cloneDeep from "lodash.clonedeep";
 
-export type AddSeedsInput = { type: CropSeedName; amount: number };
+export type AddSeedsInput = { type: PlotCropSeedName; amount: number };
 
 export type SupplyCropMachineAction = {
   type: "cropMachine.supplied";
@@ -96,7 +96,7 @@ export function getTotalOilMillisInMachine(
 
 export function calculateCropTime(
   seeds: {
-    type: CropSeedName;
+    type: PlotCropSeedName;
     amount: number;
   },
   state: GameState,

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,5 +1,9 @@
 import Decimal from "decimal.js-light";
-import { PLOT_CROPS, PlotCropName, PlotCropSeedName } from "features/game/types/crops";
+import {
+  PLOT_CROPS,
+  PlotCropName,
+  PlotCropSeedName,
+} from "features/game/types/crops";
 import {
   CropMachineBuilding,
   CropMachineQueueItem,

--- a/src/features/game/events/landExpansion/supplyCropMachine.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CROPS, CropName, CropSeedName } from "features/game/types/crops";
+import { CropName, CropSeedName, PLOT_CROPS } from "features/game/types/crops";
 import {
   CropMachineBuilding,
   CropMachineQueueItem,
@@ -107,7 +107,7 @@ export function calculateCropTime(
 
   const cropName = seeds.type.split(" ")[0] as CropName;
 
-  let milliSeconds = CROPS[cropName].harvestSeconds * 1000;
+  let milliSeconds = PLOT_CROPS[cropName].harvestSeconds * 1000;
 
   if (state.bumpkin.skills?.["Crop Processor Unit"]) {
     milliSeconds = milliSeconds * 0.95;

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
-import { CROPS, CropName } from "features/game/types/crops";
+import { CropName, PLOT_CROPS } from "features/game/types/crops";
 import { PATCH_FRUIT, PatchFruitName } from "features/game/types/fruits";
 import { GameState } from "features/game/types/game";
 import {
@@ -23,7 +23,7 @@ export const MINIGAME_CURRENCY_LIMITS: Record<MinigameCurrency, number> = {
     (acc, name) => ({ ...acc, [name]: 1000 }),
     {} as Record<CommodityName, number>,
   ),
-  ...getKeys(CROPS).reduce(
+  ...getKeys(PLOT_CROPS).reduce(
     (acc, name) => ({ ...acc, [name]: 1000 }),
     {} as Record<CropName, number>,
   ),

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { getKeys } from "features/game/types/craftables";
-import { CropName, PLOT_CROPS } from "features/game/types/crops";
+import { PLOT_CROPS, PlotCropName } from "features/game/types/crops";
 import { PATCH_FRUIT, PatchFruitName } from "features/game/types/fruits";
 import { GameState } from "features/game/types/game";
 import {
@@ -10,7 +10,7 @@ import {
 import { COMMODITIES, CommodityName } from "features/game/types/resources";
 import { produce } from "immer";
 
-export type MinigameCurrency = CropName | PatchFruitName | CommodityName;
+export type MinigameCurrency = PlotCropName | PatchFruitName | CommodityName;
 
 const SFL_LIMIT = 100;
 
@@ -25,7 +25,7 @@ export const MINIGAME_CURRENCY_LIMITS: Record<MinigameCurrency, number> = {
   ),
   ...getKeys(PLOT_CROPS).reduce(
     (acc, name) => ({ ...acc, [name]: 1000 }),
-    {} as Record<CropName, number>,
+    {} as Record<PlotCropName, number>,
   ),
 };
 

--- a/src/features/game/expansion/components/LabelTest.tsx
+++ b/src/features/game/expansion/components/LabelTest.tsx
@@ -7,7 +7,7 @@ import lock from "assets/skills/lock.png";
 import chest from "assets/icons/chest.png";
 import powerup from "assets/icons/level_up.png";
 import lightning from "assets/icons/lightning.png";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const LabelTest: React.FC = () => {
@@ -43,7 +43,7 @@ export const LabelTest: React.FC = () => {
               <Label
                 type="success"
                 icon={powerup}
-                secondaryIcon={CROP_LIFECYCLE.Pumpkin.crop}
+                secondaryIcon={PLOT_CROP_LIFECYCLE.Pumpkin.crop}
               >
                 {t("buff")}
               </Label>
@@ -122,7 +122,7 @@ export const LabelTest: React.FC = () => {
               <Label
                 type="chill"
                 icon={SUNNYSIDE.icons.heart}
-                secondaryIcon={CROP_LIFECYCLE.Sunflower.crop}
+                secondaryIcon={PLOT_CROP_LIFECYCLE.Sunflower.crop}
               >
                 {t("formula")}
               </Label>

--- a/src/features/game/expansion/components/RestockBoat.tsx
+++ b/src/features/game/expansion/components/RestockBoat.tsx
@@ -16,7 +16,7 @@ import { hasFeatureAccess } from "lib/flags";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import Decimal from "decimal.js-light";
 
 const expansions = (state: MachineState) =>
@@ -102,7 +102,7 @@ export const RestockBoat: React.FC<{
             </div>
             {restockSeeds.length > 0 && (
               <Label
-                icon={CROP_LIFECYCLE.Sunflower.seed}
+                icon={PLOT_CROP_LIFECYCLE.Sunflower.seed}
                 type="default"
                 className="ml-2 mb-1"
               >

--- a/src/features/game/expansion/components/TravelTeaser.tsx
+++ b/src/features/game/expansion/components/TravelTeaser.tsx
@@ -17,7 +17,7 @@ import { MapPlacement } from "./MapPlacement";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import { getKeys } from "features/game/types/craftables";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { translate } from "lib/i18n/translate";
 
 const isNoob = (state: MachineState) =>
@@ -44,7 +44,7 @@ const hint = (state: MachineState) => {
     return translate("expand.land");
   }
 
-  const harvestedCrops = getKeys(CROPS).reduce(
+  const harvestedCrops = getKeys(PLOT_CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Harvested`] ?? 0),
     0,
   );
@@ -53,7 +53,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.three");
   }
 
-  const soldCrops = getKeys(CROPS).reduce(
+  const soldCrops = getKeys(PLOT_CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Sold`] ?? 0),
     0,
   );
@@ -62,7 +62,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.four");
   }
 
-  const boughtCrops = getKeys(CROPS).reduce(
+  const boughtCrops = getKeys(PLOT_CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Seed Bought`] ?? 0),
     0,
   );
@@ -71,7 +71,7 @@ const hint = (state: MachineState) => {
     return translate("pete.teaser.five");
   }
 
-  const plantedCrops = getKeys(CROPS).reduce(
+  const plantedCrops = getKeys(PLOT_CROPS).reduce(
     (total, crop) => total + (activity?.[`${crop} Planted`] ?? 0),
     0,
   );

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -1,6 +1,6 @@
 import { getSellPrice } from "./boosts";
 import { TEST_FARM } from "features/game/lib/constants";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import Decimal from "decimal.js-light";
 import { PATCH_FRUIT } from "features/game/types/fruits";
 
@@ -8,7 +8,7 @@ describe("boosts", () => {
   it("applies crop shortage price", () => {
     expect(
       getSellPrice({
-        item: CROPS.Sunflower,
+        item: PLOT_CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           inventory: { "Basic Land": new Decimal(3) },
@@ -16,14 +16,14 @@ describe("boosts", () => {
         },
         now: new Date(),
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 2);
+    ).toEqual(PLOT_CROPS.Sunflower.sellPrice * 2);
   });
 
   it("removes crop shortage price after 2 hours", () => {
     const now = new Date();
     expect(
       getSellPrice({
-        item: CROPS.Sunflower,
+        item: PLOT_CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           inventory: { "Basic Land": new Decimal(3) },
@@ -32,7 +32,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice);
+    ).toEqual(PLOT_CROPS.Sunflower.sellPrice);
   });
 
   it("applies special event pricing", () => {
@@ -93,7 +93,7 @@ describe("boosts", () => {
     const now = new Date();
     expect(
       getSellPrice({
-        item: CROPS.Sunflower,
+        item: PLOT_CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           inventory: {
@@ -105,7 +105,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 1.05);
+    ).toEqual(PLOT_CROPS.Sunflower.sellPrice * 1.05);
   });
 
   it("does not apply Green Thumb boost to non crops", () => {
@@ -131,7 +131,7 @@ describe("boosts", () => {
     const now = new Date();
     expect(
       getSellPrice({
-        item: CROPS.Sunflower,
+        item: PLOT_CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           bumpkin: {
@@ -148,7 +148,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 1.1);
+    ).toEqual(PLOT_CROPS.Sunflower.sellPrice * 1.1);
   });
 
   it("applies Coin Swindler boost to crop", () => {
@@ -179,7 +179,7 @@ describe("boosts", () => {
     const now = new Date();
     expect(
       getSellPrice({
-        item: CROPS.Sunflower,
+        item: PLOT_CROPS.Sunflower,
         game: {
           ...TEST_FARM,
           bumpkin: {
@@ -197,6 +197,6 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 2.15);
+    ).toEqual(PLOT_CROPS.Sunflower.sellPrice * 2.15);
   });
 });

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 
 import { Bumpkin, GameState, Inventory } from "../../types/game";
-import { CROPS } from "../../types/crops";
+import { PLOT_CROPS } from "../../types/crops";
 import {
   COOKABLES,
   COOKABLE_CAKES,
@@ -24,7 +24,7 @@ import {
   getFactionPetBoostMultiplier,
 } from "features/game/lib/factions";
 
-const crops = CROPS;
+const crops = PLOT_CROPS;
 
 export function isCropShortage({ game }: { game: GameState }) {
   const bumpkinLevel = getBumpkinLevel(game.bumpkin?.experience ?? 0);
@@ -90,7 +90,7 @@ export const getSellPrice = ({
   const isCropShortage =
     game.createdAt + CROP_SHORTAGE_HOURS * 60 * 60 * 1000 > now.getTime();
 
-  if (item.name in CROPS && isCropShortage) {
+  if (item.name in PLOT_CROPS && isCropShortage) {
     multiplier += 1;
   }
 
@@ -107,7 +107,7 @@ export const getSellPrice = ({
     multiplier += specialEventMultiplier - 1;
   }
 
-  if (bumpkin.skills["Coin Swindler"] && item.name in CROPS) {
+  if (bumpkin.skills["Coin Swindler"] && item.name in PLOT_CROPS) {
     multiplier += 0.1;
   }
 

--- a/src/features/game/lib/conversion.ts
+++ b/src/features/game/lib/conversion.ts
@@ -1,6 +1,6 @@
 import { FERTILISERS, InventoryItemName } from "../types/game";
 import { SHOVELS, TOOLS } from "../types/craftables";
-import { CROPS, CROP_SEEDS, GREENHOUSE_CROPS } from "../types/crops";
+import { CROP_SEEDS, GREENHOUSE_CROPS, PLOT_CROPS } from "../types/crops";
 
 import { ANIMAL_RESOURCES, COMMODITIES } from "../types/resources";
 import {
@@ -20,7 +20,7 @@ import { RECIPE_CRAFTABLES } from "./crafting";
  */
 export function getItemUnit(name: InventoryItemName) {
   if (
-    name in CROPS ||
+    name in PLOT_CROPS ||
     name in PATCH_FRUIT() ||
     name in GREENHOUSE_CROPS ||
     name in GREENHOUSE_FRUIT() ||

--- a/src/features/game/lib/conversion.ts
+++ b/src/features/game/lib/conversion.ts
@@ -1,6 +1,6 @@
 import { FERTILISERS, InventoryItemName } from "../types/game";
 import { SHOVELS, TOOLS } from "../types/craftables";
-import { CROP_SEEDS, GREENHOUSE_CROPS, PLOT_CROPS } from "../types/crops";
+import { GREENHOUSE_CROPS, PLOT_CROP_SEEDS, PLOT_CROPS } from "../types/crops";
 
 import { ANIMAL_RESOURCES, COMMODITIES } from "../types/resources";
 import {
@@ -26,7 +26,7 @@ export function getItemUnit(name: InventoryItemName) {
     name in GREENHOUSE_FRUIT() ||
     name in COMMODITIES ||
     name in ANIMAL_RESOURCES ||
-    name in CROP_SEEDS ||
+    name in PLOT_CROP_SEEDS ||
     name in PATCH_FRUIT_SEEDS() ||
     name in FLOWER_SEEDS() ||
     name in TOOLS ||

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -6,10 +6,10 @@ import {
 import { getUniqueAnimalResources } from "../types/animals";
 import { Bud, StemTrait, TypeTrait } from "../types/buds";
 import {
-  CropName,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
   PLOT_CROPS,
+  PlotCropName,
 } from "../types/crops";
 import {
   GREENHOUSE_FRUIT,
@@ -22,18 +22,18 @@ import { CommodityName, MushroomName } from "../types/resources";
 
 export type Resource =
   | CommodityName
-  | CropName
+  | PlotCropName
   | PatchFruitName
   | MushroomName
   | GreenHouseCropName
   | GreenHouseFruitName
   | AnimalResource;
 
-export const isPlotCrop = (resource: Resource): resource is CropName => {
+export const isPlotCrop = (resource: Resource): resource is PlotCropName => {
   return resource in PLOT_CROPS;
 };
 
-export const isCrop = (resource: Resource): resource is CropName => {
+export const isCrop = (resource: Resource): resource is PlotCropName => {
   return resource in PLOT_CROPS || resource in GREENHOUSE_CROPS;
 };
 

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -6,10 +6,10 @@ import {
 import { getUniqueAnimalResources } from "../types/animals";
 import { Bud, StemTrait, TypeTrait } from "../types/buds";
 import {
-  CROPS,
   CropName,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
+  PLOT_CROPS,
 } from "../types/crops";
 import {
   GREENHOUSE_FRUIT,
@@ -30,11 +30,11 @@ export type Resource =
   | AnimalResource;
 
 export const isPlotCrop = (resource: Resource): resource is CropName => {
-  return resource in CROPS;
+  return resource in PLOT_CROPS;
 };
 
 export const isCrop = (resource: Resource): resource is CropName => {
-  return resource in CROPS || resource in GREENHOUSE_CROPS;
+  return resource in PLOT_CROPS || resource in GREENHOUSE_CROPS;
 };
 
 export const isAnimalProduce = (

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -33,7 +33,7 @@ export const isPlotCrop = (resource: Resource): resource is PlotCropName => {
   return resource in PLOT_CROPS;
 };
 
-export const isCrop = (resource: Resource): resource is PlotCropName => {
+export const isCrop = (resource: Resource): resource is PlotCropName | GreenHouseCropName => {
   return resource in PLOT_CROPS || resource in GREENHOUSE_CROPS;
 };
 

--- a/src/features/game/lib/getBudYieldBoosts.ts
+++ b/src/features/game/lib/getBudYieldBoosts.ts
@@ -33,7 +33,9 @@ export const isPlotCrop = (resource: Resource): resource is PlotCropName => {
   return resource in PLOT_CROPS;
 };
 
-export const isCrop = (resource: Resource): resource is PlotCropName | GreenHouseCropName => {
+export const isCrop = (
+  resource: Resource,
+): resource is PlotCropName | GreenHouseCropName => {
   return resource in PLOT_CROPS || resource in GREENHOUSE_CROPS;
 };
 

--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -4,7 +4,7 @@ import { GameState, Inventory } from "./game";
 import { CookEvent, CraftedEvent, HarvestEvent } from "./bumpkinActivity";
 import { COOKABLES, COOKABLE_CAKES } from "./consumables";
 import { getKeys, TOOLS } from "./craftables";
-import { CROPS } from "./crops";
+import { PLOT_CROPS } from "./crops";
 import { GREENHOUSE_FRUIT, PATCH_FRUIT } from "./fruits";
 import { getSeasonalTicket } from "./seasons";
 import { translate } from "lib/i18n/translate";
@@ -121,7 +121,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Farm Hand": {
     description: translate("farmHand.description"),
     progress: (gameState: GameState) => {
-      const harvestEvents = getKeys(CROPS).map(
+      const harvestEvents = getKeys(PLOT_CROPS).map(
         (name) => `${name} Harvested` as HarvestEvent,
       );
 
@@ -205,7 +205,7 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Crop Champion": {
     description: translate("cropChampion.description"),
     progress: (gameState: GameState) => {
-      const harvestEvents = getKeys(CROPS).map(
+      const harvestEvents = getKeys(PLOT_CROPS).map(
         (name) => `${name} Harvested` as HarvestEvent,
       );
 

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -1,7 +1,11 @@
 import Decimal from "decimal.js-light";
 import { ConsumableName, CookableName } from "./consumables";
 import { Animal, Food, ToolName } from "./craftables";
-import { GreenHouseCropName, GreenHouseCropSeedName, PlotCropName } from "./crops";
+import {
+  GreenHouseCropName,
+  GreenHouseCropSeedName,
+  PlotCropName,
+} from "./crops";
 import {
   AnimalFoodName,
   AnimalMedicineName,

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { ConsumableName, CookableName } from "./consumables";
 import { Animal, Food, ToolName } from "./craftables";
-import { CropName, GreenHouseCropName, GreenHouseCropSeedName } from "./crops";
+import { GreenHouseCropName, GreenHouseCropSeedName, PlotCropName } from "./crops";
 import {
   AnimalFoodName,
   AnimalMedicineName,
@@ -50,7 +50,7 @@ type BuyableName =
   | SeasonalTierItemName;
 
 type SellableName =
-  | CropName
+  | PlotCropName
   | Food
   | PatchFruitName
   | BeachBountyTreasure
@@ -61,13 +61,13 @@ type Recipes = Food | CookableName;
 type Edibles = Food | ConsumableName;
 
 export type HarvestEvent = `${
-  | CropName
+  | PlotCropName
   | PatchFruitName
   | FlowerName
   | GreenHouseCropName
   | GreenHouseFruitName
   | "Honey"} Harvested`;
-export type PlantEvent = `${CropName | PatchFruitName} Planted`;
+export type PlantEvent = `${PlotCropName | PatchFruitName} Planted`;
 export type FruitPlantEvent = `${PatchFruitSeedName} Planted`;
 export type PlantFlowerEvent = `${FlowerSeedName} Planted`;
 export type CookEvent = `${Recipes} Cooked`;

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -1,5 +1,5 @@
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { BuffLabel } from ".";
 import { BumpkinItem } from "./bumpkin";
 
@@ -60,7 +60,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       shortDescription: translate("bumpkinItemBuff.eggplant.onesie.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
-      boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Eggplant.crop,
     },
     "Golden Spatula": {
       shortDescription: translate("bumpkinItemBuff.golden.spatula.boost"),
@@ -77,31 +77,31 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       shortDescription: translate("bumpkinItemBuff.parsnip.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
-      boostedItemIcon: CROP_LIFECYCLE.Parsnip.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Parsnip.crop,
     },
     "Sunflower Shield": {
       shortDescription: translate("bumpkinItemBuff.sunflower.shield.boost"),
       labelType: "vibrant",
       boostTypeIcon: lightning,
-      boostedItemIcon: CROP_LIFECYCLE.Sunflower.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Sunflower.crop,
     },
     "Sunflower Amulet": {
       shortDescription: translate("bumpkinItemBuff.sunflower.amulet.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
-      boostedItemIcon: CROP_LIFECYCLE.Sunflower.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Sunflower.crop,
     },
     "Carrot Amulet": {
       shortDescription: translate("bumpkinItemBuff.carrot.amulet.boost"),
       labelType: "info",
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Carrot.crop,
     },
     "Beetroot Amulet": {
       shortDescription: translate("bumpkinItemBuff.beetroot.amulet.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
-      boostedItemIcon: CROP_LIFECYCLE.Beetroot.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Beetroot.crop,
     },
     "Green Amulet": {
       shortDescription: translate("bumpkinItemBuff.green.amulet.boost"),
@@ -128,7 +128,7 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<Record<BumpkinItem, BuffLabel>> =
       shortDescription: translate("bumpkinItemBuff.corn.onesie.boost"),
       labelType: "success",
       boostTypeIcon: powerup,
-      boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
+      boostedItemIcon: PLOT_CROP_LIFECYCLE.Corn.crop,
     },
     "Sunflower Rod": {
       shortDescription: translate("bumpkinItemBuff.sunflower.rod.boost"),

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -1,6 +1,6 @@
 import { getKeys } from "./craftables";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { translate } from "lib/i18n/translate";
 
 export type BumpkinSkillName =
@@ -237,7 +237,7 @@ export const BUMPKIN_SKILL_TREE: Record<BumpkinSkillName, BumpkinSkill> = {
       skill: "Master Farmer",
     },
     boosts: translate("coming.soon"),
-    image: CROP_LIFECYCLE.Radish.crop,
+    image: PLOT_CROP_LIFECYCLE.Radish.crop,
     disabled: true,
   },
   "Happy Crop": {

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -3,7 +3,7 @@ import { BuffLabel } from ".";
 import powerup from "assets/icons/level_up.png";
 import lightning from "assets/icons/lightning.png";
 import chefHat from "assets/icons/chef_hat.png";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ITEM_DETAILS } from "./images";
 import { translate } from "lib/i18n/translate";
@@ -66,103 +66,103 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     shortDescription: translate("description.peeled.potato.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Potato.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Potato.crop,
   },
   "Victoria Sisters": {
     shortDescription: translate("description.victoria.sisters.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
   },
   "Freya Fox": {
     shortDescription: translate("description.freya.fox.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
   },
   "Easter Bunny": {
     shortDescription: translate("description.easter.bunny.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Carrot.crop,
   },
   "Pablo The Bunny": {
     shortDescription: translate("description.pablo.bunny.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Carrot.crop,
   },
   "Cabbage Boy": {
     shortDescription: translate("description.cabbage.boy.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Cabbage.crop,
   },
   "Cabbage Girl": {
     shortDescription: translate("description.cabbage.girl.boost"),
     labelType: "info",
     boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Cabbage.crop,
   },
   Karkinos: {
     shortDescription: translate("description.Karkinos.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Cabbage.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Cabbage.crop,
   },
   "Golden Cauliflower": {
     shortDescription: translate("description.golden.cauliflower.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Cauliflower.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Cauliflower.crop,
   },
   "Mysterious Parsnip": {
     shortDescription: translate("description.mysterious.parsnip.boost"),
     labelType: "info",
     boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-    boostedItemIcon: CROP_LIFECYCLE.Parsnip.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Parsnip.crop,
   },
   "Purple Trail": {
     shortDescription: translate("description.purple.trail.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Eggplant.crop,
   },
   Obie: {
     shortDescription: translate("description.obie.boost"),
     labelType: "info",
     boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Eggplant.crop,
   },
   Maximus: {
     shortDescription: translate("description.maximus.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Eggplant.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Eggplant.crop,
   },
   Poppy: {
     shortDescription: translate("description.poppy.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Corn.crop,
   },
   Kernaldo: {
     shortDescription: translate("description.kernaldo.boost"),
     labelType: "info",
     boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-    boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Corn.crop,
   },
   "Queen Cornelia": {
     shortDescription: translate("description.queen.cornelia.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Corn.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Corn.crop,
   },
   Foliant: {
     shortDescription: translate("description.foliant.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Kale.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Kale.crop,
   },
   Hoot: {
     shortDescription: translate("description.hoot.boost"),
@@ -186,26 +186,23 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     shortDescription: translate("description.soybliss.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Soybean.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Soybean.crop,
   },
 
   "Grape Granny": {
     shortDescription: translate("description.grape.granny.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    // boostedItemIcon: CROP_LIFECYCLE.grape.crop,
   },
   Vinny: {
     shortDescription: translate("description.vinny.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    // boostedItemIcon: CROP_LIFECYCLE.grape.crop,
   },
   "Rice Panda": {
     shortDescription: translate("description.rice.panda.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    // boostedItemIcon: CROP_LIFECYCLE.grape.crop,
   },
 
   // Fruit Boosts
@@ -255,37 +252,37 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     shortDescription: translate("description.stellar.sunflower.boost"),
     labelType: "vibrant",
     boostTypeIcon: lightning,
-    boostedItemIcon: CROP_LIFECYCLE.Sunflower.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Sunflower.crop,
   },
   "Potent Potato": {
     shortDescription: translate("description.potent.potato.boost"),
     labelType: "vibrant",
     boostTypeIcon: lightning,
-    boostedItemIcon: CROP_LIFECYCLE.Potato.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Potato.crop,
   },
   "Radical Radish": {
     shortDescription: translate("description.radical.radish.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Radish.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Radish.crop,
   },
   "Lab Grown Pumpkin": {
     shortDescription: translate("description.lg.pumpkin.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Pumpkin.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
   },
   "Lab Grown Carrot": {
     shortDescription: translate("description.lg.carrot.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Carrot.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Carrot.crop,
   },
   "Lab Grown Radish": {
     shortDescription: translate("description.lg.radish.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Radish.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Radish.crop,
   },
 
   // Animals
@@ -763,7 +760,7 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
     shortDescription: translate("description.sheafOfPlenty.boost"),
     labelType: "success",
     boostTypeIcon: powerup,
-    boostedItemIcon: CROP_LIFECYCLE.Barley.crop,
+    boostedItemIcon: PLOT_CROP_LIFECYCLE.Barley.crop,
   },
   "Moo-ver": {
     shortDescription: translate("description.mooVer.boost"),

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CropSeedName } from "./crops";
+import { PlotCropSeedName } from "./crops";
 import {
   BedName,
   FactionBanner,
@@ -41,7 +41,7 @@ export type CraftAction = {
 export type CraftableName =
   | LimitedItemName
   | ToolName
-  | CropSeedName
+  | PlotCropSeedName
   | Food
   | Animal
   | Flag

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -18,7 +18,7 @@ export type PlotCropName =
   | "Kale"
   | "Barley";
 
-export type Crop = {
+export type PlotCrop = {
   sellPrice: number;
   harvestSeconds: number;
   name: PlotCropName;
@@ -75,7 +75,7 @@ export type GreenHouseCropSeedName = `${GreenHouseCropName} Seed`;
 /**
  * Plot crops and their original prices
  */
-export const PLOT_CROPS: Record<PlotCropName, Crop> = {
+export const PLOT_CROPS: Record<PlotCropName, PlotCrop> = {
   Sunflower: {
     name: "Sunflower",
     description: translate("description.sunflower"),

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -168,9 +168,9 @@ export const PLOT_CROPS: Record<PlotCropName, Crop> = {
   },
 };
 
-export type CropSeedName = `${PlotCropName} Seed`;
+export type PlotCropSeedName = `${PlotCropName} Seed`;
 
-export const PLOT_CROP_SEEDS: Record<CropSeedName, Seed> = {
+export const PLOT_CROP_SEEDS: Record<PlotCropSeedName, Seed> = {
   "Sunflower Seed": {
     description: translate("description.sunflower"),
     price: 0.01,

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -73,9 +73,9 @@ export const GREENHOUSE_SEEDS: Record<GreenHouseCropSeedName, Seed> = {
 export type GreenHouseCropSeedName = `${GreenHouseCropName} Seed`;
 
 /**
- * Crops and their original prices
+ * Plot crops and their original prices
  */
-export const CROPS: Record<CropName, Crop> = {
+export const PLOT_CROPS: Record<CropName, Crop> = {
   Sunflower: {
     name: "Sunflower",
     description: translate("description.sunflower"),

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -1,7 +1,7 @@
 import { translate } from "lib/i18n/translate";
 import { Seed } from "./seeds";
 
-export type CropName =
+export type PlotCropName =
   | "Sunflower"
   | "Potato"
   | "Pumpkin"
@@ -21,7 +21,7 @@ export type CropName =
 export type Crop = {
   sellPrice: number;
   harvestSeconds: number;
-  name: CropName;
+  name: PlotCropName;
   description: string;
   disabled?: boolean;
 };
@@ -75,7 +75,7 @@ export type GreenHouseCropSeedName = `${GreenHouseCropName} Seed`;
 /**
  * Plot crops and their original prices
  */
-export const PLOT_CROPS: Record<CropName, Crop> = {
+export const PLOT_CROPS: Record<PlotCropName, Crop> = {
   Sunflower: {
     name: "Sunflower",
     description: translate("description.sunflower"),
@@ -168,7 +168,7 @@ export const PLOT_CROPS: Record<CropName, Crop> = {
   },
 };
 
-export type CropSeedName = `${CropName} Seed`;
+export type CropSeedName = `${PlotCropName} Seed`;
 
 export const CROP_SEEDS: Record<CropSeedName, Seed> = {
   "Sunflower Seed": {

--- a/src/features/game/types/crops.ts
+++ b/src/features/game/types/crops.ts
@@ -170,7 +170,7 @@ export const PLOT_CROPS: Record<PlotCropName, Crop> = {
 
 export type CropSeedName = `${PlotCropName} Seed`;
 
-export const CROP_SEEDS: Record<CropSeedName, Seed> = {
+export const PLOT_CROP_SEEDS: Record<CropSeedName, Seed> = {
   "Sunflower Seed": {
     description: translate("description.sunflower"),
     price: 0.01,

--- a/src/features/game/types/flowers.ts
+++ b/src/features/game/types/flowers.ts
@@ -1,5 +1,5 @@
 import { getKeys } from "./craftables";
-import { CropName } from "./crops";
+import { PlotCropName } from "./crops";
 import { PatchFruitName } from "./fruits";
 import { translate } from "lib/i18n/translate";
 import { ResourceName } from "./resources";
@@ -105,7 +105,7 @@ export const FLOWER_SEEDS: () => Record<FlowerSeedName, FlowerSeed> = () => ({
 // Some crops have been omitted to reserve cross breeds for future use
 export type FlowerCrossBreedName =
   | Extract<
-      CropName,
+      PlotCropName,
       | "Sunflower"
       | "Beetroot"
       | "Cauliflower"

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -3,7 +3,7 @@ import { Decimal } from "decimal.js-light";
 
 import {
   PlotCropName,
-  CropSeedName,
+  PlotCropSeedName,
   GreenHouseCropName,
   GreenHouseCropSeedName,
 } from "./crops";
@@ -406,7 +406,7 @@ export type Bounties = {
 export type InventoryItemName =
   | AnimalResource
   | PlotCropName
-  | CropSeedName
+  | PlotCropSeedName
   | BeanName
   | MutantCropName
   | PatchFruitName

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -2,7 +2,7 @@
 import { Decimal } from "decimal.js-light";
 
 import {
-  CropName,
+  PlotCropName,
   CropSeedName,
   GreenHouseCropName,
   GreenHouseCropSeedName,
@@ -114,7 +114,7 @@ export type FruitFertiliser = {
 };
 
 export type FieldItem = {
-  name: CropName;
+  name: PlotCropName;
   // Epoch time in milliseconds
   plantedAt: number;
   multiplier?: number;
@@ -405,7 +405,7 @@ export type Bounties = {
 
 export type InventoryItemName =
   | AnimalResource
-  | CropName
+  | PlotCropName
   | CropSeedName
   | BeanName
   | MutantCropName
@@ -517,7 +517,7 @@ export type Wood = {
 
 export type PlantedCrop = {
   id?: string;
-  name: CropName;
+  name: PlotCropName;
   plantedAt: number;
   amount: number;
   reward?: Omit<Reward, "sfl">;
@@ -635,7 +635,7 @@ export type CompostBuilding = PlacedItem & {
 };
 
 export type CropMachineQueueItem = {
-  crop: CropName;
+  crop: PlotCropName;
   seeds: number;
   amount: number;
   growTimeRemaining: number;
@@ -1226,7 +1226,7 @@ export type Faction = {
 };
 
 export type DonationItemName =
-  | CropName
+  | PlotCropName
   | FishName
   | PatchFruitName
   | CommodityName

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -751,7 +751,7 @@ import { AchievementName, ACHIEVEMENTS } from "./achievements";
 //Golden Crop Event
 
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import {
   GREENHOUSE_FRUIT,
   GREENHOUSE_FRUIT_SEEDS,
@@ -799,127 +799,127 @@ type Items = Record<InventoryItemName | AchievementName, ItemDetails>;
 
 export const ITEM_DETAILS: Items = {
   Sunflower: {
-    image: CROP_LIFECYCLE.Sunflower.crop,
+    image: PLOT_CROP_LIFECYCLE.Sunflower.crop,
     description: PLOT_CROPS.Sunflower.description,
   },
   Potato: {
-    image: CROP_LIFECYCLE.Potato.crop,
+    image: PLOT_CROP_LIFECYCLE.Potato.crop,
     description: PLOT_CROPS.Potato.description,
   },
   Pumpkin: {
-    image: CROP_LIFECYCLE.Pumpkin.crop,
+    image: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
     description: PLOT_CROPS.Pumpkin.description,
   },
   Carrot: {
-    image: CROP_LIFECYCLE.Carrot.crop,
+    image: PLOT_CROP_LIFECYCLE.Carrot.crop,
     description: PLOT_CROPS.Carrot.description,
   },
   Cabbage: {
-    image: CROP_LIFECYCLE.Cabbage.crop,
+    image: PLOT_CROP_LIFECYCLE.Cabbage.crop,
     description: PLOT_CROPS.Cabbage.description,
   },
   Beetroot: {
-    image: CROP_LIFECYCLE.Beetroot.crop,
+    image: PLOT_CROP_LIFECYCLE.Beetroot.crop,
     description: PLOT_CROPS.Beetroot.description,
   },
   Cauliflower: {
-    image: CROP_LIFECYCLE.Cauliflower.crop,
+    image: PLOT_CROP_LIFECYCLE.Cauliflower.crop,
     description: PLOT_CROPS.Cauliflower.description,
   },
   Parsnip: {
-    image: CROP_LIFECYCLE.Parsnip.crop,
+    image: PLOT_CROP_LIFECYCLE.Parsnip.crop,
     description: PLOT_CROPS.Parsnip.description,
   },
   Eggplant: {
-    image: CROP_LIFECYCLE.Eggplant.crop,
+    image: PLOT_CROP_LIFECYCLE.Eggplant.crop,
     description: PLOT_CROPS.Eggplant.description,
   },
   Corn: {
-    image: CROP_LIFECYCLE.Corn.crop,
+    image: PLOT_CROP_LIFECYCLE.Corn.crop,
     description: PLOT_CROPS.Corn.description,
   },
   Radish: {
-    image: CROP_LIFECYCLE.Radish.crop,
+    image: PLOT_CROP_LIFECYCLE.Radish.crop,
     description: PLOT_CROPS.Radish.description,
   },
   Wheat: {
-    image: CROP_LIFECYCLE.Wheat.crop,
+    image: PLOT_CROP_LIFECYCLE.Wheat.crop,
     description: PLOT_CROPS.Wheat.description,
   },
   Kale: {
-    image: CROP_LIFECYCLE.Kale.crop,
+    image: PLOT_CROP_LIFECYCLE.Kale.crop,
     description: PLOT_CROPS.Kale.description,
   },
   Soybean: {
-    image: CROP_LIFECYCLE.Soybean.crop,
+    image: PLOT_CROP_LIFECYCLE.Soybean.crop,
     description: PLOT_CROPS.Soybean.description,
   },
   Barley: {
-    image: CROP_LIFECYCLE.Barley.crop,
+    image: PLOT_CROP_LIFECYCLE.Barley.crop,
     description: translate("description.barley"),
   },
   "Sunflower Seed": {
-    image: CROP_LIFECYCLE.Sunflower.seed,
-    secondaryImage: CROP_LIFECYCLE.Sunflower.crop,
+    image: PLOT_CROP_LIFECYCLE.Sunflower.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Sunflower.crop,
     description: CROP_SEEDS["Sunflower Seed"].description,
   },
   "Potato Seed": {
-    image: CROP_LIFECYCLE.Potato.seed,
-    secondaryImage: CROP_LIFECYCLE.Potato.crop,
+    image: PLOT_CROP_LIFECYCLE.Potato.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Potato.crop,
     description: CROP_SEEDS["Potato Seed"].description,
   },
   "Pumpkin Seed": {
-    image: CROP_LIFECYCLE.Pumpkin.seed,
-    secondaryImage: CROP_LIFECYCLE.Pumpkin.crop,
+    image: PLOT_CROP_LIFECYCLE.Pumpkin.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
     description: CROP_SEEDS["Pumpkin Seed"].description,
   },
   "Carrot Seed": {
-    image: CROP_LIFECYCLE.Carrot.seed,
-    secondaryImage: CROP_LIFECYCLE.Carrot.crop,
+    image: PLOT_CROP_LIFECYCLE.Carrot.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Carrot.crop,
     description: CROP_SEEDS["Carrot Seed"].description,
   },
   "Cabbage Seed": {
-    image: CROP_LIFECYCLE.Cabbage.seed,
-    secondaryImage: CROP_LIFECYCLE.Cabbage.crop,
+    image: PLOT_CROP_LIFECYCLE.Cabbage.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Cabbage.crop,
     description: CROP_SEEDS["Cabbage Seed"].description,
   },
   "Beetroot Seed": {
-    image: CROP_LIFECYCLE.Beetroot.seed,
-    secondaryImage: CROP_LIFECYCLE.Beetroot.crop,
+    image: PLOT_CROP_LIFECYCLE.Beetroot.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Beetroot.crop,
     description: CROP_SEEDS["Beetroot Seed"].description,
   },
   "Cauliflower Seed": {
-    image: CROP_LIFECYCLE.Cauliflower.seed,
-    secondaryImage: CROP_LIFECYCLE.Cauliflower.crop,
+    image: PLOT_CROP_LIFECYCLE.Cauliflower.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Cauliflower.crop,
     description: CROP_SEEDS["Cauliflower Seed"].description,
   },
   "Parsnip Seed": {
-    image: CROP_LIFECYCLE.Parsnip.seed,
-    secondaryImage: CROP_LIFECYCLE.Parsnip.crop,
+    image: PLOT_CROP_LIFECYCLE.Parsnip.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Parsnip.crop,
     description: CROP_SEEDS["Parsnip Seed"].description,
   },
   "Eggplant Seed": {
-    image: CROP_LIFECYCLE.Eggplant.seed,
-    secondaryImage: CROP_LIFECYCLE.Eggplant.crop,
+    image: PLOT_CROP_LIFECYCLE.Eggplant.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Eggplant.crop,
     description: CROP_SEEDS["Eggplant Seed"].description,
   },
   "Corn Seed": {
-    image: CROP_LIFECYCLE.Corn.seed,
-    secondaryImage: CROP_LIFECYCLE.Corn.crop,
+    image: PLOT_CROP_LIFECYCLE.Corn.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Corn.crop,
     description: CROP_SEEDS["Corn Seed"].description,
   },
   "Radish Seed": {
-    image: CROP_LIFECYCLE.Radish.seed,
-    secondaryImage: CROP_LIFECYCLE.Radish.crop,
+    image: PLOT_CROP_LIFECYCLE.Radish.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Radish.crop,
     description: CROP_SEEDS["Radish Seed"].description,
   },
   "Wheat Seed": {
-    image: CROP_LIFECYCLE.Wheat.seed,
-    secondaryImage: CROP_LIFECYCLE.Wheat.crop,
+    image: PLOT_CROP_LIFECYCLE.Wheat.seed,
+    secondaryImage: PLOT_CROP_LIFECYCLE.Wheat.crop,
     description: CROP_SEEDS["Wheat Seed"].description,
   },
   "Barley Seed": {
-    image: CROP_LIFECYCLE.Barley.seed,
+    image: PLOT_CROP_LIFECYCLE.Barley.seed,
     description: translate("description.barley"),
   },
   "Magic Bean": {
@@ -927,11 +927,11 @@ export const ITEM_DETAILS: Items = {
     description: BEANS()["Magic Bean"].description,
   },
   "Kale Seed": {
-    image: CROP_LIFECYCLE.Kale.seed,
+    image: PLOT_CROP_LIFECYCLE.Kale.seed,
     description: CROP_SEEDS["Kale Seed"].description,
   },
   "Soybean Seed": {
-    image: CROP_LIFECYCLE.Soybean.seed,
+    image: PLOT_CROP_LIFECYCLE.Soybean.seed,
     description: CROP_SEEDS["Soybean Seed"].description,
   },
   "Apple Seed": {

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -745,7 +745,7 @@ import mootant from "assets/sfts/mootant.webp";
 
 import { COUPONS, EASTER_EGG, FERTILISERS, InventoryItemName } from "./game";
 
-import { CROP_SEEDS, GREENHOUSE_CROPS, GREENHOUSE_SEEDS, PLOT_CROPS } from "./crops";
+import { GREENHOUSE_CROPS, GREENHOUSE_SEEDS, PLOT_CROP_SEEDS, PLOT_CROPS } from "./crops";
 import { AchievementName, ACHIEVEMENTS } from "./achievements";
 
 //Golden Crop Event
@@ -861,62 +861,62 @@ export const ITEM_DETAILS: Items = {
   "Sunflower Seed": {
     image: PLOT_CROP_LIFECYCLE.Sunflower.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Sunflower.crop,
-    description: CROP_SEEDS["Sunflower Seed"].description,
+    description: PLOT_CROP_SEEDS["Sunflower Seed"].description,
   },
   "Potato Seed": {
     image: PLOT_CROP_LIFECYCLE.Potato.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Potato.crop,
-    description: CROP_SEEDS["Potato Seed"].description,
+    description: PLOT_CROP_SEEDS["Potato Seed"].description,
   },
   "Pumpkin Seed": {
     image: PLOT_CROP_LIFECYCLE.Pumpkin.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Pumpkin.crop,
-    description: CROP_SEEDS["Pumpkin Seed"].description,
+    description: PLOT_CROP_SEEDS["Pumpkin Seed"].description,
   },
   "Carrot Seed": {
     image: PLOT_CROP_LIFECYCLE.Carrot.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Carrot.crop,
-    description: CROP_SEEDS["Carrot Seed"].description,
+    description: PLOT_CROP_SEEDS["Carrot Seed"].description,
   },
   "Cabbage Seed": {
     image: PLOT_CROP_LIFECYCLE.Cabbage.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Cabbage.crop,
-    description: CROP_SEEDS["Cabbage Seed"].description,
+    description: PLOT_CROP_SEEDS["Cabbage Seed"].description,
   },
   "Beetroot Seed": {
     image: PLOT_CROP_LIFECYCLE.Beetroot.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Beetroot.crop,
-    description: CROP_SEEDS["Beetroot Seed"].description,
+    description: PLOT_CROP_SEEDS["Beetroot Seed"].description,
   },
   "Cauliflower Seed": {
     image: PLOT_CROP_LIFECYCLE.Cauliflower.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Cauliflower.crop,
-    description: CROP_SEEDS["Cauliflower Seed"].description,
+    description: PLOT_CROP_SEEDS["Cauliflower Seed"].description,
   },
   "Parsnip Seed": {
     image: PLOT_CROP_LIFECYCLE.Parsnip.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Parsnip.crop,
-    description: CROP_SEEDS["Parsnip Seed"].description,
+    description: PLOT_CROP_SEEDS["Parsnip Seed"].description,
   },
   "Eggplant Seed": {
     image: PLOT_CROP_LIFECYCLE.Eggplant.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Eggplant.crop,
-    description: CROP_SEEDS["Eggplant Seed"].description,
+    description: PLOT_CROP_SEEDS["Eggplant Seed"].description,
   },
   "Corn Seed": {
     image: PLOT_CROP_LIFECYCLE.Corn.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Corn.crop,
-    description: CROP_SEEDS["Corn Seed"].description,
+    description: PLOT_CROP_SEEDS["Corn Seed"].description,
   },
   "Radish Seed": {
     image: PLOT_CROP_LIFECYCLE.Radish.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Radish.crop,
-    description: CROP_SEEDS["Radish Seed"].description,
+    description: PLOT_CROP_SEEDS["Radish Seed"].description,
   },
   "Wheat Seed": {
     image: PLOT_CROP_LIFECYCLE.Wheat.seed,
     secondaryImage: PLOT_CROP_LIFECYCLE.Wheat.crop,
-    description: CROP_SEEDS["Wheat Seed"].description,
+    description: PLOT_CROP_SEEDS["Wheat Seed"].description,
   },
   "Barley Seed": {
     image: PLOT_CROP_LIFECYCLE.Barley.seed,
@@ -928,11 +928,11 @@ export const ITEM_DETAILS: Items = {
   },
   "Kale Seed": {
     image: PLOT_CROP_LIFECYCLE.Kale.seed,
-    description: CROP_SEEDS["Kale Seed"].description,
+    description: PLOT_CROP_SEEDS["Kale Seed"].description,
   },
   "Soybean Seed": {
     image: PLOT_CROP_LIFECYCLE.Soybean.seed,
-    description: CROP_SEEDS["Soybean Seed"].description,
+    description: PLOT_CROP_SEEDS["Soybean Seed"].description,
   },
   "Apple Seed": {
     image: appleSeed,

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -745,7 +745,12 @@ import mootant from "assets/sfts/mootant.webp";
 
 import { COUPONS, EASTER_EGG, FERTILISERS, InventoryItemName } from "./game";
 
-import { GREENHOUSE_CROPS, GREENHOUSE_SEEDS, PLOT_CROP_SEEDS, PLOT_CROPS } from "./crops";
+import {
+  GREENHOUSE_CROPS,
+  GREENHOUSE_SEEDS,
+  PLOT_CROP_SEEDS,
+  PLOT_CROPS,
+} from "./crops";
 import { AchievementName, ACHIEVEMENTS } from "./achievements";
 
 //Golden Crop Event

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// CROPS
+// PLOT_CROPS
 import appleSeed from "assets/fruit/apple/apple_seed.png";
 import orangeSeed from "assets/fruit/orange/orange_seed.png";
 import blueberrySeed from "assets/fruit/blueberry/blueberry_seed.png";
@@ -745,7 +745,7 @@ import mootant from "assets/sfts/mootant.webp";
 
 import { COUPONS, EASTER_EGG, FERTILISERS, InventoryItemName } from "./game";
 
-import { CROPS, CROP_SEEDS, GREENHOUSE_CROPS, GREENHOUSE_SEEDS } from "./crops";
+import { CROP_SEEDS, GREENHOUSE_CROPS, GREENHOUSE_SEEDS, PLOT_CROPS } from "./crops";
 import { AchievementName, ACHIEVEMENTS } from "./achievements";
 
 //Golden Crop Event
@@ -800,59 +800,59 @@ type Items = Record<InventoryItemName | AchievementName, ItemDetails>;
 export const ITEM_DETAILS: Items = {
   Sunflower: {
     image: CROP_LIFECYCLE.Sunflower.crop,
-    description: CROPS.Sunflower.description,
+    description: PLOT_CROPS.Sunflower.description,
   },
   Potato: {
     image: CROP_LIFECYCLE.Potato.crop,
-    description: CROPS.Potato.description,
+    description: PLOT_CROPS.Potato.description,
   },
   Pumpkin: {
     image: CROP_LIFECYCLE.Pumpkin.crop,
-    description: CROPS.Pumpkin.description,
+    description: PLOT_CROPS.Pumpkin.description,
   },
   Carrot: {
     image: CROP_LIFECYCLE.Carrot.crop,
-    description: CROPS.Carrot.description,
+    description: PLOT_CROPS.Carrot.description,
   },
   Cabbage: {
     image: CROP_LIFECYCLE.Cabbage.crop,
-    description: CROPS.Cabbage.description,
+    description: PLOT_CROPS.Cabbage.description,
   },
   Beetroot: {
     image: CROP_LIFECYCLE.Beetroot.crop,
-    description: CROPS.Beetroot.description,
+    description: PLOT_CROPS.Beetroot.description,
   },
   Cauliflower: {
     image: CROP_LIFECYCLE.Cauliflower.crop,
-    description: CROPS.Cauliflower.description,
+    description: PLOT_CROPS.Cauliflower.description,
   },
   Parsnip: {
     image: CROP_LIFECYCLE.Parsnip.crop,
-    description: CROPS.Parsnip.description,
+    description: PLOT_CROPS.Parsnip.description,
   },
   Eggplant: {
     image: CROP_LIFECYCLE.Eggplant.crop,
-    description: CROPS.Eggplant.description,
+    description: PLOT_CROPS.Eggplant.description,
   },
   Corn: {
     image: CROP_LIFECYCLE.Corn.crop,
-    description: CROPS.Corn.description,
+    description: PLOT_CROPS.Corn.description,
   },
   Radish: {
     image: CROP_LIFECYCLE.Radish.crop,
-    description: CROPS.Radish.description,
+    description: PLOT_CROPS.Radish.description,
   },
   Wheat: {
     image: CROP_LIFECYCLE.Wheat.crop,
-    description: CROPS.Wheat.description,
+    description: PLOT_CROPS.Wheat.description,
   },
   Kale: {
     image: CROP_LIFECYCLE.Kale.crop,
-    description: CROPS.Kale.description,
+    description: PLOT_CROPS.Kale.description,
   },
   Soybean: {
     image: CROP_LIFECYCLE.Soybean.crop,
-    description: CROPS.Soybean.description,
+    description: PLOT_CROPS.Soybean.description,
   },
   Barley: {
     image: CROP_LIFECYCLE.Barley.crop,

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -15,9 +15,9 @@ import {
   InventoryItemName,
 } from "features/game/types/game";
 import {
-  CropName,
   GREENHOUSE_CROPS,
   GreenHouseCropName,
+  PlotCropName,
 } from "features/game/types/crops";
 import { canMine } from "../expansion/lib/utils";
 import { Bud, StemTrait, TypeTrait } from "./buds";
@@ -44,7 +44,7 @@ export type Restriction = [boolean, string];
 type RemoveCondition = (gameState: GameState) => Restriction;
 
 type CanRemoveArgs = {
-  item: CropName;
+  item: PlotCropName;
   game: GameState;
 };
 

--- a/src/features/game/types/rewards.ts
+++ b/src/features/game/types/rewards.ts
@@ -64,7 +64,9 @@ export const ONBOARDING_CHALLENGES: DailyChallenge[] = [
   {
     description: "Sell 30 Crops",
     progress: ({ game }) => {
-      const events = getKeys(PLOT_CROPS).map((name) => `${name} Sold` as SellEvent);
+      const events = getKeys(PLOT_CROPS).map(
+        (name) => `${name} Sold` as SellEvent,
+      );
 
       return events.reduce((count, activityName) => {
         const amount = game.bumpkin?.activity?.[activityName] || 0;

--- a/src/features/game/types/rewards.ts
+++ b/src/features/game/types/rewards.ts
@@ -1,6 +1,6 @@
 import { getBumpkinLevel } from "../lib/level";
 import { SellEvent } from "./bumpkinActivity";
-import { CROPS } from "./crops";
+import { PLOT_CROPS } from "./crops";
 import { getKeys } from "./decorations";
 import {
   BB_TO_GEM_RATIO,
@@ -64,7 +64,7 @@ export const ONBOARDING_CHALLENGES: DailyChallenge[] = [
   {
     description: "Sell 30 Crops",
     progress: ({ game }) => {
-      const events = getKeys(CROPS).map((name) => `${name} Sold` as SellEvent);
+      const events = getKeys(PLOT_CROPS).map((name) => `${name} Sold` as SellEvent);
 
       return events.reduce((count, activityName) => {
         const amount = game.bumpkin?.activity?.[activityName] || 0;

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -1,10 +1,10 @@
 import {
   CROP_SEEDS,
-  CropName,
   CropSeedName,
   GREENHOUSE_SEEDS,
   GreenHouseCropName,
   GreenHouseCropSeedName,
+  PlotCropName,
 } from "./crops";
 import {
   GREENHOUSE_FRUIT_SEEDS,
@@ -31,7 +31,7 @@ export type Seed = {
   bumpkinLevel: number;
   plantingSpot: ResourceName | "Greenhouse";
   yield?:
-    | CropName
+    | PlotCropName
     | PatchFruitName
     | FlowerSeedName
     | GreenHouseCropName

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -1,10 +1,10 @@
 import {
-  CropSeedName,
   GREENHOUSE_SEEDS,
   GreenHouseCropName,
   GreenHouseCropSeedName,
   PLOT_CROP_SEEDS,
   PlotCropName,
+  PlotCropSeedName,
 } from "./crops";
 import {
   GREENHOUSE_FRUIT_SEEDS,
@@ -18,7 +18,7 @@ import { FLOWER_SEEDS, FlowerSeedName } from "./flowers";
 import { ResourceName } from "./resources";
 
 export type SeedName =
-  | CropSeedName
+  | PlotCropSeedName
   | PatchFruitSeedName
   | FlowerSeedName
   | GreenHouseCropSeedName

--- a/src/features/game/types/seeds.ts
+++ b/src/features/game/types/seeds.ts
@@ -1,9 +1,9 @@
 import {
-  CROP_SEEDS,
   CropSeedName,
   GREENHOUSE_SEEDS,
   GreenHouseCropName,
   GreenHouseCropSeedName,
+  PLOT_CROP_SEEDS,
   PlotCropName,
 } from "./crops";
 import {
@@ -40,7 +40,7 @@ export type Seed = {
 };
 
 export const SEEDS: () => Record<SeedName, Seed> = () => ({
-  ...CROP_SEEDS,
+  ...PLOT_CROP_SEEDS,
   ...PATCH_FRUIT_SEEDS(),
   ...FLOWER_SEEDS(),
   ...GREENHOUSE_FRUIT_SEEDS(),

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1,8 +1,8 @@
 import {
-  CropName,
   CropSeedName,
   GreenHouseCropName,
   GreenHouseCropSeedName,
+  PlotCropName,
 } from "./crops";
 import {
   GreenHouseFruitName,
@@ -146,7 +146,7 @@ const flowerSeed: Record<FlowerSeedName, () => boolean> = {
   "Lily Seed": () => false,
 };
 
-const crops: Record<CropName, () => boolean> = {
+const crops: Record<PlotCropName, () => boolean> = {
   Beetroot: () => true,
   Cabbage: () => true,
   Carrot: () => true,

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1,8 +1,8 @@
 import {
-  CropSeedName,
   GreenHouseCropName,
   GreenHouseCropSeedName,
   PlotCropName,
+  PlotCropSeedName,
 } from "./crops";
 import {
   GreenHouseFruitName,
@@ -113,7 +113,7 @@ const animalTools: Record<LoveAnimalItem, () => boolean> = {
   "Music Box": () => false,
 };
 
-const cropSeeds: Record<CropSeedName, () => boolean> = {
+const cropSeeds: Record<PlotCropSeedName, () => boolean> = {
   "Beetroot Seed": () => false,
   "Cabbage Seed": () => false,
   "Carrot Seed": () => false,

--- a/src/features/goblins/storageHouse/lib/storageItems.ts
+++ b/src/features/goblins/storageHouse/lib/storageItems.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { PATCH_FRUIT } from "features/game/types/fruits";
 import {
   GameState,
@@ -21,7 +21,7 @@ export function getDeliverableItems({ state }: { state: GameState }) {
   return (Object.keys(inventory) as InventoryItemName[]).reduce(
     (acc, itemName) => {
       const isDeliverable =
-        itemName in CROPS ||
+        itemName in PLOT_CROPS ||
         itemName in PATCH_FRUIT() ||
         (itemName in COMMODITIES &&
           itemName !== "Chicken" &&
@@ -57,7 +57,7 @@ export function getBankItems(game: GameState) {
   return (Object.keys(inventory) as InventoryItemName[]).reduce(
     (acc, itemName) => {
       if (
-        itemName in CROPS ||
+        itemName in PLOT_CROPS ||
         itemName in PATCH_FRUIT() ||
         (itemName in COMMODITIES && itemName !== "Chicken")
       ) {

--- a/src/features/helios/components/HeliosSunflower.tsx
+++ b/src/features/helios/components/HeliosSunflower.tsx
@@ -5,7 +5,7 @@ import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const HeliosSunflower: React.FC = () => {
@@ -18,7 +18,7 @@ export const HeliosSunflower: React.FC = () => {
         onClick={() => setShowModal(true)}
       >
         <img
-          src={CROP_LIFECYCLE.Sunflower.ready}
+          src={PLOT_CROP_LIFECYCLE.Sunflower.ready}
           className="absolute"
           style={{
             width: `${PIXEL_SCALE * 16}px`,

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -28,7 +28,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import oilBarrel from "assets/icons/oil_barrel.webp";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
-import { CROP_SEEDS, CropName, CropSeedName } from "features/game/types/crops";
+import { CROP_SEEDS, CropSeedName, PlotCropName } from "features/game/types/crops";
 import { isBasicCrop } from "features/game/events/landExpansion/harvest";
 import { getKeys } from "features/game/types/craftables";
 import { useActor, useSelector } from "@xstate/react";
@@ -57,7 +57,7 @@ interface Props {
 
 const ALLOWED_SEEDS = (state: GameState): CropSeedName[] =>
   getKeys(CROP_SEEDS).filter((seed) => {
-    const crop = seed.split(" ")[0] as CropName;
+    const crop = seed.split(" ")[0] as PlotCropName;
     return (
       isBasicCrop(crop) ||
       (state.bumpkin.skills["Crop Extension Module"] &&

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -28,7 +28,11 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import oilBarrel from "assets/icons/oil_barrel.webp";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
-import { PLOT_CROP_SEEDS, PlotCropName, PlotCropSeedName } from "features/game/types/crops";
+import {
+  PLOT_CROP_SEEDS,
+  PlotCropName,
+  PlotCropSeedName,
+} from "features/game/types/crops";
 import { isBasicCrop } from "features/game/events/landExpansion/harvest";
 import { getKeys } from "features/game/types/craftables";
 import { useActor, useSelector } from "@xstate/react";

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -28,7 +28,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import oilBarrel from "assets/icons/oil_barrel.webp";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
-import { CropSeedName, PLOT_CROP_SEEDS, PlotCropName } from "features/game/types/crops";
+import { PLOT_CROP_SEEDS, PlotCropName, PlotCropSeedName } from "features/game/types/crops";
 import { isBasicCrop } from "features/game/events/landExpansion/harvest";
 import { getKeys } from "features/game/types/craftables";
 import { useActor, useSelector } from "@xstate/react";
@@ -55,7 +55,7 @@ interface Props {
   onAddOil: (oil: number) => void;
 }
 
-const ALLOWED_SEEDS = (state: GameState): CropSeedName[] =>
+const ALLOWED_SEEDS = (state: GameState): PlotCropSeedName[] =>
   getKeys(PLOT_CROP_SEEDS).filter((seed) => {
     const crop = seed.split(" ")[0] as PlotCropName;
     return (
@@ -98,7 +98,7 @@ export const CropMachineModal: React.FC<Props> = ({
   const [selectedPackIndex, setSelectedPackIndex] = useState<number>(
     growingCropPackIndex ?? 0,
   );
-  const [selectedSeed, setSelectedSeed] = useState<CropSeedName>();
+  const [selectedSeed, setSelectedSeed] = useState<PlotCropSeedName>();
   const [showOverlayScreen, setShowOverlayScreen] = useState<boolean>(false);
   const [totalSeeds, setTotalSeeds] = useState(0);
   const [totalOil, setTotalOil] = useState(0);
@@ -215,7 +215,7 @@ export const CropMachineModal: React.FC<Props> = ({
     setShowOverlayScreen(false);
   };
 
-  const handlePickSeed = (seed: CropSeedName) => {
+  const handlePickSeed = (seed: PlotCropSeedName) => {
     setSelectedSeed(seed);
     setTotalSeeds(0);
   };

--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -28,7 +28,7 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import oilBarrel from "assets/icons/oil_barrel.webp";
 import { Button } from "components/ui/Button";
 import Decimal from "decimal.js-light";
-import { CROP_SEEDS, CropSeedName, PlotCropName } from "features/game/types/crops";
+import { CropSeedName, PLOT_CROP_SEEDS, PlotCropName } from "features/game/types/crops";
 import { isBasicCrop } from "features/game/events/landExpansion/harvest";
 import { getKeys } from "features/game/types/craftables";
 import { useActor, useSelector } from "@xstate/react";
@@ -56,7 +56,7 @@ interface Props {
 }
 
 const ALLOWED_SEEDS = (state: GameState): CropSeedName[] =>
-  getKeys(CROP_SEEDS).filter((seed) => {
+  getKeys(PLOT_CROP_SEEDS).filter((seed) => {
     const crop = seed.split(" ")[0] as PlotCropName;
     return (
       isBasicCrop(crop) ||

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -5,7 +5,7 @@ import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 import {
   Crop,
-  CropName,
+  PlotCropName,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
   PLOT_CROPS,
@@ -232,7 +232,7 @@ export const Crops: React.FC = () => {
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
                 .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
-                .filter((crop) => isBasicCrop(crop.name as CropName))
+                .filter((crop) => isBasicCrop(crop.name as PlotCropName))
                 .map((item) => (
                   <Box
                     isSelected={selected.name === item.name}
@@ -256,7 +256,7 @@ export const Crops: React.FC = () => {
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
                 .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
-                .filter((crop) => isMediumCrop(crop.name as CropName))
+                .filter((crop) => isMediumCrop(crop.name as PlotCropName))
                 .map((item) => (
                   <Box
                     isSelected={selected.name === item.name}
@@ -280,7 +280,7 @@ export const Crops: React.FC = () => {
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
                 .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
-                .filter((crop) => isAdvancedCrop(crop.name as CropName))
+                .filter((crop) => isAdvancedCrop(crop.name as PlotCropName))
                 .filter(
                   (crop) =>
                     crop.name !== "Barley" || hasFeatureAccess(state, "BARLEY"),

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -32,7 +32,7 @@ import {
 import { getKeys } from "features/game/types/craftables";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { Label } from "components/ui/Label";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -223,7 +223,7 @@ export const Crops: React.FC = () => {
             <div className="flex">
               <Label
                 className="mr-3 ml-2 mb-1"
-                icon={CROP_LIFECYCLE.Sunflower.crop}
+                icon={PLOT_CROP_LIFECYCLE.Sunflower.crop}
                 type="default"
               >
                 {`Basic Crops`}
@@ -247,7 +247,7 @@ export const Crops: React.FC = () => {
             <div className="flex">
               <Label
                 className="mr-3 ml-2 mb-1"
-                icon={CROP_LIFECYCLE.Carrot.crop}
+                icon={PLOT_CROP_LIFECYCLE.Carrot.crop}
                 type="default"
               >
                 {`Medium Crops`}
@@ -271,7 +271,7 @@ export const Crops: React.FC = () => {
             <div className="flex">
               <Label
                 className="mr-3 ml-2 mb-1"
-                icon={CROP_LIFECYCLE.Kale.crop}
+                icon={PLOT_CROP_LIFECYCLE.Kale.crop}
                 type="default"
               >
                 {`Advanced Crops`}

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -6,9 +6,9 @@ import { Context } from "features/game/GameProvider";
 import {
   Crop,
   CropName,
-  CROPS,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
+  PLOT_CROPS,
 } from "features/game/types/crops";
 import { useActor } from "@xstate/react";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -54,7 +54,7 @@ export const isExoticCrop = (
 export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<
     Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
-  >(CROPS.Sunflower);
+  >(PLOT_CROPS.Sunflower);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
   const [customAmount, setCustomAmount] = useState(new Decimal(0));
@@ -142,7 +142,7 @@ export const Crops: React.FC = () => {
     );
 
   const cropsAndFruits = Object.values({
-    ...CROPS,
+    ...PLOT_CROPS,
     ...PATCH_FRUIT(),
     ...exotics,
     ...GREENHOUSE_FRUIT(),
@@ -231,7 +231,7 @@ export const Crops: React.FC = () => {
             </div>
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
-                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
                 .filter((crop) => isBasicCrop(crop.name as CropName))
                 .map((item) => (
                   <Box
@@ -255,7 +255,7 @@ export const Crops: React.FC = () => {
             </div>
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
-                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
                 .filter((crop) => isMediumCrop(crop.name as CropName))
                 .map((item) => (
                   <Box
@@ -279,7 +279,7 @@ export const Crops: React.FC = () => {
             </div>
             <div className="flex flex-wrap mb-2">
               {cropsAndFruits
-                .filter((crop) => !!crop.sellPrice && crop.name in CROPS)
+                .filter((crop) => !!crop.sellPrice && crop.name in PLOT_CROPS)
                 .filter((crop) => isAdvancedCrop(crop.name as CropName))
                 .filter(
                   (crop) =>

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -4,11 +4,11 @@ import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 import {
-  Crop,
   PlotCropName,
   GREENHOUSE_CROPS,
   GreenHouseCrop,
   PLOT_CROPS,
+  PlotCrop,
 } from "features/game/types/crops";
 import { useActor } from "@xstate/react";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -46,14 +46,14 @@ import {
 } from "features/game/events/landExpansion/harvest";
 
 export const isExoticCrop = (
-  item: Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
+  item: PlotCrop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
 ): item is ExoticCrop => {
   return item.name in EXOTIC_CROPS;
 };
 
 export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<
-    Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
+  PlotCrop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
   >(PLOT_CROPS.Sunflower);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
@@ -93,7 +93,7 @@ export const Crops: React.FC = () => {
   };
 
   const displaySellPrice = (
-    crop: Crop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
+    crop: PlotCrop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop,
   ) =>
     isExoticCrop(crop)
       ? crop.sellPrice

--- a/src/features/island/buildings/components/building/market/Crops.tsx
+++ b/src/features/island/buildings/components/building/market/Crops.tsx
@@ -53,7 +53,7 @@ export const isExoticCrop = (
 
 export const Crops: React.FC = () => {
   const [selected, setSelected] = useState<
-  PlotCrop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
+    PlotCrop | PatchFruit | ExoticCrop | GreenHouseFruit | GreenHouseCrop
   >(PLOT_CROPS.Sunflower);
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 

--- a/src/features/island/buildings/components/building/market/Market.tsx
+++ b/src/features/island/buildings/components/building/market/Market.tsx
@@ -9,7 +9,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Context } from "features/game/GameProvider";
 import { useActor, useSelector } from "@xstate/react";
 import { getKeys } from "features/game/types/craftables";
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { Bumpkin } from "features/game/types/game";
 import { loadAudio, shopAudio } from "lib/utils/sfx";
 import { CROP_SHORTAGE_HOURS } from "features/game/expansion/lib/boosts";
@@ -35,7 +35,7 @@ const hasSoldCropsBefore = (bumpkin?: Bumpkin) => {
 
   const { activity = {} } = bumpkin;
 
-  return !!getKeys(CROPS).find((crop) =>
+  return !!getKeys(PLOT_CROPS).find((crop) =>
     getKeys(activity).includes(`${crop} Sold`),
   );
 };
@@ -45,7 +45,7 @@ const hasBoughtCropsBefore = (bumpkin?: Bumpkin) => {
 
   const { activity = {} } = bumpkin;
 
-  return !!getKeys(CROPS).find((crop) =>
+  return !!getKeys(PLOT_CROPS).find((crop) =>
     getKeys(activity).includes(`${crop} Seed Bought`),
   );
 };

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -7,9 +7,9 @@ import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import {
   CROP_SEEDS,
-  CropName,
   GREENHOUSE_SEEDS,
   GreenHouseCropSeedName,
+  PlotCropName,
 } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { Decimal } from "decimal.js-light";
@@ -238,7 +238,7 @@ export const Seeds: React.FC = () => {
     }
 
     return getCropPlotTime({
-      crop: yields as CropName,
+      crop: yields as PlotCropName,
       inventory,
       game: state,
       buds: state.buds ?? {},
@@ -295,7 +295,7 @@ export const Seeds: React.FC = () => {
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in CROP_SEEDS)
-              .filter((name) => isBasicCrop(name.split(" ")[0] as CropName))
+              .filter((name) => isBasicCrop(name.split(" ")[0] as PlotCropName))
               .filter(
                 (name) =>
                   name !== "Barley Seed" || hasFeatureAccess(state, "BARLEY"),
@@ -324,7 +324,7 @@ export const Seeds: React.FC = () => {
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in CROP_SEEDS)
-              .filter((name) => isMediumCrop(name.split(" ")[0] as CropName))
+              .filter((name) => isMediumCrop(name.split(" ")[0] as PlotCropName))
               .map((name: SeedName) => (
                 <Box
                   isSelected={selectedName === name}
@@ -349,7 +349,7 @@ export const Seeds: React.FC = () => {
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in CROP_SEEDS)
-              .filter((name) => isAdvancedCrop(name.split(" ")[0] as CropName))
+              .filter((name) => isAdvancedCrop(name.split(" ")[0] as PlotCropName))
               .filter(
                 (name) =>
                   name !== "Barley Seed" || hasFeatureAccess(state, "BARLEY"),

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -6,9 +6,9 @@ import { Button } from "components/ui/Button";
 import { Context } from "features/game/GameProvider";
 import { getKeys } from "features/game/types/craftables";
 import {
-  CROP_SEEDS,
   GREENHOUSE_SEEDS,
   GreenHouseCropSeedName,
+  PLOT_CROP_SEEDS,
   PlotCropName,
 } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -294,7 +294,7 @@ export const Seeds: React.FC = () => {
           </Label>
           <div className="flex flex-wrap mb-2">
             {seeds
-              .filter((name) => name in CROP_SEEDS)
+              .filter((name) => name in PLOT_CROP_SEEDS)
               .filter((name) => isBasicCrop(name.split(" ")[0] as PlotCropName))
               .filter(
                 (name) =>
@@ -323,7 +323,7 @@ export const Seeds: React.FC = () => {
           </Label>
           <div className="flex flex-wrap mb-2">
             {seeds
-              .filter((name) => name in CROP_SEEDS)
+              .filter((name) => name in PLOT_CROP_SEEDS)
               .filter((name) => isMediumCrop(name.split(" ")[0] as PlotCropName))
               .map((name: SeedName) => (
                 <Box
@@ -348,7 +348,7 @@ export const Seeds: React.FC = () => {
           </Label>
           <div className="flex flex-wrap mb-2">
             {seeds
-              .filter((name) => name in CROP_SEEDS)
+              .filter((name) => name in PLOT_CROP_SEEDS)
               .filter((name) => isAdvancedCrop(name.split(" ")[0] as PlotCropName))
               .filter(
                 (name) =>

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -324,7 +324,9 @@ export const Seeds: React.FC = () => {
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in PLOT_CROP_SEEDS)
-              .filter((name) => isMediumCrop(name.split(" ")[0] as PlotCropName))
+              .filter((name) =>
+                isMediumCrop(name.split(" ")[0] as PlotCropName),
+              )
               .map((name: SeedName) => (
                 <Box
                   isSelected={selectedName === name}
@@ -349,7 +351,9 @@ export const Seeds: React.FC = () => {
           <div className="flex flex-wrap mb-2">
             {seeds
               .filter((name) => name in PLOT_CROP_SEEDS)
-              .filter((name) => isAdvancedCrop(name.split(" ")[0] as PlotCropName))
+              .filter((name) =>
+                isAdvancedCrop(name.split(" ")[0] as PlotCropName),
+              )
               .filter(
                 (name) =>
                   name !== "Barley Seed" || hasFeatureAccess(state, "BARLEY"),

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -32,7 +32,7 @@ import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements
 import { getFruitPatchTime } from "features/game/events/landExpansion/fruitPlanted";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { Label } from "components/ui/Label";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { FLOWER_SEEDS, FlowerSeedName } from "features/game/types/flowers";
@@ -286,7 +286,7 @@ export const Seeds: React.FC = () => {
       content={
         <div className="pl-1">
           <Label
-            icon={CROP_LIFECYCLE.Sunflower.crop}
+            icon={PLOT_CROP_LIFECYCLE.Sunflower.crop}
             type="default"
             className="ml-2 mb-1"
           >
@@ -315,7 +315,7 @@ export const Seeds: React.FC = () => {
               ))}
           </div>
           <Label
-            icon={CROP_LIFECYCLE.Carrot.crop}
+            icon={PLOT_CROP_LIFECYCLE.Carrot.crop}
             type="default"
             className="ml-2 mb-1"
           >
@@ -340,7 +340,7 @@ export const Seeds: React.FC = () => {
               ))}
           </div>
           <Label
-            icon={CROP_LIFECYCLE.Kale.crop}
+            icon={PLOT_CROP_LIFECYCLE.Kale.crop}
             type="default"
             className="ml-2 mb-1"
           >

--- a/src/features/island/buildings/components/building/market/ShopItems.tsx
+++ b/src/features/island/buildings/components/building/market/ShopItems.tsx
@@ -3,7 +3,7 @@ import { Seeds } from "./Seeds";
 import { Crops } from "./Crops";
 import { Equipped } from "features/game/types/bumpkin";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { ConversationName } from "features/game/types/announcements";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -91,7 +91,7 @@ export const ShopItems: React.FC<Props> = ({
           unread: showBuyHelper,
         },
         {
-          icon: CROP_LIFECYCLE.Sunflower.crop,
+          icon: PLOT_CROP_LIFECYCLE.Sunflower.crop,
           name: t("sell"),
           unread: !hasSoldBefore,
         },

--- a/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
@@ -16,7 +16,7 @@ import Decimal from "decimal.js-light";
 import { INITIAL_STOCK, StockableName } from "features/game/lib/constants";
 import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { SEEDS } from "features/game/types/seeds";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 
 interface RestockModalProps {
   onClose: () => void;
@@ -121,7 +121,7 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
         </div>
         {restockSeeds.length > 0 && (
           <Label
-            icon={CROP_LIFECYCLE.Sunflower.seed}
+            icon={PLOT_CROP_LIFECYCLE.Sunflower.seed}
             type="default"
             className="ml-2 mb-1"
           >

--- a/src/features/island/buildings/components/building/market/restock/Restock.tsx
+++ b/src/features/island/buildings/components/building/market/restock/Restock.tsx
@@ -26,7 +26,7 @@ import { getKeys } from "features/game/types/decorations";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { ShipmentRestockModal } from "./ShipmentRestockModal";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { capitalize } from "lodash";
 
@@ -225,14 +225,14 @@ const RestockSelectionModal: React.FC<{
                 <div className="flex flex-row flex-wrap ml-7 mb-0.5">
                   <Label
                     type="default"
-                    icon={CROP_LIFECYCLE.Sunflower.seed}
+                    icon={PLOT_CROP_LIFECYCLE.Sunflower.seed}
                     className="mt-1 ml-1 capitalize"
                   >
                     {t("basic.seeds")}
                   </Label>
                   <Label
                     type="default"
-                    icon={CROP_LIFECYCLE.Carrot.seed}
+                    icon={PLOT_CROP_LIFECYCLE.Carrot.seed}
                     className="mt-1 ml-1 capitalize"
                   >
                     {t("medium.seeds")}

--- a/src/features/island/buildings/components/building/market/restock/ShipmentRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/ShipmentRestockModal.tsx
@@ -10,7 +10,7 @@ import { StockableName, INITIAL_STOCK } from "features/game/lib/constants";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SEEDS } from "features/game/types/seeds";
 import { WORKBENCH_TOOLS, TREASURE_TOOLS } from "features/game/types/tools";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import React, { useContext } from "react";
 import stockIcon from "assets/icons/stock.webp";
@@ -98,7 +98,7 @@ export const ShipmentRestockModal: React.FC<{
         </div>
         {restockSeeds.length > 0 && (
           <Label
-            icon={CROP_LIFECYCLE.Sunflower.seed}
+            icon={PLOT_CROP_LIFECYCLE.Sunflower.seed}
             type="default"
             className="ml-2 mb-1"
           >

--- a/src/features/island/chickens/Chicken.tsx
+++ b/src/features/island/chickens/Chicken.tsx
@@ -23,7 +23,7 @@ import {
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
 import { getWheatRequiredToFeed } from "features/game/events/landExpansion/feedChicken";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "../plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "../plots/lib/plant";
 import {
   Chicken as ChickenType,
   GameState,
@@ -324,7 +324,7 @@ const PlaceableChicken: React.FC<Props> = ({ id }) => {
                 }}
               />
               <img
-                src={CROP_LIFECYCLE.Wheat.crop}
+                src={PLOT_CROP_LIFECYCLE.Wheat.crop}
                 className={classNames("transition-opacity absolute z-10", {
                   "opacity-100": showPopover,
                   "opacity-0": !showPopover,

--- a/src/features/island/common/chest-reward/StopTheGoblins.tsx
+++ b/src/features/island/common/chest-reward/StopTheGoblins.tsx
@@ -3,7 +3,7 @@ import { InventoryItemName } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { addNoise } from "lib/images";
 
-import { CROPS } from "features/game/types/crops";
+import { PLOT_CROPS } from "features/game/types/crops";
 import { getKeys } from "features/game/types/craftables";
 
 import { randomBoolean, randomDouble, randomInt } from "lib/utils/random";
@@ -75,7 +75,7 @@ const generateImages = (
   let resourceImages;
   if (isMoonSeekerMode) {
     resourceImages = [
-      ...getKeys(CROPS),
+      ...getKeys(PLOT_CROPS),
       ...getKeys(PATCH_FRUIT()),
       ...getKeys(COMMODITIES),
     ];

--- a/src/features/island/fisherman/FishingGuide.tsx
+++ b/src/features/island/fisherman/FishingGuide.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button } from "components/ui/Button";
 import { SUNNYSIDE } from "assets/sunnyside";
 import powerup from "assets/icons/level_up.png";
-import { CROP_LIFECYCLE } from "../plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "../plots/lib/plant";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { translate } from "lib/i18n/translate";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -59,7 +59,7 @@ export const FishingGuide: React.FC<Props> = ({ onClose }) => {
       content: translate("fishingGuide.condition"),
     },
     {
-      icon: CROP_LIFECYCLE.Carrot.crop,
+      icon: PLOT_CROP_LIFECYCLE.Carrot.crop,
       content: translate("fishingGuide.bait.chum"),
     },
     {

--- a/src/features/island/fruit/fruits.ts
+++ b/src/features/island/fruit/fruits.ts
@@ -7,7 +7,7 @@ import tomatoPlantReady from "assets/fruit/tomato/tomatoPlantReady.webp";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PatchFruitName } from "features/game/types/fruits";
-import { CROP_LIFECYCLE } from "../plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "../plots/lib/plant";
 
 export type PatchFruitLifecycle = {
   seedling: string;
@@ -27,49 +27,49 @@ export const PATCH_FRUIT_LIFECYCLE: Record<
   PatchFruitLifecycle
 > = {
   Apple: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: SUNNYSIDE.fruit.apple_tree,
     harvested: SUNNYSIDE.fruit.harvestedTree,
     dead: SUNNYSIDE.fruit.deadTree,
   },
   Orange: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: SUNNYSIDE.fruit.orangeTree,
     harvested: SUNNYSIDE.fruit.harvestedTree,
     dead: SUNNYSIDE.fruit.deadTree,
   },
   Blueberry: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: SUNNYSIDE.fruit.blueberryBush,
     harvested: SUNNYSIDE.fruit.harvestedBush,
     dead: SUNNYSIDE.fruit.bushShrub,
   },
   Banana: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: bananaTreeReady,
     harvested: bananaTree,
     dead: SUNNYSIDE.fruit.bushShrub,
   },
   Tomato: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: tomatoPlantReady,
     harvested: tomatoPlant,
     dead: SUNNYSIDE.fruit.bushShrub,
   },
   Lemon: {
-    seedling: CROP_LIFECYCLE.Sunflower.seedling,
-    halfway: CROP_LIFECYCLE.Sunflower.halfway,
-    almost: CROP_LIFECYCLE.Sunflower.almost,
+    seedling: PLOT_CROP_LIFECYCLE.Sunflower.seedling,
+    halfway: PLOT_CROP_LIFECYCLE.Sunflower.halfway,
+    almost: PLOT_CROP_LIFECYCLE.Sunflower.almost,
     ready: lemonTreeReady,
     harvested: lemonTree,
     dead: SUNNYSIDE.fruit.deadTree,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -10,7 +10,7 @@ import {
   EASTER_EGG,
 } from "features/game/types/game";
 import {
-  CROP_SEEDS,
+  PLOT_CROP_SEEDS,
   PLOT_CROPS,
   PlotCropName,
   GREENHOUSE_CROPS,
@@ -106,7 +106,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
   ): selected is PatchFruitSeedName => selected in PATCH_FRUIT_SEEDS();
   const isSeed = (selected: InventoryItemName): selected is SeedName =>
     isPatchFruitSeed(selected) ||
-    selected in CROP_SEEDS ||
+    selected in PLOT_CROP_SEEDS ||
     selected in FLOWER_SEEDS() ||
     selected in GREENHOUSE_SEEDS ||
     selected in GREENHOUSE_FRUIT_SEEDS();
@@ -154,7 +154,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     return getKeys(items).filter((item) => item in basketMap);
   };
 
-  const seeds = getItems(CROP_SEEDS);
+  const seeds = getItems(PLOT_CROP_SEEDS);
   const fruitSeeds = getItems(PATCH_FRUIT_SEEDS());
   const greenhouseSeeds = [
     ...getItems(GREENHOUSE_FRUIT_SEEDS()),

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -11,8 +11,8 @@ import {
 } from "features/game/types/game";
 import {
   CROP_SEEDS,
-  CropName,
   PLOT_CROPS,
+  PlotCropName,
   GREENHOUSE_CROPS,
   GREENHOUSE_SEEDS,
   GreenHouseCropSeedName,
@@ -133,7 +133,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
       return seconds;
     }
 
-    const crop = SEEDS()[seedName].yield as CropName;
+    const crop = SEEDS()[seedName].yield as PlotCropName;
     return getCropPlotTime({
       crop,
       inventory,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -12,7 +12,7 @@ import {
 import {
   CROP_SEEDS,
   CropName,
-  CROPS,
+  PLOT_CROPS,
   GREENHOUSE_CROPS,
   GREENHOUSE_SEEDS,
   GreenHouseCropSeedName,
@@ -161,7 +161,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     ...getItems(GREENHOUSE_SEEDS),
   ];
   const flowerSeeds = getItems(FLOWER_SEEDS());
-  const crops = [...getItems(CROPS), ...getItems(GREENHOUSE_CROPS)];
+  const crops = [...getItems(PLOT_CROPS), ...getItems(GREENHOUSE_CROPS)];
   const fruits = [...getItems(PATCH_FRUIT()), ...getItems(GREENHOUSE_FRUIT())];
   const flowers = getItems(FLOWERS);
   const workbenchTools = getItems(WORKBENCH_TOOLS);

--- a/src/features/island/hud/components/settings-menu/plaza-settings/PickServer.tsx
+++ b/src/features/island/hud/components/settings-menu/plaza-settings/PickServer.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../../../../world/mmoMachine";
 import { ResizableBar } from "components/ui/ProgressBar";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import brazilFlag from "assets/sfts/flags/brazil_flag.gif";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
@@ -37,10 +37,10 @@ type Server = {
 // If colyseus does not return one of the servers, it means its empty
 const ICONS = [
   SUNNYSIDE.icons.water,
-  CROP_LIFECYCLE.Sunflower.crop,
+  PLOT_CROP_LIFECYCLE.Sunflower.crop,
   SUNNYSIDE.icons.heart,
   brazilFlag,
-  CROP_LIFECYCLE.Pumpkin.crop,
+  PLOT_CROP_LIFECYCLE.Pumpkin.crop,
 ];
 
 const progressBar = (progress: number, max: number, server: number) => {

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -7,7 +7,7 @@ import {
   PlacedItem,
   InventoryItemName,
 } from "features/game/types/game";
-import { CROPS, CROP_SEEDS } from "features/game/types/crops";
+import { PLOT_CROPS, CROP_SEEDS } from "features/game/types/crops";
 import { PIXEL_SCALE, TEST_FARM } from "features/game/lib/constants";
 import { harvestAudio, plantAudio } from "lib/utils/sfx";
 import {
@@ -57,7 +57,7 @@ const selectLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 const selectHarvests = (state: MachineState) => {
-  return getKeys(CROPS).reduce(
+  return getKeys(PLOT_CROPS).reduce(
     (total, crop) =>
       total +
       (state.context.state.bumpkin?.activity?.[`${crop} Harvested`] ?? 0),
@@ -66,7 +66,7 @@ const selectHarvests = (state: MachineState) => {
 };
 
 const selectPlants = (state: MachineState) =>
-  getKeys(CROPS).reduce(
+  getKeys(PLOT_CROPS).reduce(
     (total, crop) =>
       total + (state.context.state.bumpkin?.activity?.[`${crop} Planted`] ?? 0),
     0,
@@ -218,7 +218,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
 
     // increase touch count if there is a reward
     const readyToHarvest =
-      !!crop && isReadyToHarvest(now, crop, CROPS[crop.name]);
+      !!crop && isReadyToHarvest(now, crop, PLOT_CROPS[crop.name]);
 
     if (crop?.reward && readyToHarvest) {
       if (!isSeasoned && touchCount < 1) {

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -7,7 +7,7 @@ import {
   PlacedItem,
   InventoryItemName,
 } from "features/game/types/game";
-import { PLOT_CROPS, CROP_SEEDS } from "features/game/types/crops";
+import { PLOT_CROP_SEEDS, PLOT_CROPS } from "features/game/types/crops";
 import { PIXEL_SCALE, TEST_FARM } from "features/game/lib/constants";
 import { harvestAudio, plantAudio } from "lib/utils/sfx";
 import {
@@ -260,7 +260,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     if (!crop) {
       if (
         hasFeatureAccess(state, "CROP_QUICK_SELECT") &&
-        (!seed || !(seed in CROP_SEEDS) || !inventory[seed]?.gte(1))
+        (!seed || !(seed in PLOT_CROP_SEEDS) || !inventory[seed]?.gte(1))
       ) {
         setShowQuickSelect(true);
         return;
@@ -326,9 +326,9 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
         className="flex top-[-255%] left-[50%] absolute z-40"
       >
         <QuickSelect
-          options={getKeys(CROP_SEEDS).map((seed) => ({
+          options={getKeys(PLOT_CROP_SEEDS).map((seed) => ({
             name: seed as InventoryItemName,
-            icon: CROP_SEEDS[seed].yield as InventoryItemName,
+            icon: PLOT_CROP_SEEDS[seed].yield as InventoryItemName,
             showSecondaryImage: true,
           }))}
           onClose={() => setShowQuickSelect(false)}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { CROPS, CropName } from "features/game/types/crops";
+import { CropName, PLOT_CROPS } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { GrowthStage, Soil } from "features/island/plots/components/Soil";
@@ -60,7 +60,7 @@ const FertilePlotComponent: React.FC<Props> = ({
 
   const [_, setRender] = useState<number>(0);
 
-  let harvestSeconds = cropName ? CROPS[cropName].harvestSeconds : 0;
+  let harvestSeconds = cropName ? PLOT_CROPS[cropName].harvestSeconds : 0;
   const readyAt = plantedAt ? plantedAt + harvestSeconds * 1000 : 0;
 
   let startAt = plantedAt ?? 0;

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { CropName, PLOT_CROPS } from "features/game/types/crops";
+import { PLOT_CROPS, PlotCropName } from "features/game/types/crops";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { GrowthStage, Soil } from "features/island/plots/components/Soil";
@@ -29,7 +29,7 @@ const _bumpkinLevel = (state: MachineState) =>
   getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 
 interface Props {
-  cropName?: CropName;
+  cropName?: PlotCropName;
   inventory: Inventory;
   game: GameState;
   bumpkin?: Bumpkin;

--- a/src/features/island/plots/components/SeedSelection.tsx
+++ b/src/features/island/plots/components/SeedSelection.tsx
@@ -8,7 +8,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { SEEDS, SeedName } from "features/game/types/seeds";
 import React, { useState } from "react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { CROP_SEEDS } from "features/game/types/crops";
+import { PLOT_CROP_SEEDS } from "features/game/types/crops";
 
 interface Props {
   onPlant: (seed: SeedName) => void;
@@ -19,7 +19,7 @@ export const SeedSelection: React.FC<Props> = ({ onPlant, inventory }) => {
 
   const [seed, setSeed] = useState<SeedName>();
 
-  const availableSeeds = getKeys(CROP_SEEDS).filter((name) =>
+  const availableSeeds = getKeys(PLOT_CROP_SEEDS).filter((name) =>
     inventory[name]?.gte(1),
   );
 

--- a/src/features/island/plots/components/Soil.tsx
+++ b/src/features/island/plots/components/Soil.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { CropName } from "features/game/types/crops";
+import { PlotCropName } from "features/game/types/crops";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "../lib/plant";
@@ -8,7 +8,7 @@ import { CROP_LIFECYCLE } from "../lib/plant";
 export type GrowthStage = "seedling" | "halfway" | "almost" | "ready";
 
 interface Props {
-  cropName?: CropName;
+  cropName?: PlotCropName;
   stage?: GrowthStage;
 }
 

--- a/src/features/island/plots/components/Soil.tsx
+++ b/src/features/island/plots/components/Soil.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { PlotCropName } from "features/game/types/crops";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "../lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "../lib/plant";
 
 export type GrowthStage = "seedling" | "halfway" | "almost" | "ready";
 
@@ -28,7 +28,7 @@ const getCropImage = (imageSource: string): JSX.Element => {
 const SoilComponent: React.FC<Props> = ({ cropName, stage }) => {
   if (!cropName || !stage) return getCropImage(SUNNYSIDE.soil.soil2);
 
-  const lifecycle = CROP_LIFECYCLE[cropName];
+  const lifecycle = PLOT_CROP_LIFECYCLE[cropName];
 
   switch (stage) {
     case "seedling":

--- a/src/features/island/plots/lib/plant.ts
+++ b/src/features/island/plots/lib/plant.ts
@@ -71,7 +71,7 @@ export const IMAGES: Record<PlotCropName, string> = {
   Barley: "barley",
 };
 
-export const CROP_LIFECYCLE: Record<PlotCropName, Lifecycle> = getKeys(
+export const PLOT_CROP_LIFECYCLE: Record<PlotCropName, Lifecycle> = getKeys(
   IMAGES,
 ).reduce(
   (acc, name) => ({

--- a/src/features/island/plots/lib/plant.ts
+++ b/src/features/island/plots/lib/plant.ts
@@ -1,4 +1,4 @@
-import { CropName } from "features/game/types/crops";
+import { PlotCropName } from "features/game/types/crops";
 import { getKeys } from "features/game/types/craftables";
 import { CONFIG } from "lib/config";
 
@@ -17,7 +17,7 @@ import wheatProc from "assets/crops/wheat/proc_sprite.png";
 import kaleProc from "assets/crops/kale/proc_sprite.png";
 import soybeanProc from "assets/crops/soybean/proc_sprite.png";
 
-const HARVEST_PROC_SPRITES: Record<CropName, any> = {
+const HARVEST_PROC_SPRITES: Record<PlotCropName, any> = {
   Sunflower: sunflowerProc,
   Potato: potatoProc,
   Pumpkin: pumpkinProc,
@@ -53,7 +53,7 @@ export type Lifecycle = {
 
 const URL = `${CONFIG.PROTECTED_IMAGE_URL}/crops`;
 
-export const IMAGES: Record<CropName, string> = {
+export const IMAGES: Record<PlotCropName, string> = {
   Sunflower: "sunflower",
   Potato: "potato",
   Pumpkin: "pumpkin",
@@ -71,7 +71,7 @@ export const IMAGES: Record<CropName, string> = {
   Barley: "barley",
 };
 
-export const CROP_LIFECYCLE: Record<CropName, Lifecycle> = getKeys(
+export const CROP_LIFECYCLE: Record<PlotCropName, Lifecycle> = getKeys(
   IMAGES,
 ).reduce(
   (acc, name) => ({
@@ -85,5 +85,5 @@ export const CROP_LIFECYCLE: Record<CropName, Lifecycle> = getKeys(
       seed: `${URL}/${IMAGES[name]}/seed.png`,
     },
   }),
-  {} as Record<CropName, Lifecycle>,
+  {} as Record<PlotCropName, Lifecycle>,
 );

--- a/src/features/pumpkinPlaza/lib/reactions.ts
+++ b/src/features/pumpkinPlaza/lib/reactions.ts
@@ -5,7 +5,7 @@ import crown from "assets/sfts/goblin_crown.png";
 
 import levelUp from "assets/icons/level_up.png";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { translate } from "lib/i18n/translate";
 
 export type ReactionName =
@@ -95,7 +95,7 @@ export const REACTIONS: Reaction[] = [
     hasAccess: (game: GameState) =>
       !!game.bumpkin?.achievements?.["Sunflower Superstar"],
     description: translate("reaction.sunflowers"),
-    icon: CROP_LIFECYCLE.Sunflower.crop,
+    icon: PLOT_CROP_LIFECYCLE.Sunflower.crop,
   },
   {
     name: "suspicious",

--- a/src/features/world/ui/PickServer.tsx
+++ b/src/features/world/ui/PickServer.tsx
@@ -11,7 +11,7 @@ import {
 import { MachineInterpreter } from "../mmoMachine";
 import { ResizableBar } from "components/ui/ProgressBar";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import { PLOT_CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import brazilFlag from "assets/sfts/flags/brazil_flag.gif";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { useNavigate } from "react-router-dom";
@@ -26,10 +26,10 @@ interface Props {
 // If colyseus does not return one of the servers, it means its empty
 const ICONS = [
   SUNNYSIDE.icons.water,
-  CROP_LIFECYCLE.Sunflower.crop,
+  PLOT_CROP_LIFECYCLE.Sunflower.crop,
   SUNNYSIDE.icons.heart,
   brazilFlag,
-  CROP_LIFECYCLE.Pumpkin.crop,
+  PLOT_CROP_LIFECYCLE.Pumpkin.crop,
 ];
 
 export const PickServer: React.FC<Props> = ({ mmoService }) => {


### PR DESCRIPTION
There are multiple instances of `isCrop()` that have inconsistent implementations.  The root cause appears to be that "plot crops" were never formally renamed from "crops" when greenhouse crops were introduced.

Additionally the predicate for one implementation for `isCrop()` was inaccurate.

This change includes the following:
- rename `CROPS` to `PLOT_CROPS`
- rename `CropName` to `PlotCropName`
- rename `CROP_LIFECYCLE` to `PLOT_CROP_LIFECYCLE`
- rename `CROP_SEEDS` to `PLOT_CROP_SEEDS`
- rename `CropSeedName` to `PlotCropSeedName`
- rename `Crop` to `PlotCrop`
- rename `isCrop` to `isPlotCrop` in harvest.ts
- fix predicate for `isCrop` in getBudYieldBoosts.ts
