### PR TITLE
[CHORE] Hide existing trade modals with Marketplace Access

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -196,10 +196,14 @@ export const BumpkinModal: React.FC<Props> = ({
         icon: SUNNYSIDE.icons.wardrobe,
         name: t("equip"),
       },
-      {
-        icon: token,
-        name: t("trades"),
-      },
+      ...(!hasFeatureAccess(gameState, "MARKETPLACE")
+        ? [
+            {
+              icon: token,
+              name: t("trades"),
+            },
+          ]
+        : []),
       ...(hasFeatureAccess(gameState, "SKILLS_REVAMP")
         ? [
             {

--- a/src/features/world/ui/InteractableModals.tsx
+++ b/src/features/world/ui/InteractableModals.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { PotionHouse } from "features/game/expansion/components/potions/PotionHouse";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
@@ -37,6 +37,10 @@ import { PirateChestModal } from "./chests/PirateChest";
 import { ExampleDonations } from "./donations/ExampleDonations";
 import { WorldMap } from "features/island/hud/components/deliveries/WorldMap";
 import { Halloween } from "./portals/Halloween";
+import { Marketplace } from "features/marketplace/Marketplace";
+import { hasFeatureAccess } from "lib/flags";
+import { Context } from "features/game/GameProvider";
+import { useActor } from "@xstate/react";
 
 type InteractableName =
   | "desert_noticeboard"
@@ -165,6 +169,13 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
     InteractableName | undefined
   >(getInitialModal(scene));
   const [isLoading, setIsLoading] = useState(false);
+
+  const { gameService } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
 
   useEffect(() => {
     interactableModalManager.listen((interactable, open) => {
@@ -816,7 +827,11 @@ export const InteractableModals: React.FC<Props> = ({ id, scene }) => {
         dialogClassName="md:max-w-3xl"
         onHide={closeModal}
       >
-        <TradingBoard onClose={closeModal} />
+        {hasFeatureAccess(state, "MARKETPLACE") ? (
+          <Marketplace />
+        ) : (
+          <TradingBoard onClose={closeModal} />
+        )}
       </Modal>
       <Modal
         show={interactable === "goblin_market"}

--- a/src/features/world/ui/PlayerModals.tsx
+++ b/src/features/world/ui/PlayerModals.tsx
@@ -22,6 +22,7 @@ import { secondsToString } from "lib/utils/time";
 import { secondsTillReset } from "features/helios/components/hayseedHank/HayseedHankV2";
 import { AdminSettings } from "features/island/hud/components/settings-menu/general-settings/AdminSettings";
 import { CONFIG } from "lib/config";
+import { hasFeatureAccess } from "lib/flags";
 
 type Player = {
   id: number;
@@ -191,10 +192,17 @@ export const PlayerModals: React.FC<Props> = ({ game }) => {
               icon: SUNNYSIDE.icons.player,
               name: "Player",
             },
-            {
-              icon: SUNNYSIDE.icons.heart,
-              name: "Trades",
-            },
+            ...(!hasFeatureAccess(
+              gameService.getSnapshot().context.state,
+              "MARKETPLACE",
+            )
+              ? [
+                  {
+                    icon: SUNNYSIDE.icons.heart,
+                    name: "Trades",
+                  },
+                ]
+              : []),
             ...(!!gameService.getSnapshot().context.state.wardrobe[
               "Gift Giver"
             ] || CONFIG.NETWORK === "amoy"


### PR DESCRIPTION
# Description

Hides trades tab for users with marketplace access

Emblem trading untouched

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
