### PR TITLE
[FEAT] Stella UI Update + Boost

### DIFF
--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -10,6 +10,7 @@ import {
   SeasonalStore,
   SeasonalStoreCollectible,
   SeasonalStoreItem,
+  SeasonalStoreTier,
 } from "features/game/types/megastore";
 import { ARTEFACT_SHOP_KEYS } from "features/game/types/collectibles";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
@@ -23,7 +24,7 @@ export function isCollectible(
 export type BuySeasonalItemAction = {
   type: "seasonalItem.bought";
   name: BumpkinItem | InventoryItemName;
-  tier: keyof SeasonalStore;
+  tier: SeasonalStoreTier;
 };
 
 type Options = {
@@ -105,6 +106,13 @@ export function buySeasonalItem({
           "You need to buy more basic and rare items to unlock epic items",
         );
       }
+
+      if (
+        tier === "mega" &&
+        seasonalItemsCrafted - reduction < seasonalStore.epic.requirement
+      ) {
+        throw new Error("You need to buy more epic items to unlock mega items");
+      }
     }
 
     // Check if player has enough resources
@@ -181,11 +189,13 @@ export function isKeyBoughtWithinSeason(
       ? "Treasure Key"
       : isLowerTier && tier === "epic"
         ? "Rare Key"
-        : tier === "basic"
-          ? "Treasure Key"
-          : tier === "rare"
-            ? "Rare Key"
-            : "Luxury Key";
+        : isLowerTier && tier === "mega"
+          ? "Luxury Key"
+          : tier === "basic"
+            ? "Treasure Key"
+            : tier === "rare"
+              ? "Rare Key"
+              : "Luxury Key";
 
   const keyBoughtAt =
     game.pumpkinPlaza.keysBought?.megastore[tierKey as Keys]?.boughtAt;

--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -100,7 +100,7 @@ export function buySeasonalItem({
 
       if (
         tier === "epic" &&
-        seasonalItemsCrafted - reduction < seasonalStore.rare.requirement
+        seasonalItemsCrafted - reduction < seasonalStore.epic.requirement
       ) {
         throw new Error(
           "You need to buy more basic and rare items to unlock epic items",
@@ -109,7 +109,7 @@ export function buySeasonalItem({
 
       if (
         tier === "mega" &&
-        seasonalItemsCrafted - reduction < seasonalStore.epic.requirement
+        seasonalItemsCrafted - reduction < seasonalStore.mega.requirement
       ) {
         throw new Error("You need to buy more epic items to unlock mega items");
       }

--- a/src/features/game/events/landExpansion/completeChore.test.ts
+++ b/src/features/game/events/landExpansion/completeChore.test.ts
@@ -594,6 +594,118 @@ describe("chore.completed", () => {
           ...INITIAL_BUMPKIN,
           equipped: {
             ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
+  });
+
+  it("provides +1 tickets when Cowboy Shirt is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            shirt: "Cowboy Shirt",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
+  });
+
+  it("provides +1 tickets when Cowboy Trouser is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
             pants: "Cowboy Trouser",
           },
           activity: {
@@ -617,7 +729,7 @@ describe("chore.completed", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
   });
 
-  it("does not provide +1 tickets when Cowboy Hat is worn outside Bull Run Season", () => {
+  it("does not provide +1 tickets when Cowboy Trouser is worn outside Bull Run Season", () => {
     const mockDate = new Date("2024-10-30T15:00:00Z").getTime();
     jest.useFakeTimers();
     jest.setSystemTime(mockDate);

--- a/src/features/game/events/landExpansion/completeChore.test.ts
+++ b/src/features/game/events/landExpansion/completeChore.test.ts
@@ -729,6 +729,64 @@ describe("chore.completed", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
   });
 
+  it("stacks Cowboy Set boost at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+            shirt: "Cowboy Shirt",
+            pants: "Cowboy Trouser",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(7));
+  });
+
   it("does not provide +1 tickets when Cowboy Trouser is worn outside Bull Run Season", () => {
     const mockDate = new Date("2024-10-30T15:00:00Z").getTime();
     jest.useFakeTimers();

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -40,7 +40,9 @@ export function generateChoreTickets({
 
   if (
     getCurrentSeason() === "Bull Run" &&
-    isWearableActive({ game, name: "Cowboy Trouser" })
+    (isWearableActive({ game, name: "Cowboy Hat" }) ||
+      isWearableActive({ game, name: "Cowboy Shirt" }) ||
+      isWearableActive({ game, name: "Cowboy Trouser" }))
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -40,9 +40,21 @@ export function generateChoreTickets({
 
   if (
     getCurrentSeason() === "Bull Run" &&
-    (isWearableActive({ game, name: "Cowboy Hat" }) ||
-      isWearableActive({ game, name: "Cowboy Shirt" }) ||
-      isWearableActive({ game, name: "Cowboy Trouser" }))
+    isWearableActive({ game, name: "Cowboy Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Shirt" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Trouser" })
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/completeNPCChore.test.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.test.ts
@@ -317,6 +317,42 @@ describe("completeNPCChore", () => {
     expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(2));
   });
 
+  it("stacks Cowboy Set boost at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          hat: "Cowboy Hat",
+          shirt: "Cowboy Shirt",
+          pants: "Cowboy Trouser",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Horseshoe"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(4));
+  });
+
   it("does not provide +1 tickets when Cowboy Trouser is worn outside Bull Run Season", () => {
     const mockDate = new Date("2024-10-30T15:00:00Z");
     jest.useFakeTimers();

--- a/src/features/game/events/landExpansion/completeNPCChore.test.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.test.ts
@@ -214,4 +214,140 @@ describe("completeNPCChore", () => {
 
     expect(newState.inventory["Amber Fossil"]).toEqual(new Decimal(3));
   });
+
+  it("provides +1 ticket rewards for Cowboy Hat at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          hat: "Cowboy Hat",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Horseshoe"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(2));
+  });
+
+  it("provides +1 ticket rewards for Cowboy Shirt at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          shirt: "Cowboy Shirt",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Horseshoe"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(2));
+  });
+
+  it("provides +1 ticket rewards for Cowboy Trouser at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          pants: "Cowboy Trouser",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Horseshoe"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(2));
+  });
+
+  it("does not provide +1 tickets when Cowboy Trouser is worn outside Bull Run Season", () => {
+    const mockDate = new Date("2024-10-30T15:00:00Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          pants: "Cowboy Trouser",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Horseshoe"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(1));
+  });
 });

--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -8,9 +8,11 @@ import {
 import { produce } from "immer";
 import { NPCName } from "lib/npcs";
 import {
+  getCurrentSeason,
   getSeasonalBanner,
   getSeasonalTicket,
 } from "features/game/types/seasons";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export type CompleteNPCChoreAction = {
   type: "chore.fulfilled";
@@ -104,6 +106,15 @@ export function generateChoreRewards({
     !!game.inventory["Lifetime Farmer Banner"]
   ) {
     items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 2;
+  }
+
+  if (
+    getCurrentSeason(now) === "Bull Run" &&
+    (isWearableActive({ game, name: "Cowboy Hat" }) ||
+      isWearableActive({ game, name: "Cowboy Shirt" }) ||
+      isWearableActive({ game, name: "Cowboy Trouser" }))
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
   }
 
   return items;

--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -109,10 +109,22 @@ export function generateChoreRewards({
   }
 
   if (
-    getCurrentSeason(now) === "Bull Run" &&
-    (isWearableActive({ game, name: "Cowboy Hat" }) ||
-      isWearableActive({ game, name: "Cowboy Shirt" }) ||
-      isWearableActive({ game, name: "Cowboy Trouser" }))
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Hat" })
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Shirt" })
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Trouser" })
   ) {
     items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
   }

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1066,6 +1066,52 @@ describe("deliver", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
   });
 
+  it("stacks Cowboy Set boost at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...TEST_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2024-11-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+            shirt: "Cowboy Shirt",
+            pants: "Cowboy Trouser",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
+  });
+
   it("does not provide +1 tickets when Cowboy Hat is worn outside Bull Run Season", () => {
     const mockDate = new Date("2024-10-30T15:00:00Z");
     jest.useFakeTimers();

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -978,6 +978,94 @@ describe("deliver", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
   });
 
+  it("provides +1 tickets when Cowboy Shirt is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...TEST_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2024-11-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            shirt: "Cowboy Shirt",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("provides +1 tickets when Cowboy Trouser is worn at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...TEST_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2024-11-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            pants: "Cowboy Trouser",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
   it("does not provide +1 tickets when Cowboy Hat is worn outside Bull Run Season", () => {
     const mockDate = new Date("2024-10-30T15:00:00Z");
     jest.useFakeTimers();

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -53,11 +53,24 @@ export function generateDeliveryTickets({
   ) {
     amount += 2;
   }
+
   if (
     getCurrentSeason() === "Bull Run" &&
-    (isWearableActive({ game, name: "Cowboy Hat" }) ||
-      isWearableActive({ game, name: "Cowboy Shirt" }) ||
-      isWearableActive({ game, name: "Cowboy Trouser" }))
+    isWearableActive({ game, name: "Cowboy Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Shirt" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Trouser" })
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -53,10 +53,11 @@ export function generateDeliveryTickets({
   ) {
     amount += 2;
   }
-
   if (
     getCurrentSeason() === "Bull Run" &&
-    isWearableActive({ game, name: "Cowboy Hat" })
+    (isWearableActive({ game, name: "Cowboy Hat" }) ||
+      isWearableActive({ game, name: "Cowboy Shirt" }) ||
+      isWearableActive({ game, name: "Cowboy Trouser" }))
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/sellBounty.test.ts
+++ b/src/features/game/events/landExpansion/sellBounty.test.ts
@@ -142,6 +142,33 @@ describe("sellBounty", () => {
     expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
   });
 
+  it("rewards +1 Horseshoe when Cowboy Hat is worn during Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "3",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
   it("rewards +1 Horseshoe when Cowboy Shirt is worn during Bull Run Season", () => {
     const mockDate = new Date(2024, 11, 11);
     jest.useFakeTimers();
@@ -159,6 +186,33 @@ describe("sellBounty", () => {
           equipped: {
             ...INITIAL_BUMPKIN.equipped,
             shirt: "Cowboy Shirt",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("rewards +1 Horseshoe when Cowboy Trouser is worn during Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "3",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            pants: "Cowboy Trouser",
           },
         },
       },

--- a/src/features/game/events/landExpansion/sellBounty.test.ts
+++ b/src/features/game/events/landExpansion/sellBounty.test.ts
@@ -223,6 +223,35 @@ describe("sellBounty", () => {
     expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
   });
 
+  it("stacks Cowboy Set boost at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "3",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
+            shirt: "Cowboy Shirt",
+            pants: "Cowboy Trouser",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
+  });
+
   it("subtracts the item", () => {
     const action: SellBountyAction = {
       type: "bounty.sold",

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -37,7 +37,9 @@ export function generateBountyTicket({
 
   if (
     getCurrentSeason() === "Bull Run" &&
-    isWearableActive({ game, name: "Cowboy Shirt" })
+    (isWearableActive({ game, name: "Cowboy Hat" }) ||
+      isWearableActive({ game, name: "Cowboy Shirt" }) ||
+      isWearableActive({ game, name: "Cowboy Trouser" }))
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -37,9 +37,21 @@ export function generateBountyTicket({
 
   if (
     getCurrentSeason() === "Bull Run" &&
-    (isWearableActive({ game, name: "Cowboy Hat" }) ||
-      isWearableActive({ game, name: "Cowboy Shirt" }) ||
-      isWearableActive({ game, name: "Cowboy Trouser" }))
+    isWearableActive({ game, name: "Cowboy Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Shirt" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Bull Run" &&
+    isWearableActive({ game, name: "Cowboy Trouser" })
   ) {
     amount += 1;
   }

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
@@ -89,7 +89,9 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
         ? "rare"
         : tier === "epic"
           ? "epic"
-          : "basic";
+          : tier === "mega"
+            ? "mega"
+            : "basic";
 
   const seasonalCollectiblesCrafted = getSeasonalItemsCrafted(
     state,
@@ -126,6 +128,9 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
   const isEpicUnlocked =
     tiers === "epic" &&
     seasonalItemsCrafted - reduction >= seasonalStore.epic.requirement;
+  const isMegaUnlocked =
+    tier === "mega" &&
+    seasonalItemsCrafted - reduction >= seasonalStore.mega.requirement;
 
   const keysBoughtAt = keysBought?.megastore[itemName as Keys]?.boughtAt;
   const keysBoughtToday =
@@ -165,6 +170,7 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
     if (tier !== "basic") {
       if (tier === "rare" && !isRareUnlocked) return false;
       if (tier === "epic" && !isEpicUnlocked) return false;
+      if (tier === "mega" && !isMegaUnlocked) return false;
     }
     if (itemReq) {
       const hasRequirements = getKeys(itemReq).every((name) => {

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -224,7 +224,9 @@ export const ItemsList: React.FC<Props> = ({
                     ? lock
                     : !isEpicUnlocked && tier === "epic"
                       ? lock
-                      : ""
+                      : !isMegaUnlocked && tier === "mega"
+                        ? lock
+                        : ""
                 }
                 type={
                   tier === "basic"
@@ -233,7 +235,9 @@ export const ItemsList: React.FC<Props> = ({
                       ? "info"
                       : tier === "epic" && isEpicUnlocked
                         ? "vibrant"
-                        : "danger"
+                        : tier === "mega" && isMegaUnlocked
+                          ? "warning"
+                          : "danger"
                 }
               >
                 {itemsLabel}
@@ -241,7 +245,7 @@ export const ItemsList: React.FC<Props> = ({
             )}
           </div>
           <div className="w-1/10">
-            {(tier === "rare" || tier === "epic") && (
+            {(tier === "rare" || tier === "epic" || tier === "mega") && (
               <ResizableBar
                 percentage={percentage}
                 type={"progress"}
@@ -324,7 +328,8 @@ export const ItemsList: React.FC<Props> = ({
                       !isItemKey &&
                       (tier === "basic" ||
                         (tier === "rare" && isRareUnlocked) ||
-                        (tier === "epic" && isEpicUnlocked)) && (
+                        (tier === "epic" && isEpicUnlocked) ||
+                        (tier === "mega" && isMegaUnlocked)) && (
                         <img
                           src={SUNNYSIDE.icons.confirm}
                           className="absolute -right-2 -top-3"
@@ -339,7 +344,8 @@ export const ItemsList: React.FC<Props> = ({
                       isKeyCounted === 0 &&
                       (tier === "basic" ||
                         (tier === "rare" && isRareUnlocked) ||
-                        (tier === "epic" && isEpicUnlocked)) && (
+                        (tier === "epic" && isEpicUnlocked) ||
+                        (tier === "mega" && isMegaUnlocked)) && (
                         <img
                           src={SUNNYSIDE.icons.confirm}
                           className="absolute -right-2 -top-3"
@@ -351,7 +357,8 @@ export const ItemsList: React.FC<Props> = ({
                       )}
 
                     {((tier === "rare" && !isRareUnlocked) ||
-                      (tier === "epic" && !isEpicUnlocked)) && (
+                      (tier === "epic" && !isEpicUnlocked) ||
+                      (tier === "mega" && !isMegaUnlocked)) && (
                       <img
                         src={lock}
                         className="absolute -right-2 -top-2"

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -214,7 +214,7 @@ export const ItemsList: React.FC<Props> = ({
   return (
     <div className="flex flex-col mb-5">
       {itemsLabel && (
-        <div className="flex  z-10">
+        <div className="flex z-10">
           <div className="grow w-9/10">
             {itemsLabel && (
               <Label
@@ -311,7 +311,7 @@ export const ItemsList: React.FC<Props> = ({
                   }}
                   onClick={() => onItemClick(item, tier)}
                 >
-                  <div className="flex relative justify-center items-center w-full h-full">
+                  <div className="flex relative justify-center items-center w-full h-full z-20">
                     <SquareIcon icon={getItemImage(item)} width={20} />
                     {buff && (
                       <img


### PR DESCRIPTION
# Description

This PR does the following:
- Updates Buy Action for new tier, "mega"
- Updated UI for "mega" item
- Cowboy Set Boost for Deliveries, Bounties, NPC Chores.
- Added test to check if boost applies @ Bull Run Season


Fixes #issue

# What needs to be tested by the reviewer?

Connect to BE.

# Testing UI:
1. Adjust cost to test and buy items.
2. Adjust `gameState.pumpkinPlaza.keysbought` for megastore to be outside current season to check if key is not counted toward crafting requirements.
3. Buy 3 items of the current tier + Key of the tier to test if next tier is unlocked up until the Mega Item.

# Testing Boost:
1. Give yourself a Cowboy Hat/Shirt/Trouser
2. Check if boost applied for tickets
3. Check if boost stacks for tickets

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
