### PR TITLE
[CHORE] Improve Megastore Bought Logic

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -267,6 +267,8 @@ const NON_COLLIDING_OBJECTS: InventoryItemName[] = [
   "Bumpkin Faction Rug",
   "Goblin Faction Rug",
   "Nightshade Faction Rug",
+  "Sleepy Rug",
+  "Crop Circle",
 ];
 
 function detectHomeCollision({

--- a/src/features/game/types/bumpkinActivity.ts
+++ b/src/features/game/types/bumpkinActivity.ts
@@ -33,6 +33,7 @@ import { FlowerName, FlowerSeedName } from "./flowers";
 import { FactionShopItemName } from "./factionShop";
 import { ShopDecorationName, SeasonalDecorationName } from "./decorations";
 import { AnimalType } from "./animals";
+import { SeasonalTierItemName } from "./megastore";
 
 type BuyableName =
   | SeedName
@@ -45,7 +46,8 @@ type BuyableName =
   | MegaStoreItemName
   | GreenHouseFruitSeedName
   | GreenHouseCropSeedName
-  | FactionShopItemName;
+  | FactionShopItemName
+  | SeasonalTierItemName;
 
 type SellableName =
   | CropName

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -146,15 +146,6 @@ export type MegaStoreCollectibleName =
   | "Scarab Beetle"
   | "Tomato Bombard";
 
-export type SeasonalCollectibleName =
-  // Animal Season
-  | "Cow Scratcher"
-  | "Spinning Wheel"
-  | "Sleepy Rug"
-  | "Meteorite"
-  | "Sheaf of Plenty"
-  | "Mechanical Bull";
-
 export type GoblinBlacksmithItemName =
   | "Purple Trail"
   | "Obie"

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -18,7 +18,6 @@ import {
   HeliosBlacksmithItem,
   MegaStoreCollectibleName,
   PotionHouseItemName,
-  SeasonalCollectibleName,
   SoldOutCollectibleName,
   TreasureCollectibleItem,
 } from "./collectibles";
@@ -29,6 +28,7 @@ import { EpicFlowerName, MutantFlowerName } from "./flowers";
 import { translate } from "lib/i18n/translate";
 import { FactionShopCollectibleName } from "./factionShop";
 import { BEDS } from "./beds";
+import { SeasonalCollectibleName } from "./megastore";
 
 export { FLAGS };
 
@@ -1365,6 +1365,7 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   Meteorite: { width: 2, height: 2 },
   "Sheaf of Plenty": { width: 1, height: 2 },
   "Mechanical Bull": { width: 2, height: 2 },
+  "Crop Circle": { width: 2, height: 2 },
   "Moo-ver": { width: 2, height: 2 },
   "Swiss Whiskers": { width: 1, height: 1 },
   Cluckulator: { width: 1, height: 2 },

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -126,13 +126,6 @@ export type InteriorDecorationName = "Rug" | "Wardrobe";
 export type AnimalDecorationName = "Wagon";
 
 export const DECORATION_TEMPLATES = {
-  "Crop Circle": {
-    dimensions: {
-      width: 2,
-      height: 2,
-    },
-    isWithdrawable: () => false,
-  },
   "King of Bears": {
     dimensions: {
       width: 3,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -34,7 +34,6 @@ import {
   MegaStoreCollectibleName,
   PotionHouseItemName,
   PurchasableItems,
-  SeasonalCollectibleName,
   SoldOutCollectibleName,
   TreasureCollectibleItem,
 } from "./collectibles";
@@ -85,6 +84,7 @@ import {
   RecipeWearableName,
 } from "../lib/crafting";
 import { AnimalBuildingLevel } from "../events/landExpansion/upgradeBuilding";
+import { SeasonalCollectibleName } from "./megastore";
 
 export type Reward = {
   coins?: number;

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -2,6 +2,30 @@ import { BumpkinItem } from "./bumpkin";
 import { InventoryItemName } from "./game";
 import { SeasonName } from "./seasons";
 
+export type SeasonalTierItemName =
+  | SeasonalCollectibleName
+  | SeasonalWearableName
+  | MegastoreKeys;
+
+export type SeasonalCollectibleName =
+  | "Cow Scratcher"
+  | "Spinning Wheel"
+  | "Sleepy Rug"
+  | "Meteorite"
+  | "Sheaf of Plenty"
+  | "Mechanical Bull"
+  | "Crop Circle";
+
+export type SeasonalWearableName =
+  | "Cowboy Hat"
+  | "Cowgirl Skirt"
+  | "Cowboy Shirt"
+  | "Dream Scarf"
+  | "Milk Apron"
+  | "Cowboy Trouser";
+
+export type MegastoreKeys = "Treasure Key" | "Rare Key" | "Luxury Key";
+
 type SeasonalStoreBase = {
   cost: {
     items: Partial<Record<InventoryItemName, number>>;

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -50,7 +50,6 @@ import {
   MegaStoreCollectibleName,
   PotionHouseItemName,
   PurchasableItems,
-  SeasonalCollectibleName,
   SoldOutCollectibleName,
   TreasureCollectibleItem,
 } from "./collectibles";
@@ -88,6 +87,7 @@ import {
 import { canWithdrawBoostedWearable } from "./wearableValidation";
 import { FlowerName, FlowerSeedName, MutantFlowerName } from "./flowers";
 import { FactionShopCollectibleName, FactionShopFoodName } from "./factionShop";
+import { SeasonalCollectibleName } from "./megastore";
 
 const canWithdrawTimebasedItem = (availableAt: Date) => {
   const now = new Date();
@@ -1084,6 +1084,7 @@ const seasonalStore: Record<SeasonalCollectibleName, () => boolean> = {
   Meteorite: () => hasSeasonEnded("Bull Run"),
   "Sheaf of Plenty": () => hasSeasonEnded("Bull Run"),
   "Mechanical Bull": () => hasSeasonEnded("Bull Run"),
+  "Crop Circle": () => hasSeasonEnded("Bull Run"),
 };
 
 const greenHouseFruitSeed: Record<GreenHouseFruitSeedName, () => boolean> = {

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -1365,6 +1365,21 @@ export const COLLECTIBLE_COMPONENTS: Record<
       alt="Moo-ver"
     />
   ),
+  "Crop Circle": (props: CollectibleProps) => (
+    <ImageStyle
+      {...props}
+      divStyle={{
+        width: `${PIXEL_SCALE * 39}px`,
+        bottom: `${PIXEL_SCALE * 0}px`,
+        left: `${PIXEL_SCALE * -3}px`,
+      }}
+      imgStyle={{
+        width: `${PIXEL_SCALE * 39}px`,
+      }}
+      image={ITEM_DETAILS["Crop Circle"].image}
+      alt="Crop Circle"
+    />
+  ),
   "Swiss Whiskers": (props: CollectibleProps) => (
     <ImageStyle
       {...props}

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -19,8 +19,7 @@ import lock from "assets/icons/lock.png";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { InventoryItemName, Keys } from "features/game/types/game";
 import { Context } from "features/game/GameProvider";
-import { MachineState } from "features/game/lib/gameMachine";
-import { useActor, useSelector } from "@xstate/react";
+import { useActor } from "@xstate/react";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import Decimal from "decimal.js-light";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -50,9 +49,6 @@ interface Props {
   onItemClick: (item: SeasonalStoreItem, tier: SeasonalStoreTier) => void;
 }
 
-const _inventory = (state: MachineState) => state.context.state.inventory;
-const _wardrobe = (state: MachineState) => state.context.state.wardrobe;
-
 export const ItemsList: React.FC<Props> = ({
   items,
   type,
@@ -62,8 +58,6 @@ export const ItemsList: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
 
-  const inventory = useSelector(gameService, _inventory);
-  const wardrobe = useSelector(gameService, _wardrobe);
   //For Discount
   const [
     {

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -30,6 +30,7 @@ import {
   SeasonalStoreItem,
   SeasonalStoreTier,
   SeasonalStoreWearable,
+  SeasonalTierItemName,
 } from "features/game/types/megastore";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ResizableBar } from "components/ui/ProgressBar";
@@ -74,20 +75,22 @@ export const ItemsList: React.FC<Props> = ({
     // Handling all types or specific ones if provided
     if (type === "wearables" || (!type && "wearable" in item)) {
       return (
-        wardrobe[(item as SeasonalStoreWearable).wearable as BumpkinItem] ?? 0
+        state.bumpkin.activity[
+          `${(item as SeasonalStoreWearable).wearable as SeasonalTierItemName} Bought`
+        ] ?? 0
       );
     } else if (type === "collectibles" || (!type && "collectible" in item)) {
       return (
-        inventory[
-          (item as SeasonalStoreCollectible).collectible as InventoryItemName
-        ] ?? new Decimal(0)
-      ).toNumber();
+        state.bumpkin.activity[
+          `${(item as SeasonalStoreCollectible).collectible as SeasonalTierItemName} Bought`
+        ] ?? 0
+      );
     } else if (type === "keys" || (!type && "key" in item)) {
       return (
-        inventory[
-          (item as SeasonalStoreCollectible).collectible as InventoryItemName
-        ] ?? new Decimal(0)
-      ).toNumber();
+        state.bumpkin.activity[
+          `${(item as SeasonalStoreCollectible).collectible as SeasonalTierItemName} Bought`
+        ] ?? 0
+      );
     }
 
     return 0;
@@ -184,12 +187,9 @@ export const ItemsList: React.FC<Props> = ({
   const isKey = (name: InventoryItemName): name is Keys =>
     name in ARTEFACT_SHOP_KEYS;
 
+  // For Current Tier Key - Unlocked(0) / Locked(1)
   const isKeyCounted = isKeyBoughtWithinSeason(state, tiers) ? 0 : 1;
-  const isAllKeyBought =
-    isKeyBoughtWithinSeason(state, "basic") &&
-    isKeyBoughtWithinSeason(state, "rare") &&
-    isKeyBoughtWithinSeason(state, "epic");
-
+  // Reduction is by getting the lower tier of currrent tier
   const reduction = isKeyBoughtWithinSeason(state, tiers, true) ? 0 : 1;
 
   const requirements = hasRequirement(tierData) ? tierData.requirement : 0;


### PR DESCRIPTION
# Description

Improve Crafted item count logic to be based on Bumpkin Activity for Seasonal Items of Megastore/Stella.
This PR will prevent progressing/unlocking tier items faster IF they got the Collectible/Wearable from Treasure Chest Rewards. 

Moved Crop Circle to Craftables.
Add Non-Colliders to Sleepy Rug and Crop Circle.
![image](https://github.com/user-attachments/assets/ad3f5577-525e-4e41-8b69-f77746f27a52)



Fixes #issue

# What needs to be tested by the reviewer?

Testing the new logic:
1. Connect to BE
2. Give yourself any of the Basic items
3. Check if basic items is checked. If not checked it means the new logic is working.
4. Give yourself required item to buy the basic items
5. Buy items
6. Check if Progress Bar and Check of item is working
7. Unlock Next Tiers
8. Buy Keys

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
