### PR TITLE
[FEAT] Prevent players from selling claimed bert's obsession

### DIFF
--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -103,16 +103,13 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
   const currentObsession = state.bertObsession;
   const obsessionCompletedAt = state.npcs?.bert?.questCompletedAt;
 
-  const incompleteObsession = () => {
-    if (!currentObsession) return 0;
-    if (!obsessionCompletedAt) return 1;
-    if (
+  const incompleteObsession =
+    !currentObsession ||
+    (obsessionCompletedAt &&
       obsessionCompletedAt >= currentObsession.startDate &&
-      obsessionCompletedAt <= currentObsession.endDate
-    )
-      return 0;
-    return 1;
-  };
+      obsessionCompletedAt <= currentObsession.endDate)
+      ? 0
+      : 1;
 
   const incompleteFlowerBounties = state.bounties.requests.filter(
     (deal) => deal.name in FLOWERS,
@@ -165,7 +162,7 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
     {
       name: "Leaderboard" as const,
       icon: ITEM_DETAILS[getSeasonalTicket()].image,
-      count: incompleteObsession() + incompleteFlowerBountiesCount,
+      count: incompleteObsession + incompleteFlowerBountiesCount,
     },
     {
       name: "Fish",

--- a/src/features/island/hud/components/codex/pages/Season.tsx
+++ b/src/features/island/hud/components/codex/pages/Season.tsx
@@ -130,7 +130,7 @@ export const Season: React.FC<Props> = ({ id, isLoading, data, season }) => {
         </div>
       </InnerPanel>
       <InnerPanel className="mb-1">
-        <FlowerBountiesModal readonly setDeal={() => undefined} />
+        <FlowerBountiesModal readonly />
       </InnerPanel>
       <InnerPanel className="mb-1">
         <BertObsession readonly />

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -32,10 +32,6 @@ import Decimal from "decimal.js-light";
 import { StoreOnChain } from "./StoreOnChain";
 
 const _state = (state: MachineState) => state.context.state;
-const _previousInventory = (state: MachineState) =>
-  state.context.state.previousInventory;
-const _previousWardrobe = (state: MachineState) =>
-  state.context.state.previousWardrobe;
 
 const AcceptOfferContent: React.FC<{
   onClose: () => void;
@@ -49,9 +45,8 @@ const AcceptOfferContent: React.FC<{
 
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
-  const previousInventory = useSelector(gameService, _previousInventory);
-  const previousWardrobe = useSelector(gameService, _previousWardrobe);
   const [needsSync, setNeedsSync] = useState(false);
+  const { previousInventory, previousWardrobe, bertObsession, npcs } = state;
 
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,
@@ -149,6 +144,15 @@ const AcceptOfferContent: React.FC<{
     );
   }
 
+  // Check if the item is a bert obsession and whether the bert obsession is completed
+  const isItemBertObsession = bertObsession?.name === display.name;
+  const obsessionCompletedAt = npcs?.bert?.questCompletedAt;
+  const isBertsObesessionCompleted =
+    !!obsessionCompletedAt &&
+    bertObsession &&
+    obsessionCompletedAt >= bertObsession.startDate &&
+    obsessionCompletedAt <= bertObsession.endDate;
+
   return (
     <>
       <div className="p-2">
@@ -171,10 +175,9 @@ const AcceptOfferContent: React.FC<{
       </div>
 
       {!hasItem && (
-        <Label
-          type="danger"
-          className="my-2"
-        >{`You do not have ${display.name}`}</Label>
+        <Label type="danger" className="my-2">
+          {`You do not have ${display.name}`}
+        </Label>
       )}
 
       <div className="flex">
@@ -182,7 +185,9 @@ const AcceptOfferContent: React.FC<{
           {t("cancel")}
         </Button>
         <Button
-          disabled={!hasItem}
+          disabled={
+            !hasItem || (isItemBertObsession && isBertsObesessionCompleted)
+          }
           onClick={() => confirm()}
           className="relative"
         >

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -30,7 +30,6 @@ import { useParams } from "react-router";
 import { getKeys } from "features/game/types/craftables";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 import { hasVipAccess } from "features/game/lib/vipAccess";
-import { ModalContext } from "features/game/components/modal/ModalProvider";
 import classNames from "classnames";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { isMobile } from "mobile-device-detect";
@@ -68,7 +67,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   reload,
 }) => {
   const { gameService } = useContext(Context);
-  const { openModal } = useContext(ModalContext);
   const balance = useSelector(gameService, _balance);
   const isVIP = useSelector(gameService, _isVIP);
   const params = useParams();
@@ -131,7 +129,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
 
   const showBuyNow = !isResources && cheapestListing && tradeable?.isActive;
   const showWalletRequired = showBuyNow && cheapestListing?.type === "onchain";
-  const showFreeListing = !isVIP && dailyListings === 0;
+  // const showFreeListing = !isVIP && dailyListings === 0;
 
   const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -34,7 +34,6 @@ import classNames from "classnames";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { isMobile } from "mobile-device-detect";
 import Decimal from "decimal.js-light";
-import { FLOWERS } from "features/game/types/flowers";
 
 type TradeableHeaderProps = {
   authToken: string;
@@ -56,7 +55,7 @@ const _isVIP = (state: MachineState) =>
 const _bertObsession = (state: MachineState) =>
   state.context.state.bertObsession;
 const _npcs = (state: MachineState) => state.context.state.npcs;
-const _bounties = (state: MachineState) => state.context.state.bounties;
+
 export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   dailyListings,
   authToken,
@@ -73,7 +72,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   const params = useParams();
   const bertObsession = useSelector(gameService, _bertObsession);
   const npcs = useSelector(gameService, _npcs);
-  const bounties = useSelector(gameService, _bounties);
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
 
   const { t } = useAppTranslation();
@@ -95,17 +93,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
     bertObsession &&
     obsessionCompletedAt >= bertObsession.startDate &&
     obsessionCompletedAt <= bertObsession.endDate;
-
-  // Check if item is a flower bounty and whether the bounty is completed
-  const flowerBounties = bounties.requests.filter(
-    (deal) => deal.name in FLOWERS,
-  );
-  const isFlowerBounty = flowerBounties.find(
-    (bounty) => bounty.name === display.name,
-  );
-  const isFlowerBountyCompleted = !!bounties.completed.find(
-    (bounty) => bounty.id === isFlowerBounty?.id,
-  );
 
   // Handle instant purchase
   useOnMachineTransition<ContextType, BlockchainEvent>(
@@ -288,8 +275,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                     disabled={
                       !count ||
                       (!isVIP && dailyListings >= 1) ||
-                      (isItemBertObsession && isBertsObesessionCompleted) ||
-                      (!!isFlowerBounty && isFlowerBountyCompleted)
+                      (isItemBertObsession && isBertsObesessionCompleted)
                     }
                     onClick={onListClick}
                     className="w-full sm:w-auto"
@@ -302,11 +288,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 {isItemBertObsession && isBertsObesessionCompleted && (
                   <Label type="danger">
                     {`You have completed Bert's Obsession recently`}
-                  </Label>
-                )}
-                {isFlowerBounty && isFlowerBountyCompleted && (
-                  <Label type="danger">
-                    {`You have completed this flower bounty recently`}
                   </Label>
                 )}
               </div>
@@ -331,8 +312,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 disabled={
                   !count ||
                   (!isVIP && dailyListings >= 1) ||
-                  (isItemBertObsession && isBertsObesessionCompleted) ||
-                  (!!isFlowerBounty && isFlowerBountyCompleted)
+                  (isItemBertObsession && isBertsObesessionCompleted)
                 }
                 className="w-full sm:w-auto"
               >
@@ -344,11 +324,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
             {isItemBertObsession && isBertsObesessionCompleted && (
               <Label type="danger">
                 {`You have completed Bert's Obsession recently`}
-              </Label>
-            )}
-            {isFlowerBounty && isFlowerBountyCompleted && (
-              <Label type="danger">
-                {`You have completed this flower bounty recently`}
               </Label>
             )}
           </div>

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -34,6 +34,7 @@ import classNames from "classnames";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { isMobile } from "mobile-device-detect";
 import Decimal from "decimal.js-light";
+import { FLOWERS } from "features/game/types/flowers";
 
 type TradeableHeaderProps = {
   authToken: string;
@@ -55,7 +56,7 @@ const _isVIP = (state: MachineState) =>
 const _bertObsession = (state: MachineState) =>
   state.context.state.bertObsession;
 const _npcs = (state: MachineState) => state.context.state.npcs;
-
+const _bounties = (state: MachineState) => state.context.state.bounties;
 export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   dailyListings,
   authToken,
@@ -72,7 +73,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   const params = useParams();
   const bertObsession = useSelector(gameService, _bertObsession);
   const npcs = useSelector(gameService, _npcs);
-
+  const bounties = useSelector(gameService, _bounties);
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
 
   const { t } = useAppTranslation();
@@ -86,6 +87,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
     return listing.sfl < cheapest.sfl ? listing : cheapest;
   }, filteredListings[0]);
 
+  // Check if the item is a bert obsession and whether the bert obsession is completed
   const isItemBertObsession = bertObsession?.name === display.name;
   const obsessionCompletedAt = npcs?.bert?.questCompletedAt;
   const isBertsObesessionCompleted =
@@ -93,6 +95,17 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
     bertObsession &&
     obsessionCompletedAt >= bertObsession.startDate &&
     obsessionCompletedAt <= bertObsession.endDate;
+
+  // Check if item is a flower bounty and whether the bounty is completed
+  const flowerBounties = bounties.requests.filter(
+    (deal) => deal.name in FLOWERS,
+  );
+  const isFlowerBounty = flowerBounties.find(
+    (bounty) => bounty.name === display.name,
+  );
+  const isFlowerBountyCompleted = !!bounties.completed.find(
+    (bounty) => bounty.id === isFlowerBounty?.id,
+  );
 
   // Handle instant purchase
   useOnMachineTransition<ContextType, BlockchainEvent>(
@@ -259,8 +272,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               <div className="flex items-center mr-2 sm:mb-0.5 -ml-1" />
             )}
             {/* Desktop display */}
-            <div className="flex flex-col">
-              <div className="self-end justify-between hidden sm:flex sm:visible w-full sm:w-auto">
+            <div className="flex-col hidden sm:flex sm:visible sm:w-auto">
+              <div className="flex flex-row items-end justify-end w-full">
                 {showBuyNow && (
                   <Button
                     onClick={() => setShowPurchaseModal(true)}
@@ -275,7 +288,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                     disabled={
                       !count ||
                       (!isVIP && dailyListings >= 1) ||
-                      (isItemBertObsession && isBertsObesessionCompleted)
+                      (isItemBertObsession && isBertsObesessionCompleted) ||
+                      (!!isFlowerBounty && isFlowerBountyCompleted)
                     }
                     onClick={onListClick}
                     className="w-full sm:w-auto"
@@ -286,8 +300,13 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               </div>
               <div className="mt-1">
                 {isItemBertObsession && isBertsObesessionCompleted && (
-                  <Label type="danger" className="mr-1">
+                  <Label type="danger">
                     {`You have completed Bert's Obsession recently`}
+                  </Label>
+                )}
+                {isFlowerBounty && isFlowerBountyCompleted && (
+                  <Label type="danger">
+                    {`You have completed this flower bounty recently`}
                   </Label>
                 )}
               </div>
@@ -295,8 +314,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
           </div>
         </div>
         {/* Mobile display */}
-        <div className="flex items-center justify-between sm:hidden w-full sm:w-auto">
-          <div>
+        <div className="flex flex-col items-center sm:hidden w-full sm:w-auto">
+          <div className="flex items-center justify-between w-full">
             {showBuyNow && (
               <Button
                 onClick={() => setShowPurchaseModal(true)}
@@ -312,7 +331,8 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 disabled={
                   !count ||
                   (!isVIP && dailyListings >= 1) ||
-                  (isItemBertObsession && isBertsObesessionCompleted)
+                  (isItemBertObsession && isBertsObesessionCompleted) ||
+                  (!!isFlowerBounty && isFlowerBountyCompleted)
                 }
                 className="w-full sm:w-auto"
               >
@@ -320,10 +340,15 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               </Button>
             )}
           </div>
-          <div>
+          <div className="mt-1">
             {isItemBertObsession && isBertsObesessionCompleted && (
-              <Label type="danger" className="mr-1">
+              <Label type="danger">
                 {`You have completed Bert's Obsession recently`}
+              </Label>
+            )}
+            {isFlowerBounty && isFlowerBountyCompleted && (
+              <Label type="danger">
+                {`You have completed this flower bounty recently`}
               </Label>
             )}
           </div>

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -48,6 +48,9 @@ const _balance = (state: MachineState) => state.context.state.balance;
 const _inventory = (state: MachineState) => state.context.state.inventory;
 const _isVIP = (state: MachineState) =>
   hasVipAccess(state.context.state.inventory);
+const _bertObsession = (state: MachineState) =>
+  state.context.state.bertObsession;
+const _npcs = (state: MachineState) => state.context.state.npcs;
 
 export const TradeableOffers: React.FC<{
   tradeable?: TradeableDetails;
@@ -83,6 +86,8 @@ export const TradeableOffers: React.FC<{
   const authToken = useSelector(authService, _authToken);
   const balance = useSelector(gameService, _balance);
   const inventory = useSelector(gameService, _inventory);
+  const bertObsession = useSelector(gameService, _bertObsession);
+  const npcs = useSelector(gameService, _npcs);
   const [showMakeOffer, setShowMakeOffer] = useState(false);
   const [showAcceptOffer, setShowAcceptOffer] = useState(false);
   const [selectedOffer, setSelectedOffer] = useState<Offer>();
@@ -143,6 +148,15 @@ export const TradeableOffers: React.FC<{
 
   const loading = !tradeable;
   const isResource = getKeys(TRADE_LIMITS).includes(KNOWN_ITEMS[Number(id)]);
+
+  // Check if the item is a bert obsession and whether the bert obsession is completed
+  const isItemBertObsession = bertObsession?.name === display.name;
+  const obsessionCompletedAt = npcs?.bert?.questCompletedAt;
+  const isBertsObesessionCompleted =
+    !!obsessionCompletedAt &&
+    bertObsession &&
+    obsessionCompletedAt >= bertObsession.startDate &&
+    obsessionCompletedAt <= bertObsession.endDate;
 
   return (
     <>
@@ -211,7 +225,10 @@ export const TradeableOffers: React.FC<{
 
                   {topOffer && tradeable?.isActive && (
                     <Button
-                      disabled={topOffer.offeredBy.id === farmId}
+                      disabled={
+                        topOffer.offeredBy.id === farmId ||
+                        (isItemBertObsession && isBertsObesessionCompleted)
+                      }
                       onClick={() => setShowAcceptOffer(true)}
                       className="w-full sm:w-fit"
                     >

--- a/src/features/world/ui/flowerShop/FlowerBounties.tsx
+++ b/src/features/world/ui/flowerShop/FlowerBounties.tsx
@@ -47,7 +47,6 @@ export const FlowerBounties: React.FC<Props> = ({ readonly, onClose }) => {
   const { t } = useAppTranslation();
 
   const [showIntro, setShowIntro] = useState(!hasReadIntro());
-  const [deal, setDeal] = useState<BountyRequest>();
 
   if (showIntro && !readonly) {
     return (
@@ -69,6 +68,25 @@ export const FlowerBounties: React.FC<Props> = ({ readonly, onClose }) => {
     );
   }
 
+  return (
+    <CloseButtonPanel bumpkinParts={NPC_WEARABLES.poppy} onClose={onClose}>
+      <FlowerBountiesModal readonly={readonly} />
+    </CloseButtonPanel>
+  );
+};
+
+export const FlowerBountiesModal: React.FC<{
+  readonly?: boolean;
+}> = ({ readonly }) => {
+  const { t } = useAppTranslation();
+  const expiresAt = useCountdown(weekResetsAt());
+  const [deal, setDeal] = useState<BountyRequest>();
+
+  const { gameService } = useContext(Context);
+  const exchange = useSelector(gameService, _exchange);
+  const state = useSelector(gameService, _state);
+  const deals = exchange.requests.filter((deal) => deal.name in FLOWERS);
+
   if (deal) {
     return (
       <Deal
@@ -79,24 +97,6 @@ export const FlowerBounties: React.FC<Props> = ({ readonly, onClose }) => {
     );
   }
 
-  return (
-    <CloseButtonPanel bumpkinParts={NPC_WEARABLES.poppy} onClose={onClose}>
-      <FlowerBountiesModal readonly={readonly} setDeal={setDeal} />
-    </CloseButtonPanel>
-  );
-};
-
-export const FlowerBountiesModal: React.FC<{
-  readonly?: boolean;
-  setDeal: (deal: BountyRequest) => void;
-}> = ({ readonly, setDeal }) => {
-  const { t } = useAppTranslation();
-  const expiresAt = useCountdown(weekResetsAt());
-
-  const { gameService } = useContext(Context);
-  const exchange = useSelector(gameService, _exchange);
-  const state = useSelector(gameService, _state);
-  const deals = exchange.requests.filter((deal) => deal.name in FLOWERS);
   return (
     <div className="p-1">
       <div className="flex flex-wrap items-center mb-2">


### PR DESCRIPTION
# Description

Fixed an issue where Players can sell their berts obsession item/flower bounties when they have shown/sold the item

Added UI label when player completed bert's obsession
![image](https://github.com/user-attachments/assets/dde4e9fb-4827-403d-8483-77436880819a)

Mobile


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
