### PR TITLE
[FIX] Correct Box Selector Position in Potion Game Modal

### DIFF
--- a/src/features/game/expansion/components/potions/Box.tsx
+++ b/src/features/game/expansion/components/potions/Box.tsx
@@ -65,7 +65,7 @@ const SelectBox = () => {
         className="absolute pointer-events-none"
         src={SUNNYSIDE.ui.selectBoxTL}
         style={{
-          top: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
+          top: 0,
           left: 0,
           width: `${PIXEL_SCALE * 6}px`,
         }}
@@ -74,7 +74,7 @@ const SelectBox = () => {
         className="absolute pointer-events-none"
         src={SUNNYSIDE.ui.selectBoxTR}
         style={{
-          top: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
+          top: 0,
           left: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
           width: `${PIXEL_SCALE * 6}px`,
         }}
@@ -83,7 +83,7 @@ const SelectBox = () => {
         className="absolute pointer-events-none"
         src={SUNNYSIDE.ui.selectBoxBL}
         style={{
-          top: 0,
+          top: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
           left: 0,
           width: `${PIXEL_SCALE * 6}px`,
         }}
@@ -92,7 +92,7 @@ const SelectBox = () => {
         className="absolute pointer-events-none"
         src={SUNNYSIDE.ui.selectBoxBR}
         style={{
-          top: 0,
+          top: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
           left: `${PIXEL_SCALE * INNER_CANVAS_WIDTH - 8}px`,
           width: `${PIXEL_SCALE * 6}px`,
         }}


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/57c48ace-7dcb-4b2d-9ddc-8737bb53cf73) | ![image](https://github.com/user-attachments/assets/03d32ea9-6e3a-44b1-b829-542ae3e63633) | 


Fixes #issue

# What needs to be tested by the reviewer?

- try to play potion game in the woodlands


