### PR TITLE
[FEAT] Skill points disambiguation

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -17,7 +17,7 @@ import { Skills } from "./revamp/Skills";
 import { CONFIG } from "lib/config";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SkillBadges } from "./SkillBadges";
-import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
+import { getAvailableBumpkinOldSkillPoints } from "features/game/events/landExpansion/pickSkill";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Bumpkin, GameState, Inventory } from "features/game/types/game";
 import { ResizableBar } from "components/ui/ProgressBar";
@@ -172,7 +172,7 @@ export const BumpkinModal: React.FC<Props> = ({
     );
   }
 
-  const hasAvailableSP = getAvailableBumpkinSkillPoints(bumpkin) > 0;
+  const hasAvailableSP = getAvailableBumpkinOldSkillPoints(bumpkin) > 0;
 
   const renderTabs = () => {
     if (readonly) {

--- a/src/features/bumpkins/components/SkillPath.tsx
+++ b/src/features/bumpkins/components/SkillPath.tsx
@@ -8,7 +8,7 @@ import {
 } from "features/game/types/bumpkinSkills";
 
 import { Box } from "components/ui/Box";
-import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
+import { getAvailableBumpkinOldSkillPoints } from "features/game/events/landExpansion/pickSkill";
 import Decimal from "decimal.js-light";
 import classNames from "classnames";
 import { Context } from "features/game/GameProvider";
@@ -45,7 +45,7 @@ export const SkillPath = ({
       {skillPath.map((level, index) => (
         <div className="flex justify-center" key={index}>
           {level.map((skill) => {
-            const availableSkillPoints = getAvailableBumpkinSkillPoints(
+            const availableSkillPoints = getAvailableBumpkinOldSkillPoints(
               state.bumpkin,
             );
             const hasSkill = !!bumpkin.skills[skill];

--- a/src/features/bumpkins/components/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/SkillPathDetails.tsx
@@ -8,7 +8,7 @@ import {
   BUMPKIN_SKILL_TREE,
 } from "features/game/types/bumpkinSkills";
 
-import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
+import { getAvailableBumpkinOldSkillPoints } from "features/game/events/landExpansion/pickSkill";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { getKeys } from "features/game/types/craftables";
@@ -104,7 +104,7 @@ export const SkillPathDetails: React.FC<Props> = ({
 
   const { bumpkin } = state;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+  const availableSkillPoints = getAvailableBumpkinOldSkillPoints(bumpkin);
   const hasSelectedSkill = !!bumpkin?.skills[selectedSkill];
 
   const { points: pointsRequired, skill: skillRequired } =

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -13,7 +13,7 @@ import { SkillCategoryList } from "./SkillCategoryList";
 import { SkillPathDetails } from "./SkillPathDetails";
 import { Label } from "components/ui/Label";
 import {
-  findLevelRequiredForNextSkillPoint,
+  findLevelRequiredForNextOldSkillPoint,
   isMaxLevel,
 } from "features/game/lib/level";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -65,7 +65,7 @@ export const Skills: React.FC<Props> = ({ onBack, readonly }) => {
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
 
   const nextLevelWithSkillPoint =
-    findLevelRequiredForNextSkillPoint(experience);
+    findLevelRequiredForNextOldSkillPoint(experience);
 
   return (
     <div

--- a/src/features/bumpkins/components/Skills.tsx
+++ b/src/features/bumpkins/components/Skills.tsx
@@ -5,7 +5,7 @@ import {
   getSkills,
 } from "features/game/types/bumpkinSkills";
 
-import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
+import { getAvailableBumpkinOldSkillPoints } from "features/game/events/landExpansion/pickSkill";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
 import { SkillCategoryList } from "./SkillCategoryList";
@@ -62,7 +62,7 @@ export const Skills: React.FC<Props> = ({ onBack, readonly }) => {
   const { bumpkin } = state;
   const experience = bumpkin?.experience || 0;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+  const availableSkillPoints = getAvailableBumpkinOldSkillPoints(bumpkin);
 
   const nextLevelWithSkillPoint =
     findLevelRequiredForNextOldSkillPoint(experience);

--- a/src/features/game/events/landExpansion/pickSkill.ts
+++ b/src/features/game/events/landExpansion/pickSkill.ts
@@ -18,7 +18,7 @@ type Options = {
   createdAt?: number;
 };
 
-export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
+export const getAvailableBumpkinOldSkillPoints = (bumpkin?: Bumpkin) => {
   if (!bumpkin) return 0;
 
   const bumpkinLevel = getBumpkinLevel(bumpkin.experience);
@@ -43,7 +43,7 @@ export function pickSkill({ state, action, createdAt = Date.now() }: Options) {
       throw new Error("You do not have a Bumpkin!");
     }
 
-    const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+    const availableSkillPoints = getAvailableBumpkinOldSkillPoints(bumpkin);
 
     const requirements = BUMPKIN_SKILL_TREE[action.skill].requirements;
 

--- a/src/features/game/events/landExpansion/pickSkill.ts
+++ b/src/features/game/events/landExpansion/pickSkill.ts
@@ -1,4 +1,4 @@
-import { getBumpkinLevel, SKILL_POINTS } from "features/game/lib/level";
+import { getBumpkinLevel, OLD_SKILL_POINTS } from "features/game/lib/level";
 import {
   BumpkinSkillName,
   BUMPKIN_SKILL_TREE,
@@ -22,7 +22,7 @@ export const getAvailableBumpkinSkillPoints = (bumpkin?: Bumpkin) => {
   if (!bumpkin) return 0;
 
   const bumpkinLevel = getBumpkinLevel(bumpkin.experience);
-  const totalSkillPoints = SKILL_POINTS[bumpkinLevel];
+  const totalSkillPoints = OLD_SKILL_POINTS[bumpkinLevel];
 
   const allocatedSkillPoints = getKeys({ ...bumpkin.skills } as Partial<
     Record<BumpkinSkillName, number>

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -350,20 +350,6 @@ export const findLevelRequiredForNextSkillPoint = (
   return nextLevelWithSkillPoint;
 };
 
-//Could be used later for skill revamp
-export const findLvlRequiredForNextSkillPoint = (
-  experience: number,
-): BumpkinLevel | undefined => {
-  const bumpkinLevel = getBumpkinLevel(experience);
-  const availableSkillPoints = bumpkinLevel;
-
-  if (availableSkillPoints < 1) {
-    return undefined;
-  }
-
-  return (bumpkinLevel + 1) as BumpkinLevel;
-};
-
 export const getExperienceToNextLevel = (experience: number) => {
   const level = getBumpkinLevel(experience);
 

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -224,7 +224,7 @@ export const getBumpkinLevel = (experience: number): BumpkinLevel => {
   return bumpkinLevel;
 };
 
-export const SKILL_POINTS: Record<BumpkinLevel, number> = {
+export const OLD_SKILL_POINTS: Record<BumpkinLevel, number> = {
   1: 0,
   2: 1,
   3: 2,
@@ -338,10 +338,10 @@ export const findLevelRequiredForNextSkillPoint = (
   }
 
   let nextLevelWithSkillPoint: BumpkinLevel | undefined;
-  for (const key in SKILL_POINTS) {
+  for (const key in OLD_SKILL_POINTS) {
     const level = Number(key) as BumpkinLevel;
     // Save the first level with more skill points than current
-    if (SKILL_POINTS[level] > SKILL_POINTS[currentLevel]) {
+    if (OLD_SKILL_POINTS[level] > OLD_SKILL_POINTS[currentLevel]) {
       nextLevelWithSkillPoint = level;
       break;
     }

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -328,7 +328,7 @@ export const OLD_SKILL_POINTS: Record<BumpkinLevel, number> = {
 };
 
 //currently is matched with the mainnet skill system (old bumpkin skills)
-export const findLevelRequiredForNextSkillPoint = (
+export const findLevelRequiredForNextOldSkillPoint = (
   experience: number,
 ): BumpkinLevel | undefined => {
   const currentLevel = getBumpkinLevel(experience);

--- a/src/features/island/bumpkin/lib/skillPointStorage.ts
+++ b/src/features/island/bumpkin/lib/skillPointStorage.ts
@@ -1,4 +1,4 @@
-import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/pickSkill";
+import { getAvailableBumpkinOldSkillPoints } from "features/game/events/landExpansion/pickSkill";
 import { Bumpkin } from "features/game/types/game";
 
 export function getAcknowledgedSkillPoints() {
@@ -16,7 +16,7 @@ export function getAcknowledgedSkillPointsForBumpkin(id: number) {
 export function hasUnacknowledgedSkillPoints(bumpkin?: Bumpkin) {
   if (!bumpkin) return false;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+  const availableSkillPoints = getAvailableBumpkinOldSkillPoints(bumpkin);
   const acknowledgedSkillPoints = getAcknowledgedSkillPointsForBumpkin(
     bumpkin.id,
   );
@@ -27,7 +27,7 @@ export function hasUnacknowledgedSkillPoints(bumpkin?: Bumpkin) {
 export function acknowledgeSkillPoints(bumpkin?: Bumpkin) {
   if (!bumpkin) return;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
+  const availableSkillPoints = getAvailableBumpkinOldSkillPoints(bumpkin);
   const currentAcknowledgedSkillPoints = getAcknowledgedSkillPoints();
 
   const newValue = {


### PR DESCRIPTION
The `getAvailableBumpkinSkillPoints()` function has two implementations with different behavior.

This change renames one of them to resolve the ambiguity when reading the code.