### PR TITLE
[FIX] Avoid placeable self-collision inside home

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -301,7 +301,7 @@ function detectHomeCollision({
   const placed = home.collectibles;
 
   const collidingItems = getKeys(placed).filter(
-    (name) => !NON_COLLIDING_OBJECTS.includes(name),
+    (other) => !NON_COLLIDING_OBJECTS.includes(other) && other !== name,
   );
 
   const placeableBounds = collidingItems.flatMap((name) => {


### PR DESCRIPTION
# Description

In edit mode, collectibles inside the home will collide with themselves, making it frustrating to redecorate inside. As far as I can gather from the code, this happens because in MovableComponent.tsx, the call to removePlaceable() doesn't affect inside the house, but I would greatly appreciate if anybody has a better explanation. The fix is simply to filter out the item we are currently moving from the list of already-placed items.

**Before**:
![before](https://github.com/user-attachments/assets/715c4781-a50f-412c-a60b-1afc4a1c9087)

**After**
![after](https://github.com/user-attachments/assets/0d8686fb-c4f3-440d-8eec-b403ab8dd373)


# What needs to be tested by the reviewer?
Make sure that moving items around works like expected and that the small change doesn't affect logic anywhere else inside the house.

Please describe how this can be tested.

On the island, go into edit mode and move around a collectible. Everything should be normal.
Now, go inside the house, move a collectible, you should now be able to place back to where it was before without it showing red. 
A good test is to use an item that is larger than 1x1, now you should be able to move it by 1 tile, and it works. This didn't work before, as it would still be colliding with where it was before, as seen in the Wagon gif above.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
