### PR TITLE
[FEAT] Hide Date Label For Seasonal Artifacts When Season Ends

### DIFF
--- a/src/features/game/types/treasure.ts
+++ b/src/features/game/types/treasure.ts
@@ -160,10 +160,12 @@ export const SELLABLE_TREASURE: Record<BeachBountyTreasure, SellableTreasure> =
     },
     "Cow Skull": {
       sellPrice: 200,
-      from: hasSeasonEnded("Bull Run")
-        ? undefined
-        : SEASONS["Bull Run"].startDate,
-      to: hasSeasonEnded("Bull Run") ? undefined : SEASONS["Bull Run"].endDate,
       description: translate("description.cowSkull"),
+      ...(hasSeasonEnded("Bull Run")
+        ? {}
+        : {
+            from: SEASONS["Bull Run"].startDate,
+            to: SEASONS["Bull Run"].endDate,
+          }),
     },
   };

--- a/src/features/game/types/treasure.ts
+++ b/src/features/game/types/treasure.ts
@@ -1,5 +1,5 @@
 import { translate } from "lib/i18n/translate";
-import { SEASONS } from "./seasons";
+import { hasSeasonEnded, SEASONS } from "./seasons";
 
 export type BeachBountyTreasure =
   | "Pirate Bounty"
@@ -156,14 +156,14 @@ export const SELLABLE_TREASURE: Record<BeachBountyTreasure, SellableTreasure> =
     },
     Scarab: {
       sellPrice: 200,
-      from: SEASONS["Pharaoh's Treasure"].startDate,
-      to: SEASONS["Pharaoh's Treasure"].endDate,
       description: translate("description.scarab"),
     },
     "Cow Skull": {
       sellPrice: 200,
-      from: SEASONS["Bull Run"].startDate,
-      to: SEASONS["Bull Run"].endDate,
+      from: hasSeasonEnded("Bull Run")
+        ? undefined
+        : SEASONS["Bull Run"].startDate,
+      to: hasSeasonEnded("Bull Run") ? undefined : SEASONS["Bull Run"].endDate,
       description: translate("description.cowSkull"),
     },
   };


### PR DESCRIPTION
# Description

To prevent potential confusion in the future, the label indicating the date when seasonal artifacts can be obtained through gameplay will be hidden once the corresponding season for the artifact ends.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/302ab528-7e08-4291-b28f-7681b6a31bbf) | ![image](https://github.com/user-attachments/assets/7f0c2aff-ce5b-4ce8-a5c4-caa25919dda5) | 

# What needs to be tested by the reviewer?

- click the NPC called Jafar and check the seasonal artifacts there.
