### PR TITLE
[FEAT] Megastore Buy Limit

### DIFF
--- a/src/features/game/events/landExpansion/buySeasonalItem.test.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.test.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { buySeasonalItem } from "./buySeasonalItem";
-import { TEST_FARM } from "features/game/lib/constants";
+import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";
 
 describe("buySeasonalItem", () => {
@@ -195,5 +195,251 @@ describe("buySeasonalItem", () => {
     expect(
       state.pumpkinPlaza.keysBought?.megastore["Treasure Key"]?.boughtAt,
     ).toEqual(new Date("2024-09-01").getTime());
+  });
+
+  it("throws an error if Acorn House item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    expect(() =>
+      buySeasonalItem({
+        state: {
+          ...mockState,
+          balance: new Decimal(5),
+          inventory: {
+            "Acorn House": new Decimal(0),
+          },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            activity: {
+              "Acorn House Bought": 1,
+            },
+          },
+        },
+        action: {
+          type: "seasonalItem.bought",
+          name: "Acorn House",
+          tier: "basic",
+        },
+        createdAt: new Date("2025-02-05").getTime(),
+      }),
+    ).toThrow("This item has already been crafted");
+  });
+
+  it("does not throw an error if Treasure Key item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    const state = buySeasonalItem({
+      state: {
+        ...mockState,
+        balance: new Decimal(5),
+        inventory: {
+          "Treasure Key": new Decimal(1),
+          Timeshard: new Decimal(300),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          activity: {
+            "Treasure Key Bought": 1,
+          },
+        },
+      },
+      action: {
+        type: "seasonalItem.bought",
+        name: "Treasure Key",
+        tier: "basic",
+      },
+      createdAt: new Date("2025-02-05").getTime(),
+    });
+    expect(state.inventory["Treasure Key"]).toStrictEqual(new Decimal(2));
+    expect(state.bumpkin.activity["Treasure Key Bought"])?.toEqual(2);
+    expect(state.inventory["Timeshard"]).toStrictEqual(new Decimal(100));
+  });
+
+  it("throws an error if Igloo item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    expect(() =>
+      buySeasonalItem({
+        state: {
+          ...mockState,
+          balance: new Decimal(5),
+          inventory: {
+            Timeshard: new Decimal(600),
+          },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            activity: {
+              "Acorn House Bought": 1,
+              "Kite Bought": 1,
+              "Spring Duckling Bought": 1,
+              "Acorn Hat Bought": 1,
+              "Igloo Bought": 1,
+            },
+          },
+        },
+        action: {
+          type: "seasonalItem.bought",
+          name: "Igloo",
+          tier: "rare",
+        },
+        createdAt: new Date("2025-02-05").getTime(),
+      }),
+    ).toThrow("This item has already been crafted");
+  });
+
+  it("does not throw an error if Rare Key item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+
+    const state = buySeasonalItem({
+      state: {
+        ...mockState,
+        balance: new Decimal(5),
+        inventory: {
+          Timeshard: new Decimal(600),
+          "Rare Key": new Decimal(1),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          activity: {
+            "Acorn House Bought": 1,
+            "Kite Bought": 1,
+            "Spring Duckling Bought": 1,
+            "Acorn Hat Bought": 1,
+            "Rare Key Bought": 1,
+          },
+        },
+      },
+      action: {
+        type: "seasonalItem.bought",
+        name: "Rare Key",
+        tier: "rare",
+      },
+      createdAt: new Date("2025-02-05").getTime(),
+    });
+    expect(state.inventory["Rare Key"]).toStrictEqual(new Decimal(2));
+    expect(state.bumpkin.activity["Rare Key Bought"])?.toEqual(2);
+  });
+
+  it("throws an error if Mammoth item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    expect(() =>
+      buySeasonalItem({
+        state: {
+          ...mockState,
+          balance: new Decimal(5),
+          inventory: {
+            Timeshard: new Decimal(2000),
+          },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            activity: {
+              "Acorn House Bought": 1,
+              "Kite Bought": 1,
+              "Spring Duckling Bought": 1,
+              "Acorn Hat Bought": 1,
+              "Igloo Bought": 1,
+              "Ladybug Suit Bought": 1,
+              "Ugly Duckling Bought": 1,
+              "Lake Rug Bought": 1,
+              "Mammoth Bought": 1,
+            },
+          },
+        },
+        action: {
+          type: "seasonalItem.bought",
+          name: "Mammoth",
+          tier: "epic",
+        },
+        createdAt: new Date("2025-02-05").getTime(),
+      }),
+    ).toThrow("This item has already been crafted");
+  });
+
+  it("does not throw an error if Luxury Key item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+
+    const state = buySeasonalItem({
+      state: {
+        ...mockState,
+        balance: new Decimal(5),
+        inventory: {
+          Timeshard: new Decimal(1000),
+          "Luxury Key": new Decimal(1),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          activity: {
+            "Acorn House Bought": 1,
+            "Kite Bought": 1,
+            "Spring Duckling Bought": 1,
+            "Acorn Hat Bought": 1,
+            "Igloo Bought": 1,
+            "Ladybug Suit Bought": 1,
+            "Ugly Duckling Bought": 1,
+            "Lake Rug Bought": 1,
+            "Mammoth Bought": 1,
+            "Luxury Key Bought": 1,
+          },
+        },
+      },
+      action: {
+        type: "seasonalItem.bought",
+        name: "Luxury Key",
+        tier: "epic",
+      },
+      createdAt: new Date("2025-02-05").getTime(),
+    });
+    expect(state.inventory["Luxury Key"]).toStrictEqual(new Decimal(2));
+    expect(state.bumpkin.activity["Luxury Key Bought"])?.toEqual(2);
+  });
+
+  it("throws an error if Sickle item is already crafted", () => {
+    const mockedDate = new Date(2025, 1, 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    expect(() =>
+      buySeasonalItem({
+        state: {
+          ...mockState,
+          balance: new Decimal(5),
+          inventory: {
+            Timeshard: new Decimal(4500),
+          },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            activity: {
+              "Acorn House Bought": 1,
+              "Kite Bought": 1,
+              "Spring Duckling Bought": 1,
+              "Acorn Hat Bought": 1,
+              "Igloo Bought": 1,
+              "Ladybug Suit Bought": 1,
+              "Ugly Duckling Bought": 1,
+              "Lake Rug Bought": 1,
+              "Mammoth Bought": 1,
+              "Hammock Bought": 1,
+              "Crab Hat Bought": 1,
+              "Cup of Chocolate Bought": 1,
+              "Sickle Bought": 1,
+            },
+          },
+        },
+        action: {
+          type: "seasonalItem.bought",
+          name: "Sickle",
+          tier: "mega",
+        },
+        createdAt: new Date("2025-02-05").getTime(),
+      }),
+    ).toThrow("This item has already been crafted");
   });
 });

--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -114,6 +114,16 @@ export function buySeasonalItem({
       }
     }
 
+    // Ensure item can only be crafted once, except for keys
+    if (!isKey(name as InventoryItemName)) {
+      const itemCrafted =
+        stateCopy.bumpkin.activity[`${name as SeasonalTierItemName} Bought`];
+
+      if (itemCrafted) {
+        throw new Error("This item has already been crafted");
+      }
+    }
+
     // Check if player has enough resources
     const { sfl, items } = item.cost;
 

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
@@ -28,6 +28,7 @@ import {
   SeasonalStoreCollectible,
   SeasonalStoreItem,
   SeasonalStoreWearable,
+  SeasonalTierItemName,
 } from "features/game/types/megastore";
 import { getItemDescription } from "../SeasonalStore";
 import { getKeys } from "features/game/types/craftables";
@@ -138,6 +139,9 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
 
   const keysAmountBoughtToday = keysBoughtToday ? 1 : 0;
 
+  const itemCrafted =
+    state.bumpkin.activity[`${itemName as SeasonalTierItemName} Bought`];
+
   const description = getItemDescription(item);
   const { sfl = 0 } = item?.cost || {};
   const itemReq = item?.cost?.items;
@@ -169,6 +173,11 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
       if (tier === "rare" && !isRareUnlocked) return false;
       if (tier === "epic" && !isEpicUnlocked) return false;
       if (tier === "mega" && !isMegaUnlocked) return false;
+    }
+    if (!isKey(itemName as InventoryItemName)) {
+      if (itemCrafted) {
+        return false;
+      }
     }
     if (itemReq) {
       const hasRequirements = getKeys(itemReq).every((name) => {
@@ -340,13 +349,21 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
                         width: `${imageWidth}px`,
                       }}
                     />
-
-                    {itemName && isKey(itemName as Keys) && (
+                    {itemName && isKey(itemName as Keys) ? (
                       <Label
                         type={keysBoughtToday ? "danger" : "default"}
                         className="absolute bottom-1 right-1 text-xxs"
                       >
                         {t("keys.dailyLimit", { keysAmountBoughtToday })}
+                      </Label>
+                    ) : (
+                      <Label
+                        type={itemCrafted ? "danger" : "default"}
+                        className="absolute bottom-1 right-1 text-xxs"
+                      >
+                        {t("season.megastore.crafting.limit", {
+                          limit: itemCrafted ? 1 : 0,
+                        })}
                       </Label>
                     )}
                   </div>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3279,6 +3279,7 @@
   "season.wearableAirdrop": "Seasonal Wearable Airdrop",
   "season.place.land": "You must place it on your land",
   "season.megastore.discount": "Megastore SFL discount",
+  "season.megastore.crafting.limit": "Limit: {{limit}}/1",
   "season.supporter.gift": "Supporter Gift",
   "season.free.season.passes": "Free Season Banners",
   "season.free.season.passes.description": "Receive banners for every Season",


### PR DESCRIPTION
# Description

This PR adds a buy limit(1 per person) in the Megastore for collectibles and wearables except for keys.
![image](https://github.com/user-attachments/assets/50cc21e7-c184-481b-9768-6c70b7d077fb)


Fixes #issue

# What needs to be tested by the reviewer?

Modify `bumpkin.activity` and add `{Seasonal Item Name} Bought: 1` and check if X item can be bought in Megastore. Buy Button Should be disabled.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
