### PR TITLE
[CHORE] Show more accurate restock numbers

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -95,9 +95,6 @@ export type StockableName = Extract<
   | "Lily Seed"
   | "Sand Shovel"
   | "Sand Drill"
-  | "Chicken"
-  | "Magic Bean"
-  | "Immortal Pear"
 >;
 
 export const INITIAL_STOCK = (
@@ -184,9 +181,6 @@ export const INITIAL_STOCK = (
 
     "Sand Shovel": new Decimal(50),
     "Sand Drill": new Decimal(10),
-    Chicken: new Decimal(5),
-    "Magic Bean": new Decimal(5),
-    "Immortal Pear": new Decimal(1),
   };
 };
 

--- a/src/features/island/buildings/components/building/market/Restock.tsx
+++ b/src/features/island/buildings/components/building/market/Restock.tsx
@@ -160,15 +160,23 @@ const RestockModal: React.FC<{ onClose: () => void }> = ({ onClose }) => {
 
         <p className="mb-1">{t("gems.buyReplenish")}</p>
       </div>
-      <div className="mt-1 flex flex-wrap h-40 scrollable overflow-y-scroll">
+      <div className="mt-1 flex flex-wrap h-40 scrollable">
         {Object.entries(INITIAL_STOCK(gameState.context.state)).map(
-          ([item, amount]) => (
-            <Box
-              key={item}
-              count={new Decimal(amount)}
-              image={ITEM_DETAILS[item as StockableName].image}
-            />
-          ),
+          ([item, amount]) => {
+            const remainingStock =
+              gameState.context.state.stock[item as StockableName] ?? 0;
+            const restockedAmount = amount.sub(remainingStock); // Restock the difference if there's remaining stock left
+
+            return (
+              restockedAmount.gt(0) && (
+                <Box
+                  key={item}
+                  count={restockedAmount}
+                  image={ITEM_DETAILS[item as StockableName].image}
+                />
+              )
+            );
+          },
         )}
       </div>
       <div className="flex justify-content-around mt-2 space-x-1">
@@ -243,13 +251,34 @@ const ExperimentRestockModal: React.FC<{ onClose: () => void }> = ({
           <p className="text-sm mb-2">{t("gems.shipment.success")}</p>
         </div>
         <div className="mt-1 flex flex-wrap">
-          {Object.entries(SHIPMENT_STOCK).map(([item, amount]) => (
-            <Box
-              key={item}
-              count={new Decimal(amount)}
-              image={ITEM_DETAILS[item as StockableName].image}
-            />
-          ))}
+          {Object.entries(SHIPMENT_STOCK).map(([item, amount]) => {
+            const totalStock = INITIAL_STOCK(gameState.context.state)[
+              item as StockableName
+            ];
+            const remainingStock =
+              gameState.context.state.stock[item as StockableName] ??
+              new Decimal(0);
+            let shipmentAmount = new Decimal(0);
+            if (
+              // If Shipment amount will exceed total stock
+              remainingStock.add(new Decimal(amount)).greaterThan(totalStock)
+            ) {
+              // restock the difference between remaining stock and total stock
+              shipmentAmount = remainingStock
+                .add(new Decimal(amount))
+                .sub(totalStock);
+            } else {
+              // Otherwise restock shipmentAmount
+              shipmentAmount = new Decimal(amount);
+            }
+            return (
+              <Box
+                key={item}
+                count={new Decimal(shipmentAmount)}
+                image={ITEM_DETAILS[item as StockableName].image}
+              />
+            );
+          })}
         </div>
         <p className="text-xs p-1 pb-1.5 italic">
           {`(${t("gems.shipment.useGems")})`}
@@ -279,15 +308,23 @@ const ExperimentRestockModal: React.FC<{ onClose: () => void }> = ({
 
         <p className="mb-1">{t("gems.buyReplenish")}</p>
       </div>
-      <div className="mt-1 flex flex-wrap h-40 scrollable overflow-y-scroll">
+      <div className="mt-1 flex flex-wrap h-40 scrollable">
         {Object.entries(INITIAL_STOCK(gameState.context.state)).map(
-          ([item, amount]) => (
-            <Box
-              key={item}
-              count={new Decimal(amount)}
-              image={ITEM_DETAILS[item as StockableName].image}
-            />
-          ),
+          ([item, amount]) => {
+            const remainingStock =
+              gameState.context.state.stock[item as StockableName] ?? 0;
+            const restockedAmount = amount.sub(remainingStock);
+
+            return (
+              restockedAmount.gt(0) && (
+                <Box
+                  key={item}
+                  count={restockedAmount}
+                  image={ITEM_DETAILS[item as StockableName].image}
+                />
+              )
+            );
+          },
         )}
       </div>
       <div className="flex justify-content-around mt-2 space-x-1">

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3717,7 +3717,7 @@
   "crafting.readySoon": "{{name}} will be ready soon...",
   "crafting.expansionSoon": "Your land will be ready soon...",
   "crafting.viewRecipes": "View recipes",
-  "gems.buyReplenish": "Would to like to replenish the shops now for 20 Gems?",
+  "gems.buyReplenish": "Would you like to replenish the shops now for 20 Gems?",
   "gems.replenish": "Replenish stock",
   "gems.nextFreeShipment": "Next free shipment:",
   "gems.outOfstock": "Out of stock",


### PR DESCRIPTION
# Description

Currently the restock modal shows the total stock for each item

I've edited the numbers such that it shows the amount of stock they are expected to get from a restock.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
