### PR TITLE
[FIX] Allow claimPurchase to handle old trade system

### DIFF
--- a/src/features/game/events/claimPurchase.test.ts
+++ b/src/features/game/events/claimPurchase.test.ts
@@ -368,4 +368,33 @@ describe("purchase.claimed", () => {
       new Decimal(0),
     );
   });
+
+  it("allows a player to claim a purchase that was bought in the old trade system", () => {
+    const state = claimPurchase({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(0),
+        trades: {
+          listings: {
+            "123": {
+              collection: "collectibles",
+              items: {
+                Potato: 200,
+              },
+              sfl: 1,
+              createdAt: 0,
+              boughtAt: Date.now() - 60 * 1000,
+              buyerId: 43,
+            },
+          },
+        },
+      },
+      action: {
+        type: "purchase.claimed",
+        tradeIds: ["123"],
+      },
+    });
+
+    expect(state.balance).toStrictEqual(new Decimal(0.9));
+  });
 });

--- a/src/features/game/events/claimPurchase.ts
+++ b/src/features/game/events/claimPurchase.ts
@@ -28,7 +28,10 @@ export function claimPurchase({ state, action }: Options) {
 
     if (
       purchaseIds.some(
-        (purchaseId) => !game.trades.listings?.[purchaseId].fulfilledAt,
+        (purchaseId) =>
+          !game.trades.listings?.[purchaseId].fulfilledAt &&
+          // To handle old trade system
+          !game.trades.listings?.[purchaseId].boughtAt,
       )
     ) {
       throw new Error("One or more purchases have not been fulfilled");


### PR DESCRIPTION
# Description

Update `claimPurchase` to handle trades bought through the old trade system.

Fixes #issue

# What needs to be tested by the reviewer?

- Check code

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
