### PR TITLE
[FIX] Wearables Image Loading

### DIFF
--- a/src/components/ui/FriendshipInfoPanel.tsx
+++ b/src/components/ui/FriendshipInfoPanel.tsx
@@ -60,7 +60,12 @@ export const FriendshipInfoPanel: React.FC<Props> = ({
                   {!!wearable && (
                     <>
                       <img
-                        src={`/src/assets/wearables/${ITEM_IDS[wearable[0]]}.webp`}
+                        src={
+                          new URL(
+                            `/src/assets/wearables/${ITEM_IDS[wearable[0]]}.webp`,
+                            import.meta.url,
+                          ).href
+                        }
                         alt={wearable[0]}
                         className="w-4 mr-0.5"
                       />

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -110,8 +110,8 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
       obsessionCompletedAt >= currentObsession.startDate &&
       obsessionCompletedAt <= currentObsession.endDate
     )
-      return 1;
-    return 0;
+      return 0;
+    return 1;
   };
 
   const incompleteFlowerBounties = state.bounties.requests.filter(


### PR DESCRIPTION
# Description
This PR should address the issue that prevents background-less images for wearables from loading in the friendship info panel.