### PR TITLE
[FIX] Prevent Preloader from Looping

### DIFF
--- a/src/features/marketplace/Marketplace.tsx
+++ b/src/features/marketplace/Marketplace.tsx
@@ -2,7 +2,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import React, { useContext } from "react";
 import sflIcon from "assets/icons/sfl.webp";
 import { MarketplaceNavigation } from "./components/MarketplaceHome";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { OuterPanel } from "components/ui/Panel";
 import { Context } from "features/game/GameProvider";
@@ -17,8 +17,16 @@ export const Marketplace: React.FC = () => {
   const { gameService, fromRoute } = useContext(Context);
   const balance = useSelector(gameService, _balance);
   const navigate = useNavigate();
-
+  const location = useLocation();
   const { t } = useAppTranslation();
+
+  const handleClose = () => {
+    const defaultRoute = location.pathname.includes("/world")
+      ? "/world/plaza"
+      : "/";
+
+    fromRoute ? navigate(fromRoute) : navigate(defaultRoute);
+  };
 
   return (
     <>
@@ -56,9 +64,7 @@ export const Marketplace: React.FC = () => {
             <img
               src={SUNNYSIDE.icons.close}
               className="flex-none cursor-pointer absolute right-2"
-              onClick={() => {
-                fromRoute ? navigate(fromRoute) : navigate("/");
-              }}
+              onClick={handleClose}
               style={{
                 width: `${PIXEL_SCALE * 11}px`,
                 height: `${PIXEL_SCALE * 11}px`,

--- a/src/features/world/World.tsx
+++ b/src/features/world/World.tsx
@@ -6,7 +6,7 @@ import { useActor, useInterpret, useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
-import { Outlet, useNavigate, useParams } from "react-router";
+import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { SceneId } from "./mmoMachine";
 import { SUNNYSIDE } from "assets/sunnyside";
 import PubSub from "pubsub-js";
@@ -90,6 +90,7 @@ export const MMO: React.FC<MMOProps> = ({ isCommunity }) => {
   const [gameState] = useActor(gameService);
   const { name } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const mmoService = useInterpret(mmoMachine, {
     context: {
@@ -97,7 +98,7 @@ export const MMO: React.FC<MMOProps> = ({ isCommunity }) => {
       farmId: gameState.context.farmId,
       bumpkin: gameState.context.state.bumpkin,
       faction: gameState.context.state.faction?.name,
-      sceneId: name as SceneId,
+      sceneId: (name ?? "plaza") as SceneId,
       experience: gameState.context.state.bumpkin?.experience ?? 0,
       isCommunity,
       moderation: gameState.context.moderation,
@@ -107,7 +108,10 @@ export const MMO: React.FC<MMOProps> = ({ isCommunity }) => {
   const [mmoState] = useActor(mmoService);
 
   useEffect(() => {
-    if (mmoState.context.sceneId) {
+    if (
+      mmoState.context.sceneId &&
+      !location.pathname.includes("marketplace")
+    ) {
       navigate(`/world/${mmoState.context.sceneId}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Description

Prevents the preloader from getting stuck in infinite loop when `sceneId` is not set.