### PR TITLE
[FIX] Shipment clears stock of items not in shipment

### DIFF
--- a/src/features/game/events/landExpansion/shipmentRestocked.test.ts
+++ b/src/features/game/events/landExpansion/shipmentRestocked.test.ts
@@ -24,8 +24,31 @@ describe("shipmentRestocked", () => {
 
     expect(state.shipments.restockedAt).toBeCloseTo(now);
     expect(state.stock["Sunflower Seed"]).toEqual(
-      new Decimal(SHIPMENT_STOCK["Sunflower Seed"] ?? 0),
+      new Decimal((SHIPMENT_STOCK["Sunflower Seed"] ?? 0) + 5),
     );
+  });
+
+  it("restocks a shipment to max stock", () => {
+    const now = Date.now();
+    const state = shipmentRestock({
+      action: {
+        type: "shipment.restocked",
+      },
+      state: {
+        ...INITIAL_FARM,
+        stock: {
+          ...INITIAL_FARM.stock,
+          "Sunflower Seed": new Decimal(350),
+        },
+        shipments: {
+          restockedAt: new Date("2023-04-04").getTime(),
+        },
+      },
+      createdAt: now,
+    });
+
+    expect(state.shipments.restockedAt).toEqual(now);
+    expect(state.stock["Sunflower Seed"]).toEqual(new Decimal(400));
   });
 
   it("does not reduce existing stock", () => {
@@ -38,7 +61,7 @@ describe("shipmentRestocked", () => {
         ...INITIAL_FARM,
         stock: {
           ...INITIAL_FARM.stock,
-          "Sunflower Seed": new Decimal(500),
+          "Sunflower Seed": new Decimal(400),
         },
         shipments: {
           restockedAt: new Date("2023-04-04").getTime(),
@@ -48,7 +71,32 @@ describe("shipmentRestocked", () => {
     });
 
     expect(state.shipments.restockedAt).toEqual(now);
-    expect(state.stock["Sunflower Seed"]).toEqual(new Decimal(500));
+    expect(state.stock["Sunflower Seed"]).toEqual(new Decimal(400));
+  });
+
+  it("does not change existing stock of other seeds", () => {
+    const now = Date.now();
+    const state = shipmentRestock({
+      action: {
+        type: "shipment.restocked",
+      },
+      state: {
+        ...INITIAL_FARM,
+        stock: {
+          ...INITIAL_FARM.stock,
+          "Sunflower Seed": new Decimal(300),
+          "Eggplant Seed": new Decimal(50),
+        },
+        shipments: {
+          restockedAt: new Date("2023-04-04").getTime(),
+        },
+      },
+      createdAt: now,
+    });
+
+    expect(state.shipments.restockedAt).toEqual(now);
+    expect(state.stock["Sunflower Seed"]).toEqual(new Decimal(400));
+    expect(state.stock["Eggplant Seed"]).toEqual(new Decimal(50));
   });
 
   it("only restocks a shipment once per day", () => {

--- a/src/features/game/events/landExpansion/shipmentRestocked.ts
+++ b/src/features/game/events/landExpansion/shipmentRestocked.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { StockableName } from "features/game/lib/constants";
+import { INITIAL_STOCK, StockableName } from "features/game/lib/constants";
 import { getKeys } from "features/game/types/decorations";
 import { GameState } from "features/game/types/game";
 import { produce } from "immer";
@@ -70,13 +70,23 @@ export function shipmentRestock({
       throw new Error("Already restocked today");
     }
 
-    game.stock = getKeys(SHIPMENT_STOCK).reduce((acc, name) => {
-      const previous = game.stock[name] ?? new Decimal(0);
-      const newAmount = new Decimal(SHIPMENT_STOCK[name] ?? 0);
+    game.stock = getKeys(INITIAL_STOCK(game)).reduce((acc, name) => {
+      let remainingStock = game.stock[name] ?? new Decimal(0);
+      const totalStock = INITIAL_STOCK(game)[name];
+      const shipmentAmount = SHIPMENT_STOCK[name] ?? 0;
+
+      // If shipment amount will exceed total stock
+      if (remainingStock.add(shipmentAmount).gt(totalStock)) {
+        // return the difference between total and remaining stock
+        remainingStock = remainingStock.add(totalStock.sub(remainingStock));
+      } else {
+        // else return shipment stock
+        remainingStock = remainingStock.add(shipmentAmount);
+      }
 
       return {
         ...acc,
-        [name]: previous.gt(newAmount) ? previous : newAmount,
+        [name]: remainingStock,
       };
     }, {});
 

--- a/src/features/game/events/landExpansion/shipmentRestocked.ts
+++ b/src/features/game/events/landExpansion/shipmentRestocked.ts
@@ -28,10 +28,9 @@ export const SHIPMENT_STOCK: Partial<Record<StockableName, number>> = {
   Axe: 50,
   Pickaxe: 15,
   "Stone Pickaxe": 5,
-  "Iron Pickaxe": 2,
-  "Gold Pickaxe": 2,
+  "Iron Pickaxe": 1,
   Rod: 10,
-  "Sand Shovel": 25,
+  "Sand Shovel": 5,
 };
 
 export function canRestockShipment({

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -776,11 +776,7 @@ export const Land: React.FC = () => {
             <DirtRenderer island={island.type} grid={gameGrid} />
 
             {!landscaping && (
-              <Water
-                expansionCount={expansionCount}
-                townCenterBuilt={(buildings["Town Center"]?.length ?? 0) >= 1}
-                gameState={state}
-              />
+              <Water expansionCount={expansionCount} gameState={state} />
             )}
             {!landscaping && <UpcomingExpansion />}
 

--- a/src/features/game/expansion/components/RestockBoat.tsx
+++ b/src/features/game/expansion/components/RestockBoat.tsx
@@ -4,10 +4,7 @@ import { MapPlacement } from "./MapPlacement";
 import { PIXEL_SCALE, StockableName } from "features/game/lib/constants";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
-import {
-  canRestockShipment,
-  SHIPMENT_STOCK,
-} from "features/game/events/landExpansion/shipmentRestocked";
+import { canRestockShipment } from "features/game/events/landExpansion/shipmentRestocked";
 import { Context } from "features/game/GameProvider";
 import { Modal } from "components/ui/Modal";
 import { Label } from "components/ui/Label";
@@ -17,9 +14,10 @@ import { Button } from "components/ui/Button";
 import confetti from "canvas-confetti";
 import { hasFeatureAccess } from "lib/flags";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { Decimal } from "decimal.js-light";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
+import Decimal from "decimal.js-light";
 
 const expansions = (state: MachineState) =>
   state.context.state.inventory["Basic Land"]?.toNumber() ?? 3;
@@ -28,7 +26,11 @@ const canRestock = (state: MachineState) =>
   canRestockShipment({ game: state.context.state }) &&
   !!state.context.state.shipments.restockedAt;
 
-export const RestockBoat: React.FC = () => {
+export const RestockBoat: React.FC<{
+  restockSeeds: [string, number][];
+  restockTools: [string, number][];
+  getShipmentAmount: (item: StockableName, amount: number) => Decimal;
+}> = ({ restockSeeds, restockTools, getShipmentAmount }) => {
   const { t } = useAppTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const { gameService, showAnimations } = useContext(Context);
@@ -73,14 +75,55 @@ export const RestockBoat: React.FC = () => {
             <p className="text-sm mb-2">{t("gems.shipment.success")}</p>
             <p className="text-sm mb-2">{t("gems.shipment.shops")}</p>
           </div>
-          <div className="mt-1 flex flex-wrap">
-            {Object.entries(SHIPMENT_STOCK).map(([item, amount]) => (
-              <Box
-                key={item}
-                count={new Decimal(amount)}
-                image={ITEM_DETAILS[item as StockableName].image}
-              />
-            ))}
+          <div className="mt-1 h-auto overflow-y-auto overflow-x-hidden scrollable pl-1">
+            {restockTools.length > 0 && (
+              <Label
+                icon={ITEM_DETAILS.Axe.image}
+                type="default"
+                className="ml-2 mb-1"
+              >
+                {t("tools")}
+              </Label>
+            )}
+            <div className="flex flex-wrap mb-2">
+              {restockTools.map(([item, amount]) => {
+                const shipmentAmount = getShipmentAmount(
+                  item as StockableName,
+                  amount,
+                );
+                return (
+                  <Box
+                    key={item}
+                    count={shipmentAmount}
+                    image={ITEM_DETAILS[item as StockableName].image}
+                  />
+                );
+              })}
+            </div>
+            {restockSeeds.length > 0 && (
+              <Label
+                icon={CROP_LIFECYCLE.Sunflower.seed}
+                type="default"
+                className="ml-2 mb-1"
+              >
+                {t("seeds")}
+              </Label>
+            )}
+            <div className="flex flex-wrap mb-2">
+              {restockSeeds.map(([item, amount]) => {
+                const shipmentAmount = getShipmentAmount(
+                  item as StockableName,
+                  amount,
+                );
+                return (
+                  <Box
+                    key={item}
+                    count={shipmentAmount}
+                    image={ITEM_DETAILS[item as StockableName].image}
+                  />
+                );
+              })}
+            </div>
           </div>
           <Button
             onClick={() => {

--- a/src/features/game/expansion/components/Water.tsx
+++ b/src/features/game/expansion/components/Water.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React from "react";
 
 import {
   GRID_WIDTH_PX,
@@ -18,7 +18,6 @@ import { TravelTeaser } from "./TravelTeaser";
 import { DiscordBoat } from "./DiscordBoat";
 import { IslandUpgrader } from "./IslandUpgrader";
 import { GameState } from "features/game/types/game";
-import { Context } from "features/game/GameProvider";
 
 import { CONFIG } from "lib/config";
 import { LaTomatina } from "./LaTomatina";
@@ -30,18 +29,14 @@ import { WORKBENCH_TOOLS, TREASURE_TOOLS } from "features/game/types/tools";
 import Decimal from "decimal.js-light";
 
 interface Props {
-  townCenterBuilt: boolean;
   expansionCount: number;
   gameState: GameState;
 }
 
 export const WaterComponent: React.FC<Props> = ({
-  townCenterBuilt,
   expansionCount,
   gameState,
 }) => {
-  const { showAnimations } = useContext(Context);
-
   // As the land gets bigger, push the water decorations out
   const offset = Math.ceil((Math.sqrt(expansionCount) * LAND_WIDTH) / 2);
 

--- a/src/features/island/buildings/components/building/market/Restock.tsx
+++ b/src/features/island/buildings/components/building/market/Restock.tsx
@@ -252,7 +252,7 @@ const RestockModal: React.FC<RestockModalProps> = ({
           })}
         </div>
       </div>
-      <p className="text-xs p-1 pb-1.5 italic">{t("gems.purchasedStock")}</p>
+      <p className="text-xs p-1 pb-1.5 italic">{t("gems.restockToMaxStock")}</p>
       <div className="flex justify-content-around mt-2 space-x-1">
         <Button onClick={onClose}>{t("cancel")}</Button>
         <Button className="relative" onClick={handleRestock}>
@@ -394,7 +394,7 @@ const ExperimentRestockModal: React.FC<{ onClose: () => void }> = ({
         {!restockIsEmpty && (
           <>
             <p className="text-xs p-1 pb-1.5 italic">
-              {t("gems.purchasedStock")}
+              {t("gems.restockToMaxStock")}
             </p>
             <p className="text-xs p-1 pb-1.5 italic">
               {`(${t("gems.shipment.useGems")})`}

--- a/src/features/island/buildings/components/building/market/Restock.tsx
+++ b/src/features/island/buildings/components/building/market/Restock.tsx
@@ -202,7 +202,7 @@ const RestockModal: React.FC<RestockModalProps> = ({
         )}
         <p className="mb-1">{t("gems.buyReplenish")}</p>
       </div>
-      <div className="mt-1 h-auto overflow-y-auto overflow-x-hidden scrollable pl-1">
+      <div className="mt-1 h-40 overflow-y-auto overflow-x-hidden scrollable pl-1">
         {restockTools.length > 0 && (
           <Label
             icon={ITEM_DETAILS.Axe.image}
@@ -341,7 +341,7 @@ const ExperimentRestockModal: React.FC<{ onClose: () => void }> = ({
             <p className="text-sm mb-2">{t("gems.shipment.success")}</p>
           </div>
         )}
-        <div className="mt-1 h-auto overflow-y-auto overflow-x-hidden scrollable pl-1">
+        <div className="mt-1 h-40 overflow-y-auto overflow-x-hidden scrollable pl-1">
           {restockTools.length > 0 && (
             <Label
               icon={ITEM_DETAILS.Axe.image}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3718,7 +3718,7 @@
   "crafting.expansionSoon": "Your land will be ready soon...",
   "crafting.viewRecipes": "View recipes",
   "gems.buyReplenish": "Would you like to replenish the shops now for 20 Gems?",
-  "gems.purchasedStock": "Restocks purchased stock only",
+  "gems.restockToMaxStock": "Restocks up to maximum stock",
   "gems.noShipment": "No Shipment",
   "gems.buyStock": "Please buy your stock to get your shipment.",
   "gems.replenish": "Replenish stock",


### PR DESCRIPTION
# Description

This PR fixes the following issues:
1. Restocking shipment clears the stock of items that aren't in the `SHIPMENT_STOCK` object
2. Restocking shipment now adds on to existing stock 
3. Adjusted shipment stock of certain tools

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
