### PR TITLE
[FEAT] Show cooldown label for power skills that are ready

### DIFF
--- a/src/features/island/hud/components/PowerSkills.tsx
+++ b/src/features/island/hud/components/PowerSkills.tsx
@@ -32,6 +32,7 @@ import { SkillSquareIcon } from "features/bumpkins/components/revamp/SkillSquare
 import { getSkillImage } from "features/bumpkins/components/revamp/SkillPathDetails";
 import tradeOffs from "src/assets/icons/tradeOffs.png";
 import { powerSkillDisabledConditions } from "features/game/events/landExpansion/skillUsed";
+import { millisecondsToString } from "lib/utils/time";
 
 interface PowerSkillsProps {
   show: boolean;
@@ -253,7 +254,7 @@ const PowerSkillsContent: React.FC<PowerSkillsContentProps> = ({ onClose }) => {
                 />
               </div>
             )}
-            <div className="flex flex-col lg:items-center">
+            <div className="flex flex-wrap justify-between gap-x-2 sm:flex-col lg:items-center">
               <Label
                 type={
                   !powerSkillReady ? "info" : disabled ? "danger" : "success"
@@ -277,6 +278,21 @@ const PowerSkillsContent: React.FC<PowerSkillsContentProps> = ({ onClose }) => {
                   t("powerSkills.ready")
                 )}
               </Label>
+              {powerSkillReady && (
+                <Label
+                  type="info"
+                  icon={SUNNYSIDE.icons.stopwatch}
+                  className="mb-2"
+                >
+                  {t("skill.cooldown", {
+                    cooldown: millisecondsToString(requirements.cooldown ?? 0, {
+                      length: "short",
+                      isShortFormat: true,
+                      removeTrailingZeros: true,
+                    }),
+                  })}
+                </Label>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
# Description

- Show cooldown label for power skills that are ready, so players know what the cooldown is before using the skill
  - Label will not be shown if the skill is in cooldown

Before|After
---|---
![image](https://github.com/user-attachments/assets/98917b7e-6cae-4e01-80d8-a78b2dd04053)|![image](https://github.com/user-attachments/assets/2c4e7f27-ff84-4bae-9296-8fb64af6d22e)


# What needs to be tested by the reviewer?

- Attempt to use power skills

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
