### PR TITLE
[FIX] Cancel Collectibles Only From Old Board

### DIFF
--- a/src/features/bumpkins/components/Trade.tsx
+++ b/src/features/bumpkins/components/Trade.tsx
@@ -478,9 +478,13 @@ export const Trade: React.FC<{
 
   const resourceListings = getKeys(trades).filter((listingId) => {
     const listing = trades[listingId];
+    const collection = listing.collection;
     const item = getKeys(listing.items)[0];
 
-    return getKeys(TRADE_LIMITS).includes(item as InventoryItemName);
+    return (
+      getKeys(TRADE_LIMITS).includes(item as InventoryItemName) &&
+      collection === "collectibles"
+    );
   });
 
   const onList = (items: Items, sfl: number) => {

--- a/src/features/game/events/landExpansion/cancelTrade.test.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.test.ts
@@ -14,6 +14,33 @@ describe("cancelTrade", () => {
       }),
     ).toThrow("Trade #123 does not exist");
   });
+
+  it("throws if not collectible", () => {
+    expect(() =>
+      cancelTrade({
+        action: {
+          tradeId: "123",
+          type: "trade.cancelled",
+        },
+        state: {
+          ...TEST_FARM,
+          trades: {
+            listings: {
+              "123": {
+                collection: "wearables",
+                createdAt: 1000000,
+                sfl: 5,
+                items: {
+                  Parsnip: 10,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("Trade #123 is not a collectible");
+  });
+
   it("enures trade is not bought", () => {
     expect(() =>
       cancelTrade({

--- a/src/features/game/events/landExpansion/cancelTrade.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.ts
@@ -26,6 +26,10 @@ export function cancelTrade({
       throw new Error(`Trade #${action.tradeId} does not exist`);
     }
 
+    if (trade.collection !== "collectibles") {
+      throw new Error(`Trade #${action.tradeId} is not a collectible`);
+    }
+
     if (trade.boughtAt) {
       throw new Error(`Trade #${action.tradeId} already bought`);
     }

--- a/src/features/marketplace/components/ListViewCard.tsx
+++ b/src/features/marketplace/components/ListViewCard.tsx
@@ -30,7 +30,6 @@ export const ListViewCard: React.FC<Props> = ({
 }) => {
   const { type, name, image, buff } = details;
   const { t } = useAppTranslation();
-  const isResources = getKeys(TRADE_LIMITS).includes(name as InventoryItemName);
 
   const itemId = getItemId({ name, collection: type });
   const tradeType = getTradeType({
@@ -38,6 +37,9 @@ export const ListViewCard: React.FC<Props> = ({
     id: itemId,
     trade: { sfl: price?.toNumber() ?? 0 },
   });
+  const isResources =
+    getKeys(TRADE_LIMITS).includes(name as InventoryItemName) &&
+    type === "collectibles";
 
   return (
     <div className="relative cursor-pointer h-full">


### PR DESCRIPTION
# Description

- Only cancel collectible trades from old trade board

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
