### PR TITLE
[FIX] Add lava pits when expanding

### DIFF
--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -247,6 +247,21 @@ export function revealLand({
       land.oilReserves?.length ?? 0,
     );
 
+    // Add lava pits
+    land.lavaPits?.forEach((coords) => {
+      const id = randomUUID();
+      game.lavaPits[id] = {
+        height: 2,
+        width: 2,
+        x: coords.x + origin.x,
+        y: coords.y + origin.y,
+        createdAt,
+      };
+    });
+    inventory["Lava Pit"] = (inventory["Lava Pit"] || new Decimal(0)).add(
+      land.lavaPits?.length ?? 0,
+    );
+
     // Refresh all basic resources
     game.trees = getKeys(game.trees).reduce(
       (acc, id) => {

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -205,6 +205,12 @@ export function getLand({
     (game.inventory["Oil Reserve"]?.toNumber() ?? 0);
   land.oilReserves = land.oilReserves?.slice(0, availableOilReserves);
 
+  // Add Lava
+  const availableLavaPit =
+    expectedResources["Lava Pit"] -
+    (game.inventory["Lava Pit"]?.toNumber() ?? 0);
+  land.lavaPits = land.lavaPits?.slice(0, availableLavaPit);
+
   return land;
 }
 
@@ -2463,6 +2469,7 @@ export type Layout = {
   flowerBeds?: Coordinates[];
   fruitPatches?: Coordinates[];
   oilReserves?: Coordinates[];
+  lavaPits?: Coordinates[];
 };
 
 /**


### PR DESCRIPTION
# Description

Lava pits were popping up in chests, instead of on the land