### PR TITLE
[CHORE] Disable Animal Teaser(Coming Soon Boat)

### DIFF
--- a/src/features/game/expansion/components/Water.tsx
+++ b/src/features/game/expansion/components/Water.tsx
@@ -19,7 +19,6 @@ import { CONFIG } from "lib/config";
 import { LaTomatina } from "./LaTomatina";
 import { Richie } from "./Richie";
 import { RestockBoat } from "./RestockBoat";
-import { AnimalTeaser } from "./AnimalTeaser";
 
 interface Props {
   townCenterBuilt: boolean;
@@ -45,7 +44,6 @@ export const WaterComponent: React.FC<Props> = ({
       }}
     >
       {/* Decorations */}
-      {<AnimalTeaser />}
 
       {CONFIG.NETWORK === "mainnet" && <DiscordBoat />}
 


### PR DESCRIPTION
# Description

The season already started on November 1st, so the date on the message is not valid now. Also, we can merge it on November 4th along with releasing the Animal Update to the public.
![image](https://github.com/user-attachments/assets/22ea7198-b4c5-40e2-8ffc-5e6ea5126a99)
