### PR TITLE
[FEAT] Repeat Level for Max Level Animals

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -23,8 +23,7 @@ import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/decorations";
 
-// export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
-export const ANIMAL_SLEEP_DURATION = 20 * 1000;
+export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
 
 export const REQUIRED_FOOD_QTY: Record<AnimalType, number> = {
   Chicken: 1,

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -23,7 +23,8 @@ import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/decorations";
 
-export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
+// export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
+export const ANIMAL_SLEEP_DURATION = 20 * 1000;
 
 export const REQUIRED_FOOD_QTY: Record<AnimalType, number> = {
   Chicken: 1,
@@ -205,7 +206,7 @@ export function feedAnimal({
     const maxLevelXp = ANIMAL_LEVELS[action.animal][maxLevel];
     const levelBeforeMaxXp = ANIMAL_LEVELS[action.animal][levelBeforeMax];
     const cycleXP = maxLevelXp - levelBeforeMaxXp;
-    const excessXpBeforeFeed = beforeFeedXp - maxLevelXp;
+    const excessXpBeforeFeed = Math.max(beforeFeedXp - maxLevelXp, 0);
     const currentCycleProgress = excessXpBeforeFeed % cycleXP;
 
     if (currentCycleProgress + foodXp >= cycleXP) {

--- a/src/features/game/expansion/components/animals/LevelProgress.tsx
+++ b/src/features/game/expansion/components/animals/LevelProgress.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useState } from "react";
 import { AnimatedBar } from "components/ui/ProgressBar";
-import { ANIMAL_LEVELS, AnimalLevel } from "features/game/types/animals";
+import {
+  ANIMAL_LEVELS,
+  AnimalLevel,
+  AnimalType,
+} from "features/game/types/animals";
 import { getAnimalLevel, isMaxLevel } from "features/game/lib/animals";
 import { TState } from "features/game/lib/animalMachine";
 import { Transition } from "@headlessui/react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Animal } from "features/game/types/game";
+import { getKeys } from "features/game/types/decorations";
 
 type Props = {
   animal: Animal;
@@ -13,6 +18,17 @@ type Props = {
   experience: number;
   className?: string;
   onLevelUp: () => void;
+};
+
+const getMaxLevelCycleProgress = (animal: AnimalType, experience: number) => {
+  const maxLevel = (getKeys(ANIMAL_LEVELS[animal]).length - 1) as AnimalLevel;
+  const maxLevelXp = ANIMAL_LEVELS[animal][maxLevel];
+  const oneLevelBeforeMaxXp =
+    ANIMAL_LEVELS[animal][(maxLevel - 1) as AnimalLevel];
+  const cycleXP = maxLevelXp - oneLevelBeforeMaxXp;
+  const excessXPoverMax = experience - maxLevelXp;
+
+  return ((excessXPoverMax % cycleXP) / cycleXP) * 100;
 };
 
 export const LevelProgress = ({
@@ -26,6 +42,7 @@ export const LevelProgress = ({
   const [showLevelUp, setShowLevelUp] = useState(false);
   const [displayExperience, setDisplayExperience] = useState(experience);
   const [isLevelingUp, setIsLevelingUp] = useState(false);
+
   const { t } = useAppTranslation();
 
   // Handle level up animation sequence
@@ -62,8 +79,12 @@ export const LevelProgress = ({
     (animalState === "sleeping" && animal.state === "ready");
 
   const getProgressPercentage = () => {
-    if (isMaxLevel(animal.type, level) || hasLeveledUp) {
+    if (animalState === "ready") {
       return 100;
+    }
+
+    if (isMaxLevel(animal.type, level)) {
+      return getMaxLevelCycleProgress(animal.type, experience);
     }
 
     const nextThreshold =
@@ -74,7 +95,10 @@ export const LevelProgress = ({
   // An animal get xp on every feed so they may already be in the next level
   // however, we want to have them interact with the "level up"
   // so if an animal is ready, we want to show the previous level
-  const displayLevel = hasLeveledUp ? level - 1 : level;
+  const displayLevel =
+    animalState === "ready" && !isMaxLevel(animal.type, level)
+      ? level - 1
+      : level;
 
   return (
     <>
@@ -96,7 +120,7 @@ export const LevelProgress = ({
             color: "#71e358",
           }}
         >
-          {t("levelUp")}
+          {isMaxLevel(animal.type, level) ? t("levelUpMax") : t("levelUp")}
         </span>
       </Transition>
 

--- a/src/features/game/expansion/components/animals/LevelProgress.tsx
+++ b/src/features/game/expansion/components/animals/LevelProgress.tsx
@@ -87,9 +87,14 @@ export const LevelProgress = ({
       return getMaxLevelCycleProgress(animal.type, experience);
     }
 
+    const currentThreshold = ANIMAL_LEVELS[animal.type][level as AnimalLevel];
     const nextThreshold =
       ANIMAL_LEVELS[animal.type][(level + 1) as AnimalLevel];
-    return (displayExperience / nextThreshold) * 100;
+    return (
+      ((displayExperience - currentThreshold) /
+        (nextThreshold - currentThreshold)) *
+      100
+    );
   };
 
   // An animal get xp on every feed so they may already be in the next level

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -77,7 +77,8 @@ export function makeAnimalBuilding(
 }
 
 export const isMaxLevel = (animal: AnimalType, level: AnimalLevel) => {
-  return level === Object.keys(ANIMAL_LEVELS[animal]).length;
+  const maxLevel = Math.max(...Object.keys(ANIMAL_LEVELS[animal]).map(Number));
+  return level === maxLevel;
 };
 
 export function getAnimalLevel(experience: number, animal: AnimalType) {

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -431,6 +431,8 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Barn: new Decimal(1),
     "Hen House": new Decimal(1),
     Hay: new Decimal(100),
+    "Mixed Grain": new Decimal(100),
+    NutriBarley: new Decimal(100),
     Bale: new Decimal(1),
     "Kernel Blend": new Decimal(100),
     "Rich Chicken": new Decimal(1),
@@ -1544,7 +1546,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
       abc: {
         asleepAt: 0,
         awakeAt: 0,
-        experience: 60,
+        experience: 2640,
         id: "abc",
         type: "Chicken",
         createdAt: 0,
@@ -1561,7 +1563,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
       abc: {
         asleepAt: 0,
         awakeAt: 0,
-        experience: 0,
+        experience: 8100,
         id: "abc",
         type: "Cow",
         createdAt: 0,
@@ -1573,7 +1575,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
       def: {
         asleepAt: 0,
         awakeAt: 0,
-        experience: 0,
+        experience: 5400,
         id: "def",
         type: "Sheep",
         createdAt: 0,

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -83,6 +83,18 @@ const _chicken = (id: string) => (state: MachineState) =>
 const _game = (state: MachineState) => state.context.state;
 const _inventory = (state: MachineState) => state.context.state.inventory;
 
+export const getMedicineOption = (): {
+  name: InventoryItemName;
+  icon: InventoryItemName;
+  showSecondaryImage: boolean;
+}[] => [
+  {
+    name: "Barn Delight" as InventoryItemName,
+    icon: "Barn Delight" as InventoryItemName,
+    showSecondaryImage: false,
+  },
+];
+
 export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
   id,
   disabled,
@@ -468,7 +480,7 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
       </Transition>
       <Transition
         appear={true}
-        id="oil-reserve-collected-amount"
+        id="love-xp"
         show={showLoveXp}
         enter="transition-opacity transition-transform duration-200"
         enterFrom="opacity-0 translate-y-4"

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3772,6 +3772,7 @@
   "wakesIn": "Wakes in:",
   "animal.noFoodMessage": "No food selected",
   "levelUp": "Level Up!",
+  "levelUpMax": "Max Level!",
   "unknown": "Unknown",
   "crafting.selectIngredients": "Select ingredients",
   "crafting.readyToCollect": "Ready to collect",


### PR DESCRIPTION
# Description

When an animal is at the max level they should just continue to cycle through that max level.

![max_level](https://github.com/user-attachments/assets/643f8615-6f4e-41dc-9698-83b6b7a1f67a)


Fixes #issue

# What needs to be tested by the reviewer?

- Level up to the max level
- Keep feeding and make sure you produce again using the same `maxLevel - maxLevel - 1` threshold

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
