### PR TITLE
[CHORE] Standardize marketplace SFL decimal places display

### DIFF
--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -100,7 +100,6 @@ export const MarketplaceSalesPopup: React.FC = () => {
                         <span className="text-xs">
                           {`${formatNumber(estTradePoints, {
                             decimalPlaces: 2,
-                            showTrailingZeros: false,
                           })} Trade Points`}
                         </span>
                         <img

--- a/src/features/game/expansion/components/OffersAcceptedPopup.tsx
+++ b/src/features/game/expansion/components/OffersAcceptedPopup.tsx
@@ -97,7 +97,6 @@ export const OffersAcceptedPopup: React.FC = () => {
                         <span className="text-xs">
                           {`${formatNumber(estTradePoints, {
                             decimalPlaces: 2,
-                            showTrailingZeros: false,
                           })} Trade Points`}
                         </span>
                         <img

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -35,11 +35,7 @@ import { generateChoreRewards } from "features/game/events/landExpansion/complet
 import { CHORE_DIALOGUES } from "features/game/types/stories";
 import { isMobile } from "mobile-device-detect";
 import { Context } from "features/game/GameProvider";
-
-const formatNumber = (num: number, decimals = 2) => {
-  // Check if the number has a fractional part
-  return num % 1 === 0 ? num : num.toFixed(decimals);
-};
+import { formatNumber } from "lib/utils/formatNumber";
 
 interface Props {
   state: GameState;

--- a/src/features/marketplace/Marketplace.tsx
+++ b/src/features/marketplace/Marketplace.tsx
@@ -10,6 +10,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { MarketplaceIntroduction } from "./components/MarketplaceIntroduction";
+import { formatNumber } from "lib/utils/formatNumber";
 
 const _balance = (state: MachineState) => state.context.state.balance;
 
@@ -59,7 +60,9 @@ export const Marketplace: React.FC = () => {
 
             <div className="flex items-center z-10">
               <img src={sflIcon} className="w-8 mr-1" />
-              <p className="text-sm text-white">{balance.toFixed(2)}</p>
+              <p className="text-sm text-white">
+                {formatNumber(balance, { decimalPlaces: 4 })}
+              </p>
             </div>
             <img
               src={SUNNYSIDE.icons.close}

--- a/src/features/marketplace/components/ListViewCard.tsx
+++ b/src/features/marketplace/components/ListViewCard.tsx
@@ -181,7 +181,7 @@ export const ListViewCard: React.FC<Props> = ({
           {lastSalePrice?.gt(0) && (
             <p className="text-xxs truncate pb-0.5">
               {`Last sale: ${formatNumber(lastSalePrice, {
-                decimalPlaces: 2,
+                decimalPlaces: 4,
               })} SFL`}
             </p>
           )}

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -256,7 +256,7 @@ export const MakeOffer: React.FC<{
           <NumberInput
             value={offer}
             onValueChange={(decimal) => setOffer(decimal.toNumber())}
-            maxDecimalPlaces={tradeType === "onchain" ? 0 : 2}
+            maxDecimalPlaces={tradeType === "onchain" ? 0 : 4}
             isOutOfRange={balance.lt(offer)}
             icon={sflIcon}
           />

--- a/src/features/marketplace/components/TableRow.tsx
+++ b/src/features/marketplace/components/TableRow.tsx
@@ -63,7 +63,7 @@ export const TableRow: React.FC<RowProps> = ({
     >
       <div className="p-1.5 truncate flex sm:w-1/3 items-center">
         <div className="flex items-center">
-          <div className="relative w-8 h-8 flex items-center">
+          <div className="relative w-6 sm:w-8 h-8 flex items-center">
             <NPCIcon
               width={24}
               parts={interpretTokenUri(createdBy.bumpkinUri).equipped}
@@ -72,11 +72,16 @@ export const TableRow: React.FC<RowProps> = ({
           <p className="hidden sm:block truncate py-1">{createdBy.username}</p>
         </div>
       </div>
-      <div className="p-1.5 truncate flex flex-1 items-center">
+      <div
+        className={classNames("p-1.5 truncate flex items-center", {
+          "flex-1": !isResource,
+          "w-1/4 sm:flex-1": isResource,
+        })}
+      >
         <div className="flex items-center justify-start space-x-1">
           <img
             src={details.image}
-            className="h-6 w-6 sm:h-8 sm:w-8 object-contain mr-3 sm:mr-4"
+            className="h-6 w-6 sm:h-8 sm:w-8 object-contain mr-1 sm:mr-4"
           />
           <p className="py-0.5 text-xxs sm:text-sm">
             {`${isResource ? quantity : details.name}`}
@@ -93,7 +98,7 @@ export const TableRow: React.FC<RowProps> = ({
           <div className="flex items-center justify-start space-x-1">
             <img src={token} className="h-6" />
             <div>
-              <span className="text-xxs sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
+              <span className="text-xxs sm:text-sm">{`${formatNumber(price, { decimalPlaces: 4 })} SFL`}</span>
               {!isResource && (
                 <p className="text-xxs">
                   {`$${new Decimal(item.usd ?? 0).mul(price).toFixed(2)} USD`}

--- a/src/features/marketplace/components/TopTrades.tsx
+++ b/src/features/marketplace/components/TopTrades.tsx
@@ -12,6 +12,7 @@ import { useLocation, useNavigate } from "react-router";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
+import { formatNumber } from "lib/utils/formatNumber";
 
 const _state = (state: MachineState) => state.context.state;
 export const TopTrades: React.FC<{
@@ -81,7 +82,9 @@ export const TopTrades: React.FC<{
               <div className="p-1.5 text-right relative flex items-center justify-end w-32">
                 <img src={sflIcon} className="h-6 mr-1" />
                 <div>
-                  <p className="text-sm">{new Decimal(price).toFixed(2)}</p>
+                  <p className="text-sm">
+                    {formatNumber(price, { decimalPlaces: 4 })}
+                  </p>
                   <p className="text-xxs">
                     {`$${new Decimal(usd).mul(price).toFixed(2)}`}
                   </p>

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -209,10 +209,9 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                   >
                     <p className={classNames("text-base")}>
                       {!tradeable
-                        ? "0.00 SFL"
+                        ? "0 SFL"
                         : `${formatNumber(cheapestListing?.sfl ?? 0, {
-                            decimalPlaces: 2,
-                            showTrailingZeros: true,
+                            decimalPlaces: 4,
                           })} SFL`}
                     </p>
                     <p className="text-xs">
@@ -236,7 +235,6 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                             price: tradeable.floor
                               ? formatNumber(tradeable.floor, {
                                   decimalPlaces: 4,
-                                  showTrailingZeros: true,
                                 })
                               : "?",
                           })}
@@ -245,7 +243,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                         <>
                           <span className="text-base loading-fade-pulse">
                             {t("marketplace.pricePerUnit", {
-                              price: "0.0000",
+                              price: "0",
                             })}
                           </span>
                         </>

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -410,7 +410,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
               <NumberInput
                 value={price}
                 onValueChange={(decimal) => setPrice(decimal.toNumber())}
-                maxDecimalPlaces={tradeType === "onchain" ? 0 : 2}
+                maxDecimalPlaces={tradeType === "onchain" ? 0 : 4}
                 icon={sflIcon}
               />
               <p className="text-xxs ml-2">
@@ -425,7 +425,10 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
               }}
             >
               <span className="text-xs"> {t("bumpkinTrade.listingPrice")}</span>
-              <p className="text-xs font-secondary">{`${price} SFL`}</p>
+              <p className="text-xs font-secondary">{`${formatNumber(price, {
+                decimalPlaces: 4,
+                showTrailingZeros: true,
+              })} SFL`}</p>
             </div>
             <div
               className="flex justify-between"
@@ -438,8 +441,8 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
               <p className="text-xs font-secondary">{`${formatNumber(
                 price * 0.1,
                 {
-                  decimalPlaces: 1,
-                  showTrailingZeros: false,
+                  decimalPlaces: 4,
+                  showTrailingZeros: true,
                 },
               )} SFL`}</p>
             </div>
@@ -456,8 +459,8 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
               <p className="text-xs font-secondary">{`${formatNumber(
                 new Decimal(price).mul(1 - MARKETPLACE_TAX),
                 {
-                  decimalPlaces: 1,
-                  showTrailingZeros: false,
+                  decimalPlaces: 4,
+                  showTrailingZeros: true,
                 },
               )} SFL`}</p>
             </div>
@@ -473,7 +476,6 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
                   new Decimal(estTradePoints),
                   {
                     decimalPlaces: 2,
-                    showTrailingZeros: false,
                   },
                 )}`}</p>
                 <img src={ITEM_DETAILS["Trade Point"].image} />

--- a/src/features/marketplace/components/TradeableSummary.tsx
+++ b/src/features/marketplace/components/TradeableSummary.tsx
@@ -53,7 +53,6 @@ export const TradeableItemDetails: React.FC<{
             <span className="text-sm">
               {`${formatNumber(estTradePoints, {
                 decimalPlaces: 2,
-                showTrailingZeros: false,
               })} Trade Points`}
             </span>
             <img src={ITEM_DETAILS["Trade Point"].image} className="h-4 ml-1" />
@@ -86,7 +85,7 @@ export const TradeableSummary: React.FC<{
       >
         <span className="text-xs"> {t("marketplace.salePrice")}</span>
         <p className="text-xs font-secondary">{`${formatNumber(sfl, {
-          decimalPlaces: 2,
+          decimalPlaces: 4,
           showTrailingZeros: true,
         })} SFL`}</p>
       </div>
@@ -102,7 +101,7 @@ export const TradeableSummary: React.FC<{
         <p className="text-xs font-secondary">{`${formatNumber(
           new Decimal(sfl).mul(MARKETPLACE_TAX),
           {
-            decimalPlaces: 2,
+            decimalPlaces: 4,
             showTrailingZeros: true,
           },
         )} SFL`}</p>
@@ -119,7 +118,7 @@ export const TradeableSummary: React.FC<{
         <p className="text-xs font-secondary">{`${formatNumber(
           new Decimal(sfl).mul(1 - MARKETPLACE_TAX),
           {
-            decimalPlaces: 2,
+            decimalPlaces: 4,
             showTrailingZeros: true,
           },
         )} SFL`}</p>
@@ -137,7 +136,6 @@ export const TradeableSummary: React.FC<{
               new Decimal(estTradePoints),
               {
                 decimalPlaces: 2,
-                showTrailingZeros: false,
               },
             )}`}</p>
             <img src={ITEM_DETAILS["Trade Point"].image} />

--- a/src/features/marketplace/components/TrendingTrades.tsx
+++ b/src/features/marketplace/components/TrendingTrades.tsx
@@ -10,11 +10,11 @@ import { useLocation, useNavigate } from "react-router";
 import sflIcon from "assets/icons/sfl.webp";
 import increaseIcon from "assets/icons/increase_arrow.png";
 import decreaseIcon from "assets/icons/decrease_arrow.png";
-import Decimal from "decimal.js-light";
 import { Loading } from "features/auth/components";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
+import { formatNumber } from "lib/utils/formatNumber";
 
 const _state = (state: MachineState) => state.context.state;
 export const TrendingTrades: React.FC<{
@@ -92,7 +92,7 @@ export const TrendingTrades: React.FC<{
                   <img src={sflIcon} className="h-5 mr-1" />
                   <div>
                     <p className="text-sm">
-                      {new Decimal(prices.dates[0].low).toFixed(4)}
+                      {formatNumber(prices.dates[0].low, { decimalPlaces: 4 })}
                     </p>
                   </div>
                 </div>
@@ -105,7 +105,7 @@ export const TrendingTrades: React.FC<{
                     }
                     className="h-5 mr-1"
                   />
-                  <p className="text-sm">{`${prices.sevenDayChange.toFixed(2)}%`}</p>
+                  <p className="text-sm">{`${formatNumber(prices.sevenDayChange)}%`}</p>
                 </div>
               </td>
             </tr>

--- a/src/features/marketplace/components/profile/MyTableRow.tsx
+++ b/src/features/marketplace/components/profile/MyTableRow.tsx
@@ -10,6 +10,7 @@ import sflIcon from "assets/icons/sfl.webp";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
+import { formatNumber } from "lib/utils/formatNumber";
 
 type MyTableRowProps = {
   index: number;
@@ -85,16 +86,16 @@ export const MyTableRow: React.FC<MyTableRowProps> = ({
           <div className="flex items-center justify-start space-x-1">
             <img src={sflIcon} className="h-6" />
             <div>
-              <span className="sm:text-sm">{`${price.toFixed(2)} SFL`}</span>
+              <span className="text-xs sm:text-sm">{`${formatNumber(price, { decimalPlaces: 4 })} SFL`}</span>
               {!isResource && (
                 <p className="text-xxs">
                   {`$${new Decimal(usdPrice).mul(price).toFixed(2)} USD`}
                 </p>
               )}
               {isResource && (
-                <div className="text-xxs w-full">
+                <div className="text-[16px] sm:text-xxs w-full">
                   {t("bumpkinTrade.price/unit", {
-                    price: unitPrice.toFixed(4),
+                    price: formatNumber(unitPrice, { decimalPlaces: 4 }),
                   })}
                 </div>
               )}


### PR DESCRIPTION
# Description

Show only necessary amount of decimal places (max 4dp for SFL, fixed 2dp for USD, else max 2dp everything else) for marketplace UI

Before|After
---|---
![image](https://github.com/user-attachments/assets/068f7c1c-ef33-490d-b841-c2078a06425b)|![image](https://github.com/user-attachments/assets/a80d701a-8b84-4e02-9ef1-50b4d76d1bbd)
![image](https://github.com/user-attachments/assets/a927dd00-587e-4e69-aa56-c91a57d6c2e4)|![image](https://github.com/user-attachments/assets/374f37f3-f879-4f52-a463-9ccf55362b19)

# What needs to be tested by the reviewer?

- test marketplace displays
  - resources
  - tradables
  - trending pages
  - attempt to offer/list/accept items

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
