### PR TITLE
[FEAT] Show Confirm Button instead of Confirmation Modal

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
@@ -15,7 +15,6 @@ import { Label } from "components/ui/Label";
 import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
 import { SquareIcon } from "components/ui/SquareIcon";
-import { ConfirmationModal } from "components/ui/ConfirmationModal";
 
 // Function imports
 import {
@@ -51,7 +50,7 @@ export const SkillPathDetails: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const bumpkin = useSelector(gameService, _bumpkin);
 
-  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<BumpkinSkillRevamp>(
     skillsInPath[0],
   );
@@ -77,7 +76,7 @@ export const SkillPathDetails: React.FC<Props> = ({
     readonly;
 
   const handleClaim = () => {
-    setShowConfirmationModal(false);
+    setShowConfirmation(false);
     const state = gameService.send("skill.chosen", { skill: name });
 
     gameAnalytics.trackMilestone({
@@ -182,29 +181,29 @@ export const SkillPathDetails: React.FC<Props> = ({
 
           {/* Claim/Claimed/Use Button */}
           {!readonly && (
-            <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
-              <Button
-                disabled={isClaimDisabled}
-                onClick={() => setShowConfirmationModal(true)}
-              >
-                {t(hasSelectedSkill ? "skill.claimed" : "skill.claim")}
-              </Button>
+            <div className="flex sm:flex-col-reverse w-full">
+              {showConfirmation ? (
+                <>
+                  <Button
+                    className="mr-1 sm:mt-1"
+                    onClick={() => setShowConfirmation(false)}
+                  >
+                    {t("cancel")}
+                  </Button>
+                  <Button disabled={isClaimDisabled} onClick={handleClaim}>
+                    {t("skill.claimSkill")}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  disabled={isClaimDisabled}
+                  onClick={() => setShowConfirmation(true)}
+                >
+                  {t(hasSelectedSkill ? "skill.claimed" : "skill.claim")}
+                </Button>
+              )}
             </div>
           )}
-
-          {/* Confirmation Modal */}
-          <ConfirmationModal
-            show={showConfirmationModal}
-            onHide={() => setShowConfirmationModal(false)}
-            messages={[
-              t("skill.confirmationMessage", { skillName: name }),
-              t("skill.costMessage", { points }),
-            ]}
-            onCancel={() => setShowConfirmationModal(false)}
-            onConfirm={handleClaim}
-            confirmButtonLabel={t("skill.claimSkill")}
-            disabled={isClaimDisabled}
-          />
         </div>
       }
       content={

--- a/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
@@ -181,16 +181,20 @@ export const SkillPathDetails: React.FC<Props> = ({
 
           {/* Claim/Claimed/Use Button */}
           {!readonly && (
-            <div className="flex sm:flex-col-reverse w-full">
+            <div className="flex sm:flex-col w-full">
               {showConfirmation ? (
                 <>
                   <Button
-                    className="mr-1 sm:mt-1"
+                    className="mr-1 sm:mr-0"
                     onClick={() => setShowConfirmation(false)}
                   >
                     {t("cancel")}
                   </Button>
-                  <Button disabled={isClaimDisabled} onClick={handleClaim}>
+                  <Button
+                    className="sm:mt-1"
+                    disabled={isClaimDisabled}
+                    onClick={handleClaim}
+                  >
                     {t("skill.claimSkill")}
                   </Button>
                 </>

--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -289,8 +289,8 @@ const BaitSelection: React.FC<{
       <div>
         <InnerPanel className="my-1 relative">
           <div className="flex p-1">
-            <div className="h-10 w-10 mr-2 justify-items-center" >
-              <img src={ITEM_DETAILS[bait].image} className="h-10"/>
+            <div className="h-10 w-10 mr-2 justify-items-center">
+              <img src={ITEM_DETAILS[bait].image} className="h-10" />
             </div>
             <div>
               <p className="text-sm mb-1">{bait}</p>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4719,8 +4719,6 @@
   "skillTier.skillDisabled": "Skill is disabled",
   "skill.claimed": "Claimed",
   "skill.claim": "Claim",
-  "skill.confirmationMessage": "Are you sure you want to claim {{skillName}}?",
-  "skill.costMessage": "This will cost {{points}} skill points.",
   "skill.claimSkill": "Claim Skill",
   "skill.cooldown": "{{cooldown}} Cooldown",
   "skill.powerSkill": "Power Skill",


### PR DESCRIPTION
# Description

Show a confirmation button instead of a modal
|Desktop|Mobile|
|---|---|
|![image](https://github.com/user-attachments/assets/7818816a-a70a-4489-88b9-97aebbad6063)|![image](https://github.com/user-attachments/assets/c0c6cf9e-eaa4-48fb-9ef1-7ea01b3cf97b)|

Cancel button is on top on desktop to disrupt player's muscle memory in case they double click and confirmed a skill they don't want to pick

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
