### PR TITLE
[FIX] Preserve home buds during farm upgrade

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -756,4 +756,45 @@ describe("upgradeFarm", () => {
       },
     });
   });
+
+  it("removes buds from farm on upgrade", () => {
+    const state = upgrade({
+      action: {
+        type: "farm.upgraded",
+      },
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Basic Land": new Decimal(25),
+          Oil: new Decimal(200),
+        },
+        island: {
+          type: "desert",
+        },
+        buds: {
+          "1": {
+            type: "Beach",
+            colour: "Beige",
+            stem: "3 Leaf Clover",
+            aura: "Basic",
+            ears: "Ears",
+            location: "farm",
+            coordinates: { x: 0, y: 0 },
+          },
+        },
+      },
+    });
+
+    expect(state.buds).toEqual({
+      "1": {
+        type: "Beach",
+        colour: "Beige",
+        stem: "3 Leaf Clover",
+        aura: "Basic",
+        ears: "Ears",
+        coordinates: undefined,
+        location: undefined,
+      },
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -715,4 +715,45 @@ describe("upgradeFarm", () => {
       }),
     ).toThrow("Not implemented");
   });
+
+  it("does not remove buds from home on upgrade", () => {
+    const state = upgrade({
+      action: {
+        type: "farm.upgraded",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Basic Land": new Decimal(25),
+          Oil: new Decimal(200),
+        },
+        island: {
+          type: "desert",
+        },
+        buds: {
+          "1": {
+            type: "Beach",
+            colour: "Beige",
+            stem: "3 Leaf Clover",
+            aura: "Basic",
+            ears: "Ears",
+            location: "home",
+            coordinates: { x: 0, y: 0 },
+          },
+        },
+      },
+    });
+
+    expect(state.buds).toEqual({
+      "1": {
+        type: "Beach",
+        colour: "Beige",
+        stem: "3 Leaf Clover",
+        aura: "Basic",
+        ears: "Ears",
+        location: "home",
+        coordinates: { x: 0, y: 0 },
+      },
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -1228,16 +1228,15 @@ export function upgrade({ state, action, createdAt = Date.now() }: Options) {
     mushrooms: {},
     spawnedAt: game.mushrooms?.spawnedAt ?? 0,
   };
-  game.buds = getKeys(game.buds ?? {}).reduce(
-    (acc, key) => ({
-      ...acc,
-      [key]: {
-        ...(game.buds ?? {})[key],
-        location: undefined,
-        coordinates: undefined,
+  game.buds = Object.fromEntries(
+    Object.entries(game.buds ?? {}).map(([budId, bud]) => [
+      budId,
+      {
+        ...bud,
+        location: bud.location === "home" ? "home" : undefined,
+        coordinates: bud.location === "home" ? bud.coordinates : undefined,
       },
-    }),
-    game.buds,
+    ]),
   );
   game.crimstones = {};
   game.beehives = {};


### PR DESCRIPTION
# Description

Buds in home are being removed on upgrade. which is a different behaviour from other collectibles in home. 

This PR adds a condition to preserve buds in home on upgrade

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
