### PR TITLE
[FEAT] Auction Total Supply UI

### DIFF
--- a/src/features/game/lib/auctionMachine.ts
+++ b/src/features/game/lib/auctionMachine.ts
@@ -56,6 +56,7 @@ export interface Context {
   username?: string;
   bid?: GameState["auctioneer"]["bid"];
   auctions: Auction[];
+  totalSupply: Record<string, number>;
   auctionId: string;
   transactionId: string;
   results?: AuctionResults;
@@ -139,6 +140,7 @@ export const createAuctioneerMachine = ({
         deviceTrackerId: "",
         canAccess: false,
         linkedAddress: "",
+        totalSupply: {},
 
         // Offline testing
         results: {
@@ -228,13 +230,14 @@ export const createAuctioneerMachine = ({
           entry: "setTransactionId",
           invoke: {
             src: async (context, event) => {
-              const { auctions } = await loadAuctions({
+              const { auctions, totalSupply } = await loadAuctions({
                 token: context.token,
                 transactionId: context.transactionId as string,
               });
 
               return {
                 auctions,
+                totalSupply,
                 auctionId:
                   auctions.length > 0 ? auctions[0].auctionId : undefined,
               };
@@ -243,6 +246,7 @@ export const createAuctioneerMachine = ({
               target: "initialising",
               actions: [
                 assign({
+                  totalSupply: (_, event) => event.data.totalSupply,
                   auctions: (_, event) => event.data.auctions,
                   auctionId: (_, event) => event.data.auctionId,
                 }),

--- a/src/features/retreat/components/auctioneer/actions/loadAuctions.ts
+++ b/src/features/retreat/components/auctioneer/actions/loadAuctions.ts
@@ -11,6 +11,7 @@ const API_URL = CONFIG.API_URL;
 
 export async function loadAuctions(request: Request): Promise<{
   auctions: Auction[];
+  totalSupply: Record<string, number>;
 }> {
   const response = await window.fetch(`${API_URL}/auctions`, {
     method: "GET",
@@ -31,5 +32,5 @@ export async function loadAuctions(request: Request): Promise<{
 
   const { auctions } = await response.json();
 
-  return { auctions };
+  return { auctions: auctions.auctions, totalSupply: auctions.totalSupply };
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3299,6 +3299,7 @@
   "season.codex.howToEarn.three": "Trade animal and flower bounties! (Nov 11th)",
   "season.codex.nextDrop": "Next Drop",
   "season.codex.nextDrop.available": "{{dropSupply}} available",
+  "season.codex.auction.totalSupply": "Total Supply: {{totalSupply}}",
   "season.codex.seasonalDrops": "Seasonal Drops",
   "season.codex.seasonalDrops.description": "Compete with others for the rarest items! Visit the Auctioneer in the plaza for more details.",
   "season.codex.soldOut": "Sold out",


### PR DESCRIPTION
# Description

In the Codex Auction section, a new Label has been added which shows the supply e.g. - "Total Supply: 250"
![image](https://github.com/user-attachments/assets/0c052a59-207b-49b9-b60a-f37e912f5a8a)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
