### PR TITLE
[FIX] Scene transitions

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -270,14 +270,14 @@ export const PhaserComponent: React.FC<Props> = ({
 
   // When route changes, switch scene
   useEffect(() => {
-    if (!loaded || !route || mmoService.state.context.sceneId === route) return;
+    if (!loaded) return;
 
     const activeScene = game.current?.scene
       .getScenes(false)
       // Corn maze pauses when game is over so we need to filter for active and paused scenes.
       .filter((s) => s.scene.isActive() || s.scene.isPaused())[0];
 
-    if (activeScene) {
+    if (activeScene && activeScene.scene.key !== route) {
       activeScene.scene.start(route);
       mmoService.send("SWITCH_SCENE", { sceneId: route });
       mmoService.send("UPDATE_PREVIOUS_SCENE", {


### PR DESCRIPTION
# Description

Walking between scenes was not starting the new scene. This PR fixes the issue.

Fixes #issue

# What needs to be tested by the reviewer?

Walk between scenes and confirm the new scene loads.
Move somewhere other than the spawn position, open the marketplace, close the marketplace and confirm your location is the same. (Working on this is what broke the scene transitions)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
