### PR TITLE
[FIX] Resources doesn't reward trade points

### DIFF
--- a/src/features/game/events/claimPurchase.test.ts
+++ b/src/features/game/events/claimPurchase.test.ts
@@ -288,6 +288,7 @@ describe("purchase.claimed", () => {
       },
     });
     expect(state.trades.tradePoints).toEqual(70);
+    expect(state.inventory["Trade Point"]).toEqual(new Decimal(70));
   });
 
   it("awards lesser trade points when claiming an instant trade", () => {
@@ -325,5 +326,46 @@ describe("purchase.claimed", () => {
       },
     });
     expect(state.trades.tradePoints).toEqual(28);
+    expect(state.inventory["Trade Point"]).toEqual(new Decimal(28));
+  });
+
+  it("does not award trade points for resources", () => {
+    const state = claimPurchase({
+      state: {
+        ...TEST_FARM,
+        trades: {
+          listings: {
+            "123": {
+              collection: "collectibles",
+              items: {
+                Barley: 1,
+              },
+              sfl: 13,
+              createdAt: 0,
+              fulfilledAt: Date.now() - 60 * 1000,
+              fulfilledById: 43,
+            },
+            "124": {
+              collection: "collectibles",
+              items: {
+                Feather: 1,
+              },
+              sfl: 13,
+              createdAt: 0,
+              fulfilledAt: Date.now() - 60 * 1000,
+              fulfilledById: 43,
+            },
+          },
+        },
+      },
+      action: {
+        type: "purchase.claimed",
+        tradeIds: ["123", "124"],
+      },
+    });
+    expect(state.trades.tradePoints ?? 0).toEqual(0);
+    expect(state.inventory["Trade Point"] ?? new Decimal(0)).toEqual(
+      new Decimal(0),
+    );
   });
 });

--- a/src/features/game/events/claimPurchase.ts
+++ b/src/features/game/events/claimPurchase.ts
@@ -54,6 +54,7 @@ export function claimPurchase({ state, action }: Options) {
         state: game,
         points: 1,
         sfl: game.trades.listings?.[purchaseId].sfl ?? 0,
+        items: game.trades.listings?.[purchaseId].items,
       });
     });
 
@@ -62,6 +63,7 @@ export function claimPurchase({ state, action }: Options) {
         state: game,
         points: 5,
         sfl: game.trades.listings?.[purchaseId].sfl ?? 0,
+        items: game.trades.listings?.[purchaseId].items,
       });
     });
 

--- a/src/features/game/events/claimPurchase.ts
+++ b/src/features/game/events/claimPurchase.ts
@@ -63,7 +63,6 @@ export function claimPurchase({ state, action }: Options) {
         state: game,
         points: 5,
         sfl: game.trades.listings?.[purchaseId].sfl ?? 0,
-        items: game.trades.listings?.[purchaseId].items,
       });
     });
 

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -1,15 +1,46 @@
 import Decimal from "decimal.js-light";
-import { GameState } from "features/game/types/game";
+import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
+import { KNOWN_IDS } from "features/game/types";
+import { getKeys } from "features/game/types/decorations";
+import { GameState, InventoryItemName } from "features/game/types/game";
+import { MarketplaceTradeableName } from "features/game/types/marketplace";
 
 export function addTradePoints({
   state,
   points,
   sfl,
+  items,
+  itemName,
 }: {
   state: GameState;
   points: number;
   sfl: number;
+  items?: Partial<Record<MarketplaceTradeableName, number>>;
+  itemName?: string;
 }) {
+  // Exclude resources
+  // Some functinos use items object and some others just have itemName itself. Creating different conditions for each case
+  if (items) {
+    const name = getKeys(items).filter(
+      (itemName) => itemName in KNOWN_IDS,
+    )[0] as InventoryItemName;
+    const isResource = getKeys(TRADE_LIMITS).includes(name);
+
+    if (isResource) {
+      return state;
+    }
+  }
+
+  if (itemName) {
+    const isResource = getKeys(TRADE_LIMITS).includes(
+      itemName as InventoryItemName,
+    );
+
+    if (isResource) {
+      return state;
+    }
+  }
+
   // Define Constants
   const TRADE_POINTS_MULTIPLIER = 1; // Value adjustable
   const pointsCalculation = 1 + sfl ** TRADE_POINTS_MULTIPLIER;

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -10,13 +10,11 @@ export function addTradePoints({
   points,
   sfl,
   items,
-  itemName,
 }: {
   state: GameState;
   points: number;
   sfl: number;
   items?: Partial<Record<MarketplaceTradeableName, number>>;
-  itemName?: string;
 }) {
   // Exclude resources
   // Some functinos use items object and some others just have itemName itself. Creating different conditions for each case
@@ -25,16 +23,6 @@ export function addTradePoints({
       (itemName) => itemName in KNOWN_IDS,
     )[0] as InventoryItemName;
     const isResource = getKeys(TRADE_LIMITS).includes(name);
-
-    if (isResource) {
-      return state;
-    }
-  }
-
-  if (itemName) {
-    const isResource = getKeys(TRADE_LIMITS).includes(
-      itemName as InventoryItemName,
-    );
 
     if (isResource) {
       return state;

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -17,7 +17,6 @@ export function addTradePoints({
   items?: Partial<Record<MarketplaceTradeableName, number>>;
 }) {
   // Exclude resources
-  // Some functinos use items object and some others just have itemName itself. Creating different conditions for each case
   if (items) {
     const name = getKeys(items).filter(
       (itemName) => itemName in KNOWN_IDS,

--- a/src/features/game/events/landExpansion/offerClaimed.test.ts
+++ b/src/features/game/events/landExpansion/offerClaimed.test.ts
@@ -215,6 +215,38 @@ describe("offer.claimed", () => {
     expect(state.trades.tradePoints).toBeGreaterThanOrEqual(160);
   });
 
+  it("does not reward trade points for resources", () => {
+    const state = claimOffer({
+      action: {
+        tradeIds: ["123"],
+        type: "offer.claimed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        trades: {
+          offers: {
+            "123": {
+              collection: "collectibles",
+              items: {
+                Barley: 1,
+              },
+              createdAt: Date.now(),
+              sfl: 15,
+              fulfilledAt: Date.now(),
+              fulfilledById: 67,
+              signature: "123",
+            },
+          },
+        },
+      },
+    });
+
+    expect(state.trades.tradePoints ?? 0).toEqual(0);
+    expect(state.inventory["Trade Point"] ?? new Decimal(0)).toEqual(
+      new Decimal(0),
+    );
+  });
+
   it("gives the items from multiple instant offers", () => {
     const state = claimOffer({
       action: {

--- a/src/features/game/events/landExpansion/offerClaimed.test.ts
+++ b/src/features/game/events/landExpansion/offerClaimed.test.ts
@@ -234,7 +234,6 @@ describe("offer.claimed", () => {
               sfl: 15,
               fulfilledAt: Date.now(),
               fulfilledById: 67,
-              signature: "123",
             },
           },
         },

--- a/src/features/game/events/landExpansion/offerClaimed.ts
+++ b/src/features/game/events/landExpansion/offerClaimed.ts
@@ -59,14 +59,17 @@ export function claimOffer({ state, action, createdAt = Date.now() }: Options) {
     // Remove trade
     offerIds.forEach((offerId) => {
       const offer = game.trades.offers?.[offerId] as TradeOffer;
-      const points = offer.signature ? 10 : 2;
 
-      game = addTradePoints({
-        state: game,
-        points,
-        sfl: offer.sfl,
-        items: offer.items,
-      });
+      if (offer.signature) {
+        game = addTradePoints({ state: game, points: 10, sfl: offer.sfl });
+      } else {
+        game = addTradePoints({
+          state: game,
+          points: 2,
+          sfl: offer.sfl,
+          items: offer.items,
+        });
+      }
 
       delete game.trades.offers?.[offerId];
     });

--- a/src/features/game/events/landExpansion/offerClaimed.ts
+++ b/src/features/game/events/landExpansion/offerClaimed.ts
@@ -61,7 +61,12 @@ export function claimOffer({ state, action, createdAt = Date.now() }: Options) {
       const offer = game.trades.offers?.[offerId] as TradeOffer;
       const points = offer.signature ? 10 : 2;
 
-      game = addTradePoints({ state: game, points, sfl: offer.sfl });
+      game = addTradePoints({
+        state: game,
+        points,
+        sfl: offer.sfl,
+        items: offer.items,
+      });
 
       delete game.trades.offers?.[offerId];
     });


### PR DESCRIPTION
# Description

Resources is currently rewarding trade points when they shouldn't.

Adds a check in addTradePoints to not reward trade points for resource trades

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
