### PR TITLE
[FEAT] Add Marketplace Sold Popup

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -42,6 +42,7 @@ import { NewMail } from "./components/NewMail";
 import { Blacklisted } from "../components/Blacklisted";
 import { AirdropPopup } from "./components/Airdrop";
 import { OffersPopup } from "./components/Offers";
+import { MarketplaceSalesPopup } from "./components/MarketplaceSalesPopup";
 import { isBuildingReady, PIXEL_SCALE, TEST_FARM } from "../lib/constants";
 import classNames from "classnames";
 import { Label } from "components/ui/Label";
@@ -137,6 +138,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   blacklisted: true,
   airdrop: true,
   offers: true,
+  marketplaceSale: true,
   portalling: true,
   provingPersonhood: false,
   sellMarketResource: false,
@@ -209,6 +211,8 @@ const isEffectFailure = (state: MachineState) =>
   Object.values(EFFECT_EVENTS).some((stateName) =>
     state.matches(`${stateName}Failure`),
   );
+const hasMarketplaceSales = (state: MachineState) =>
+  state.matches("marketplaceSale");
 
 const GameContent: React.FC = () => {
   const { gameService } = useContext(Context);
@@ -369,6 +373,7 @@ export const GameWrapper: React.FC = ({ children }) => {
   const effectPending = useSelector(gameService, isEffectPending);
   const effectSuccess = useSelector(gameService, isEffectSuccess);
   const effectFailure = useSelector(gameService, isEffectFailure);
+  const showSales = useSelector(gameService, hasMarketplaceSales);
 
   const showPWAInstallPrompt = useSelector(authService, _showPWAInstallPrompt);
 
@@ -586,6 +591,7 @@ export const GameWrapper: React.FC = ({ children }) => {
             {promo && <Promo />}
             {airdrop && <AirdropPopup />}
             {showOffers && <OffersPopup />}
+            {showSales && <MarketplaceSalesPopup />}
             {specialOffer && <VIPOffer />}
             {hasSomethingArrived && <SomethingArrived />}
             {hasBBs && <Gems />}

--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -1,0 +1,96 @@
+import { useActor } from "@xstate/react";
+import React, { useContext } from "react";
+
+import { Context } from "features/game/GameProvider";
+import { getKeys } from "features/game/types/decorations";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { Button } from "components/ui/Button";
+import { Label } from "components/ui/Label";
+import { InlineDialogue } from "features/world/ui/TypingMessage";
+import { Box } from "components/ui/Box";
+import trade from "assets/icons/trade.png";
+import token from "assets/icons/sfl.webp";
+import { formatNumber } from "lib/utils/formatNumber";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { InventoryItemName } from "features/game/types/game";
+
+/**
+ * Display listings that have been fulfilled
+ */
+export const MarketplaceSalesPopup: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const [state] = useActor(gameService);
+
+  const { t } = useAppTranslation();
+
+  const { trades } = state.context.state;
+  const soldListings = getKeys(trades.listings ?? {}).filter(
+    (id) => !!trades.listings?.[id].fulfilledAt,
+  );
+
+  if (soldListings.length === 0) {
+    return (
+      <div>
+        <Button onClick={() => gameService.send("RESET")}>
+          {t("continue")}
+        </Button>
+      </div>
+    );
+  }
+
+  const close = () => {
+    gameService.send("CLOSE");
+  };
+
+  const claim = (listingId: string) => {
+    gameService.send("purchase.claimed", {
+      tradeId: listingId,
+    });
+  };
+
+  return (
+    <>
+      <div className="p-1">
+        <Label className="ml-2 mb-2 mt-1" type="default" icon={trade}>
+          {t("marketplace.itemSold")}
+        </Label>
+        <div className="mb-2 ml-1">
+          <InlineDialogue message={t("marketplace.youHaveHadSales")} />
+        </div>
+        {soldListings.map((listingId) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const listing = trades.listings![listingId];
+          const itemName = getKeys(listing.items)[0];
+          const amount = listing.items[itemName as InventoryItemName];
+          const sfl = listing.sfl;
+          return (
+            <div className="flex flex-col space-y-1" key={listingId}>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center w-3/4 space-x-2">
+                  <Box
+                    image={ITEM_DETAILS[itemName as InventoryItemName].image}
+                  />
+                  <div className="flex flex-col">
+                    <div>
+                      <p className="text-xs mt-0.5">{`${amount} x ${itemName}`}</p>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <p className="text-xs mt-0.5">{`${formatNumber(sfl, {
+                        decimalPlaces: 4,
+                      })} SFL`}</p>
+                      <img src={token} className="w-4" />
+                    </div>
+                  </div>
+                </div>
+                <Button className="max-w-xs" onClick={() => claim(listingId)}>
+                  {t("claim")}
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <Button onClick={close}>{t("close")}</Button>
+    </>
+  );
+};

--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -24,11 +24,11 @@ export const MarketplaceSalesPopup: React.FC = () => {
   const { t } = useAppTranslation();
 
   const { trades } = state.context.state;
-  const soldListings = getKeys(trades.listings ?? {}).filter(
+  const soldListingIds = getKeys(trades.listings ?? {}).filter(
     (id) => !!trades.listings?.[id].fulfilledAt,
   );
 
-  if (soldListings.length === 0) {
+  if (soldListingIds.length === 0) {
     return (
       <div>
         <Button onClick={() => gameService.send("RESET")}>
@@ -38,26 +38,28 @@ export const MarketplaceSalesPopup: React.FC = () => {
     );
   }
 
-  const close = () => {
-    gameService.send("CLOSE");
-  };
-
-  const claim = (listingId: string) => {
+  const claimAll = () => {
     gameService.send("purchase.claimed", {
-      tradeId: listingId,
+      tradeIds: soldListingIds,
     });
+
+    if (soldListingIds.some((id) => trades.listings?.[id].signature)) {
+      gameService.send("RESET");
+    }
+
+    gameService.send("CLOSE");
   };
 
   return (
     <>
       <div className="p-1">
-        <Label className="ml-2 mb-2 mt-1" type="default" icon={trade}>
+        <Label className="ml-2 mb-2 mt-1" type="success" icon={trade}>
           {t("marketplace.itemSold")}
         </Label>
         <div className="mb-2 ml-1">
           <InlineDialogue message={t("marketplace.youHaveHadSales")} />
         </div>
-        {soldListings.map((listingId) => {
+        {soldListingIds.map((listingId) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const listing = trades.listings![listingId];
           const itemName = getKeys(listing.items)[0];
@@ -82,15 +84,12 @@ export const MarketplaceSalesPopup: React.FC = () => {
                     </div>
                   </div>
                 </div>
-                <Button className="max-w-xs" onClick={() => claim(listingId)}>
-                  {t("claim")}
-                </Button>
               </div>
             </div>
           );
         })}
       </div>
-      <Button onClick={close}>{t("close")}</Button>
+      <Button onClick={() => claimAll()}>{t("claim")}</Button>
     </>
   );
 };

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -975,9 +975,6 @@ export function startGame(authContext: AuthContext) {
             RESET: {
               target: "refreshing",
             },
-            CLOSE: {
-              target: "playing",
-            },
           },
         },
         marketplaceSale: {

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -530,6 +530,7 @@ export type BlockchainState = {
     | "buds"
     | "airdrop"
     | "offers"
+    | "marketplaceSale"
     | "coolingDown"
     | "buyingBlockBucks"
     | "auctionResults"
@@ -899,6 +900,13 @@ export function startGame(authContext: AuthContext) {
                 ),
             },
             {
+              target: "marketplaceSale",
+              cond: (context: Context) =>
+                getKeys(context.state.trades.listings ?? {}).some(
+                  (id) => !!context.state.trades.listings![id].fulfilledAt,
+                ),
+            },
+            {
               target: "playing",
             },
           ],
@@ -964,6 +972,19 @@ export function startGame(authContext: AuthContext) {
         offers: {
           on: {
             "offer.claimed": (GAME_EVENT_HANDLERS as any)["offer.claimed"],
+            RESET: {
+              target: "refreshing",
+            },
+            CLOSE: {
+              target: "playing",
+            },
+          },
+        },
+        marketplaceSale: {
+          on: {
+            "purchase.claimed": (GAME_EVENT_HANDLERS as any)[
+              "purchase.claimed"
+            ],
             RESET: {
               target: "refreshing",
             },

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -34,7 +34,7 @@ export const MyListings: React.FC = () => {
     const listing = listings[claimId as string];
 
     gameService.send("purchase.claimed", {
-      tradeId: claimId,
+      tradeIds: [claimId],
     });
 
     const itemId = getItemId({ details: listing });

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2384,7 +2384,7 @@
   "marketplace.offerClaimed": "Congratulations, your offer was accepted!",
   "marketplace.itemSold": "Item sold",
   "marketplace.congratulationsItemSold": "Congratulations, your item has sold!",
-  "marketplace.youHaveHadSales": "Something sold while you were away!",
+  "marketplace.youHaveHadSales": "You item(s) sold while you were away!",
   "megaStore.visit": "Visit the Megastore in the plaza before time runs out!",
   "megaStore.message": "Welcome to the Mega Store! Check out this month's limited items. If you like something, be sure to grab it before it vanishes into the realms of time.",
   "megaStore.month.sale": "This month's sales",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2384,6 +2384,7 @@
   "marketplace.offerClaimed": "Congratulations, your offer was accepted!",
   "marketplace.itemSold": "Item sold",
   "marketplace.congratulationsItemSold": "Congratulations, your item has sold!",
+  "marketplace.youHaveHadSales": "Something sold while you were away!",
   "megaStore.visit": "Visit the Megastore in the plaza before time runs out!",
   "megaStore.message": "Welcome to the Mega Store! Check out this month's limited items. If you like something, be sure to grab it before it vanishes into the realms of time.",
   "megaStore.month.sale": "This month's sales",


### PR DESCRIPTION
# Description

Add a popup on load when an item has sold at the marketplace while you're away. 

You can claim multiple sales at one. If any of the items where "on chain" then we will refresh when the modal closes and you will get your SFL from on chain. Instant trades will just airdrop the SFL immediately.

Fixes #issue

# What needs to be tested by the reviewer?

- List an item (farm a)
- Have another farm purchase the item (farm b)
- Reload game (farm a)
- Claim SFL (farm a)
- Repeat wil multiple items
- Repeat with a mixture of off chain and on chain items

<img width="512" alt="Screenshot 2024-11-14 at 1 34 42 PM" src="https://github.com/user-attachments/assets/6ccac589-dffd-47b6-9337-7ccc9ef85757">

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
