### PR TITLE
[FIX] Insta-chop and Tap Prospector not working on claim

### DIFF
--- a/src/features/builder/components/ResourcePlacer.tsx
+++ b/src/features/builder/components/ResourcePlacer.tsx
@@ -61,7 +61,7 @@ export const getResources = (
     },
   },
   stones: {
-    component: () => <Stone id="1" index={0} />,
+    component: () => <Stone id="1" />,
     dimensions: {
       height: 1,
       width: 1,
@@ -69,7 +69,7 @@ export const getResources = (
     icon: SUNNYSIDE.resource.small_stone,
   },
   iron: {
-    component: () => <Iron id="1" index={0} />,
+    component: () => <Iron id="1" />,
     dimensions: {
       height: 1,
       width: 1,
@@ -77,7 +77,7 @@ export const getResources = (
     icon: ironStone,
   },
   gold: {
-    component: () => <Gold id="1" index={0} />,
+    component: () => <Gold id="1" />,
     dimensions: {
       height: 1,
       width: 1,

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -55,7 +55,9 @@ const compareResource = (prev: TreeType, next: TreeType) => {
 };
 const compareGame = (prev: GameState, next: GameState) =>
   isCollectibleBuilt({ name: "Foreman Beaver", game: prev }) ===
-  isCollectibleBuilt({ name: "Foreman Beaver", game: next });
+    isCollectibleBuilt({ name: "Foreman Beaver", game: next }) &&
+  (prev.bumpkin?.skills["Insta-Chop"] ?? false) ===
+    (next.bumpkin?.skills["Insta-Chop"] ?? false);
 
 // A player that has been vetted and is engaged in the season.
 const isSeasonedPlayer = (state: MachineState) =>
@@ -144,6 +146,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
       // insta-chop the tree
       claimAnyReward();
       chop();
+      setTouchCount(0);
     }
 
     // need to hit enough times to collect resource


### PR DESCRIPTION
# Description

This PR fixes the issue where insta-chop and Tap prospector doesn't apply immediately after claiming skill and relied on a refresh to work

Fixes #issue

# What needs to be tested by the reviewer?

Run FE
- Test chopping tree without picking up skill => It should require 3 taps to chop
- Pick up Insta-chop skill
- Tree to allow 1 tap to chop

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
