### PR TITLE
[FIX] Ensure animals level up only when awake

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -108,7 +108,11 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
   const [showMutantAnimalModal, setShowMutantAnimalModal] = useState(false);
 
   useEffect(() => {
-    if (cow.state === "ready" && cowMachineState !== "ready") {
+    if (
+      cow.state === "ready" &&
+      cow.awakeAt < Date.now() &&
+      cowMachineState !== "ready"
+    ) {
       cowService.send({
         type: "INSTANT_LEVEL_UP",
         animal: cow,

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -101,7 +101,11 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
   const { name: mutantName } = sheep.reward?.items?.[0] ?? {};
 
   useEffect(() => {
-    if (sheep.state === "ready" && sheepState !== "ready") {
+    if (
+      sheep.state === "ready" &&
+      sheep.awakeAt < Date.now() &&
+      sheepState !== "ready"
+    ) {
       sheepService.send({
         type: "INSTANT_LEVEL_UP",
         animal: sheep,

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -116,7 +116,11 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
   const chickenMachineState = useSelector(chickenService, _animalState);
 
   useEffect(() => {
-    if (chicken.state === "ready" && chickenMachineState !== "ready") {
+    if (
+      chicken.state === "ready" &&
+      chicken.awakeAt < Date.now() &&
+      chickenMachineState !== "ready"
+    ) {
       chickenService.send({
         type: "INSTANT_LEVEL_UP",
         animal: chicken,


### PR DESCRIPTION
# Description

Fixed a bug that came with #4985 that allows animals to level up after petting

Fixes #issue

# What needs to be tested by the reviewer?
- Set conditions in gamestate that will let you pet animal and level it up
- ensure that it doesn't let you collect yield

- Ensure that Apple-tastic still works

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
