### PR TITLE
[FIX] Cooking Buildings do not have removal restrictions

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -39,6 +39,8 @@ import { getKeys } from "./decorations";
 import { BED_FARMHAND_COUNT } from "./beds";
 import { AnimalType } from "./animals";
 import { getBaseAnimalCapacity } from "../events/landExpansion/buyAnimal";
+import { CookingBuildingName } from "./buildings";
+import { BUILDING_DAILY_OIL_CAPACITY } from "../events/landExpansion/supplyCookingOil";
 
 export type Restriction = [boolean, string];
 type RemoveCondition = (gameState: GameState) => Restriction;
@@ -430,6 +432,28 @@ function hasBonusAnimals(game: GameState, animalType: AnimalType): Restriction {
   return [bonusAnimalCount > 0, translate("restrictionReason.hasBonusAnimals")];
 }
 
+export function isCookingBuildingWorking(
+  buildingName: CookingBuildingName,
+  game: GameState,
+): Restriction {
+  const isBuildingCooking = !!game.buildings[buildingName]?.some(
+    (building) => !!building.crafting,
+  );
+
+  return [isBuildingCooking, "Building is in use"];
+}
+
+export function areAnyCookingBuildingWorking(game: GameState): Restriction {
+  const areAnyCookingBuildingWorking = getKeys(
+    BUILDING_DAILY_OIL_CAPACITY,
+  ).some(
+    (building) =>
+      !!game.buildings[building]?.some((building) => !!building.crafting),
+  );
+
+  return [areAnyCookingBuildingWorking, "Building is in use"];
+}
+
 export const REMOVAL_RESTRICTIONS: Partial<
   Record<InventoryItemName, RemoveCondition>
 > = {
@@ -541,7 +565,6 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Knight Chicken": (game) => areAnyOilReservesDrilled(game),
   "Battle Fish": (game) => areAnyOilReservesDrilled(game),
   "Turbo Sprout": (game) => areAnyGreenhouseCropGrowing(game),
-  Greenhouse: (game) => areAnyGreenhouseCropGrowing(game),
   "Pharaoh Gnome": (game) => areAnyGreenhouseCropGrowing(game),
   Vinny: (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
   "Grape Granny": (game) => greenhouseCropIsGrowing({ crop: "Grape", game }),
@@ -549,6 +572,12 @@ export const REMOVAL_RESTRICTIONS: Partial<
 
   // Buildings
   "Crop Machine": (game) => hasSeedsCropsInMachine(game),
+  Greenhouse: (game) => areAnyGreenhouseCropGrowing(game),
+  "Fire Pit": (game) => isCookingBuildingWorking("Fire Pit", game),
+  Kitchen: (game) => isCookingBuildingWorking("Kitchen", game),
+  Bakery: (game) => isCookingBuildingWorking("Bakery", game),
+  Deli: (game) => isCookingBuildingWorking("Deli", game),
+  "Smoothie Shack": (game) => isCookingBuildingWorking("Smoothie Shack", game),
 
   // Hourglass
   "Time Warp Totem": (_: GameState) => [

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -18,6 +18,7 @@ import {
   areAnySheepSleeping,
   areAnyCowsSleeping,
   areTreasureHolesDug,
+  areAnyCookingBuildingWorking,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -56,14 +57,8 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
     !greenhouseCropIsGrowing({ crop: "Grape", game: state })[0],
   "Lemon Shield": (state) => !areFruitsGrowing(state, "Lemon")[0],
   Cattlegrim: (state) => !areAnyChickensSleeping(state)[0],
-  "Luna's Hat": (state) =>
-    !(
-      state.buildings["Fire Pit"]?.[0].crafting ||
-      state.buildings["Kitchen"]?.[0].crafting ||
-      state.buildings["Bakery"]?.[0].crafting ||
-      state.buildings["Deli"]?.[0].crafting ||
-      state.buildings["Smoothie Shack"]?.[0].crafting
-    ),
+
+  "Luna's Hat": (state) => !areAnyCookingBuildingWorking(state)[0],
   "Ancient Rod": (state) => !hasFishedToday(state)[0],
   "Flower Crown": (state) => !areFlowersGrowing(state)[0],
   "Beekeeper Hat": (state) => !isProducingHoney(state)[0],


### PR DESCRIPTION
# Description

Players have been able to remove their cooking buildings to reset their cooking progress in the building. This was especially helpful for daily chores since they are on a 1-2 day restricted timeframe.

Since chores are now weekly, it's about time we revisit this exploit and patch it, since there's a timeframe of 1 week now, players will have ample time to complete their chores within a week

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
