### PR TITLE
[FEAT] Adjust Trade Points Formula

### DIFF
--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -10,12 +10,31 @@ const TRADE_POINTS_MULTIPLIER = 0.25; // Value adjustable
 export function calculateTradePoints({
   points,
   sfl,
+  items,
 }: {
   points: number;
   sfl: number;
+  items?: Partial<Record<MarketplaceTradeableName, number>>;
 }) {
+  let multipliedPoints = 0;
+
+  if (items) {
+    const name = getKeys(items).filter(
+      (itemName) => itemName in KNOWN_IDS,
+    )[0] as InventoryItemName;
+    const isResource = getKeys(TRADE_LIMITS).includes(name);
+
+    if (isResource) {
+      return { multipliedPoints };
+    }
+  }
+
+  if (sfl < 5) {
+    return { multipliedPoints };
+  }
+
   const pointsCalculation = sfl * TRADE_POINTS_MULTIPLIER;
-  const multipliedPoints = points * pointsCalculation;
+  multipliedPoints = points * pointsCalculation;
 
   return { multipliedPoints };
 }
@@ -43,7 +62,11 @@ export function addTradePoints({
     }
   }
 
-  const { multipliedPoints } = calculateTradePoints({ points, sfl });
+  if (sfl < 5) {
+    return state;
+  }
+
+  const { multipliedPoints } = calculateTradePoints({ points, sfl, items });
 
   // Add points to gamestate
   state.trades.tradePoints = (state.trades.tradePoints ?? 0) + multipliedPoints;

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -50,22 +50,6 @@ export function addTradePoints({
   sfl: number;
   items?: Partial<Record<MarketplaceTradeableName, number>>;
 }) {
-  // Exclude resources
-  if (items) {
-    const name = getKeys(items).filter(
-      (itemName) => itemName in KNOWN_IDS,
-    )[0] as InventoryItemName;
-    const isResource = getKeys(TRADE_LIMITS).includes(name);
-
-    if (isResource) {
-      return state;
-    }
-  }
-
-  if (sfl < 5) {
-    return state;
-  }
-
   const { multipliedPoints } = calculateTradePoints({ points, sfl, items });
 
   // Add points to gamestate

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -29,10 +29,6 @@ export function calculateTradePoints({
     }
   }
 
-  if (sfl < 5) {
-    return { multipliedPoints };
-  }
-
   const pointsCalculation = sfl * TRADE_POINTS_MULTIPLIER;
   multipliedPoints = points * pointsCalculation;
 

--- a/src/features/game/events/landExpansion/addTradePoints.ts
+++ b/src/features/game/events/landExpansion/addTradePoints.ts
@@ -5,7 +5,7 @@ import { getKeys } from "features/game/types/decorations";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { MarketplaceTradeableName } from "features/game/types/marketplace";
 
-const TRADE_POINTS_MULTIPLIER = 0.5; // Value adjustable
+const TRADE_POINTS_MULTIPLIER = 0.25; // Value adjustable
 
 export function calculateTradePoints({
   points,
@@ -14,7 +14,7 @@ export function calculateTradePoints({
   points: number;
   sfl: number;
 }) {
-  const pointsCalculation = 1 + sfl ** TRADE_POINTS_MULTIPLIER;
+  const pointsCalculation = sfl * TRADE_POINTS_MULTIPLIER;
   const multipliedPoints = points * pointsCalculation;
 
   return { multipliedPoints };

--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -73,7 +73,7 @@ export const MarketplaceSalesPopup: React.FC = () => {
           const sfl = new Decimal(listing.sfl).mul(1 - MARKETPLACE_TAX);
           const estTradePoints = calculateTradePoints({
             sfl: listing.sfl,
-            points: !listing.signature ? 1 : 5,
+            points: !listing.signature ? 1 : 3,
           }).multipliedPoints;
 
           const isResource = getKeys(TRADE_LIMITS).includes(

--- a/src/features/game/expansion/components/OffersAcceptedPopup.tsx
+++ b/src/features/game/expansion/components/OffersAcceptedPopup.tsx
@@ -71,7 +71,7 @@ export const OffersAcceptedPopup: React.FC = () => {
           const sfl = new Decimal(offer.sfl);
           const estTradePoints = calculateTradePoints({
             sfl: offer.sfl,
-            points: !offer.signature ? 2 : 10,
+            points: !offer.signature ? 2 : 4,
           }).multipliedPoints;
           const isResource = getKeys(TRADE_LIMITS).includes(
             KNOWN_ITEMS[Number(itemId)],

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -131,7 +131,7 @@ const AcceptOfferContent: React.FC<{
       ? 0
       : calculateTradePoints({
           sfl: offer.sfl,
-          points: offer.type === "instant" ? 1 : 5,
+          points: offer.type === "instant" ? 1 : 3,
         }).multipliedPoints;
 
   if (needsSync) {

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -149,7 +149,7 @@ export const MakeOffer: React.FC<{
       ? 0
       : calculateTradePoints({
           sfl: offer,
-          points: tradeType === "instant" ? 2 : 10,
+          points: tradeType === "instant" ? 2 : 4,
         }).multipliedPoints;
 
   if (needsSync) {

--- a/src/features/marketplace/components/PurchaseModalContent.tsx
+++ b/src/features/marketplace/components/PurchaseModalContent.tsx
@@ -103,7 +103,7 @@ export const PurchaseModalContent: React.FC<PurchaseModalContentProps> = ({
       ? 0
       : calculateTradePoints({
           sfl: price,
-          points: listing.type === "instant" ? 2 : 10,
+          points: listing.type === "instant" ? 2 : 4,
         }).multipliedPoints;
 
   if (hasMax && listing.type === "instant") {

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -115,6 +115,9 @@ export const TradeableDescription: React.FC<{
 
   const isWearable = display.type === "wearables";
   const isCollectible = display.type === "collectibles";
+  const isResource = getKeys(TRADE_LIMITS).includes(
+    display.name as InventoryItemName,
+  );
 
   return (
     <InnerPanel>
@@ -125,15 +128,18 @@ export const TradeableDescription: React.FC<{
         <div className="flex flex-col space-y-1">
           <p className="text-xs mb-1">{display.description}</p>
           <div className="flex flex-col space-y-1">
-            {isWearable && (
+            {isWearable ? (
               <div className="flex items-center space-x-1">
                 <Label type="default">{t("wearable")}</Label>
                 <Label type="default" className="capitalize">
-                  {`${BUMPKIN_ITEM_PART[display.name as BumpkinItem]}`}
+                  {BUMPKIN_ITEM_PART[display.name as BumpkinItem]}
                 </Label>
               </div>
+            ) : isResource ? (
+              <Label type="default">{t("marketplace.resource")}</Label>
+            ) : (
+              isCollectible && <Label type="default">{t("collectible")}</Label>
             )}
-            {isCollectible && <Label type="default">{t("collectible")}</Label>}
             {display.buffs.map((buff) => (
               <Label
                 key={buff.shortDescription}

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -283,7 +283,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
       ? 0
       : calculateTradePoints({
           sfl: price,
-          points: tradeType === "instant" ? 1 : 5,
+          points: tradeType === "instant" ? 1 : 3,
         }).multipliedPoints;
 
   if (showConfirmation) {


### PR DESCRIPTION
# Description

Adjust the trade point formula to the following:
- (SFL x 0.25) x (trade type)

Change trade type to:
buying on chain: 4
Selling on chain: 3
Buying off chain: 2
Selling off chain: 1

The issue with the previous formula is the exponential scales low SFL trades harder than curves high SFL and the 1+ is skewing points as well.

With this equation we would have the following trades:

on chain buy:
.1 SFL = .1 point
1 SFL = 1 point
10 SFL = 10 points 
100 SFL = 100 points
1000 SFL = 1000 points 
10000 SFL = 10000 points (sounds like a lot but also is 500 usd worth of SFL)

Off chain buys would be:

.1 SFL = .05 point
1 SFL =  .5 point
10 SFL = 5 points 
100 SFL = 50 points
1000 SFL = 500 points 
10000 SFL = 5000 points

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
