### PR TITLE
[FIX] Error in console when Aura is undefined

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -454,7 +454,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     if (this.frontfx && this.backfx) {
       this.removeAura();
     }
-    if (this.clothing.aura !== undefined) {
+
+    if (this.clothing?.aura) {
+      if (!this.clothing?.aura) return; // Returns when no aura equipped
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const container = this;
       const auraName = this.clothing.aura;


### PR DESCRIPTION
# Description
**Before the fix:**
![image](https://github.com/user-attachments/assets/111d9b78-69a2-4f8b-b370-995abb7134ca)
Aura checks in `showAura()` is being executed even if no aura equipped on a Bumpkin thus loading of aura front/back spritesheet that is `undefined`. 
Fixed 404 error showing in Console for undefined.png related to aura.
Added extra checks: a skip/return when no aura is equipped on Bumpkins.

Fixes #issue

# What needs to be tested by the reviewer?

Connect Local MMO(Colyseus). 
Add Coin Aura to Offline Farm / constants.ts `wardrobe{}`
Check console.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
