### PR TITLE
[FEAT] More details for Novice and Advanced Angler milestones

### DIFF
--- a/src/features/island/hud/components/codex/components/Milestone.tsx
+++ b/src/features/island/hud/components/codex/components/Milestone.tsx
@@ -5,6 +5,7 @@ import { Label } from "components/ui/Label";
 import { InnerPanel } from "components/ui/Panel";
 import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { GameState } from "features/game/types/game";
+import { ITEM_DETAILS } from "features/game/types/images";
 
 import chest from "assets/icons/chest.png";
 import { Button } from "components/ui/Button";
@@ -15,6 +16,10 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getImageUrl } from "lib/utils/getImageURLS";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { ResizableBar } from "components/ui/ProgressBar";
+
+import { getFishByType } from "../lib/utils";
+import { FishName, MarineMarvelName } from "features/game/types/fishing";
+import { pixelDarkBorderStyle } from "features/game/lib/style";
 
 import TwilightAnglerfish from "assets/fish/twilight_anglerfish_trophy.png";
 import StarlightTuna from "assets/fish/starlight_tuna_trophy.png";
@@ -27,8 +32,16 @@ export const MilestonePanel: React.FC<{
   farmActivity: GameState["farmActivity"];
   onClaim: () => void;
   onBack: () => void;
+  setSelectedFish: (fish: FishName | MarineMarvelName) => void;
   isClaimed?: boolean;
-}> = ({ milestone, farmActivity, onClaim, onBack, isClaimed }) => {
+}> = ({
+  milestone,
+  farmActivity,
+  onClaim,
+  onBack,
+  setSelectedFish,
+  isClaimed,
+}) => {
   const { t } = useAppTranslation();
 
   const percentageComplete = milestone.percentageComplete(farmActivity);
@@ -46,6 +59,8 @@ export const MilestonePanel: React.FC<{
     PhantomBarracuda,
     GildedSwordfish,
   ];
+
+  const FISH_BY_TYPE = getFishByType();
 
   return (
     <InnerPanel>
@@ -109,6 +124,59 @@ export const MilestonePanel: React.FC<{
                     src={name}
                     className="h-7 sm:h-8 mr-1 sm:mr-1.5 mt-0.5"
                   />
+                ))}
+              </div>
+            )}
+            {reward === "Sunflower Rod" && (
+              <div className="flex items-center flex-wrap mb-1">
+                {FISH_BY_TYPE["basic"].map((name) => (
+                  <div className="relative" key={name}>
+                    <div
+                      className="flex justify-center w-8 sm:w-12 h-8 sm:h-12 m-1 p-0.5 bg-brown-600 cursor-pointer"
+                      style={{ ...pixelDarkBorderStyle }}
+                      onClick={() => setSelectedFish(name)}
+                    >
+                      <img
+                        className={classNames({
+                          silhouette: !farmActivity[`${name} Caught`],
+                        })}
+                        src={ITEM_DETAILS[name].image}
+                      />
+                      {farmActivity[`${name} Caught`] && (
+                        <img
+                          src={SUNNYSIDE.icons.confirm}
+                          className="h-3 sm:h-5 absolute -top-0 -right-0 sm:-top-1 sm:-right-1"
+                        />
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {reward === "Fishing Hat" && (
+              <div className="flex items-center flex-wrap mb-1">
+                {FISH_BY_TYPE["advanced"].map((name) => (
+                  <div className="relative" key={name}>
+                    <div
+                      className="flex justify-center w-8 sm:w-12 h-8 sm:h-12 m-1 p-0.5 bg-brown-600 cursor-pointer"
+                      style={{ ...pixelDarkBorderStyle }}
+                      onClick={() => setSelectedFish(name)}
+                    >
+                      <img
+                        className={classNames({
+                          silhouette: !farmActivity[`${name} Caught`],
+                        })}
+                        src={ITEM_DETAILS[name].image}
+                      />
+                      {farmActivity[`${name} Caught`] && (
+                        <img
+                          src={SUNNYSIDE.icons.confirm}
+                          className="h-3 sm:h-5 absolute -top-0 -right-0 sm:-top-1 sm:-right-1"
+                        />
+                      )}
+                    </div>
+                  </div>
                 ))}
               </div>
             )}

--- a/src/features/island/hud/components/codex/pages/Fish.tsx
+++ b/src/features/island/hud/components/codex/pages/Fish.tsx
@@ -108,7 +108,6 @@ export const Fish: React.FC<Props> = ({ onMilestoneReached, state }) => {
       />
     );
   }
-
   if (selectedMilestone) {
     return (
       <MilestonePanel
@@ -116,6 +115,7 @@ export const Fish: React.FC<Props> = ({ onMilestoneReached, state }) => {
         farmActivity={farmActivity}
         onClaim={() => handleClaimReward(selectedMilestone)}
         onBack={() => setSelectedMilestone(undefined)}
+        setSelectedFish={setSelectedFish}
         isClaimed={!!milestones[selectedMilestone]}
       />
     );


### PR DESCRIPTION
# Description

Show exactly which fish the user has caught and is missing for the Novice and Advanced Angler milestones.

**Before**
<img src="https://github.com/user-attachments/assets/671ef903-a06a-43e1-a95f-af7e6bbd3903" width="400px">

**After**
Novice Angler:
<img src="https://github.com/user-attachments/assets/ce5079bd-5e56-49b1-b08f-9b9de61561fd" width="400px">
After catching a fish:
<img src="https://github.com/user-attachments/assets/b679eea3-cd45-441d-a111-6624961b8d66" width="400px">

Advanced Angler:
<img src="https://github.com/user-attachments/assets/74f8f259-81b1-4e7b-9dc7-ea4dee9e6000" width="400px">

On small screens:
<p>
<img src="https://github.com/user-attachments/assets/491c1053-81ec-4611-be59-67f9e4c8f539" width="300px">
<img src="https://github.com/user-attachments/assets/f30fad49-0225-42a2-b65d-d0a5a0e92d37" width="300px">
<p>


# What needs to be tested by the reviewer?

* Go into fish codex
* If you have caught 0 fish, all the fish should be blacked out for both novice and advanced angler milestones
* Catch a fish, that fish should now be seen inside the milestones, just like it already is in the codex

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
