### PR TITLE
[FIX] Ensure placed items cannot be crafted

### DIFF
--- a/src/features/game/events/landExpansion/startCrafting.test.ts
+++ b/src/features/game/events/landExpansion/startCrafting.test.ts
@@ -223,6 +223,8 @@ describe("startCrafting", () => {
   });
 
   it("if recipes exists - subtracts the ingredients from the player's inventory", () => {
+    gameState.inventory.Stone = new Decimal(1);
+
     gameState.craftingBox.recipes = {
       "Dirt Path": {
         name: "Dirt Path",
@@ -259,6 +261,180 @@ describe("startCrafting", () => {
 
     const state = startCrafting({ state: gameState, action });
 
-    expect(state.inventory.Stone).toStrictEqual(new Decimal(9));
+    expect(state.inventory.Stone).toStrictEqual(new Decimal(0));
+  });
+
+  it("if recipes exists - does not allow crafting when the ingredient is placed", () => {
+    gameState.craftingBox.recipes = {
+      "Sturdy Bed": {
+        name: "Sturdy Bed",
+        type: "collectible",
+        ingredients: [
+          { collectible: "Merino Cushion" },
+          { collectible: "Merino Cushion" },
+          { collectible: "Merino Cushion" },
+          { collectible: "Crimsteel" },
+          { collectible: "Crimsteel" },
+          { collectible: "Crimsteel" },
+          { collectible: "Crimsteel" },
+          { collectible: "Basic Bed" },
+          { collectible: "Crimsteel" },
+        ],
+        time: 0,
+      },
+    };
+
+    gameState.inventory["Basic Bed"] = new Decimal(1);
+    gameState.inventory["Merino Cushion"] = new Decimal(3);
+    gameState.inventory["Crimsteel"] = new Decimal(5);
+
+    gameState.collectibles = {};
+    gameState.collectibles["Basic Bed"] = [
+      {
+        id: "123",
+        coordinates: { x: 0, y: 0 },
+        createdAt: 0,
+        readyAt: 0,
+      },
+    ];
+
+    const action: StartCraftingAction = {
+      type: "crafting.started",
+      ingredients: [
+        { collectible: "Merino Cushion" },
+        { collectible: "Merino Cushion" },
+        { collectible: "Merino Cushion" },
+        { collectible: "Crimsteel" },
+        { collectible: "Crimsteel" },
+        { collectible: "Crimsteel" },
+        { collectible: "Crimsteel" },
+        { collectible: "Basic Bed" },
+        { collectible: "Crimsteel" },
+      ],
+    };
+
+    expect(() => startCrafting({ state: { ...gameState }, action })).toThrow(
+      "You do not have the ingredients to craft this item",
+    );
+  });
+
+  it("if recipes exists - does not allow crafting when the wearable is worn", () => {
+    gameState.craftingBox.recipes = {
+      "Farmer Overalls": {
+        name: "Farmer Overalls",
+        type: "wearable",
+        ingredients: [
+          null,
+          null,
+          null,
+          null,
+          { wearable: "Farmer Pants" },
+          null,
+          { collectible: "Leather" },
+          null,
+          { collectible: "Leather" },
+        ],
+        time: 0,
+      },
+    };
+
+    gameState.inventory["Leather"] = new Decimal(2);
+    gameState.wardrobe = {};
+    gameState.wardrobe["Farmer Pants"] = 1;
+
+    gameState.farmHands = {
+      bumpkins: {},
+    };
+    gameState.farmHands.bumpkins = {
+      "0": {
+        equipped: {
+          background: "Farm Background",
+          hair: "Buzz Cut",
+          body: "Beige Farmer Potion",
+          pants: "Farmer Pants",
+          shoes: "Black Farmer Boots",
+          tool: "Axe",
+        },
+      },
+    };
+
+    const action: StartCraftingAction = {
+      type: "crafting.started",
+      ingredients: [
+        null,
+        null,
+        null,
+        null,
+        { wearable: "Farmer Pants" },
+        null,
+        { collectible: "Leather" },
+        null,
+        { collectible: "Leather" },
+      ],
+    };
+
+    expect(() => startCrafting({ state: { ...gameState }, action })).toThrow(
+      "You do not have the ingredients to craft this item",
+    );
+  });
+
+  it("if recipes exists - allows crafting when the wearable is worn and there is a spare", () => {
+    gameState.craftingBox.recipes = {
+      "Farmer Overalls": {
+        name: "Farmer Overalls",
+        type: "wearable",
+        ingredients: [
+          null,
+          null,
+          null,
+          null,
+          { wearable: "Farmer Pants" },
+          null,
+          { collectible: "Leather" },
+          null,
+          { collectible: "Leather" },
+        ],
+        time: 0,
+      },
+    };
+
+    gameState.inventory["Leather"] = new Decimal(2);
+    gameState.wardrobe = {};
+    gameState.wardrobe["Farmer Pants"] = 2;
+
+    gameState.farmHands = {
+      bumpkins: {},
+    };
+    gameState.farmHands.bumpkins = {
+      "0": {
+        equipped: {
+          background: "Farm Background",
+          hair: "Buzz Cut",
+          body: "Beige Farmer Potion",
+          pants: "Farmer Pants",
+          shoes: "Black Farmer Boots",
+          tool: "Axe",
+        },
+      },
+    };
+
+    const action: StartCraftingAction = {
+      type: "crafting.started",
+      ingredients: [
+        null,
+        null,
+        null,
+        null,
+        { wearable: "Farmer Pants" },
+        null,
+        { collectible: "Leather" },
+        null,
+        { collectible: "Leather" },
+      ],
+    };
+
+    const newState = startCrafting({ state: { ...gameState }, action });
+    expect(newState.inventory["Leather"]).toStrictEqual(new Decimal(0));
+    expect(newState.wardrobe["Farmer Pants"]).toBe(1);
   });
 });

--- a/src/features/game/events/landExpansion/startCrafting.ts
+++ b/src/features/game/events/landExpansion/startCrafting.ts
@@ -59,8 +59,10 @@ export function startCrafting({
             copy.inventory[ingredient.collectible] ?? new Decimal(0);
 
           const placedCount =
-            copy.collectibles[ingredient.collectible as CollectibleName]
-              ?.length ?? 0;
+            (copy.collectibles[ingredient.collectible as CollectibleName]
+              ?.length ?? 0) +
+            (copy.home?.collectibles[ingredient.collectible as CollectibleName]
+              ?.length ?? 0);
 
           if (inventoryCount.sub(placedCount).lt(1)) {
             throw new Error(

--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -26,6 +26,8 @@ import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { useSound } from "lib/utils/hooks/useSound";
 import { ModalOverlay } from "components/ui/ModalOverlay";
 import { ButtonPanel, InnerPanel } from "components/ui/Panel";
+import { CollectibleName, getKeys } from "features/game/types/craftables";
+import { availableWardrobe } from "features/game/events/landExpansion/equip";
 
 const VALID_CRAFTING_RESOURCES: InventoryItemName[] = [
   "Wood",
@@ -131,6 +133,22 @@ export const CraftTab: React.FC<Props> = ({
 
   const remainingInventory = useMemo(() => {
     const updatedInventory = { ...inventory };
+
+    // Removed placed items
+    getKeys(updatedInventory).forEach((itemName) => {
+      const placedCount =
+        (gameService.state.context.state.collectibles[
+          itemName as CollectibleName
+        ]?.length ?? 0) +
+        (gameService.state.context.state.home?.collectibles[
+          itemName as CollectibleName
+        ]?.length ?? 0);
+
+      updatedInventory[itemName] = (
+        updatedInventory[itemName] ?? new Decimal(0)
+      ).minus(placedCount);
+    });
+
     selectedItems.forEach((item) => {
       const collectible = item?.collectible;
       if (collectible && updatedInventory[collectible]) {
@@ -141,7 +159,8 @@ export const CraftTab: React.FC<Props> = ({
   }, [inventory, selectedItems]);
 
   const remainingWardrobe = useMemo(() => {
-    const updatedWardrobe = { ...wardrobe };
+    const updatedWardrobe = availableWardrobe(gameService.state.context.state);
+
     selectedItems.forEach((item) => {
       const wearable = item?.wearable;
       if (wearable && updatedWardrobe[wearable]) {


### PR DESCRIPTION
# Description

Fixes a bug where placed items could be crafted. It now checks collectibles and available wardrobe before crafting.

Fixes #issue

# What needs to be tested by the reviewer?

Place an item, and make sure it doesn't show up in crafting UI. Basic Bed is the easiest.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
