### PR TITLE
[FIX] Cancel Trade

### DIFF
--- a/src/features/game/events/landExpansion/cancelTrade.test.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.test.ts
@@ -41,6 +41,32 @@ describe("cancelTrade", () => {
     ).toThrow("Trade #123 is not a collectible");
   });
 
+  it("does not throw if trade is resources", () => {
+    expect(() =>
+      cancelTrade({
+        action: {
+          tradeId: "123",
+          type: "trade.cancelled",
+        },
+        state: {
+          ...TEST_FARM,
+          trades: {
+            listings: {
+              "123": {
+                collection: "resources",
+                createdAt: 1000000,
+                sfl: 5,
+                items: {
+                  Parsnip: 10,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("enures trade is not bought", () => {
     expect(() =>
       cancelTrade({

--- a/src/features/game/events/landExpansion/cancelTrade.ts
+++ b/src/features/game/events/landExpansion/cancelTrade.ts
@@ -26,7 +26,11 @@ export function cancelTrade({
       throw new Error(`Trade #${action.tradeId} does not exist`);
     }
 
-    if (trade.collection !== "collectibles") {
+    // Some older trades still have the collection listed as "resources". They are still collectibles.
+    if (
+      trade.collection !== "collectibles" &&
+      trade.collection !== "resources"
+    ) {
       throw new Error(`Trade #${action.tradeId} is not a collectible`);
     }
 


### PR DESCRIPTION
# Description

Allow players with older resource trades with collection "resources" to be able to cancel the trade.

Fixes #issue

# What needs to be tested by the reviewer?



# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
