### PR TITLE
[FIX] Chicken Coop removal condition

### DIFF
--- a/src/features/barn/components/BarnModal.tsx
+++ b/src/features/barn/components/BarnModal.tsx
@@ -16,7 +16,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { AnimalBuildingKey } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getTotalAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
+import { getBoostedAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
 import { Label } from "components/ui/Label";
 import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeable/lib/collisionDetection";
 
@@ -83,7 +83,7 @@ export const BarnModal: React.FC<Props> = ({ show, buildingKey, onClose }) => {
   };
 
   const atMaxCapacity =
-    getAnimalCount() >= getTotalAnimalCapacity(buildingKey, state);
+    getAnimalCount() >= getBoostedAnimalCapacity(buildingKey, state);
 
   return (
     <Modal show={show} onHide={onClose}>
@@ -100,7 +100,7 @@ export const BarnModal: React.FC<Props> = ({ show, buildingKey, onClose }) => {
               details={{
                 item: selectedName,
               }}
-              limit={getTotalAnimalCapacity("barn", state)}
+              limit={getBoostedAnimalCapacity("barn", state)}
               requirements={{
                 coins: ANIMALS[selectedName].coins,
                 showCoinsIfFree: true,

--- a/src/features/barn/components/BarnModal.tsx
+++ b/src/features/barn/components/BarnModal.tsx
@@ -16,7 +16,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { AnimalBuildingKey } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
+import { getTotalAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
 import { Label } from "components/ui/Label";
 import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeable/lib/collisionDetection";
 
@@ -83,7 +83,7 @@ export const BarnModal: React.FC<Props> = ({ show, buildingKey, onClose }) => {
   };
 
   const atMaxCapacity =
-    getAnimalCount() >= getAnimalCapacity(buildingKey, state);
+    getAnimalCount() >= getTotalAnimalCapacity(buildingKey, state);
 
   return (
     <Modal show={show} onHide={onClose}>
@@ -100,7 +100,7 @@ export const BarnModal: React.FC<Props> = ({ show, buildingKey, onClose }) => {
               details={{
                 item: selectedName,
               }}
-              limit={getAnimalCapacity("barn", state)}
+              limit={getTotalAnimalCapacity("barn", state)}
               requirements={{
                 coins: ANIMALS[selectedName].coins,
                 showCoinsIfFree: true,

--- a/src/features/game/events/landExpansion/buyAnimal.test.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.test.ts
@@ -1,5 +1,5 @@
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { buyAnimal, getTotalAnimalCapacity } from "./buyAnimal";
+import { buyAnimal, getBoostedAnimalCapacity } from "./buyAnimal";
 import { Animal } from "features/game/types/game";
 import { AnimalType } from "features/game/types/animals";
 
@@ -292,13 +292,13 @@ describe("buyAnimal", () => {
 describe("getAnimalCapacity", () => {
   it("returns 10 for level 1 with no coop", () => {
     expect(
-      getTotalAnimalCapacity("henHouse", { ...TEST_FARM, collectibles: {} }),
+      getBoostedAnimalCapacity("henHouse", { ...TEST_FARM, collectibles: {} }),
     ).toBe(10);
   });
 
   it("returns 15 from level 1 with coop", () => {
     expect(
-      getTotalAnimalCapacity("henHouse", {
+      getBoostedAnimalCapacity("henHouse", {
         ...TEST_FARM,
         collectibles: {
           "Chicken Coop": [
@@ -316,7 +316,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 25 from level 2 with coop", () => {
     expect(
-      getTotalAnimalCapacity("henHouse", {
+      getBoostedAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,
@@ -338,7 +338,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 20 from level 3 with no coop", () => {
     expect(
-      getTotalAnimalCapacity("henHouse", {
+      getBoostedAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,
@@ -350,7 +350,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 35 from level 3 with coop", () => {
     expect(
-      getTotalAnimalCapacity("henHouse", {
+      getBoostedAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,

--- a/src/features/game/events/landExpansion/buyAnimal.test.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.test.ts
@@ -1,5 +1,5 @@
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { buyAnimal, getAnimalCapacity } from "./buyAnimal";
+import { buyAnimal, getTotalAnimalCapacity } from "./buyAnimal";
 import { Animal } from "features/game/types/game";
 import { AnimalType } from "features/game/types/animals";
 
@@ -292,13 +292,13 @@ describe("buyAnimal", () => {
 describe("getAnimalCapacity", () => {
   it("returns 10 for level 1 with no coop", () => {
     expect(
-      getAnimalCapacity("henHouse", { ...TEST_FARM, collectibles: {} }),
+      getTotalAnimalCapacity("henHouse", { ...TEST_FARM, collectibles: {} }),
     ).toBe(10);
   });
 
   it("returns 15 from level 1 with coop", () => {
     expect(
-      getAnimalCapacity("henHouse", {
+      getTotalAnimalCapacity("henHouse", {
         ...TEST_FARM,
         collectibles: {
           "Chicken Coop": [
@@ -316,7 +316,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 25 from level 2 with coop", () => {
     expect(
-      getAnimalCapacity("henHouse", {
+      getTotalAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,
@@ -338,7 +338,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 20 from level 3 with no coop", () => {
     expect(
-      getAnimalCapacity("henHouse", {
+      getTotalAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,
@@ -350,7 +350,7 @@ describe("getAnimalCapacity", () => {
 
   it("returns 35 from level 3 with coop", () => {
     expect(
-      getAnimalCapacity("henHouse", {
+      getTotalAnimalCapacity("henHouse", {
         ...TEST_FARM,
         henHouse: {
           ...TEST_FARM.henHouse,

--- a/src/features/game/events/landExpansion/buyAnimal.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.ts
@@ -39,7 +39,7 @@ export const getBaseAnimalCapacity = (level: number): number => {
   return baseCapacity;
 };
 
-export const getTotalAnimalCapacity = (
+export const getBoostedAnimalCapacity = (
   buildingKey: keyof GameState,
   game: GameState,
 ): number => {
@@ -100,7 +100,7 @@ export function buyAnimal({
       buildingRequired as AnimalBuildingType,
     );
 
-    const capacity = getTotalAnimalCapacity(buildingKey, copy);
+    const capacity = getBoostedAnimalCapacity(buildingKey, copy);
     const totalAnimalsInBuilding = getKeys(copy[buildingKey].animals).length;
 
     if (totalAnimalsInBuilding >= capacity) {

--- a/src/features/game/events/landExpansion/buyAnimal.ts
+++ b/src/features/game/events/landExpansion/buyAnimal.ts
@@ -29,31 +29,38 @@ type Options = {
   createdAt?: number;
 };
 
-export const getAnimalCapacity = (
+export const getBaseAnimalCapacity = (level: number): number => {
+  const DEFAULT_CAPACITY = 10;
+  const EXTRA_CAPACITY_PER_LEVEL = 5;
+
+  const baseCapacity =
+    DEFAULT_CAPACITY + (level - 1) * EXTRA_CAPACITY_PER_LEVEL;
+
+  return baseCapacity;
+};
+
+export const getTotalAnimalCapacity = (
   buildingKey: keyof GameState,
   game: GameState,
 ): number => {
-  const DEFAULT_CAPACITY = 10;
-  const EXTRA_CAPACITY_PER_LEVEL = 5;
   const COOP_BONUS_CAPACITY = 5;
 
   const building = game[buildingKey] as AnimalBuilding;
   const level = building.level;
-
-  const coopActive = isCollectibleBuilt({
-    name: "Chicken Coop",
-    game,
-  });
+  const baseCapacity = getBaseAnimalCapacity(level);
 
   if (buildingKey === "henHouse") {
-    const baseCapacity =
-      DEFAULT_CAPACITY + (level - 1) * EXTRA_CAPACITY_PER_LEVEL;
+    const coopActive = isCollectibleBuilt({
+      name: "Chicken Coop",
+      game,
+    });
+
     const coopBonus = coopActive ? COOP_BONUS_CAPACITY * level : 0;
 
     return baseCapacity + coopBonus;
   }
 
-  return DEFAULT_CAPACITY + (level - 1) * EXTRA_CAPACITY_PER_LEVEL;
+  return baseCapacity;
 };
 
 export function buyAnimal({
@@ -93,7 +100,7 @@ export function buyAnimal({
       buildingRequired as AnimalBuildingType,
     );
 
-    const capacity = getAnimalCapacity(buildingKey, copy);
+    const capacity = getTotalAnimalCapacity(buildingKey, copy);
     const totalAnimalsInBuilding = getKeys(copy[buildingKey].animals).length;
 
     if (totalAnimalsInBuilding >= capacity) {

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -19,7 +19,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { AnimalBounty, AnimalBuildingKey } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getTotalAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
+import { getBoostedAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
 import { Label } from "components/ui/Label";
 import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeable/lib/collisionDetection";
 
@@ -121,7 +121,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
     bumpkinLevel >= ANIMALS[selectedName].levelRequired;
 
   const atMaxCapacity =
-    getTotalAnimalsInBuilding() >= getTotalAnimalCapacity(buildingKey, state);
+    getTotalAnimalsInBuilding() >= getBoostedAnimalCapacity(buildingKey, state);
 
   if (showIntro) {
     return (
@@ -215,7 +215,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
                 type={atMaxCapacity ? "danger" : "info"}
                 className="absolute bottom-3 sm:bottom-2 left-2"
               >
-                {`${getTotalAnimalsInBuilding()}/${getTotalAnimalCapacity(
+                {`${getTotalAnimalsInBuilding()}/${getBoostedAnimalCapacity(
                   buildingKey,
                   state,
                 )} ${t("capacity")}`}

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -19,7 +19,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { AnimalBounty, AnimalBuildingKey } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { getAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
+import { getTotalAnimalCapacity } from "features/game/events/landExpansion/buyAnimal";
 import { Label } from "components/ui/Label";
 import { pickRandomPositionInAnimalHouse } from "features/game/expansion/placeable/lib/collisionDetection";
 
@@ -121,7 +121,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
     bumpkinLevel >= ANIMALS[selectedName].levelRequired;
 
   const atMaxCapacity =
-    getTotalAnimalsInBuilding() >= getAnimalCapacity(buildingKey, state);
+    getTotalAnimalsInBuilding() >= getTotalAnimalCapacity(buildingKey, state);
 
   if (showIntro) {
     return (
@@ -215,7 +215,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
                 type={atMaxCapacity ? "danger" : "info"}
                 className="absolute bottom-3 sm:bottom-2 left-2"
               >
-                {`${getTotalAnimalsInBuilding()}/${getAnimalCapacity(
+                {`${getTotalAnimalsInBuilding()}/${getTotalAnimalCapacity(
                   buildingKey,
                   state,
                 )} ${t("capacity")}`}

--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -1,9 +1,27 @@
 import Decimal from "decimal.js-light";
 import { hasRemoveRestriction } from "./removeables";
 import { INITIAL_FARM, TEST_FARM } from "../lib/constants";
+import { makeAnimals } from "../events/landExpansion/buyAnimal.test";
 
 describe("canremove", () => {
   describe("prevents", () => {
+    it("prevents a user from removing a Chicken Coop if they have a boosted number of chickens", () => {
+      const [restricted] = hasRemoveRestriction("Chicken Coop", "1", {
+        ...TEST_FARM,
+        inventory: {
+          "Chicken Coop": new Decimal(1),
+        },
+        henHouse: {
+          level: 1,
+          animals: {
+            ...makeAnimals(15, "Chicken"),
+          },
+        },
+      });
+
+      expect(restricted).toBe(true);
+    });
+
     it("prevents a user from removing Grinx Hammer if recently expanded", () => {
       const [restricted] = hasRemoveRestriction("Grinx's Hammer", "1", {
         ...TEST_FARM,
@@ -40,23 +58,6 @@ describe("canremove", () => {
               readyAt: 0,
             },
           ],
-        },
-      });
-
-      expect(restricted).toBe(true);
-    });
-
-    it("prevents a user from removing chicken coop if some chicken is fed", () => {
-      const [restricted] = hasRemoveRestriction("Chicken Coop", "1", {
-        ...TEST_FARM,
-        inventory: {
-          "Chicken Coop": new Decimal(1),
-        },
-        chickens: {
-          1: {
-            multiplier: 1,
-            fedAt: Date.now(),
-          },
         },
       });
 

--- a/src/features/game/types/removeables.test.ts
+++ b/src/features/game/types/removeables.test.ts
@@ -494,6 +494,18 @@ describe("canremove", () => {
   });
 
   describe("enables", () => {
+    it("enables a user to remove a chicken coop when they have a base amount or less chickens", () => {
+      const [restricted] = hasRemoveRestriction("Chicken Coop", "1", {
+        ...TEST_FARM,
+        henHouse: {
+          level: 1,
+          animals: makeAnimals(10, "Chicken"),
+        },
+      });
+
+      expect(restricted).toBe(false);
+    });
+
     it("enables a user to remove Alien Chicken when no chickens are sleeping", () => {
       const [restricted] = hasRemoveRestriction("Alien Chicken", "123", {
         ...TEST_FARM,

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3470,6 +3470,7 @@
   "worm.grub": "A juicy grub - perfect for advanced fish.",
   "worm.redWiggler": "An exotic worm that entices rare fish.",
   "restrictionReason.isGrowing": "{{item}} is growing",
+  "restrictionReason.hasBonusAnimals": "Bonus animals in {{building}}",
   "restrictionReason.beanPlanted": "Magic Bean is planted",
   "restrictionReason.cropsGrowing": "Crops are growing",
   "restrictionReason.?cropGrowing": "{{crop}} is growing",


### PR DESCRIPTION
# Description

Block removal of chicken coop if bonus chickens are in the hen house.

Fixes #issue

# What needs to be tested by the reviewer?

Remove if you have the default allowed amount of chickens or less. 
Block if you have bonus chickens.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
