### PR TITLE
[FEAT] Remove quick select UI from animals

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -19,7 +19,8 @@ import {
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 
-export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
+export const ANIMAL_SLEEP_DURATION = 20 * 1000;
+// export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
 
 export const REQUIRED_FOOD_QTY: Record<AnimalType, number> = {
   Chicken: 1,

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -19,8 +19,7 @@ import {
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 
-export const ANIMAL_SLEEP_DURATION = 20 * 1000;
-// export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
+export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
 
 export const REQUIRED_FOOD_QTY: Record<AnimalType, number> = {
   Chicken: 1,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -423,6 +423,8 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   inventory: {
+    "Barn Delight": new Decimal(1),
+    Brush: new Decimal(1),
     "Alien Chicken": new Decimal(1),
     "Toxic Tuft": new Decimal(1),
     Mootant: new Decimal(1),
@@ -1541,7 +1543,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
         createdAt: 0,
         coordinates: { x: 0, y: 0 },
         lovedAt: 0,
-        state: "happy",
+        state: "sick",
         item: "Brush",
       },
     },

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3768,7 +3768,7 @@
   "2x.rewards": "2x Rewards",
   "quickSelect.animalFeed": "Prepare some animal feed.",
   "wakesIn": "Wakes in:",
-  "animal.noFoodMessage": "No food available",
+  "animal.noFoodMessage": "No food selected",
   "levelUp": "Level Up!",
   "unknown": "Unknown",
   "crafting.selectIngredients": "Select ingredients",


### PR DESCRIPTION
# Description

This PR removes the Quick Select UI from animals as it was discombobulating in many situations. 

The selection of the required item will now be consistent with the rest of the game. In the case of the affection tool and medicine, it will just auto select them for you if you have them in your inventory.

Fixes #issue

# What needs to be tested by the reviewer?

- Just test that thew interactions with animals still work eg. feeding, affection and treating illness.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
