### PR TITLE
[FIX] On Chain Success Modal Showing Prematurely

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -477,6 +477,19 @@ const EFFECT_STATES = Object.values(EFFECT_EVENTS).reduce(
         onDone: [
           {
             target: `${stateName}Success`,
+            cond: (_: Context, event: DoneInvokeEvent<any>) =>
+              !event.data.state.transaction,
+            actions: [
+              assign((_, event: DoneInvokeEvent<any>) => ({
+                actions: [],
+                state: event.data.state,
+              })),
+            ],
+          },
+          // If there is a transaction on the gameState move into playing so that
+          // the transaction flow can handle the rest of the flow
+          {
+            target: `playing`,
             actions: [
               assign((_, event: DoneInvokeEvent<any>) => ({
                 actions: [],


### PR DESCRIPTION
# Description

When purchasing an on chain item the success modal shows up underneath the transaction modal. This was happening because the game machine was moving into the `[effect]Success` state even through the on chain purchase had not gone through the transaction flow. 

This PR fixes this issue by only moving into the success state if a transaction is not present on the new game state. If a transaction is in progress AFTER the effect is called then the game machine moves back to playing so the `Transaction` component can handle the rest of the purchase. 

Fixes #issue

# What needs to be tested by the reviewer?

- Purchase an on chain item
- Confirm that you don't get a success modal and confetti
- Ensure that you can continue playing the game as normal after the transaction has completed or while its in progress

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
