### PR TITLE
[FEAT] Add New Artefact Formations

### DIFF
--- a/src/features/game/types/desert.ts
+++ b/src/features/game/types/desert.ts
@@ -132,6 +132,87 @@ export const DIGGING_FORMATIONS = {
     { x: 1, y: 1, name: "Camel Bone" },
   ],
 
+  ARTEFACT_THIRTEEN: [
+    { x: 0, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 2, y: 0, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_FOURTEEN: [
+    { x: 0, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 0, y: 2, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_FIFTEEN: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 2, y: 0, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_SIXTEEN: [
+    { x: 0, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 1, y: 1, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_SEVENTEEN: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 1, y: 1, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+  ],
+
+  ARTEFACT_EIGHTEEN: [
+    { x: 0, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 0, y: 1, name: "Camel Bone" },
+    { x: 1, y: 1, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_NINETEEN: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 2, y: 0, name: "Camel Bone" },
+    { x: 1, y: 1, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+  ],
+
+  ARTEFACT_TWENTY: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 0, y: 1, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 1, y: 1, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_TWENTY_ONE: [
+    { x: 0, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 2, y: 0, name: "Camel Bone" },
+    { x: 0, y: 1, name: "Camel Bone" },
+    { x: 1, y: 1, name: "Camel Bone" },
+  ],
+
+  ARTEFACT_TWENTY_TWO: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 2, y: 0, name: "Camel Bone" },
+    { x: 0, y: 1, name: "Camel Bone" },
+    { x: 1, y: 1, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+  ],
+
+  ARTEFACT_TWENTY_THREE: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: "Camel Bone" },
+    { x: 2, y: 0, name: "Camel Bone" },
+    { x: 1, y: 1, name: "Camel Bone" },
+    { x: 2, y: 1, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+  ],
+
+  ARTEFACT_TWENTY_FOUR: [
+    { x: 0, y: 0, name: "Camel Bone" },
+    { x: 1, y: 0, name: SEASONAL_ARTEFACT[getCurrentSeason()] },
+    { x: 2, y: 0, name: "Camel Bone" },
+    { x: 0, y: 1, name: "Camel Bone" },
+    { x: 2, y: 1, name: "Camel Bone" },
+  ],
+
   // Small L - X Coins
   HIEROGLYPH: [
     { x: 0, y: 0, name: "Vase" },


### PR DESCRIPTION
# Description

This PR adds new unique artefact formations. This removes the formations that are "subsets" of other formations. This was causing the FE to think a formation had been found when it was actually a subset of another formation.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
