### PR TITLE
[FEAT] SFL USD

### DIFF
--- a/src/features/game/actions/loadSession.ts
+++ b/src/features/game/actions/loadSession.ts
@@ -36,6 +36,12 @@ type Response = {
   discordId?: string;
   fslId?: string;
   oauthNonce: string;
+  prices: {
+    sfl: {
+      usd: number;
+      timestamp: number;
+    };
+  };
 };
 
 const API_URL = CONFIG.API_URL;
@@ -107,6 +113,7 @@ export async function loadSession(request: Request): Promise<Response> {
     discordId,
     fslId,
     oauthNonce,
+    prices,
   } = await sanitizeHTTPResponse<{
     farm: any;
     startedAt: string;
@@ -128,6 +135,12 @@ export async function loadSession(request: Request): Promise<Response> {
     discordId?: string;
     fslId?: string;
     oauthNonce: string;
+    prices: {
+      sfl: {
+        usd: number;
+        timestamp: number;
+      };
+    };
   }>(response);
 
   saveSession(farm.id);
@@ -151,6 +164,7 @@ export async function loadSession(request: Request): Promise<Response> {
     fslId,
     discordId,
     oauthNonce,
+    prices,
   };
 }
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -137,6 +137,12 @@ export interface Context {
     wardrobe: Record<BumpkinItem, number>;
   };
   announcements: Announcements;
+  prices: {
+    sfl: {
+      usd: number;
+      timestamp: number;
+    } | null;
+  };
   auctionResults?: AuctionResults;
   promoCode?: string;
   moderation: Moderation;
@@ -638,6 +644,12 @@ export function startGame(authContext: AuthContext) {
         state: EMPTY,
         sessionId: INITIAL_SESSION,
         announcements: {},
+        prices: {
+          sfl: {
+            timestamp: Date.now(),
+            usd: 1.23,
+          },
+        },
         moderation: {
           muted: [],
           kicked: [],
@@ -705,6 +717,7 @@ export function startGame(authContext: AuthContext) {
                 discordId: response.discordId,
                 fslId: response.fslId,
                 oauthNonce: response.oauthNonce,
+                prices: response.prices,
               };
             },
             onDone: [
@@ -2120,6 +2133,7 @@ export function startGame(authContext: AuthContext) {
           discordId: (_, event) => event.data.discordId,
           fslId: (_, event) => event.data.fslId,
           oauthNonce: (_, event) => event.data.oauthNonce,
+          prices: (_, event) => event.data.prices,
         }),
         setTransactionId: assign<Context, any>({
           transactionId: () => randomID(),

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -683,7 +683,10 @@ export function startGame(authContext: AuthContext) {
               }),
             },
           ],
-          entry: () => preloadHotNow(authContext.user.rawToken as string),
+          entry: () => {
+            if (CONFIG.API_URL)
+              preloadHotNow(authContext.user.rawToken as string);
+          },
           invoke: {
             src: async (context) => {
               const fingerprint = "X";

--- a/src/features/marketplace/components/ListViewCard.tsx
+++ b/src/features/marketplace/components/ListViewCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import Decimal from "decimal.js-light";
 import { ButtonPanel } from "components/ui/Panel";
 import sfl from "assets/icons/sfl.webp";
@@ -16,6 +16,7 @@ import { Label } from "components/ui/Label";
 import classNames from "classnames";
 import { secondsToString } from "lib/utils/time";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { Context } from "features/game/GameProvider";
 
 type Props = {
   details: TradeableDisplay;
@@ -32,6 +33,9 @@ export const ListViewCard: React.FC<Props> = ({
   count,
   expiresAt,
 }) => {
+  const { gameService } = useContext(Context);
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   const { type, name, image, buff } = details;
   const { t } = useAppTranslation();
 
@@ -71,18 +75,23 @@ export const ListViewCard: React.FC<Props> = ({
           }}
         >
           {price && price.gt(0) && (
-            <div className="flex items-center absolute top-0 left-0">
-              <img src={sfl} className="h-4 sm:h-5 mr-1" />
-              <p className="text-xs whitespace-nowrap">
-                {isResources
-                  ? t("marketplace.pricePerUnit", {
-                      price: formatNumber(price, {
+            <div className="absolute top-0 left-0">
+              <div className="flex items-center ">
+                <img src={sfl} className="h-4 sm:h-5 mr-1" />
+                <p className="text-xs whitespace-nowrap">
+                  {isResources
+                    ? t("marketplace.pricePerUnit", {
+                        price: formatNumber(price, {
+                          decimalPlaces: 4,
+                        }),
+                      })
+                    : `${formatNumber(price, {
                         decimalPlaces: 4,
-                      }),
-                    })
-                  : `${formatNumber(price, {
-                      decimalPlaces: 4,
-                    })}`}
+                      })}`}
+                </p>
+              </div>
+              <p className="text-xxs">
+                ${new Decimal(usd).mul(price).toFixed(2)}
               </p>
             </div>
           )}

--- a/src/features/marketplace/components/ListViewCard.tsx
+++ b/src/features/marketplace/components/ListViewCard.tsx
@@ -91,7 +91,7 @@ export const ListViewCard: React.FC<Props> = ({
                 </p>
               </div>
               <p className="text-xxs">
-                ${new Decimal(usd).mul(price).toFixed(2)}
+                {`$${new Decimal(usd).mul(price).toFixed(2)}`}
               </p>
             </div>
           )}

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -23,6 +23,7 @@ import { InventoryItemName } from "features/game/types/game";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 import { getKeys } from "features/game/types/craftables";
 import { KNOWN_ITEMS } from "features/game/types";
+import Decimal from "decimal.js-light";
 
 const _balance = (state: MachineState) => state.context.state.balance;
 
@@ -35,6 +36,8 @@ export const MakeOffer: React.FC<{
 }> = ({ onClose, display, itemId, authToken, floorPrice }) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
+
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   const balance = useSelector(gameService, _balance);
 
@@ -207,6 +210,9 @@ export const MakeOffer: React.FC<{
             isOutOfRange={balance.lt(offer)}
             icon={sflIcon}
           />
+          <p className="text-xxs ml-2">
+            {`$${new Decimal(usd).mul(offer).toFixed(2)}`}
+          </p>
         </div>
 
         <Label type="default" className="-ml-1 mb-1" icon={lockIcon}>

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -60,6 +60,10 @@ export const MarketplaceNavigation: React.FC = () => {
       <Modal show={showFilters} onHide={() => setShowFilters(false)}>
         <CloseButtonPanel>
           <Filters onClose={() => setShowFilters(false)} />
+          <EstimatedPrice
+            price={price}
+            onClick={() => setShowQuickswap(true)}
+          />
         </CloseButtonPanel>
       </Modal>
 
@@ -116,23 +120,10 @@ export const MarketplaceNavigation: React.FC = () => {
             </div>
           </InnerPanel>
 
-          <InnerPanel
-            className="cursor-pointer"
-            onClick={() => {
-              setShowQuickswap(true);
-            }}
-          >
-            <div className="flex justify-between items-center pr-1">
-              <div className="flex items-center">
-                <img src={sflIcon} className="w-6" />
-                <span className="text-sm ml-2">{`$${price.toFixed(2)}`}</span>
-              </div>
-              <p className="text-xxs underline">{t("marketplace.quickswap")}</p>
-            </div>
-            <p className="text-xxs italic">
-              {t("marketplace.estimated.price")}
-            </p>
-          </InnerPanel>
+          <EstimatedPrice
+            price={price}
+            onClick={() => setShowQuickswap(true)}
+          />
         </div>
 
         <div className="flex-1 flex flex-col w-full">
@@ -350,5 +341,24 @@ const Filters: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         </div>
       </div>
     </div>
+  );
+};
+
+const EstimatedPrice: React.FC<{ price: number; onClick: () => void }> = ({
+  price,
+  onClick,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <InnerPanel className="cursor-pointer" onClick={onClick}>
+      <div className="flex justify-between items-center pr-1">
+        <div className="flex items-center">
+          <img src={sflIcon} className="w-6" />
+          <span className="text-sm ml-2">{`$${price.toFixed(2)}`}</span>
+        </div>
+        <p className="text-xxs underline">{t("marketplace.quickswap")}</p>
+      </div>
+      <p className="text-xxs italic">{t("marketplace.estimated.price")}</p>
+    </InnerPanel>
   );
 };

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -35,17 +35,20 @@ import { Context } from "features/game/GameProvider";
 import * as Auth from "features/auth/lib/Provider";
 import { useActor } from "@xstate/react";
 import { useTranslation } from "react-i18next";
+import { Label } from "components/ui/Label";
+import { Button } from "components/ui/Button";
 
 export const MarketplaceNavigation: React.FC = () => {
   const [search, setSearch] = useState("");
   const [showFilters, setShowFilters] = useState(false);
+  const [showQuickswap, setShowQuickswap] = useState(false);
 
   const { authService } = useContext(Auth.Context);
   const [authState] = useActor(authService);
 
   useEffect(() => {
     const token = authState.context.user.rawToken as string;
-    preloadCollections(token);
+    if (CONFIG.API_URL) preloadCollections(token);
   }, []);
   const { t } = useTranslation();
 
@@ -57,6 +60,30 @@ export const MarketplaceNavigation: React.FC = () => {
       <Modal show={showFilters} onHide={() => setShowFilters(false)}>
         <CloseButtonPanel>
           <Filters onClose={() => setShowFilters(false)} />
+        </CloseButtonPanel>
+      </Modal>
+
+      <Modal show={showQuickswap} onHide={() => setShowQuickswap(false)}>
+        <CloseButtonPanel onClose={() => setShowQuickswap(false)}>
+          <div className="p-1">
+            <Label type="danger" className="mb-2">
+              {t("marketplace.quickswap")}
+            </Label>
+            <p className="text-sm mb-2">
+              {t("marketplace.quickswap.description")}
+            </p>
+            <p className="text-sm mb-2">{t("marketplace.quickswap.warning")}</p>
+            <Button
+              onClick={() => {
+                window.open(
+                  "https://quickswap.exchange/#/swap?swapIndex=0&currency0=ETH&currency1=0xD1f9c58e33933a993A3891F8acFe05a68E1afC05",
+                  "_blank",
+                );
+              }}
+            >
+              {t("continue")}
+            </Button>
+          </div>
         </CloseButtonPanel>
       </Modal>
 
@@ -92,7 +119,7 @@ export const MarketplaceNavigation: React.FC = () => {
           <InnerPanel
             className="cursor-pointer"
             onClick={() => {
-              window.open("https://sunflower-land.com/sfl", "_blank");
+              setShowQuickswap(true);
             }}
           >
             <div className="flex justify-between items-center pr-1">
@@ -102,6 +129,9 @@ export const MarketplaceNavigation: React.FC = () => {
               </div>
               <p className="text-xxs underline">{t("marketplace.quickswap")}</p>
             </div>
+            <p className="text-xxs italic">
+              {t("marketplace.estimated.price")}
+            </p>
           </InnerPanel>
         </div>
 

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -7,6 +7,7 @@ import lightning from "assets/icons/lightning.png";
 import filterIcon from "assets/icons/filter_icon.webp";
 import tradeIcon from "assets/icons/trade.png";
 import trade_point from "src/assets/icons/trade_points_coupon.webp";
+import sflIcon from "assets/icons/sfl.webp";
 
 import {
   Route,
@@ -46,6 +47,9 @@ export const MarketplaceNavigation: React.FC = () => {
     preloadCollections(token);
   }, []);
 
+  const { gameService } = useContext(Context);
+  const price = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   return (
     <>
       <Modal show={showFilters} onHide={() => setShowFilters(false)}>
@@ -68,19 +72,36 @@ export const MarketplaceNavigation: React.FC = () => {
       </div>
 
       <div className="flex h-[calc(100%-50px)] lg:h-full">
-        <InnerPanel className="w-64 h-96 mr-1 hidden lg:flex  flex-col">
-          <div className="flex  items-center">
-            <TextInput
-              icon={SUNNYSIDE.icons.search}
-              value={search}
-              onValueChange={setSearch}
-              onCancel={() => setSearch("")}
-            />
-          </div>
-          <div className="flex-1">
-            <Filters onClose={() => setShowFilters(false)} />
-          </div>
-        </InnerPanel>
+        <div className="w-64  mr-1 hidden lg:flex  flex-col">
+          <InnerPanel className="w-full flex-col mb-1">
+            <div className="flex  items-center">
+              <TextInput
+                icon={SUNNYSIDE.icons.search}
+                value={search}
+                onValueChange={setSearch}
+                onCancel={() => setSearch("")}
+              />
+            </div>
+            <div className="flex-1">
+              <Filters onClose={() => setShowFilters(false)} />
+            </div>
+          </InnerPanel>
+
+          <InnerPanel
+            className="cursor-pointer"
+            onClick={() => {
+              window.open("https://sunflower-land.com/sfl", "_blank");
+            }}
+          >
+            <div className="flex justify-between items-center pr-1">
+              <div className="flex items-center">
+                <img src={sflIcon} className="w-6" />
+                <span className="text-sm ml-2">{`$${price.toFixed(2)}`}</span>
+              </div>
+              <p className="text-xxs underline">Quickswap</p>
+            </div>
+          </InnerPanel>
+        </div>
 
         <div className="flex-1 flex flex-col w-full">
           {search ? (

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -34,6 +34,7 @@ import { hasFeatureAccess } from "lib/flags";
 import { Context } from "features/game/GameProvider";
 import * as Auth from "features/auth/lib/Provider";
 import { useActor } from "@xstate/react";
+import { useTranslation } from "react-i18next";
 
 export const MarketplaceNavigation: React.FC = () => {
   const [search, setSearch] = useState("");
@@ -46,6 +47,7 @@ export const MarketplaceNavigation: React.FC = () => {
     const token = authState.context.user.rawToken as string;
     preloadCollections(token);
   }, []);
+  const { t } = useTranslation();
 
   const { gameService } = useContext(Context);
   const price = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
@@ -98,7 +100,7 @@ export const MarketplaceNavigation: React.FC = () => {
                 <img src={sflIcon} className="w-6" />
                 <span className="text-sm ml-2">{`$${price.toFixed(2)}`}</span>
               </div>
-              <p className="text-xxs underline">Quickswap</p>
+              <p className="text-xxs underline">{t("marketplace.quickswap")}</p>
             </div>
           </InnerPanel>
         </div>

--- a/src/features/marketplace/components/MarketplaceHotNow.tsx
+++ b/src/features/marketplace/components/MarketplaceHotNow.tsx
@@ -17,8 +17,11 @@ import * as Auth from "features/auth/lib/Provider";
 import { useActor } from "@xstate/react";
 import { TopTrades } from "./TopTrades";
 import useSWR, { preload } from "swr";
+import { CONFIG } from "lib/config";
 
-const hotNowFetcher = ([, token]: [string, string]) => loadTrends({ token });
+const hotNowFetcher = ([, token]: [string, string]) => {
+  if (CONFIG.API_URL) return loadTrends({ token });
+};
 export const preloadHotNow = (token: string) =>
   preload(["/marketplace/trends", token], hotNowFetcher);
 

--- a/src/features/marketplace/components/TopTrades.tsx
+++ b/src/features/marketplace/components/TopTrades.tsx
@@ -1,6 +1,6 @@
 import { MarketplaceTrends } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React from "react";
+import React, { useContext } from "react";
 import { getTradeableDisplay } from "../lib/tradeables";
 import classNames from "classnames";
 import sflIcon from "assets/icons/sfl.webp";
@@ -9,12 +9,16 @@ import { Loading } from "features/auth/components";
 import { NPC } from "features/island/bumpkin/components/NPC";
 import { interpretTokenUri } from "lib/utils/tokenUriBuilder";
 import { useNavigate } from "react-router-dom";
+import { Context } from "features/game/GameProvider";
 
 export const TopTrades: React.FC<{
   trends?: MarketplaceTrends;
 }> = ({ trends }) => {
   const { t } = useAppTranslation();
   const navigate = useNavigate();
+  const { gameService } = useContext(Context);
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   if (!trends) {
     return <Loading />;
   }
@@ -69,8 +73,13 @@ export const TopTrades: React.FC<{
               </div>
 
               <div className="p-1.5 text-right relative flex items-center justify-end w-32">
-                <img src={sflIcon} className="h-5 mr-1" />
-                <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
+                <img src={sflIcon} className="h-6 mr-1" />
+                <div>
+                  <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
+                  <p className="text-xxs">
+                    ${new Decimal(usd).mul(price).toFixed(2)}
+                  </p>
+                </div>
               </div>
             </div>
           );

--- a/src/features/marketplace/components/TopTrades.tsx
+++ b/src/features/marketplace/components/TopTrades.tsx
@@ -77,7 +77,7 @@ export const TopTrades: React.FC<{
                 <div>
                   <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
                   <p className="text-xxs">
-                    ${new Decimal(usd).mul(price).toFixed(2)}
+                    {`$${new Decimal(usd).mul(price).toFixed(2)}`}
                   </p>
                 </div>
               </div>

--- a/src/features/marketplace/components/TradeTable.tsx
+++ b/src/features/marketplace/components/TradeTable.tsx
@@ -4,7 +4,7 @@ import {
   Listing,
   Offer,
 } from "features/game/types/marketplace";
-import React from "react";
+import React, { useContext } from "react";
 import { TradeableDisplay } from "../lib/tradeables";
 import Decimal from "decimal.js-light";
 import { formatNumber } from "lib/utils/formatNumber";
@@ -14,6 +14,7 @@ import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 import { InventoryItemName } from "features/game/types/game";
 import { NPC } from "features/island/bumpkin/components/NPC";
 import { interpretTokenUri } from "lib/utils/tokenUriBuilder";
+import { Context } from "features/game/GameProvider";
 
 type TradeTableItem = {
   price: number;
@@ -27,6 +28,9 @@ export const OfferTable: React.FC<{
   id: number;
   details: TradeableDisplay;
 }> = ({ offers, id, details }) => {
+  const { gameService } = useContext(Context);
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   if (offers.length === 0) {
     return null;
   }
@@ -74,8 +78,13 @@ export const OfferTable: React.FC<{
                   </p>
                 </div>
                 <div className="p-1.5 text-right relative flex items-center justify-end">
-                  <img src={sflIcon} className="h-5 mr-1" />
-                  <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
+                  <img src={sflIcon} className="h-6 mr-1" />
+                  <div>
+                    <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
+                    <p className="text-xxs">
+                      ${new Decimal(usd).mul(price).toFixed(2)}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -91,6 +100,9 @@ export const ListingTable: React.FC<{
   collection: CollectionName;
   details: TradeableDisplay;
 }> = ({ listings, collection, details }) => {
+  const { gameService } = useContext(Context);
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   return (
     <div className="w-full text-xs  border-collapse  ">
       <div>
@@ -139,16 +151,21 @@ export const ListingTable: React.FC<{
                   </p>
                 </div>
                 <div className="p-1.5 text-right relative flex items-center justify-end">
-                  <img src={sflIcon} className="h-5 mr-1" />
-                  <p className="text-sm">
-                    {new Decimal(
-                      isResource
-                        ? formatNumber(price / Number(quantity), {
-                            decimalPlaces: 4,
-                          })
-                        : price,
-                    ).toFixed(2)}
-                  </p>
+                  <img src={sflIcon} className="h-6 mr-1" />
+                  <div>
+                    <p className="text-sm">
+                      {new Decimal(
+                        isResource
+                          ? formatNumber(price / Number(quantity), {
+                              decimalPlaces: 4,
+                            })
+                          : price,
+                      ).toFixed(2)}
+                    </p>
+                    <p className="text-xxs">
+                      ${new Decimal(usd).mul(price).toFixed(2)}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/features/marketplace/components/TradeTable.tsx
+++ b/src/features/marketplace/components/TradeTable.tsx
@@ -82,7 +82,7 @@ export const OfferTable: React.FC<{
                   <div>
                     <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
                     <p className="text-xxs">
-                      ${new Decimal(usd).mul(price).toFixed(2)}
+                      {`${new Decimal(usd).mul(price).toFixed(2)}`}
                     </p>
                   </div>
                 </div>
@@ -163,7 +163,7 @@ export const ListingTable: React.FC<{
                       ).toFixed(2)}
                     </p>
                     <p className="text-xxs">
-                      ${new Decimal(usd).mul(price).toFixed(2)}
+                      {`$${new Decimal(usd).mul(price).toFixed(2)}`}
                     </p>
                   </div>
                 </div>

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -218,10 +218,9 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                         : cheapestListing?.sfl ?? "? SFL"}
                     </p>
                     <p className="text-xs">
-                      $
-                      {new Decimal(usd)
+                      {`${new Decimal(usd)
                         .mul(cheapestListing?.sfl ?? 0)
-                        .toFixed(2)}
+                        .toFixed(2)}`}
                     </p>
                   </div>
                 </>

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -35,6 +35,7 @@ import { ModalContext } from "features/game/components/modal/ModalProvider";
 import classNames from "classnames";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { isMobile } from "mobile-device-detect";
+import Decimal from "decimal.js-light";
 
 type TradeableHeaderProps = {
   authToken: string;
@@ -118,6 +119,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   const showBuyNow = !isResources && cheapestListing && tradeable?.isActive;
   const showWalletRequired = showBuyNow && cheapestListing?.type === "onchain";
   const showFreeListing = !isVIP && dailyListings === 0;
+
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   return (
     <>
@@ -204,14 +207,23 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               <div className="flex items-center mr-2 sm:mb-0.5 -ml-1">
                 <>
                   <img src={sflIcon} className="h-8 mr-2" />
-                  <p
+                  <div
                     className={classNames(
-                      "text-base",
                       !tradeable ? "loading-fade-pulse" : "",
                     )}
                   >
-                    {!tradeable ? "0.00 SFL" : cheapestListing?.sfl ?? "? SFL"}
-                  </p>
+                    <p className={classNames("text-base")}>
+                      {!tradeable
+                        ? "0.00 SFL"
+                        : cheapestListing?.sfl ?? "? SFL"}
+                    </p>
+                    <p className="text-xs">
+                      $
+                      {new Decimal(usd)
+                        .mul(cheapestListing?.sfl ?? 0)
+                        .toFixed(2)}
+                    </p>
+                  </div>
                 </>
               </div>
             )}

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -278,6 +278,8 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
     );
   }
 
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
   return (
     <div className="flex flex-col">
       <div className="flex justify-between">
@@ -321,6 +323,9 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
                 maxDecimalPlaces={2}
                 icon={sflIcon}
               />
+              <p className="text-xxs ml-2">
+                {`$${new Decimal(usd).mul(price).toFixed(2)}`}
+              </p>
             </div>
             <div
               className="flex justify-between"

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -177,7 +177,7 @@ export const TradeableOffers: React.FC<{
                   <div>
                     <p className="text-base">{`${topOffer.sfl} SFL`}</p>
                     <p className="text-xxs">
-                      ${new Decimal(usd).mul(topOffer.sfl).toFixed(2)}
+                      {`$${new Decimal(usd).mul(topOffer.sfl).toFixed(2)}`}
                     </p>
                   </div>
                 </div>

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -36,6 +36,7 @@ import { VIPAccess } from "features/game/components/VipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { useParams } from "react-router-dom";
+import Decimal from "decimal.js-light";
 
 // JWT TOKEN
 
@@ -61,6 +62,8 @@ export const TradeableOffers: React.FC<{
   const isVIP = useSelector(gameService, _isVIP);
   const { t } = useAppTranslation();
   const { id } = useParams();
+
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,
@@ -171,7 +174,12 @@ export const TradeableOffers: React.FC<{
               {topOffer ? (
                 <div className="flex items-center">
                   <img src={sflIcon} className="h-8 mr-2" />
-                  <p className="text-base">{`${topOffer.sfl} SFL`}</p>
+                  <div>
+                    <p className="text-base">{`${topOffer.sfl} SFL`}</p>
+                    <p className="text-xxs">
+                      ${new Decimal(usd).mul(topOffer.sfl).toFixed(2)}
+                    </p>
+                  </div>
                 </div>
               ) : !loading && tradeable?.offers.length === 0 ? (
                 <p className="text-sm self-end mb-2 text-left">

--- a/src/features/marketplace/components/TrendingTrades.tsx
+++ b/src/features/marketplace/components/TrendingTrades.tsx
@@ -91,7 +91,7 @@ export const TrendingTrades: React.FC<{
                       {new Decimal(prices.dates[0].low).toFixed(2)}
                     </p>
                     <p className="text-xxs">
-                      ${new Decimal(usd).mul(prices.dates[0].low).toFixed(2)}
+                      {`$${new Decimal(usd).mul(prices.dates[0].low).toFixed(2)}`}
                     </p>
                   </div>
                 </div>

--- a/src/features/marketplace/components/TrendingTrades.tsx
+++ b/src/features/marketplace/components/TrendingTrades.tsx
@@ -3,7 +3,7 @@ import {
   MarketplaceTrends,
 } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React from "react";
+import React, { useContext } from "react";
 import { getTradeableDisplay } from "../lib/tradeables";
 import classNames from "classnames";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -12,12 +12,16 @@ import increaseIcon from "assets/icons/increase_arrow.png";
 import decreaseIcon from "assets/icons/decrease_arrow.png";
 import Decimal from "decimal.js-light";
 import { Loading } from "features/auth/components";
+import { Context } from "features/game/GameProvider";
 
 export const TrendingTrades: React.FC<{
   trends?: MarketplaceTrends;
 }> = ({ trends }) => {
   const { t } = useAppTranslation();
   const isWorldRoute = useLocation().pathname.includes("/world");
+
+  const { gameService } = useContext(Context);
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   const navigate = useNavigate();
 
@@ -82,9 +86,14 @@ export const TrendingTrades: React.FC<{
               <td className="p-1.5 text-left relative">
                 <div className="flex items-center">
                   <img src={sflIcon} className="h-5 mr-1" />
-                  <p className="text-sm">
-                    {new Decimal(prices.dates[0].low).toFixed(2)}
-                  </p>
+                  <div>
+                    <p className="text-sm">
+                      {new Decimal(prices.dates[0].low).toFixed(2)}
+                    </p>
+                    <p className="text-xxs">
+                      ${new Decimal(usd).mul(prices.dates[0].low).toFixed(2)}
+                    </p>
+                  </div>
                 </div>
               </td>
               <td className="p-1.5 text-right relative">

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -187,7 +187,7 @@ export const MyListings: React.FC = () => {
                             <div>
                               <span className="sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
                               <p className="text-xxs">
-                                ${new Decimal(usd).mul(price).toFixed(2)}
+                                {`$${new Decimal(usd).mul(price).toFixed(2)}`}
                               </p>
                             </div>
                           </div>

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -22,6 +22,7 @@ import { AuthMachineState } from "features/auth/lib/authMachine";
 import { RemoveListing } from "../RemoveListing";
 import { tradeToId } from "features/marketplace/lib/offers";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
+import Decimal from "decimal.js-light";
 
 const _isCancellingOffer = (state: MachineState) =>
   state.matches("marketplaceListingCancelling");
@@ -35,6 +36,8 @@ export const MyListings: React.FC = () => {
   const { gameService } = useContext(Context);
   const { authService } = useContext(Auth.Context);
   const isWorldRoute = useLocation().pathname.includes("/world");
+
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   const [claimId, setClaimId] = useState<string>();
   const [removeListingId, setRemoveListingId] = useState<string>();
@@ -179,10 +182,16 @@ export const MyListings: React.FC = () => {
                       </div>
                       <div className="p-1.5 truncate flex flex-1 items-center">
                         <div className="flex flex-col items-start justify-center">
-                          <div className="flex justify-start space-x-1">
-                            <img src={sflIcon} className="h-5" />
-                            <span className="sm:text-sm">{`${price.toFixed(2)}`}</span>
+                          <div className="flex items-center justify-start space-x-1">
+                            <img src={sflIcon} className="h-6" />
+                            <div>
+                              <span className="sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
+                              <p className="text-xxs">
+                                ${new Decimal(usd).mul(price).toFixed(2)}
+                              </p>
+                            </div>
                           </div>
+
                           {isResource && (
                             <div className="text-xxs w-full text-end">
                               {t("bumpkinTrade.price/unit", {

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -25,6 +25,7 @@ import { Button } from "components/ui/Button";
 import { InventoryItemName } from "features/game/types/game";
 import { formatNumber } from "lib/utils/formatNumber";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
+import Decimal from "decimal.js-light";
 
 const _authToken = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
@@ -88,6 +89,8 @@ export const MyOffers: React.FC = () => {
 
     setClaimId(undefined);
   };
+
+  const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   return (
     <>
@@ -198,11 +201,14 @@ export const MyOffers: React.FC = () => {
                       </div>
                       <div className="p-1.5 truncate flex flex-1 items-center">
                         <div className="flex flex-col items-start justify-center">
-                          <div className="flex justify-start space-x-1">
-                            <img src={sflIcon} className="h-5" />
-                            <span className="sm:text-sm">
-                              {price.toFixed(2)}
-                            </span>
+                          <div className="flex items-center justify-start space-x-1">
+                            <img src={sflIcon} className="h-6" />
+                            <div>
+                              <span className="sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
+                              <p className="text-xxs">
+                                ${new Decimal(usd).mul(price).toFixed(2)}
+                              </p>
+                            </div>
                           </div>
                           {isResource && (
                             <div className="text-xxs w-full text-end">

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -206,7 +206,7 @@ export const MyOffers: React.FC = () => {
                             <div>
                               <span className="sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
                               <p className="text-xxs">
-                                ${new Decimal(usd).mul(price).toFixed(2)}
+                                {`$${new Decimal(usd).mul(price).toFixed(2)}`}
                               </p>
                             </div>
                           </div>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4477,5 +4477,6 @@
   "marketplace.welcome.gotIt": "Got it",
   "marketplace.welcome.title": "Welcome to the Marketplace",
   "marketplace.topFriends": "Top Friends",
-  "marketplace.notForSale": "Not for sale"
+  "marketplace.notForSale": "Not for sale",
+  "marketplace.quickswap": "Quickswap"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4478,5 +4478,9 @@
   "marketplace.welcome.title": "Welcome to the Marketplace",
   "marketplace.topFriends": "Top Friends",
   "marketplace.notForSale": "Not for sale",
-  "marketplace.quickswap": "Quickswap"
+  "marketplace.quickswap": "Quickswap",
+  "marketplace.quickswap.description": "You are about to be redirected to Quickswap, a decentralized and community-driven exchange to buy $SFL.",
+  "marketplace.quickswap.warning": "Prices shown in-game are estimated based on community prices & may not reflect the current market. Proceed at your own risk.",
+  "marketplace.estimated.price": "*Estimated SFL/USD price",
+  "marketplace.quickswap.continue": "Continue"
 }


### PR DESCRIPTION
# Description

Adds indicators for SFL/USD based on Quickswap. This helps players give some relative value when listing/offering items.

**Includes**

- SFL $USD price on left of Marketplace
- A **dollar** value next to SFL listed prices in the marketplace

<img width="1133" alt="Screenshot 2024-12-05 at 8 17 04 PM" src="https://github.com/user-attachments/assets/0b0afbde-3fd1-4d97-aac1-b95f6366abad">
<img width="192" alt="Screenshot 2024-12-05 at 8 17 09 PM" src="https://github.com/user-attachments/assets/7564987b-2ef5-4713-b98a-8c07e26a637c">
<img width="881" alt="Screenshot 2024-12-05 at 8 17 31 PM" src="https://github.com/user-attachments/assets/7c74a265-c8ff-43d3-b017-596518fae41d">
<img width="528" alt="Screenshot 2024-12-05 at 8 22 26 PM" src="https://github.com/user-attachments/assets/ab5ddcbc-d201-4af0-8b2a-58c9fd4c72bb">

## How to test?

_Note: Testnet prices are based on a testnet pool and are not the normal SFL price._

SFL prices are updated **hourly** on a CRON job. This means the price will likely be 0.00 when you start testing.

1. Connect to API
2. Open marketplace and navigate around