### PR TITLE
[FIX] Key Reduction When No History in Megastore

### DIFF
--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -200,15 +200,18 @@ export function isKeyBoughtWithinSeason(
   const keyBoughtAt =
     game.pumpkinPlaza.keysBought?.megastore[tierKey as Keys]?.boughtAt;
   const seasonTime = SEASONS[getCurrentSeason()];
+  //If player has no history of buying keys at megastore
+  if (!keyBoughtAt && isLowerTier) return true;
 
+  // Returns false if key is bought outside current season, otherwise, true
   if (keyBoughtAt) {
     const isWithinSeason =
       new Date(keyBoughtAt) >= seasonTime.startDate &&
       new Date(keyBoughtAt) <= seasonTime.endDate;
-
     return isWithinSeason;
   }
 
+  // This will only be triggered if isLowerTier is false
   return false;
 }
 

--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -200,8 +200,9 @@ export function isKeyBoughtWithinSeason(
   const keyBoughtAt =
     game.pumpkinPlaza.keysBought?.megastore[tierKey as Keys]?.boughtAt;
   const seasonTime = SEASONS[getCurrentSeason()];
+  const currentKey = game.inventory[tierKey]; // used to check if player has key in inventory
   //If player has no history of buying keys at megastore
-  if (!keyBoughtAt && isLowerTier) return true;
+  if (!keyBoughtAt && isLowerTier && !currentKey) return true;
 
   // Returns false if key is bought outside current season, otherwise, true
   if (keyBoughtAt) {


### PR DESCRIPTION
# Description
This PR fixes issues regarding Key Guard Logic within season. If no history found from players buying a key, it will not be reduced in the guard logic. 
Fixes #issue

# What needs to be tested by the reviewer?
Connect to BE.
Make sure to have no history of keys being bought at megastore.
Airdrop yourself some requirements to buy the items.
Check if progress bar is working as intended tier by tier.
Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
