### PR TITLE
[FIX] Animal food discount

### DIFF
--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -23,6 +23,7 @@ import {
 import { getCurrentSeason } from "../types/seasons";
 import { isCollectibleBuilt } from "./collectibleBuilt";
 import { getBudYieldBoosts } from "./getBudYieldBoosts";
+import { hasVipAccess } from "./vipAccess";
 import { isWearableActive } from "./wearables";
 
 export const makeAnimalBuildingKey = (
@@ -327,7 +328,7 @@ export function getBoostedFoodQuantity({
   }
 
   if (
-    isCollectibleBuilt({ name: "Bull Run Banner", game }) &&
+    hasVipAccess(game.inventory) &&
     getCurrentSeason() === "Bull Run"
   ) {
     foodQuantity *= 0.9;

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -327,10 +327,7 @@ export function getBoostedFoodQuantity({
     foodQuantity *= 0.5;
   }
 
-  if (
-    hasVipAccess(game.inventory) &&
-    getCurrentSeason() === "Bull Run"
-  ) {
+  if (hasVipAccess(game.inventory) && getCurrentSeason() === "Bull Run") {
     foodQuantity *= 0.9;
   }
 


### PR DESCRIPTION
# Description

Animal food discount for Bull Run season was not being applied for Lifetime Farmer Banner or for in-inventory Bull Run Banner.

As per discussion that led to #4729 the proper check is `hasVipAccess()`.
