### PR TITLE
[FIX] Toast Panel Z Index

### DIFF
--- a/src/components/ui/HudContainer.tsx
+++ b/src/components/ui/HudContainer.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 import { createPortal } from "react-dom";
 
+interface Props {
+  className?: string | undefined;
+}
+
 /**
  * Heads up display container which portals all Hud Components out to the body and applies safe area styling - should be used for all game Hud components
  */
-export const HudContainer: React.FC = ({ children }) => {
+export const HudContainer: React.FC<Props> = ({ children, className }) => {
   return (
     <>
       {createPortal(
         <div
           data-html2canvas-ignore="true"
           aria-label="Hud"
-          className="fixed inset-safe-area pointer-events-none z-10"
+          className={`fixed inset-safe-area pointer-events-none ${className ?? "z-10"}`}
         >
           <div // Prevent click through to Phaser
             onMouseDown={(e) => e.stopPropagation()}

--- a/src/features/game/toast/ToastPanel.tsx
+++ b/src/features/game/toast/ToastPanel.tsx
@@ -136,9 +136,9 @@ export const ToastPanel: React.FC = () => {
   return (
     <>
       {showToasts && (
-        <HudContainer>
+        <HudContainer className="z-[99999]">
           <InnerPanel
-            className="flex flex-col items-start absolute z-[99999] pointer-events-none"
+            className="flex flex-col items-start absolute pointer-events-none"
             style={{
               top: `${PIXEL_SCALE * 54}px`,
               left: `${PIXEL_SCALE * 3}px`,


### PR DESCRIPTION
# Description

This PR fixes the long-standing issue where mobile players do not see the items or XP they gain when performing actions such as buying tools, feeding the bumpkin, completing deliveries, etc. Additionally, it ensures that players can see when items are removed from their inventory.

Fixes #issue