### PR TITLE
[FEAT] Add setting to disable QuickSelect

### DIFF
--- a/src/features/farming/hud/lib/quickSelect.ts
+++ b/src/features/farming/hud/lib/quickSelect.ts
@@ -1,0 +1,14 @@
+/**
+ * Cache show timers setting in local storage so we can remember next time we open the HUD.
+ */
+const LOCAL_STORAGE_KEY = "settings.enableQuickSelect";
+
+export function cacheEnableQuickSelectSetting(show: boolean) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(show));
+}
+
+export function getEnableQuickSelectSetting(): boolean {
+  const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return cached ? JSON.parse(cached) : true;
+}

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -18,6 +18,10 @@ import {
   getShowAnimationsSetting,
 } from "features/farming/hud/lib/animations";
 import {
+  cacheEnableQuickSelectSetting,
+  getEnableQuickSelectSetting,
+} from "features/farming/hud/lib/quickSelect";
+import {
   cacheShowTimersSetting,
   getShowTimersSetting,
 } from "features/farming/hud/lib/timers";
@@ -28,6 +32,8 @@ interface GameContext {
   gameService: MachineInterpreter;
   showAnimations: boolean;
   toggleAnimations: () => void;
+  enableQuickSelect: boolean;
+  toggleQuickSelect: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
   fromRoute: string;
@@ -48,6 +54,9 @@ export const GameProvider: React.FC = ({ children }) => {
     useState<InventoryItemName[]>(getShortcuts());
   const [showAnimations, setShowAnimations] = useState<boolean>(
     getShowAnimationsSetting(),
+  );
+  const [enableQuickSelect, setEnableQuickSelect] = useState<boolean>(
+    getEnableQuickSelectSetting(),
   );
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
   const [fromRoute, setFromRoute] = useState<string>("");
@@ -73,6 +82,13 @@ export const GameProvider: React.FC = ({ children }) => {
     cacheShowAnimationsSetting(newValue);
   };
 
+  const toggleQuickSelect = () => {
+    const newValue = !enableQuickSelect;
+
+    setEnableQuickSelect(newValue);
+    cacheEnableQuickSelectSetting(newValue);
+  };
+
   const toggleTimers = () => {
     const newValue = !showTimers;
 
@@ -90,6 +106,8 @@ export const GameProvider: React.FC = ({ children }) => {
         gameService,
         showAnimations,
         toggleAnimations,
+        enableQuickSelect,
+        toggleQuickSelect,
         showTimers,
         toggleTimers,
         fromRoute,

--- a/src/features/greenhouse/GreenhousePot.tsx
+++ b/src/features/greenhouse/GreenhousePot.tsx
@@ -73,8 +73,13 @@ const selectPots = (state: MachineState) => state.context.state.greenhouse.pots;
 const selectInventory = (state: MachineState) => state.context.state.inventory;
 
 export const GreenhousePot: React.FC<Props> = ({ id }) => {
-  const { gameService, selectedItem, showAnimations, showTimers } =
-    useContext(Context);
+  const {
+    gameService,
+    selectedItem,
+    showAnimations,
+    enableQuickSelect,
+    showTimers,
+  } = useContext(Context);
 
   const { t } = useAppTranslation();
   const [_, setRender] = useState<number>(0);
@@ -97,7 +102,9 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
       !SEED_TO_PLANT[seed as GreenHouseCropSeedName] ||
       !inventory[seed]?.gte(1)
     ) {
-      setShowQuickSelect(true);
+      if (enableQuickSelect) {
+        setShowQuickSelect(true);
+      }
       return;
     }
 

--- a/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
@@ -12,10 +12,20 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
 }) => {
   const { t } = useAppTranslation();
 
-  const { gameService, showAnimations, toggleAnimations } = useContext(Context);
+  const {
+    gameService,
+    showAnimations,
+    toggleAnimations,
+    enableQuickSelect,
+    toggleQuickSelect,
+  } = useContext(Context);
 
   const onToggleAnimations = () => {
     toggleAnimations();
+  };
+
+  const onToggleQuickSelect = () => {
+    toggleQuickSelect();
   };
 
   return (
@@ -53,6 +63,13 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
           {showAnimations
             ? t("gameOptions.generalSettings.disableAnimations")
             : t("gameOptions.generalSettings.enableAnimations")}
+        </span>
+      </Button>
+      <Button className="mb-1" onClick={onToggleQuickSelect}>
+        <span>
+          {enableQuickSelect
+            ? t("gameOptions.generalSettings.disableQuickSelect")
+            : t("gameOptions.generalSettings.enableQuickSelect")}
         </span>
       </Button>
       <Button onClick={() => onSubMenuClick("share")} className="mb-1">

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -106,6 +106,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     gameService,
     selectedItem,
     showAnimations,
+    enableQuickSelect,
     showTimers,
     shortcutItem,
   } = useContext(Context);
@@ -263,6 +264,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     if (!crop) {
       if (
         hasFeatureAccess(state, "CROP_QUICK_SELECT") &&
+        enableQuickSelect &&
         (!seed || !(seed in CROP_SEEDS) || !inventory[seed]?.gte(1))
       ) {
         setShowQuickSelect(true);

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1687,6 +1687,8 @@
   "gameOptions.generalSettings.font": "Font",
   "gameOptions.generalSettings.disableAnimations": "Disable Animations",
   "gameOptions.generalSettings.enableAnimations": "Enable Animations",
+  "gameOptions.generalSettings.disableQuickSelect": "Disable QuickSelect",
+  "gameOptions.generalSettings.enableQuickSelect": "Enable QuickSelect",
   "gameOptions.generalSettings.share": "Share",
   "gameOptions.plazaSettings": "Plaza Settings",
   "gameOptions.plazaSettings.title.mutedPlayers": "Muted Players",


### PR DESCRIPTION
# Description

The QuickSelect UI for the Greenhouse has always bothered me.  I know what I want to plant and it's a source of mistimed planting of something I don't want planted.

There was an effort to try this out for normal crop plots and it was very problematic.  It interrupted the flow and introduced the misplanting problem (the wrong crop, and sometimes when you don't even want to plant a crop b/c you're just trying to harvest).

This change introduces a setting to prevent this "helper" UI from doing harm to those of us that don't want or need the feature.
