### PR TITLE
[FEAT] Festive Tree 2024 Reward + Logic Update

### DIFF
--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -226,3 +226,12 @@ export const MANEKI_NEKO_REWARDS: ChestReward[] = [
   { items: { "Kale Stew": 1 }, weighting: 10 },
   { items: { "Sunflower Cake": 1 }, weighting: 5 },
 ];
+
+export const FESTIVE_TREE_REWARDS: ChestReward[] = [
+  { items: { "Treasure Key": 1 }, wearables: {}, weighting: 20 },
+  { items: { "Golden Christmas Stocking": 1 }, wearables: {}, weighting: 20 },
+  { items: { "Christmas Candle": 1 }, wearables: {}, weighting: 20 },
+  { items: { "Christmas Rug": 1 }, wearables: {}, weighting: 20 },
+  { items: { "Rare Key": 1 }, wearables: {}, weighting: 10 },
+  { items: {}, wearables: { "Candy Cane": 1 }, weighting: 10 },
+];

--- a/src/features/island/collectibles/components/FestiveTree.tsx
+++ b/src/features/island/collectibles/components/FestiveTree.tsx
@@ -5,7 +5,6 @@ import festiveTreeImage from "assets/sfts/festive_tree.png";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
-import { Revealing } from "features/game/components/Revealing";
 import { Revealed } from "features/game/components/Revealed";
 import { Panel } from "components/ui/Panel";
 import { Modal } from "components/ui/Modal";
@@ -14,6 +13,7 @@ import { Label } from "components/ui/Label";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { NPC_WEARABLES } from "lib/npcs";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { ChestRevealing } from "features/world/ui/chests/ChestRevealing";
 
 interface Props {
   id: string;
@@ -26,7 +26,10 @@ export const FestiveTree: React.FC<Props> = ({ id }) => {
 
   const [showGiftedModal, setShowGiftedModal] = useState(false);
   const [showWrongTimeModal, setShowWrongTimeModal] = useState(false);
-  const trees = gameState.context.state.collectibles["Festive Tree"] ?? [];
+  const trees = [
+    ...(gameState.context.state.collectibles["Festive Tree"] || []),
+    ...(gameState.context.state.home.collectibles["Festive Tree"] || []),
+  ];
   const tree = trees.find((t) => t.id === id);
 
   const [isRevealing, setIsRevealing] = useState(false);
@@ -105,8 +108,8 @@ export const FestiveTree: React.FC<Props> = ({ id }) => {
 
       {gameState.matches("revealing") && isRevealing && (
         <Modal show>
-          <Panel bumpkinParts={NPC_WEARABLES.santa}>
-            <Revealing icon={festiveTreeImage} />
+          <Panel>
+            <ChestRevealing type="Festive Tree Rewards" />
           </Panel>
         </Modal>
       )}

--- a/src/features/world/ui/chests/ChestRevealing.tsx
+++ b/src/features/world/ui/chests/ChestRevealing.tsx
@@ -10,6 +10,7 @@ import {
   ChestReward,
   PIRATE_CHEST_REWARDS,
   MANEKI_NEKO_REWARDS,
+  FESTIVE_TREE_REWARDS,
 } from "features/game/types/chests";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React, { useCallback, useContext, useEffect } from "react";
@@ -35,7 +36,8 @@ export type ChestRewardType =
   | "Expert Desert Rewards"
   | "Pirate Chest"
   | "Maneki Neko"
-  | "Daily Reward";
+  | "Daily Reward"
+  | "Festive Tree Rewards";
 
 interface Props {
   type: ChestRewardType;
@@ -55,6 +57,7 @@ const CHEST_LOOT: (
   "Pirate Chest": PIRATE_CHEST_REWARDS,
   "Maneki Neko": MANEKI_NEKO_REWARDS,
   "Daily Reward": possibleRewards(state),
+  "Festive Tree Rewards": FESTIVE_TREE_REWARDS,
 });
 
 export const ChestRevealing: React.FC<Props> = ({ type }) => {


### PR DESCRIPTION

# Description

This PR updates the reward for Festive Tree and also makes Festive Tree to be shaken in both farm and home.
Also update Festive Tree to use the Chest Reveal Modal.

**Shaking Tree at Farm:**
![image](https://github.com/user-attachments/assets/0e6c2509-0580-4b3a-98a9-16e67e7c1e56)

**Shaking Tree at Home:**
![image](https://github.com/user-attachments/assets/f93e4b04-a13a-47ef-8063-82237404774f)


Fixes #issue

# What needs to be tested by the reviewer?

Connect to BE locally. 
Give yourself Festive Tree.
Place Festive Tree in Farm and claim reward.
Place Festive Tree in Home and claim reward.
# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
