### PR TITLE
[FEAT] Add Scrollable Listings and Offers for Wearables/Collectibles in the Market

### DIFF
--- a/src/features/marketplace/components/TradeTable.tsx
+++ b/src/features/marketplace/components/TradeTable.tsx
@@ -17,7 +17,7 @@ export const OfferTable: React.FC<{
   if (offers.length === 0) return null;
 
   return (
-    <div className="w-full text-xs border-collapse mb-2">
+    <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
       <div>
         {offers.map((offer, index) => {
           return (
@@ -54,7 +54,7 @@ export const ListingTable: React.FC<{
   const usd = gameService.getSnapshot().context.prices.sfl?.usd ?? 0.0;
 
   return (
-    <div className="w-full text-xs border-collapse">
+    <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
       <div>
         {listings.map((listing, index) => {
           return (

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -124,7 +124,7 @@ export const MyListings: React.FC = () => {
             {getKeys(filteredListings).length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyListings")}</p>
             ) : (
-              <div className="w-full text-xs border-collapse mb-2">
+              <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
                 {getKeys(filteredListings).map((id, index) => {
                   const listing = listings[id];
                   const itemName = getKeys(

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -138,7 +138,7 @@ export const MyOffers: React.FC = () => {
             {getKeys(filteredOffers).length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyOffers")}</p>
             ) : (
-              <div className="w-full text-xs border-collapse mb-2">
+              <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
                 {getKeys(filteredOffers).map((id, index) => {
                   const offer = filteredOffers[id];
                   const itemName = getKeys(


### PR DESCRIPTION
# Description

This PR adds a feature to make some offers and listings in the market scrollable, for those on the wearables and collectibles page or in the `My trades` modal. Additionally, it addresses the issue where players have to scroll down excessively on some of the cosmetic or boosted items page due to the large number of listings and offers. The same problem occurs in the My trades modal when players have numerous listings and offers. This fix ensures that players can easily scroll down to view the `Your Collection` section there.

| Mobile | Desktop |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/25ad3b81-32a6-42b9-b251-403dae8ea022) | ![image](https://github.com/user-attachments/assets/1ce1f93d-1913-45ff-af80-1b87c0ce4916) | 

---
# My Trades Modal:

| Mobile | Desktop |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6149c478-7c4e-4c7a-95e1-8cd74d0e60bb) | ![image](https://github.com/user-attachments/assets/8f53f61b-e26d-4fbb-8a8d-938d94eb1392) | 

# What needs to be tested by the reviewer?

- open the market and check wearables and collectibles page to see how listings and offers look like when there are too many off them there, also do the same for my trades tab.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have performed a self-review of my own code
