### PR TITLE
[FIX] Sheep showing wrong boost amount

### DIFF
--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -92,7 +92,7 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
   const idle = sheepState === "idle";
 
   const requiredFoodQty = getBoostedFoodQuantity({
-    animalType: "Cow",
+    animalType: "Sheep",
     foodQuantity: REQUIRED_FOOD_QTY.Sheep,
     game,
   });

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -259,7 +259,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   island: {
-    type: "basic",
+    type: "spring",
   },
   mysteryPrizes: {},
   minigames: {
@@ -325,6 +325,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     ...TEST_BUMPKIN,
     skills: {
       "Double Nom": 1,
+      "Cow-Smart Nutrition": 1,
     },
   },
   buds: {
@@ -1705,7 +1706,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
         type: "Cow",
         createdAt: 0,
         lovedAt: 0,
-        state: "ready",
+        state: "idle",
         item: "Brush",
         reward: {
           items: [
@@ -1724,7 +1725,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
         type: "Sheep",
         createdAt: 0,
         lovedAt: 0,
-        state: "happy",
+        state: "idle",
         item: "Brush",
       },
     },


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue
Sheep feed amount in UI drops instead of increases with Cow Smart Nutrition

# What needs to be tested by the reviewer?

Go into local
- Check cow and sheep feed amounts
- pick up Cow Smart Nutrition
- make sure cow feed goes down and sheep goes up

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
