### PR TITLE
[FEAT] Winds of Change Megastore Buffs

### DIFF
--- a/src/features/game/events/landExpansion/claimProduce.test.ts
+++ b/src/features/game/events/landExpansion/claimProduce.test.ts
@@ -1082,6 +1082,51 @@ describe("claimProduce", () => {
     expect(state.barn.animals["0"].awakeAt).toEqual(boostedAwakeAt);
   });
 
+  it("reduces the sleep time of Cow by 25% if Mammoth is placed and ready", () => {
+    const state = claimProduce({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        collectibles: {
+          Mammoth: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin?.equipped,
+          },
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              state: "ready",
+              type: "Cow",
+              experience: 60,
+            },
+          },
+        },
+      },
+      action: {
+        type: "produce.claimed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+
+    const boostedAwakeAt = now + ANIMAL_SLEEP_DURATION * 0.75;
+
+    expect(state.barn.animals["0"].awakeAt).toEqual(boostedAwakeAt);
+  });
+
   it("reduces the sleep time by 10% for a Cow if player has Wrangler skill", () => {
     const state = claimProduce({
       createdAt: now,

--- a/src/features/game/events/landExpansion/completeChore.test.ts
+++ b/src/features/game/events/landExpansion/completeChore.test.ts
@@ -842,4 +842,134 @@ describe("chore.completed", () => {
 
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
   });
+
+  it("provides +1 tickets when Acorn Hat is worn at Winds of Change", () => {
+    const mockDate = new Date(2025, 2, 5).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Acorn Hat",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(5));
+  });
+
+  it("stacks timeshard boosts at Winds of Change", () => {
+    const mockDate = new Date(2025, 2, 5).getTime();
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const chore: ChoreV2 = {
+      activity: "Sunflower Harvested",
+      description: "Harvest 30 Sunflowers",
+      createdAt: mockDate,
+      bumpkinId: INITIAL_BUMPKIN.id,
+      startCount: 0,
+      requirement: 30,
+    };
+
+    const state = completeChore({
+      createdAt: mockDate,
+      action: {
+        type: "chore.completed",
+        id: 4,
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {},
+        collectibles: {
+          Igloo: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        faction: {
+          name: "bumpkins",
+          pledgedAt: 0,
+          points: 0,
+          history: {},
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Acorn Hat",
+          },
+          activity: {
+            "Sunflower Harvested": 50,
+          },
+        },
+        chores: {
+          choresCompleted: 0,
+          choresSkipped: 0,
+          chores: {
+            "1": chore,
+            "2": chore,
+            "3": chore,
+            "4": chore,
+            "5": chore,
+          },
+        },
+      },
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(7));
+  });
 });

--- a/src/features/game/events/landExpansion/completeChore.ts
+++ b/src/features/game/events/landExpansion/completeChore.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { isWearableActive } from "features/game/lib/wearables";
 import { ChoreV2Name, GameState } from "features/game/types/game";
@@ -52,6 +53,27 @@ export function generateChoreTickets({
   if (
     getCurrentSeason() === "Bull Run" &&
     isWearableActive({ game, name: "Cowboy Trouser" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isWearableActive({ game, name: "Acorn Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Igloo" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Hammock" })
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/completeNPCChore.test.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.test.ts
@@ -386,4 +386,89 @@ describe("completeNPCChore", () => {
 
     expect(newState.inventory["Horseshoe"]).toEqual(new Decimal(1));
   });
+
+  it("provides +1 ticket rewards for Acorn Hat at Winds of Change", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          hat: "Acorn Hat",
+        },
+      },
+      inventory: {},
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Timeshard"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Timeshard"]).toEqual(new Decimal(2));
+  });
+  it("stacks timeshard boosts at Winds of Change", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        activity: { "Tree Chopped": 1 },
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          hat: "Acorn Hat",
+        },
+      },
+      inventory: {},
+      collectibles: {
+        Igloo: [
+          {
+            id: "123",
+            coordinates: { x: -1, y: -1 },
+            createdAt: Date.now() - 100,
+            readyAt: Date.now() - 100,
+          },
+        ],
+        Hammock: [
+          {
+            id: "123",
+            coordinates: { x: -1, y: -1 },
+            createdAt: Date.now() - 100,
+            readyAt: Date.now() - 100,
+          },
+        ],
+      },
+      choreBoard: {
+        chores: {
+          "pumpkin' pete": {
+            ...CHORE,
+            reward: { items: { ["Timeshard"]: 1 } },
+          },
+        },
+      },
+    };
+
+    const newState = completeNPCChore({
+      state,
+      action: { type: "chore.fulfilled", npcName: "pumpkin' pete" },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(newState.inventory["Timeshard"]).toEqual(new Decimal(4));
+  });
 });

--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -13,6 +13,7 @@ import {
 } from "features/game/types/seasons";
 import { isWearableActive } from "features/game/lib/wearables";
 import { hasVipAccess } from "features/game/lib/vipAccess";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
 export type CompleteNPCChoreAction = {
   type: "chore.fulfilled";
@@ -122,6 +123,27 @@ export function generateChoreRewards({
   if (
     getCurrentSeason() === "Bull Run" &&
     isWearableActive({ game, name: "Cowboy Trouser" })
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isWearableActive({ game, name: "Acorn Hat" })
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Igloo" })
+  ) {
+    items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Hammock" })
   ) {
     items[getSeasonalTicket(now)] = (items[getSeasonalTicket(now)] ?? 0) + 1;
   }

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1161,6 +1161,270 @@ describe("deliver", () => {
     expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
   });
 
+  it("provides +1 tickets when Acorn Hat is worn at Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2025-02-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            hat: "Acorn Hat",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("provides +1 tickets when Igloo is placed at Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        collectibles: {
+          Igloo: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2025-02-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("provides +1 tickets when Hammock is placed at Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        collectibles: {
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2025-02-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("stacks Timeshard boost collectibles and wearables", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        collectibles: {
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+          Igloo: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2025-02-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            hat: "Acorn Hat",
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
+  });
+  it("does not provides +1 tickets when Hammock is placed outside the WoC Chapter", () => {
+    const mockDate = new Date(2025, 0, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Sunflower: new Decimal(60),
+        },
+        collectibles: {
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 3,
+          orders: [
+            {
+              id: "123",
+              createdAt: mockDate.getTime(),
+              readyAt: new Date("2025-01-04T15:00:00Z").getTime(),
+              from: "pumpkin' pete",
+              items: {
+                Sunflower: 50,
+              },
+              reward: {},
+            },
+          ],
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+          },
+        },
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(1));
+  });
+
   it("add 30% coins bonus if has Betty's Friend skill on Betty's orders with Coins reward", () => {
     const state = deliverOrder({
       state: {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -28,6 +28,7 @@ import { FISH } from "features/game/types/fishing";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { hasFeatureAccess } from "lib/flags";
 import { getActiveCalendarEvent } from "features/game/types/calendar";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   "pumpkin' pete": 1,
@@ -81,6 +82,27 @@ export function generateDeliveryTickets({
   if (
     getCurrentSeason() === "Bull Run" &&
     isWearableActive({ game, name: "Cowboy Trouser" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isWearableActive({ game, name: "Acorn Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Igloo" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Hammock" })
   ) {
     amount += 1;
   }

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -2228,6 +2228,43 @@ describe("getCropTime", () => {
     );
   });
 
+  it("gives +2 Wheat when Sickle is worn and ready", () => {
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            tool: "Sickle",
+          },
+        },
+        inventory: {
+          "Wheat Seed": new Decimal(1),
+        },
+        collectibles: {},
+      },
+      createdAt: dateNow,
+      action: {
+        type: "seed.planted",
+        cropId: "123",
+        index: "0",
+        item: "Wheat Seed",
+      },
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+    expect((plots as Record<number, CropPlot>)[0].crop).toEqual(
+      expect.objectContaining({
+        name: "Wheat",
+        plantedAt: expect.any(Number),
+        amount: 3,
+      }),
+    );
+  });
+
   it("applies a +5% speed boost with Green Thumb skill", () => {
     const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -522,6 +522,10 @@ export function getCropYieldAmount({
     amount += 0.1;
   }
 
+  if (crop === "Wheat" && isWearableActive({ name: "Sickle", game })) {
+    amount += 2;
+  }
+
   if (
     crop === "Barley" &&
     isCollectibleBuilt({ name: "Sheaf of Plenty", game })

--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -350,6 +350,9 @@ describe("animal.sold", () => {
   });
 
   it("rewards +1 Horseshoe when Cowboy Hat is worn during Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
     const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
     const state = sellAnimal({
       state: {
@@ -386,6 +389,9 @@ describe("animal.sold", () => {
   });
 
   it("stacks Cowboy Set boosts at Bull Run Season", () => {
+    const mockDate = new Date(2024, 11, 11);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
     const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
     const state = sellAnimal({
       state: {
@@ -421,5 +427,100 @@ describe("animal.sold", () => {
     });
 
     expect(state.inventory["Horseshoe"]).toEqual(new Decimal(10));
+  });
+  it("rewards +1 Timeshard when Acorn Hat is worn during Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
+    const state = sellAnimal({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin.equipped,
+            hat: "Acorn Hat",
+          },
+        },
+        bounties: {
+          completed: [],
+          requests: [
+            {
+              id: "123",
+              items: { Timeshard: 7 },
+              level: 0,
+              name: "Chicken",
+            },
+          ],
+        },
+      },
+      action: {
+        requestId: "123",
+        animalId,
+
+        type: "animal.sold",
+      },
+      createdAt: new Date("2025-02-05").getTime(),
+    });
+
+    expect(state.inventory["Timeshard"]).toEqual(new Decimal(8));
+  });
+
+  it("stacks timeshard boosts during Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
+    const state = sellAnimal({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin.equipped,
+            hat: "Acorn Hat",
+          },
+        },
+        collectibles: {
+          Igloo: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        bounties: {
+          completed: [],
+          requests: [
+            {
+              id: "123",
+              items: { Timeshard: 7 },
+              level: 0,
+              name: "Chicken",
+            },
+          ],
+        },
+      },
+      action: {
+        requestId: "123",
+        animalId,
+
+        type: "animal.sold",
+      },
+      createdAt: new Date("2025-02-05").getTime(),
+    });
+
+    expect(state.inventory["Timeshard"]).toEqual(new Decimal(10));
   });
 });

--- a/src/features/game/events/landExpansion/sellBounty.test.ts
+++ b/src/features/game/events/landExpansion/sellBounty.test.ts
@@ -41,6 +41,13 @@ describe("sellBounty", () => {
           name: "Obsidian",
           sfl: 100,
         },
+        {
+          id: "5",
+          name: "Blue Balloon Flower",
+          items: {
+            Timeshard: 1,
+          },
+        },
       ],
       completed: [],
     },
@@ -262,6 +269,80 @@ describe("sellBounty", () => {
             hat: "Cowboy Hat",
             shirt: "Cowboy Shirt",
             pants: "Cowboy Trouser",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(4));
+  });
+
+  it("rewards +1 TimeShard when Acorn Hat is worn during Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "5",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Acorn Hat",
+          },
+        },
+      },
+      action,
+      createdAt: mockDate.getTime(),
+    });
+
+    expect(result.inventory[getSeasonalTicket()]).toEqual(new Decimal(2));
+  });
+
+  it("stacks timeshard boosts during Winds of Change Chapter", () => {
+    const mockDate = new Date(2025, 2, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+
+    const action: SellBountyAction = {
+      type: "bounty.sold",
+      requestId: "5",
+    };
+
+    const result = sellBounty({
+      state: {
+        ...GAME_STATE,
+        collectibles: {
+          Igloo: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+          Hammock: [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: Date.now() - 100,
+              readyAt: Date.now() - 100,
+            },
+          ],
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            hat: "Acorn Hat",
           },
         },
       },

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { isWearableActive } from "features/game/lib/wearables";
 import { ANIMALS } from "features/game/types/animals";
 import { getKeys } from "features/game/types/decorations";
@@ -55,6 +56,27 @@ export function generateBountyTicket({
   if (
     getCurrentSeason() === "Bull Run" &&
     isWearableActive({ game, name: "Cowboy Trouser" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isWearableActive({ game, name: "Acorn Hat" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Igloo" })
+  ) {
+    amount += 1;
+  }
+
+  if (
+    getCurrentSeason() === "Winds of Change" &&
+    isCollectibleBuilt({ game, name: "Hammock" })
   ) {
     amount += 1;
   }

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -434,6 +434,7 @@ export function getBoostedAwakeAt({
 
   const isChicken = animalType === "Chicken";
   const isSheep = animalType === "Sheep";
+  const isCow = animalType === "Cow";
 
   // Apply fixed time reductions first
   if (isChicken) {
@@ -452,6 +453,12 @@ export function getBoostedAwakeAt({
     }
 
     if (isCollectibleBuilt({ name: "Farm Dog", game })) {
+      totalDuration *= 0.75;
+    }
+  }
+
+  if (isCow) {
+    if (isCollectibleBuilt({ name: "Mammoth", game })) {
       totalDuration *= 0.75;
     }
   }

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -648,6 +648,9 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Farm Dog": (game) => areAnySheepSleeping(game),
   Mootant: (game) => areAnyCowsSleeping(game),
   "Alien Chicken": (game) => areAnyChickensSleeping(game),
+
+  // Winds of Change
+  Mammoth: (game) => areAnyCowsSleeping(game),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -83,6 +83,7 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
   "Chicken Suit": (state) => !areAnyChickensSleeping(state)[0],
   "Merino Jumper": (state) => !areAnySheepSleeping(state)[0],
   "Cowbell Necklace": (state) => !areAnyCowsSleeping(state)[0],
+  Sickle: (state) => !cropIsGrowing({ item: "Wheat", game: state })[0],
 };
 
 export const canWithdrawBoostedWearable = (


### PR DESCRIPTION
# Description

This PR Adds the following boost for Megastore Items:
Acorn Hat, Igloo, Hammock - +1 Timeshard on Deliveries,Chores,Bounties(Flower,Animal)
Mammoth - -25% Cow Sleep Time
Sickle(wearable) - +2 Wheat

**Crab Hat Boost will be followed once Fishing Bounty mechanics is live.**
Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
