### PR TITLE
[FIX] Image Layering in Farm

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -229,7 +229,7 @@ const getIslandElements = ({
               y={y}
               height={height}
               width={width}
-              z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : 1}
+              z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : "unset"}
             >
               <Collectible
                 location="farm"
@@ -825,7 +825,20 @@ export const Land: React.FC = () => {
                 airdrops,
                 beehives,
                 oilReserves,
-              }).sort((a, b) => b.props.y - a.props.y)}
+              }).sort((a, b) => {
+                if (a.props.z === 0) {
+                  return -1;
+                }
+
+                if (b.props.y > a.props.y) {
+                  return 1;
+                }
+                if (a.props.y > b.props.y) {
+                  return -1;
+                }
+
+                return 0;
+              })}
           </div>
 
           {landscaping && <Placeable location="farm" />}

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -229,7 +229,7 @@ const getIslandElements = ({
               y={y}
               height={height}
               width={width}
-              z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : "unset"}
+              canCollide={NON_COLLIDING_OBJECTS.includes(name) ? false : true}
             >
               <Collectible
                 location="farm"
@@ -242,6 +242,7 @@ const getIslandElements = ({
                 y={coordinates.y}
                 grid={grid}
                 game={game}
+                z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : "unset"}
               />
             </MapPlacement>
           );
@@ -826,7 +827,7 @@ export const Land: React.FC = () => {
                 beehives,
                 oilReserves,
               }).sort((a, b) => {
-                if (a.props.z === 0) {
+                if (a.props.canCollide === false) {
                   return -1;
                 }
 

--- a/src/features/game/expansion/components/MapPlacement.tsx
+++ b/src/features/game/expansion/components/MapPlacement.tsx
@@ -9,7 +9,7 @@ export type Coordinates = {
 export type Position = {
   height?: number;
   width?: number;
-  z?: number;
+  z?: number | string;
 } & Coordinates;
 
 type Props = Position;

--- a/src/features/game/expansion/components/MapPlacement.tsx
+++ b/src/features/game/expansion/components/MapPlacement.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable unused-imports/no-unused-vars */
 import React from "react";
 import { GRID_WIDTH_PX } from "../../lib/constants";
 
@@ -9,7 +11,8 @@ export type Coordinates = {
 export type Position = {
   height?: number;
   width?: number;
-  z?: number | string;
+  z?: number;
+  canCollide?: boolean;
 } & Coordinates;
 
 type Props = Position;
@@ -26,6 +29,7 @@ export const MapPlacement: React.FC<Props> = ({
   width,
   children,
   z = "unset",
+  canCollide = true,
 }) => {
   return (
     <div

--- a/src/features/island/collectibles/Collectible.tsx
+++ b/src/features/island/collectibles/Collectible.tsx
@@ -42,6 +42,7 @@ export type CollectibleProps = {
   grid: GameGrid;
   location: PlaceableLocation;
   game: GameState;
+  z?: number | string;
 };
 
 type Props = CollectibleProps & {
@@ -151,6 +152,7 @@ const CollectibleComponent: React.FC<Props> = ({
   grid,
   location,
   game,
+  z,
 }) => {
   const CollectiblePlaced = COLLECTIBLE_COMPONENTS[name];
 
@@ -159,7 +161,7 @@ const CollectibleComponent: React.FC<Props> = ({
   useUiRefresher({ active: inProgress });
 
   return (
-    <div className="h-full">
+    <div className="h-full" style={{ zIndex: z }}>
       {inProgress ? (
         <InProgressCollectible
           key={id}
@@ -228,14 +230,18 @@ const LandscapingCollectible: React.FC<Props> = (props) => {
             </InnerPanel>
           </div>
         )}
-        <CollectiblePlaced {...props} />
+        <div style={{ zIndex: props.z }}>
+          <CollectiblePlaced {...props} />
+        </div>
       </div>
     );
   }
 
   return (
     <MoveableComponent {...(props as any)}>
-      <CollectiblePlaced {...props} />
+      <div style={{ zIndex: props.z }}>
+        <CollectiblePlaced {...props} />
+      </div>
     </MoveableComponent>
   );
 };


### PR DESCRIPTION
# Description

This fixes layering bug of collectibles specially rug. This PR makes it so that the rug will render below every collectibles/buildings/resources in the farm. 
![image](https://github.com/user-attachments/assets/98c3d5d2-3f28-4bb7-87bb-d3e0d7529c45)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
