### PR TITLE
[FEAT] Quick Select for Fruits

### DIFF
--- a/src/features/builder/components/ResourcePlacer.tsx
+++ b/src/features/builder/components/ResourcePlacer.tsx
@@ -47,7 +47,7 @@ export const RESOURCES: Record<
     },
   },
   fruitPatches: {
-    component: () => <FruitPatch id="1" index={0} />,
+    component: () => <FruitPatch id="1" />,
     icon: fruitPatch,
     dimensions: {
       height: 2,

--- a/src/features/farming/hud/lib/quickSelect.ts
+++ b/src/features/farming/hud/lib/quickSelect.ts
@@ -10,5 +10,5 @@ export function cacheEnableQuickSelectSetting(show: boolean) {
 export function getEnableQuickSelectSetting(): boolean {
   const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
 
-  return cached ? JSON.parse(cached) : true;
+  return cached ? JSON.parse(cached) : false;
 }

--- a/src/features/farming/hud/lib/quickSelect.ts
+++ b/src/features/farming/hud/lib/quickSelect.ts
@@ -1,0 +1,14 @@
+/**
+ * Cache show timers setting in local storage so we can remember next time we open the HUD.
+ */
+const LOCAL_STORAGE_KEY = "settings.enableQuickSelect";
+
+export function cacheEnableQuickSelectSetting(show: boolean) {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(show));
+}
+
+export function getEnableQuickSelectSetting(): boolean {
+  const cached = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  return cached ? JSON.parse(cached) : true;
+}

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -18,6 +18,10 @@ import {
   getShowAnimationsSetting,
 } from "features/farming/hud/lib/animations";
 import {
+  cacheEnableQuickSelectSetting,
+  getEnableQuickSelectSetting,
+} from "features/farming/hud/lib/quickSelect";
+import {
   cacheShowTimersSetting,
   getShowTimersSetting,
 } from "features/farming/hud/lib/timers";
@@ -28,6 +32,8 @@ interface GameContext {
   gameService: MachineInterpreter;
   showAnimations: boolean;
   toggleAnimations: () => void;
+  enableQuickSelect: boolean;
+  toggleQuickSelect: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
   fromRoute: string;
@@ -48,6 +54,9 @@ export const GameProvider: React.FC = ({ children }) => {
     useState<InventoryItemName[]>(getShortcuts());
   const [showAnimations, setShowAnimations] = useState<boolean>(
     getShowAnimationsSetting(),
+  );
+  const [enableQuickSelect, setEnableQuickSelect] = useState<boolean>(
+    getEnableQuickSelectSetting(),
   );
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
   const [fromRoute, setFromRoute] = useState<string>("");
@@ -73,6 +82,13 @@ export const GameProvider: React.FC = ({ children }) => {
     cacheShowAnimationsSetting(newValue);
   };
 
+  const toggleQuickSelect = () => {
+    const newValue = !enableQuickSelect;
+
+    setEnableQuickSelect(newValue);
+    cacheEnableQuickSelectSetting(newValue);
+  };
+
   const toggleTimers = () => {
     const newValue = !showTimers;
 
@@ -90,6 +106,8 @@ export const GameProvider: React.FC = ({ children }) => {
         gameService,
         showAnimations,
         toggleAnimations,
+        enableQuickSelect,
+        toggleQuickSelect,
         showTimers,
         toggleTimers,
         fromRoute,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -438,6 +438,11 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   inventory: {
+    "Orange Seed": new Decimal(10),
+    "Lemon Seed": new Decimal(10),
+    "Tomato Seed": new Decimal(10),
+    "Blueberry Seed": new Decimal(10),
+    "Banana Plant": new Decimal(10),
     "Golden Cow": new Decimal(1),
     "Trade Point": new Decimal(500),
     "Fairy Circle": new Decimal(1),

--- a/src/features/greenhouse/GreenhousePot.tsx
+++ b/src/features/greenhouse/GreenhousePot.tsx
@@ -73,8 +73,13 @@ const selectPots = (state: MachineState) => state.context.state.greenhouse.pots;
 const selectInventory = (state: MachineState) => state.context.state.inventory;
 
 export const GreenhousePot: React.FC<Props> = ({ id }) => {
-  const { gameService, selectedItem, showAnimations, showTimers } =
-    useContext(Context);
+  const {
+    gameService,
+    selectedItem,
+    showAnimations,
+    enableQuickSelect,
+    showTimers,
+  } = useContext(Context);
 
   const { t } = useAppTranslation();
   const [_, setRender] = useState<number>(0);
@@ -97,7 +102,9 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
       !SEED_TO_PLANT[seed as GreenHouseCropSeedName] ||
       !inventory[seed]?.gte(1)
     ) {
-      setShowQuickSelect(true);
+      if (enableQuickSelect) {
+        setShowQuickSelect(true);
+      }
       return;
     }
 

--- a/src/features/greenhouse/GreenhousePot.tsx
+++ b/src/features/greenhouse/GreenhousePot.tsx
@@ -173,6 +173,7 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
               setShowQuickSelect(false);
             }}
             type={t("quickSelect.greenhouseSeeds")}
+            showExpanded
           />
         </Transition>
 

--- a/src/features/greenhouse/QuickSelect.tsx
+++ b/src/features/greenhouse/QuickSelect.tsx
@@ -18,6 +18,7 @@ type BaseProps = {
   }[];
   onClose: () => void;
   onSelected?: (name: InventoryItemName) => void;
+  showExpanded?: boolean;
 };
 
 type PropsWithType = BaseProps & {
@@ -40,6 +41,7 @@ export const QuickSelect: React.FC<Props> = ({
   onSelected,
   type = "", // Provide a default empty string
   emptyMessage,
+  showExpanded,
 }) => {
   const { gameService, shortcutItem } = useContext(Context);
   const ref = useRef<HTMLDivElement>(null); // Create a ref to the component
@@ -49,6 +51,7 @@ export const QuickSelect: React.FC<Props> = ({
 
   const [showEmptyPanel, setShowEmptyPanel] = useState(true);
   const available = options.filter((option) => inventory[option.name]?.gte(1));
+  const seedsShown = showExpanded ? available : available.slice(0, 3);
 
   useEffect(() => {
     if (available.length === 0) {
@@ -107,57 +110,55 @@ export const QuickSelect: React.FC<Props> = ({
     );
   }
 
-  const showBasket = available.length > 3;
-  const discLength = available.slice(0, 3).length + (showBasket ? 1 : 0);
+  const showBasket = available.length > 3 && !showExpanded;
+  const discLength = seedsShown.length + (showBasket ? 1 : 0);
 
   return (
     <div
       ref={ref}
-      className="flex shadow-md"
+      className="flex"
       style={{
         left: `50%`,
         transform: "translatex(-50%)",
       }}
     >
-      {available
-        .slice(0, 3)
-        .map(({ name, icon, showSecondaryImage }, index) => (
-          <div
+      {seedsShown.map(({ name, icon, showSecondaryImage }, index) => (
+        <div
+          style={{
+            width: `${PIXEL_SCALE * 18}px`,
+            height: `${PIXEL_SCALE * 19}px`,
+            top:
+              // The first and last item in the array will be lower
+              index !== 0 && index !== discLength - 1
+                ? `${PIXEL_SCALE * -6}px`
+                : 0,
+          }}
+          className="flex items-center justify-center relative mr-1 cursor-pointer"
+          onClick={() => select(name)}
+          key={name}
+        >
+          <img
+            src={SUNNYSIDE.icons.disc}
+            className="absolute w-full h-full inset-0"
+          />
+          <img
+            src={ITEM_DETAILS[icon as InventoryItemName].image}
+            className="z-10 -mt-1"
             style={{
-              width: `${PIXEL_SCALE * 18}px`,
-              height: `${PIXEL_SCALE * 19}px`,
-              top:
-                (discLength === 3 && index === 1) ||
-                (discLength === 4 && index >= 1)
-                  ? `${PIXEL_SCALE * -6}px`
-                  : 0,
+              width: `${PIXEL_SCALE * 10}px`,
             }}
-            className="flex items-center justify-center relative mr-1 cursor-pointer"
-            onClick={() => select(name)}
-            key={name}
-          >
+          />
+          {showSecondaryImage && (
             <img
-              src={SUNNYSIDE.icons.disc}
-              className="absolute w-full h-full inset-0"
-            />
-            <img
-              src={ITEM_DETAILS[icon as InventoryItemName].image}
-              className="z-10 -mt-1"
+              src={ITEM_DETAILS[name].image}
+              className="z-10 absolute top-0 right-0"
               style={{
-                width: `${PIXEL_SCALE * 10}px`,
+                width: `${PIXEL_SCALE * 6}px`,
               }}
             />
-            {showSecondaryImage && (
-              <img
-                src={ITEM_DETAILS[name].image}
-                className="z-10 absolute top-0 right-0"
-                style={{
-                  width: `${PIXEL_SCALE * 6}px`,
-                }}
-              />
-            )}
-          </div>
-        ))}
+          )}
+        </div>
+      ))}
       {showBasket && (
         <div
           style={{

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -31,6 +31,7 @@ import { getKeys } from "features/game/types/decorations";
 import { QuickSelect } from "features/greenhouse/QuickSelect";
 import { Transition } from "@headlessui/react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { hasFeatureAccess } from "lib/flags";
 
 const HasAxes = (
   inventory: Partial<Record<InventoryItemName, Decimal>>,
@@ -104,6 +105,7 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
     }
 
     if (
+      hasFeatureAccess(game, "FRUIT_PATCH_QUICK_SELECT") &&
       enableQuickSelect &&
       (!item || !(item in PATCH_FRUIT_SEEDS()) || !inventory[item]?.gte(1))
     ) {

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -2,7 +2,11 @@ import React, { useContext, useState } from "react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
-import { PatchFruitName } from "features/game/types/fruits";
+import {
+  PATCH_FRUIT_SEEDS,
+  PatchFruitName,
+  PatchFruitSeedName,
+} from "features/game/types/fruits";
 import { FruitTree } from "./FruitTree";
 import Decimal from "decimal.js-light";
 import {
@@ -21,9 +25,12 @@ import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { ResourceDropAnimator } from "components/animation/ResourceDropAnimator";
 
 import powerup from "assets/icons/level_up.png";
-import { getBumpkinLevel } from "features/game/lib/level";
 import { FRUIT_PATCH_VARIANTS } from "../lib/alternateArt";
 import { useSound } from "lib/utils/hooks/useSound";
+import { getKeys } from "features/game/types/decorations";
+import { QuickSelect } from "features/greenhouse/QuickSelect";
+import { Transition } from "@headlessui/react";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 const HasAxes = (
   inventory: Partial<Record<InventoryItemName, Decimal>>,
@@ -51,17 +58,15 @@ const compareGame = (prev: GameState, next: GameState) =>
   isCollectibleBuilt({ name: "Foreman Beaver", game: prev }) ===
   isCollectibleBuilt({ name: "Foreman Beaver", game: next });
 
-const _bumpkinLevel = (state: MachineState) =>
-  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
 const _island = (state: MachineState) => state.context.state.island.type;
 
 interface Props {
   id: string;
-  index: number;
 }
 
-export const FruitPatch: React.FC<Props> = ({ id, index }) => {
+export const FruitPatch: React.FC<Props> = ({ id }) => {
   const { gameService, selectedItem, shortcutItem } = useContext(Context);
+  const { t } = useAppTranslation();
 
   const [playShakingAnimation, setPlayShakingAnimation] = useState(false);
   const [collectingFruit, setCollectingFruit] = useState(false);
@@ -70,13 +75,13 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
     useState<PatchFruitName>();
   const [collectedFruitAmount, setCollectedFruitAmount] = useState<number>();
   const [collectedWoodAmount, setCollectedWoodAmount] = useState<number>();
+  const [showQuickSelect, setShowQuickSelect] = useState(false);
   const fruitPatch = useSelector(
     gameService,
     (state) => state.context.state.fruitPatches[id],
     compareFruit,
   );
-  const fruit = fruitPatch?.fruit;
-  const fertiliser = fruitPatch.fertiliser;
+  const { fruit, fertiliser } = fruitPatch;
   const game = useSelector(gameService, selectGame, compareGame);
   const inventory = useSelector(
     gameService,
@@ -91,35 +96,32 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
 
   const hasAxes = HasAxes(inventory, game, fruit);
 
-  const plantTree = async () => {
-    if (selectedItem === "Fruitful Blend") {
+  const plantTree = async (item?: InventoryItemName) => {
+    if (item === "Fruitful Blend" && !fertiliser) {
       fertilise();
       return;
     }
 
-    try {
-      const newState = gameService.send("fruit.planted", {
-        index: id,
-        seed: selectedItem,
-      });
+    if (!item || !(item in PATCH_FRUIT_SEEDS()) || !inventory[item]?.gte(1)) {
+      setShowQuickSelect(true);
+      return;
+    }
 
-      if (!newState.matches("hoarding")) {
-        plantAudio();
-      }
-    } catch {
-      undefined;
+    const newState = gameService.send("fruit.planted", {
+      index: id,
+      seed: item,
+    });
+
+    if (!newState.matches("hoarding")) {
+      plantAudio();
     }
   };
 
   const fertilise = () => {
-    try {
-      gameService.send("fruitPatch.fertilised", {
-        patchID: id,
-        fertiliser: selectedItem,
-      });
-    } catch {
-      undefined;
-    }
+    gameService.send("fruitPatch.fertilised", {
+      patchID: id,
+      fertiliser: selectedItem,
+    });
   };
 
   const harvestFruit = async () => {
@@ -175,57 +177,85 @@ export const FruitPatch: React.FC<Props> = ({ id, index }) => {
   };
 
   return (
-    <div className="w-full h-full relative">
-      {/* Fruit patch soil */}
-      <img
-        src={FRUIT_PATCH_VARIANTS[island]}
-        className="absolute pointer-events-none"
-        style={{
-          width: `${PIXEL_SCALE * 30}px`,
-          left: `${PIXEL_SCALE * 1}px`,
-          top: `${PIXEL_SCALE * 2}px`,
-        }}
-      />
-
-      {/* Fruit tree stages */}
-      <FruitTree
-        plantedFruit={fruit}
-        plantTree={plantTree}
-        harvestFruit={harvestFruit}
-        removeTree={removeTree}
-        fertilise={fertilise}
-        playShakingAnimation={playShakingAnimation}
-        hasAxes={hasAxes}
-      />
-
-      {/* Fertiliser */}
-      {!!fertiliser && (
+    <>
+      <div className="w-full h-full relative">
+        {/* Fruit patch soil */}
         <img
-          className="absolute z-10 pointer-events-none"
-          src={powerup}
+          src={FRUIT_PATCH_VARIANTS[island]}
+          className="absolute pointer-events-none"
           style={{
-            width: `${PIXEL_SCALE * 5}px`,
-            bottom: `${PIXEL_SCALE * 16}px`,
-            right: `${PIXEL_SCALE * 2}px`,
+            width: `${PIXEL_SCALE * 30}px`,
+            left: `${PIXEL_SCALE * 1}px`,
+            top: `${PIXEL_SCALE * 2}px`,
           }}
         />
-      )}
 
-      {/* Fruit drop animation */}
-      {collectingFruit && (
-        <ResourceDropAnimator
-          resourceName={collectedFruitName}
-          resourceAmount={collectedFruitAmount}
+        {/* Fruit tree stages */}
+        <FruitTree
+          plantedFruit={fruit}
+          plantTree={() => plantTree(selectedItem)}
+          harvestFruit={harvestFruit}
+          removeTree={removeTree}
+          fertilise={fertilise}
+          playShakingAnimation={playShakingAnimation}
+          hasAxes={hasAxes}
         />
-      )}
 
-      {/* Wood drop animation */}
-      {collectingWood && (
-        <ResourceDropAnimator
-          resourceName={"Wood"}
-          resourceAmount={collectedWoodAmount}
+        {/* Fertiliser */}
+        {!!fertiliser && (
+          <img
+            className="absolute z-10 pointer-events-none"
+            src={powerup}
+            style={{
+              width: `${PIXEL_SCALE * 5}px`,
+              bottom: `${PIXEL_SCALE * 16}px`,
+              right: `${PIXEL_SCALE * 2}px`,
+            }}
+          />
+        )}
+
+        {/* Fruit drop animation */}
+        {collectingFruit && (
+          <ResourceDropAnimator
+            resourceName={collectedFruitName}
+            resourceAmount={collectedFruitAmount}
+          />
+        )}
+
+        {/* Wood drop animation */}
+        {collectingWood && (
+          <ResourceDropAnimator
+            resourceName={"Wood"}
+            resourceAmount={collectedWoodAmount}
+          />
+        )}
+      </div>
+      <Transition
+        appear={true}
+        show={showQuickSelect}
+        enter="transition-opacity duration-300"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-300"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+        className="flex bottom-20 left-10 absolute z-40"
+      >
+        <QuickSelect
+          options={getKeys(PATCH_FRUIT_SEEDS()).map((seed) => ({
+            name: seed as InventoryItemName,
+            icon: PATCH_FRUIT_SEEDS()[seed].yield as InventoryItemName,
+            showSecondaryImage: true,
+          }))}
+          onClose={() => setShowQuickSelect(false)}
+          onSelected={(seed) => {
+            plantTree(seed as PatchFruitSeedName);
+            setShowQuickSelect(false);
+          }}
+          type={t("quickSelect.cropSeeds")}
+          showExpanded
         />
-      )}
-    </div>
+      </Transition>
+    </>
   );
 };

--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -65,7 +65,8 @@ interface Props {
 }
 
 export const FruitPatch: React.FC<Props> = ({ id }) => {
-  const { gameService, selectedItem, shortcutItem } = useContext(Context);
+  const { gameService, selectedItem, shortcutItem, enableQuickSelect } =
+    useContext(Context);
   const { t } = useAppTranslation();
 
   const [playShakingAnimation, setPlayShakingAnimation] = useState(false);
@@ -102,7 +103,10 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
       return;
     }
 
-    if (!item || !(item in PATCH_FRUIT_SEEDS()) || !inventory[item]?.gte(1)) {
+    if (
+      enableQuickSelect &&
+      (!item || !(item in PATCH_FRUIT_SEEDS()) || !inventory[item]?.gte(1))
+    ) {
       setShowQuickSelect(true);
       return;
     }

--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -50,6 +50,7 @@ import { WalletAddressLabel } from "components/ui/WalletAddressLabel";
 import { PickServer } from "./plaza-settings/PickServer";
 import { PlazaShaderSettings } from "./plaza-settings/PlazaShaderSettings";
 import { AdminSettings } from "./general-settings/AdminSettings";
+import { BehaviourSettings } from "./general-settings/BehaviourSettings";
 
 export interface ContentComponentProps {
   onSubMenuClick: (id: SettingMenuId) => void;
@@ -71,7 +72,6 @@ const GameOptions: React.FC<ContentComponentProps> = ({
   const [showNftId, setShowNftId] = useState(false);
 
   const copypaste = useSound("copypaste");
-  const button = useSound("button");
 
   const isPWA = useIsPWA();
   const isWeb3MobileBrowser = isMobile && !!window.ethereum;
@@ -274,6 +274,7 @@ export type SettingMenuId =
   | "changeLanguage"
   | "share"
   | "appearance"
+  | "behaviour"
   | "font"
 
   // Amoy Testnet Actions
@@ -364,6 +365,11 @@ export const settingMenus: Record<SettingMenuId, SettingMenu> = {
     title: translate("gameOptions.generalSettings.appearance"),
     parent: "general",
     content: AppearanceSettings,
+  },
+  behaviour: {
+    title: translate("gameOptions.generalSettings.behaviour"),
+    parent: "general",
+    content: BehaviourSettings,
   },
   font: {
     title: translate("gameOptions.generalSettings.font"),

--- a/src/features/island/hud/components/settings-menu/general-settings/BehaviourSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/BehaviourSettings.tsx
@@ -1,0 +1,33 @@
+import { Button } from "components/ui/Button";
+import { Context } from "features/game/GameProvider";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import React, { useContext } from "react";
+
+export const BehaviourSettings: React.FC = () => {
+  const { t } = useAppTranslation();
+  const {
+    showAnimations,
+    toggleAnimations,
+    enableQuickSelect,
+    toggleQuickSelect,
+  } = useContext(Context);
+
+  return (
+    <>
+      <Button className="mb-1" onClick={toggleAnimations}>
+        <span>
+          {showAnimations
+            ? t("gameOptions.generalSettings.disableAnimations")
+            : t("gameOptions.generalSettings.enableAnimations")}
+        </span>
+      </Button>
+      <Button className="mb-1" onClick={toggleQuickSelect}>
+        <span>
+          {enableQuickSelect
+            ? t("gameOptions.generalSettings.disableQuickSelect")
+            : t("gameOptions.generalSettings.enableQuickSelect")}
+        </span>
+      </Button>
+    </>
+  );
+};

--- a/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
@@ -12,10 +12,20 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
 }) => {
   const { t } = useAppTranslation();
 
-  const { gameService, showAnimations, toggleAnimations } = useContext(Context);
+  const {
+    gameService,
+    showAnimations,
+    toggleAnimations,
+    enableQuickSelect,
+    toggleQuickSelect,
+  } = useContext(Context);
 
   const onToggleAnimations = () => {
     toggleAnimations();
+  };
+
+  const onToggleQuickSelect = () => {
+    toggleQuickSelect();
   };
 
   return (
@@ -53,6 +63,13 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
           {showAnimations
             ? t("gameOptions.generalSettings.disableAnimations")
             : t("gameOptions.generalSettings.enableAnimations")}
+        </span>
+      </Button>
+      <Button className="mb-1" onClick={onToggleQuickSelect}>
+        <span>
+          {enableQuickSelect
+            ? t("gameOptions.generalSettings.disableQuickSelect")
+            : t("gameOptions.generalSettings.enableQuickSelect")}
         </span>
       </Button>
       <Button onClick={() => onSubMenuClick("share")} className="mb-1">

--- a/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/GeneralSettings.tsx
@@ -12,21 +12,7 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
 }) => {
   const { t } = useAppTranslation();
 
-  const {
-    gameService,
-    showAnimations,
-    toggleAnimations,
-    enableQuickSelect,
-    toggleQuickSelect,
-  } = useContext(Context);
-
-  const onToggleAnimations = () => {
-    toggleAnimations();
-  };
-
-  const onToggleQuickSelect = () => {
-    toggleQuickSelect();
-  };
+  const { gameService } = useContext(Context);
 
   return (
     <>
@@ -47,7 +33,6 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
           )}
         </Button>
       )}
-
       <Button onClick={() => onSubMenuClick("discord")} className="mb-1">
         <span>{`Discord`}</span>
       </Button>
@@ -58,19 +43,8 @@ export const GeneralSettings: React.FC<ContentComponentProps> = ({
       <Button className="mb-1" onClick={() => onSubMenuClick("appearance")}>
         <span>{t("gameOptions.generalSettings.appearance")}</span>
       </Button>
-      <Button className="mb-1" onClick={onToggleAnimations}>
-        <span>
-          {showAnimations
-            ? t("gameOptions.generalSettings.disableAnimations")
-            : t("gameOptions.generalSettings.enableAnimations")}
-        </span>
-      </Button>
-      <Button className="mb-1" onClick={onToggleQuickSelect}>
-        <span>
-          {enableQuickSelect
-            ? t("gameOptions.generalSettings.disableQuickSelect")
-            : t("gameOptions.generalSettings.enableQuickSelect")}
-        </span>
+      <Button className="mb-1" onClick={() => onSubMenuClick("behaviour")}>
+        <span>{t("gameOptions.generalSettings.behaviour")}</span>
       </Button>
       <Button onClick={() => onSubMenuClick("share")} className="mb-1">
         <span>{t("gameOptions.generalSettings.share")}</span>

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -106,6 +106,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     gameService,
     selectedItem,
     showAnimations,
+    enableQuickSelect,
     showTimers,
     shortcutItem,
   } = useContext(Context);
@@ -263,6 +264,7 @@ export const Plot: React.FC<Props> = ({ id, index }) => {
     if (!crop) {
       if (
         hasFeatureAccess(state, "CROP_QUICK_SELECT") &&
+        enableQuickSelect &&
         (!seed || !(seed in CROP_SEEDS) || !inventory[seed]?.gte(1))
       ) {
         setShowQuickSelect(true);

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -77,6 +77,7 @@ const featureFlags = {
     start: new Date("2024-12-18T00:00:00Z"),
     end: new Date("2025-01-31T00:00:00Z"),
   }),
+  FRUIT_PATCH_QUICK_SELECT: defaultFeatureFlag,
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof featureFlags;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1684,6 +1684,7 @@
   "gameOptions.generalSettings.darkMode": "Dark Mode",
   "gameOptions.generalSettings.lightMode": "Light Mode",
   "gameOptions.generalSettings.appearance": "Appearance",
+  "gameOptions.generalSettings.behaviour": "Behaviour",
   "gameOptions.generalSettings.font": "Font",
   "gameOptions.generalSettings.disableAnimations": "Disable Animations",
   "gameOptions.generalSettings.enableAnimations": "Enable Animations",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1687,6 +1687,8 @@
   "gameOptions.generalSettings.font": "Font",
   "gameOptions.generalSettings.disableAnimations": "Disable Animations",
   "gameOptions.generalSettings.enableAnimations": "Enable Animations",
+  "gameOptions.generalSettings.disableQuickSelect": "Disable QuickSelect",
+  "gameOptions.generalSettings.enableQuickSelect": "Enable QuickSelect",
   "gameOptions.generalSettings.share": "Share",
   "gameOptions.plazaSettings": "Plaza Settings",
   "gameOptions.plazaSettings.title.mutedPlayers": "Muted Players",


### PR DESCRIPTION
# Description

Add buttons to select fruits when clicking on the plot
![image](https://github.com/user-attachments/assets/c10db58c-ae0b-4433-8b22-f1061a1175c7)

Added a new settings menu for behaviour inside general settings
Added a new toggle for quick select (disabled by default) (by @brian-man)
![image](https://github.com/user-attachments/assets/78726fdc-932a-4ab6-8e55-edbf231cac07)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
