### PR TITLE
[CHORE] Put Marketplace Rewards behind separate feature flag

### DIFF
--- a/src/features/marketplace/components/rewards/MarketplaceRewardsShop.tsx
+++ b/src/features/marketplace/components/rewards/MarketplaceRewardsShop.tsx
@@ -12,6 +12,7 @@ import { Context } from "features/game/GameProvider";
 import { ItemDetail } from "./ItemDetail";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Modal } from "components/ui/Modal";
+import { hasFeatureAccess } from "lib/flags";
 
 export const TradeRewardsShop: React.FC = () => {
   const { t } = useAppTranslation();
@@ -31,6 +32,15 @@ export const TradeRewardsShop: React.FC = () => {
   };
 
   const onClose = () => setShowDetails(false);
+
+  if (!hasFeatureAccess(state, "MARKETPLACE_REWARDS")) {
+    return (
+      <InnerPanel className="h-auto  w-full mb-1">
+        <p>{`Coming Soon`}</p>
+      </InnerPanel>
+    );
+  }
+
   return (
     <>
       <InnerPanel className="h-auto  w-full mb-1">

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -46,6 +46,7 @@ const featureFlags = {
   SEASONAL_TIERS: timeBasedFeatureFlag(new Date("2024-11-01T00:00:00Z")),
   MARKETPLACE: defaultFeatureFlag,
   MARKETPLACE_ADMIN: adminFeatureFlag,
+  MARKETPLACE_REWARDS: defaultFeatureFlag,
   CROP_QUICK_SELECT: () => false,
   PORTALS: testnetFeatureFlag,
   JEST_TEST: defaultFeatureFlag,


### PR DESCRIPTION
# Description

I've created a separate feature flag for marketplace rewards. This allows us to release it independently from the main marketplace feature. We'll monitor the average trade points players are earning and adjust the reward shop values accordingly.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
