### PR TITLE
[FEAT] Don't show category if there aren't any skill trees in the category

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -110,12 +110,15 @@ export const SkillCategoryList = ({
           return (
             <div key={islandType} className="flex flex-col items-stretch">
               <div className="flex items-center gap-2 mt-1 mb-2">
-                <Label
-                  type={hasUnlockedIslandCategory ? "default" : "warning"}
-                  className="capitalize"
-                >
-                  {`${islandType} Skills`}
-                </Label>
+                {getRevampSkillTreeCategoriesByIsland(islandType).length >
+                  0 && (
+                  <Label
+                    type={hasUnlockedIslandCategory ? "default" : "warning"}
+                    className="capitalize"
+                  >
+                    {`${islandType} Skills`}
+                  </Label>
+                )}
                 {!hasUnlockedIslandCategory && (
                   <Label type="warning">
                     {`Reach ${islandType} island to unlock`}


### PR DESCRIPTION
# Description

UI is showing that there are volcano skills, but there aren't any

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
