### PR TITLE
[FEAT] One Click Feed With Free Feed SFT

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -1297,4 +1297,191 @@ describe("feedAnimal", () => {
 
     expect(state.inventory["Mixed Grain"]).toEqual(new Decimal(2));
   });
+
+  it("feeds a cow to the next level if the player has a Golden Cow", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          "Golden Cow": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.henHouse.animals["0"],
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+
+    expect(state.barn.animals["0"].experience).toEqual(180);
+  });
+
+  it("feeds a max level chicken the max level xp if the player has a Gold Egg", () => {
+    const maxLevelXP = ANIMAL_LEVELS["Chicken"][15];
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          "Gold Egg": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.henHouse.animals["0"],
+              experience: maxLevelXP,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: "0",
+      },
+    });
+
+    expect(state.henHouse.animals["0"].experience).toEqual(
+      maxLevelXP + maxLevelXP,
+    );
+  });
+
+  it("feeds a chicken that is over max level the max level xp if the player has a Gold Egg", () => {
+    const maxLevelXP = ANIMAL_LEVELS["Chicken"][15];
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          "Gold Egg": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.henHouse.animals["0"],
+              experience: maxLevelXP + 100,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: "0",
+      },
+    });
+
+    expect(state.henHouse.animals["0"].experience).toEqual(
+      maxLevelXP + maxLevelXP,
+    );
+  });
+
+  it("feeds a max level cow the max level xp if the player has a Golden Cow", () => {
+    const maxLevelXP = ANIMAL_LEVELS["Cow"][15];
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          "Golden Cow": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              experience: maxLevelXP,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+
+    expect(state.barn.animals["0"].experience).toEqual(maxLevelXP + maxLevelXP);
+  });
+
+  it("feeds a cow that is over max level the max level xp if the player has a Golden Cow", () => {
+    const maxLevelXP = ANIMAL_LEVELS["Cow"][15];
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          "Golden Cow": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              experience: maxLevelXP + 100,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+
+    expect(state.barn.animals["0"].experience).toEqual(maxLevelXP + maxLevelXP);
+  });
 });

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -83,27 +83,34 @@ const handleAnimalExperience = (
   return currentCycleProgress + foodXp >= cycleXP;
 };
 
-const handleFreeFeeding = (
-  animal: Animal,
-  animalType: AnimalType,
-  level: number,
-  favouriteFood: AnimalFoodName,
-  copy: GameState,
-) => {
-  const { foodXp } = handleFoodXP({
-    state: copy,
-    animal: animalType,
-    level: level as AnimalLevel,
-    food: favouriteFood,
-  });
+const handleFreeFeeding = ({
+  animal,
+  animalType,
+  level,
+  copy,
+}: {
+  animal: Animal;
+  animalType: AnimalType;
+  level: number;
+  copy: GameState;
+}) => {
   const beforeFeedXp = animal.experience;
+  const nextLevel = (level + 1) as AnimalLevel;
+  let isReady = false;
 
-  const isReady = handleAnimalExperience(
-    animal,
-    animalType,
-    beforeFeedXp,
-    foodXp,
-  );
+  // Is max level
+  if (nextLevel > 15) {
+    const maxLevelXp = ANIMAL_LEVELS[animalType][15];
+    const currentCycleProgress = beforeFeedXp % maxLevelXp;
+    const xpDiff = maxLevelXp - currentCycleProgress;
+
+    isReady = handleAnimalExperience(animal, animalType, beforeFeedXp, xpDiff);
+  } else {
+    const nextLevelXp = ANIMAL_LEVELS[animalType][nextLevel];
+    const xpDiff = nextLevelXp - beforeFeedXp;
+
+    isReady = handleAnimalExperience(animal, animalType, beforeFeedXp, xpDiff);
+  }
 
   animal.state = isReady ? "ready" : "happy";
 
@@ -203,24 +210,22 @@ export function feedAnimal({
 
     // Handle Golden Egg Free Food
     if (action.animal === "Chicken" && hasGoldenEggPlaced) {
-      return handleFreeFeeding(
+      return handleFreeFeeding({
         animal,
-        action.animal,
+        animalType: action.animal,
         level,
-        favouriteFood,
         copy,
-      );
+      });
     }
 
     // Handle Golden Cow Free Food
     if (action.animal === "Cow" && hasGoldenCowPlaced) {
-      return handleFreeFeeding(
+      return handleFreeFeeding({
         animal,
-        action.animal,
+        animalType: action.animal,
         level,
-        favouriteFood,
         copy,
-      );
+      });
     }
 
     // Regular feeding logic


### PR DESCRIPTION
# Description

Require only one feed when feeding an animal with a free fee SFT placed eg. Gold Egg, Golden Cow

![cow-feed](https://github.com/user-attachments/assets/f3efaa96-5aab-46d3-95d5-6dca92b4e7b3)
![chicken-feed](https://github.com/user-attachments/assets/bb154e4a-1ede-47d9-b936-4fdda40b9843)


Fixes #issue

# What needs to be tested by the reviewer?

- Place a Gold Egg and feed a chicken with just one click (you still need to collect the produce)
- Place a Golden Cow and feed a cow with just one click (you still need to collect the produce)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
