### PR TITLE
[FIX] Megastore canBuy SFL Discount not applied

### DIFF
--- a/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
@@ -180,7 +180,10 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
       });
       if (!hasRequirements) return false;
     }
-    if (item) return sflBalance.greaterThanOrEqualTo(new Decimal(sfl));
+    if (item)
+      return sflBalance.greaterThanOrEqualTo(
+        SFLDiscount(state, new Decimal(sfl)),
+      );
   };
 
   const trackAnalytics = () => {


### PR DESCRIPTION
# Description

This PR fixes the canBuy not applying SFL Discount on check.
Scenario: Player has banner and has 44 SFL. 
Bug: The UI still thinks that the SFL required is 50 for Sleepy Rug as no SFL Discount check is added. 
**BEFORE:**
![image](https://github.com/user-attachments/assets/ea70fba5-b2f7-4e64-803c-000c9bea344d)
**AFTER:**
![image](https://github.com/user-attachments/assets/4d54fbe9-c97c-4a7e-a67d-85d56e8895bd)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
