### PR TITLE
[FIX] Dont render Red Pansy if dirty

### DIFF
--- a/src/features/game/types/flowers.ts
+++ b/src/features/game/types/flowers.ts
@@ -372,6 +372,13 @@ export const FLOWERS: Record<FlowerName, Flower> = {
   ...LILY_FLOWERS,
 };
 
+export type FlowerGrowthStage =
+  | "seedling"
+  | "sprout"
+  | "halfway"
+  | "almost"
+  | "ready";
+
 type Lifecycle = {
   seedling: any;
   sprout: any;

--- a/src/features/island/flowers/FlowerBed.tsx
+++ b/src/features/island/flowers/FlowerBed.tsx
@@ -12,6 +12,7 @@ import {
   FLOWER_LIFECYCLE,
   FLOWER_SEEDS,
   FlowerName,
+  FlowerGrowthStage,
 } from "features/game/types/flowers";
 import { TimerPopover } from "../common/TimerPopover";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -62,6 +63,23 @@ const FlowerCongratulations: React.FC<{ flowerName: FlowerName }> = ({
     ))}
   </div>
 );
+
+const getGrowthStage = (
+  growPercentage: number,
+  dirty: boolean,
+): FlowerGrowthStage => {
+  // It's possible with boosts that the initial growth stage is not sprout.
+  // Always render a sprout if the flower is dirt (i.e. data not from backend).
+  if (dirty) return "sprout";
+
+  return growPercentage >= 100
+    ? "ready"
+    : growPercentage >= 66
+      ? "almost"
+      : growPercentage >= 44
+        ? "halfway"
+        : "sprout";
+};
 
 export const FlowerBed: React.FC<Props> = ({ id }) => {
   const { t } = useAppTranslation();
@@ -117,16 +135,7 @@ export const FlowerBed: React.FC<Props> = ({ id }) => {
 
   const isGrowing = timeLeft > 0;
 
-  const stage =
-    growPercentage >= 100
-      ? "ready"
-      : growPercentage >= 66
-        ? "almost"
-        : growPercentage >= 44
-          ? "halfway"
-          : growPercentage >= 22
-            ? "sprout"
-            : "seedling";
+  const stage = getGrowthStage(growPercentage, !!flower.dirty);
 
   const hasHarvestedBefore = !!farmActivity[`${flower.name} Harvested`];
   const reward = flower.reward;


### PR DESCRIPTION
# Description

It's possible with boosts that the initial growth stage is not sprout.
Always render a sprout if the flower is dirty (i.e. data not from backend).

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
