### PR TITLE
[FIX] Delivery Requirement Label counting items that are placed down

### DIFF
--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -15,6 +15,7 @@ import { isWearableActive } from "features/game/lib/wearables";
 import { FACTION_OUTFITS } from "features/game/lib/factions";
 import { PATCH_FRUIT, PatchFruitName } from "features/game/types/fruits";
 import { produce } from "immer";
+import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   "pumpkin' pete": 1,
@@ -361,7 +362,10 @@ export function deliverOrder({
 
         game.balance = sfl.sub(amount);
       } else {
-        const count = game.inventory[name] || new Decimal(0);
+        const count =
+          name in getChestItems(game)
+            ? getChestItems(game)[name] ?? new Decimal(0)
+            : game.inventory[name] ?? new Decimal(0);
         const amount = order.items[name] || new Decimal(0);
 
         if (count.lessThan(amount)) {

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -69,7 +69,7 @@ export const getChestBuds = (
   );
 };
 
-export const getChestItems = (state: GameState) => {
+export const getChestItems = (state: GameState): Inventory => {
   const availableItems = getKeys(state.inventory).reduce((acc, itemName) => {
     if (itemName === "Tree") {
       return {

--- a/src/features/world/ui/WorldIntroduction.tsx
+++ b/src/features/world/ui/WorldIntroduction.tsx
@@ -18,17 +18,21 @@ interface Props {
 
 export const WorldIntroduction: React.FC<Props> = ({ onClose }) => {
   const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
 
   const [showNPCFind, setShowNPCFind] = useState(false);
 
   const { t } = useAppTranslation();
 
-  const { balance, coins, inventory } = gameState.context.state;
+  const { balance, coins, inventory } = state;
 
   // Find a delivery that is ready
-  const delivery = gameState.context.state.delivery.orders.find((order) =>
-    hasOrderRequirements({ order, sfl: balance, coins, inventory }),
+  const delivery = state.delivery.orders.find((order) =>
+    hasOrderRequirements({ order, sfl: balance, coins, inventory, state }),
   );
 
   if (showNPCFind && delivery) {

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -49,6 +49,7 @@ import { SquareIcon } from "components/ui/SquareIcon";
 import { formatNumber } from "lib/utils/formatNumber";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { TranslationKeys } from "lib/i18n/dictionaries/types";
+import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
 
 export const OrderCard: React.FC<{
   order: Order;
@@ -117,7 +118,11 @@ export const OrderCard: React.FC<{
                   key={itemName}
                   type="item"
                   item={itemName}
-                  balance={inventory[itemName] ?? new Decimal(0)}
+                  balance={
+                    itemName in getChestItems(game)
+                      ? getChestItems(game)[itemName] ?? new Decimal(0)
+                      : inventory[itemName] ?? new Decimal(0)
+                  }
                   showLabel
                   requirement={new Decimal(order?.items[itemName] ?? 0)}
                 />
@@ -578,6 +583,10 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
 
     if (name === "sfl") {
       return game.balance?.gte(delivery?.items.sfl ?? 0);
+    }
+
+    if (name in getChestItems(game)) {
+      return getChestItems(game)[name]?.gte(delivery?.items[name] ?? 0);
     }
 
     return game.inventory[name]?.gte(delivery?.items[name] ?? 0);


### PR DESCRIPTION
# Description

Since decorations are part of deliveries now, we need to make sure that decorations that are placed down are not included in the inventory count in deliveries

Fixes #issue

# What needs to be tested by the reviewer?

- set a delivery that requires a decoration
- Add enough of that decoration in inventory
- Place one decoration down
- Inventory amount in Delivery requirement label should show 1 less item
- Pick up decoration 
- Delivery requirement should now be met

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
