### PR TITLE
[FIX] Use standard error modal

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -551,21 +551,7 @@ export const GameWrapper: React.FC = ({ children }) => {
               </>
             )}
             {effectFailure && (
-              <>
-                <div className="p-1.5">
-                  <Label type="danger" className="mb-2">
-                    {t("error")}
-                  </Label>
-                  <p className="text-sm mb-2">{t(effectTranslationKey)}</p>
-                </div>
-                <Button
-                  onClick={() => {
-                    gameService.send("CONTINUE");
-                  }}
-                >
-                  {t("close")}
-                </Button>
-              </>
+              <ErrorMessage errorCode={errorCode as ErrorCode} />
             )}
 
             {loading && <Loading />}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -437,6 +437,7 @@ const EFFECT_STATES = Object.values(EFFECT_EVENTS).reduce(
     [`${stateName}Failure`]: {
       on: {
         CONTINUE: { target: "playing" },
+        REFRESH: { target: "playing" },
       },
     },
     [stateName]: {


### PR DESCRIPTION
# Description

Use the standard error modal when an `effect` fails.

This will help us debug the error codes players are facing in testing the marketplace.