### PR TITLE
[FEAT] Add islandtype requirement

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -33,7 +33,7 @@ import {
   getListingsFloorPrices,
 } from "features/game/actions/getListingsFloorPrices";
 import { Context as AuthContext } from "features/auth/lib/Provider";
-import { useSelector } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { Loading } from "features/auth/components";
 import { formatNumber } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
@@ -106,6 +106,11 @@ export const BumpkinModal: React.FC<Props> = ({
   gameState,
 }) => {
   const { gameService } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
   const experience = useSelector(gameService, _experience);
   const level = getBumpkinLevel(experience);
   const maxLevel = isMaxLevel(experience);
@@ -115,7 +120,9 @@ export const BumpkinModal: React.FC<Props> = ({
   const rawToken = useSelector(authService, _rawToken);
   const [floorPrices, setFloorPrices] = useState<FloorPrices>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [view, setView] = useState<ViewState>(initialView);
+  const [view, setView] = useState<ViewState>(
+    !hasFeatureAccess(state, "SKILLS_REVAMP") ? initialView : "home",
+  );
 
   const [tab, setTab] = useState(0);
   const { t } = useAppTranslation();

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -33,7 +33,7 @@ import {
   getListingsFloorPrices,
 } from "features/game/actions/getListingsFloorPrices";
 import { Context as AuthContext } from "features/auth/lib/Provider";
-import { useActor, useSelector } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { Loading } from "features/auth/components";
 import { formatNumber } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
@@ -106,11 +106,6 @@ export const BumpkinModal: React.FC<Props> = ({
   gameState,
 }) => {
   const { gameService } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
   const experience = useSelector(gameService, _experience);
   const level = getBumpkinLevel(experience);
   const maxLevel = isMaxLevel(experience);
@@ -121,7 +116,7 @@ export const BumpkinModal: React.FC<Props> = ({
   const [floorPrices, setFloorPrices] = useState<FloorPrices>({});
   const [isLoading, setIsLoading] = useState(false);
   const [view, setView] = useState<ViewState>(
-    !hasFeatureAccess(state, "SKILLS_REVAMP") ? initialView : "home",
+    !hasFeatureAccess(gameState, "SKILLS_REVAMP") ? initialView : "home",
   );
 
   const [tab, setTab] = useState(0);

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -98,17 +98,10 @@ export const SkillCategoryList = ({
   return (
     <>
       <InnerPanel className="flex flex-col h-full overflow-y-auto scrollable max-h-96">
-        <div
-          className="flex flex-row my-2 items-center"
-          style={{ margin: `${PIXEL_SCALE * 2}px` }}
-        >
-          <div className="flex flex-wrap gap-1">
-            {availableSkillPoints > 0 && (
-              <Label type="default">
-                {`You have ${availableSkillPoints} skill point${availableSkillPoints > 1 ? "s" : ""}`}
-              </Label>
-            )}
-          </div>
+        <div className="flex flex-row mt-2 mb-1 items-center">
+          {availableSkillPoints > 0 && (
+            <Label type="default">{`${t("skillPts")} ${availableSkillPoints}`}</Label>
+          )}
         </div>
         {ISLAND_EXPANSIONS.map((islandType) => {
           const hasUnlockedIslandCategory = hasRequiredIslandExpansion(

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -8,8 +8,10 @@ import {
 
 import { Modal } from "components/ui/Modal";
 import { Label } from "components/ui/Label";
+import { getKeys } from "features/game/types/craftables";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
+import { setImageWidth } from "lib/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -21,8 +23,6 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ONE_DAY, secondsToString } from "lib/utils/time";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ISLAND_EXPANSIONS } from "features/game/types/game";
-import { getKeys } from "features/game/types/decorations";
-import { setImageWidth } from "lib/images";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import classNames from "classnames";
 

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -23,10 +23,9 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ONE_DAY, secondsToString } from "lib/utils/time";
 import { ITEM_DETAILS } from "features/game/types/images";
 
-const iconList = {
+const iconList: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
   Trees: SUNNYSIDE.skills.trees,
-  Rocks: SUNNYSIDE.skills.rocks,
   Cooking: SUNNYSIDE.skills.cooking,
   Animals: SUNNYSIDE.skills.animals,
   Fruit: ITEM_DETAILS.Apple.image,
@@ -34,7 +33,6 @@ const iconList = {
   Greenhouse: ITEM_DETAILS.Greenhouse.image,
   Mining: SUNNYSIDE.tools.stone_pickaxe,
   "Bees & Flowers": ITEM_DETAILS["Red Pansy"].image,
-  Oil: ITEM_DETAILS.Oil.image,
   Machinery: ITEM_DETAILS["Crop Machine"].image,
 };
 

--- a/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
@@ -25,6 +25,7 @@ import { gameAnalytics } from "lib/gameAnalytics";
 
 // Icon imports
 import { SUNNYSIDE } from "assets/sunnyside";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 interface Props {
   selectedSkillPath: BumpkinRevampSkillTree;
@@ -39,6 +40,7 @@ export const SkillPathDetails: React.FC<Props> = ({
   readonly,
   onBack,
 }) => {
+  const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
   const {
@@ -202,7 +204,7 @@ export const SkillPathDetails: React.FC<Props> = ({
             <Label type="default">{selectedSkillPath + " Skills"}</Label>
             {availableSkillPoints > 0 && (
               <Label type="default" className="ml-1">
-                {`You have ${availableSkillPoints} skill point${availableSkillPoints > 1 ? "s" : ""}`}
+                {`${t("skillPts")} ${availableSkillPoints}`}
               </Label>
             )}
           </div>

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -5,7 +5,7 @@ import {
   BumpkinRevampSkillTree,
 } from "features/game/types/bumpkinSkills";
 import { Bumpkin, GameState } from "features/game/types/game";
-import cloneDeep from "lodash.clonedeep";
+import { produce } from "immer";
 
 export type ChoseSkillAction = {
   type: "skill.chosen";
@@ -63,38 +63,39 @@ export const getUnlockedTierForTree = (
   return 1;
 };
 
-export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
-  const stateCopy = cloneDeep(state);
-  const { bumpkin, island } = stateCopy;
+export function choseSkill({ state, action }: Options) {
+  return produce(state, (stateCopy) => {
+    const { bumpkin, island } = stateCopy;
 
-  if (bumpkin == undefined) {
-    throw new Error("You do not have a Bumpkin!");
-  }
+    if (!bumpkin) {
+      throw new Error("You do not have a Bumpkin!");
+    }
 
-  const { requirements, tree } = BUMPKIN_REVAMP_SKILL_TREE[action.skill];
-  const bumpkinHasSkill = bumpkin.skills[action.skill];
+    const { requirements, tree } = BUMPKIN_REVAMP_SKILL_TREE[action.skill];
+    const bumpkinHasSkill = bumpkin.skills[action.skill];
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
-  const availableTier = getUnlockedTierForTree(tree, bumpkin);
+    const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+    const availableTier = getUnlockedTierForTree(tree, bumpkin);
 
-  if (island.type !== requirements.island) {
-    throw new Error("You are not at the correct island!");
-  }
+    if (island.type !== requirements.island) {
+      throw new Error("You are not at the correct island!");
+    }
 
-  if (availableSkillPoints < requirements.points) {
-    throw new Error("You do not have enough skill points");
-  }
+    if (availableSkillPoints < requirements.points) {
+      throw new Error("You do not have enough skill points");
+    }
 
-  if (requirements.tier > availableTier) {
-    throw new Error(`You need to unlock tier ${requirements.tier} first`);
-  }
+    if (requirements.tier > availableTier) {
+      throw new Error(`You need to unlock tier ${requirements.tier} first`);
+    }
 
-  if (bumpkinHasSkill) {
-    throw new Error("You already have this skill");
-  }
+    if (bumpkinHasSkill) {
+      throw new Error("You already have this skill");
+    }
 
-  // Add the selected skill to the bumpkin's skills
-  bumpkin.skills = { ...bumpkin.skills, [action.skill]: 1 };
+    // Add the selected skill to the bumpkin's skills
+    bumpkin.skills = { ...bumpkin.skills, [action.skill]: 1 };
 
-  return stateCopy;
+    return stateCopy;
+  });
 }

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -65,18 +65,21 @@ export const getUnlockedTierForTree = (
 
 export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
   const stateCopy = cloneDeep(state);
-  const { bumpkin } = stateCopy;
+  const { bumpkin, island } = stateCopy;
 
   if (bumpkin == undefined) {
     throw new Error("You do not have a Bumpkin!");
   }
 
-  const requirements = BUMPKIN_REVAMP_SKILL_TREE[action.skill].requirements;
-  const tree = BUMPKIN_REVAMP_SKILL_TREE[action.skill].tree;
+  const { requirements, tree } = BUMPKIN_REVAMP_SKILL_TREE[action.skill];
   const bumpkinHasSkill = bumpkin.skills[action.skill];
 
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
   const availableTier = getUnlockedTierForTree(tree, bumpkin);
+
+  if (island.type !== requirements.island) {
+    throw new Error("You are not at the correct island!");
+  }
 
   if (availableSkillPoints < requirements.points) {
     throw new Error("You do not have enough skill points");

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -2,6 +2,7 @@ import { getKeys } from "./craftables";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { translate } from "lib/i18n/translate";
+import { IslandType } from "./game";
 
 export type BumpkinSkillName =
   | "Green Thumb"
@@ -184,6 +185,7 @@ export type BumpkinSkillRevamp = {
   requirements: {
     points: number;
     tier: 1 | 2 | 3;
+    island: IslandType;
   };
   boosts: string;
   image: string;
@@ -422,6 +424,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.greenThumb"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -432,6 +435,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.youngFarmer"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -442,6 +446,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.experiencedFarmer"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -452,6 +457,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.bettysFriend"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -462,6 +468,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.efficientBin"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -472,6 +479,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: translate("skill.oldFarmer"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -483,6 +491,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: translate("skill.strongRoots"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -493,6 +502,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: translate("skill.coinSwindler"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -503,6 +513,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: translate("skill.goldenSunflower"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -513,6 +524,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: translate("skill.chonkyScarecrow"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -523,6 +535,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: translate("skill.horrorMike"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -534,6 +547,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: translate("skill.instantGrowth"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -545,6 +559,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: translate("skill.acreFarm"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -555,6 +570,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: translate("skill.hectareFarm"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -565,6 +581,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: translate("skill.premiumWorms"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -575,6 +592,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: translate("skill.lauriesGains"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -587,6 +605,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "+0.1 Fruit Yield (Tomatoes, Lemons)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -597,6 +616,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "+0.1 Basic Fruit Yield (Blueberries, Oranges)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -607,6 +627,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "+0.1 Advanced Fruit Yield (Apples, Bananas)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -617,6 +638,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: translate("skill.turboCharged"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -628,6 +650,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "Tomatoes & Lemons grows 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -638,6 +661,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "Blueberries & Oranges grows 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -648,6 +672,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "Apples & Bananas grows 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -659,6 +684,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts: "Tango Coins revenue doubled",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -669,6 +695,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts:
       "Ability to make all fruit currently growing ready to be harvested (1/72h)",
@@ -683,6 +710,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Trees drop +0.1 wood",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -693,6 +721,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Trees grow 10% quicker",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -703,6 +732,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Increase stock of axes by 50",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -713,6 +743,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "1 Tap Trees",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -724,6 +755,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Fruit plants drop +1 wood when chopped",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -734,6 +766,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "1/10 chance of +3 wood yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -744,6 +777,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Axes cost 20% less coins",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -754,6 +788,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "1% chance of finding 200 Coins when chopping trees",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -765,6 +800,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "Insta Grow Chance (10%)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -775,6 +811,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "Ability to make all trees instantly grow (1/24h)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -788,6 +825,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Composter speed 10% quicker",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -798,6 +836,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+5 Fishing daily limit",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -808,6 +847,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+1 EarthWorm bait from composting",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -818,6 +858,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "10% chance of +1 fish",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -829,6 +870,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "+1 Grub bait from composting",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -839,6 +881,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "+1 Red Wriggler bait from composting",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -849,6 +892,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Corale deliveries coin revenue increased by 50%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -859,6 +903,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Increase bar for catching game",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -870,6 +915,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+1 Bait from all composters",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -880,6 +926,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+1 Yield during fish frenzy",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -890,6 +937,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts:
       "+2 Baits from all composters but reduced fertiliser drop (-5 Sprout Mixes, -5 Rapid Growth, -1 Fruit Blend)",
@@ -901,6 +949,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+10 daily fishing limit but -1 bait from all composters",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -913,6 +962,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+0.1 Egg Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -923,6 +973,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Chickens lay eggs 10% quicker",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -934,6 +985,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Hay Bale effect increased to +0.4",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -944,6 +996,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Unlock 2nd Hay Bale",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -955,6 +1008,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+5 Hen capacity per House",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -965,6 +1019,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts:
       "Ability to instantly reduce egg laying time by 10hours to chickens currently laying eggs (1/96h)",
@@ -979,6 +1034,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "+0.2 Olive Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -989,6 +1045,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "+0.2 Rice Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -999,6 +1056,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "+0.2 Grape Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1010,6 +1068,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "10% faster Olive growth",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1020,6 +1079,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "10% faster Rice growth",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1030,6 +1090,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "10% faster Grape growth",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1041,6 +1102,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts:
       "Ability to make all Greenhouse crops currently growing ready to be harvested (1/96h)",
@@ -1053,6 +1115,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "5% Chances of +1 yield for Greenhouse crops/fruits",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1063,6 +1126,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "Greenhouse plants need 1 less oil",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1075,6 +1139,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+0.1 Stone Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1085,6 +1150,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+0.1 Iron Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1095,6 +1161,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Stone recovers 20% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1105,6 +1172,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Iron recovers 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1115,6 +1183,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "1 tap small mineral nodes",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1126,6 +1195,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "+20% Blacksmith deliveries revenue",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1136,6 +1206,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Pickaxes cost 20% less Coins",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1146,6 +1217,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Crimstone recovers 5% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1156,6 +1228,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "+1 Iron yield, -0.5 Stone yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1167,6 +1240,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+0.5 Gold Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1177,6 +1251,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "Gold Recovers 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1187,6 +1262,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts:
       "Increase stock of pickaxe by 70, stone pickaxe by 20, iron pickaxe by 7",
@@ -1198,6 +1274,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+1 Crimstone yield on 5th consecutive day",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1210,6 +1287,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Meals from Firepit, Kitchen cook 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1220,6 +1298,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+5% Food deliveries revenue",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1230,6 +1309,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "+5% Experience from eating meals",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1240,6 +1320,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "basic",
     },
     boosts: "Firepit cooking speed with oil increased by 40%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1251,6 +1332,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Cakes cook 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1261,6 +1343,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "+10% experience from drinking juices",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1271,6 +1354,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "50% chance of +1 food but requires 2x the ingredients",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1281,6 +1365,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "basic",
     },
     boosts: "Kitchen cooking speed with oil increased by 50%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1292,6 +1377,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts:
       "Ability make all meals currently cooking ready to be eaten (1/72h)",
@@ -1304,6 +1390,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "Eating meals from Deli adds +15% experience",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1314,6 +1401,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "+20% Chance of +1 food from Firepit",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1324,6 +1412,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "basic",
     },
     boosts: "Deli cooking speed with oil increased by 60%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1336,6 +1425,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "+0.1 Honey on claim",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1346,6 +1436,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "+0.1 Honey production speed",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1356,6 +1447,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "spring",
     },
     boosts: "Flowers grow 10% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1367,6 +1459,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "+10% Experience on food made with Honey",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1377,6 +1470,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "Increased gifting effect of flowers, +2 relationship",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1387,6 +1481,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "spring",
     },
     boosts: "Pollination effect increases to +0.3 yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1398,6 +1493,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts: "Increased Bee Swarm chance by 20%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1408,6 +1504,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts: "Flowers grow 20% faster",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1418,6 +1515,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts: "10% chance of +1 Flower",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1428,6 +1526,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "spring",
     },
     boosts: "Honey speed increased by +0.5 but yield reduced by -0.5",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1440,6 +1539,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "Crop Machine grow time reduced by 5% but consumes 10% more oil",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1450,6 +1550,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "Machine uses 10% less oil",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1460,6 +1561,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "+1 Oil when collecting from reserves",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1470,6 +1572,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 1,
       tier: 1,
+      island: "desert",
     },
     boosts: "Triple oil tank capacity",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1481,6 +1584,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "Add Carrot and Cabbage seeds to machine",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1491,6 +1595,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "Crops grow 20% faster but consumes 40% more oil",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1501,6 +1606,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 2,
       tier: 2,
+      island: "desert",
     },
     boosts: "Oil refill time reduced by 20%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1512,6 +1618,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "+5 packs added to machine",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1522,6 +1629,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "+5 plots added to machine",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1532,6 +1640,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "Machine uses 30% less oil",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
@@ -1542,6 +1651,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     requirements: {
       points: 3,
       tier: 3,
+      island: "desert",
     },
     boosts: "Ability to make empty oil wells instantly refill (1/96h)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -484,6 +484,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
     boosts: translate("skill.oldFarmer"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Turbo Charged": {
+    name: "Turbo Charged",
+    tree: "Crops",
+    requirements: {
+      points: 1,
+      tier: 1,
+      island: "basic",
+    },
+    boosts: translate("skill.turboCharged"),
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
+
   // Crops - Tier 2
   "Strong Roots": {
     name: "Strong Roots",
@@ -630,17 +642,6 @@ export const BUMPKIN_REVAMP_SKILL_TREE: Record<
       island: "spring",
     },
     boosts: "+0.1 Advanced Fruit Yield (Apples, Bananas)",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-  },
-  "Turbo Charged": {
-    name: "Turbo Charged",
-    tree: "Crops",
-    requirements: {
-      points: 1,
-      tier: 1,
-      island: "spring",
-    },
-    boosts: translate("skill.turboCharged"),
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   // Fruit - Tier 2
@@ -1665,13 +1666,21 @@ export const SKILL_TREE_CATEGORIES = Array.from(
   ),
 );
 
-export const REVAMP_SKILL_TREE_CATEGORIES = Array.from(
-  new Set(
-    getKeys(BUMPKIN_REVAMP_SKILL_TREE).map(
-      (skill) => BUMPKIN_REVAMP_SKILL_TREE[skill].tree,
+export const getRevampSkillTreeCategoriesByIsland = (
+  islandType: IslandType,
+) => {
+  const skillTreeCategoriesByIsland = Array.from(
+    new Set(
+      getKeys(BUMPKIN_REVAMP_SKILL_TREE)
+        .filter(
+          (skill) =>
+            BUMPKIN_REVAMP_SKILL_TREE[skill].requirements.island === islandType,
+        )
+        .map((skill) => BUMPKIN_REVAMP_SKILL_TREE[skill].tree),
     ),
-  ),
-);
+  );
+  return skillTreeCategoriesByIsland;
+};
 
 export const getSkills = (treeName: BumpkinSkillTree) => {
   return Object.values(BUMPKIN_SKILL_TREE).filter(

--- a/src/features/island/hud/components/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/BumpkinProfile.tsx
@@ -22,6 +22,7 @@ import classNames from "classnames";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { SpringValue } from "@react-spring/web";
 import { useSound } from "lib/utils/hooks/useSound";
+import { hasFeatureAccess } from "lib/flags";
 
 const DIMENSIONS = {
   original: 80,
@@ -221,7 +222,9 @@ export const BumpkinProfile: React.FC<{
 
   const handleShowHomeModal = () => {
     profile.play();
-    setViewSkillsPage(showSkillPointAlert);
+    setViewSkillsPage(
+      !hasFeatureAccess(state, "SKILLS_REVAMP") ? showSkillPointAlert : false,
+    );
     setShowModal(true);
     if (showSkillPointAlert) {
       acknowledgeSkillPoints(state.bumpkin);


### PR DESCRIPTION
# Description

This PR adds island type requirement for categories of skills that they unlock later on 

![image](https://github.com/user-attachments/assets/7583104b-bc49-4fe2-98b4-0304ba58d5f3)
![image](https://github.com/user-attachments/assets/0f6ce9fe-490a-4589-9000-3fb29e53f722)


If player hasn't reached the island, a label will show saying they need to unlock the island
![image](https://github.com/user-attachments/assets/b8445b1b-535c-4ca5-a5e0-13a2a3e8ec7c)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
