### PR TITLE
[FEAT] Add animals guide

### DIFF
--- a/src/assets/sunnyside.ts
+++ b/src/assets/sunnyside.ts
@@ -809,7 +809,7 @@ export const SUNNYSIDE = {
   },
   //Tutorials
   tutorial: {
-    animals: `${CONFIG.PROTECTED_IMAGE_URL}/tutorials/animals.png`,
+    animals: `${CONFIG.PROTECTED_IMAGE_URL}/tutorials/new_animals.png`,
     workbench: `${CONFIG.PROTECTED_IMAGE_URL}/tutorials/workbench.png`,
     harvesting: `${CONFIG.PROTECTED_IMAGE_URL}/tutorials/harvesting.png`,
     cooking: `${CONFIG.PROTECTED_IMAGE_URL}/tutorials/fire_pit.png`,

--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -16,7 +16,10 @@ import { Sheep } from "./components/Sheep";
 
 import shopDisc from "assets/icons/shop_disc.png";
 
-import { AnimalBuildingModal } from "features/game/expansion/components/animals/AnimalBuildingModal";
+import {
+  AnimalBuildingModal,
+  hasReadGuide,
+} from "features/game/expansion/components/animals/AnimalBuildingModal";
 import { FeederMachine } from "features/feederMachine/FeederMachine";
 import { AnimalBuildingLevel } from "features/game/events/landExpansion/upgradeBuilding";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -50,7 +53,7 @@ const BARN_ANIMAL_COMPONENTS: Record<
 
 export const BarnInside: React.FC = () => {
   const { gameService } = useContext(Context);
-  const [showModal, setShowModal] = useState(false);
+  const [showModal, setShowModal] = useState(!hasReadGuide());
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [selected, setSelected] = useState<Animal>();
   const [deal, setDeal] = useState<AnimalBounty>();

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -24,12 +24,13 @@ import { Label } from "components/ui/Label";
 import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeable/lib/collisionDetection";
 
 import coinsIcon from "assets/icons/coins.webp";
+import brush from "assets/animals/brush.webp";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { makeAnimalBuildingKey } from "features/game/lib/animals";
 import { AnimalBounties } from "features/barn/components/AnimalBounties";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
 import { NPC_WEARABLES } from "lib/npcs";
-import { OuterPanel } from "components/ui/Panel";
+import { InnerPanel, OuterPanel } from "components/ui/Panel";
 import classNames from "classnames";
 import { isMobile } from "mobile-device-detect";
 
@@ -42,6 +43,14 @@ function acknowledgeIntro() {
 
 function hasReadIntro() {
   return !!localStorage.getItem("animal.bounties.acknowledged");
+}
+
+export function acknowledgeGuide() {
+  localStorage.setItem("animal.guide.acknowledged", new Date().toISOString());
+}
+
+export function hasReadGuide() {
+  return !!localStorage.getItem("animal.guide.acknowledged");
 }
 
 type Props = {
@@ -62,6 +71,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
   const [showIntro, setShowIntro] = useState(!hasReadIntro());
+  const [currentTab, setCurrentTab] = useState(!hasReadGuide() ? 2 : 0);
 
   const state = useSelector(gameService, _state);
   const bumpkin = useSelector(gameService, _bumpkin);
@@ -75,7 +85,6 @@ export const AnimalBuildingModal: React.FC<Props> = ({
     (animal) => ANIMALS[animal].buildingRequired === buildingName,
   );
 
-  const [currentTab, setCurrentTab] = useState(0);
   const [selectedName, setSelectedName] = useState<AnimalType>(animals[0]);
 
   const handleBuyAnimal = () => {
@@ -143,6 +152,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
       tabs={[
         { name: t("buy"), icon: coinsIcon },
         { name: t("sell"), icon: SUNNYSIDE.icons.death },
+        { name: t("guide"), icon: SUNNYSIDE.icons.expression_confused },
       ]}
       currentTab={currentTab}
       setCurrentTab={setCurrentTab}
@@ -220,6 +230,74 @@ export const AnimalBuildingModal: React.FC<Props> = ({
           type={buildingName === "Barn" ? ["Cow", "Sheep"] : ["Chicken"]}
           onExchanging={onExchanging}
         />
+      )}
+
+      {currentTab === 2 && (
+        <>
+          <div className="flex flex-col p-1 space-y-1 mb-2">
+            <InnerPanel className="p-1">
+              <img src={SUNNYSIDE.tutorial.animals} className="w-full" />
+            </InnerPanel>
+            <div className="flex flex-col space-y-2 text-xs">
+              <div className="flex items-center space-x-1">
+                <img
+                  src={SUNNYSIDE.building.feederMachine}
+                  className="h-8"
+                  alt="feeder machine"
+                />
+                <p>{t("animals.guide.feeder")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img
+                  src={SUNNYSIDE.animalFoods.kernel_blend}
+                  className="h-6"
+                  alt="animal food"
+                />
+                <p>{t("animals.guide.food_preference")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img
+                  src={SUNNYSIDE.icons.expression_ready}
+                  className="h-6"
+                  alt="animal food"
+                />
+                <p>{t("animals.guide.progress")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img
+                  src={SUNNYSIDE.icons.sleeping}
+                  className="h-6"
+                  alt="animal food"
+                />
+                <p>{t("animals.guide.sleeping")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img src={brush} className="h-6" alt="brush" />
+                <p>{t("animals.guide.affection")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img src={SUNNYSIDE.icons.death} className="h-6" alt="trade" />
+                <p>{t("animals.guide.bounties")}</p>
+              </div>
+              <div className="flex items-center space-x-1">
+                <img
+                  src={SUNNYSIDE.animalFoods.barn_delight}
+                  className="h-6"
+                  alt="barn delight medicine"
+                />
+                <p>{t("animals.guide.sickness")}</p>
+              </div>
+            </div>
+          </div>
+          <Button
+            onClick={() => {
+              acknowledgeGuide();
+              onClose();
+            }}
+          >
+            {t("gotIt")}
+          </Button>
+        </>
       )}
     </CloseButtonPanel>
   );

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -28,6 +28,7 @@ import { isValidDeal } from "features/game/events/landExpansion/sellAnimal";
 import classNames from "classnames";
 import { EXTERIOR_ISLAND_BG } from "features/barn/BarnInside";
 import { ANIMAL_HOUSE_BOUNDS } from "features/game/expansion/placeable/lib/collisionDetection";
+import { hasReadGuide } from "features/game/expansion/components/animals/AnimalBuildingModal";
 
 const _henHouse = (state: MachineState) => state.context.state.henHouse;
 
@@ -42,7 +43,7 @@ export const ANIMAL_HOUSE_IMAGES: Record<
 
 export const HenHouseInside: React.FC = () => {
   const { gameService } = useContext(Context);
-  const [showModal, setShowModal] = useState(false);
+  const [showModal, setShowModal] = useState(!hasReadGuide());
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [deal, setDeal] = useState<AnimalBounty>();
   const [selected, setSelected] = useState<Animal>();

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4200,7 +4200,11 @@
   "whatsOn.date.feb1": "February 1st",
   "chickens.deprecated.1": "Chickens are now fed in the hen house.",
   "chickens.deprecated.2": "Sell existing chickens at Garbo.",
-  "description.alien.chicken": "A peculiar chicken from another galaxy, here to boost your feather production!",
-  "description.toxic.tuft": "A mutated sheep whose toxic fleece produces the finest merino wool in the land!",
-  "description.mootant": "This genetically enhanced bovine here to boost your leather production!"
+  "animals.guide.feeder": "Prepare food for your animals using the feeder machine.",
+  "animals.guide.food_preference": "Animals prefer their favourite food but will eat any food.",
+  "animals.guide.progress": "Once the progress bar is full your animal is ready to level up & drop resources.",
+  "animals.guide.sleeping": "After levelling up your animal will sleep for 24 hours.",
+  "animals.guide.affection": "Show affection to sleeping animals when they request it.",
+  "animals.guide.bounties": "Complete weekly bounties by trading your animals for rewards..",
+  "animals.guide.sickness": "Beware of sickness! Older animals are more susceptible - use Barn Delight medicine to cure them."
 }


### PR DESCRIPTION
# Description

Animals guide. This will show when you first enter the hen house. Once acknowledged it will not auto show but will remain visible as a guide.

<img width="499" alt="Screenshot 2024-11-03 at 7 51 34 AM" src="https://github.com/user-attachments/assets/2a3c3c55-d3f2-46b3-a4da-c69c93729138">


Fixes #issue

# What needs to be tested by the reviewer?

- Open hen house
- Confirm you see the guide
- Acknowledge guide and close hen house
- Open again and confirm you don't see the auto pop up guide

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
