### PR TITLE
[FIX] Handle Free feeding with Chonky Feed Skill

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -1300,6 +1300,130 @@ describe("feedAnimal", () => {
     expect(state.inventory["Mixed Grain"]).toEqual(new Decimal(0.5));
     expect(state.henHouse.animals["0"].experience).toEqual(foodXp);
   });
+  it("handles chonky feed skill for chicken with Gold Egg placed", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          skills: {
+            "Chonky Feed": 1,
+          },
+        },
+        collectibles: {
+          "Gold Egg": [
+            {
+              id: "1",
+              coordinates: {
+                x: 0,
+                y: 0,
+              },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.henHouse.animals["0"],
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: "0",
+      },
+    });
+    expect(state.henHouse.animals["0"].experience).toEqual(120);
+  });
+
+  it("handles chonky feed skill for cows with Golden Cow placed", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          skills: {
+            "Chonky Feed": 1,
+          },
+        },
+        collectibles: {
+          "Golden Cow": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              type: "Cow",
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+    expect(state.barn.animals["0"].experience).toEqual(240);
+  });
+
+  it("handles chonky feed skill for sheep with Golden Sheep placed", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          skills: {
+            "Chonky Feed": 1,
+          },
+        },
+        collectibles: {
+          "Golden Sheep": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.barn.animals["0"],
+              type: "Sheep",
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Sheep",
+        id: "0",
+      },
+    });
+    expect(state.barn.animals["0"].experience).toEqual(120);
+  });
 
   it("feeds a cow for free if the player has a Golden Cow", () => {
     const state = feedAnimal({
@@ -1371,7 +1495,7 @@ describe("feedAnimal", () => {
       },
     });
 
-    expect(state.barn.animals["0"].experience).toEqual(180);
+    expect(state.barn.animals["0"].experience).toEqual(200);
   });
 
   it("feeds a max level chicken the max level xp if the player has a Gold Egg", () => {

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -109,7 +109,23 @@ const handleFreeFeeding = ({
     const nextLevelXp = ANIMAL_LEVELS[animalType][nextLevel];
     const xpDiff = nextLevelXp - beforeFeedXp;
 
-    isReady = handleAnimalExperience(animal, animalType, beforeFeedXp, xpDiff);
+    const favouriteFood = getAnimalFavoriteFood(animalType, beforeFeedXp);
+
+    const { foodXp } = handleFoodXP({
+      state: copy,
+      animal: animalType,
+      level: nextLevel,
+      food: favouriteFood,
+    });
+
+    const noOfFeed = Math.ceil(xpDiff / foodXp);
+    const xpToFeed = noOfFeed * foodXp;
+    isReady = handleAnimalExperience(
+      animal,
+      animalType,
+      beforeFeedXp,
+      xpToFeed,
+    );
   }
 
   animal.state = isReady ? "ready" : "happy";


### PR DESCRIPTION
# Description

This PR fixes an issue where player with gold egg/sheep/cow doesn't have chonky feed skill boost at lower levels

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
