### PR TITLE
[FIX] Required Items Check when Crafting

### DIFF
--- a/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
@@ -21,9 +21,12 @@ import {
   Recipes,
 } from "features/game/lib/crafting";
 import { getImageUrl } from "lib/utils/getImageURLS";
-import { ITEM_IDS } from "features/game/types/bumpkin";
-import { Decimal } from "decimal.js";
+import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
+import Decimal from "decimal.js-light";
 import { IngredientsInfoPanel } from "features/world/ui/IngredientsInfoPanel";
+import { getKeys } from "features/game/types/decorations";
+import { CollectibleName } from "features/game/types/craftables";
+import { availableWardrobe } from "features/game/events/landExpansion/equip";
 
 const _craftingBoxRecipes = (state: MachineState) =>
   state.context.state.craftingBox.recipes;
@@ -74,15 +77,61 @@ export const RecipesTab: React.FC<Props> = ({
   const inventory = useSelector(gameService, _inventory);
   const wardrobe = useSelector(gameService, _wardrobe);
 
+  const remainingInventory = useMemo(() => {
+    const updatedInventory = { ...inventory };
+
+    // Removed placed items
+    getKeys(updatedInventory).forEach((itemName) => {
+      const placedCount =
+        (gameService.state.context.state.collectibles[
+          itemName as CollectibleName
+        ]?.length ?? 0) +
+        (gameService.state.context.state.home?.collectibles[
+          itemName as CollectibleName
+        ]?.length ?? 0);
+
+      updatedInventory[itemName] = (
+        updatedInventory[itemName] ?? new Decimal(0)
+      ).minus(placedCount);
+    });
+
+    return updatedInventory;
+  }, [inventory]);
+
+  const remainingWardrobe = useMemo(() => {
+    const updatedWardrobe = availableWardrobe(gameService.state.context.state);
+
+    return updatedWardrobe;
+  }, [wardrobe]);
+
   const hasRequiredIngredients = (recipe: Recipe) => {
-    return recipe.ingredients.every((ingredient) => {
+    // Track required amounts for each ingredient
+    const requiredAmounts: Record<string, number> = {};
+
+    // Count up total required for each ingredient
+    recipe.ingredients.forEach((ingredient) => {
       if (ingredient?.collectible) {
-        return (inventory[ingredient.collectible] ?? new Decimal(0)).gte(1);
+        requiredAmounts[ingredient.collectible] =
+          (requiredAmounts[ingredient.collectible] || 0) + 1;
       }
       if (ingredient?.wearable) {
-        return (wardrobe[ingredient.wearable] ?? 0) >= 1;
+        requiredAmounts[ingredient.wearable] =
+          (requiredAmounts[ingredient.wearable] || 0) + 1;
       }
-      return true;
+    });
+
+    // Check if we have enough of each required ingredient
+    return Object.entries(requiredAmounts).every(([item, amount]) => {
+      const inventoryAmount = remainingInventory[item as CollectibleName];
+      if (inventoryAmount) {
+        return inventoryAmount.gte(amount);
+      }
+
+      const wardrobeAmount = remainingWardrobe[item as BumpkinItem];
+      if (wardrobeAmount) {
+        return wardrobeAmount >= amount;
+      }
+      return false;
     });
   };
 


### PR DESCRIPTION
# Description

Fixes the required items check in the crafting box. It now checks all ingredients instead of "at least one"

<img width="158" alt="1" src="https://github.com/user-attachments/assets/3a777ee8-457b-4433-8fd9-596eb56e5a76">
<img width="164" alt="2" src="https://github.com/user-attachments/assets/6103ea83-f12b-4581-b278-f3a585f4f014">

# What needs to be tested by the reviewer?

Check you cannot click recipes until you have all the ingredients.

- Update `OFFLINE_FARM` to equal `STATIC_OFFLINE_FARM`
- Give `STATIC_OFFLINE_FARM` 3 Radish and 5 Wool.
- Ensure you cannot craft red farmers shirt.
- Give yourself an extra radish and ensure you can craft.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes