### PR TITLE
[FEAT] Add close option to claim notification

### DIFF
--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -42,6 +42,7 @@ export const MarketplaceSalesPopup: React.FC = () => {
 
     if (soldListingIds.some((id) => trades.listings?.[id].signature)) {
       gameService.send("RESET");
+      return;
     }
 
     gameService.send("CLOSE");
@@ -105,7 +106,14 @@ export const MarketplaceSalesPopup: React.FC = () => {
           );
         })}
       </div>
-      <Button onClick={() => claimAll()}>{t("claim")}</Button>
+      <div className="flex space-x-1">
+        <Button className="w-full" onClick={() => gameService.send("CLOSE")}>
+          {t("close")}
+        </Button>
+        <Button className="w-full" onClick={() => claimAll()}>
+          {t("claim")}
+        </Button>
+      </div>
     </>
   );
 };

--- a/src/features/game/expansion/components/OffersAcceptedPopup.tsx
+++ b/src/features/game/expansion/components/OffersAcceptedPopup.tsx
@@ -104,7 +104,14 @@ export const OffersAcceptedPopup: React.FC = () => {
           );
         })}
       </div>
-      <Button onClick={() => claimAll()}>{t("claim")}</Button>
+      <div className="flex space-x-1">
+        <Button className="w-full" onClick={() => claimAll()}>
+          {t("claim")}
+        </Button>
+        <Button className="w-full" onClick={() => gameService.send("CLOSE")}>
+          {t("close")}
+        </Button>
+      </div>
     </>
   );
 };

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -98,17 +98,17 @@ export const TradeableOffers: React.FC<{
     gameService,
     "marketplaceOfferCancellingSuccess",
     "playing",
-    () => {
-      reload();
-      if (showAnimations) confetti();
-    },
+    reload,
   );
 
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,
     "marketplaceAcceptingSuccess",
     "playing",
-    reload,
+    () => {
+      reload();
+      if (showAnimations) confetti();
+    },
   );
 
   const handleHide = () => {


### PR DESCRIPTION
# Description

Add ability for a player to not claim immediately (close the modal) as they may want to be strategic around daily earned SFL amount.

<img width="507" alt="Screenshot 2024-12-12 at 11 50 12 AM" src="https://github.com/user-attachments/assets/8bf484f2-fb42-4ef2-a7a8-31c603e0c2d2" />


Fixes #issue

# What needs to be tested by the reviewer?

- Have a trade fulfilled
- Close the claim modal that pops up at the beginning of a session

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes