### PR TITLE
[FIX] Force Integer when Listing on Chain

### DIFF
--- a/src/components/ui/NumberInput.tsx
+++ b/src/components/ui/NumberInput.tsx
@@ -29,7 +29,7 @@ export const NumberInput: React.FC<Props> = ({
   onValueChange,
   icon,
 }) => {
-  const VALID_DECIMAL_NUMBER = new RegExp(
+  const VALID_DECIMAL_NUMBER_WITH_PRECISION = new RegExp(
     `^\\d*(\\.\\d{0,${maxDecimalPlaces}})?$`,
   );
   const INPUT_MAX_CHAR = Math.max(maxDecimalPlaces + 4, 20);
@@ -38,14 +38,20 @@ export const NumberInput: React.FC<Props> = ({
   const [isFocused, setIsFocused] = useState(false); // State for focus
 
   useEffect(() => {
+    const newValue = setPrecision(
+      new Decimal(value),
+      maxDecimalPlaces,
+    ).toString();
+
     if (
-      new Decimal(value).equals(new Decimal(numberDisplay ? numberDisplay : 0))
+      new Decimal(newValue).equals(
+        new Decimal(numberDisplay ? numberDisplay : 0),
+      )
     )
       return;
 
-    setNumberDisplay(
-      setPrecision(new Decimal(value), maxDecimalPlaces).toString(),
-    );
+    setNumberDisplay(newValue);
+    onValueChange?.(new Decimal(newValue));
   }, [value]);
 
   return (
@@ -74,9 +80,10 @@ export const NumberInput: React.FC<Props> = ({
             setNumberDisplay("");
             onValueChange?.(new Decimal(0));
           } else if (
-            (maxDecimalPlaces > 0 ? VALID_DECIMAL_NUMBER : VALID_INTEGER).test(
-              e.target.value,
-            )
+            (maxDecimalPlaces > 0
+              ? VALID_DECIMAL_NUMBER_WITH_PRECISION
+              : VALID_INTEGER
+            ).test(e.target.value)
           ) {
             const amount = e.target.value.slice(0, INPUT_MAX_CHAR);
             setNumberDisplay(amount);

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -256,7 +256,7 @@ export const MakeOffer: React.FC<{
           <NumberInput
             value={offer}
             onValueChange={(decimal) => setOffer(decimal.toNumber())}
-            maxDecimalPlaces={2}
+            maxDecimalPlaces={tradeType === "onchain" ? 0 : 2}
             isOutOfRange={balance.lt(offer)}
             icon={sflIcon}
           />

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -410,7 +410,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
               <NumberInput
                 value={price}
                 onValueChange={(decimal) => setPrice(decimal.toNumber())}
-                maxDecimalPlaces={2}
+                maxDecimalPlaces={tradeType === "onchain" ? 0 : 2}
                 icon={sflIcon}
               />
               <p className="text-xxs ml-2">


### PR DESCRIPTION
# Description

Forces the number input to an integer when listing on chain

## How to Test

Listings:
1. In the number input of an instant trade put a decimal value.
2. Increase the value until it exceeds 250 SFL
3. Ensure the input switches to integer

Offers:
1. Add a decimal offer in an instant trade
2. Increase the offer until it exceeds 250 SFL
3. Ensure the input switches to integer

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
