### PR TITLE
[FIX] Disable SFL/Coins exchange button if not enough SFL

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -213,7 +213,7 @@ export const SkillCategoryList = ({
             )} */}
             {!enoughSfl && (
               <Label type="danger" icon={sflIcon} className="mb-2">
-                {"You do not have enough SFL"}
+                {t("not.enough.sfl")}
               </Label>
             )}
             <Button

--- a/src/features/island/hud/components/BuyCurrenciesModal.tsx
+++ b/src/features/island/hud/components/BuyCurrenciesModal.tsx
@@ -45,6 +45,7 @@ type Props = {
 const _token = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
 const _farmId = (state: MachineState) => state.context.farmId;
+const _balance = (state: MachineState) => state.context.state.balance;
 const _autosaving = (state: MachineState) => state.matches("autosaving");
 
 export const BuyCurrenciesModal: React.FC<Props> = ({
@@ -69,9 +70,16 @@ export const BuyCurrenciesModal: React.FC<Props> = ({
 
   const token = useSelector(authService, _token);
   const farmId = useSelector(gameService, _farmId);
+  const balance = useSelector(gameService, _balance);
   const autosaving = useSelector(gameService, _autosaving);
 
-  const showStarter = useEffect(() => {
+  const enoughSfl =
+    !!exchangePackageId &&
+    balance.greaterThanOrEqualTo(
+      SFL_TO_COIN_PACKAGES[Number(exchangePackageId)].sfl,
+    );
+
+  useEffect(() => {
     // Trigger an autosave in case they have changes so user can sync right away
     gameService.send("SAVE");
 
@@ -237,7 +245,10 @@ export const BuyCurrenciesModal: React.FC<Props> = ({
                   <div className="py-1">
                     <img
                       src={SUNNYSIDE.icons.arrow_left}
-                      className="h-6 w-6 ml-2 cursor-pointer"
+                      className="ml-2 cursor-pointer"
+                      style={{
+                        width: `${PIXEL_SCALE * 11}px`,
+                      }}
                       onClick={() => setExchangePackageId(undefined)}
                     />
                   </div>
@@ -254,7 +265,13 @@ export const BuyCurrenciesModal: React.FC<Props> = ({
                       SFL_TO_COIN_PACKAGES[Number(exchangePackageId)].sfl
                     } SFL`}</span>
                   </div>
+                  {!enoughSfl && (
+                    <Label type="danger" icon={sflIcon} className="mb-2">
+                      {t("not.enough.sfl")}
+                    </Label>
+                  )}
                   <Button
+                    disabled={!enoughSfl}
                     onClick={() => handleSFLtoCoinsExchange(exchangePackageId)}
                   >
                     {t("confirm")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5173,5 +5173,6 @@
   "time.left": "left",
   "competition.ended": "Competition has ended",
   "competition.ended.description": "The competition has ended. Thank you for participating!",
-  "competition.ended.description.two": "The winners are being calculated and will be announced on February 7th!"
+  "competition.ended.description.two": "The winners are being calculated and will be announced on February 7th!",
+  "not.enough.sfl": "You do not have enough SFL"
 }


### PR DESCRIPTION
# Description

- Disable confirm button iand add not enough SFL label if players plan to exchange SFL/Coins but do not have enough SFL

Before|After
---|---
![image](https://github.com/user-attachments/assets/ea853c04-e27e-4810-a891-ba64e9c76467)|![image](https://github.com/user-attachments/assets/977c7c44-9a9d-4651-a638-cd1fae63b4c6)

# What needs to be tested by the reviewer?

- Exchange SFL to Coins with enough SFL
- Exchange SFL to Coins without sufficient SFL

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
