### PR TITLE
[CHORE] Reduce Protective Pesticide dimensions

### DIFF
--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -151,8 +151,8 @@ export const DECORATION_TEMPLATES = {
   },
   "Protective Pesticide": {
     dimensions: {
-      width: 2,
-      height: 2,
+      width: 1,
+      height: 1,
     },
     isWithdrawable: () => false,
   },


### PR DESCRIPTION
# Description

- Reduce Protective Pesticide dimensions from 2x2 to 1x1
- Backend changes needed

Before|After
---|---
![image](https://github.com/user-attachments/assets/f18f96f7-f9a5-4d7c-93b8-e1ead7139b63)|![image](https://github.com/user-attachments/assets/d4b294fe-2d4b-4147-9df9-fc6b8e960278)

# What needs to be tested by the reviewer?

- Place Protective Pesticide in farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
