### PR TITLE
[FIX] Barn animal drops block clicks

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -428,7 +428,7 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
                 top: ANIMAL_EMOTION_ICONS[cowMachineState].top,
                 right: ANIMAL_EMOTION_ICONS[cowMachineState].right,
               }}
-              className="absolute"
+              className="absolute pointer-events-none"
             />
           )}
           {/* Request */}

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -364,7 +364,7 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
                 top: ANIMAL_EMOTION_ICONS[sheepState].top,
                 right: ANIMAL_EMOTION_ICONS[sheepState].right,
               }}
-              className="absolute"
+              className="absolute pointer-events-none"
             />
           )}
           {/* Request */}

--- a/src/features/game/expansion/components/animals/ProduceDrops.tsx
+++ b/src/features/game/expansion/components/animals/ProduceDrops.tsx
@@ -46,7 +46,7 @@ export const ProduceDrops: React.FC<Props> = ({
         return (
           <div
             key={item}
-            className={`flex items-center justify-center absolute bounce-drop ${className}`}
+            className={`flex items-center justify-center absolute bounce-drop pointer-events-none ${className}`}
             style={
               {
                 "--drop-delay": `${index * 400}ms`,

--- a/src/features/game/expansion/components/animals/ProduceDrops.tsx
+++ b/src/features/game/expansion/components/animals/ProduceDrops.tsx
@@ -10,6 +10,7 @@ import { getResourceDropAmount } from "features/game/lib/animals";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
+import { formatNumber } from "lib/utils/formatNumber";
 
 interface Props {
   animalType: AnimalType;
@@ -53,7 +54,7 @@ export const ProduceDrops: React.FC<Props> = ({
               } as React.CSSProperties
             }
           >
-            <span className="text-xs yield-text">{`+${boostedAmount}`}</span>
+            <span className="text-xs yield-text">{`+${formatNumber(boostedAmount)}`}</span>
             <img
               src={ITEM_DETAILS[item as InventoryItemName]?.image}
               alt={item}

--- a/src/features/game/expansion/components/animals/RequestBubble.tsx
+++ b/src/features/game/expansion/components/animals/RequestBubble.tsx
@@ -80,7 +80,7 @@ export const RequestBubble: React.FC<RequestBubbleProps> = ({
 
   return (
     <div
-      className={`absolute inline-flex justify-center items-center z-10`}
+      className={`absolute inline-flex justify-center items-center z-10 pointer-events-none`}
       style={{
         top: `${top}px`,
         left: `${left}px`,

--- a/src/features/game/expansion/components/animals/RequestBubble.tsx
+++ b/src/features/game/expansion/components/animals/RequestBubble.tsx
@@ -8,6 +8,7 @@ import {
 } from "features/game/types/game";
 
 import { ITEM_DETAILS } from "features/game/types/images";
+import { formatNumber } from "lib/utils/formatNumber";
 // TODO: Add love items
 
 type RequestItem = AnimalFoodName | AnimalMedicineName | LoveAnimalItem;
@@ -103,13 +104,7 @@ export const RequestBubble: React.FC<RequestBubbleProps> = ({
           <img className="w-full h-full" src={image.src} />
         </div>
         {quantity && (
-          <span className="text-xxs text-black">{`x${
-            Number.isInteger(Number(quantity))
-              ? Number(quantity)
-              : Number(quantity)
-                  .toFixed(2)
-                  .replace(/\.?0+$/, "")
-          }`}</span>
+          <span className="text-xxs text-black">{`x${formatNumber(quantity)}`}</span>
         )}
       </div>
     </div>

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -457,7 +457,7 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
                 top: CHICKEN_EMOTION_ICONS[chickenMachineState].top,
                 right: CHICKEN_EMOTION_ICONS[chickenMachineState].right,
               }}
-              className="absolute"
+              className="absolute pointer-events-none"
             />
           )}
           {/* Request */}


### PR DESCRIPTION
# Description

add pointer-events-none to components that blocks clicks (similar to # 4918).  One of the most annoything thing is that animal drops blocks harvesting/feeding actions to animals that are nearby.

# What needs to be tested by the reviewer?

- Click anywhere to feed cows/sheeps/chickens when the adjacent animal resource is dropping

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warningsfeature works
- [x] New and existing unit tests pass locally with my changes
