### PR TITLE
[FIX] Required Reputation to Make Offers for Resources

### DIFF
--- a/src/features/marketplace/components/ResourceOffer.tsx
+++ b/src/features/marketplace/components/ResourceOffer.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { useSelector } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
@@ -17,6 +18,10 @@ import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import sflIcon from "assets/icons/sfl.webp";
 import tradeIcon from "assets/icons/trade.png";
 import lockIcon from "assets/icons/lock.png";
+import { RequiredReputation } from "features/island/hud/components/reputation/Reputation";
+import { hasReputation, Reputation } from "features/game/lib/reputation";
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
 
 type Props = {
   itemName: TradeResource;
@@ -32,6 +37,12 @@ type Props = {
 
 const MAX_SFL = 150;
 
+const _hasReputation = (state: MachineState) =>
+  hasReputation({
+    game: state.context.state,
+    reputation: Reputation.Cropkeeper,
+  });
+
 export const ResourceOffer: React.FC<Props> = ({
   itemName,
   floorPrice,
@@ -44,6 +55,8 @@ export const ResourceOffer: React.FC<Props> = ({
   onOffer,
 }) => {
   const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+  const hasTradeReputation = useSelector(gameService, _hasReputation);
 
   const unitPrice = new Decimal(quantity).equals(0)
     ? new Decimal(0)
@@ -70,9 +83,14 @@ export const ResourceOffer: React.FC<Props> = ({
   return (
     <>
       <div>
-        <Label type="default" className="my-1 ml-2" icon={tradeIcon}>
-          {t("marketplace.makeOffer")}
-        </Label>
+        <div className="flex flex-wrap justify-between mb-1">
+          <Label type="default" className="my-1 ml-2" icon={tradeIcon}>
+            {t("marketplace.makeOffer")}
+          </Label>
+          {!hasTradeReputation && (
+            <RequiredReputation reputation={Reputation.Cropkeeper} />
+          )}
+        </div>
         <div className="flex justify-between">
           <div className="flex items-center">
             <Box image={ITEM_DETAILS[itemName].image} disabled />
@@ -249,7 +267,8 @@ export const ResourceOffer: React.FC<Props> = ({
               ) ||
               new Decimal(quantity).equals(0) || // Disable when quantity is 0
               new Decimal(price).equals(0) || // Disable when sfl is 0
-              isSaving
+              isSaving ||
+              !hasTradeReputation
             }
             onClick={onOffer}
           >

--- a/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerModal.tsx
@@ -122,7 +122,7 @@ export const AuctioneerModal: React.FC<Props> = ({
           <div className="flex flex-col">
             {!hasAuctionAccess && (
               <div className="pt-2 pl-2">
-                <RequiredReputation reputation={Reputation.Seedling} />
+                <RequiredReputation reputation={Reputation.Grower} />
               </div>
             )}
             <AuctioneerContent


### PR DESCRIPTION
# Description
This issue is among the most frequently reported ones since the reputation system's release. Players who lack sufficient reputation (Crop Keeper) to make offers in the marketplace encounter an EF-001 error when attempting to make offers for resources. This PR addresses the issue by displaying the required reputation for making resource offers and disabling the "Offer" button for players with insufficient reputation. Currently, this button panel(Rep Info) and FE restriction exist for making offers on wearables, collectables, and Bud NFTs, but not for resources.

| Before | After |
|--------|--------|
| <img width="300" alt="1" src="https://github.com/user-attachments/assets/83fd4441-1523-4323-ac50-5c6de20103e0" /> | <img width="300" alt="2" src="https://github.com/user-attachments/assets/0eee001d-bed1-4d5a-8e91-de9e584da431" /> | 

Fixes #issue

# What needs to be tested by the reviewer?

- Make offers for resources in the marketplace.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
