### PR TITLE
[FIX] Bountiful Bounties skill for Selling Animals

### DIFF
--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -199,6 +199,11 @@ export const AnimalDeal: React.FC<{
     return null;
   }
 
+  const { coins } = generateBountyCoins({
+    game: state,
+    bounty: deal,
+  });
+
   return (
     <>
       {animal.state === "sick" ? (
@@ -213,7 +218,7 @@ export const AnimalDeal: React.FC<{
                     className="w-4"
                     alt="Coins"
                   />
-                  <p>{`x ${getSickAnimalRewardAmount(deal.coins)} coins`}</p>
+                  <p>{`x ${getSickAnimalRewardAmount(coins)} coins`}</p>
                 </div>
               )}
               {getKeys(deal.items ?? {}).map((name) => {
@@ -248,7 +253,7 @@ export const AnimalDeal: React.FC<{
               </Label>
               {!!deal.coins && (
                 <Label type="warning" icon={SUNNYSIDE.ui.coinsImg}>
-                  {deal.coins}
+                  {coins}
                 </Label>
               )}
 
@@ -270,7 +275,7 @@ export const AnimalDeal: React.FC<{
 
             <p>
               {deal.coins
-                ? t("bounties.sell.coins", { amount: deal.coins })
+                ? t("bounties.sell.coins", { amount: coins })
                 : t("bounties.sell.items", {
                     amount: getKeys(deal.items ?? {})
                       .map(
@@ -305,6 +310,14 @@ export const ExchangeHud: React.FC<{
   onClose: () => void;
 }> = ({ deal, onClose }) => {
   const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+  const state = gameService.getSnapshot().context.state;
+
+  const { coins } = generateBountyCoins({
+    game: state,
+    bounty: deal,
+  });
+
   return (
     <HudContainer>
       <div className="absolute items-start flex top-3 px-2 cursor-pointer z-10 w-full justify-between">
@@ -316,7 +329,7 @@ export const ExchangeHud: React.FC<{
 
             {!!deal.coins && (
               <Label type="warning" icon={SUNNYSIDE.ui.coinsImg}>
-                {deal.coins}
+                {coins}
               </Label>
             )}
 

--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -266,6 +266,51 @@ describe("animal.sold", () => {
     expect(deal?.soldAt).toEqual(now);
   });
 
+  it("gives 50% more coins when selling bountiful bounties", () => {
+    const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
+    const state = sellAnimal({
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          skills: {
+            "Bountiful Bounties": 1,
+          },
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            ...INITIAL_FARM.henHouse.animals,
+            [animalId]: {
+              ...INITIAL_FARM.henHouse.animals[animalId],
+              experience: 1000,
+            },
+          },
+        },
+        bounties: {
+          completed: [],
+          requests: [
+            {
+              id: "123",
+
+              coins: 100,
+              items: {},
+              level: 1,
+              name: "Chicken",
+            },
+          ],
+        },
+      },
+      action: {
+        requestId: "123",
+        animalId,
+        type: "animal.sold",
+      },
+    });
+
+    expect(state.coins).toEqual(150);
+  });
+
   it("gives 25% less coins when selling sick animals", () => {
     const animalId = Object.keys(INITIAL_FARM.henHouse.animals)[0];
     const state = sellAnimal({

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -5,7 +5,7 @@ import { trackFarmActivity } from "features/game/types/farmActivity";
 import { Animal, BountyRequest, GameState } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
 import { produce } from "immer";
-import { generateBountyTicket } from "./sellBounty";
+import { generateBountyTicket, generateBountyCoins } from "./sellBounty";
 
 export function isValidDeal({
   animal,
@@ -82,9 +82,11 @@ export function sellAnimal({
     delete animals[action.animalId];
 
     if (request.coins) {
-      game.coins += isSick
-        ? getSickAnimalRewardAmount(request.coins)
-        : request.coins;
+      const { coins } = generateBountyCoins({
+        game: state,
+        bounty: request,
+      });
+      game.coins += isSick ? getSickAnimalRewardAmount(coins) : coins;
     }
 
     getKeys(request.items ?? {}).forEach((name) => {


### PR DESCRIPTION
# Description

Regarding the issue that posted on Discord. The Bountiful Bounties skill is not functioning as intended; when you want to sell an animal for coins at the bounty board after obtaining this skill, the game shows the correct price (810 coins) based on the skill's boost (photo 1). but when you select the bounty and want to confirm selling (photo 2), it shows the default price (540 coins) and gives only this amount without applying the skill's boost. **(BE changes probably is needed)**

|  |  |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/acbbcc4e-1840-408c-a888-0d9b677025d3) | ![image](https://github.com/user-attachments/assets/cbf281de-823f-4360-b621-57af9242248d) | 


Fixes #issue

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
