### PR TITLE
[FIX] Show in Progress Food Details Instead of Selected Food For Boosting with Gems

### DIFF
--- a/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
+++ b/src/features/island/buildings/components/building/bakery/BakeryModal.tsx
@@ -66,7 +66,7 @@ export const BakeryModal: React.FC<Props> = ({
           craftingService={craftingService}
           buildingId={buildingId}
           buildingName="Bakery"
-          currentlyCooking={selected.name}
+          itemInProgress={itemInProgress}
         />
       </CloseButtonPanel>
     </Modal>

--- a/src/features/island/buildings/components/building/deli/DeliModal.tsx
+++ b/src/features/island/buildings/components/building/deli/DeliModal.tsx
@@ -65,7 +65,7 @@ export const DeliModal: React.FC<Props> = ({
           craftingService={craftingService}
           buildingName="Deli"
           buildingId={buildingId}
-          currentlyCooking={selected.name}
+          itemInProgress={itemInProgress}
         />
       </CloseButtonPanel>
     </Modal>

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -95,7 +95,7 @@ export const FirePitModal: React.FC<Props> = ({
             craftingService={craftingService}
             buildingName="Fire Pit"
             buildingId={buildingId}
-            currentlyCooking={selected.name}
+            itemInProgress={itemInProgress}
           />
         </CloseButtonPanel>
       )}

--- a/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
+++ b/src/features/island/buildings/components/building/kitchen/KitchenModal.tsx
@@ -67,7 +67,7 @@ export const KitchenModal: React.FC<Props> = ({
             craftingService={craftingService}
             buildingName="Kitchen"
             buildingId={buildingId}
-            currentlyCooking={selected.name}
+            itemInProgress={itemInProgress}
           />
         </CloseButtonPanel>
       </Modal>

--- a/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
+++ b/src/features/island/buildings/components/building/smoothieShack/SmoothieShackModal.tsx
@@ -65,7 +65,7 @@ export const SmoothieShackModal: React.FC<Props> = ({
           craftingService={craftingService}
           buildingName="Smoothie Shack"
           buildingId={buildingId}
-          currentlyCooking={selected.name}
+          itemInProgress={itemInProgress}
         />
       </CloseButtonPanel>
     </Modal>

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -56,7 +56,7 @@ interface Props {
   crafting: boolean;
   buildingName: BuildingName;
   buildingId?: string;
-  currentlyCooking?: CookableName;
+  itemInProgress?: CookableName;
 }
 
 /**
@@ -79,7 +79,7 @@ export const Recipes: React.FC<Props> = ({
   crafting,
   craftingService,
   buildingId,
-  currentlyCooking,
+  itemInProgress,
   buildingName,
 }) => {
   const { gameService } = useContext(Context);
@@ -143,7 +143,7 @@ export const Recipes: React.FC<Props> = ({
   if (!hideCooking && crafting) {
     return (
       <Cooking
-        name={currentlyCooking as CookableName}
+        name={itemInProgress as CookableName}
         craftingService={craftingService!}
         state={state}
         onClose={() => setHideCooking(true)}

--- a/src/features/island/buildings/components/ui/Recipes.tsx
+++ b/src/features/island/buildings/components/ui/Recipes.tsx
@@ -45,6 +45,7 @@ import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDeta
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { getInstantGems } from "features/game/events/landExpansion/speedUpRecipe";
 import { gameAnalytics } from "lib/gameAnalytics";
+import { formatNumber } from "lib/utils/formatNumber";
 
 interface Props {
   selected: Cookable;
@@ -285,7 +286,14 @@ export const Cooking: React.FC<{
             <div className="flex items-center">
               <img src={xpIcon} className="h-4 mr-0.5" />
               <p className="text-xs">
-                {getFoodExpBoost(CONSUMABLES[name], bumpkin, state, buds ?? {})}
+                {formatNumber(
+                  getFoodExpBoost(
+                    CONSUMABLES[name],
+                    bumpkin,
+                    state,
+                    buds ?? {},
+                  ),
+                )}
               </p>
             </div>
           </div>


### PR DESCRIPTION
# Description

This PR fixes the bug in the following modal that causes seeing some details(name, image and xp) related to the food different from the one is currently being cooked, it happens when players click "View recipes", select another food, close the cooking building modal and click the building again before the food is ready.

![image](https://github.com/user-attachments/assets/32853362-00b5-48cc-a423-bcde2f5c6e77)
