### PR TITLE
[FEAT] Increase initial water-free plots to 18

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -2356,7 +2356,7 @@ describe("getCropTime", () => {
 });
 
 describe("isPlotFertile", () => {
-  it("cannot plant on 18th field if a well is not available", () => {
+  it("cannot plant on 19th field if a well is not available", () => {
     let counter = 1;
     const fakePlot = () => ({
       createdAt: Date.now() + counter++,
@@ -2387,7 +2387,7 @@ describe("isPlotFertile", () => {
         99: fakePlot(), // 18th
         100: fakePlot(), // 19th
       },
-      plotIndex: "99",
+      plotIndex: "100",
       buildings: {},
       bumpkin: { ...INITIAL_BUMPKIN },
     });
@@ -2395,7 +2395,7 @@ describe("isPlotFertile", () => {
     expect(isFertile).toBeFalsy();
   });
 
-  it("cannot plant on 25th field if 2 wells are not avilable", () => {
+  it("cannot plant on 26th field if 2 wells are not avilable", () => {
     let counter = 1;
     const fakePlot = () => ({
       createdAt: Date.now() + counter++,
@@ -2440,11 +2440,12 @@ describe("isPlotFertile", () => {
         20: fakePlot(),
         21: fakePlot(),
         22: fakePlot(),
-        23: fakePlot(), // 24th
+        23: fakePlot(),
         24: fakePlot(), // 25th
         25: fakePlot(), // 26th
+        26: fakePlot(), // 27th
       },
-      plotIndex: "25",
+      plotIndex: "26",
     });
 
     expect(isFertile).toBeFalsy();

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -67,8 +67,8 @@ type IsPlotFertile = {
   bumpkin?: Bumpkin;
 };
 
-// First 15 plots do not need water
-const INITIAL_SUPPORTED_PLOTS = 17;
+// First 18 plots do not need water
+const INITIAL_SUPPORTED_PLOTS = 18;
 // Each well can support an additional 8 plots
 const WELL_PLOT_SUPPORT = 8;
 

--- a/src/features/game/events/landExpansion/removeBuilding.ts
+++ b/src/features/game/events/landExpansion/removeBuilding.ts
@@ -29,8 +29,8 @@ type Options = {
   createdAt?: number;
 };
 
-// First 15 plots do not need water
-const INITIAL_SUPPORTED_PLOTS = 15;
+// First 18 plots do not need water
+const INITIAL_SUPPORTED_PLOTS = 18;
 // Each well can support an additional 8 plots
 const WELL_PLOT_SUPPORT = 8;
 


### PR DESCRIPTION
# Description

Since on upgrade, the initial islands all start with 18 plots, it's a little triggering when the 1 plot is not fertile, while the other 17 are fertile. Increasing initial fertile plots to 18 allows players to access all 18 plots upon upgrade without needing a water well. 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
