### PR TITLE
[FIX] Gems Speed up enabled in volcano island

### DIFF
--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -26,6 +26,7 @@ import { gameAnalytics } from "lib/gameAnalytics";
 import { Context } from "features/game/GameProvider";
 import { craftingRequirementsMet } from "features/game/lib/craftingRequirement";
 import { getInstantGems } from "features/game/events/landExpansion/speedUpRecipe";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 /**
  * The props for the component.
  * @param gameState The game state.
@@ -188,7 +189,7 @@ export const Expanding: React.FC<{
     game: state,
   });
 
-  const hasAccess = state.island.type !== "desert";
+  const hasAccess = !hasRequiredIslandExpansion(state.island.type, "desert");
 
   useEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
# Description

Fixes a bug where speed up is enabled in volcano island. 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
