### PR TITLE
[FIX] Marketplace sort

### DIFF
--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -105,6 +105,26 @@ export const Collection: React.FC<{
       ...(limited?.items || []),
     ],
   };
+
+  if (!filters.includes("resources")) {
+    // Sort by price
+    data.items.sort((a, b) => {
+      // If floor prices are equal, sort by lastSalePrice
+      if (a.floor === b.floor) {
+        // If lastSalePrice is empty, order last
+        if (a.lastSalePrice === 0) return 1;
+        if (b.lastSalePrice === 0) return -1;
+        return a.lastSalePrice - b.lastSalePrice;
+      }
+
+      // If floor price is empty, order last
+      if (a.floor === 0) return 1;
+      if (b.floor === 0) return -1;
+
+      return a.floor - b.floor;
+    });
+  }
+
   const isLoading =
     isWearablesLoading ||
     isCollectiblesLoading ||


### PR DESCRIPTION
# Description

Wearables were showing at the bottom of the marketplace, instead of ordered by price with the collectibles.

This PR copies the sort logic from the backend.

<img width="1210" alt="Screenshot 2024-12-17 at 9 52 20 AM" src="https://github.com/user-attachments/assets/d510fc85-46e0-4381-9ff0-786547b7687d" />
