### PR TITLE
[FIX] Some skill category icons are squished

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -11,8 +11,6 @@ import { Label } from "components/ui/Label";
 import { getKeys } from "features/game/types/craftables";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { setImageWidth } from "lib/images";
-import { PIXEL_SCALE } from "features/game/lib/constants";
 
 import { SUNNYSIDE } from "assets/sunnyside";
 import sflIcon from "assets/icons/sfl.webp";
@@ -25,6 +23,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ISLAND_EXPANSIONS } from "features/game/types/game";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import classNames from "classnames";
+import { SquareIcon } from "components/ui/SquareIcon";
 
 export const SKILL_TREE_ICONS: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
@@ -143,7 +142,7 @@ export const SkillCategoryList = ({
                             : undefined
                         }
                         className={classNames(
-                          `flex relative items-center !py-2 mb-1 hover:bg-brown-200`,
+                          `flex relative items-center mb-1 hover:bg-brown-200`,
                           { "cursor-pointer": hasUnlockedIslandCategory },
                         )}
                       >
@@ -153,17 +152,8 @@ export const SkillCategoryList = ({
                         >
                           {`${skillsAcquiredInCategoryCount}/${skills.filter((skill) => !skill.disabled).length}`}
                         </Label>
-                        <div className="flex justify-center items-center">
-                          <img
-                            src={icon}
-                            style={{
-                              opacity: 0,
-                              marginRight: `${PIXEL_SCALE * 4}px`,
-                              maxWidth: `${PIXEL_SCALE * 10}px`,
-                              maxHeight: `${PIXEL_SCALE * 10}px`,
-                            }}
-                            onLoad={(e) => setImageWidth(e.currentTarget)}
-                          />
+                        <div className="flex gap-2 justify-center items-center">
+                          <SquareIcon icon={icon} width={14} />
                           <span className="text-sm">{category}</span>
                         </div>
                       </ButtonPanel>


### PR DESCRIPTION
# Description

- Fix squishy skill category icons

Before|After
---|---
![image](https://github.com/user-attachments/assets/d5862298-9c73-4cb3-bcf2-210e9ead21a2)|![image](https://github.com/user-attachments/assets/5cb80e13-2047-45d3-9fc7-b27e428d5c97)

# What needs to be tested by the reviewer?

- Check skill categories

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
