### PR TITLE
[FEAT] Reset Skills Restrictions

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -26,11 +26,11 @@ import { gameAnalytics } from "lib/gameAnalytics";
 import {
   canResetForFree,
   getGemCost,
-  getTimeUntilNextFreeReset,
   PaymentType,
+  getTimeUntilNextFreeReset,
 } from "features/game/events/landExpansion/resetSkills";
-import { millisecondsToString } from "lib/utils/time";
 import { SkillReset } from "./SkillReset";
+import Decimal from "decimal.js-light";
 
 export const SKILL_TREE_ICONS: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
@@ -65,21 +65,29 @@ export const SkillCategoryList: React.FC<{
 
   const hasSkills = getKeys(skills).length > 0;
 
-  const getTimeUntilNextResetText = () => {
-    const timeRemaining = getTimeUntilNextFreeReset(
-      previousFreeSkillResetAt,
-      Date.now(),
-    );
+  const getNextResetDateAndTime = () => {
+    const nextResetTime =
+      Date.now() + getTimeUntilNextFreeReset(previousFreeSkillResetAt);
+    const nextResetDate = new Date(nextResetTime);
 
-    return millisecondsToString(timeRemaining, {
-      length: "medium",
-      removeTrailingZeros: true,
-    });
+    return {
+      date: nextResetDate.toLocaleDateString(navigator.language, {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      }),
+      time: nextResetDate.toLocaleTimeString(navigator.language, {
+        hour: "numeric",
+        minute: "numeric",
+        hour12: false,
+      }),
+    };
   };
 
   const gemCost = getGemCost(paidSkillResets);
 
   const hasEnoughGems = inventory.Gem?.gte(gemCost) ?? false;
+  const gemBalance = inventory.Gem ?? new Decimal(0);
 
   const resetType: PaymentType = canResetForFree(previousFreeSkillResetAt)
     ? "free"
@@ -241,8 +249,8 @@ export const SkillCategoryList: React.FC<{
         <SkillReset
           resetType={resetType}
           gemCost={gemCost}
-          hasEnoughGems={hasEnoughGems}
-          getTimeUntilNextResetText={getTimeUntilNextResetText}
+          gemBalance={gemBalance}
+          getNextResetDateAndTime={getNextResetDateAndTime}
           getCropMachineResetWarning={getCropMachineResetWarning}
           hasSkills={hasSkills}
           canResetSkills={canResetSkills}

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { ButtonPanel, InnerPanel, OuterPanel } from "components/ui/Panel";
+import { ButtonPanel, InnerPanel } from "components/ui/Panel";
 import {
   BumpkinRevampSkillTree,
   getRevampSkills,
@@ -13,7 +13,6 @@ import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 
 import { SUNNYSIDE } from "assets/sunnyside";
-import { Button } from "components/ui/Button";
 import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/choseSkill";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -31,6 +30,7 @@ import {
   PaymentType,
 } from "features/game/events/landExpansion/resetSkills";
 import { millisecondsToString } from "lib/utils/time";
+import { SkillReset } from "./SkillReset";
 
 export const SKILL_TREE_ICONS: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
@@ -238,73 +238,18 @@ export const SkillCategoryList: React.FC<{
           setShowSkillsResetConfirmation(false);
         }}
       >
-        <OuterPanel>
-          <InnerPanel className="flex flex-col items-center">
-            <div className="flex flex-col items-center w-full gap-2 my-1">
-              <Label type="warning">{`Skills Reset`}</Label>
-
-              <Label type={resetType === "free" ? "success" : "vibrant"}>
-                {resetType === "free" ? `Free Reset` : `Gem Reset`}
-              </Label>
-
-              {resetType === "free" ? (
-                <p className="text-xs text-center">
-                  {`Reset all your skills for free. You can do this once every 6 months.`}
-                </p>
-              ) : (
-                <>
-                  <Label type="default" icon={ITEM_DETAILS.Gem.image}>
-                    {`${gemCost} Gems`}
-                  </Label>
-                  <p className="text-xs text-center">
-                    {`Reset your skills immediately using gems. Cost doubles with each use until next free reset.`}
-                  </p>
-                  {!hasEnoughGems && (
-                    <Label type="danger" icon={ITEM_DETAILS.Gem.image}>
-                      {`Not enough gems`}
-                    </Label>
-                  )}
-                  <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-                    {`Next free reset in ${getTimeUntilNextResetText()}`}
-                  </Label>
-                </>
-              )}
-
-              {!hasSkills && (
-                <Label type="danger">{`No skills to reset`}</Label>
-              )}
-
-              {getCropMachineResetWarning() && (
-                <Label type="danger">{getCropMachineResetWarning()}</Label>
-              )}
-
-              {!showSkillsResetConfirmation ? (
-                <Button
-                  onClick={() => setShowSkillsResetConfirmation(true)}
-                  disabled={!canResetSkills()}
-                >
-                  {`Reset Skills`}
-                </Button>
-              ) : (
-                <div className="flex justify-between gap-2 w-full">
-                  <Button
-                    className="w-full"
-                    onClick={() => setShowSkillsResetConfirmation(false)}
-                  >
-                    {`Cancel`}
-                  </Button>
-                  <Button
-                    className="w-full"
-                    onClick={handleSkillsReset}
-                    disabled={!canResetSkills()}
-                  >
-                    {`Confirm`}
-                  </Button>
-                </div>
-              )}
-            </div>
-          </InnerPanel>
-        </OuterPanel>
+        <SkillReset
+          resetType={resetType}
+          gemCost={gemCost}
+          hasEnoughGems={hasEnoughGems}
+          getTimeUntilNextResetText={getTimeUntilNextResetText}
+          getCropMachineResetWarning={getCropMachineResetWarning}
+          hasSkills={hasSkills}
+          canResetSkills={canResetSkills}
+          handleSkillsReset={handleSkillsReset}
+          showSkillsResetConfirmation={showSkillsResetConfirmation}
+          setShowSkillsResetConfirmation={setShowSkillsResetConfirmation}
+        />
       </Modal>
     </>
   );

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -249,7 +249,7 @@ export const SkillCategoryList: React.FC<{
 
               {resetType === "free" ? (
                 <p className="text-xs text-center">
-                  {`Reset all your skills for free. You can do this once every 4 months.`}
+                  {`Reset all your skills for free. You can do this once every 6 months.`}
                 </p>
               ) : (
                 <>

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -186,16 +186,15 @@ export const SkillCategoryList = ({
             <div className="flex flex-row items-center w-full justify-between">
               <Label type="danger">{"Skills Reset"}</Label>
               <Label type="warning" icon={sflIcon}>
-                {"0 SFL"} {/* Will change to 10 SFL on release */}
+                {"10 SFL"}
               </Label>
             </div>
             <p className="text-xs py-4 px-2 text-center">
               {
-                "Are you sure you want to reset all your skills? This action cannot be undone and will cost 0 SFL. You will be able to reset your skills again in 3 months."
+                "Are you sure you want to reset all your skills? This action cannot be undone and will cost 10 SFL. You will be able to reset your skills again in 3 months."
               }
-              {/* Will change to 10 SFL on release */}
             </p>
-            {/* {!threeMonthsSinceLastReset && (
+            {!threeMonthsSinceLastReset && (
               <Label
                 type="danger"
                 icon={SUNNYSIDE.icons.stopwatch}
@@ -203,7 +202,7 @@ export const SkillCategoryList = ({
               >
                 {`${getTimeUntilNextReset()} until you can reset your skills again`}
               </Label>
-            )} */}
+            )}
             {!enoughSfl && (
               <Label type="danger" icon={sflIcon} className="mb-2">
                 {t("not.enough.sfl")}
@@ -211,7 +210,7 @@ export const SkillCategoryList = ({
             )}
             <Button
               onClick={handleSkillsReset}
-              disabled={!hasSkills} // || !threeMonthsSinceLastReset|| !enoughSfl
+              disabled={!hasSkills || !threeMonthsSinceLastReset || !enoughSfl}
             >
               {"Reset Skills"}
             </Button>

--- a/src/features/bumpkins/components/revamp/SkillReset.tsx
+++ b/src/features/bumpkins/components/revamp/SkillReset.tsx
@@ -2,6 +2,8 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
 import { OuterPanel, InnerPanel } from "components/ui/Panel";
+import { RequirementLabel } from "components/ui/RequirementsLabel";
+import Decimal from "decimal.js-light";
 import { PaymentType } from "features/game/events/landExpansion/resetSkills";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React from "react";
@@ -9,8 +11,11 @@ import React from "react";
 interface SkillResetProps {
   resetType: PaymentType;
   gemCost: number;
-  hasEnoughGems: boolean;
-  getTimeUntilNextResetText: () => string;
+  gemBalance: Decimal;
+  getNextResetDateAndTime: () => {
+    date: string;
+    time: string;
+  };
   getCropMachineResetWarning: () => string | undefined;
   hasSkills: boolean;
   canResetSkills: () => boolean;
@@ -22,8 +27,8 @@ interface SkillResetProps {
 export const SkillReset: React.FC<SkillResetProps> = ({
   resetType,
   gemCost,
-  hasEnoughGems,
-  getTimeUntilNextResetText,
+  gemBalance,
+  getNextResetDateAndTime,
   getCropMachineResetWarning,
   hasSkills,
   canResetSkills,
@@ -34,33 +39,42 @@ export const SkillReset: React.FC<SkillResetProps> = ({
   <OuterPanel>
     <InnerPanel className="flex flex-col items-center">
       <div className="flex flex-col items-center w-full gap-2 my-1">
-        <Label type="warning">{`Skills Reset`}</Label>
+        <Label type="default">{`Skills Reset`}</Label>
 
-        <Label type={resetType === "free" ? "success" : "vibrant"}>
+        <Label
+          type={resetType === "free" ? "success" : "vibrant"}
+          icon={resetType === "gems" ? ITEM_DETAILS.Gem.image : undefined}
+        >
           {resetType === "free" ? `Free Reset` : `Gem Reset`}
         </Label>
 
         {resetType === "free" ? (
-          <p className="text-xs text-center">
-            {`Reset all your skills for free. You can do this once every 6 months.`}
-          </p>
-        ) : (
-          <>
-            <Label type="default" icon={ITEM_DETAILS.Gem.image}>
-              {`${gemCost} Gems`}
-            </Label>
+          <div className="flex flex-col items-center gap-2">
             <p className="text-xs text-center">
-              {`Reset your skills immediately using gems. Cost doubles with each use until next free reset.`}
+              {`Reset all your skills for free.`}
             </p>
-            {!hasEnoughGems && (
-              <Label type="danger" icon={ITEM_DETAILS.Gem.image}>
-                {`Not enough gems`}
-              </Label>
-            )}
-            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-              {`Next free reset in ${getTimeUntilNextResetText()}`}
+            <Label type="warning">
+              {`You can do this once every 6 months.`}
             </Label>
-          </>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-2">
+            <RequirementLabel
+              type="item"
+              item={"Gem"}
+              balance={gemBalance}
+              requirement={new Decimal(gemCost)}
+            />
+            <p className="text-xs text-center">
+              {`Reset your skills immediately using gems.`}
+            </p>
+            <Label type="warning">
+              {`Cost doubles with each use until next free reset.`}
+            </Label>
+            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+              {`Next free reset on ${getNextResetDateAndTime().date} at ${getNextResetDateAndTime().time}`}
+            </Label>
+          </div>
         )}
 
         {!hasSkills && <Label type="danger">{`No skills to reset`}</Label>}

--- a/src/features/bumpkins/components/revamp/SkillReset.tsx
+++ b/src/features/bumpkins/components/revamp/SkillReset.tsx
@@ -1,0 +1,99 @@
+import { SUNNYSIDE } from "assets/sunnyside";
+import { Button } from "components/ui/Button";
+import { Label } from "components/ui/Label";
+import { OuterPanel, InnerPanel } from "components/ui/Panel";
+import { PaymentType } from "features/game/events/landExpansion/resetSkills";
+import { ITEM_DETAILS } from "features/game/types/images";
+import React from "react";
+
+interface SkillResetProps {
+  resetType: PaymentType;
+  gemCost: number;
+  hasEnoughGems: boolean;
+  getTimeUntilNextResetText: () => string;
+  getCropMachineResetWarning: () => string | undefined;
+  hasSkills: boolean;
+  canResetSkills: () => boolean;
+  handleSkillsReset: () => void;
+  showSkillsResetConfirmation: boolean;
+  setShowSkillsResetConfirmation: (show: boolean) => void;
+}
+
+export const SkillReset: React.FC<SkillResetProps> = ({
+  resetType,
+  gemCost,
+  hasEnoughGems,
+  getTimeUntilNextResetText,
+  getCropMachineResetWarning,
+  hasSkills,
+  canResetSkills,
+  handleSkillsReset,
+  showSkillsResetConfirmation,
+  setShowSkillsResetConfirmation,
+}) => (
+  <OuterPanel>
+    <InnerPanel className="flex flex-col items-center">
+      <div className="flex flex-col items-center w-full gap-2 my-1">
+        <Label type="warning">{`Skills Reset`}</Label>
+
+        <Label type={resetType === "free" ? "success" : "vibrant"}>
+          {resetType === "free" ? `Free Reset` : `Gem Reset`}
+        </Label>
+
+        {resetType === "free" ? (
+          <p className="text-xs text-center">
+            {`Reset all your skills for free. You can do this once every 6 months.`}
+          </p>
+        ) : (
+          <>
+            <Label type="default" icon={ITEM_DETAILS.Gem.image}>
+              {`${gemCost} Gems`}
+            </Label>
+            <p className="text-xs text-center">
+              {`Reset your skills immediately using gems. Cost doubles with each use until next free reset.`}
+            </p>
+            {!hasEnoughGems && (
+              <Label type="danger" icon={ITEM_DETAILS.Gem.image}>
+                {`Not enough gems`}
+              </Label>
+            )}
+            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+              {`Next free reset in ${getTimeUntilNextResetText()}`}
+            </Label>
+          </>
+        )}
+
+        {!hasSkills && <Label type="danger">{`No skills to reset`}</Label>}
+
+        {getCropMachineResetWarning() && (
+          <Label type="danger">{getCropMachineResetWarning()}</Label>
+        )}
+
+        {!showSkillsResetConfirmation ? (
+          <Button
+            onClick={() => setShowSkillsResetConfirmation(true)}
+            disabled={!canResetSkills()}
+          >
+            {`Reset Skills`}
+          </Button>
+        ) : (
+          <div className="flex justify-between gap-2 w-full">
+            <Button
+              className="w-full"
+              onClick={() => setShowSkillsResetConfirmation(false)}
+            >
+              {`Cancel`}
+            </Button>
+            <Button
+              className="w-full"
+              onClick={handleSkillsReset}
+              disabled={!canResetSkills()}
+            >
+              {`Confirm`}
+            </Button>
+          </div>
+        )}
+      </div>
+    </InnerPanel>
+  </OuterPanel>
+);

--- a/src/features/game/events/landExpansion/resetSkills.test.ts
+++ b/src/features/game/events/landExpansion/resetSkills.test.ts
@@ -5,7 +5,7 @@ import Decimal from "decimal.js-light";
 describe("resetSkills", () => {
   const dateNow = Date.now();
 
-  it.only("requires Bumpkin to have skills", () => {
+  it("requires Bumpkin to have skills", () => {
     expect(() => {
       resetSkills({
         state: {
@@ -35,8 +35,7 @@ describe("resetSkills", () => {
         action: { type: "skills.reset" },
         createdAt: dateNow,
       });
-      //}).toThrow("You can only reset your skills once every 3 months");
-    }).toThrow("You can only reset your skills once every 5 minutes");
+    }).toThrow("You can only reset your skills once every 3 months");
   });
 
   it("requires player to have enough SFL to reset skills", () => {

--- a/src/features/game/events/landExpansion/resetSkills.test.ts
+++ b/src/features/game/events/landExpansion/resetSkills.test.ts
@@ -23,9 +23,9 @@ describe("resetSkills", () => {
   });
 
   describe("free reset", () => {
-    it("requires Bumpkin to wait 4 months before free reset", () => {
-      const threeMonthsAgo = new Date(dateNow);
-      threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+    it("requires Bumpkin to wait 6 months before free reset", () => {
+      const fiveMonthsAgo = new Date(dateNow);
+      fiveMonthsAgo.setMonth(fiveMonthsAgo.getMonth() - 5);
 
       expect(() => {
         resetSkills({
@@ -34,18 +34,18 @@ describe("resetSkills", () => {
             bumpkin: {
               ...TEST_BUMPKIN,
               skills: { "Green Thumb": 1 },
-              previousFreeSkillResetAt: threeMonthsAgo.getTime(),
+              previousFreeSkillResetAt: fiveMonthsAgo.getTime(),
             },
           },
           action: { type: "skills.reset", paymentType: "free" },
           createdAt: dateNow,
         });
-      }).toThrow("Wait 28 more days for free reset or use gems");
+      }).toThrow("Wait 27 more days for free reset or use gems");
     });
 
-    it("resets Bumpkin skills after 4 months for free", () => {
-      const fourMonthsAgo = new Date(dateNow);
-      fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4);
+    it("resets Bumpkin skills after 6 months for free", () => {
+      const sixMonthsAgo = new Date(dateNow);
+      sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
 
       const state = resetSkills({
         state: {
@@ -53,7 +53,7 @@ describe("resetSkills", () => {
           bumpkin: {
             ...TEST_BUMPKIN,
             skills: { "Green Thumb": 1 },
-            previousFreeSkillResetAt: fourMonthsAgo.getTime(),
+            previousFreeSkillResetAt: sixMonthsAgo.getTime(),
             paidSkillResets: 2, // Should be cleared after free reset
           },
         },

--- a/src/features/game/events/landExpansion/resetSkills.test.ts
+++ b/src/features/game/events/landExpansion/resetSkills.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js-light";
 import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
 import { INITIAL_FARM } from "features/game/lib/constants";
-import { resetSkills } from "./resetSkills";
+import { getTimeUntilNextFreeReset, resetSkills } from "./resetSkills";
 
 describe("resetSkills", () => {
   const dateNow = Date.now();
@@ -27,6 +27,14 @@ describe("resetSkills", () => {
       const fiveMonthsAgo = new Date(dateNow);
       fiveMonthsAgo.setMonth(fiveMonthsAgo.getMonth() - 5);
 
+      const timeUntilNextReset = getTimeUntilNextFreeReset(
+        fiveMonthsAgo.getTime(),
+        dateNow,
+      );
+      const daysRemaining = Math.ceil(
+        timeUntilNextReset / (1000 * 60 * 60 * 24),
+      );
+
       expect(() => {
         resetSkills({
           state: {
@@ -40,7 +48,7 @@ describe("resetSkills", () => {
           action: { type: "skills.reset", paymentType: "free" },
           createdAt: dateNow,
         });
-      }).toThrow("Wait 27 more days for free reset or use gems");
+      }).toThrow(`Wait ${daysRemaining} more days for free reset or use gems`);
     });
 
     it("resets Bumpkin skills after 6 months for free", () => {

--- a/src/features/game/events/landExpansion/resetSkills.test.ts
+++ b/src/features/game/events/landExpansion/resetSkills.test.ts
@@ -63,7 +63,7 @@ describe("resetSkills", () => {
 
       expect(state.bumpkin?.skills).toEqual({});
       expect(state.bumpkin?.previousFreeSkillResetAt).toEqual(dateNow);
-      expect(state.bumpkin?.paidSkillResets).toBeUndefined();
+      expect(state.bumpkin?.paidSkillResets ?? new Decimal(0)).toEqual(new Decimal(0));
     });
   });
 

--- a/src/features/game/events/landExpansion/resetSkills.test.ts
+++ b/src/features/game/events/landExpansion/resetSkills.test.ts
@@ -63,7 +63,7 @@ describe("resetSkills", () => {
 
       expect(state.bumpkin?.skills).toEqual({});
       expect(state.bumpkin?.previousFreeSkillResetAt).toEqual(dateNow);
-      expect(state.bumpkin?.paidSkillResets ?? new Decimal(0)).toEqual(new Decimal(0));
+      expect(state.bumpkin?.paidSkillResets ?? 0).toEqual(0);
     });
   });
 

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -1,5 +1,5 @@
 import { GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type ResetSkillsAction = {
   type: "skills.reset";
@@ -11,55 +11,40 @@ type Options = {
   createdAt?: number;
 };
 
-export function resetSkills({
-  state,
-  action,
-  createdAt = Date.now(),
-}: Options) {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin } = stateCopy;
+export function resetSkills({ state, createdAt = Date.now() }: Options) {
+  return produce(state, (game) => {
+    const { bumpkin } = game;
 
-  // Check if bumpkin exists
-  if (bumpkin == undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
-
-  // Check if bumpkin has any skills
-  if (Object.keys(bumpkin.skills).length === 0) {
-    throw new Error("You do not have any skills to reset");
-  }
-
-  // Check if allowed to reset skills (once per 3 months)
-  /* if (bumpkin.previousSkillsResetAt) {
-    const threeMonthsAgo = new Date();
-    threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
-
-    if (bumpkin.previousSkillsResetAt > threeMonthsAgo.getTime()) {
-      throw new Error("You can only reset your skills once every 3 months");
+    // Check if bumpkin exists
+    if (bumpkin == undefined) {
+      throw new Error("You do not have a Bumpkin!");
     }
-  } */
 
-  // Temp remove of fn above, for testing purposes we move to a 5min limit
-  // if (bumpkin.previousSkillsResetAt) {
-  //   const fiveMinutesAgo = new Date();
-  //   fiveMinutesAgo.setMinutes(fiveMinutesAgo.getMinutes() - 5);
+    // Check if bumpkin has any skills
+    if (Object.keys(bumpkin.skills).length === 0) {
+      throw new Error("You do not have any skills to reset");
+    }
 
-  //   if (bumpkin.previousSkillsResetAt > fiveMinutesAgo.getTime()) {
-  //     throw new Error("You can only reset your skills once every 5 minutes");
-  //   }
-  // }
+    // Check if allowed to reset skills (once per 3 months)
+    if (bumpkin.previousSkillsResetAt) {
+      const threeMonthsAgo = new Date();
+      threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
 
-  // Check of player has enough SFL to reset skills
-  // if (stateCopy.balance.toNumber() < 10) {
-  //   throw new Error("You do not have enough SFL to reset your skills");
-  // }
+      if (bumpkin.previousSkillsResetAt > threeMonthsAgo.getTime()) {
+        throw new Error("You can only reset your skills once every 3 months");
+      }
+    }
 
-  // All checks passed, reset skills
-  bumpkin.skills = {};
-  // bumpkin.previousSkillsResetAt = createdAt;
-  // stateCopy.balance = stateCopy.balance.minus(10);
-  bumpkin.previousSkillsResetAt = 1;
-  stateCopy.balance = stateCopy.balance.minus(0);
+    // Check of player has enough SFL to reset skills
+    if (game.balance.toNumber() < 10) {
+      throw new Error("You do not have enough SFL to reset your skills");
+    }
 
-  return stateCopy;
+    // All checks passed, reset skills
+    bumpkin.skills = {};
+    bumpkin.previousSkillsResetAt = createdAt;
+    game.balance = game.balance.minus(10);
+
+    return game;
+  });
 }

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -59,7 +59,7 @@ export function resetSkills({ state, createdAt = Date.now() }: Options) {
     }
 
     // Check of player has enough SFL to reset skills
-    if (game.balance.toNumber() < 10) {
+    if (game.balance.lt(10)) {
       throw new Error("You do not have enough SFL to reset your skills");
     }
 

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -23,9 +23,9 @@ export function getTimeUntilNextFreeReset(
   previousFreeSkillResetAt: number,
   now = Date.now(),
 ) {
-  const fourMonthsInMs = 4 * 30 * 24 * 60 * 60 * 1000; // 4 months in milliseconds
+  const sixMonthsInMs = 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
   const timeSinceLastFreeReset = now - previousFreeSkillResetAt;
-  const timeRemaining = fourMonthsInMs - timeSinceLastFreeReset;
+  const timeRemaining = sixMonthsInMs - timeSinceLastFreeReset;
   return timeRemaining;
 }
 
@@ -33,8 +33,8 @@ export function canResetForFree(
   previousFreeSkillResetAt: number,
   now = Date.now(),
 ) {
-  const fourMonthsInMs = 4 * 30 * 24 * 60 * 60 * 1000; // 4 months in milliseconds
-  return now - previousFreeSkillResetAt >= fourMonthsInMs;
+  const sixMonthsInMs = 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
+  return now - previousFreeSkillResetAt >= sixMonthsInMs;
 }
 
 export function resetSkills({

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -23,9 +23,23 @@ export function getTimeUntilNextFreeReset(
   previousFreeSkillResetAt: number,
   now = Date.now(),
 ) {
-  const sixMonthsInMs = 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
-  const timeSinceLastFreeReset = now - previousFreeSkillResetAt;
-  const timeRemaining = sixMonthsInMs - timeSinceLastFreeReset;
+  // Get the reset date
+  const resetDate = new Date(previousFreeSkillResetAt);
+
+  // Create next reset date
+  const nextResetDate = new Date(resetDate);
+
+  // First set the month, which might give us an incorrect date
+  nextResetDate.setMonth(resetDate.getMonth() + 6);
+
+  // If we've gone beyond 6 months due to day overflow,
+  // set to the last day of the target month
+  while (nextResetDate.getMonth() !== (resetDate.getMonth() + 6) % 12) {
+    nextResetDate.setDate(nextResetDate.getDate() - 1);
+  }
+
+  // Calculate time remaining
+  const timeRemaining = nextResetDate.getTime() - now;
   return timeRemaining;
 }
 
@@ -33,8 +47,11 @@ export function canResetForFree(
   previousFreeSkillResetAt: number,
   now = Date.now(),
 ) {
-  const sixMonthsInMs = 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
-  return now - previousFreeSkillResetAt >= sixMonthsInMs;
+  const timeUntilNextReset = getTimeUntilNextFreeReset(
+    previousFreeSkillResetAt,
+    now,
+  );
+  return timeUntilNextReset <= 0;
 }
 
 export function resetSkills({

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -98,7 +98,7 @@ export function resetSkills({
       }
 
       // Reset paid resets counter since 4 months have passed
-      delete bumpkin.paidSkillResets;
+      bumpkin.paidSkillResets = 0;
     }
 
     // Handle gem reset

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -381,8 +381,9 @@ export type Bumpkin = {
   skills: Skills;
   achievements?: Partial<Record<AchievementName, number>>;
   activity: Partial<Record<BumpkinActivityName, number>>;
-  previousSkillsResetAt?: number;
+  previousFreeSkillResetAt?: number;
   previousPowerUseAt?: Partial<Record<BumpkinRevampSkillName, number>>;
+  paidSkillResets?: number;
 };
 
 export type SpecialEvent = "Chef Apron" | "Chef Hat";

--- a/src/lib/gameAnalytics.ts
+++ b/src/lib/gameAnalytics.ts
@@ -139,7 +139,8 @@ class GameAnalyticTracker {
       | "FishingReels"
       | "Instant Expand"
       | "Instant Build"
-      | "Instant Cook";
+      | "Instant Cook"
+      | "Skills Reset";
   }) {
     const { currency, amount, type, item } = event;
 


### PR DESCRIPTION
# Description

Player gets 1 free reset every 6 months ie reset on 27 Jan, next free reset is on 27th July

Any reset during the 6 month waiting period will require gems, starting at 200 gems, doubles every time a reset is performed. the price of gem reset goes back to 200 after the next free reset

Free Reset
![image](https://github.com/user-attachments/assets/5a772e6a-9d09-45cf-919f-171111e153c0)

Gem Reset
![image](https://github.com/user-attachments/assets/bb74de49-2533-4d8f-a9a6-5e6e74620422)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
