### PR TITLE
[FIX] El pollo should be calculated after percentage boosts

### DIFF
--- a/src/features/game/events/landExpansion/claimProduce.test.ts
+++ b/src/features/game/events/landExpansion/claimProduce.test.ts
@@ -1202,6 +1202,64 @@ describe("claimProduce", () => {
     expect(state.henHouse.animals["0"].awakeAt).toBeCloseTo(boostedAwakeAt);
   });
 
+  it("stacks speed boosts for chickens", () => {
+    const state = claimProduce({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Speed Chicken": new Decimal(1),
+          Wrangler: new Decimal(1),
+          "El Pollo Veloz": new Decimal(1),
+        },
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          skills: {
+            "Restless Animals": 1,
+          },
+        },
+        collectibles: {
+          "Speed Chicken": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+          "El Pollo Veloz": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": {
+              ...INITIAL_FARM.henHouse.animals["0"],
+              state: "ready",
+              experience: 60,
+            },
+          },
+        },
+      },
+      action: {
+        type: "produce.claimed",
+        animal: "Chicken",
+        id: "0",
+      },
+    });
+
+    const boostedAwakeAt =
+      now + ANIMAL_SLEEP_DURATION * 0.9 * 0.9 * 0.9 - 1000 * 60 * 60 * 2;
+
+    expect(state.henHouse.animals["0"].awakeAt).toEqual(boostedAwakeAt);
+  });
+
   it("stacks all possible speed boosts for chickens", () => {
     const state = claimProduce({
       createdAt: now,
@@ -1255,9 +1313,8 @@ describe("claimProduce", () => {
     });
 
     const twoHoursInMs = 2 * 60 * 60 * 1000;
-    // First subtract 2 hours, then apply percentage reductions
-    const afterFixedReduction = ANIMAL_SLEEP_DURATION - twoHoursInMs;
-    const finalDuration = afterFixedReduction * 0.9 * 0.9 * 0.9; // Apply all 10% reductions
+    const finalDuration =
+      ANIMAL_SLEEP_DURATION * 0.9 * 0.9 * 0.9 - twoHoursInMs; // Apply all 10% reductions
     const boostedAwakeAt = now + finalDuration;
 
     expect(state.henHouse.animals["0"].awakeAt).toBeCloseTo(boostedAwakeAt);
@@ -1476,7 +1533,7 @@ describe("claimProduce", () => {
 
     const twoHoursInMs = 2 * 60 * 60 * 1000;
     // First subtract 2 hours, then apply 10% reduction
-    const reducedDuration = (ANIMAL_SLEEP_DURATION - twoHoursInMs) * 0.9;
+    const reducedDuration = ANIMAL_SLEEP_DURATION * 0.9 - twoHoursInMs;
     const boostedAwakeAt = now + reducedDuration;
 
     expect(state.henHouse.animals["0"].awakeAt).toEqual(boostedAwakeAt);

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -425,56 +425,47 @@ export function getBoostedAwakeAt({
   createdAt: number;
   game: GameState;
 }) {
-  const sleepDuration = ANIMAL_SLEEP_DURATION;
+  let totalDuration = ANIMAL_SLEEP_DURATION;
   const { bumpkin } = game;
-  const twoHoursInMs = 2 * 60 * 60 * 1000;
 
-  // Start with the base duration
-  let totalDuration = sleepDuration;
-
-  const isChicken = animalType === "Chicken";
-  const isSheep = animalType === "Sheep";
-  const isCow = animalType === "Cow";
-
-  // Apply fixed time reductions first
-  if (isChicken) {
-    if (isCollectibleBuilt({ name: "El Pollo Veloz", game })) {
-      totalDuration -= twoHoursInMs;
-    }
-
-    if (isCollectibleBuilt({ name: "Speed Chicken", game })) {
-      totalDuration *= 0.9;
-    }
+  // Animal-specific boosts
+  if (
+    animalType === "Chicken" &&
+    isCollectibleBuilt({ name: "Speed Chicken", game })
+  ) {
+    totalDuration *= 0.9;
   }
-
-  if (isSheep) {
+  if (animalType === "Sheep") {
     if (isWearableActive({ name: "Dream Scarf", game })) {
       totalDuration *= 0.8;
     }
-
     if (isCollectibleBuilt({ name: "Farm Dog", game })) {
       totalDuration *= 0.75;
     }
   }
 
-  if (isCow) {
-    if (isCollectibleBuilt({ name: "Mammoth", game })) {
-      totalDuration *= 0.75;
-    }
+  if (animalType === "Cow" && isCollectibleBuilt({ name: "Mammoth", game })) {
+    totalDuration *= 0.75;
   }
 
+  // Global boosts
   if (game.inventory["Wrangler"]?.gt(0)) {
     totalDuration *= 0.9;
   }
-
   if (bumpkin.skills["Stable Hand"]) {
     totalDuration *= 0.9;
   }
-
   if (bumpkin.skills["Restless Animals"]) {
     totalDuration *= 0.9;
   }
 
-  // Add the boosted duration to the created time
+  // Fixed time reduction after multipliers
+  if (
+    animalType === "Chicken" &&
+    isCollectibleBuilt({ name: "El Pollo Veloz", game })
+  ) {
+    totalDuration -= 2 * 60 * 60 * 1000; // 2 hours
+  }
+
   return createdAt + totalDuration;
 }


### PR DESCRIPTION
# Description

Typically we add additive and subtractive boosts after percentage boosts. 

This PR fixes the issue where el pollo's buff was subtracted before all the percentage boosts

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
