### PR TITLE
[FIX] Max Level Chickens With Gold Egg

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -1020,6 +1020,59 @@ describe("feedAnimal", () => {
     expect(state.henHouse.animals["0"].state).toBe("ready");
   });
 
+  it("sets animal to ready state when completing a cycle at max level with a Gold Egg", () => {
+    // Setup chicken at max level (15)
+    const maxLevelXP = ANIMAL_LEVELS["Chicken"][15];
+    // Add enough XP to complete one cycle (240 XP - difference between level 14-15)
+    const cycleXP = ANIMAL_LEVELS["Chicken"][15] - ANIMAL_LEVELS["Chicken"][14];
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Mixed Grain": new Decimal(1),
+        },
+        collectibles: {
+          "Gold Egg": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              coordinates: { x: 0, y: 0 },
+              id: "0",
+              type: "Chicken",
+              createdAt: 0,
+              state: "idle",
+              experience: maxLevelXP + cycleXP - 60, // One Favourite Food feed away from cycle
+              asleepAt: 0,
+              awakeAt: 0,
+              lovedAt: 0,
+              item: "Petting Hand",
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: "0",
+        item: "Mixed Grain",
+      },
+    });
+
+    expect(state.henHouse.animals["0"].state).toBe("ready");
+  });
+
   it("maintains correct state through multiple cycles", () => {
     // Setup chicken at max level (15)
     const maxLevelXP = ANIMAL_LEVELS["Chicken"][15];
@@ -1100,6 +1153,7 @@ describe("feedAnimal", () => {
 
     expect(state.henHouse.animals["0"].state).toBe("ready");
   });
+
   it("correctly transitions to ready state at exact cycle completion", () => {
     const maxLevelXP = ANIMAL_LEVELS["Chicken"][15];
     const cycleXP = ANIMAL_LEVELS["Chicken"][15] - ANIMAL_LEVELS["Chicken"][14];


### PR DESCRIPTION
# Description

There was an issue with level 15 chickens with a gold egg placed. They weren't getting set to ready when cycling the max level.

This PR fixes this problem.
![max-level](https://github.com/user-attachments/assets/bd0876e5-874a-47b3-a6a2-26e94024eb55)

Fixes #issue

# What needs to be tested by the reviewer?

Check that a level 15 chicken gets into the "ready" state and drops progress once the level bar is full again.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
