### PR TITLE
[FEAT] Skill Revamp: Tier unlock logic

### DIFF
--- a/src/features/game/events/landExpansion/choseSkill.test.ts
+++ b/src/features/game/events/landExpansion/choseSkill.test.ts
@@ -59,14 +59,14 @@ describe("choseSkill", () => {
     });
   });
 
-  it("throws an error if player doesn't have enough claimed skills for tier 2", () => {
+  it("throws an error if player doesn't have enough used skill points for tier 2", () => {
     expect(() => {
       choseSkill({
         state: {
           ...TEST_FARM,
           bumpkin: {
             ...INITIAL_BUMPKIN,
-            experience: LEVEL_EXPERIENCE[5],
+            experience: LEVEL_EXPERIENCE[4],
             skills: { "Green Thumb 2": 1 },
           },
         },
@@ -82,7 +82,7 @@ describe("choseSkill", () => {
         ...TEST_FARM,
         bumpkin: {
           ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[5],
+          experience: LEVEL_EXPERIENCE[4],
           skills: { "Green Thumb 2": 1, "Young Farmer": 1 },
         },
       },
@@ -97,19 +97,18 @@ describe("choseSkill", () => {
     });
   });
 
-  it("throws an error if player doesn't have enough claimed skills for tier 3", () => {
+  it("throws an error if player doesn't have enough used skill points for tier 3", () => {
     expect(() => {
       choseSkill({
         state: {
           ...TEST_FARM,
           bumpkin: {
             ...INITIAL_BUMPKIN,
-            experience: LEVEL_EXPERIENCE[7],
+            experience: LEVEL_EXPERIENCE[8],
             skills: {
               "Green Thumb 2": 1,
               "Young Farmer": 1,
               "Experienced Farmer": 1,
-              "Betty's Friend": 1,
             },
           },
         },
@@ -125,13 +124,12 @@ describe("choseSkill", () => {
         ...TEST_FARM,
         bumpkin: {
           ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[10],
+          experience: LEVEL_EXPERIENCE[8],
           skills: {
             "Green Thumb 2": 1,
             "Young Farmer": 1,
             "Experienced Farmer": 1,
-            "Betty's Friend": 1,
-            "Efficient Bin": 1,
+            "Strong Roots": 1,
           },
         },
       },
@@ -143,8 +141,7 @@ describe("choseSkill", () => {
       "Green Thumb 2": 1,
       "Young Farmer": 1,
       "Experienced Farmer": 1,
-      "Betty's Friend": 1,
-      "Efficient Bin": 1,
+      "Strong Roots": 1,
       "Instant Growth": 1,
     });
   });

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -26,7 +26,11 @@ export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
 
   const totalUsedSkillPoints = skillsClaimed.reduce((acc, skill) => {
     const skillData = BUMPKIN_REVAMP_SKILL_TREE[skill];
-    return acc + skillData.requirements.points;
+    if (skillData) {
+      return acc + skillData.requirements.points;
+    }
+
+    return acc;
   }, 0);
 
   return bumpkinLevel - totalUsedSkillPoints;
@@ -43,9 +47,12 @@ export const getUnlockedTierForTree = (
     (acc, skill) => {
       const skillData =
         BUMPKIN_REVAMP_SKILL_TREE[skill as BumpkinRevampSkillName];
-      return skillData?.tree === tree
-        ? acc + skillData.requirements.points
-        : acc;
+
+      if (skillData && skillData.tree === tree) {
+        return acc + skillData.requirements.points;
+      }
+
+      return acc;
     },
     0,
   );

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -35,19 +35,24 @@ export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
 export const getUnlockedTierForTree = (
   tree: BumpkinRevampSkillTree,
   bumpkin?: Bumpkin,
-) => {
+): number => {
   if (!bumpkin) return 1;
 
-  // Count how many skills in the tree are unlocked
-  const skillsInTree = Object.keys(bumpkin.skills).filter((skill) => {
-    const skillData =
-      BUMPKIN_REVAMP_SKILL_TREE[skill as BumpkinRevampSkillName];
-    return skillData?.tree === tree;
-  }).length;
+  // Calculate the total points used in the tree
+  const totalUsedSkillPoints = Object.keys(bumpkin.skills).reduce(
+    (acc, skill) => {
+      const skillData =
+        BUMPKIN_REVAMP_SKILL_TREE[skill as BumpkinRevampSkillName];
+      return skillData?.tree === tree
+        ? acc + skillData.requirements.points
+        : acc;
+    },
+    0,
+  );
 
-  // Determine the tier based on the count
-  if (skillsInTree >= 5) return 3;
-  if (skillsInTree >= 2) return 2;
+  // Determine the tier based on the total points used
+  if (totalUsedSkillPoints >= 5) return 3;
+  if (totalUsedSkillPoints >= 2) return 2;
   return 1;
 };
 


### PR DESCRIPTION
# Description

Moving to "used skill points in tree" base for tier unlocking.

Basically,
| Tier | Used Skill Points in Tree needed |
|--------|--------|
| 1 | Unlocked by default |
| 2 | 2 | 
| 3 | 5 | 

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
