### PR TITLE
[FEAT] Show items in sales

### DIFF
--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -83,6 +83,8 @@ export type Sale = {
     bumpkinUri: string;
   };
   source: "offer" | "listing";
+  itemId: number;
+  collection: CollectionName;
 };
 
 export type SaleHistory = {

--- a/src/features/marketplace/components/PriceHistory.tsx
+++ b/src/features/marketplace/components/PriceHistory.tsx
@@ -8,11 +8,13 @@ import { Loading } from "features/auth/components";
 import classNames from "classnames";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { interpretTokenUri } from "lib/utils/tokenUriBuilder";
-import { getRelativeTime, getShortRelativeTime } from "lib/utils/time";
+import { getRelativeTime } from "lib/utils/time";
 import increaseRightArrow from "assets/icons/increase_right_arrow.webp";
 import decreaseLeftArrow from "assets/icons/decrease_left_arrow.webp";
 import { useNavigate } from "react-router";
-import { isMobile } from "mobile-device-detect";
+import { getTradeableDisplay } from "../lib/tradeables";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 export const SaleHistory: React.FC<{ history?: ISaleHistory }> = ({
   history,
@@ -47,9 +49,24 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
         <tbody>
           {sales.map(
             (
-              { sfl, quantity, fulfilledAt, fulfilledBy, initiatedBy, source },
+              {
+                sfl,
+                quantity,
+                collection,
+                itemId,
+                fulfilledAt,
+                fulfilledBy,
+                initiatedBy,
+                source,
+              },
               index,
             ) => {
+              const details = getTradeableDisplay({
+                id: itemId,
+                type: collection,
+                state: INITIAL_FARM,
+              });
+
               const [seller, buyer] =
                 source === "listing"
                   ? [initiatedBy, fulfilledBy]
@@ -97,16 +114,48 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
                     </div>
                   </td>
 
-                  <td className="p-1.5 ">
-                    <div className="flex items-center">
-                      <img src={sflIcon} className="w-4 mr-1" />
-                      <p className="text-xs sm:text-sm">{sfl}</p>
+                  <td className="p-1.5 hidden sm:table-cell">
+                    <div className="flex items-center mb-1">
+                      <img src={details.image} className="w-4 mr-1" />
+                      <p className="text-xs sm:text-sm truncate">
+                        {details.name}
+                      </p>
                     </div>
                   </td>
-                  <td className="p-1.5 text-xs sm:text-sm truncate text-center">
-                    {isMobile
-                      ? getShortRelativeTime(fulfilledAt)
-                      : getRelativeTime(fulfilledAt)}
+                  <td className="p-1.5 hidden sm:table-cell">
+                    <div className="flex items-center">
+                      <img src={sflIcon} className="w-4 mr-1" />
+                      <p className="text-xs sm:text-sm">{`${sfl}`}</p>
+                    </div>
+                  </td>
+                  <td className="p-1.5 text-xs   hidden sm:table-cell">
+                    <div className="flex items-center justify-end">
+                      <p className="text-xs truncate">
+                        {getRelativeTime(fulfilledAt)}
+                      </p>
+                    </div>
+                  </td>
+                  <td className="p-1.5 table-cell sm:hidden">
+                    <div className="flex items-center mb-1">
+                      <img src={details.image} className="w-4 mr-1" />
+                      {quantity > 1 && (
+                        <p className="text-xs sm:text-sm mr-1">{`${quantity}x`}</p>
+                      )}
+                      <p className="text-xs sm:text-sm">{details.name}</p>
+                    </div>
+                    <div className="flex items-center mb-1">
+                      <img src={sflIcon} className="w-4 mr-1" />
+                      <p className="text-xs sm:text-sm">{`${sfl} SFL`}</p>
+                    </div>
+                    <div className="flex items-center">
+                      <img
+                        src={SUNNYSIDE.icons.stopwatch}
+                        className="w-4 mr-1"
+                      />
+                      <p className="text-xs sm:text-sm">
+                        {getRelativeTime(fulfilledAt)}
+                      </p>
+                    </div>
                   </td>
                 </tr>
               );

--- a/src/features/marketplace/components/PriceHistory.tsx
+++ b/src/features/marketplace/components/PriceHistory.tsx
@@ -117,6 +117,9 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
                   <td className="p-1.5 hidden sm:table-cell">
                     <div className="flex items-center mb-1">
                       <img src={details.image} className="w-4 mr-1" />
+                      {quantity > 1 && (
+                        <p className="text-xs sm:text-sm mr-1.5">{`${quantity} x `}</p>
+                      )}
                       <p className="text-xs sm:text-sm truncate">
                         {details.name}
                       </p>
@@ -139,7 +142,7 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
                     <div className="flex items-center mb-1">
                       <img src={details.image} className="w-4 mr-1" />
                       {quantity > 1 && (
-                        <p className="text-xs sm:text-sm mr-1">{`${quantity}x`}</p>
+                        <p className="text-xs sm:text-sm mr-1.5">{`${quantity} x `}</p>
                       )}
                       <p className="text-xs sm:text-sm">{details.name}</p>
                     </div>


### PR DESCRIPTION
# Description

This PR shows the items that were included in a sale. Useful for:

- Determining how many resources were bought/sold
- View a user's trade history and figure out what they were doing.

<img width="497" alt="Screenshot 2024-12-18 at 4 05 16 PM" src="https://github.com/user-attachments/assets/d3981d05-629d-4a93-b35b-e397aa2fb45e" />
<img width="841" alt="Screenshot 2024-12-18 at 4 05 58 PM" src="https://github.com/user-attachments/assets/7d44f3e3-229e-4408-a892-a4fd07c0de04" />
<img width="1118" alt="Screenshot 2024-12-18 at 4 06 02 PM" src="https://github.com/user-attachments/assets/163f2fc9-9100-4257-98d9-2e2699993460" />
