### PR TITLE
[FIX] Chicken Placement

### DIFF
--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useLayoutEffect,
-  useMemo,
-  useState,
-  useEffect,
-} from "react";
+import React, { useContext, useLayoutEffect, useMemo, useState } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -61,31 +55,9 @@ export const HenHouseInside: React.FC = () => {
   const [scrollIntoView] = useScrollIntoView();
   const navigate = useNavigate();
 
-  const [orderedIds, setOrderedIds] = useState<string[]>([]);
-
   useLayoutEffect(() => {
     scrollIntoView(Section.GenesisBlock, "auto");
   }, []);
-
-  useEffect(() => {
-    if (orderedIds.length === 0) {
-      // Initial load - sort by experience
-      const sortedIds = getKeys(henHouse.animals).sort(
-        (a, b) =>
-          henHouse.animals[b].experience - henHouse.animals[a].experience,
-      );
-      setOrderedIds(sortedIds);
-    } else {
-      // Add any new animals to the end
-      const currentIds = getKeys(henHouse.animals);
-      const newIds = currentIds.filter((id) => !orderedIds.includes(id));
-      if (newIds.length > 0) {
-        setOrderedIds((prev) => [...prev, ...newIds]);
-      }
-    }
-  }, [henHouse.animals]);
-
-  const nextLevel = Math.min(level + 1, 3) as Exclude<AnimalBuildingLevel, 1>;
 
   const {
     x: floorX,
@@ -94,25 +66,32 @@ export const HenHouseInside: React.FC = () => {
     width: floorWidth,
   } = ANIMAL_HOUSE_BOUNDS.henHouse[level];
 
+  // Organise the animals neatly in the barn
   const organizedAnimals = useMemo(() => {
-    const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Chicken.width);
+    // First, group animals by type and sort within each group
+    const animals = getKeys(henHouse.animals)
+      .map((id) => ({
+        ...henHouse.animals[id],
+      }))
+      .sort((a, b) => b.experience - a.experience);
 
-    return orderedIds
-      .filter((id) => henHouse.animals[id]) // Remove any sold animals
-      .map((id, index) => {
-        const animal = henHouse.animals[id];
-        const row = Math.floor(index / maxAnimalsPerRow);
-        const col = index % maxAnimalsPerRow;
-        return {
-          ...animal,
-          coordinates: {
-            x: col * ANIMALS.Chicken.width,
-            y: row * ANIMALS.Chicken.height,
-          },
-        };
-      });
-  }, [orderedIds, henHouse.animals, floorWidth]);
+    const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Cow.width);
+    const verticalGap = 0.5; // Add a 0.5 grid unit gap between rows
 
+    return animals.map((animal, index) => {
+      const row = Math.floor(index / maxAnimalsPerRow);
+      const col = index % maxAnimalsPerRow;
+      return {
+        ...animal,
+        coordinates: {
+          x: col * ANIMALS.Cow.width,
+          y: row * (ANIMALS.Cow.height + verticalGap),
+        },
+      };
+    });
+  }, [getKeys(henHouse.animals).length, floorWidth]);
+
+  const nextLevel = Math.min(level + 1, 3) as Exclude<AnimalBuildingLevel, 1>;
   return (
     <>
       <Modal show={showModal} onHide={() => setShowModal(false)}>


### PR DESCRIPTION
# Description

Chickens are ordered in ascending order. They only get reordered when you re-enter into the building or if you buy new chickens.

This behaviour is the same as the barn.

Fixes #issue

# What needs to be tested by the reviewer?

Check the chickens are ordered and that they don't bounce around when feeding.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
