### PR TITLE
[FIX] Show amount that shop will restock to, instead of amount that will be added to shop

### DIFF
--- a/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
@@ -12,7 +12,6 @@ import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDeta
 import { Label } from "components/ui/Label";
 import confetti from "canvas-confetti";
 import { Box } from "components/ui/Box";
-import Decimal from "decimal.js-light";
 import { INITIAL_STOCK, StockableName } from "features/game/lib/constants";
 import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { SEEDS } from "features/game/types/seeds";
@@ -64,32 +63,13 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
     onClose();
   };
 
-  const getRestockAmount = (item: StockableName, amount: Decimal): Decimal => {
-    const remainingStock = state.stock[item];
+  const restockTools = Object.entries(INITIAL_STOCK(state)).filter(
+    (item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS },
+  );
 
-    // If there's no stock left
-    if (!remainingStock) {
-      // return total stock amount
-      return amount;
-    } else {
-      // else return difference between total and remaining stock
-      return amount.sub(remainingStock);
-    }
-  };
-
-  const restockTools = Object.entries(INITIAL_STOCK(state))
-    .filter((item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS })
-    .filter(([item, amount]) => {
-      const restockAmount = getRestockAmount(item as StockableName, amount);
-      return restockAmount.gt(0);
-    });
-
-  const restockSeeds = Object.entries(INITIAL_STOCK(state))
-    .filter((item) => item[0] in SEEDS())
-    .filter(([item, amount]) => {
-      const restockAmount = getRestockAmount(item as StockableName, amount);
-      return restockAmount.gt(0);
-    });
+  const restockSeeds = Object.entries(INITIAL_STOCK(state)).filter(
+    (item) => item[0] in SEEDS(),
+  );
 
   return (
     <>
@@ -98,7 +78,7 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
           {t("restock")}
         </Label>
         <p className="mb-1">{t("gems.buyReplenish")}</p>
-        <div className="mb-2 text-xs">{t("restock.itemsToRestock")}</div>
+        <div className="mb-2 text-xs">{t("restock.restocktoAmount")}</div>
       </div>
       <div className="mt-1 h-40 overflow-y-auto overflow-x-hidden scrollable pl-1">
         {restockTools.length > 0 && (
@@ -114,7 +94,7 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
           {restockTools.map(([item, amount]) => (
             <Box
               key={item}
-              count={getRestockAmount(item as StockableName, amount)}
+              count={amount}
               image={ITEM_DETAILS[item as StockableName].image}
             />
           ))}
@@ -132,7 +112,7 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
           {restockSeeds.map(([item, amount]) => (
             <Box
               key={item}
-              count={getRestockAmount(item as StockableName, amount)}
+              count={amount}
               image={ITEM_DETAILS[item as StockableName].image}
             />
           ))}

--- a/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
@@ -12,7 +12,6 @@ import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDeta
 import { Label } from "components/ui/Label";
 import confetti from "canvas-confetti";
 import { Box } from "components/ui/Box";
-import Decimal from "decimal.js-light";
 import { INITIAL_STOCK, StockableName } from "features/game/lib/constants";
 import {
   RestockItems,
@@ -71,26 +70,11 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
     onClose();
   };
 
-  const getRestockAmount = (item: StockableName, amount: Decimal): Decimal => {
-    const remainingStock = state.stock[item];
-
-    // If there's no stock left
-    if (!remainingStock) {
-      // return total stock amount
-      return amount;
-    } else {
-      // else return difference between total and remaining stock
-      return amount.sub(remainingStock);
-    }
-  };
-
   const { labelText, icon } = categoryLabel;
 
-  const restockItems = Object.entries(INITIAL_STOCK(state))
-    .filter((item) => item[0] in restockItem)
-    .filter(([item, amount]) =>
-      getRestockAmount(item as StockableName, amount).gt(0),
-    );
+  const restockItems = Object.entries(INITIAL_STOCK(state)).filter(
+    (item) => item[0] in restockItem,
+  );
 
   return (
     <>
@@ -104,7 +88,7 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
             gemPrice,
           })}
         </p>
-        <div className="mb-2 text-xs">{t("restock.itemsToRestock")}</div>
+        <div className="mb-2 text-xs">{t("restock.restocktoAmount")}</div>
       </div>
       <div className="mt-1 h-40 overflow-y-auto overflow-x-hidden scrollable pl-1">
         {restockItems.length > 0 && (
@@ -116,7 +100,7 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
               {restockItems.map(([item, amount]) => (
                 <Box
                   key={item}
-                  count={getRestockAmount(item as StockableName, amount)}
+                  count={amount}
                   image={ITEM_DETAILS[item as StockableName].image}
                 />
               ))}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3772,6 +3772,7 @@
   "restock.outOfStock": "{{npc}} ran out of stock. Choose your desired restock option below:",
   "restock.selectOption": "Select your desired restock option:",
   "restock.itemsToRestock": "The following quantities will be added to the existing stock in your shop:",
+  "restock.restocktoAmount": "Your shop will restock to the following amounts:",
   "restock.moreStock": "Restock to get more stock.",
   "restock.dailyShipment": "Daily Shipment",
   "restock.shipmentArrived": "Your daily free shipment has arrived!",


### PR DESCRIPTION
# Description

After some feedback and deliberation, I realised how confusing the previous amounts were when they showed the amount that would be added to the stock. 

Showing the amount your shop would restock **to** is clearer and players can fact-check it afterwards.

Shipment restock will still show the amount that will be added to their stock since it's not a full restock

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/defdf42c-c4de-4de0-a470-7f957c82f4b3)|![image](https://github.com/user-attachments/assets/70b5bacf-f8b5-404c-b0b3-978431865983)|

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
