### PR TITLE
[FIX] Oil reserve initial amount

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -102,7 +102,7 @@ describe("upgradeFarm", () => {
         oilReserves: {
           oil: {
             oil: {
-              amount: 1,
+              amount: 10,
               drilledAt: 1,
             },
             createdAt: 1,

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -691,7 +691,7 @@ const INITIAL_VOLCANO_LAND: Pick<
       width: 2,
       height: 2,
       oil: {
-        amount: 1,
+        amount: 10,
         drilledAt: 0,
       },
       drilled: 0,


### PR DESCRIPTION
# Description

- Fix oil reserve initial amount for volcano island.  It should be 10 instead of 1\
- Backend changes might be needed

# What needs to be tested by the reviewer?

- Upgrade to volcano island and drill the initial oil reserve

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
