### PR TITLE
[FIX] Bait Icon Aspect Ratio

### DIFF
--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -289,7 +289,7 @@ const BaitSelection: React.FC<{
       <div>
         <InnerPanel className="my-1 relative">
           <div className="flex p-1">
-            <div className="h-10 w-10 mr-2 justify-items-center">
+            <div className="flex-shrink-0 h-10 w-10 mr-2 justify-items-center">
               <img src={ITEM_DETAILS[bait].image} className="h-10" />
             </div>
             <div>


### PR DESCRIPTION
# Description

Update CSS so the bait-icon in FishermanModel doesn't shrink on small resolutions

**Before**
![image](https://github.com/user-attachments/assets/94e56787-c611-4a92-b3f5-40e6a19657f6)
**After**
![image](https://github.com/user-attachments/assets/63b4cd4a-b461-4b44-983d-24ee69d0d756)

# What needs to be tested by the reviewer?

Test FishermanModel in various aspect ratios

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
