### PR TITLE
[FIX] Hoarding Warning for resources

### DIFF
--- a/src/features/marketplace/components/PurchaseModalContent.tsx
+++ b/src/features/marketplace/components/PurchaseModalContent.tsx
@@ -8,6 +8,15 @@ import walletIcon from "assets/icons/wallet.png";
 import { Context } from "features/game/GameProvider";
 import { TradeableItemDetails } from "./TradeableSummary";
 import { KNOWN_ITEMS } from "features/game/types";
+import { useSelector } from "@xstate/react";
+import { MachineState } from "features/game/lib/gameMachine";
+import { hasMaxItems } from "features/game/lib/processEvent";
+import Decimal from "decimal.js-light";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+
+const _inventory = (state: MachineState) => state.context.state.inventory;
+const _previousInventory = (state: MachineState) =>
+  state.context.state.previousInventory;
 
 type PurchaseModalContentProps = {
   authToken: string;
@@ -27,12 +36,31 @@ export const PurchaseModalContent: React.FC<PurchaseModalContentProps> = ({
   listing,
 }) => {
   const { gameService } = useContext(Context);
+  const { openModal } = useContext(ModalContext);
   const { t } = useAppTranslation();
+
+  const inventory = useSelector(gameService, _inventory);
+  const previousInventory = useSelector(gameService, _previousInventory);
 
   const collection = getCollectionName(KNOWN_ITEMS[tradeable.id]);
   const display = getTradeableDisplay({
     id: tradeable.id,
     type: collection,
+  });
+
+  let updatedInventory = inventory;
+  if (collection === "resources" || collection === "collectibles") {
+    updatedInventory = {
+      ...inventory,
+      [KNOWN_ITEMS[tradeable.id]]: (
+        inventory[KNOWN_ITEMS[tradeable.id]] ?? new Decimal(0)
+      ).add(listing.quantity),
+    };
+  }
+
+  const hasMax = hasMaxItems({
+    current: updatedInventory,
+    old: previousInventory,
   });
 
   const confirm = async () => {
@@ -47,6 +75,39 @@ export const PurchaseModalContent: React.FC<PurchaseModalContentProps> = ({
     onClose();
   };
 
+  if (hasMax && listing.type === "instant") {
+    return (
+      <>
+        <div className="p-2">
+          <div className="flex justify-between">
+            <Label type="danger" className="mb-2 ml-1" icon={walletIcon}>
+              {t("marketplace.hoarding")}
+            </Label>
+          </div>
+          <p className="mb-3">{t("marketplace.hoarding.description")}</p>
+          <div className="opacity-50">
+            <TradeableItemDetails
+              display={display}
+              sfl={price}
+              quantity={listing.quantity}
+            />
+          </div>
+        </div>
+        <div className="flex space-x-1">
+          <Button onClick={onClose}>{t("cancel")}</Button>
+          <Button
+            onClick={() => {
+              onClose();
+              openModal("STORE_ON_CHAIN");
+            }}
+            className="relative"
+          >
+            <span>{t("gameOptions.blockchainSettings.storeOnChain")}</span>
+          </Button>
+        </div>
+      </>
+    );
+  }
   return (
     <>
       <div className="p-2">
@@ -67,7 +128,11 @@ export const PurchaseModalContent: React.FC<PurchaseModalContentProps> = ({
       </div>
       <div className="flex space-x-1">
         <Button onClick={onClose}>{t("cancel")}</Button>
-        <Button onClick={() => confirm()} className="relative">
+        <Button
+          onClick={() => confirm()}
+          disabled={hasMax}
+          className="relative"
+        >
           <span>{t("confirm")}</span>
           {listing.type === "onchain" && (
             <img src={walletIcon} className="absolute right-1 top-0.5 h-7" />

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4445,5 +4445,7 @@
   "marketplace.oneDayChange": "24h Change",
   "marketplace.sevenDayChange": "7d Change",
   "marketplace.sales": "Sales",
-  "marketplace.currentPrice": "Current Price"
+  "marketplace.currentPrice": "Current Price",
+  "marketplace.hoarding": "Store progress required",
+  "marketplace.hoarding.description": "You must store your game progress in order to be able to purchase this listing."
 }


### PR DESCRIPTION
# Description

Adds a hoarding check when buying a listing.

<img width="609" alt="store" src="https://github.com/user-attachments/assets/6b570c60-077a-4fc3-8299-f11a2ebca9cb">

# What needs to be tested by the reviewer?

Set one farm up close to hoarding limit
Attempt to buy a listing that pushes over the hoarding limit

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes