### PR TITLE
[CHORE] Pass farmId and jwt to portal leaderboard

### DIFF
--- a/src/features/world/ui/portals/ChickenRescue.tsx
+++ b/src/features/world/ui/portals/ChickenRescue.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 import { Button } from "components/ui/Button";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
+import * as AuthProvider from "features/auth/lib/Provider";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { OuterPanel } from "components/ui/Panel";
@@ -88,6 +89,7 @@ interface Props {
 }
 
 export const ChickenRescue: React.FC<Props> = ({ onClose }) => {
+  const { authService } = useContext(AuthProvider.Context);
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -173,6 +175,8 @@ export const ChickenRescue: React.FC<Props> = ({ onClose }) => {
   if (page === "leaderboard") {
     return (
       <PortalLeaderboard
+        farmId={gameService.state.context.farmId}
+        jwt={authService.state.context.user.rawToken as string}
         onBack={() => setPage("play")}
         name={"chicken-rescue"}
       />

--- a/src/features/world/ui/portals/Halloween.tsx
+++ b/src/features/world/ui/portals/Halloween.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Button } from "components/ui/Button";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
+import * as AuthProvider from "features/auth/lib/Provider";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { OuterPanel } from "components/ui/Panel";
@@ -96,6 +97,7 @@ interface Props {
 }
 
 export const Halloween: React.FC<Props> = ({ onClose }) => {
+  const { authService } = useContext(AuthProvider.Context);
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
 
@@ -186,6 +188,8 @@ export const Halloween: React.FC<Props> = ({ onClose }) => {
   if (page === "leaderboard") {
     return (
       <PortalLeaderboard
+        farmId={gameService.state.context.farmId}
+        jwt={authService.state.context.user.rawToken as string}
         onBack={() => setPage("play")}
         name={"halloween"}
         startDate={new Date(Date.UTC(2024, 10, 1))}
@@ -200,6 +204,8 @@ export const Halloween: React.FC<Props> = ({ onClose }) => {
   if (page === "accumulator") {
     return (
       <PortalLeaderboard
+        farmId={gameService.state.context.farmId}
+        jwt={authService.state.context.user.rawToken as string}
         onBack={() => setPage("play")}
         name={"halloween"}
         formatPoints={(points: number) =>

--- a/src/features/world/ui/portals/PortalLeaderboard.tsx
+++ b/src/features/world/ui/portals/PortalLeaderboard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import * as AuthProvider from "features/auth/lib/Provider";
 
 import { useEffect } from "react";
 import { useState } from "react";
@@ -8,10 +7,8 @@ import {
   CompetitionPlayer,
 } from "features/game/types/competitions";
 import { MinigameName } from "features/game/types/minigames";
-import { useContext } from "react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getPortalLeaderboard } from "features/game/expansion/components/leaderboard/actions/leaderboard";
-import { Context } from "features/game/GameProvider";
 import { Loading } from "features/auth/components/Loading";
 import { Label } from "components/ui/Label";
 import classNames from "classnames";
@@ -21,14 +18,23 @@ import { Button } from "components/ui/Button";
 
 export const PortalLeaderboard: React.FC<{
   name: MinigameName;
+  farmId: number;
+  jwt: string;
   onBack: () => void;
   startDate?: Date;
   endDate?: Date;
   formatPoints?: (value: number) => string;
   isAccumulator?: boolean;
-}> = ({ name, onBack, startDate, endDate, formatPoints, isAccumulator }) => {
-  const { authService } = useContext(AuthProvider.Context);
-  const { gameService } = useContext(Context);
+}> = ({
+  name,
+  farmId,
+  jwt,
+  onBack,
+  startDate,
+  endDate,
+  formatPoints,
+  isAccumulator,
+}) => {
   const [data, setData] = useState<CompetitionLeaderboardResponse>();
 
   const formatDate = (date: Date) => date.toISOString().substring(0, 10);
@@ -45,9 +51,9 @@ export const PortalLeaderboard: React.FC<{
   useEffect(() => {
     const load = async () => {
       const data = await getPortalLeaderboard({
-        farmId: gameService.state.context.farmId,
+        farmId,
         name,
-        jwt: authService.state.context.user.rawToken as string,
+        jwt,
         from,
         to,
       });
@@ -60,14 +66,8 @@ export const PortalLeaderboard: React.FC<{
 
   if (!data) return <Loading />;
 
-  const {
-    leaderboard,
-    accumulators,
-    lastUpdated,
-    miniboard,
-    accumulatorMiniboard,
-    player,
-  } = data;
+  const { leaderboard, accumulators, miniboard, accumulatorMiniboard, player } =
+    data;
   const items = (!!isAccumulator && accumulators?.slice(0, 10)) || leaderboard;
   const title =
     !!isAccumulator && accumulators?.length


### PR DESCRIPTION
# Description

- pull out authService and gameService in PortalLeaderboard so PortalLeaderboard can be used as a component in portals

# What needs to be tested by the reviewer?

- no regressions

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
