### PR TITLE
[FEAT] Daily Reset For Season Events

### DIFF
--- a/src/assets/sound-effects/soundEffects.ts
+++ b/src/assets/sound-effects/soundEffects.ts
@@ -58,6 +58,7 @@ export const SOUNDS = {
     produce_drop: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Menu_UI/Collects/Farm_Game_User_Interface_Collect_Item_1_Click_Pop_Fun_Cartoon.mp3`,
     feed_animal: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Farming/Eat/Farm_Game_Farming_Eat_Organic_Food_Chew_Consume_Player_Chomp_Bite_Fruit_Veg_4_Short.mp3`,
     cure_animal: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Menu_UI/Organic/Farm_Game_User_Interface_Organic_Generic_Select_2_Click_Pop_Short_Option.mp3`,
+    morning_rooster: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Animals/Bird/Bird_Rooster_Cock_A_Doodle_Doo_1.mp3`,
   },
   buildings: {
     bank: `${CONFIG.PROTECTED_IMAGE_URL}/sfx/Buildings/bank.mp3`,

--- a/src/features/game/components/DailyReset.tsx
+++ b/src/features/game/components/DailyReset.tsx
@@ -1,0 +1,59 @@
+import { useContext, useEffect } from "react";
+import { Context } from "../GameProvider";
+import { useSound } from "lib/utils/hooks/useSound";
+
+interface DailyResetActions {
+  triggerReset: () => void;
+}
+
+const useDailyResetActions = (): DailyResetActions => {
+  const { gameService } = useContext(Context);
+  const { play } = useSound("morning_rooster");
+
+  return {
+    triggerReset: () => {
+      gameService.send("daily.reset");
+      gameService.send("SAVE");
+      play();
+    },
+  };
+};
+
+export const DailyReset: React.FC = () => {
+  const { triggerReset } = useDailyResetActions();
+
+  useEffect(() => {
+    // Calculate time until next check
+    const getNextCheckTime = () => {
+      const now = new Date();
+
+      // In development: check at the start of each minute
+      //   const nextMinute = new Date(now);
+      //   nextMinute.setSeconds(0);
+      //   nextMinute.setMilliseconds(0);
+      //   nextMinute.setMinutes(nextMinute.getMinutes() + 1);
+      //   return nextMinute.getTime() - now.getTime();
+
+      // In production: check at UTC midnight
+      const tomorrow = new Date(now);
+      tomorrow.setUTCHours(24, 0, 0, 0);
+      return tomorrow.getTime() - now.getTime();
+    };
+
+    const scheduleNextReset = () => {
+      const timeUntilCheck = getNextCheckTime();
+
+      return setTimeout(() => {
+        triggerReset();
+        // Schedule next check
+        timeoutId = scheduleNextReset();
+      }, timeUntilCheck);
+    };
+
+    let timeoutId = scheduleNextReset();
+
+    return () => clearTimeout(timeoutId);
+  }, [triggerReset]);
+
+  return null;
+};

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -426,6 +426,11 @@ import {
   triggerTornado,
   TriggerTornadoAction,
 } from "./landExpansion/triggerTornado";
+import { dailyReset, DailyResetAction } from "./landExpansion/dailyReset";
+import {
+  acknowledgeCalendarEvent,
+  AcknowledgeCalendarEventAction,
+} from "./landExpansion/acknowledgeCalendarEvent";
 
 export type PlayingEvent =
   | TriggerTornadoAction
@@ -557,6 +562,8 @@ export type PlayingEvent =
   | UnlockFarmhandAction
   | ClaimPurchaseAction
   | RedeemTradeRewardsAction
+  | DailyResetAction
+  | AcknowledgeCalendarEventAction
   // To remove once December is finished
   | CollectCandyAction;
 
@@ -755,6 +762,8 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "purchase.claimed": claimPurchase,
   "reward.redeemed": redeemTradeReward,
   "candy.collected": collectCandy,
+  "daily.reset": dailyReset,
+  "calendarEvent.acknowledged": acknowledgeCalendarEvent,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/acknowledgeCalendarEvent.test.ts
+++ b/src/features/game/events/landExpansion/acknowledgeCalendarEvent.test.ts
@@ -1,0 +1,47 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { GameState } from "features/game/types/game";
+import { acknowledgeCalendarEvent } from "./acknowledgeCalendarEvent";
+
+jest.mock("features/game/types/calendar", () => ({
+  getActiveCalenderEvent: jest.fn(() => "tornado"),
+}));
+
+describe("acknowledgeCalendarEvent", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws an error if no event is not found", () => {
+    expect(() =>
+      acknowledgeCalendarEvent({
+        state: TEST_FARM,
+        action: { type: "calendarEvent.acknowledged" },
+      }),
+    ).toThrow();
+  });
+
+  it("should make a calendar event as acknowledged", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      calendar: {
+        dates: [],
+        tornado: {
+          triggeredAt: Date.now(),
+          protected: false,
+        },
+      },
+    };
+
+    const acknowledgedAt = Date.now();
+
+    const newGame = acknowledgeCalendarEvent({
+      state,
+      action: {
+        type: "calendarEvent.acknowledged",
+      },
+      createdAt: acknowledgedAt,
+    });
+
+    expect(newGame.calendar.tornado?.acknowledgedAt).toBe(acknowledgedAt);
+  });
+});

--- a/src/features/game/events/landExpansion/acknowledgeCalendarEvent.ts
+++ b/src/features/game/events/landExpansion/acknowledgeCalendarEvent.ts
@@ -1,0 +1,35 @@
+import {
+  CalendarEventName,
+  getActiveCalenderEvent,
+} from "features/game/types/calendar";
+import { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+export type AcknowledgeCalendarEventAction = {
+  type: "calendarEvent.acknowledged";
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: AcknowledgeCalendarEventAction;
+  createdAt?: number;
+};
+
+export function acknowledgeCalendarEvent({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (stateCopy) => {
+    const event = getActiveCalenderEvent({ game: stateCopy });
+
+    if (!event) {
+      throw new Error("Event not found");
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    stateCopy.calendar[event as CalendarEventName]!.acknowledgedAt = createdAt;
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/events/landExpansion/dailyReset.ts
+++ b/src/features/game/events/landExpansion/dailyReset.ts
@@ -1,0 +1,17 @@
+import { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+export type DailyResetAction = {
+  type: "daily.reset";
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: DailyResetAction;
+};
+
+export function dailyReset({ state }: Options) {
+  return produce(state, (stateCopy) => {
+    return stateCopy;
+  });
+}

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -77,6 +77,7 @@ import { Marketplace } from "features/marketplace/Marketplace";
 import { CompetitionModal } from "features/competition/CompetitionBoard";
 import { SeasonChanged } from "./components/temperateSeason/SeasonChanged";
 import { CalendarEvent } from "./components/temperateSeason/CalendarEvent";
+import { DailyReset } from "../components/DailyReset";
 
 function camelToDotCase(str: string): string {
   return str.replace(/([a-z])([A-Z])/g, "$1.$2").toLowerCase() as string;
@@ -626,6 +627,8 @@ export const GameWrapper: React.FC = ({ children }) => {
 
         {children}
       </ToastProvider>
+      {/* Handles daily reset */}
+      <DailyReset />
     </>
   );
 };

--- a/src/features/game/expansion/components/temperateSeason/CalendarEvent.tsx
+++ b/src/features/game/expansion/components/temperateSeason/CalendarEvent.tsx
@@ -3,21 +3,30 @@ import { Button } from "components/ui/Button";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
 import { useGame } from "features/game/GameProvider";
-import { getPendingCalendarEvent } from "features/game/types/calendar";
+import { getActiveCalenderEvent } from "features/game/types/calendar";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Tornado } from "./Tornado";
 
 export const CalendarEvent: React.FC = () => {
   const { gameState, gameService } = useGame();
   const { t } = useAppTranslation();
-  const event = getPendingCalendarEvent({ game: gameState.context.state });
+  const event = getActiveCalenderEvent({ game: gameState.context.state });
+
+  const handleAcknowledge = () => {
+    gameService.send({ type: "calendarEvent.acknowledged" });
+    gameService.send({ type: "ACKNOWLEDGE" });
+  };
 
   return (
     <Modal show>
-      {event === "tornado" && <Tornado />}
+      {event === "tornado" && <Tornado acknowledge={handleAcknowledge} />}
       {!event && (
         <Panel>
-          <Button onClick={() => gameService.send("ACKNOWLEDGE")}>
+          <Button
+            onClick={() => {
+              gameService.send({ type: "ACKNOWLEDGE" });
+            }}
+          >
             {t("close")}
           </Button>
         </Panel>

--- a/src/features/game/expansion/components/temperateSeason/Tornado.tsx
+++ b/src/features/game/expansion/components/temperateSeason/Tornado.tsx
@@ -9,8 +9,10 @@ import tornado from "assets/icons/tornado.webp";
 import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
 import { ITEM_DETAILS } from "features/game/types/images";
 
-export const Tornado: React.FC = () => {
-  const { gameState, gameService } = useGame();
+export const Tornado: React.FC<{
+  acknowledge: () => void;
+}> = ({ acknowledge }) => {
+  const { gameState } = useGame();
   const { t } = useAppTranslation();
 
   const tornadoPositions = useRef<
@@ -26,11 +28,6 @@ export const Tornado: React.FC = () => {
       delay: Math.random() * 2,
     })),
   );
-
-  const acknowledge = () => {
-    gameService.send("tornado.triggered");
-    gameService.send("ACKNOWLEDGE");
-  };
 
   const hasPinwheel =
     !!gameState.context.state.collectibles["Tornado Pinwheel"];

--- a/src/features/game/types/calendar.ts
+++ b/src/features/game/types/calendar.ts
@@ -6,6 +6,7 @@ export type CalendarEventName = "tornado";
 export type CalendarEvent = {
   triggeredAt: number;
   protected?: boolean;
+  acknowledgedAt?: number;
 };
 
 export function getPendingCalendarEvent({
@@ -41,6 +42,8 @@ export function getActiveCalenderEvent({
 }: {
   game: GameState;
 }): CalendarEventName | undefined {
+  if (!game.calendar) return undefined;
+
   // If trigger in last 24 hours
   if (
     game.calendar.tornado?.triggeredAt &&

--- a/src/lib/utils/hooks/useSound.ts
+++ b/src/lib/utils/hooks/useSound.ts
@@ -227,6 +227,11 @@ const HOWLERS = {
     preload: false,
     volume: 0.05,
   }),
+  morning_rooster: new Howl({
+    src: [SOUNDS.animals.morning_rooster],
+    preload: false,
+    volume: 0.05,
+  }),
 };
 
 let lastSoundPlayedAt = 0;


### PR DESCRIPTION
# Description

This introduces a `DailyEvent` component which will fire a no op event on UTC midnight change over to trigger a seasonal event. The game machine will then handle moving the player through an acknowledgement step so they are informed on what has occurred.

There can be more added to this component like a countdown, more "new day" communication. This is not included in this PR.

Fixes #issue

# What needs to be tested by the reviewer?

- Inside of `DailyReset` uncomment the test version and comment out the prod version. This will trigger the reset every minute. Once this is done then go the BE and uncomment the tornado for today.
- Come back to the FE and on the next reset you should automatically be notified of the tornado. 
- Acknowledge
- Refresh, tornado should still be in affect but you will not be notified again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
