### PR TITLE
[CHORE] Do not shortcut barn delight when healing animals

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -242,7 +242,6 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
     const hasEnoughMedicine = medicineCount.gte(1);
 
     if (hasEnoughMedicine) {
-      shortcutItem("Barn Delight");
       playCureAnimal();
       cureCow("Barn Delight");
       return;

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -190,7 +190,6 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
     const hasEnoughMedicine = medicineCount.gte(1);
 
     if (hasEnoughMedicine) {
-      shortcutItem("Barn Delight");
       playCureAnimal();
       cureSheep("Barn Delight");
       return;

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -253,7 +253,6 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
     const hasEnoughMedicine = medicineCount.gte(1);
 
     if (hasEnoughMedicine) {
-      shortcutItem("Barn Delight");
       playCureAnimal();
       cureChicken("Barn Delight");
       return;


### PR DESCRIPTION
# Description

- not adding barn delight to shortcut to avoid disrupting feeding flow

# What needs to be tested by the reviewer?

- Heal chickens/cows/sheeps

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warningsfeature works
- [x] New and existing unit tests pass locally with my changes
