### PR TITLE
[FIX] Animal Bounty shouldn't be sellable while animal is sleeping

### DIFF
--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -22,6 +22,10 @@ export function isValidDeal({
     return false;
   }
 
+  if (animal.awakeAt && animal.awakeAt > Date.now()) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
# Description

Players have been able to sell their animals when their animal is sleeping, which allowed players to be able to do the following

1. Feed Animal
2. Collect produce
3. Sell Animal
4. Buy Animal
5. Feed new Animal
6. Collect produce again

After this update the flow would be
1. Feed Animal
2. Collect Produce
3. Wait until animal wakes up
4. Sell Animal

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
