### PR TITLE
[FIX] Bud Box types should be evenly distributed

### DIFF
--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -39,10 +39,9 @@ const BUD_ORDER: TypeTrait[] = [
 /**
  * Based on day of year + year to get a consistent order of buds
  */
-export function getDailyBudBoxType(date: Date): TypeTrait {
-  const dayOfYear = getDayOfYear(date);
-
-  const index = dayOfYear % BUD_ORDER.length;
+export function getDailyBudBoxType(ms: number): TypeTrait {
+  const daysSinceEpoch = Math.floor(ms / (1000 * 60 * 60 * 24));
+  const index = daysSinceEpoch % BUD_ORDER.length;
   return BUD_ORDER[index];
 }
 
@@ -149,8 +148,9 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
         </div>
         <p className="text-xs mb-2">{t("budBox.description")}</p>
         {days.map((_, index) => {
-          const date = new Date(now + 24 * 60 * 60 * 1000 * index);
-          const dailyBud = getDailyBudBoxType(date);
+          const budTypeTimestamp = now + 24 * 60 * 60 * 1000 * index;
+          const date = new Date(budTypeTimestamp);
+          const dailyBud = getDailyBudBoxType(budTypeTimestamp);
           const hasBud = playerBudTypes.includes(dailyBud);
 
           return (

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -40,7 +40,7 @@ const BUD_ORDER: TypeTrait[] = [
  * Based on day of year + year to get a consistent order of buds
  */
 export function getDailyBudBoxType(ms: number): TypeTrait {
-  const daysSinceEpoch = Math.floor(ms / (1000 * 60 * 60 * 24));
+  const daysSinceEpoch = Math.floor(ms / (1000 * 60 * 60 * 24)) + 2; // +2 to match with current order
   const index = daysSinceEpoch % BUD_ORDER.length;
   return BUD_ORDER[index];
 }

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -152,6 +152,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
           const date = new Date(budTypeTimestamp);
           const dailyBud = getDailyBudBoxType(budTypeTimestamp);
           const hasBud = playerBudTypes.includes(dailyBud);
+          const ISOdate = new Date(date).toISOString().split("T")[0];
 
           return (
             <OuterPanel
@@ -206,7 +207,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
                   type="default"
                   className="absolute -top-2 -right-2 capitalize"
                 >
-                  {new Date(date).toISOString().split("T")[0]}
+                  {ISOdate}
                 </Label>
               )}
             </OuterPanel>

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -48,7 +48,7 @@ export function getDailyBudBoxType(ms: number): TypeTrait {
 export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
   const { gameService } = useContext(Context);
   const [gameState] = useActor(gameService);
-  const { t, i18n } = useAppTranslation();
+  const { t } = useAppTranslation();
 
   // Just a prolonged UI state to show the shuffle of items animation
   const [isPicking, setIsPicking] = useState(false);
@@ -70,29 +70,6 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
     setIsRevealing(true);
     setIsPicking(false);
     setIsLoading && setIsLoading(false);
-  };
-
-  const getDayOfWeek = (date: Date): string => {
-    const options: Intl.DateTimeFormatOptions = {
-      weekday: "long",
-    };
-
-    switch (i18n.language) {
-      case "fr":
-        return date.toLocaleDateString("fr-FR", options);
-      case "pt":
-        return date.toLocaleDateString("pt-PT", options);
-      case "tk":
-        return date.toLocaleDateString("tr-TR", options);
-      case "zh-CN":
-        return date.toLocaleDateString("zh-CN", options);
-      case "ko":
-        return date.toLocaleDateString("ko-KR", options);
-      case "ru":
-        return date.toLocaleDateString("ru-RU", options);
-      default:
-        return date.toLocaleDateString("en-US", options);
-    }
   };
 
   if (isPicking || (gameState.matches("revealing") && isRevealing)) {
@@ -117,7 +94,6 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
 
   const buds = getKeys(gameState.context.state.buds ?? {});
 
-  const days = new Array<number>(7).fill(0);
   const now = Date.now();
 
   const playerBudTypes = buds.map((id) => {

--- a/src/features/world/ui/chests/BudBox.tsx
+++ b/src/features/world/ui/chests/BudBox.tsx
@@ -147,7 +147,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
           </Label>
         </div>
         <p className="text-xs mb-2">{t("budBox.description")}</p>
-        {days.map((_, index) => {
+        {BUD_ORDER.map((_, index) => {
           const budTypeTimestamp = now + 24 * 60 * 60 * 1000 * index;
           const date = new Date(budTypeTimestamp);
           const dailyBud = getDailyBudBoxType(budTypeTimestamp);
@@ -206,7 +206,7 @@ export const BudBox: React.FC<Props> = ({ onClose, setIsLoading }) => {
                   type="default"
                   className="absolute -top-2 -right-2 capitalize"
                 >
-                  {getDayOfWeek(date)}
+                  {new Date(date).toISOString().split("T")[0]}
                 </Label>
               )}
             </OuterPanel>


### PR DESCRIPTION
# Description

The yearly transition is disjoint.  Some bud types have an advantage over others.

This change updates and simplifies the algorithm to be fair.

Updated the UI to show all 10 bud types and the corresponding dates of the bud box
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/26aa4ec3-dc29-4e39-8c99-2d06f138c29c)|![image](https://github.com/user-attachments/assets/12413c3b-0880-44e9-81a9-25502e3ce14b)|
