### PR TITLE
[FIX] Megastore Pop-up Mobile

### DIFF
--- a/src/features/world/ui/megastore/SeasonalStore.tsx
+++ b/src/features/world/ui/megastore/SeasonalStore.tsx
@@ -114,7 +114,26 @@ export const SeasonalStore: React.FC<{
   const megaItems = MEGASTORE[currentSeason].mega.items;
 
   return (
-    <div className="relative h-full w-full">
+    <>
+      <ModalOverlay
+        show={!!selectedItem}
+        onBackdropClick={() => setSelectedItem(null)}
+      >
+        <ItemDetail
+          isVisible={isVisible}
+          item={selectedItem}
+          tier={selectedTier}
+          image={getItemImage(selectedItem)}
+          buff={getItemBuffLabel(selectedItem)}
+          isWearable={selectedItem ? isWearablesItem(selectedItem) : false}
+          onClose={() => {
+            setSelectedItem(null);
+            setSelectedTier("basic"); // Reset tier on close
+          }}
+          readonly={readonly}
+        />
+      </ModalOverlay>
+
       <div className="flex justify-between px-2 flex-wrap pb-1">
         <Label type="default" className="mb-1">
           {"Stella"}
@@ -130,7 +149,7 @@ export const SeasonalStore: React.FC<{
       </div>
       <div
         className={classNames("flex flex-col p-2 pt-1", {
-          ["max-h-[450px] overflow-y-auto scrollable "]: !readonly,
+          ["max-h-[300px] overflow-y-auto scrollable "]: !readonly,
         })}
       >
         <span className="text-xs pb-1">
@@ -160,25 +179,6 @@ export const SeasonalStore: React.FC<{
           onItemClick={handleClickItem}
         />
       </div>
-
-      <ModalOverlay
-        show={!!selectedItem}
-        onBackdropClick={() => setSelectedItem(null)}
-      >
-        <ItemDetail
-          isVisible={isVisible}
-          item={selectedItem}
-          tier={selectedTier}
-          image={getItemImage(selectedItem)}
-          buff={getItemBuffLabel(selectedItem)}
-          isWearable={selectedItem ? isWearablesItem(selectedItem) : false}
-          onClose={() => {
-            setSelectedItem(null);
-            setSelectedTier("basic"); // Reset tier on close
-          }}
-          readonly={readonly}
-        />
-      </ModalOverlay>
-    </div>
+    </>
   );
 };

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemsList.tsx
@@ -303,7 +303,7 @@ export const ItemsList: React.FC<Props> = ({
                   }}
                   onClick={() => onItemClick(item, tier)}
                 >
-                  <div className="flex relative justify-center items-center w-full h-full z-20">
+                  <div className="flex justify-center items-center w-full h-full z-20">
                     <SquareIcon icon={getItemImage(item)} width={20} />
                     {buff && (
                       <img


### PR DESCRIPTION
# Description

This fixes pop-up modal for megastore on Seasonal Codex. It should cover the whole tab for the Seasonal Codex when items are clicked. Can be reproduced from mobile/mobile-view

**BEFORE:**
![image](https://github.com/user-attachments/assets/2b93ba1f-11c9-4c9e-90b2-09083667471c)
**AFTER:**
![image](https://github.com/user-attachments/assets/e8dbf2f9-d400-4e5f-bacb-9afc941413b5)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
