### PR TITLE
[FIX] Make Bait Icon Size Fixed

### DIFF
--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -289,7 +289,9 @@ const BaitSelection: React.FC<{
       <div>
         <InnerPanel className="my-1 relative">
           <div className="flex p-1">
-            <img src={ITEM_DETAILS[bait].image} className="h-10 mr-2" />
+            <div className="h-10 w-10 mr-2 justify-items-center" >
+              <img src={ITEM_DETAILS[bait].image} className="h-10"/>
+            </div>
             <div>
               <p className="text-sm mb-1">{bait}</p>
               <p className="text-xs">{ITEM_DETAILS[bait].description}</p>


### PR DESCRIPTION
# Description

This simply sets the bait icon image to always be size 10x10. This ensures that the bait name and description text are in the same location regardless of bait in the FishermanModal
**Before**
![image](https://github.com/user-attachments/assets/9351469d-198f-446c-bf3f-9674bd655064)
![image](https://github.com/user-attachments/assets/9ae6e5a2-c610-4d83-a290-acbacbcf5f32)


**After**
![image](https://github.com/user-attachments/assets/9351469d-198f-446c-bf3f-9674bd655064)
![image](https://github.com/user-attachments/assets/e5ca134f-dcd1-4d6b-b45d-1b66b6814fc4)


# What needs to be tested by the reviewer?

Test for different scenarios such as when the "Craft at Composter" or "Craft at Beach" labels are present

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
