### PR TITLE
[FEAT] Basic island stays on spring

### DIFF
--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -46,10 +46,10 @@ const UPGRADE_RAFTS: Record<IslandType, string | null> = {
 };
 
 const UPGRADE_PREVIEW: Record<IslandType, string | null> = {
-  basic: SUNNYSIDE.announcement.springPrestige,
-  spring: SUNNYSIDE.announcement.desertPrestige,
-  desert: SUNNYSIDE.announcement.volcanoPrestige,
-  volcano: null, // Next prestige after volcano
+  basic: null,
+  spring: SUNNYSIDE.announcement.springPrestige,
+  desert: SUNNYSIDE.announcement.desertPrestige,
+  volcano: SUNNYSIDE.announcement.volcanoPrestige,
 };
 
 const UPGRADE_MESSAGES: Record<IslandType, string | null> = {

--- a/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
+++ b/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
@@ -112,6 +112,70 @@ export const getCalendarDays = ({
 
 const ONE_MINUTE = 1000 * 60; // 1 minute
 
+interface GameCalendarButtonProps {
+  onClick: () => void;
+  season: TemperateSeasonName;
+  utcDay: string;
+  utcDate: string;
+  showTutorial: boolean;
+}
+const GameCalendarButton: React.FC<GameCalendarButtonProps> = ({
+  onClick,
+  season,
+  utcDay,
+  utcDate,
+  showTutorial,
+}) => {
+  const seasonDetails = SEASON_DETAILS[season];
+
+  return (
+    <div
+      className="absolute z-50 flex flex-col justify-between hover:img-highlight"
+      style={{
+        top: `${100}px`,
+        left: `${PIXEL_SCALE * 3}px`,
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+    >
+      <div className="relative">
+        <img
+          src={seasonDetails.icon}
+          className="absolute z-10 w-5 sm:w-6"
+          style={{
+            transform: "translate(50%, -50%)",
+            right: 1,
+            top: 2,
+          }}
+        />
+        <Button className="h-8 sm:h-10 mb-0">
+          <div className="flex items-center space-x-1">
+            <div className="flex items-center space-x-1 text-xs sm:text-sm">
+              <span>{utcDay}</span>
+              <span>{utcDate}</span>
+            </div>
+            <img src={calendarIcon} className="h-6 sm:h-7 mr-1" />
+          </div>
+        </Button>
+        {showTutorial && (
+          <img
+            className="absolute cursor-pointer group-hover:img-highlight z-30 animate-pulsate"
+            src={SUNNYSIDE.icons.click_icon}
+            onClick={() => onClick()}
+            style={{
+              width: `${PIXEL_SCALE * 18}px`,
+              right: `${PIXEL_SCALE * -8}px`,
+              top: `${PIXEL_SCALE * 6}px`,
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const GameCalendar: React.FC = () => {
   const { gameService } = useContext(Context);
 
@@ -126,8 +190,6 @@ export const GameCalendar: React.FC = () => {
   const { t } = useTranslation();
   useUiRefresher({ delay: ONE_MINUTE });
 
-  const seasonDetails = SEASON_DETAILS[season.season];
-
   const now = new Date();
   const utcDay = now.toLocaleString("en-US", {
     weekday: "short",
@@ -138,13 +200,14 @@ export const GameCalendar: React.FC = () => {
     day: "numeric",
     timeZone: "UTC",
   });
-
   const utcTime = now.toLocaleTimeString("en-US", {
     timeZone: "UTC",
     hour: "2-digit",
     minute: "2-digit",
     hour12: true,
   });
+
+  const seasonDetails = SEASON_DETAILS[season.season];
 
   const formattedTime = () => {
     const lowerCaseTime = utcTime.toLowerCase();
@@ -159,9 +222,18 @@ export const GameCalendar: React.FC = () => {
 
   if (!hasReadTutorial) {
     return (
-      <Modal show={isCalendarOpen} onHide={() => setIsCalendarOpen(false)}>
-        <SeasonsIntroduction onClose={acknowledgeTutorial} />
-      </Modal>
+      <>
+        <Modal show={isCalendarOpen} onHide={() => setIsCalendarOpen(false)}>
+          <SeasonsIntroduction onClose={acknowledgeTutorial} />
+        </Modal>
+        <GameCalendarButton
+          onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+          season={season.season}
+          utcDay={utcDay}
+          utcDate={utcDate}
+          showTutorial={true}
+        />
+      </>
     );
   }
 
@@ -246,38 +318,13 @@ export const GameCalendar: React.FC = () => {
           />
         </ModalOverlay>
       </Modal>
-      <div
-        className="absolute z-50 flex flex-col justify-between hover:img-highlight"
-        style={{
-          top: `${100}px`,
-          left: `${PIXEL_SCALE * 3}px`,
-        }}
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsCalendarOpen(!isCalendarOpen);
-        }}
-      >
-        <div className="relative">
-          <img
-            src={seasonDetails.icon}
-            className="absolute z-10 w-5 sm:w-6"
-            style={{
-              transform: "translate(50%, -50%)",
-              right: 1,
-              top: 2,
-            }}
-          />
-          <Button className="h-8 sm:h-10 mb-0">
-            <div className="flex items-center space-x-1">
-              <div className="flex items-center space-x-1 text-xs sm:text-sm">
-                <span>{utcDay}</span>
-                <span>{utcDate}</span>
-              </div>
-              <img src={calendarIcon} className="h-6 sm:h-7 mr-1" />
-            </div>
-          </Button>
-        </div>
-      </div>
+      <GameCalendarButton
+        onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+        season={season.season}
+        utcDay={utcDay}
+        utcDate={utcDate}
+        showTutorial={false}
+      />
     </>
   );
 };

--- a/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
+++ b/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
@@ -20,6 +20,11 @@ import { GameState, TemperateSeasonName } from "features/game/types/game";
 import { DateCard } from "./DateCard";
 import { ModalOverlay } from "components/ui/ModalOverlay";
 import { SeasonDayDetails } from "./SeasonDayDetails";
+import {
+  getHasReadTemperateSeasonTutorial,
+  setHasReadTemperateSeasonTutorial,
+} from "features/game/lib/temperateSeason";
+import { SeasonsIntroduction } from "./SeasonsIntroduction";
 
 export type LocalCalendarDetails = {
   dateNumber: number;
@@ -114,6 +119,9 @@ export const GameCalendar: React.FC = () => {
   const calendar = useSelector(gameService, _calendar);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState<LocalCalendarDetails>();
+  const [hasReadTutorial, setHasReadTutorial] = useState(
+    getHasReadTemperateSeasonTutorial(),
+  );
 
   const { t } = useTranslation();
   useUiRefresher({ delay: ONE_MINUTE });
@@ -143,6 +151,19 @@ export const GameCalendar: React.FC = () => {
     // remove space
     return lowerCaseTime.replace(/\s/g, "");
   };
+
+  const acknowledgeTutorial = () => {
+    setHasReadTemperateSeasonTutorial();
+    setHasReadTutorial(true);
+  };
+
+  if (!hasReadTutorial) {
+    return (
+      <Modal show={isCalendarOpen} onHide={() => setIsCalendarOpen(false)}>
+        <SeasonsIntroduction onClose={acknowledgeTutorial} />
+      </Modal>
+    );
+  }
 
   return (
     <>

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -919,6 +919,8 @@ export function startGame(authContext: AuthContext) {
                 return (
                   hasFeatureAccess(context.state, "TEMPERATE_SEASON") &&
                   context.state.island.type !== "basic" &&
+                  (context.state.island.upgradedAt ?? 0) <
+                    context.state.season.startedAt &&
                   context.state.season.startedAt !==
                     getLastTemperateSeasonStartedAt()
                 );
@@ -1356,8 +1358,11 @@ export function startGame(authContext: AuthContext) {
                   }
 
                   return (
+                    context.state.island.type !== "basic" &&
+                    (context.state.island.upgradedAt ?? 0) <
+                      event.data.farm.seasonStartedAt &&
                     event.data.farm.season.startedAt !==
-                    getLastTemperateSeasonStartedAt()
+                      getLastTemperateSeasonStartedAt()
                   );
                 },
                 actions: assign((context: Context, event) =>

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -918,6 +918,7 @@ export function startGame(authContext: AuthContext) {
               cond: (context) => {
                 return (
                   hasFeatureAccess(context.state, "TEMPERATE_SEASON") &&
+                  context.state.island.type !== "basic" &&
                   context.state.season.startedAt !==
                     getLastTemperateSeasonStartedAt()
                 );

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -51,6 +51,14 @@ export const CropGuide = () => {
               text: t("cropGuide.payAttentionToSeason"),
               icon: seasonIcon,
             },
+            ...(gameState.context.state.island.type === "basic"
+              ? [
+                  {
+                    text: t("cropGuide.tutorialAlwaysSpring"),
+                    icon: SEASON_ICONS["spring"],
+                  },
+                ]
+              : []),
           ]}
         />
       </div>

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -71,6 +71,7 @@ const HudComponent: React.FC<{
 
   const isFullUser = farmAddress !== undefined;
   const isTutorial = gameState.context.state.island.type === "basic";
+
   const powerSkills = getPowerSkills();
   const { skills } = gameState.context.state.bumpkin;
   const hasPowerSkills = powerSkills.some(

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -70,6 +70,7 @@ const HudComponent: React.FC<{
   };
 
   const isFullUser = farmAddress !== undefined;
+  const isTutorial = gameState.context.state.island.type === "basic";
   const powerSkills = getPowerSkills();
   const { skills } = gameState.context.state.bumpkin;
   const hasPowerSkills = powerSkills.some(
@@ -199,9 +200,8 @@ const HudComponent: React.FC<{
           <Settings isFarming={isFarming} />
         </div>
         <BumpkinProfile isFullUser={isFullUser} />
-        {hasFeatureAccess(gameState.context.state, "TEMPERATE_SEASON") && (
-          <GameCalendar />
-        )}
+        {hasFeatureAccess(gameState.context.state, "TEMPERATE_SEASON") &&
+          !isTutorial && <GameCalendar />}
 
         <DepositModal
           farmAddress={farmAddress ?? ""}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5042,6 +5042,7 @@
   "cropGuide.cropMachine.seeds": "Crop Machine Seeds",
   "cropGuide.cantPlantSeeds": "Seeds can't be planted",
   "cropGuide.onlyInCropMachine": "Seeds can only be planted in Crop Machine",
+  "cropGuide.tutorialAlwaysSpring": "On your first island, it is always Spring! When you upgrade your island, the seasons will begin to change.",
   "spring.seeds": "Spring Seeds",
   "summer.seeds": "Summer Seeds",
   "autumn.seeds": "Autumn Seeds",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2333,7 +2333,7 @@
   "islandupgrade.welcomeVolcanoIsland": "Welcome to Volcano Island!",
   "islandupgrade.itemsReturned": "Your items have been safely returned to your inventory.",
   "islandupgrade.notReadyExpandMore": "You are not ready. Expand {{remainingExpansions}} more times",
-  "islandupgrade.exoticResourcesDescription": "This area of Sunflower Land is known for its exotic resources. Expand your land to discover fruit, flowers, bee hives & rare minerals!",
+  "islandupgrade.exoticResourcesDescription": "This area of Sunflower Land is known for its exotic resources. Expand your land to discover fruit, flowers, bee hives & rare minerals! Keep an eye on the seasons as they affect what you can grow.",
   "islandupgrade.desertResourcesDescription": "The harsh desert environment requires new technology to survive. Expand your land to discover new buildings and what's inside!",
   "islandupgrade.volcanoResourcesDescription": "A dangerous volcanic terrain with precious minerals and rare resources waiting to be discovered. Expand your land to uncover its secrets!",
   "islandupgrade.requiredIsland": "Unlocks at {{islandType}}",


### PR DESCRIPTION
# Description

- Ensures basic island has no events
- Ensures basic island is on spring always
- Adds introduction when upgrading from petal paradise


# What needs to be tested by the reviewer?

- Clear season tutorial in local storage
- Start on basic island
- Check stella guide
- Update to petal paradise
- Click the tutorial

## Screenshots

<img width="544" alt="1" src="https://github.com/user-attachments/assets/a2fdae8b-9c87-4efc-a46e-ce6d2b033144" />
<img width="515" alt="2" src="https://github.com/user-attachments/assets/84620443-f8a8-459f-bfd7-8f4b1e5eb726" />
<img width="160" alt="3" src="https://github.com/user-attachments/assets/c48a6bd9-6d35-4225-aa0f-beb2e729214c" />


# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
