### PR TITLE
[FIX] Horsehoe animal bounties

### DIFF
--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -348,4 +348,78 @@ describe("animal.sold", () => {
     expect(state.coins).toEqual(75);
     expect(state.inventory["Amber Fossil"]).toEqual(new Decimal(5));
   });
+
+  it("rewards +1 Horseshoe when Cowboy Hat is worn during Bull Run Season", () => {
+    const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
+    const state = sellAnimal({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin.equipped,
+            hat: "Cowboy Hat",
+          },
+        },
+        bounties: {
+          completed: [],
+          requests: [
+            {
+              id: "123",
+              items: { Horseshoe: 7 },
+              level: 0,
+              name: "Chicken",
+            },
+          ],
+        },
+      },
+      action: {
+        requestId: "123",
+        animalId,
+
+        type: "animal.sold",
+      },
+      createdAt: new Date("2024-11-03").getTime(),
+    });
+
+    expect(state.inventory["Horseshoe"]).toEqual(new Decimal(8));
+  });
+
+  it("stacks Cowboy Set boosts at Bull Run Season", () => {
+    const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
+    const state = sellAnimal({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin.equipped,
+            hat: "Cowboy Hat",
+            shirt: "Cowboy Shirt",
+            pants: "Cowboy Trouser",
+          },
+        },
+        bounties: {
+          completed: [],
+          requests: [
+            {
+              id: "123",
+              items: { Horseshoe: 7 },
+              level: 0,
+              name: "Chicken",
+            },
+          ],
+        },
+      },
+      action: {
+        requestId: "123",
+        animalId,
+
+        type: "animal.sold",
+      },
+      createdAt: new Date("2024-11-03").getTime(),
+    });
+
+    expect(state.inventory["Horseshoe"]).toEqual(new Decimal(10));
+  });
 });

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -3,7 +3,9 @@ import { getAnimalLevel } from "features/game/lib/animals";
 import { getKeys } from "features/game/types/decorations";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { Animal, BountyRequest, GameState } from "features/game/types/game";
+import { getSeasonalTicket } from "features/game/types/seasons";
 import { produce } from "immer";
+import { generateBountyTicket } from "./sellBounty";
 
 export function isValidDeal({
   animal,
@@ -83,7 +85,16 @@ export function sellAnimal({
 
     getKeys(request.items ?? {}).forEach((name) => {
       const previous = game.inventory[name] ?? new Decimal(0);
-      const amount = request.items?.[name] ?? 0;
+      let amount = request.items?.[name] ?? 0;
+
+      if (name === getSeasonalTicket(new Date(createdAt))) {
+        amount = generateBountyTicket({
+          game,
+          bounty: request,
+          now: createdAt,
+        });
+      }
+
       game.inventory[name] = previous.add(
         isSick ? getSickAnimalRewardAmount(amount) : amount,
       );

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -25,11 +25,13 @@ type Options = {
 export function generateBountyTicket({
   game,
   bounty,
+  now = Date.now(),
 }: {
   game: GameState;
   bounty: BountyRequest;
+  now?: number;
 }) {
-  let amount = bounty.items?.[getSeasonalTicket()] ?? 0;
+  let amount = bounty.items?.[getSeasonalTicket(new Date(now))] ?? 0;
 
   if (!amount) {
     return 0;


### PR DESCRIPTION
# Description

We were checking `bounties.sold` (flowers) for the extra horseshoe, but didn't include `animals.sold`.

This PR adds the bonus horseshoes for animal bounties.

Players that claimed before this fix will get airdropped the missing horseshoes 🤗 