### PR TITLE
[FIX] Ancient Shovel Withdrawal Restriction

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -264,13 +264,19 @@ export function areAnyCowsSleeping(game: GameState): Restriction {
 }
 
 const MAX_DIGS = 25;
-export function areBonusTreasureHolesDug(game: GameState): Restriction {
+export function areTreasureHolesDug({
+  game,
+  minHoles,
+}: {
+  game: GameState;
+  minHoles: number;
+}): Restriction {
   const holes = game.desert.digging.grid.flat().map((hole) => {
     const today = new Date().toISOString().substring(0, 10);
 
     return +(new Date(hole.dugAt).toISOString().substring(0, 10) === today);
   });
-  const holesDug = holes.reduce((sum, value) => sum + value, 0) > MAX_DIGS;
+  const holesDug = holes.reduce((sum, value) => sum + value, 0) > minHoles;
 
   return [holesDug, translate("restrictionReason.treasuresDug")];
 }
@@ -498,7 +504,8 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Potent Potato": (game) => cropIsGrowing({ item: "Potato", game }),
   "Radical Radish": (game) => cropIsGrowing({ item: "Radish", game }),
 
-  "Heart of Davy Jones": (game) => areBonusTreasureHolesDug(game),
+  "Heart of Davy Jones": (game) =>
+    areTreasureHolesDug({ game, minHoles: MAX_DIGS }),
 
   "Maneki Neko": (game) => hasShakenManeki(game),
   "Festive Tree": (game) => hasShakenTree(game),
@@ -570,7 +577,8 @@ export const REMOVAL_RESTRICTIONS: Partial<
   ],
 
   // Pharaoh's Treasure
-  "Pharaoh Chicken": (game) => areBonusTreasureHolesDug(game),
+  "Pharaoh Chicken": (game) =>
+    areTreasureHolesDug({ game, minHoles: MAX_DIGS }),
   "Desert Rose": (game) => areFlowersGrowing(game),
   "Lemon Shark": (game) => areFruitsGrowing(game, "Lemon"),
   "Lemon Frog": (game) => areFruitsGrowing(game, "Lemon"),

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -13,11 +13,11 @@ import {
   isCrimstoneHammerActive,
   areAnyOGFruitsGrowing,
   hasFishedToday,
-  areBonusTreasureHolesDug,
   areAnyCropsOrGreenhouseCropsGrowing,
   hasOpenedPirateChest,
   areAnySheepSleeping,
   areAnyCowsSleeping,
+  areTreasureHolesDug,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -77,7 +77,8 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
   "Dev Wrench": (state) => !areAnyOilReservesDrilled(state)[0],
   "Oil Overalls": (state) => !areAnyOilReservesDrilled(state)[0],
   "Hornet Mask": (state) => isBeehivesFull(state)[0],
-  "Ancient Shovel": (state) => areBonusTreasureHolesDug(state)[0],
+  "Ancient Shovel": (state) =>
+    areTreasureHolesDug({ game: state, minHoles: 0 })[0],
   "Pirate Potion": (state) => !hasOpenedPirateChest(state)[0],
   "Dream Scarf": (state) => !areAnySheepSleeping(state)[0],
   "Milk Apron": (state) => !areAnyCowsSleeping(state)[0],


### PR DESCRIPTION
# Description

Currently Ancient shovel is able to be withdrawn when the player dug below 25 digs

I edited the function to take in a number such that the restriction is active if the player has dug an amount over that number (i.e. ancient shovel: if player has dug more than 0 times; HODJ & Pharaoh Chicken, if player has dug more than 25 times)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
