### PR TITLE
[FEAT] Fruit Skills revamp

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1280,7 +1280,7 @@ describe("deliver", () => {
     expect(state.coins).toEqual(100);
   });
 
-  it("gives 100% (x2) more Coins profit on completed fruit deliveries if player has Fruity Profit skill", () => {
+  it("gives 50% more Coins profit on completed fruit deliveries if player has Fruity Profit skill", () => {
     const state = deliverOrder({
       state: {
         ...TEST_FARM,
@@ -1318,7 +1318,7 @@ describe("deliver", () => {
       },
     });
 
-    expect(state.coins).toEqual(640);
+    expect(state.coins).toEqual(480);
   });
 
   it("does not give Fruity Profit bonus if item is not fruit", () => {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -283,7 +283,7 @@ export function getOrderSellPrice<T>(
   ) {
     const items = getKeys(order.items);
     if (items.some((name) => isFruit(name as PatchFruitName))) {
-      mul += 1;
+      mul += 0.5;
     }
   }
 

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -886,40 +886,6 @@ describe("fruitHarvested", () => {
       });
     });
 
-    it("gives +.1 Tomato & Lemon yield with Red Sour skill", () => {
-      const amount = getFruitYield({
-        game: {
-          ...TEST_FARM,
-          bumpkin: {
-            ...TEST_FARM.bumpkin,
-            skills: {
-              "Red Sour": 1,
-            },
-          },
-        },
-        name: "Tomato",
-      });
-
-      expect(amount).toEqual(1.1);
-    });
-
-    it("does not give Red Sour skill bonus if not a Tomato or Lemon", () => {
-      const amount = getFruitYield({
-        game: {
-          ...TEST_FARM,
-          bumpkin: {
-            ...TEST_FARM.bumpkin,
-            skills: {
-              "Red Sour": 1,
-            },
-          },
-        },
-        name: "Blueberry",
-      });
-
-      expect(amount).toEqual(1);
-    });
-
     it("gives +.1 basic fruit yield with Fruitful Fumble skill", () => {
       const amount = getFruitYield({
         game: {
@@ -935,40 +901,6 @@ describe("fruitHarvested", () => {
       });
 
       expect(amount).toEqual(1.1);
-    });
-
-    it("gives +.1 advanced fruit yield with Tropical Orchard skill", () => {
-      const amount = getFruitYield({
-        game: {
-          ...TEST_FARM,
-          bumpkin: {
-            ...TEST_FARM.bumpkin,
-            skills: {
-              "Tropical Orchard": 1,
-            },
-          },
-        },
-        name: "Apple",
-      });
-
-      expect(amount).toEqual(1.1);
-    });
-
-    it("does not give Tropical Orchard skill bonus if not a basic fruit", () => {
-      const amount = getFruitYield({
-        game: {
-          ...TEST_FARM,
-          bumpkin: {
-            ...TEST_FARM.bumpkin,
-            skills: {
-              "Tropical Orchard": 1,
-            },
-          },
-        },
-        name: "Blueberry",
-      });
-
-      expect(amount).toEqual(1);
     });
   });
 });

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -1,5 +1,9 @@
 import Decimal from "decimal.js-light";
-import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+import {
+  INITIAL_BUMPKIN,
+  INITIAL_FARM,
+  TEST_FARM,
+} from "features/game/lib/constants";
 import { PATCH_FRUIT, PATCH_FRUIT_SEEDS } from "features/game/types/fruits";
 import { GameState, FruitPatch } from "features/game/types/game";
 import {
@@ -901,6 +905,50 @@ describe("fruitHarvested", () => {
       });
 
       expect(amount).toEqual(1.1);
+    });
+    it("give +0.1 fruit yield when macaw is placed", () => {
+      const amount = getFruitYield({
+        game: {
+          ...INITIAL_FARM,
+          collectibles: {
+            Macaw: [
+              {
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                id: "123",
+                readyAt: 0,
+              },
+            ],
+          },
+        },
+        name: "Apple",
+      });
+
+      expect(amount).toEqual(1.1);
+    });
+    it("gives +0.2 fruit yield when macaw is placed AND has Loyal Macaw Skill", () => {
+      const amount = getFruitYield({
+        game: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Loyal Macaw": 1 },
+          },
+          collectibles: {
+            Macaw: [
+              {
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                id: "123",
+                readyAt: 0,
+              },
+            ],
+          },
+        },
+        name: "Apple",
+      });
+
+      expect(amount).toEqual(1.2);
     });
   });
 });

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -970,22 +970,5 @@ describe("fruitHarvested", () => {
 
       expect(amount).toEqual(1);
     });
-
-    it("gives +0.05 fruit bonus with Fruity Heaven", () => {
-      const amount = getFruitYield({
-        game: {
-          ...GAME_STATE,
-          bumpkin: {
-            ...GAME_STATE.bumpkin,
-            skills: {
-              "Fruity Heaven": 1,
-            },
-          },
-        },
-        name: "Blueberry",
-      });
-
-      expect(amount).toEqual(1.05);
-    });
   });
 });

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -937,23 +937,6 @@ describe("fruitHarvested", () => {
       expect(amount).toEqual(1.1);
     });
 
-    it("does not give Fruitful Fumble skill bonus if not a basic fruit", () => {
-      const amount = getFruitYield({
-        game: {
-          ...TEST_FARM,
-          bumpkin: {
-            ...TEST_FARM.bumpkin,
-            skills: {
-              "Fruitful Fumble": 1,
-            },
-          },
-        },
-        name: "Apple",
-      });
-
-      expect(amount).toEqual(1);
-    });
-
     it("gives +.1 advanced fruit yield with Tropical Orchard skill", () => {
       const amount = getFruitYield({
         game: {

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -135,7 +135,7 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
     amount += 0.1;
   }
 
-  if (bumpkin.skills["Fruitful Fumble"] && isBasicFruit(name)) {
+  if (bumpkin.skills["Fruitful Fumble"]) {
     amount += 0.1;
   }
 

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -210,6 +210,14 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
     amount += 2;
   }
 
+  if (game.bumpkin.skills["Zesty Vibes"] && !isGreenhouseFruit(name)) {
+    if (name === "Tomato" || name === "Lemon") {
+      amount += 1;
+    } else {
+      amount -= 0.5;
+    }
+  }
+
   // Greenhouse Gamble 5% chance of +1 yield
   if (isGreenhouseFruit(name) && bumpkin.skills["Greenhouse Gamble"]) {
     if (randomInt(0, 20) === 1) {

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -110,7 +110,11 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
   }
 
   if (isFruit(name) && isCollectibleBuilt({ name: "Macaw", game })) {
-    amount += 0.1;
+    if (game.bumpkin.skills["Loyal Macaw"]) {
+      amount += 0.2;
+    } else {
+      amount += 0.1;
+    }
   }
 
   if (isFruit(name) && isWearableActive({ name: "Camel Onesie", game })) {

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -127,15 +127,7 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
     amount += 0.1;
   }
 
-  if (bumpkin.skills["Red Sour"] && (name === "Tomato" || name === "Lemon")) {
-    amount += 0.1;
-  }
-
   if (bumpkin.skills["Fruitful Fumble"]) {
-    amount += 0.1;
-  }
-
-  if (bumpkin.skills["Tropical Orchard"] && isAdvancedFruit(name)) {
     amount += 0.1;
   }
 

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -15,7 +15,7 @@ import {
   PatchFruit,
   PatchFruitName,
 } from "features/game/types/fruits";
-import { Bumpkin, GameState, PlantedFruit } from "features/game/types/game";
+import { GameState, PlantedFruit } from "features/game/types/game";
 import { getTimeLeft } from "lib/utils/time";
 import { FruitPatch } from "features/game/types/game";
 import { FruitCompostName } from "features/game/types/composters";
@@ -64,7 +64,7 @@ export function isFruitGrowing(patch: FruitPatch) {
   const fruit = patch.fruit;
   if (!fruit) return false;
 
-  const { name, amount, harvestsLeft, harvestedAt, plantedAt } = fruit;
+  const { name, harvestsLeft, harvestedAt, plantedAt } = fruit;
   if (!harvestsLeft) return false;
 
   const { seed } = PATCH_FRUIT()[name];
@@ -228,7 +228,7 @@ export function harvestFruit({
   createdAt = Date.now(),
 }: Options): GameState {
   return produce(state, (stateCopy) => {
-    const { fruitPatches, bumpkin, collectibles } = stateCopy;
+    const { fruitPatches, bumpkin } = stateCopy;
 
     if (!bumpkin) {
       throw new Error("You do not have a Bumpkin!");
@@ -265,12 +265,7 @@ export function harvestFruit({
       stateCopy.inventory[name]?.add(amount) ?? new Decimal(amount);
 
     patch.fruit.harvestsLeft = patch.fruit.harvestsLeft - 1;
-    patch.fruit.harvestedAt = getPlantedAt(
-      seed,
-      (stateCopy.bumpkin as Bumpkin).equipped,
-      stateCopy,
-      createdAt,
-    );
+    patch.fruit.harvestedAt = getPlantedAt(seed, stateCopy, createdAt);
 
     patch.fruit.amount = getFruitYield({
       game: stateCopy,

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -117,10 +117,6 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
     amount += 0.1;
   }
 
-  if (isFruit(name) && bumpkin.skills["Fruity Heaven"]) {
-    amount += 0.05;
-  }
-
   if (
     (name === "Apple" ||
       name === "Orange" ||

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -1266,160 +1266,129 @@ describe("getFruitTime", () => {
   it("applies a 50% speed boost with Squirrel Monkey placed for orange seeds", () => {
     const seed = "Orange Seed";
     const orangePlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Squirrel Monkey": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Squirrel Monkey": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(orangePlantSeconds * 0.5);
   });
   it("does not apply a 50% speed boost with Squirrel Monkey placed for other seeds", () => {
     const seed = "Apple Seed";
     const applePlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Squirrel Monkey": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Squirrel Monkey": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(applePlantSeconds);
   });
 
   it("applies a 50% time reduction for Lemons when Lemon Tea Bath is placed", () => {
     const seed = "Lemon Seed";
     const lemonPlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Lemon Tea Bath": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Lemon Tea Bath": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(lemonPlantSeconds * 0.5);
   });
 
   it("gives a 50% growth time reduction for tomatoes when Tomato Clown is placed", () => {
     const seed = "Tomato Seed";
     const tomatoPlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Tomato Clown": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Tomato Clown": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(tomatoPlantSeconds * 0.5);
   });
 
   it("applies a 10% speed boost with Nana placed for Banana plant", () => {
     const seed = "Banana Plant";
     const orangePlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          Nana: [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        Nana: [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(orangePlantSeconds * 0.9);
   });
   it("does not apply a 10% speed boost with Nana placed for other seeds", () => {
     const seed = "Apple Seed";
     const applePlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          Nana: [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: 0,
-              id: "123",
-              readyAt: 0,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        Nana: [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            id: "123",
+            readyAt: 0,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(applePlantSeconds);
   });
 
   it("applies a 20% speed boost with Banana Onesie", () => {
     const seed = "Banana Plant";
     const orangePlantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          equipped: {
-            ...INITIAL_BUMPKIN.equipped,
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
 
-            onesie: "Banana Onesie",
-          },
+          onesie: "Banana Onesie",
         },
       },
-      {
-        ...INITIAL_BUMPKIN.equipped,
-        onesie: "Banana Onesie",
-      },
-    );
+    });
     expect(time).toEqual(orangePlantSeconds * 0.8);
   });
 
@@ -1427,23 +1396,19 @@ describe("getFruitTime", () => {
     const now = Date.now();
     const seed = "Banana Plant";
     const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Orchard Hourglass": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: now,
-              id: "123",
-              readyAt: now,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Orchard Hourglass": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: now,
+            id: "123",
+            readyAt: now,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(plantSeconds * 0.75);
   });
 
@@ -1452,43 +1417,59 @@ describe("getFruitTime", () => {
     const sevenHoursAgo = now - 1000 * 60 * 60 * 7;
     const seed = "Banana Plant";
     const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        collectibles: {
-          "Orchard Hourglass": [
-            {
-              coordinates: { x: 0, y: 0 },
-              createdAt: sevenHoursAgo,
-              id: "123",
-              readyAt: sevenHoursAgo,
-            },
-          ],
-        },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      collectibles: {
+        "Orchard Hourglass": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: sevenHoursAgo,
+            id: "123",
+            readyAt: sevenHoursAgo,
+          },
+        ],
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
     expect(time).toEqual(plantSeconds);
   });
 
   it("applies a 10% growth speed boost on Fruit seeds with Catchup skill", () => {
     const seed = "Tomato Seed";
     const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            Catchup: 1,
-          },
+    const time = getFruitPatchTime(seed, {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        skills: {
+          Catchup: 1,
         },
       },
-      INITIAL_BUMPKIN.equipped,
-    );
+    });
 
     expect(time).toEqual(plantSeconds * 0.9);
+  });
+  it("takes 2x faster to grow Apples with Long Pickings skill, but Oranges take 2x longer to grow", () => {
+    const applePlantSeconds = PATCH_FRUIT_SEEDS()["Apple Seed"].plantSeconds;
+    const appleTime = getFruitPatchTime("Apple Seed", {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        skills: {
+          "Long Pickings": 1,
+        },
+      },
+    });
+    const orangePlantSeconds = PATCH_FRUIT_SEEDS()["Orange Seed"].plantSeconds;
+    const orangeTime = getFruitPatchTime("Orange Seed", {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        skills: {
+          "Long Pickings": 1,
+        },
+      },
+    });
+    expect(appleTime).toEqual(applePlantSeconds * 0.5);
+    expect(orangeTime).toEqual(orangePlantSeconds * 2);
   });
 });

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -1499,7 +1499,7 @@ describe("getFruitTime", () => {
     expect(time).toEqual(plantSeconds);
   });
 
-  it("applies a 10% growth speed boost on Tomato & Lemon seeds with Catchup skill", () => {
+  it("applies a 10% growth speed boost on Fruit seeds with Catchup skill", () => {
     const seed = "Tomato Seed";
     const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
     const time = getFruitPatchTime(
@@ -1517,26 +1517,6 @@ describe("getFruitTime", () => {
     );
 
     expect(time).toEqual(plantSeconds * 0.9);
-  });
-
-  it("does not applies Catchup skill on other seeds", () => {
-    const seed = "Apple Seed";
-    const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            Catchup: 1,
-          },
-        },
-      },
-      INITIAL_BUMPKIN.equipped,
-    );
-
-    expect(time).toEqual(plantSeconds);
   });
 
   it("applies a 10% growth speed boost on basic fruit with Fruit Turbocharge skill", () => {

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -540,33 +540,6 @@ describe("fruitPlanted", () => {
     );
   });
 
-  it("gives a 5% growth time reduction when Accelerated Fruit skill is active", () => {
-    const state = plantFruit({
-      state: {
-        ...GAME_STATE,
-        bumpkin: {
-          ...GAME_STATE.bumpkin,
-          skills: {
-            "Accelerated Fruit": 1,
-          },
-        },
-        inventory: {
-          "Apple Seed": new Decimal(1),
-        },
-      },
-      action: {
-        type: "fruit.planted",
-        index: "1",
-        seed: "Apple Seed",
-      },
-      createdAt: dateNow,
-    });
-
-    expect(state.fruitPatches["1"].fruit?.plantedAt).toEqual(
-      dateNow - PATCH_FRUIT_SEEDS()["Apple Seed"].plantSeconds * 1000 * 0.05,
-    );
-  });
-
   it("gives a 50% growth time reduction on tomatoes when Tomato Clown is placed", () => {
     const seedAmount = new Decimal(5);
 
@@ -1517,85 +1490,5 @@ describe("getFruitTime", () => {
     );
 
     expect(time).toEqual(plantSeconds * 0.9);
-  });
-
-  it("applies a 10% growth speed boost on basic fruit with Fruit Turbocharge skill", () => {
-    const seed = "Blueberry Seed";
-    const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            "Fruit Turbocharge": 1,
-          },
-        },
-      },
-      INITIAL_BUMPKIN.equipped,
-    );
-
-    expect(time).toEqual(plantSeconds * 0.9);
-  });
-
-  it("does not applies Fruit Turbocharge skill on advanced fruit", () => {
-    const seed = "Apple Seed";
-    const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            "Fruit Turbocharge": 1,
-          },
-        },
-      },
-      INITIAL_BUMPKIN.equipped,
-    );
-
-    expect(time).toEqual(plantSeconds);
-  });
-
-  it("applies a 10% growth speed boost on advanced fruit with Prime Produce skill", () => {
-    const seed = "Apple Seed";
-    const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            "Prime Produce": 1,
-          },
-        },
-      },
-      INITIAL_BUMPKIN.equipped,
-    );
-
-    expect(time).toEqual(plantSeconds * 0.9);
-  });
-
-  it("does not applies Prime Produce skill on basic fruit", () => {
-    const seed = "Blueberry Seed";
-    const plantSeconds = PATCH_FRUIT_SEEDS()[seed].plantSeconds;
-    const time = getFruitPatchTime(
-      seed,
-      {
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          skills: {
-            "Prime Produce": 1,
-          },
-        },
-      },
-      INITIAL_BUMPKIN.equipped,
-    );
-
-    expect(time).toEqual(plantSeconds);
   });
 });

--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -1472,4 +1472,28 @@ describe("getFruitTime", () => {
     expect(appleTime).toEqual(applePlantSeconds * 0.5);
     expect(orangeTime).toEqual(orangePlantSeconds * 2);
   });
+  it("takes 2x faster to grow Orange with Short Pickings skill, but Apples take 2x longer to grow", () => {
+    const applePlantSeconds = PATCH_FRUIT_SEEDS()["Apple Seed"].plantSeconds;
+    const appleTime = getFruitPatchTime("Apple Seed", {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        skills: {
+          "Short Pickings": 1,
+        },
+      },
+    });
+    const orangePlantSeconds = PATCH_FRUIT_SEEDS()["Orange Seed"].plantSeconds;
+    const orangeTime = getFruitPatchTime("Orange Seed", {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        skills: {
+          "Short Pickings": 1,
+        },
+      },
+    });
+    expect(appleTime).toEqual(applePlantSeconds * 2);
+    expect(orangeTime).toEqual(orangePlantSeconds * 0.5);
+  });
 });

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -196,6 +196,14 @@ export const getFruitPatchTime = (
     }
   }
 
+  if (bumpkin.skills["Short Pickings"]) {
+    if (isBasicFruitSeed(patchFruitSeedName)) {
+      seconds = seconds * 0.5;
+    } else {
+      seconds = seconds * 2;
+    }
+  }
+
   return seconds;
 };
 

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -156,26 +156,6 @@ export const getFruitPatchTime = (
     seconds = seconds * 0.9;
   }
 
-  // Fruit Turbocharge Skill: 10% reduction
-  if (
-    isBasicFruitSeed(patchFruitSeedName) &&
-    bumpkin.skills["Fruit Turbocharge"]
-  ) {
-    seconds = seconds * 0.9;
-  }
-
-  // Prime Produce Skill: 10% reduction
-  if (
-    isAdvancedFruitSeed(patchFruitSeedName) &&
-    bumpkin.skills["Prime Produce"]
-  ) {
-    seconds = seconds * 0.9;
-  }
-
-  if (bumpkin.skills["Accelerated Fruit"]) {
-    seconds = seconds * 0.95;
-  }
-
   return seconds;
 };
 

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -152,11 +152,7 @@ export const getFruitPatchTime = (
   }
 
   // Catchup Skill: 10% reduction
-  if (
-    (patchFruitSeedName === "Tomato Seed" ||
-      patchFruitSeedName === "Lemon Seed") &&
-    bumpkin.skills["Catchup"]
-  ) {
+  if (bumpkin.skills["Catchup"]) {
     seconds = seconds * 0.9;
   }
 

--- a/src/features/game/events/landExpansion/fruitTreeRemoved.ts
+++ b/src/features/game/events/landExpansion/fruitTreeRemoved.ts
@@ -45,6 +45,15 @@ export function getRequiredAxeAmount(
     }
   }
 
+  if (
+    (patchFruitName === "Tomato" ||
+      patchFruitName === "Blueberry" ||
+      patchFruitName === "Banana") &&
+    game.bumpkin.skills["No Axe No Worries"]
+  ) {
+    return new Decimal(0);
+  }
+
   return new Decimal(1);
 }
 
@@ -54,6 +63,12 @@ export function getWoodReward({ state }: { state: GameState }) {
   if (state.bumpkin.skills["Fruity Woody"]) {
     woodReward += 1;
   }
+
+  // Get no wood reward with No Axe No Worries Skill
+  if (state.bumpkin.skills["No Axe No Worries"]) {
+    return { woodReward: 0 };
+  }
+
   return { woodReward };
 }
 
@@ -107,8 +122,7 @@ export function removeFruitTree({
     const { woodReward } = getWoodReward({ state: stateCopy });
 
     inventory.Axe = axeAmount.sub(requiredAxes);
-    stateCopy.inventory.Wood =
-      stateCopy.inventory.Wood?.add(woodReward) || new Decimal(1);
+    inventory.Wood = inventory.Wood?.add(woodReward) || new Decimal(1);
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/fruitTreeRemoved.ts
+++ b/src/features/game/events/landExpansion/fruitTreeRemoved.ts
@@ -64,9 +64,9 @@ export function getWoodReward({ state }: { state: GameState }) {
     woodReward += 1;
   }
 
-  // Get no wood reward with No Axe No Worries Skill
+  // Get -1 wood reward with No Axe No Worries Skill
   if (state.bumpkin.skills["No Axe No Worries"]) {
-    return { woodReward: 0 };
+    woodReward -= 1;
   }
 
   return { woodReward };

--- a/src/features/game/events/landExpansion/seedBought.ts
+++ b/src/features/game/events/landExpansion/seedBought.ts
@@ -9,6 +9,7 @@ import { Seed, SeedName, SEEDS } from "features/game/types/seeds";
 import { isWearableActive } from "features/game/lib/wearables";
 import { FLOWER_SEEDS } from "features/game/types/flowers";
 import { produce } from "immer";
+import { isPatchFruitSeed } from "features/game/types/fruits";
 
 export type SeedBoughtAction = {
   type: "seed.bought";
@@ -45,6 +46,10 @@ export function getBuyPrice(name: SeedName, seed: Seed, game: GameState) {
 
   if (name in FLOWER_SEEDS() && bumpkin.skills["Flower Sale"]) {
     price = price * 0.8;
+  }
+
+  if (isPatchFruitSeed(name) && bumpkin.skills["Fruity Heaven"]) {
+    price = price * 0.9;
   }
 
   return price;

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -220,15 +220,19 @@ export const INVENTORY_LIMIT = (state?: GameState): Inventory => {
   };
 
   if (
-    state?.buildings.Warehouse &&
-    isBuildingReady(state.buildings.Warehouse)
+    state?.buildings["Warehouse"] &&
+    isBuildingReady(state?.buildings["Warehouse"])
   ) {
-    // Multiply each seed quantity by 1.2
-    for (const seed in seeds) {
-      seeds[seed as keyof typeof seeds] = new Decimal(
-        Math.ceil(seeds[seed as keyof typeof seeds].toNumber() * 1.2),
-      );
-    }
+    // Multiply each seed quantity by 1.2 and round up
+    getKeys(seeds).forEach(
+      (seed) =>
+        (seeds[seed] = new Decimal(Math.ceil(seeds[seed].mul(1.2).toNumber()))),
+    );
+  }
+
+  if (state?.bumpkin.skills["Crime Fruit"]) {
+    seeds["Tomato Seed"] = seeds["Tomato Seed"].add(10);
+    seeds["Lemon Seed"] = seeds["Lemon Seed"].add(10);
   }
 
   return seeds;

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -567,6 +567,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     boosts: "Double Immortal Pear's effect",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Crime Fruit": {
+    name: "Crime Fruit",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 2,
+      tier: 2,
+      island: "spring",
+    },
+    boosts: "Increase Tomato and Lemon stock by 10",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
   // Fruit - Tier 3
 
   // Trees - Tier 1

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -576,7 +576,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 3,
       island: "spring",
     },
-    boosts: "Tango Coins revenue doubled",
+    boosts: "Tango coins deliveries revenue +50%",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -527,7 +527,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 2,
       island: "spring",
     },
-    boosts: "-10% growth time for Tomatoes and Lemons",
+    boosts: "-10% patch fruit growth time ",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -470,18 +470,6 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
   },
 
   // Fruit - Tier 1
-  "Red Sour": {
-    name: "Red Sour",
-    tree: "Fruit",
-    requirements: {
-      points: 1,
-      tier: 1,
-      island: "spring",
-    },
-    boosts: "+0.1 Fruit Yield (Tomatoes, Lemons)",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
   "Fruitful Fumble": {
     name: "Fruitful Fumble",
     tree: "Fruit",
@@ -491,18 +479,6 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       island: "spring",
     },
     boosts: "+0.1 Fruit Patch Yield",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
-  "Tropical Orchard": {
-    name: "Tropical Orchard",
-    tree: "Fruit",
-    requirements: {
-      points: 1,
-      tier: 1,
-      island: "spring",
-    },
-    boosts: "+0.1 Advanced Fruit Yield (Apples, Bananas)",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },
@@ -518,6 +494,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },
+  "Fruity Profit": {
+    name: "Fruity Profit",
+    tree: "Fruit",
+    requirements: {
+      points: 1,
+      tier: 1,
+      island: "spring",
+    },
+    boosts: "Tango coins deliveries revenue +50%",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+    disabled: false,
+  },
   // Fruit - Tier 2
   Catchup: {
     name: "Catchup",
@@ -527,85 +515,11 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 2,
       island: "spring",
     },
-    boosts: "-10% patch fruit growth time ",
+    boosts: "-10% patch fruit growth time",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
-  },
-  "Fruit Turbocharge": {
-    name: "Fruit Turbocharge",
-    tree: "Fruit",
-    requirements: {
-      points: 2,
-      tier: 2,
-      island: "spring",
-    },
-    boosts: "-10% growth time for Blueberries and Oranges",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
-  "Prime Produce": {
-    name: "Prime Produce",
-    tree: "Fruit",
-    requirements: {
-      points: 2,
-      tier: 2,
-      island: "spring",
-    },
-    boosts: "-10% growth time for Apples and Bananas",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
-  "Accelerated Fruit": {
-    name: "Accelerated Fruit",
-    tree: "Fruit",
-    disabled: false,
-    requirements: {
-      points: 2,
-      tier: 2,
-      island: "spring",
-    },
-    boosts: "-5% growth time for all patch fruits",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   // Fruit - Tier 3
-  "Fruity Profit": {
-    name: "Fruity Profit",
-    tree: "Fruit",
-    requirements: {
-      points: 3,
-      tier: 3,
-      island: "spring",
-    },
-    boosts: "Tango coins deliveries revenue +50%",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
-  "Plantation Goodies": {
-    name: "Plantation Goodies",
-    tree: "Fruit",
-    disabled: false,
-    requirements: {
-      points: 3,
-      tier: 3,
-      island: "spring",
-    },
-    boosts: "5% chance of +1 patch fruit yield",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-  },
-  "Fruity Rush Hour": {
-    name: "Fruity Rush Hour",
-    tree: "Fruit",
-    requirements: {
-      points: 3,
-      tier: 3,
-      island: "spring",
-    },
-    boosts:
-      "Ability to make all fruit currently growing ready to be harvested (1/72h)",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-    power: true,
-  },
 
   // Trees - Tier 1
   "Lumberjack's Extra": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -602,7 +602,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       island: "spring",
     },
     boosts:
-      "Apple and Banana grow 2x faster, but Tomato, Lemon, Blueberry and Orange take 2x longer to grow",
+      "Apple and Banana grow 2x faster, but all other patch fruits take 2x longer to grow",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   "Short Pickings": {
@@ -615,7 +615,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       island: "spring",
     },
     boosts:
-      "Blueberry and Orange grow 2x faster, but Tomato, Lemon, Apple and Banana take 2x longer to grow",
+      "Blueberry and Orange grow 2x faster, but all other patch fruits take 2x longer to grow",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   "Zesty Vibes": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -506,6 +506,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },
+  "Loyal Macaw": {
+    name: "Loyal Macaw",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 1,
+      tier: 1,
+      island: "spring",
+    },
+    boosts: "Macaw's effect doubled",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
   // Fruit - Tier 2
   Catchup: {
     name: "Catchup",

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -540,7 +540,8 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 2,
       island: "spring",
     },
-    boosts: "Chop fruit branches without axes, but get no wood drops",
+    boosts:
+      "Chop fruit branches without axes, but get -1 wood from fruit branches",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   "Fruity Woody": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -580,6 +580,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
   // Fruit - Tier 3
+  "Generous Orchard": {
+    name: "Gene",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 2,
+      tier: 2,
+      island: "spring",
+    },
+    boosts: "10% chance to get +1 patch fruit yield",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
 
   // Trees - Tier 1
   "Lumberjack's Extra": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -543,6 +543,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     boosts: "Chop fruit branches without axes, but get no wood drops",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Pear Turbocharge": {
+    name: "Pear Turbocharge",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 2,
+      tier: 2,
+      island: "spring",
+    },
+    boosts: "Double Immortal Pear's effect",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
   // Fruit - Tier 3
 
   // Trees - Tier 1

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -543,6 +543,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     boosts: "Chop fruit branches without axes, but get no wood drops",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Fruity Woody": {
+    name: "Fruity Woody",
+    tree: "Fruit",
+    requirements: {
+      points: 2,
+      tier: 2,
+      island: "spring",
+    },
+    boosts: "Fruit plants drop +1 wood when chopped",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+    disabled: false,
+  },
   "Pear Turbocharge": {
     name: "Pear Turbocharge",
     tree: "Fruit",
@@ -607,18 +619,6 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     disabled: false,
   },
   // Trees - Tier 2
-  "Fruity Woody": {
-    name: "Fruity Woody",
-    tree: "Trees",
-    requirements: {
-      points: 2,
-      tier: 2,
-      island: "basic",
-    },
-    boosts: "Fruit plants drop +1 wood when chopped",
-    image: SUNNYSIDE?.skills?.green_thumb_LE,
-    disabled: false,
-  },
   "Tough Tree": {
     name: "Tough Tree",
     tree: "Trees",

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -581,15 +581,28 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
   },
   // Fruit - Tier 3
   "Generous Orchard": {
-    name: "Gene",
+    name: "Generous Orchard",
     tree: "Fruit",
     disabled: false,
     requirements: {
-      points: 2,
-      tier: 2,
+      points: 3,
+      tier: 3,
       island: "spring",
     },
     boosts: "10% chance to get +1 patch fruit yield",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
+  "Long Pickings": {
+    name: "Long Pickings",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 3,
+      tier: 3,
+      island: "spring",
+    },
+    boosts:
+      "Apple and Banana grow 2x faster, but Tomato, Lemon, Blueberry and Orange take 2x longer to grow",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
 

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -514,7 +514,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 1,
       island: "spring",
     },
-    boosts: "+0.05 patch fruit yield",
+    boosts: "Fruit Patch seeds cost 10% less",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -490,7 +490,7 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       tier: 1,
       island: "spring",
     },
-    boosts: "+0.1 Basic Fruit Yield (Blueberries, Oranges)",
+    boosts: "+0.1 Fruit Patch Yield",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -605,6 +605,19 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       "Apple and Banana grow 2x faster, but Tomato, Lemon, Blueberry and Orange take 2x longer to grow",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Short Pickings": {
+    name: "Short Pickings",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 3,
+      tier: 3,
+      island: "spring",
+    },
+    boosts:
+      "Blueberry and Orange grow 2x faster, but Tomato, Lemon, Apple and Banana take 2x longer to grow",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
 
   // Trees - Tier 1
   "Lumberjack's Extra": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -618,6 +618,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
       "Blueberry and Orange grow 2x faster, but Tomato, Lemon, Apple and Banana take 2x longer to grow",
     image: SUNNYSIDE?.skills?.green_thumb_LE,
   },
+  "Zesty Vibes": {
+    name: "Zesty Vibes",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 3,
+      tier: 3,
+      island: "spring",
+    },
+    boosts: "+1 Tomato and Lemon yield, but -0.5 all other patch fruit yield",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
 
   // Trees - Tier 1
   "Lumberjack's Extra": {

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -531,6 +531,18 @@ export const BUMPKIN_REVAMP_SKILL_TREE = {
     image: SUNNYSIDE?.skills?.green_thumb_LE,
     disabled: false,
   },
+  "No Axe No Worries": {
+    name: "No Axe No Worries",
+    tree: "Fruit",
+    disabled: false,
+    requirements: {
+      points: 2,
+      tier: 2,
+      island: "spring",
+    },
+    boosts: "Chop fruit branches without axes, but get no wood drops",
+    image: SUNNYSIDE?.skills?.green_thumb_LE,
+  },
   // Fruit - Tier 3
 
   // Trees - Tier 1

--- a/src/features/game/types/fruits.ts
+++ b/src/features/game/types/fruits.ts
@@ -5,6 +5,7 @@
 import { getKeys } from "./craftables";
 import { translate } from "lib/i18n/translate";
 import { ResourceName } from "./resources";
+import { SeedName } from "./seeds";
 
 export type PatchFruitName =
   | "Apple"
@@ -35,8 +36,8 @@ export type PatchFruitSeed = {
   disabled?: boolean;
 };
 
-export function isPatchFruitSeed(seed: PatchFruitSeedName) {
-  return getKeys(PATCH_FRUIT_SEEDS()).includes(seed);
+export function isPatchFruitSeed(seed: SeedName) {
+  return getKeys(PATCH_FRUIT_SEEDS()).includes(seed as PatchFruitSeedName);
 }
 
 export const PATCH_FRUIT_SEEDS: () => Record<

--- a/src/features/island/buildings/components/building/market/Seeds.tsx
+++ b/src/features/island/buildings/components/building/market/Seeds.tsx
@@ -19,7 +19,6 @@ import { INVENTORY_LIMIT } from "features/game/lib/constants";
 import { makeBulkBuySeeds } from "./lib/makeBulkBuyAmount";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { SEEDS, SeedName } from "features/game/types/seeds";
-import { Bumpkin } from "features/game/types/game";
 import {
   GREENHOUSE_FRUIT_SEEDS,
   PATCH_FRUIT,
@@ -219,11 +218,7 @@ export const Seeds: React.FC = () => {
     }
 
     if (yields && yields in PATCH_FRUIT())
-      return getFruitPatchTime(
-        selectedName as PatchFruitSeedName,
-        state,
-        (state.bumpkin as Bumpkin)?.equipped ?? {},
-      );
+      return getFruitPatchTime(selectedName as PatchFruitSeedName, state);
 
     if (
       selectedName in GREENHOUSE_SEEDS ||

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -118,11 +118,7 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
     }
 
     if (isPatchFruitSeed(seedName)) {
-      return getFruitPatchTime(
-        seedName,
-        gameState,
-        (gameState.bumpkin as Bumpkin)?.equipped ?? {},
-      );
+      return getFruitPatchTime(seedName, gameState);
     }
     if (seedName in GREENHOUSE_SEEDS || seedName in GREENHOUSE_FRUIT_SEEDS()) {
       const plant = SEED_TO_PLANT[seedName as GreenHouseCropSeedName];


### PR DESCRIPTION
# Description

## Balances
- Fruitful Fumble - Changed from affecting only blueberries and oranges to affect all fruits
- Fruity Profit - Moved from tier 2 to 1 and nerfed to from 100% profit to 50%
- Fruity Heaven - Changed to 10% cheaper fruit seeds
- Catchup - changed from affecting tomatoes and lemons to affect all fruits
- Fruity Woody - Moved from trees to fruit 

## New Skills
- All other skills removed
- Loyal Macaw - Doubles Macaw's effect
- No Axe No Worries - 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
