### PR TITLE
[CHORE] Localize reset skill message

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -26,6 +26,9 @@ import { ISLAND_EXPANSIONS } from "features/game/types/game";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import classNames from "classnames";
 
+const RESET_SKILLS_SFL_BASE_COST = 0;
+const RESET_SKILLS_COOLDOWN_DAYS = 90;
+
 export const SKILL_TREE_ICONS: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
   Trees: SUNNYSIDE.skills.trees,
@@ -69,7 +72,7 @@ export const SkillCategoryList = ({
     ? new Date().getTime() - new Date(lastResetDate).getTime() >=
       90 * 24 * 60 * 60 * 1000
     : true;
-  const enoughSfl = state.balance.toNumber() >= 10;
+  const enoughSfl = state.balance.toNumber() >= RESET_SKILLS_SFL_BASE_COST;
 
   const handleSkillsReset = () => {
     setShowSkillsResetModal(false);
@@ -197,9 +200,10 @@ export const SkillCategoryList = ({
               </Label>
             </div>
             <p className="text-xs py-4 px-2 text-center">
-              {
-                "Are you sure you want to reset all your skills? This action cannot be undone and will cost 0 SFL. You will be able to reset your skills again in 3 months."
-              }
+              {t("confirm.skillReset", {
+                sfl: RESET_SKILLS_SFL_BASE_COST,
+                days: RESET_SKILLS_COOLDOWN_DAYS,
+              })}
               {/* Will change to 10 SFL on release */}
             </p>
             {/* {!threeMonthsSinceLastReset && (

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -70,7 +70,7 @@ export const SkillCategoryList = ({
   const lastResetDate = bumpkin?.previousSkillsResetAt || null;
   const threeMonthsSinceLastReset = lastResetDate
     ? new Date().getTime() - new Date(lastResetDate).getTime() >=
-      90 * 24 * 60 * 60 * 1000
+      RESET_SKILLS_COOLDOWN_DAYS * 24 * 60 * 60 * 1000
     : true;
   const enoughSfl = state.balance.toNumber() >= RESET_SKILLS_SFL_BASE_COST;
 
@@ -86,7 +86,8 @@ export const SkillCategoryList = ({
   const getTimeUntilNextReset = () => {
     if (!lastResetDate) return "";
     const nextResetDate =
-      new Date(lastResetDate).getTime() + 90 * ONE_DAY * 1000;
+      new Date(lastResetDate).getTime() +
+      RESET_SKILLS_COOLDOWN_DAYS * ONE_DAY * 1000;
     const timeLeftInSeconds = Math.max(
       (nextResetDate - new Date().getTime()) / 1000,
       0,

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -657,6 +657,7 @@
   "confirmation.sellSeasonalArtefact": "This bounty is a seasonal artefact! Are you sure you want to sell it?",
   "confirmation.valuableTreasure": "This bounty is very valuable! Are you sure you want to sell it?",
   "confirm.skillClaim": "Are you sure you want to claim the skill?",
+  "confirm.skillReset": "Are you sure you want to reset all your skills? This action cannot be undone and will cost {{sfl}} SFL. You will be able to reset your skills again in {{days}} days.",
   "faction-intro.one": "Welcome to your new faction house... We need your help to become more powerful and dominate the kingdom.",
   "faction-intro.two": "You will be rewarded with marks by completing chores, delivering items to the kitchen and feeding our majestic pet.",
   "faction-intro.three": "At the end of each week, bonus prizes will be given to our best members. Good luck!",


### PR DESCRIPTION
# Description

- Localize reset skill message
- Change 3 months to 90 days.  Months is vague because some months are longer and some are shorter
- Pull out constants so they serve as the source of truth for the SFL cost and days in other places in the logic
- Fix issue where the not enough SFL label is showing if players has less than 10 SFL

Before|After
---|---
![image](https://github.com/user-attachments/assets/4bdb80b9-ae74-4e0d-8730-5025a7c756b3)|![image](https://github.com/user-attachments/assets/c5793213-7f75-4e48-be97-73d1a379c9b8)

# What needs to be tested by the reviewer?

- Check skill categories

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
