### PR TITLE
[FEAT] Display Friendship Points for Each Selected Flower in NPC Modal

### DIFF
--- a/src/features/game/events/landExpansion/giftFlowers.ts
+++ b/src/features/game/events/landExpansion/giftFlowers.ts
@@ -20,7 +20,10 @@ type Options = {
   createdAt?: number;
 };
 
-const calculateRelationshipPoints = (points: number, game: GameState) => {
+export const calculateRelationshipPoints = (
+  points: number,
+  game: GameState,
+) => {
   const { bumpkin } = game;
 
   let total = points;

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -36,7 +36,10 @@ import {
   getSeasonalTicket,
 } from "features/game/types/seasons";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { BUMPKIN_FLOWER_BONUSES } from "features/game/types/gifts";
+import {
+  BUMPKIN_FLOWER_BONUSES,
+  DEFAULT_FLOWER_POINTS,
+} from "features/game/types/gifts";
 import {
   generateDeliveryTickets,
   getCountAndTypeForDelivery,
@@ -50,6 +53,7 @@ import { SquareIcon } from "components/ui/SquareIcon";
 import { formatNumber } from "lib/utils/formatNumber";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { TranslationKeys } from "lib/i18n/dictionaries/types";
+import { calculateRelationshipPoints } from "features/game/events/landExpansion/giftFlowers";
 
 export const OrderCard: React.FC<{
   order: Order;
@@ -352,6 +356,16 @@ export const Gifts: React.FC<{
     translated = `${translated} ${t("npcDialogues.default.locked")}`;
   }
 
+  let flowerPoints = calculateRelationshipPoints(
+    DEFAULT_FLOWER_POINTS[selected as FlowerName],
+    game,
+  );
+  const bumpkinFlowerBonuses =
+    BUMPKIN_FLOWER_BONUSES[name]?.[selected as FlowerName] ?? 0;
+  if (bumpkinFlowerBonuses > 0) {
+    flowerPoints += bumpkinFlowerBonuses;
+  }
+
   return (
     <>
       <InnerPanel className="mb-1">
@@ -384,10 +398,10 @@ export const Gifts: React.FC<{
         </div>
       </InnerPanel>
       <InnerPanel className="mb-1">
-        <div className="flex justify-between">
+        <div className="flex flex-wrap justify-between mb-1.5">
           <Label
             type="default"
-            className="mb-2 ml-1"
+            className="mb-1 ml-1"
             icon={ITEM_DETAILS["White Pansy"].image}
           >
             {t("bumpkin.delivery.selectFlower")}
@@ -395,7 +409,7 @@ export const Gifts: React.FC<{
           {selected && (
             <Label
               type="default"
-              className="mb-2"
+              className="mb-1 ml-1"
               icon={ITEM_DETAILS[selected].image}
             >
               {selected}
@@ -407,7 +421,7 @@ export const Gifts: React.FC<{
           <p className="text-xs mb-2">{`${t("bumpkin.delivery.noFlowers")}`}</p>
         )}
         {flowers.length > 0 && (
-          <div className="flex w-full flex-wrap">
+          <div className="flex w-full flex-wrap mb-2">
             {flowers.map((flower) => (
               <Box
                 key={flower}
@@ -428,6 +442,7 @@ export const Gifts: React.FC<{
         <Button
           disabled={isLocked || !selected || !game.inventory[selected]?.gte(1)}
           onClick={onGift}
+          className="relative"
         >
           <div className="flex items-center">
             {isLocked && (
@@ -441,6 +456,22 @@ export const Gifts: React.FC<{
             )}
             {t("gift")}
           </div>
+          {selected && !isLocked && (
+            <div className="absolute -right-0.5 -top-[17px]">
+              <Label
+                type={bumpkinFlowerBonuses === 0 ? "warning" : "vibrant"}
+                icon={
+                  bumpkinFlowerBonuses === 0 ? SUNNYSIDE.icons.heart : lightning
+                }
+              >
+                <span
+                  className={classNames("text-xs", {
+                    "-ml-1": bumpkinFlowerBonuses !== 0,
+                  })}
+                >{`+${flowerPoints}`}</span>
+              </Label>
+            </div>
+          )}
         </Button>
       </div>
     </>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f426038b-1af1-422c-b4e3-cb7a94f51cdc) | ![image](https://github.com/user-attachments/assets/c680cac8-6084-41e5-89d5-d05714042684) | 

_Blossom Bonding skill (+2 points) is active._


---
- **Display the points for NPCs' favourite flower with a different label and icon:**

![image](https://github.com/user-attachments/assets/3a9a1935-291a-491e-8402-d55384357647)
