### PR TITLE
[FEAT] Legacy Badges Section in Profile

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -345,19 +345,6 @@ export const BumpkinInfo: React.FC<{
           </ButtonPanel>
         )}
 
-        <ButtonPanel
-          onClick={() => setView("achievements")}
-          className="mb-2 relative mt-1 !px-2 !py-1"
-        >
-          <div className="flex items-center mb-1 justify-between">
-            <div className="flex items-center">
-              <span className="text-sm">{t("achievements")}</span>
-            </div>
-            <span className="underline text-sm">{t("viewAll")}</span>
-          </div>
-          <AchievementBadges achievements={bumpkin?.achievements} />
-        </ButtonPanel>
-
         {badges.length > 0 && (
           <ButtonPanel
             className="mb-2 relative mt-1 !px-2 !py-1"
@@ -372,6 +359,19 @@ export const BumpkinInfo: React.FC<{
             <div className="flex flex-wrap items-center mt-2">{badges}</div>
           </ButtonPanel>
         )}
+
+        <ButtonPanel
+          onClick={() => setView("achievements")}
+          className="mb-2 relative mt-1 !px-2 !py-1"
+        >
+          <div className="flex items-center mb-1 justify-between">
+            <div className="flex items-center">
+              <span className="text-sm">{t("achievements")}</span>
+            </div>
+            <span className="underline text-sm">{t("viewAll")}</span>
+          </div>
+          <AchievementBadges achievements={bumpkin?.achievements} />
+        </ButtonPanel>
       </div>
     </div>
   );

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -40,10 +40,10 @@ import { MyReputation } from "features/island/hud/components/reputation/Reputati
 import { ITEM_DETAILS } from "features/game/types/images";
 import { LEGACY_SKILL_TREE } from "features/game/types/skills";
 import { setImageWidth } from "lib/images";
-import { LegacySkills } from "./LegacySkills";
+import { LegacyBadges } from "./LegacyBadges";
 import { getKeys } from "features/game/types/decorations";
 
-export type ViewState = "home" | "achievements" | "skills" | "legacySkills";
+export type ViewState = "home" | "achievements" | "skills" | "legacyBadges";
 
 const _rawToken = (state: AuthMachineState) => state.context.user.rawToken;
 
@@ -178,8 +178,8 @@ export const BumpkinModal: React.FC<Props> = ({
     );
   }
 
-  if (view === "legacySkills") {
-    return <LegacySkills onBack={() => setView("home")} onClose={onClose} />;
+  if (view === "legacyBadges") {
+    return <LegacyBadges onBack={() => setView("home")} onClose={onClose} />;
   }
 
   const hasAvailableSP = getAvailableBumpkinOldSkillPoints(bumpkin) > 0;
@@ -361,11 +361,11 @@ export const BumpkinInfo: React.FC<{
         {badges.length > 0 && (
           <ButtonPanel
             className="mb-2 relative mt-1 !px-2 !py-1"
-            onClick={() => setView("legacySkills")}
+            onClick={() => setView("legacyBadges")}
           >
             <div className="flex items-center mb-1 justify-between">
               <div className="flex items-center">
-                <span className="text-sm">{`Legacy Skills`}</span>
+                <span className="text-sm">{`Legacy Badges`}</span>
               </div>
               <span className="underline text-sm">{t("viewAll")}</span>
             </div>

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -38,7 +38,7 @@ import { AuthMachineState } from "features/auth/lib/authMachine";
 import { MachineState } from "features/game/lib/gameMachine";
 import { MyReputation } from "features/island/hud/components/reputation/Reputation";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { LEGACY_SKILL_TREE } from "features/game/types/skills";
+import { LEGACY_BADGE_TREE } from "features/game/types/skills";
 import { setImageWidth } from "lib/images";
 import { LegacyBadges } from "./LegacyBadges";
 import { getKeys } from "features/game/types/decorations";
@@ -268,7 +268,7 @@ export const BumpkinInfo: React.FC<{
 }> = ({ readonly, level, maxLevel, gameState, setView, hasAvailableSP }) => {
   const { t } = useAppTranslation();
   const { bumpkin, inventory } = gameState;
-  const BADGES = getKeys(LEGACY_SKILL_TREE);
+  const BADGES = getKeys(LEGACY_BADGE_TREE);
 
   const badges = BADGES.map((badge) => {
     if (inventory[badge]) {

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -37,8 +37,13 @@ import { hasFeatureAccess } from "lib/flags";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import { MachineState } from "features/game/lib/gameMachine";
 import { MyReputation } from "features/island/hud/components/reputation/Reputation";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { LEGACY_SKILL_TREE } from "features/game/types/skills";
+import { setImageWidth } from "lib/images";
+import { LegacySkills } from "./LegacySkills";
+import { getKeys } from "features/game/types/decorations";
 
-type ViewState = "home" | "achievements" | "skills";
+export type ViewState = "home" | "achievements" | "skills" | "legacySkills";
 
 const _rawToken = (state: AuthMachineState) => state.context.user.rawToken;
 
@@ -173,6 +178,10 @@ export const BumpkinModal: React.FC<Props> = ({
     );
   }
 
+  if (view === "legacySkills") {
+    return <LegacySkills onBack={() => setView("home")} onClose={onClose} />;
+  }
+
   const hasAvailableSP = getAvailableBumpkinOldSkillPoints(bumpkin) > 0;
 
   const renderTabs = () => {
@@ -221,89 +230,14 @@ export const BumpkinModal: React.FC<Props> = ({
         className="scrollable"
       >
         {tab === 0 && (
-          <div className="flex flex-wrap">
-            <div className="w-full sm:w-1/3 z-10 mr-0 sm:mr-2">
-              <div className="w-full rounded-md overflow-hidden mb-1">
-                <DynamicNFT
-                  showBackground
-                  bumpkinParts={bumpkin?.equipped as BumpkinParts}
-                />
-              </div>
-              {/* {isFullUser && (
-              <div className="ml-1">
-                <a
-                  href={getVisitBumpkinUrl()}
-                  target="_blank"
-                  className="underline text-xxs"
-                  rel="noreferrer"
-                >
-                  Visit Bumpkin
-                </a>
-              </div>
-            )} */}
-            </div>
-
-            <div className="flex-1">
-              <div className="mb-3">
-                <div className="flex items-center ml-1 my-2">
-                  <img
-                    src={levelIcon}
-                    style={{
-                      width: `${PIXEL_SCALE * 10}px`,
-                      marginRight: `${PIXEL_SCALE * 4}px`,
-                    }}
-                  />
-                  <div>
-                    <p>
-                      {t("lvl")} {level}
-                      {maxLevel ? " (Max)" : ""}
-                    </p>
-                    {/* Progress bar */}
-                    <BumpkinLevel experience={bumpkin.experience} />
-                  </div>
-                </div>
-              </div>
-
-              <MyReputation />
-
-              {!hasFeatureAccess(gameState, "SKILLS_REVAMP") && (
-                <ButtonPanel
-                  onClick={() => setView("skills")}
-                  className="mb-2 relative mt-1 !px-2 !py-1"
-                >
-                  <div className="flex items-center mb-1 justify-between">
-                    <div className="flex items-center">
-                      <span className="text-sm">{t("skills")}</span>
-                      {hasAvailableSP && !readonly && (
-                        <img
-                          src={SUNNYSIDE.icons.expression_alerted}
-                          className="h-4 ml-2"
-                        />
-                      )}
-                    </div>
-                    <span className="text-sm underline">{t("viewAll")}</span>
-                  </div>
-                  <SkillBadges
-                    inventory={inventory}
-                    bumpkin={bumpkin as Bumpkin}
-                  />
-                </ButtonPanel>
-              )}
-
-              <ButtonPanel
-                onClick={() => setView("achievements")}
-                className="mb-2 relative mt-1 !px-2 !py-1"
-              >
-                <div className="flex items-center mb-1 justify-between">
-                  <div className="flex items-center">
-                    <span className="text-sm">{t("achievements")}</span>
-                  </div>
-                  <span className="underline text-sm">{t("viewAll")}</span>
-                </div>
-                <AchievementBadges achievements={bumpkin?.achievements} />
-              </ButtonPanel>
-            </div>
-          </div>
+          <BumpkinInfo
+            readonly={readonly}
+            level={level}
+            maxLevel={maxLevel}
+            gameState={gameState}
+            setView={setView}
+            hasAvailableSP={hasAvailableSP}
+          />
         )}
 
         {tab === 1 && (
@@ -321,5 +255,124 @@ export const BumpkinModal: React.FC<Props> = ({
         {tab === 2 && <Skills readonly={readonly} />}
       </div>
     </CloseButtonPanel>
+  );
+};
+
+export const BumpkinInfo: React.FC<{
+  readonly: boolean;
+  level: number;
+  maxLevel: boolean;
+  gameState: GameState;
+  setView: (view: ViewState) => void;
+  hasAvailableSP: boolean;
+}> = ({ readonly, level, maxLevel, gameState, setView, hasAvailableSP }) => {
+  const { t } = useAppTranslation();
+  const { bumpkin, inventory } = gameState;
+  const BADGES = getKeys(LEGACY_SKILL_TREE);
+
+  const badges = BADGES.map((badge) => {
+    if (inventory[badge]) {
+      return (
+        <img
+          key={badge}
+          src={ITEM_DETAILS[badge].image}
+          alt={badge}
+          style={{
+            opacity: 0,
+            marginRight: `${PIXEL_SCALE * 2}px`,
+            marginBottom: `${PIXEL_SCALE * 2}px`,
+          }}
+          onLoad={(e) => setImageWidth(e.currentTarget)}
+        />
+      );
+    }
+
+    return null;
+  }).filter(Boolean);
+
+  return (
+    <div className="flex flex-wrap">
+      <div className="w-full sm:w-1/3 z-10 mr-0 sm:mr-2">
+        <div className="w-full rounded-md overflow-hidden mb-1">
+          <DynamicNFT
+            showBackground
+            bumpkinParts={bumpkin?.equipped as BumpkinParts}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1">
+        <div className="mb-3">
+          <div className="flex items-center ml-1 my-2">
+            <img
+              src={levelIcon}
+              style={{
+                width: `${PIXEL_SCALE * 10}px`,
+                marginRight: `${PIXEL_SCALE * 4}px`,
+              }}
+            />
+            <div>
+              <p>
+                {t("lvl")} {level}
+                {maxLevel ? " (Max)" : ""}
+              </p>
+              {/* Progress bar */}
+              <BumpkinLevel experience={bumpkin.experience} />
+            </div>
+          </div>
+        </div>
+
+        <MyReputation />
+
+        {!hasFeatureAccess(gameState, "SKILLS_REVAMP") && (
+          <ButtonPanel
+            onClick={() => setView("skills")}
+            className="mb-2 relative mt-1 !px-2 !py-1"
+          >
+            <div className="flex items-center mb-1 justify-between">
+              <div className="flex items-center">
+                <span className="text-sm">{t("skills")}</span>
+                {hasAvailableSP && !readonly && (
+                  <img
+                    src={SUNNYSIDE.icons.expression_alerted}
+                    className="h-4 ml-2"
+                  />
+                )}
+              </div>
+              <span className="text-sm underline">{t("viewAll")}</span>
+            </div>
+            <SkillBadges inventory={inventory} bumpkin={bumpkin as Bumpkin} />
+          </ButtonPanel>
+        )}
+
+        <ButtonPanel
+          onClick={() => setView("achievements")}
+          className="mb-2 relative mt-1 !px-2 !py-1"
+        >
+          <div className="flex items-center mb-1 justify-between">
+            <div className="flex items-center">
+              <span className="text-sm">{t("achievements")}</span>
+            </div>
+            <span className="underline text-sm">{t("viewAll")}</span>
+          </div>
+          <AchievementBadges achievements={bumpkin?.achievements} />
+        </ButtonPanel>
+
+        {badges.length > 0 && (
+          <ButtonPanel
+            className="mb-2 relative mt-1 !px-2 !py-1"
+            onClick={() => setView("legacySkills")}
+          >
+            <div className="flex items-center mb-1 justify-between">
+              <div className="flex items-center">
+                <span className="text-sm">{`Legacy Skills`}</span>
+              </div>
+              <span className="underline text-sm">{t("viewAll")}</span>
+            </div>
+            <div className="flex flex-wrap items-center mt-2">{badges}</div>
+          </ButtonPanel>
+        )}
+      </div>
+    </div>
   );
 };

--- a/src/features/bumpkins/components/LegacyBadges.tsx
+++ b/src/features/bumpkins/components/LegacyBadges.tsx
@@ -1,5 +1,5 @@
 import { SplitScreenView } from "components/ui/SplitScreenView";
-import { LEGACY_SKILL_TREE } from "features/game/types/skills";
+import { LEGACY_BADGE_TREE } from "features/game/types/skills";
 import React, { useState } from "react";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -19,7 +19,7 @@ interface Props {
 
 export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
   const { t } = useAppTranslation();
-  const BADGES = getObjectEntries(LEGACY_SKILL_TREE);
+  const BADGES = getObjectEntries(LEGACY_BADGE_TREE);
   const [selectedSkill, setSelectedSkill] = useState(BADGES[0]);
   const [LegacyBadgeName, legacySkillDetails] = selectedSkill;
   const { buff } = legacySkillDetails;

--- a/src/features/bumpkins/components/LegacyBadges.tsx
+++ b/src/features/bumpkins/components/LegacyBadges.tsx
@@ -17,7 +17,7 @@ interface Props {
   onClose: () => void;
 }
 
-export const LegacySkills: React.FC<Props> = ({ onBack, onClose }) => {
+export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
   const { t } = useAppTranslation();
   const BADGES = getObjectEntries(LEGACY_SKILL_TREE);
   const [selectedSkill, setSelectedSkill] = useState(BADGES[0]);
@@ -25,7 +25,7 @@ export const LegacySkills: React.FC<Props> = ({ onBack, onClose }) => {
   const { buff } = legacySkillDetails;
   return (
     <CloseButtonPanel
-      tabs={[{ icon: SUNNYSIDE.badges.seedSpecialist, name: "Legacy Skills" }]}
+      tabs={[{ icon: SUNNYSIDE.badges.seedSpecialist, name: "Legacy Badges" }]}
       container={OuterPanel}
       onClose={onClose}
     >
@@ -96,7 +96,7 @@ export const LegacySkills: React.FC<Props> = ({ onBack, onClose }) => {
                 }}
                 onClick={onBack}
               />
-              <Label type="default">{`Legacy Skills`}</Label>
+              <Label type="default">{`Legacy Badges`}</Label>
             </div>
             {/* Skills */}
             <div className="flex flex-row flex-wrap gap-0">

--- a/src/features/bumpkins/components/LegacyBadges.tsx
+++ b/src/features/bumpkins/components/LegacyBadges.tsx
@@ -30,8 +30,6 @@ export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
       onClose={onClose}
     >
       <SplitScreenView
-        tallDesktopContent
-        tallMobileContent
         wideModal
         panel={
           <div className="flex flex-col h-full justify-between">

--- a/src/features/bumpkins/components/LegacyBadges.tsx
+++ b/src/features/bumpkins/components/LegacyBadges.tsx
@@ -21,7 +21,7 @@ export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
   const { t } = useAppTranslation();
   const BADGES = getObjectEntries(LEGACY_SKILL_TREE);
   const [selectedSkill, setSelectedSkill] = useState(BADGES[0]);
-  const [legacySkillName, legacySkillDetails] = selectedSkill;
+  const [LegacyBadgeName, legacySkillDetails] = selectedSkill;
   const { buff } = legacySkillDetails;
   return (
     <CloseButtonPanel
@@ -46,11 +46,11 @@ export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
               />
               <div className="sm:mt-2">
                 <SquareIcon
-                  icon={ITEM_DETAILS[legacySkillName].image}
+                  icon={ITEM_DETAILS[LegacyBadgeName].image}
                   width={14}
                 />
               </div>
-              <span className="sm:text-center">{legacySkillName}</span>
+              <span className="sm:text-center">{LegacyBadgeName}</span>
             </div>
             <div className="flex sm:flex-col flex-wrap gap-1 mt-2 ml-2 sm:ml-0 justify-start sm:justify-center items-start sm:items-center">
               {buff &&
@@ -104,7 +104,7 @@ export const LegacyBadges: React.FC<Props> = ({ onBack, onClose }) => {
                     key={skill}
                     image={ITEM_DETAILS[skill].image}
                     onClick={() => setSelectedSkill([skill, details])}
-                    isSelected={legacySkillName === skill}
+                    isSelected={LegacyBadgeName === skill}
                   />
                 );
               })}

--- a/src/features/bumpkins/components/LegacySkills.tsx
+++ b/src/features/bumpkins/components/LegacySkills.tsx
@@ -1,0 +1,119 @@
+import { SplitScreenView } from "components/ui/SplitScreenView";
+import { LEGACY_SKILL_TREE } from "features/game/types/skills";
+import React, { useState } from "react";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { Label } from "components/ui/Label";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { OuterPanel } from "components/ui/Panel";
+import { Box } from "components/ui/Box";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SquareIcon } from "components/ui/SquareIcon";
+import { getObjectEntries } from "features/game/expansion/lib/utils";
+
+interface Props {
+  onBack: () => void;
+  onClose: () => void;
+}
+
+export const LegacySkills: React.FC<Props> = ({ onBack, onClose }) => {
+  const { t } = useAppTranslation();
+  const BADGES = getObjectEntries(LEGACY_SKILL_TREE);
+  const [selectedSkill, setSelectedSkill] = useState(BADGES[0]);
+  const [legacySkillName, legacySkillDetails] = selectedSkill;
+  const { buff } = legacySkillDetails;
+  return (
+    <CloseButtonPanel
+      tabs={[{ icon: SUNNYSIDE.badges.seedSpecialist, name: "Legacy Skills" }]}
+      container={OuterPanel}
+      onClose={onClose}
+    >
+      <SplitScreenView
+        tallDesktopContent
+        tallMobileContent
+        wideModal
+        panel={
+          <div className="flex flex-col h-full justify-between">
+            <div className="flex gap-x-2 justify-start items-center sm:flex-col-reverse sm:py-0 py-2">
+              <img
+                src={SUNNYSIDE.icons.arrow_left}
+                className="cursor-pointer block sm:hidden"
+                alt="back"
+                style={{
+                  width: `${PIXEL_SCALE * 11}px`,
+                  marginRight: `${PIXEL_SCALE * 1}px`,
+                }}
+                onClick={onBack}
+              />
+              <div className="sm:mt-2">
+                <SquareIcon
+                  icon={ITEM_DETAILS[legacySkillName].image}
+                  width={14}
+                />
+              </div>
+              <span className="sm:text-center">{legacySkillName}</span>
+            </div>
+            <div className="flex sm:flex-col flex-wrap gap-1 mt-2 ml-2 sm:ml-0 justify-start sm:justify-center items-start sm:items-center">
+              {buff &&
+                buff.map(
+                  (
+                    {
+                      labelType,
+                      shortDescription,
+                      boostedItemIcon,
+                      boostTypeIcon,
+                    },
+                    index,
+                  ) => (
+                    <Label
+                      key={index}
+                      type={labelType}
+                      icon={boostTypeIcon}
+                      secondaryIcon={boostedItemIcon}
+                    >
+                      {shortDescription}
+                    </Label>
+                  ),
+                )}
+            </div>
+          </div>
+        }
+        content={
+          <div>
+            {/* Header */}
+            <div
+              className="flex flex-row my-2 items-center"
+              style={{ margin: `${PIXEL_SCALE * 2}px` }}
+            >
+              <img
+                src={SUNNYSIDE.icons.arrow_left}
+                className="cursor-pointer hidden sm:block"
+                alt="back"
+                style={{
+                  width: `${PIXEL_SCALE * 11}px`,
+                  marginRight: `${PIXEL_SCALE * 4}px`,
+                }}
+                onClick={onBack}
+              />
+              <Label type="default">{`Legacy Skills`}</Label>
+            </div>
+            {/* Skills */}
+            <div className="flex flex-row flex-wrap gap-0">
+              {BADGES.map(([skill, details]) => {
+                return (
+                  <Box
+                    key={skill}
+                    image={ITEM_DETAILS[skill].image}
+                    onClick={() => setSelectedSkill([skill, details])}
+                    isSelected={legacySkillName === skill}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        }
+      />
+    </CloseButtonPanel>
+  );
+};

--- a/src/features/bumpkins/components/SkillBadges.tsx
+++ b/src/features/bumpkins/components/SkillBadges.tsx
@@ -6,7 +6,7 @@ import {
   InventoryItemName,
 } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { SKILL_TREE } from "features/game/types/skills";
+import { LEGACY_SKILL_TREE } from "features/game/types/skills";
 import { setImageWidth } from "lib/images";
 import {
   BUMPKIN_SKILL_TREE,
@@ -21,7 +21,7 @@ export const SkillBadges: React.FC<{
     (skill) => skill as BumpkinSkillName,
   );
 
-  const BADGES: InventoryItemName[] = Object.keys(SKILL_TREE).map(
+  const BADGES: InventoryItemName[] = Object.keys(LEGACY_SKILL_TREE).map(
     (badge) => badge as InventoryItemName,
   );
 

--- a/src/features/bumpkins/components/SkillBadges.tsx
+++ b/src/features/bumpkins/components/SkillBadges.tsx
@@ -6,7 +6,7 @@ import {
   InventoryItemName,
 } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { LEGACY_SKILL_TREE } from "features/game/types/skills";
+import { LEGACY_BADGE_TREE } from "features/game/types/skills";
 import { setImageWidth } from "lib/images";
 import {
   BUMPKIN_SKILL_TREE,
@@ -21,7 +21,7 @@ export const SkillBadges: React.FC<{
     (skill) => skill as BumpkinSkillName,
   );
 
-  const BADGES: InventoryItemName[] = Object.keys(LEGACY_SKILL_TREE).map(
+  const BADGES: InventoryItemName[] = Object.keys(LEGACY_BADGE_TREE).map(
     (badge) => badge as InventoryItemName,
   );
 

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -7,7 +7,7 @@ import {
   InventoryItemName,
   Wardrobe,
 } from "../types/game";
-import { SKILL_TREE } from "../types/skills";
+import { LEGACY_SKILL_TREE } from "../types/skills";
 import { Announcements } from "../types/announcements";
 import { EXOTIC_CROPS } from "../types/beans";
 import { BASIC_DECORATIONS, BasicDecorationName } from "../types/decorations";
@@ -41,7 +41,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   ),
 
   // Max of 1 skill badge
-  ...(Object.keys(SKILL_TREE) as InventoryItemName[]).reduce(
+  ...(Object.keys(LEGACY_SKILL_TREE) as InventoryItemName[]).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(1),

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -10,12 +10,9 @@ import {
 import { LEGACY_SKILL_TREE } from "../types/skills";
 import { Announcements } from "../types/announcements";
 import { EXOTIC_CROPS } from "../types/beans";
-import { BASIC_DECORATIONS, BasicDecorationName } from "../types/decorations";
-import { FISH, FishName, MarineMarvelName } from "../types/fishing";
-import {
-  LANDSCAPING_DECORATIONS,
-  LandscapingDecorationName,
-} from "../types/decorations";
+import { BASIC_DECORATIONS } from "../types/decorations";
+import { FISH } from "../types/fishing";
+import { LANDSCAPING_DECORATIONS } from "../types/decorations";
 import { getActiveListedItems } from "features/island/hud/components/inventory/utils/inventory";
 import { KNOWN_IDS } from "../types";
 import { ANIMAL_FOODS } from "../types/animals";
@@ -23,7 +20,7 @@ import { BumpkinItem, ITEM_IDS } from "../types/bumpkin";
 import { MaxedItem } from "./gameMachine";
 
 export const MAX_INVENTORY_ITEMS: Inventory = {
-  ...(Object.keys(EXOTIC_CROPS) as InventoryItemName[]).reduce(
+  ...getKeys(EXOTIC_CROPS).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(50),
@@ -32,7 +29,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   ),
 
   // Max of 1000 food item
-  ...(Object.keys(FOODS()) as InventoryItemName[]).reduce(
+  ...getKeys(FOODS()).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(1000),
@@ -41,7 +38,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   ),
 
   // Max of 1 skill badge
-  ...(Object.keys(LEGACY_SKILL_TREE) as InventoryItemName[]).reduce(
+  ...getKeys(LEGACY_SKILL_TREE).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(1),
@@ -49,7 +46,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
     {},
   ),
 
-  ...(Object.keys(EXOTIC_CROPS) as InventoryItemName[]).reduce(
+  ...getKeys(EXOTIC_CROPS).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(50),
@@ -58,7 +55,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   ),
 
   // Max of 100 basic decoration
-  ...(Object.keys(BASIC_DECORATIONS()) as BasicDecorationName[]).reduce(
+  ...getKeys(BASIC_DECORATIONS()).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(100),
@@ -69,7 +66,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   "Basic Bear": new Decimal(1000),
 
   // Max of 100 fish
-  ...(Object.keys(FISH) as (FishName | MarineMarvelName)[]).reduce(
+  ...getKeys(FISH).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(100),
@@ -82,7 +79,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   "Red Snapper": new Decimal(200),
 
   // Max of 1000 landscaping decoration, but only 100 for mushrooms
-  ...(Object.keys(LANDSCAPING_DECORATIONS()) as LandscapingDecorationName[])
+  ...getKeys(LANDSCAPING_DECORATIONS())
     .filter(
       (name) => !LANDSCAPING_DECORATIONS()[name].ingredients["Wild Mushroom"],
     )
@@ -93,7 +90,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
       }),
       {},
     ),
-  ...(Object.keys(LANDSCAPING_DECORATIONS()) as LandscapingDecorationName[])
+  ...getKeys(LANDSCAPING_DECORATIONS())
     .filter(
       (name) => LANDSCAPING_DECORATIONS()[name].ingredients["Wild Mushroom"],
     )
@@ -105,7 +102,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
       {},
     ),
 
-  ...(Object.keys(ANIMAL_FOODS) as InventoryItemName[]).reduce(
+  ...getKeys(ANIMAL_FOODS).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(1500),

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -7,7 +7,7 @@ import {
   InventoryItemName,
   Wardrobe,
 } from "../types/game";
-import { LEGACY_SKILL_TREE } from "../types/skills";
+import { LEGACY_BADGE_TREE } from "../types/skills";
 import { Announcements } from "../types/announcements";
 import { EXOTIC_CROPS } from "../types/beans";
 import { BASIC_DECORATIONS } from "../types/decorations";
@@ -38,7 +38,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   ),
 
   // Max of 1 skill badge
-  ...getKeys(LEGACY_SKILL_TREE).reduce(
+  ...getKeys(LEGACY_BADGE_TREE).reduce(
     (acc, name) => ({
       ...acc,
       [name]: new Decimal(1),

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -10,7 +10,7 @@ import {
 
 import { CollectibleName, CraftableName, Food } from "./craftables";
 import { CommodityName, MushroomName, ResourceName } from "./resources";
-import { LegacySkillName } from "./skills";
+import { LegacyBadgeName } from "./skills";
 import { BuildingName } from "./buildings";
 import { GameEvent } from "../events";
 import { BumpkinItem, Equipped as BumpkinParts } from "./bumpkin";
@@ -441,7 +441,7 @@ export type InventoryItemName =
   | CraftableName
   | CommodityName
   | ResourceName
-  | LegacySkillName
+  | LegacyBadgeName
   | EasterEgg
   | EasterEventItemName
   | Food

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -10,7 +10,7 @@ import {
 
 import { CollectibleName, CraftableName, Food } from "./craftables";
 import { CommodityName, MushroomName, ResourceName } from "./resources";
-import { SkillName } from "./skills";
+import { LegacySkillName } from "./skills";
 import { BuildingName } from "./buildings";
 import { GameEvent } from "../events";
 import { BumpkinItem, Equipped as BumpkinParts } from "./bumpkin";
@@ -441,7 +441,7 @@ export type InventoryItemName =
   | CraftableName
   | CommodityName
   | ResourceName
-  | SkillName
+  | LegacySkillName
   | EasterEgg
   | EasterEventItemName
   | Food

--- a/src/features/game/types/skills.ts
+++ b/src/features/game/types/skills.ts
@@ -250,6 +250,11 @@ export function getLevel(experience: Decimal) {
     return 10;
   }
 
+  // Around 2 months farming
+  if (experience.gte(REQUIRED_XP.LEVEL_9)) {
+    return 9;
+  }
+
   // Around 6 weeks farming
   if (experience.gte(REQUIRED_XP.LEVEL_8)) {
     return 8;

--- a/src/features/game/types/skills.ts
+++ b/src/features/game/types/skills.ts
@@ -1,6 +1,10 @@
 import Decimal from "decimal.js-light";
+import { BuffLabel } from ".";
+import { SUNNYSIDE } from "assets/sunnyside";
+import powerup from "assets/icons/level_up.png";
+import { ITEM_DETAILS } from "./images";
 
-export type SkillName =
+export type LegacySkillName =
   | "Green Thumb"
   | "Barn Manager"
   | "Seed Specialist"
@@ -30,14 +34,15 @@ enum REQUIRED_XP {
   LEVEL_10 = 5000,
 }
 
-export const SKILL_TREE: Record<
-  SkillName,
+export const LEGACY_SKILL_TREE: Record<
+  LegacySkillName,
   {
     level: number;
     profession: Profession;
-    conflicts?: SkillName;
-    requires?: SkillName;
+    conflicts?: LegacySkillName;
+    requires?: LegacySkillName;
     perks: string[];
+    buff?: BuffLabel[];
   }
 > = {
   "Green Thumb": {
@@ -45,12 +50,36 @@ export const SKILL_TREE: Record<
     conflicts: "Barn Manager",
     profession: "farming",
     perks: ["Crops are worth 5% more", "Increase mutant crop chance"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+5% Crop sell price",
+        boostTypeIcon: powerup,
+      },
+      {
+        labelType: "vibrant",
+        shortDescription: "+10% Mutant crop chance",
+        boostTypeIcon: SUNNYSIDE.icons.lightning,
+      },
+    ],
   },
   "Barn Manager": {
     level: 5,
     conflicts: "Green Thumb",
     profession: "farming",
     perks: ["Animals yield 10% more goods", "Increase mutant animal chance"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+10% Animal produce",
+        boostTypeIcon: powerup,
+      },
+      {
+        labelType: "vibrant",
+        shortDescription: "+10% Mutant animal chance",
+        boostTypeIcon: SUNNYSIDE.icons.lightning,
+      },
+    ],
   },
   "Seed Specialist": {
     level: 10,
@@ -58,6 +87,18 @@ export const SKILL_TREE: Record<
     requires: "Green Thumb",
     profession: "farming",
     perks: ["Crops take 10% less time to grow", "Increase mutant crop chance"],
+    buff: [
+      {
+        labelType: "info",
+        shortDescription: "-10% Crop growth time",
+        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      },
+      {
+        labelType: "vibrant",
+        shortDescription: "+10% Mutant crop chance",
+        boostTypeIcon: SUNNYSIDE.icons.lightning,
+      },
+    ],
   },
   Wrangler: {
     level: 10,
@@ -68,18 +109,46 @@ export const SKILL_TREE: Record<
       "Animals take 10% less time to produce goods",
       "Increase mutant animal chance",
     ],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "-10% Animal sleep time",
+        boostTypeIcon: powerup,
+      },
+      {
+        labelType: "vibrant",
+        shortDescription: "+10% Mutant animal chance",
+        boostTypeIcon: SUNNYSIDE.icons.lightning,
+      },
+    ],
   },
   Lumberjack: {
     level: 5,
     conflicts: "Prospector",
     profession: "gathering",
     perks: ["Increase wood drops by 10%"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+10% Wood",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS.Wood.image,
+      },
+    ],
   },
   Prospector: {
     level: 5,
     conflicts: "Lumberjack",
     profession: "gathering",
     perks: ["Increase stone drops by 20%"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+20% Stone",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS.Stone.image,
+      },
+    ],
   },
   Logger: {
     level: 10,
@@ -87,6 +156,14 @@ export const SKILL_TREE: Record<
     conflicts: "Gold Rush",
     profession: "gathering",
     perks: ["Axes last 50% longer"],
+    buff: [
+      {
+        labelType: "vibrant",
+        shortDescription: "2x Axe durability",
+        boostTypeIcon: SUNNYSIDE.icons.lightning,
+        boostedItemIcon: ITEM_DETAILS.Axe.image,
+      },
+    ],
   },
   "Gold Rush": {
     level: 10,
@@ -94,26 +171,68 @@ export const SKILL_TREE: Record<
     conflicts: "Logger",
     profession: "gathering",
     perks: ["Increase gold drops by 50%"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+50% Gold",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS.Gold.image,
+      },
+    ],
   },
   Artist: {
     level: 1,
     profession: "contributor",
     perks: ["Save 10% on shop & blacksmith tools"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "-10% Seeds cost",
+        boostTypeIcon: powerup,
+      },
+      {
+        labelType: "success",
+        shortDescription: "-10% Tools cost",
+        boostTypeIcon: powerup,
+      },
+    ],
   },
   Coder: {
     level: 1,
     profession: "contributor",
     perks: ["Crops yield 20% more"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+20% Crop yield",
+        boostTypeIcon: powerup,
+      },
+    ],
   },
   "Discord Mod": {
     level: 1,
     profession: "contributor",
     perks: ["Yield 35% more wood"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "+35% Wood",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS.Wood.image,
+      },
+    ],
   },
   "Liquidity Provider": {
     level: 1,
     profession: "contributor",
     perks: ["50% reduced SFL withdrawal fee"],
+    buff: [
+      {
+        labelType: "success",
+        shortDescription: "-50% SFL withdrawal fee",
+        boostTypeIcon: powerup,
+      },
+    ],
   },
   Warrior: {
     level: 1,
@@ -129,11 +248,6 @@ export function getLevel(experience: Decimal) {
   // Around 3 months farming
   if (experience.gte(REQUIRED_XP.LEVEL_10)) {
     return 10;
-  }
-
-  // Around 2 months farming
-  if (experience.gte(REQUIRED_XP.LEVEL_9)) {
-    return 9;
   }
 
   // Around 6 weeks farming

--- a/src/features/game/types/skills.ts
+++ b/src/features/game/types/skills.ts
@@ -34,7 +34,7 @@ enum REQUIRED_XP {
   LEVEL_10 = 5000,
 }
 
-export const LEGACY_SKILL_TREE: Record<
+export const LEGACY_BADGE_TREE: Record<
   LegacyBadgeName,
   {
     level: number;

--- a/src/features/game/types/skills.ts
+++ b/src/features/game/types/skills.ts
@@ -4,7 +4,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import powerup from "assets/icons/level_up.png";
 import { ITEM_DETAILS } from "./images";
 
-export type LegacySkillName =
+export type LegacyBadgeName =
   | "Green Thumb"
   | "Barn Manager"
   | "Seed Specialist"
@@ -35,12 +35,12 @@ enum REQUIRED_XP {
 }
 
 export const LEGACY_SKILL_TREE: Record<
-  LegacySkillName,
+  LegacyBadgeName,
   {
     level: number;
     profession: Profession;
-    conflicts?: LegacySkillName;
-    requires?: LegacySkillName;
+    conflicts?: LegacyBadgeName;
+    requires?: LegacyBadgeName;
     perks: string[];
     buff?: BuffLabel[];
   }


### PR DESCRIPTION
# Description

Add a section in profile if player has legacy badges, opens up a modal and tells player the details of their legacy skill
This section only appears if player has at least 1 legacy badge
![image](https://github.com/user-attachments/assets/b22a9b58-2b42-480c-bece-6cada001bb3d)
![image](https://github.com/user-attachments/assets/161c1a00-942c-48b7-97da-93b127689754)


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
