### PR TITLE
[FEAT] Temporary items

### DIFF
--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -17,6 +17,8 @@ export type Tradeable = {
   floor: number;
   supply: number;
   collection: CollectionName;
+  isActive: boolean;
+  expiresAt?: number;
 };
 
 export type Offer = {

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -71,7 +71,9 @@ const AcceptOfferContent: React.FC<{
 
   if (display.type === "collectibles") {
     const name = KNOWN_ITEMS[itemId];
-    hasItem = !!getChestItems(game)[name]?.gte(1);
+    hasItem =
+      !!getChestItems(game)[name]?.gte(1) ||
+      !!getBasketItems(game.inventory)[name]?.gte(1);
   }
 
   if (display.type === "wearables") {

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -72,8 +72,13 @@ const AcceptOfferContent: React.FC<{
   if (display.type === "collectibles") {
     const name = KNOWN_ITEMS[itemId];
     hasItem =
-      !!getChestItems(game)[name]?.gte(1) ||
-      !!getBasketItems(game.inventory)[name]?.gte(1);
+      !!getChestItems(game)[name]?.gte(offer.quantity) ||
+      !!getBasketItems(game.inventory)[name]?.gte(offer.quantity);
+  }
+
+  if (display.type === "resources") {
+    const name = KNOWN_ITEMS[itemId];
+    hasItem = !!getBasketItems(game.inventory)[name]?.gte(offer.quantity);
   }
 
   if (display.type === "wearables") {

--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -82,6 +82,7 @@ export const Collection: React.FC<{
                   );
                   onNavigated?.();
                 }}
+                expiresAt={item.expiresAt}
               />
             </div>
           );

--- a/src/features/marketplace/components/ListViewCard.tsx
+++ b/src/features/marketplace/components/ListViewCard.tsx
@@ -14,12 +14,15 @@ import { getKeys } from "features/game/types/craftables";
 import { InventoryItemName } from "features/game/types/game";
 import { Label } from "components/ui/Label";
 import classNames from "classnames";
+import { secondsToString } from "lib/utils/time";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 type Props = {
   details: TradeableDisplay;
   count?: number;
   price?: Decimal;
   onClick?: () => void;
+  expiresAt?: number;
 };
 
 export const ListViewCard: React.FC<Props> = ({
@@ -27,6 +30,7 @@ export const ListViewCard: React.FC<Props> = ({
   price,
   onClick,
   count,
+  expiresAt,
 }) => {
   const { type, name, image, buff } = details;
   const { t } = useAppTranslation();
@@ -102,6 +106,18 @@ export const ListViewCard: React.FC<Props> = ({
                 className="h-4 mr-1"
               />
               <p className="text-xs truncate pb-0.5">{buff.shortDescription}</p>
+            </div>
+          )}
+
+          {expiresAt && (
+            <div className="flex items-center">
+              <img src={SUNNYSIDE.icons.stopwatch} className="h-4 mr-1" />
+              <p className="text-xs truncate pb-0.5">
+                {" "}
+                {`${secondsToString((expiresAt - Date.now()) / 1000, {
+                  length: "short",
+                })} left`}
+              </p>
             </div>
           )}
         </div>

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -216,6 +216,16 @@ const Filters: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           />
 
           <Option
+            icon={SUNNYSIDE.icons.stopwatch}
+            label="Limited"
+            onClick={() => {
+              navigate(`/marketplace/collection?filters=temporary`);
+              onClose();
+            }}
+            isActive={filters === "temporary"}
+          />
+
+          <Option
             icon={SUNNYSIDE.icons.heart}
             label="Cosmetics"
             onClick={() => {

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -29,10 +29,10 @@ import { TradeableListings } from "./TradeableListings";
 import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { TradeableStats } from "./TradeableStats";
-import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 import { getKeys } from "features/game/types/decorations";
 import { tradeToId } from "../lib/offers";
 import { getDayOfYear } from "lib/utils/time";
+import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 
 export const Tradeable: React.FC = () => {
   const { authService } = useContext(Auth.Context);
@@ -64,11 +64,10 @@ export const Tradeable: React.FC = () => {
   if (display.type === "collectibles") {
     const name = KNOWN_ITEMS[Number(id)];
 
-    if (name in TRADE_LIMITS) {
-      // Resources
-      count = getBasketItems(inventory)[name]?.toNumber() ?? 0;
-    } else {
+    if (name in COLLECTIBLES_DIMENSIONS) {
       count = getChestItems(game)[name]?.toNumber() ?? 0;
+    } else {
+      count = getBasketItems(inventory)[name]?.toNumber() ?? 0;
     }
   }
 

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -115,7 +115,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
     getKeys(TRADE_LIMITS).includes(KNOWN_ITEMS[Number(params.id)]) &&
     params.collection === "collectibles";
 
-  const showBuyNow = !isResources && cheapestListing;
+  const showBuyNow = !isResources && cheapestListing && tradeable?.isActive;
   const showWalletRequired = showBuyNow && cheapestListing?.type === "onchain";
   const showFreeListing = !isVIP && dailyListings === 0;
 
@@ -260,13 +260,15 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                   {t("marketplace.buyNow")}
                 </Button>
               )}
-              <Button
-                disabled={!count}
-                onClick={onListClick}
-                className="w-full sm:w-auto"
-              >
-                {t("marketplace.listForSale")}
-              </Button>
+              {tradeable?.isActive && (
+                <Button
+                  disabled={!count}
+                  onClick={onListClick}
+                  className="w-full sm:w-auto"
+                >
+                  {t("marketplace.listForSale")}
+                </Button>
+              )}
             </div>
           </div>
         </div>
@@ -281,13 +283,15 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               {t("marketplace.buyNow")}
             </Button>
           )}
-          <Button
-            onClick={onListClick}
-            disabled={!count || (!isVIP && dailyListings >= 1)}
-            className="w-full sm:w-auto"
-          >
-            {t("marketplace.listForSale")}
-          </Button>
+          {tradeable?.isActive && (
+            <Button
+              onClick={onListClick}
+              disabled={!count || (!isVIP && dailyListings >= 1)}
+              className="w-full sm:w-auto"
+            >
+              {t("marketplace.listForSale")}
+            </Button>
+          )}
         </div>
       </InnerPanel>
     </>

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -108,7 +108,7 @@ export const TradeableDescription: React.FC<{
       {tradeable && !tradeable?.isActive && (
         <div className="p-2">
           <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
-            {`Not for sale`}
+            {t("marketplace.notForSale")}
           </Label>
         </div>
       )}

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -14,6 +14,7 @@ import { getKeys } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 import { useParams } from "react-router-dom";
 import { TradeableStats } from "./TradeableStats";
+import { secondsToString } from "lib/utils/time";
 
 export const TradeableImage: React.FC<{
   display: TradeableDisplay;
@@ -74,7 +75,8 @@ export const TradeableImage: React.FC<{
 
 export const TradeableDescription: React.FC<{
   display: TradeableDisplay;
-}> = ({ display }) => {
+  tradeable?: TradeableDetails;
+}> = ({ display, tradeable }) => {
   const { t } = useAppTranslation();
 
   return (
@@ -94,6 +96,22 @@ export const TradeableDescription: React.FC<{
           </Label>
         )}
       </div>
+      {tradeable?.expiresAt && (
+        <div className="p-2">
+          <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+            {`${secondsToString((tradeable.expiresAt - Date.now()) / 1000, {
+              length: "short",
+            })} left`}
+          </Label>
+        </div>
+      )}
+      {tradeable && !tradeable?.isActive && (
+        <div className="p-2">
+          <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
+            {`Not for sale`}
+          </Label>
+        </div>
+      )}
     </InnerPanel>
   );
 };
@@ -105,7 +123,7 @@ export const TradeableInfo: React.FC<{
   return (
     <>
       <TradeableImage display={display} supply={tradeable?.supply} />
-      <TradeableDescription display={display} />
+      <TradeableDescription display={display} tradeable={tradeable} />
     </>
   );
 };

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -32,7 +32,11 @@ import { getTradeType } from "../lib/getTradeType";
 import { ResourceList } from "./ResourceList";
 import { KNOWN_ITEMS } from "features/game/types";
 import Decimal from "decimal.js-light";
-import { getKeys } from "features/game/types/craftables";
+import {
+  CollectibleName,
+  COLLECTIBLES_DIMENSIONS,
+  getKeys,
+} from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 
 type TradeableListItemProps = {
@@ -92,15 +96,23 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
   };
 
   const getAvailable = () => {
+    const isPlaceable =
+      COLLECTIBLES_DIMENSIONS[display.name as CollectibleName];
     switch (display.type) {
       case "collectibles":
-        return isResource
-          ? getBasketItems(state.inventory)[
+        if (isPlaceable) {
+          return (
+            getChestItems(state)[
               display.name as InventoryItemName
             ]?.toNumber() ?? 0
-          : getChestItems(state)[
-              display.name as InventoryItemName
-            ]?.toNumber() ?? 0;
+          );
+        }
+
+        return (
+          getBasketItems(state.inventory)[
+            display.name as InventoryItemName
+          ]?.toNumber() ?? 0
+        );
       case "buds":
         return getChestBuds(state)[id] ? 1 : 0;
       case "wearables":

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -182,14 +182,17 @@ export const TradeableOffers: React.FC<{
               )}
               {!loading && (
                 <div className="flex items-center">
-                  <Button
-                    className="w-full sm:w-fit mr-1"
-                    disabled={!tradeable}
-                    onClick={() => setShowMakeOffer(true)}
-                  >
-                    {t("marketplace.makeOffer")}
-                  </Button>
-                  {topOffer && (
+                  {tradeable?.isActive && (
+                    <Button
+                      className="w-full sm:w-fit mr-1"
+                      disabled={!tradeable || !tradeable?.isActive}
+                      onClick={() => setShowMakeOffer(true)}
+                    >
+                      {t("marketplace.makeOffer")}
+                    </Button>
+                  )}
+
+                  {topOffer && tradeable?.isActive && (
                     <Button
                       onClick={() => setShowAcceptOffer(true)}
                       className="w-fit "

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4470,5 +4470,6 @@
   "marketplace.welcome.seven": "The marketplace items are intended for in-game use, not speculation or investment",
   "marketplace.welcome.gotIt": "Got it",
   "marketplace.welcome.title": "Welcome to the Marketplace",
-  "marketplace.topFriends": "Top Friends"
+  "marketplace.topFriends": "Top Friends",
+  "marketplace.notForSale": "Not for sale"
 }


### PR DESCRIPTION
# Description

Adds support for 'temporary' items. This includes bounties and Bert's obsessions. Includes:

- You can now access non tradeable items, but they are marked as Not for sale
- "Limited" section
- Buy, list, offers etc for items during this period.

<img width="999" alt="Screenshot 2024-12-04 at 7 01 24 PM" src="https://github.com/user-attachments/assets/3af863e9-0263-4f85-833c-b614ca4b4d39">

## How to tests?

1. Connect to local API
2. Go to Limited section
3. Open an item & list, buy, offer it
4. Go to a non tradeable item (manually change ID in URL and refresh) > should not be able to trade.