### PR TITLE
[FEAT] Abstract count label. Add to view card.

### DIFF
--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -199,6 +199,7 @@ export const Box: React.FC<BoxProps> = ({
         {/** Show alternate Icon */}
         {!showCountLabel && alternateIcon && (
           <CountLabel
+            isHover={isHover}
             count={precisionCount}
             labelType={countLabelType}
             rightShiftPx={LABEL_RIGHT_SHIFT_PX}

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -1,16 +1,17 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState } from "react";
 import classNames from "classnames";
 import Decimal from "decimal.js-light";
 
-import { Label, LabelType } from "./Label";
+import { LabelType } from "./Label";
 import { useLongPress } from "lib/utils/hooks/useLongPress";
-import { setPrecision, shortenCount } from "lib/utils/formatNumber";
+import { setPrecision } from "lib/utils/formatNumber";
 import { isMobile } from "mobile-device-detect";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SquareIcon } from "./SquareIcon";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ProgressType, ResizableBar } from "./ProgressBar";
+import { CountLabel } from "./CountLabel";
 
 const LABEL_RIGHT_SHIFT_PX = -5 * PIXEL_SCALE;
 const LABEL_TOP_SHIFT_PX = -5 * PIXEL_SCALE;
@@ -83,19 +84,8 @@ export const Box: React.FC<BoxProps> = ({
   onDrop,
 }) => {
   const [isHover, setIsHover] = useState(false);
-  const [showHiddenCountLabel, setShowHiddenCountLabel] = useState(false);
-  const [shortCount, setShortCount] = useState("");
-
-  const labelRef = useRef<HTMLDivElement>(null);
-  const labelCheckerRef = useRef<HTMLDivElement>(null);
 
   const precisionCount = setPrecision(count ?? 0, 2);
-
-  // re-execute function on count change
-  useEffect(
-    () => setShortCount(shortenCount(precisionCount)),
-    [precisionCount],
-  );
 
   const canClick = !locked && !disabled && !!onClick;
 
@@ -114,57 +104,10 @@ export const Box: React.FC<BoxProps> = ({
 
   const showCountLabel = !locked && !hideCount && precisionCount.greaterThan(0);
 
-  // shift count label position to right if out of parent div or viewport bounds on hover
-  // restore count label position when not on hover
-  // hidden count label is needed to prevent flickering of the visible count label on hover
-  useEffect(() => {
-    setShowHiddenCountLabel(false);
-
-    // restore count label position when not on hover
-    if (!isHover && labelRef.current) {
-      labelRef.current.style.right = `${LABEL_RIGHT_SHIFT_PX}px`;
-      return;
-    }
-
-    // null check
-    if (!labelRef.current || !labelCheckerRef.current) {
-      return;
-    }
-
-    // get hidden count label and parent div/viewport bounding
-    const hiddenCountLabelBounding =
-      labelCheckerRef.current.getBoundingClientRect();
-    const parentDivBounding = parentDivRef?.current?.getBoundingClientRect();
-
-    // if parent div is defined,
-    // shift count label to the right so left most bounds for count label touches that of the parent div
-    if (
-      parentDivBounding &&
-      hiddenCountLabelBounding.left < parentDivBounding.left
-    ) {
-      labelRef.current.style.right = `${
-        LABEL_RIGHT_SHIFT_PX +
-        hiddenCountLabelBounding.left -
-        parentDivBounding.left
-      }px`;
-      return;
-    }
-
-    // else shift count label to the right so left most bounds for count label touches that of the viewport
-    if (hiddenCountLabelBounding?.left < 0) {
-      labelRef.current.style.right = `${
-        LABEL_RIGHT_SHIFT_PX + hiddenCountLabelBounding.left
-      }px`;
-    }
-  }, [isHover]);
-
   return (
     <div
       className={`relative ${className}`}
-      onMouseEnter={() => {
-        setShowHiddenCountLabel(true);
-        setIsHover(true);
-      }}
+      onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
       <div
@@ -243,75 +186,25 @@ export const Box: React.FC<BoxProps> = ({
 
         {/* Count label */}
         {showCountLabel && (
-          <div
-            ref={labelRef}
-            className={classNames("absolute", {
-              "z-10": !isHover,
-              "z-20": isHover,
-            })}
-            style={{
-              right: `${LABEL_RIGHT_SHIFT_PX}px`,
-              top: `${LABEL_TOP_SHIFT_PX}px`,
-              pointerEvents: "none",
-            }}
-          >
-            <Label
-              type={countLabelType}
-              style={{
-                padding: "0 2.5",
-                height: "24px",
-              }}
-            >
-              {isHover && !showHiddenCountLabel
-                ? precisionCount.toString()
-                : shortCount}
-            </Label>
-          </div>
-        )}
-
-        {/* Transparent long count label to adjust the visible count label position on hover */}
-        {showCountLabel && showHiddenCountLabel && (
-          <div
-            ref={labelCheckerRef}
-            className="absolute opacity-0"
-            style={{
-              right: `${LABEL_RIGHT_SHIFT_PX}px`,
-              top: `${LABEL_TOP_SHIFT_PX}px`,
-              pointerEvents: "none",
-            }}
-          >
-            <Label
-              type="default"
-              style={{
-                padding: "0 2.5",
-                height: "24px",
-              }}
-            >
-              {precisionCount.toString()}
-            </Label>
-          </div>
+          <CountLabel
+            isHover={isHover}
+            count={precisionCount}
+            labelType={countLabelType}
+            rightShiftPx={LABEL_RIGHT_SHIFT_PX}
+            topShiftPx={LABEL_TOP_SHIFT_PX}
+            parentDivRef={parentDivRef}
+          />
         )}
 
         {/** Show alternate Icon */}
         {!showCountLabel && alternateIcon && (
-          <div
-            ref={labelRef}
-            className={classNames("absolute", {
-              "z-10": !isHover,
-              "z-20": isHover,
-            })}
-            style={{
-              right: `${LABEL_RIGHT_SHIFT_PX}px`,
-              top: `${LABEL_TOP_SHIFT_PX}px`,
-              pointerEvents: "none",
-            }}
-          >
-            <SquareIcon
-              icon={alternateIcon}
-              width={INNER_CANVAS_WIDTH}
-              className={iconClassName}
-            />
-          </div>
+          <CountLabel
+            count={precisionCount}
+            labelType={countLabelType}
+            rightShiftPx={LABEL_RIGHT_SHIFT_PX}
+            topShiftPx={LABEL_TOP_SHIFT_PX}
+            parentDivRef={parentDivRef}
+          />
         )}
 
         {/** Overlay icon */}

--- a/src/components/ui/CountLabel.tsx
+++ b/src/components/ui/CountLabel.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect, useRef } from "react";
+import classNames from "classnames";
+import Decimal from "decimal.js-light";
+import { Label, LabelType } from "./Label";
+import { setPrecision, shortenCount } from "lib/utils/formatNumber";
+
+interface CountLabelProps {
+  isHover: boolean;
+  count: Decimal;
+  labelType?: LabelType;
+  rightShiftPx: number;
+  topShiftPx: number;
+  parentDivRef?: React.RefObject<HTMLElement>;
+}
+
+export const CountLabel: React.FC<CountLabelProps> = ({
+  isHover,
+  count,
+  labelType = "default",
+  rightShiftPx,
+  topShiftPx,
+  parentDivRef,
+}) => {
+  const [showHiddenCountLabel, setShowHiddenCountLabel] = useState(false);
+  const [shortCount, setShortCount] = useState("");
+
+  const labelRef = useRef<HTMLDivElement>(null);
+  const labelCheckerRef = useRef<HTMLDivElement>(null);
+
+  const precisionCount = setPrecision(count, 4);
+
+  useEffect(() => {
+    setShortCount(shortenCount(precisionCount));
+  }, [precisionCount]);
+
+  // Handle label positioning
+  useEffect(() => {
+    setShowHiddenCountLabel(false);
+
+    if (!isHover && labelRef.current) {
+      labelRef.current.style.right = `${rightShiftPx}px`;
+      return;
+    }
+
+    if (!labelRef.current || !labelCheckerRef.current) {
+      return;
+    }
+
+    const hiddenCountLabelBounding =
+      labelCheckerRef.current.getBoundingClientRect();
+    const parentDivBounding = parentDivRef?.current?.getBoundingClientRect();
+
+    if (
+      parentDivBounding &&
+      hiddenCountLabelBounding.left < parentDivBounding.left
+    ) {
+      labelRef.current.style.right = `${
+        rightShiftPx + hiddenCountLabelBounding.left - parentDivBounding.left
+      }px`;
+      return;
+    }
+
+    if (hiddenCountLabelBounding?.left < 0) {
+      labelRef.current.style.right = `${
+        rightShiftPx + hiddenCountLabelBounding.left
+      }px`;
+    }
+  }, [isHover, rightShiftPx]);
+
+  return (
+    <div
+      onMouseEnter={() => {
+        setShowHiddenCountLabel(true);
+      }}
+      onMouseLeave={() => setShowHiddenCountLabel(false)}
+    >
+      {/* Visible Label */}
+      <div
+        ref={labelRef}
+        className={classNames("absolute", {
+          "z-10": !isHover,
+          "z-20": isHover,
+        })}
+        style={{
+          right: `${rightShiftPx}px`,
+          top: `${topShiftPx}px`,
+          pointerEvents: "none",
+        }}
+      >
+        <Label
+          type={labelType}
+          style={{
+            padding: "0 2.5",
+            height: "24px",
+          }}
+        >
+          {isHover && !showHiddenCountLabel
+            ? precisionCount.toString()
+            : shortCount}
+        </Label>
+      </div>
+
+      {/* Hidden Label for Position Calculation */}
+      {showHiddenCountLabel && (
+        <div
+          ref={labelCheckerRef}
+          className="absolute opacity-0"
+          style={{
+            right: `${rightShiftPx}px`,
+            top: `${topShiftPx}px`,
+            pointerEvents: "none",
+          }}
+        >
+          <Label
+            type="default"
+            style={{
+              padding: "0 2.5",
+              height: "24px",
+            }}
+          >
+            {precisionCount.toString()}
+          </Label>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -28,6 +28,7 @@ export const Collection: React.FC<{
   onNavigated?: () => void;
 }> = ({ search, onNavigated }) => {
   const { authService } = useContext(Auth.Context);
+
   const [authState] = useActor(authService);
 
   const isWorldRoute = useLocation().pathname.includes("/world");

--- a/src/features/marketplace/components/profile/MyCollection.tsx
+++ b/src/features/marketplace/components/profile/MyCollection.tsx
@@ -115,7 +115,6 @@ export const MyCollection: React.FC = () => {
                         `${isWorldRoute ? "/world" : ""}/marketplace/${details.type}/${item.id}`,
                       );
                     }}
-                    count={item.count}
                   />
                 </div>
               );

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2329,7 +2329,7 @@
   "marketplace.unlockSelling": "Unlock selling",
   "marketplace.unlockOffering": "Unlock offering",
   "marketplace.youOwn": "You own: {{count}}",
-  "marketplace.pricePerUnit": "{{price}} per unit",
+  "marketplace.pricePerUnit": "{{price}}/unit",
   "marketplace.areYouSureYouWantToBuy": "Are you sure you want to buy this item?",
   "marketplace.successfulPurchase": "You just successfully bought this item!",
   "marketplace.signAndBuy": "Sign & Buy",


### PR DESCRIPTION
# Description

- Abstract the count label into a reusable component
- Add count to the `ListViewCard`

<img width="1500" alt="Screenshot 2024-12-09 at 10 45 25 AM" src="https://github.com/user-attachments/assets/5d411be3-8dd3-4e34-8a22-877fdf8cb374">
<img width="1491" alt="Screenshot 2024-12-09 at 10 44 40 AM" src="https://github.com/user-attachments/assets/bb6802e3-5e37-4d89-820e-725863ec2a3b">

Fixes #issue

# What needs to be tested by the reviewer?

- Count should be displayed on the `ListViewCard`
- Count in inventory should still be correct

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
