### PR TITLE
[FIX] Popup reconnent panel on Plaza server leave

### DIFF
--- a/src/features/world/mmoMachine.ts
+++ b/src/features/world/mmoMachine.ts
@@ -336,7 +336,7 @@ export const mmoMachine = createMachine<MMOContext, MMOEvent, MMOState>({
     joining: {
       invoke: {
         id: "joining",
-        src: (context, event) => async () => {
+        src: (context, event) => async (send) => {
           // Join server based on what was selected
           const server = await context.client?.joinOrCreate<PlazaRoomState>(
             context.serverId,
@@ -353,6 +353,10 @@ export const mmoMachine = createMachine<MMOContext, MMOEvent, MMOState>({
               moderation: context.moderation,
             },
           );
+
+          server?.onLeave((client) => {
+            send("DISCONNECTED");
+          });
 
           return { server };
         },
@@ -385,6 +389,9 @@ export const mmoMachine = createMachine<MMOContext, MMOEvent, MMOState>({
               serverId: (_, event) => event.serverId,
             }),
           ],
+        },
+        DISCONNECTED: {
+          target: "error",
         },
       },
     },


### PR DESCRIPTION
# Description

Adds a small callback to fire a disconnect event onLeave of the server. This should hopefully fire if the server is restarted.

# What needs to be tested by the reviewer?

1. run backend and frontend.
2. Disconnect player from backend.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]