### PR TITLE
[FIX] Bert's Obsession blocking resource listings and offers

### DIFF
--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -153,6 +153,8 @@ const AcceptOfferContent: React.FC<{
     obsessionCompletedAt >= bertObsession.startDate &&
     obsessionCompletedAt <= bertObsession.endDate;
 
+  const isResource = display.type === "resources";
+
   return (
     <>
       <div className="p-2">
@@ -186,7 +188,8 @@ const AcceptOfferContent: React.FC<{
         </Button>
         <Button
           disabled={
-            !hasItem || (isItemBertObsession && isBertsObesessionCompleted)
+            !hasItem ||
+            (isItemBertObsession && isBertsObesessionCompleted && !isResource)
           }
           onClick={() => confirm()}
           className="relative"

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -275,7 +275,9 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                     disabled={
                       !count ||
                       (!isVIP && dailyListings >= 1) ||
-                      (isItemBertObsession && isBertsObesessionCompleted)
+                      (isItemBertObsession &&
+                        isBertsObesessionCompleted &&
+                        !isResources)
                     }
                     onClick={onListClick}
                     className="w-full sm:w-auto"
@@ -285,11 +287,13 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 )}
               </div>
               <div className="mt-1">
-                {isItemBertObsession && isBertsObesessionCompleted && (
-                  <Label type="danger">
-                    {`You have completed Bert's Obsession recently`}
-                  </Label>
-                )}
+                {isItemBertObsession &&
+                  isBertsObesessionCompleted &&
+                  !isResources && (
+                    <Label type="danger">
+                      {`You have completed Bert's Obsession recently`}
+                    </Label>
+                  )}
               </div>
             </div>
           </div>
@@ -312,7 +316,9 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 disabled={
                   !count ||
                   (!isVIP && dailyListings >= 1) ||
-                  (isItemBertObsession && isBertsObesessionCompleted)
+                  (isItemBertObsession &&
+                    isBertsObesessionCompleted &&
+                    !isResources)
                 }
                 className="w-full sm:w-auto"
               >
@@ -321,11 +327,13 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
             )}
           </div>
           <div className="mt-1">
-            {isItemBertObsession && isBertsObesessionCompleted && (
-              <Label type="danger">
-                {`You have completed Bert's Obsession recently`}
-              </Label>
-            )}
+            {isItemBertObsession &&
+              isBertsObesessionCompleted &&
+              !isResources && (
+                <Label type="danger">
+                  {`You have completed Bert's Obsession recently`}
+                </Label>
+              )}
           </div>
         </div>
       </InnerPanel>

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -227,7 +227,9 @@ export const TradeableOffers: React.FC<{
                     <Button
                       disabled={
                         topOffer.offeredBy.id === farmId ||
-                        (isItemBertObsession && isBertsObesessionCompleted)
+                        (isItemBertObsession &&
+                          isBertsObesessionCompleted &&
+                          !isResource)
                       }
                       onClick={() => setShowAcceptOffer(true)}
                       className="w-full sm:w-fit"

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -159,63 +159,15 @@ export const BertObsession: React.FC<{ readonly?: boolean }> = ({
 
   if (readonly) {
     return (
-      <>
-        <div className="flex flex-col items-center space-y-2 mb-2">
-          <div className="flex flex-row justify-between w-full my-1">
-            <Label type="default">{"Bert's Obsession"}</Label>
-            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-              {`${t("offer.end")} ${secondsToString(resetSeconds, {
-                length: "medium",
-                removeTrailingZeros: true,
-              })}`}
-            </Label>
-          </div>
-          <div className="w-full mb-1 mx-1">
-            <div className="flex">
-              <div
-                className="w-[40%] relative min-w-[40%] rounded-md overflow-hidden shadow-md mr-2 flex justify-center items-center h-32"
-                style={
-                  isObsessionCollectible
-                    ? {
-                        backgroundImage: `url(${SUNNYSIDE.ui.grey_background})`,
-                        backgroundSize: "cover",
-                        backgroundPosition: "center",
-                      }
-                    : {}
-                }
-              >
-                <img
-                  src={image}
-                  className="absolute w-1/2 z-20 object-cover mb-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-                />
-              </div>
-              <div className="flex flex-col space-y-2 justify-between">
-                <span className="text-xs leading-none">
-                  {t("obsessionDialogue.codex", {
-                    itemName: obsessionName ?? "",
-                    seasonalTicket: getSeasonalTicket().toLowerCase(),
-                  })}
-                </span>
-                <div className="flex flex-row flex-wrap">
-                  <Label
-                    className="whitespace-nowrap font-secondary relative mr-2"
-                    type="default"
-                  >
-                    {`Reward: ${reward} ${getSeasonalTicket()}s`}
-                  </Label>
-                  {obsessionCompletedAt &&
-                    obsessionCompletedAt >= currentObsession.startDate &&
-                    obsessionCompletedAt <= currentObsession.endDate && (
-                      <Label type="success" icon={SUNNYSIDE.icons.confirm}>
-                        {t("alr.completed")}
-                      </Label>
-                    )}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </>
+      <BertObsessionReadonly
+        resetSeconds={resetSeconds}
+        isObsessionCollectible={isObsessionCollectible}
+        image={image}
+        reward={reward}
+        obsessionName={obsessionName}
+        obsessionCompletedAt={obsessionCompletedAt}
+        currentObsession={currentObsession}
+      />
     );
   }
 
@@ -311,5 +263,82 @@ const CompleteObsession: React.FC<{
         {t("bert.day", { seasonalTicket: getSeasonalTicket() })}
       </span>
     </>
+  );
+};
+
+const BertObsessionReadonly: React.FC<{
+  resetSeconds: number;
+  isObsessionCollectible: boolean;
+  image: string;
+  reward: number;
+  obsessionName?: string;
+  obsessionCompletedAt?: number;
+  currentObsession: CurrentObsession;
+}> = ({
+  resetSeconds,
+  isObsessionCollectible,
+  image,
+  reward,
+  obsessionName,
+  obsessionCompletedAt,
+  currentObsession,
+}) => {
+  const { t } = useAppTranslation();
+  return (
+    <div className="flex flex-col items-center space-y-2 mb-2">
+      <div className="flex flex-row justify-between w-full my-1">
+        <Label type="default">{"Bert's Obsession"}</Label>
+        <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+          {`${t("offer.end")} ${secondsToString(resetSeconds, {
+            length: "medium",
+            removeTrailingZeros: true,
+          })}`}
+        </Label>
+      </div>
+      <div className="w-full mb-1 mx-1">
+        <div className="flex">
+          <div
+            className="relative min-w-[40%] rounded-md overflow-hidden shadow-md mx-2 flex justify-center items-center w-32 h-32 md:w-64 md:h-64"
+            style={
+              isObsessionCollectible
+                ? {
+                    backgroundImage: `url(${SUNNYSIDE.ui.grey_background})`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                  }
+                : {}
+            }
+          >
+            <img
+              src={image}
+              className="absolute w-1/2 z-20 object-cover mb-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+            />
+          </div>
+          <div className="flex flex-col space-y-2 justify-between">
+            <span className="text-xs leading-none">
+              {t("obsessionDialogue.codex", {
+                itemName: obsessionName ?? "",
+                seasonalTicket: getSeasonalTicket().toLowerCase(),
+              })}
+            </span>
+            <div className="flex flex-row flex-wrap gap-1">
+              <Label
+                className="whitespace-nowrap font-secondary relative"
+                type="default"
+              >
+                {`Reward: ${reward} ${getSeasonalTicket()}s`}
+              </Label>
+              {obsessionCompletedAt &&
+                obsessionCompletedAt >= currentObsession.startDate &&
+                obsessionCompletedAt <= currentObsession.endDate && (
+                  <Label type="success" icon={SUNNYSIDE.icons.confirm}>
+                    {t("alr.completed")}
+                  </Label>
+                )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };


### PR DESCRIPTION
# Description

Fix an issue that prevents players from listing a resource if 
- Resource is Bert's Obession
- Resource obsession is completed

As resources are obtainable by anyone, we don't need to restrict it from trade after completed

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
