### PR TITLE
[FIX] Restock boat positions

### DIFF
--- a/src/features/game/expansion/components/RestockBoat.tsx
+++ b/src/features/game/expansion/components/RestockBoat.tsx
@@ -40,12 +40,12 @@ export const RestockBoat: React.FC<{
 
   const wharfCoords = () => {
     if (expansionCount < 7) {
-      return { x: -6, y: -3 };
+      return { x: -2, y: -7 };
     }
     if (expansionCount >= 7 && expansionCount < 21) {
-      return { x: -13, y: -9 };
+      return { x: -9, y: -13 };
     } else {
-      return { x: -19, y: -15 };
+      return { x: -15, y: -19 };
     }
   };
 

--- a/src/features/game/expansion/components/RestockBoat.tsx
+++ b/src/features/game/expansion/components/RestockBoat.tsx
@@ -40,12 +40,12 @@ export const RestockBoat: React.FC<{
 
   const wharfCoords = () => {
     if (expansionCount < 7) {
-      return { x: -2, y: -7 };
+      return { x: -1, y: -7 };
     }
     if (expansionCount >= 7 && expansionCount < 21) {
-      return { x: -9, y: -13 };
+      return { x: -8, y: -13 };
     } else {
-      return { x: -15, y: -19 };
+      return { x: -14, y: -19 };
     }
   };
 

--- a/src/features/game/expansion/components/Water.tsx
+++ b/src/features/game/expansion/components/Water.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 
-import {
-  GRID_WIDTH_PX,
-  INITIAL_STOCK,
-  PIXEL_SCALE,
-  StockableName,
-} from "features/game/lib/constants";
+import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
 
 import { MapPlacement } from "./MapPlacement";
 import { Snorkler } from "./water/Snorkler";
@@ -22,10 +17,6 @@ import { GameState } from "features/game/types/game";
 import { CONFIG } from "lib/config";
 import { LaTomatina } from "./LaTomatina";
 import { RestockBoat } from "./RestockBoat";
-import { SHIPMENT_STOCK } from "features/game/events/landExpansion/shipmentRestocked";
-import { SEEDS } from "features/game/types/seeds";
-import { WORKBENCH_TOOLS, TREASURE_TOOLS } from "features/game/types/tools";
-import Decimal from "decimal.js-light";
 
 import fins1 from "assets/decorations/fins_yellow.webp";
 import fins2 from "assets/decorations/fins_green.webp";
@@ -44,34 +35,6 @@ export const WaterComponent: React.FC<Props> = ({
   const offset = Math.ceil((Math.sqrt(expansionCount) * LAND_WIDTH) / 2);
   const season = gameState.season.season;
   const weather = gameState.fishing.weather;
-  const getShipmentAmount = (item: StockableName, amount: number): Decimal => {
-    const totalStock = INITIAL_STOCK(gameState)[item];
-    const remainingStock = gameState.stock[item] ?? new Decimal(0);
-    // If shipment amount will exceed total stock
-    if (remainingStock.add(amount).gt(totalStock)) {
-      // return the difference between total and remaining stock
-      return totalStock.sub(remainingStock);
-    } else {
-      // else return shipment stock
-      return new Decimal(amount);
-    }
-  };
-
-  const restockTools = Object.entries(SHIPMENT_STOCK)
-    .filter((item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS })
-    .filter(([item, amount]) => {
-      const shipmentAmount = getShipmentAmount(item as StockableName, amount);
-      return shipmentAmount.gt(0);
-    });
-
-  const restockSeeds = Object.entries(SHIPMENT_STOCK)
-    .filter((item) => item[0] in SEEDS)
-    .filter(([item, amount]) => {
-      const shipmentAmount = getShipmentAmount(item as StockableName, amount);
-      return shipmentAmount.gt(0);
-    });
-
-  const restockIsEmpty = [...restockSeeds, ...restockTools].length <= 0;
 
   return (
     // Container
@@ -295,13 +258,7 @@ export const WaterComponent: React.FC<Props> = ({
 
       <IslandUpgrader gameState={gameState} offset={offset} />
 
-      {!restockIsEmpty && (
-        <RestockBoat
-          restockSeeds={restockSeeds}
-          restockTools={restockTools}
-          getShipmentAmount={getShipmentAmount}
-        />
-      )}
+      <RestockBoat />
 
       <MapPlacement x={-5 - offset} y={2} width={4}>
         <LaTomatina event={gameState.specialEvents.current["La Tomatina"]} />


### PR DESCRIPTION
# Description

- Change restock boat position so that it never overlaps with constructing land

Before|After
---|---
![image](https://github.com/user-attachments/assets/3ea03d7c-4b20-43e5-a2a2-1656d26cf939)|![image](https://github.com/user-attachments/assets/3d5bb53d-895d-43ba-880b-79837894b09c)

# What needs to be tested by the reviewer?

- expand land when restock boat is visible

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
