### PR TITLE
[FIX] useCountdown not updated immediately when timeLeft changes

### DIFF
--- a/src/lib/utils/hooks/useCountdown.ts
+++ b/src/lib/utils/hooks/useCountdown.ts
@@ -13,17 +13,21 @@ export const getReturnValues = (timeLeft: number) => {
 };
 
 export const useCountdown = (targetDate: number) => {
-  const [countDown, setCountDown] = useState<number>(
-    Math.max(targetDate - Date.now(), 0),
-  );
+  const timeRemaining = Math.max(targetDate - Date.now(), 0);
+
+  const [countDown, setCountDown] = useState<number>(timeRemaining);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setCountDown(Math.max(targetDate - Date.now(), 0));
+      setCountDown(timeRemaining);
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [targetDate]);
+  }, [timeRemaining]);
+
+  useEffect(() => {
+    setCountDown(timeRemaining);
+  }, [timeRemaining]);
 
   return getReturnValues(countDown);
 };


### PR DESCRIPTION
# Description

- Fixed an issue where countdown hook isn't updated when time left is updated

![pss_time_delay](https://github.com/user-attachments/assets/57472e09-7073-49bb-a6e8-199413d3006b)

# What needs to be tested by the reviewer?

- unlock multiple power skills, use all of them, then toggle between them

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
