### PR TITLE
[FEAT] Tradeable Layout

### DIFF
--- a/src/features/marketplace/actions/loadTradeable.ts
+++ b/src/features/marketplace/actions/loadTradeable.ts
@@ -16,6 +16,25 @@ export async function loadTradeable({
   id: number;
   token: string;
 }): Promise<TradeableDetails> {
+  if (!CONFIG.API_URL)
+    return {
+      id,
+      floor: 0,
+      supply: 0,
+      collection: type,
+      isActive: false,
+      offers: [],
+      listings: [],
+      history: {
+        sales: [],
+        history: {
+          totalSales: 0,
+          totalVolume: 0,
+          dates: {},
+        },
+      },
+    };
+
   const url = new URL(`${API_URL}/collection/${type}/${id}`);
   url.searchParams.append("type", type);
 

--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -9,9 +9,11 @@ import Decimal from "decimal.js-light";
 import { getTradeableDisplay } from "../lib/tradeables";
 import { InnerPanel } from "components/ui/Panel";
 import useSWR, { preload } from "swr";
+import { CONFIG } from "lib/config";
 
-export const collectionFetcher = ([filters, token]: [string, string]) =>
-  loadMarketplace({ filters, token });
+export const collectionFetcher = ([filters, token]: [string, string]) => {
+  if (CONFIG.API_URL) return loadMarketplace({ filters, token });
+};
 
 export const preloadCollections = (token: string) => {
   preload(["collectibles", token], collectionFetcher);

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -197,7 +197,7 @@ export const MakeOffer: React.FC<{
   return (
     <>
       <div className="p-2">
-        <div className="flex justify-between mb-2">
+        <div className="flex flex-wrap justify-between mb-2">
           <Label type="default" className="-ml-1 mb-1">
             {t("marketplace.makeOffer")}
           </Label>
@@ -207,7 +207,7 @@ export const MakeOffer: React.FC<{
               onUpgrade={() => {
                 openModal("BUY_BANNER");
               }}
-              text={t("marketplace.unlockSelling")}
+              // text={t("marketplace.unlockSelling")}
               labelType={!isVIP ? "danger" : undefined}
             />
           )}

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -8,7 +8,7 @@ import filterIcon from "assets/icons/filter_icon.webp";
 import tradeIcon from "assets/icons/trade.png";
 import trade_point from "src/assets/icons/trade_points_coupon.webp";
 import sflIcon from "assets/icons/sfl.webp";
-
+import crownIcon from "assets/icons/vip.webp";
 import {
   Route,
   Routes,
@@ -33,15 +33,23 @@ import { MarketplaceUser } from "./MarketplaceUser";
 import { hasFeatureAccess } from "lib/flags";
 import { Context } from "features/game/GameProvider";
 import * as Auth from "features/auth/lib/Provider";
-import { useActor } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { useTranslation } from "react-i18next";
 import { Label } from "components/ui/Label";
 import { Button } from "components/ui/Button";
+import { MachineState } from "features/game/lib/gameMachine";
+import { hasVipAccess } from "features/game/lib/vipAccess";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+
+const _isVIP = (state: MachineState) =>
+  hasVipAccess(state.context.state.inventory);
 
 export const MarketplaceNavigation: React.FC = () => {
   const [search, setSearch] = useState("");
   const [showFilters, setShowFilters] = useState(false);
   const [showQuickswap, setShowQuickswap] = useState(false);
+
+  const { openModal } = useContext(ModalContext);
 
   const { authService } = useContext(Auth.Context);
   const [authState] = useActor(authService);
@@ -54,6 +62,8 @@ export const MarketplaceNavigation: React.FC = () => {
 
   const { gameService } = useContext(Context);
   const price = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
+
+  const isVIP = useSelector(gameService, _isVIP);
 
   return (
     <>
@@ -124,6 +134,23 @@ export const MarketplaceNavigation: React.FC = () => {
             price={price}
             onClick={() => setShowQuickswap(true)}
           />
+
+          {!isVIP && (
+            <InnerPanel
+              className="p-2 cursor-pointer"
+              onClick={() => {
+                openModal("VIP_ITEMS");
+              }}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <Label icon={crownIcon} type="danger" className="ml-1">
+                  {t("vipAccess")}
+                </Label>
+                <p className="text-xxs underline">{t("readMore")}</p>
+              </div>
+              <p className="text-xxs">{t("marketplace.wantToUnlock")}</p>
+            </InnerPanel>
+          )}
         </div>
 
         <div className="flex-1 flex flex-col w-full">
@@ -350,7 +377,7 @@ const EstimatedPrice: React.FC<{ price: number; onClick: () => void }> = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <InnerPanel className="cursor-pointer" onClick={onClick}>
+    <InnerPanel className="cursor-pointer mb-1" onClick={onClick}>
       <div className="flex justify-between items-center pr-1">
         <div className="flex items-center">
           <img src={sflIcon} className="w-6" />

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -30,7 +30,6 @@ import { tradeToId } from "../lib/offers";
 import { getDayOfYear } from "lib/utils/time";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import useSWR from "swr";
-import { Label } from "components/ui/Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const Tradeable: React.FC = () => {
@@ -141,23 +140,14 @@ export const Tradeable: React.FC = () => {
             <img src={SUNNYSIDE.icons.arrow_left} className="h-6 mr-2 mt-1" />
             <p className="capitalize underline">{display.name}</p>
           </div>
-          <Label
-            secondaryIcon={SUNNYSIDE.icons.basket}
-            type="transparent"
-            className="mr-4"
-          >
+          <p className="text-xs mr-4">
             {t("marketplace.youOwn", {
               count: Math.floor(count),
             })}
-          </Label>
+          </p>
         </div>
       </InnerPanel>
-      <InnerPanel className="flex flex-col sm:flex-row w-full mr-1 mb-1">
-        {/* {isMobile ? (
-          <TradeableMobileInfo display={display} tradeable={tradeable} />
-        ) : ( */}
-        {/* <TradeableInfo display={display} tradeable={tradeable} /> */}
-        {/* )} */}
+      <InnerPanel className="flex flex-col sm:flex-row w-full mb-1">
         <div className="w-full sm:w-1/3 md:w-1/4 sm:max-w-[300px] mr-2">
           <TradeableImage display={display} supply={tradeable?.supply} />
         </div>

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -147,8 +147,46 @@ export const Tradeable: React.FC = () => {
           </p>
         </div>
       </InnerPanel>
-      <InnerPanel className="flex flex-col sm:flex-row w-full mb-1">
-        <div className="w-full sm:w-1/3 md:w-1/4 sm:max-w-[300px] mr-2">
+      {/* Mobile Header */}
+      <InnerPanel className=" w-full mb-1 sm:hidden flex">
+        <div className="w-1/3 mr-2">
+          <TradeableImage display={display} supply={tradeable?.supply} />
+        </div>
+        <div className="flex-1">
+          <TradeableHeader
+            dailyListings={getDailyListings()}
+            authToken={authToken}
+            farmId={farmId}
+            collection={collection as CollectionName}
+            display={display}
+            count={count}
+            tradeable={tradeable}
+            onBack={onBack}
+            reload={reload}
+            onListClick={() => setShowListItem(true)}
+          />
+        </div>
+        {/* <div className="flex-1 flex flex-col">
+          <TradeableDescription display={display} tradeable={tradeable} />
+
+          <div className="flex flex-1 items-end">
+            <TradeableStats history={tradeable?.history} price={latestSale} />
+          </div>
+        </div> */}
+      </InnerPanel>
+      <InnerPanel className=" w-full mb-1 sm:hidden flex">
+        <div className="flex-1 flex flex-col">
+          <TradeableDescription display={display} tradeable={tradeable} />
+
+          <div className="flex flex-1 items-end">
+            <TradeableStats history={tradeable?.history} price={latestSale} />
+          </div>
+        </div>
+      </InnerPanel>
+
+      {/* Desktop Header */}
+      <InnerPanel className="hidden sm:flex flex-col sm:flex-row w-full mb-1">
+        <div className="h-full mr-2">
           <TradeableImage display={display} supply={tradeable?.supply} />
         </div>
         <div className="flex-1 flex flex-col">

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -5,7 +5,6 @@ import { useActor } from "@xstate/react";
 import { useNavigate, useParams } from "react-router";
 import { loadTradeable } from "../actions/loadTradeable";
 import { getTradeableDisplay } from "../lib/tradeables";
-import { isMobile } from "mobile-device-detect";
 
 import { SaleHistory } from "./PriceHistory";
 import { TradeableOffers } from "./TradeableOffers";
@@ -19,7 +18,7 @@ import {
 import { ITEM_NAMES } from "features/game/types/bumpkin";
 import { availableWardrobe } from "features/game/events/landExpansion/equip";
 import { TradeableHeader } from "./TradeableHeader";
-import { TradeableInfo, TradeableMobileInfo } from "./TradeableInfo";
+import { TradeableDescription, TradeableImage } from "./TradeableInfo";
 import { MyListings } from "./profile/MyListings";
 import { MyOffers } from "./profile/MyOffers";
 import { TradeableListings } from "./TradeableListings";
@@ -31,12 +30,16 @@ import { tradeToId } from "../lib/offers";
 import { getDayOfYear } from "lib/utils/time";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import useSWR from "swr";
+import { Label } from "components/ui/Label";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 export const Tradeable: React.FC = () => {
   const { authService } = useContext(Auth.Context);
   const [authState] = useActor(authService);
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
+
+  const { t } = useAppTranslation();
 
   const farmId = gameState.context.farmId;
   const authToken = authState.context.user.rawToken as string;
@@ -128,43 +131,58 @@ export const Tradeable: React.FC = () => {
   }
 
   return (
-    <div className="flex sm:flex-row flex-col w-full scrollable overflow-y-auto h-[calc(100vh-112px)] pr-1 pb-8">
-      <div className="flex flex-col w-full sm:w-1/3 mr-1 mb-1">
-        <InnerPanel
-          className="mb-1  z-10 sticky top-0 cursor-pointer"
-          onClick={onBack}
-        >
-          <div className="flex flex-wrap justify-between items-center">
-            <div className="flex cursor-pointer items-center w-fit">
-              <img src={SUNNYSIDE.icons.arrow_left} className="h-6 mr-2 mt-1" />
-              <p className="capitalize underline">{display.name}</p>
-            </div>
+    <div className="flex  flex-col w-full scrollable overflow-y-auto h-[calc(100vh-112px)] pr-1 pb-8">
+      <InnerPanel
+        className="mb-1  z-10 sticky top-0 cursor-pointer"
+        onClick={onBack}
+      >
+        <div className="flex flex-wrap justify-between items-center">
+          <div className="flex cursor-pointer items-center w-fit">
+            <img src={SUNNYSIDE.icons.arrow_left} className="h-6 mr-2 mt-1" />
+            <p className="capitalize underline">{display.name}</p>
           </div>
-        </InnerPanel>
-        {isMobile ? (
+          <Label
+            secondaryIcon={SUNNYSIDE.icons.basket}
+            type="transparent"
+            className="mr-4"
+          >
+            {t("marketplace.youOwn", {
+              count: Math.floor(count),
+            })}
+          </Label>
+        </div>
+      </InnerPanel>
+      <InnerPanel className="flex flex-col sm:flex-row w-full mr-1 mb-1">
+        {/* {isMobile ? (
           <TradeableMobileInfo display={display} tradeable={tradeable} />
-        ) : (
-          <TradeableInfo display={display} tradeable={tradeable} />
-        )}
-      </div>
+        ) : ( */}
+        {/* <TradeableInfo display={display} tradeable={tradeable} /> */}
+        {/* )} */}
+        <div className="w-full sm:w-1/3 md:w-1/4 sm:max-w-[300px] mr-2">
+          <TradeableImage display={display} supply={tradeable?.supply} />
+        </div>
+        <div className="flex-1 flex flex-col">
+          <TradeableHeader
+            dailyListings={getDailyListings()}
+            authToken={authToken}
+            farmId={farmId}
+            collection={collection as CollectionName}
+            display={display}
+            count={count}
+            tradeable={tradeable}
+            onBack={onBack}
+            reload={reload}
+            onListClick={() => setShowListItem(true)}
+          />
+
+          <TradeableDescription display={display} tradeable={tradeable} />
+
+          <div className="flex flex-1 items-end">
+            <TradeableStats history={tradeable?.history} price={latestSale} />
+          </div>
+        </div>
+      </InnerPanel>
       <div className="w-full">
-        <TradeableHeader
-          dailyListings={getDailyListings()}
-          authToken={authToken}
-          farmId={farmId}
-          collection={collection as CollectionName}
-          display={display}
-          count={count}
-          tradeable={tradeable}
-          onBack={onBack}
-          reload={reload}
-          onListClick={() => setShowListItem(true)}
-        />
-
-        {!isMobile && (
-          <TradeableStats history={tradeable?.history} price={latestSale} />
-        )}
-
         {hasListings && <MyListings />}
         {hasOffers && <MyOffers />}
 

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -1,8 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Button } from "components/ui/Button";
-import { Label } from "components/ui/Label";
 import { Modal } from "components/ui/Modal";
-import { Panel, InnerPanel } from "components/ui/Panel";
+import { Panel } from "components/ui/Panel";
 import {
   CollectionName,
   TradeableDetails,
@@ -11,7 +10,6 @@ import {
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import sflIcon from "assets/icons/sfl.webp";
-import walletIcon from "assets/icons/wallet.png";
 import { GameWallet } from "features/wallet/Wallet";
 import { Context } from "features/game/GameProvider";
 import confetti from "canvas-confetti";
@@ -29,12 +27,9 @@ import { useSelector } from "@xstate/react";
 import { useParams } from "react-router";
 import { getKeys } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
-import { VIPAccess } from "features/game/components/VipAccess";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import classNames from "classnames";
-import { ITEM_DETAILS } from "features/game/types/images";
-import { isMobile } from "mobile-device-detect";
 import Decimal from "decimal.js-light";
 
 type TradeableHeaderProps = {
@@ -154,54 +149,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
           </Panel>
         </Modal>
       )}
-      <InnerPanel className="w-full mb-1">
+      <div className="w-full mb-1">
         <div className="p-2 pt-1">
-          <div className="flex flex-wrap items-center justify-between mb-3 space-y-1">
-            <div
-              className={classNames("flex items-center justify-between", {
-                "w-full": isMobile && showWalletRequired,
-              })}
-            >
-              <Label
-                type="default"
-                className="mr-0 sm:mr-3"
-                icon={
-                  isResources
-                    ? ITEM_DETAILS[KNOWN_ITEMS[Number(params.id)]].image
-                    : undefined
-                }
-              >
-                {t("marketplace.youOwn", {
-                  count: Math.floor(count),
-                })}
-              </Label>
-              {showWalletRequired && (
-                <Label type="formula" icon={walletIcon}>
-                  {t("marketplace.walletRequired")}
-                </Label>
-              )}
-            </div>
-            <div
-              className={classNames("flex items-center justify-between", {
-                "w-full": isMobile && showFreeListing,
-              })}
-            >
-              <VIPAccess
-                isVIP={isVIP}
-                onUpgrade={() => {
-                  openModal("BUY_BANNER");
-                }}
-                text={t("marketplace.unlockSelling")}
-                labelType={!isVIP && dailyListings >= 1 ? "danger" : undefined}
-              />
-              {!isVIP && dailyListings === 0 && (
-                <Label type="success" className="ml-0 sm:ml-3">
-                  {t("remaining.free.listing")}
-                </Label>
-              )}
-            </div>
-          </div>
-
           <div className="flex items-center justify-between flex-wrap">
             {!isResources && (
               <div className="flex items-center mr-2 sm:mb-0.5 -ml-1">
@@ -304,7 +253,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
             </Button>
           )}
         </div>
-      </InnerPanel>
+      </div>
     </>
   );
 };

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -149,8 +149,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
           </Panel>
         </Modal>
       )}
-      <div className="w-full mb-1">
-        <div className="p-2 pt-1">
+      <div className="w-full mb-1 flex flex-col h-full">
+        <div className="px-2 pt-1 mb-2 sm:mb-0">
           <div className="flex items-center justify-between flex-wrap">
             {!isResources && (
               <div className="flex items-center mr-2 sm:mb-0.5 -ml-1">
@@ -164,7 +164,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                     <p className={classNames("text-base")}>
                       {!tradeable
                         ? "0.00 SFL"
-                        : cheapestListing?.sfl ?? "? SFL"}
+                        : `${cheapestListing?.sfl ?? "?"} SFL`}
                     </p>
                     <p className="text-xs">
                       {`$${new Decimal(usd)
@@ -180,9 +180,9 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 <>
                   <div className="flex flex-col space-y-1">
                     <div className="flex">
-                      <img src={sflIcon} className="h-8 mr-2" />
+                      <img src={sflIcon} className="h-10 mr-2" />
                       {tradeable ? (
-                        <p className="text-base">
+                        <p className="text-lg">
                           {t("marketplace.pricePerUnit", {
                             price: tradeable.floor
                               ? formatNumber(tradeable.floor, {
@@ -194,7 +194,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                         </p>
                       ) : (
                         <>
-                          <span className="text-base loading-fade-pulse">
+                          <span className="text-lg loading-fade-pulse">
                             {t("marketplace.pricePerUnit", {
                               price: "0.0000",
                             })}
@@ -215,12 +215,12 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 <Button
                   onClick={() => setShowPurchaseModal(true)}
                   disabled={!balance.gt(cheapestListing.sfl)}
-                  className="mr-1 w-full sm:w-auto"
+                  className="w-full sm:w-auto"
                 >
                   {t("marketplace.buyNow")}
                 </Button>
               )}
-              {tradeable?.isActive && (
+              {tradeable?.isActive && isResources && (
                 <Button
                   disabled={!count}
                   onClick={onListClick}
@@ -233,17 +233,17 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
           </div>
         </div>
         {/* Mobile display */}
-        <div className="flex items-center justify-between sm:hidden w-full sm:w-auto">
+        <div className="sm:hidden w-full sm:w-auto flex-1 flex flex-col justify-end">
           {showBuyNow && (
             <Button
               onClick={() => setShowPurchaseModal(true)}
               disabled={!balance.gt(cheapestListing.sfl)}
-              className="mr-1 w-full sm:w-auto"
+              className="w-full sm:w-auto"
             >
               {t("marketplace.buyNow")}
             </Button>
           )}
-          {tradeable?.isActive && (
+          {tradeable?.isActive && isResources && (
             <Button
               onClick={onListClick}
               disabled={!count || (!isVIP && dailyListings >= 1)}

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -167,7 +167,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                         : cheapestListing?.sfl ?? "? SFL"}
                     </p>
                     <p className="text-xs">
-                      {`${new Decimal(usd)
+                      {`$${new Decimal(usd)
                         .mul(cheapestListing?.sfl ?? 0)
                         .toFixed(2)}`}
                     </p>

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
-import { InnerPanel } from "components/ui/Panel";
 import { TradeableDetails } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { TradeableDisplay } from "../lib/tradeables";
 
 import grassBg from "assets/ui/3x3_bg.png";
 import brownBg from "assets/brand/brown_background.png";
-
+import lightningIcon from "assets/icons/lightning.png";
 import { InventoryItemName } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
@@ -38,7 +37,7 @@ export const TradeableImage: React.FC<{
   };
 
   return (
-    <InnerPanel className="w-full flex relative mb-1" style={{ padding: 0 }}>
+    <div className="w-full flex relative mb-1" style={{ padding: 0 }}>
       <div className="flex flex-wrap absolute top-2 right-2">
         {/* {tradeable && (
       <Label
@@ -48,7 +47,7 @@ export const TradeableImage: React.FC<{
       >{`42% (7D)`}</Label>
     )} */}
 
-        {supply && !isResource && (
+        {!!supply && !isResource && (
           <Label type="default">{t("marketplace.supply", { supply })}</Label>
         )}
       </div>
@@ -60,7 +59,7 @@ export const TradeableImage: React.FC<{
       {!isBackground && (
         <img
           src={display.image}
-          className={`absolute ${isPortrait ? "h-1/2" : "w-1/3"}`}
+          className={`absolute rounded-md ${isPortrait ? "h-1/2" : "w-1/3"}`}
           style={{
             left: "50%",
             transform: "translate(-50%, 50%)",
@@ -69,7 +68,7 @@ export const TradeableImage: React.FC<{
           onLoad={handleImageLoad}
         />
       )}
-    </InnerPanel>
+    </div>
   );
 };
 
@@ -80,17 +79,28 @@ export const TradeableDescription: React.FC<{
   const { t } = useAppTranslation();
 
   return (
-    <InnerPanel>
+    <div>
       <div className="p-2">
-        <Label type="default" className="mb-1" icon={SUNNYSIDE.icons.search}>
-          {t("marketplace.description")}
-        </Label>
+        <div className="flex items-center justify-between">
+          <Label type="default" className="mb-1" icon={SUNNYSIDE.icons.search}>
+            {t("marketplace.about")}
+          </Label>
+          {tradeable && !tradeable?.isActive && (
+            <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
+              {t("marketplace.notForSale")}
+            </Label>
+          )}
+        </div>
         <p className="text-sm mb-2">{display.description}</p>
         {display.buff && (
           <Label
-            icon={display.buff.boostTypeIcon}
-            type={display.buff.labelType}
-            className="mb-2"
+            icon={
+              display.buff.boostedItemIcon ??
+              display.buff.boostTypeIcon ??
+              lightningIcon
+            }
+            type={"transparent"}
+            className="mb-2 ml-2"
           >
             {display.buff.shortDescription}
           </Label>
@@ -105,14 +115,7 @@ export const TradeableDescription: React.FC<{
           </Label>
         </div>
       )}
-      {tradeable && !tradeable?.isActive && (
-        <div className="p-2">
-          <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
-            {t("marketplace.notForSale")}
-          </Label>
-        </div>
-      )}
-    </InnerPanel>
+    </div>
   );
 };
 

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -37,24 +37,10 @@ export const TradeableImage: React.FC<{
   };
 
   return (
-    <div className="w-full flex relative mb-1" style={{ padding: 0 }}>
-      <div className="flex flex-wrap absolute top-2 right-2">
-        {/* {tradeable && (
-      <Label
-        type="formula"
-        icon={increaseArrow}
-        className="mr-2"
-      >{`42% (7D)`}</Label>
-    )} */}
-
-        {!!supply && !isResource && (
-          <Label type="default">{t("marketplace.supply", { supply })}</Label>
-        )}
-      </div>
-
+    <div className="w-full h-full flex relative mb-1" style={{ padding: 0 }}>
       <img
         src={isBackground ? display.image : background}
-        className="w-full rounded-sm"
+        className="w-full h-full rounded-lg object-contain"
       />
       {!isBackground && (
         <img
@@ -99,8 +85,8 @@ export const TradeableDescription: React.FC<{
               display.buff.boostTypeIcon ??
               lightningIcon
             }
-            type={"transparent"}
-            className="mb-2 ml-2"
+            type={"vibrant"}
+            className="mb-2"
           >
             {display.buff.shortDescription}
           </Label>

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { useActor } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { Label } from "components/ui/Label";
 import { Context } from "features/game/GameProvider";
@@ -38,6 +38,14 @@ import {
   getKeys,
 } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
+import { VIPAccess } from "features/game/components/VipAccess";
+import { hasVipAccess } from "features/game/lib/vipAccess";
+import { MachineState } from "features/game/lib/gameMachine";
+import { getDayOfYear } from "lib/utils/time";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+
+const _isVIP = (state: MachineState) =>
+  hasVipAccess(state.context.state.inventory);
 
 type TradeableListItemProps = {
   authToken: string;
@@ -64,7 +72,25 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
   const [price, setPrice] = useState(0);
   const [quantity, setQuantity] = useState(0);
 
+  const { openModal } = useContext(ModalContext);
+
+  const isVIP = useSelector(gameService, _isVIP);
+
   const { state } = gameState.context;
+
+  const getDailyListings = () => {
+    const today = getDayOfYear(new Date());
+    const dailyListings = gameState.context.state.trades.dailyListings ?? {
+      date: 0,
+      count: 0,
+    };
+
+    return dailyListings.date === today ? dailyListings.count : 0;
+  };
+
+  const dailyListings = getDailyListings();
+
+  const hasAccess = isVIP || dailyListings < 1;
 
   const tradeType = getTradeType({
     collection: display.type,
@@ -292,6 +318,17 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
           <Label type="formula" icon={walletIcon} className="my-1 mr-0.5">
             {t("marketplace.walletRequired")}
           </Label>
+        )}
+
+        {!hasAccess && (
+          <VIPAccess
+            isVIP={isVIP}
+            onUpgrade={() => {
+              openModal("BUY_BANNER");
+            }}
+            text={t("marketplace.unlockSelling")}
+            labelType={!isVIP && dailyListings >= 1 ? "danger" : undefined}
+          />
         )}
       </div>
       <div className="flex justify-between">

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -23,10 +23,8 @@ import {
 import { useOnMachineTransition } from "lib/utils/hooks/useOnMachineTransition";
 import confetti from "canvas-confetti";
 import { ResourceTable } from "./ResourceTable";
-import { formatNumber, shortenCount } from "lib/utils/formatNumber";
-import { useParams } from "react-router";
 import { formatNumber } from "lib/utils/formatNumber";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { PurchaseModalContent } from "./PurchaseModalContent";
 import { TradeableDisplay } from "../lib/tradeables";
 import { KNOWN_ITEMS } from "features/game/types";

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -25,11 +25,14 @@ import confetti from "canvas-confetti";
 import { ResourceTable } from "./ResourceTable";
 import { formatNumber, shortenCount } from "lib/utils/formatNumber";
 import { useParams } from "react-router";
+import { formatNumber } from "lib/utils/formatNumber";
+import { useParams } from "react-router-dom";
 import { PurchaseModalContent } from "./PurchaseModalContent";
 import { TradeableDisplay } from "../lib/tradeables";
 import { KNOWN_ITEMS } from "features/game/types";
 import { getKeys } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
+import { Button } from "components/ui/Button";
 
 type TradeableListingsProps = {
   authToken: string;
@@ -57,6 +60,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
   showListItem,
   reload,
   onListClose,
+  onListClick,
 }) => {
   const { gameService, showAnimations } = useContext(Context);
   const { t } = useAppTranslation();
@@ -148,15 +152,14 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
       </Modal>
       <InnerPanel className="mb-1">
         <div className="p-2">
-          <div className="flex items-center justify-between mb-1">
+          <div className="flex items-start justify-between mb-1">
             <Label icon={tradeIcon} type="default" className="mb-2">
               {t("marketplace.listings")}
             </Label>
-            <Label type="default" className="mb-2">
-              {t("marketplace.availableListings", {
-                count: shortenCount(tradeable?.listings.length ?? 0),
-              })}
-            </Label>
+
+            <Button onClick={onListClick} className="w-auto">
+              {t("marketplace.listForSale")}
+            </Button>
           </div>
           <div className="mb-2">
             {loading && <Loading />}

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -157,9 +157,11 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
               {t("marketplace.listings")}
             </Label>
 
-            <Button onClick={onListClick} className="w-auto">
-              {t("marketplace.listForSale")}
-            </Button>
+            {!isResource && (
+              <Button onClick={onListClick} className="w-auto">
+                {t("marketplace.listForSale")}
+              </Button>
+            )}
           </div>
           <div className="mb-2">
             {loading && <Loading />}

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -32,7 +32,7 @@ import { formatNumber } from "lib/utils/formatNumber";
 import { getBasketItems } from "features/island/hud/components/inventory/utils/inventory";
 import { KNOWN_ITEMS } from "features/game/types";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
-import { VIPAccess } from "features/game/components/VipAccess";
+
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import Decimal from "decimal.js-light";
@@ -161,14 +161,6 @@ export const TradeableOffers: React.FC<{
               <Label type="default" icon={increaseArrow}>
                 {t("marketplace.offers")}
               </Label>
-              <VIPAccess
-                isVIP={isVIP}
-                onUpgrade={() => {
-                  openModal("BUY_BANNER");
-                }}
-                text={t("marketplace.unlockSelling")}
-                labelType={!isVIP ? "danger" : undefined}
-              />
             </div>
             <div className="flex items-center justify-between">
               {topOffer ? (
@@ -232,14 +224,6 @@ export const TradeableOffers: React.FC<{
               <Label type="default" icon={increaseArrow}>
                 {t("marketplace.offers")}
               </Label>
-              <VIPAccess
-                isVIP={isVIP}
-                onUpgrade={() => {
-                  openModal("BUY_BANNER");
-                }}
-                text={t("marketplace.unlockSelling")}
-                labelType={!isVIP ? "danger" : undefined}
-              />
             </div>
             <div className="mb-2">
               {loading && <Loading />}

--- a/src/features/marketplace/components/TradeableStats.tsx
+++ b/src/features/marketplace/components/TradeableStats.tsx
@@ -42,9 +42,9 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
 
   return (
     <div
-      className="flex w-full  gap-0 flex-wrap mb-1"
+      className="flex w-full  gap-0 flex-wrap mb-1 mx-1"
       style={{
-        background: "#ead4aa",
+        background: "#c2856978",
         border: "1px solid #c28569",
         borderRadius: "5px",
         padding: "3px",

--- a/src/features/marketplace/components/TradeableStats.tsx
+++ b/src/features/marketplace/components/TradeableStats.tsx
@@ -1,5 +1,4 @@
 import { Label } from "components/ui/Label";
-import { InnerPanel } from "components/ui/Panel";
 import React, { useEffect, useState } from "react";
 import increaseArrow from "assets/icons/increase_arrow.png";
 import decreaseArrow from "assets/icons/decrease_arrow.png";
@@ -42,11 +41,19 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
       };
 
   return (
-    <div className="flex w-full gap-0.5 flex-col justify-evenly sm:gap-0 sm:flex-row sm:flex-wrap sm:mb-1">
-      <div className="w-full sm:w-1/3 sm:pr-1">
-        <InnerPanel>
+    <div
+      className="flex w-full  gap-0 flex-wrap mb-1"
+      style={{
+        background: "#ead4aa",
+        border: "1px solid #c28569",
+        borderRadius: "5px",
+        padding: "3px",
+      }}
+    >
+      <div className="w-1/3 pr-1">
+        <div>
           <div className="flex justify-between">
-            <Label type="info" className="whitespace-nowrap">
+            <Label type="transparent" className="whitespace-nowrap">
               <span className="text-xxs sm:text-xs">
                 {t("marketplace.oneDayChange")}
               </span>
@@ -68,12 +75,12 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
               `${prices.oneDayPriceChange.toFixed(2)} SFL`
             )}
           </p>
-        </InnerPanel>
+        </div>
       </div>
-      <div className="w-full sm:w-1/3 sm:pr-1">
-        <InnerPanel>
+      <div className="w-1/3 pr-1">
+        <div>
           <div className="flex justify-between">
-            <Label type="info" className="whitespace-nowrap">
+            <Label type="transparent" className="whitespace-nowrap">
               <span className="text-xxs sm:text-xs">
                 {t("marketplace.sevenDayChange")}
               </span>
@@ -95,13 +102,13 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
               `${prices.sevenDayPriceChange.toFixed(2)} SFL`
             )}
           </p>
-        </InnerPanel>
+        </div>
       </div>
-      <div className="w-full md:w-1/3">
-        <InnerPanel>
+      <div className="w-1/3">
+        <div>
           <div className="flex justify-between">
             <div>
-              <Label type="info" className="whitespace-nowrap">
+              <Label type="transparent" className="whitespace-nowrap">
                 <span className="text-xxs sm:text-xs">
                   {t("marketplace.sales")}
                 </span>
@@ -115,7 +122,7 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
               </p>
             </div>
           </div>
-        </InnerPanel>
+        </div>
       </div>
     </div>
   );

--- a/src/features/marketplace/components/TradeableStats.tsx
+++ b/src/features/marketplace/components/TradeableStats.tsx
@@ -52,8 +52,8 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
     >
       <div className="w-1/3 pr-1">
         <div>
-          <div className="flex justify-between">
-            <Label type="transparent" className="whitespace-nowrap">
+          <div className="flex">
+            <Label type="transparent" className="whitespace-nowrap mr-2">
               <span className="text-xxs sm:text-xs">
                 {t("marketplace.oneDayChange")}
               </span>
@@ -79,8 +79,8 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
       </div>
       <div className="w-1/3 pr-1">
         <div>
-          <div className="flex justify-between">
-            <Label type="transparent" className="whitespace-nowrap">
+          <div className="flex ">
+            <Label type="transparent" className="whitespace-nowrap mr-2">
               <span className="text-xxs sm:text-xs">
                 {t("marketplace.sevenDayChange")}
               </span>
@@ -106,9 +106,9 @@ export const TradeableStats: React.FC<Props> = ({ history, price }) => {
       </div>
       <div className="w-1/3">
         <div>
-          <div className="flex justify-between">
+          <div className="flex">
             <div>
-              <Label type="transparent" className="whitespace-nowrap">
+              <Label type="transparent" className="whitespace-nowrap mr-2">
                 <span className="text-xxs sm:text-xs">
                   {t("marketplace.sales")}
                 </span>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4487,5 +4487,6 @@
   "marketplace.quickswap.description": "You are about to be redirected to Quickswap, a decentralized and community-driven exchange to buy $SFL.",
   "marketplace.quickswap.warning": "Prices shown in-game are estimated based on community prices & may not reflect the current market. Proceed at your own risk.",
   "marketplace.estimated.price": "*Estimated SFL/USD price",
-  "marketplace.quickswap.continue": "Continue"
+  "marketplace.quickswap.continue": "Continue",
+  "marketplace.about": "About"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4488,5 +4488,6 @@
   "marketplace.quickswap.warning": "Prices shown in-game are estimated based on community prices & may not reflect the current market. Proceed at your own risk.",
   "marketplace.estimated.price": "*Estimated SFL/USD price",
   "marketplace.quickswap.continue": "Continue",
-  "marketplace.about": "About"
+  "marketplace.about": "About",
+  "marketplace.wantToUnlock": "Want to unlock unlimited trades?"
 }


### PR DESCRIPTION
# Description

This PR updates the trade-able layout to reduce bloat + too many panels:

- A single header section
- Reduced trading stats section
- Removed a bunch of labels - there were too many CTAs
- Moved VIP labels into Make Offer + Listing components
- Added a VIP section to the left of the navigation

<img width="1265" alt="Screenshot 2024-12-06 at 12 07 21 PM" src="https://github.com/user-attachments/assets/e151f977-0775-47bc-b25a-3a331974f534">

## How to test?

1. Open and navigate around marketplace