### PR TITLE
[FIX] Marketplace crash if price is undefined

### DIFF
--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -277,7 +277,7 @@ export function getMarketPrice({
       return listing.sfl < cheapest.sfl ? listing : cheapest;
     }, tradeable.listings[0]);
 
-    price = cheapestListing?.sfl;
+    price = cheapestListing?.sfl ?? 0;
   } else if (tradeable?.history.sales.length) {
     // Set it to the latest sale
     price =

--- a/src/features/marketplace/components/TradeableStats.tsx
+++ b/src/features/marketplace/components/TradeableStats.tsx
@@ -9,6 +9,7 @@ import {
   SaleHistory,
 } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { formatNumber } from "lib/utils/formatNumber";
 
 interface Props {
   marketPrice: number;
@@ -60,15 +61,15 @@ export const TradeableStats: React.FC<Props> = ({ history, marketPrice }) => {
                 className="whitespace-nowrap"
                 icon={prices.oneDayChange > 0 ? increaseArrow : decreaseArrow}
               >
-                <span className="text-xxs sm:text-xs">{`${prices.oneDayChange.toFixed(2)}%`}</span>
+                <span className="text-xxs sm:text-xs">{`${formatNumber(prices.oneDayChange)}%`}</span>
               </Label>
             )}
           </div>
           <p className="text-xxs pl-0.5 sm:text-xs sm:p-1">
             {loading ? (
-              <span className="loading-fade-pulse">{`0.00 SFL`}</span>
+              <span className="loading-fade-pulse">{`${formatNumber(0, { decimalPlaces: 4 })} SFL`}</span>
             ) : (
-              `${prices.oneDayPrice.toFixed(2)} SFL > ${marketPrice.toFixed(2)} SFL`
+              `${formatNumber(prices.oneDayPrice, { decimalPlaces: 4 })} SFL > ${formatNumber(marketPrice, { decimalPlaces: 4 })} SFL`
             )}
           </p>
         </InnerPanel>
@@ -87,15 +88,15 @@ export const TradeableStats: React.FC<Props> = ({ history, marketPrice }) => {
                 className="whitespace-nowrap"
                 icon={prices.sevenDayChange > 0 ? increaseArrow : decreaseArrow}
               >
-                <span className="text-xxs sm:text-xs">{`${prices.sevenDayChange.toFixed(2)}%`}</span>
+                <span className="text-xxs sm:text-xs">{`${formatNumber(prices.sevenDayChange)}%`}</span>
               </Label>
             )}
           </div>
           <p className="text-xxs pl-0.5 sm:text-xs sm:p-1">
             {loading ? (
-              <span className="loading-fade-pulse">{`0.00 SFL`}</span>
+              <span className="loading-fade-pulse">{`${formatNumber(0, { decimalPlaces: 4 })} SFL`}</span>
             ) : (
-              `${prices.sevenDayPrice.toFixed(2)} SFL > ${marketPrice.toFixed(2)} SFL`
+              `${formatNumber(prices.sevenDayPrice, { decimalPlaces: 4 })} SFL > ${formatNumber(marketPrice, { decimalPlaces: 4 })} SFL`
             )}
           </p>
         </InnerPanel>

--- a/src/lib/utils/formatNumber.test.ts
+++ b/src/lib/utils/formatNumber.test.ts
@@ -6,6 +6,8 @@ describe("formatNumber", () => {
     expect(formatNumber(undefined)).toBe("");
 
     expect(formatNumber(new Decimal(0))).toBe("0");
+    expect(formatNumber(Infinity)).toBe("Infinity");
+    expect(formatNumber(-Infinity)).toBe("-Infinity");
 
     expect(formatNumber(new Decimal(0.001))).toBe("0");
     expect(formatNumber(new Decimal(0.009))).toBe("0");

--- a/src/lib/utils/formatNumber.ts
+++ b/src/lib/utils/formatNumber.ts
@@ -23,6 +23,7 @@ export const formatNumber = (
   },
 ) => {
   if (_number === undefined) return "";
+  if (!Number.isFinite(Number(_number))) return _number.toString();
 
   const number = new Decimal(_number);
   const roundedNumber = number.toDecimalPlaces(


### PR DESCRIPTION
# Description

- fix crash when current price is undefined or percentage change is infinite (happens often in testnet)
- use formatNumber and display SFL to 4 decimals for TradableStats.tsx (will be doing the same for the rest of the marketplace components eventually in other PRs)

![image](https://github.com/user-attachments/assets/b8f4773e-33b0-45e4-ba86-75b4a3b924a3)

# What needs to be tested by the reviewer?

- Load marketplace resource listings in testnet

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
