### PR TITLE
[FIX] Black sheep placeable dimensions

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1371,7 +1371,7 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   Cluckulator: { width: 1, height: 2 },
   UFO: { width: 2, height: 2 },
   Wagon: { width: 2, height: 2 },
-  "Black Sheep": { width: 2, height: 2 },
+  "Black Sheep": { width: 2, height: 1 },
   "Alien Chicken": { width: 1, height: 1 },
   "Toxic Tuft": { width: 2, height: 1 },
   Mootant: { width: 2, height: 1 },

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -350,6 +350,7 @@ import { FrozenSheep } from "./components/FrozenSheep";
 import { SummerChicken } from "./components/SummerChicken";
 import { Jellyfish } from "./components/Jellyfish";
 import { Chamomile } from "./components/Chamomile";
+import { BlackSheep } from "./components/BlackSheep";
 
 export const COLLECTIBLE_COMPONENTS: Record<
   CollectibleName | "Bud",
@@ -1439,21 +1440,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
       alt="UFO"
     />
   ),
-  "Black Sheep": (props: CollectibleProps) => (
-    <ImageStyle
-      {...props}
-      divStyle={{
-        width: `${PIXEL_SCALE * 25}px`,
-        bottom: `${PIXEL_SCALE * 4}px`,
-        left: `${PIXEL_SCALE * -3}px`,
-      }}
-      imgStyle={{
-        width: `${PIXEL_SCALE * 25}px`,
-      }}
-      image={ITEM_DETAILS["Black Sheep"].image}
-      alt="Black Sheep"
-    />
-  ),
+  "Black Sheep": BlackSheep,
   "Halloween Scarecrow": (props: CollectibleProps) => (
     <ImageStyle
       {...props}

--- a/src/features/island/collectibles/components/BlackSheep.tsx
+++ b/src/features/island/collectibles/components/BlackSheep.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-import toxicTuft from "assets/sfts/toxic_tuft.webp";
+import blackSheep from "assets/sfts/black_sheep.webp";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 
-export const ToxicTuft: React.FC = () => {
+export const BlackSheep: React.FC = () => {
   return (
     <div
       className="absolute bottom-0 left-1/2 -translate-x-1/2 pointer-events-none"
@@ -11,7 +11,7 @@ export const ToxicTuft: React.FC = () => {
         width: `${PIXEL_SCALE * 25}px`,
       }}
     >
-      <img src={toxicTuft} className="w-full" alt="Toxic Tuft" />
+      <img src={blackSheep} className="w-full" alt="Black Sheep" />
     </div>
   );
 };


### PR DESCRIPTION
# Description

- reduce Black Sheep dimensions to 2 x 1
- add `pointer-events-none` to Black Sheep and Toxic Tuft so the extra height outside the collectable area does not block clicks on other placeables (devs keep this in mind when implementing new placeables)

Before|After
---|---
![image](https://github.com/user-attachments/assets/771f633b-3fe7-4d87-a5c4-2d891852231c)|![image](https://github.com/user-attachments/assets/029d6f2d-3c12-43a7-9977-07db1c922118)

# What needs to be tested by the reviewer?

- place Black Sheep and Toxic Tuft in farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
