### PR TITLE
[FIX] Prevent speeding up expansions on unsupported islands

### DIFF
--- a/src/features/game/events/landExpansion/speedUpExpansion.test.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.test.ts
@@ -94,4 +94,22 @@ describe("instantExpand", () => {
 
     expect(state.expansionConstruction?.readyAt).toEqual(now);
   });
+  it("cannot speed up expansion on desert island", () => {
+    expect(() =>
+      speedUpExpansion({
+        action: { type: "expansion.spedUp" },
+        state: {
+          ...INITIAL_FARM,
+          island: {
+            ...INITIAL_FARM.island,
+            type: "desert",
+          },
+          expansionConstruction: {
+            createdAt: 0,
+            readyAt: Date.now() + 1000,
+          },
+        },
+      }),
+    ).toThrow("You can't speed up the expansion on this island");
+  });
 });

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -26,7 +26,7 @@ export function speedUpExpansion({
       throw new Error("Expansion not in progress");
     }
 
-    if (!hasRequiredIslandExpansion(game.island.type, "desert")) {
+    if (hasRequiredIslandExpansion(game.island.type, "desert")) {
       throw new Error("You can't speed up the expansion on this island");
     }
 

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -2,6 +2,7 @@ import { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import { getInstantGems, makeGemHistory } from "./speedUpRecipe";
 import Decimal from "decimal.js-light";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 
 export type InstantExpand = {
   type: "expansion.spedUp";
@@ -23,6 +24,10 @@ export function speedUpExpansion({
 
     if (!expansion) {
       throw new Error("Expansion not in progress");
+    }
+
+    if (!hasRequiredIslandExpansion(game.island.type, "desert")) {
+      throw new Error("You can't speed up the expansion on this island");
     }
 
     if (expansion.readyAt <= createdAt) {


### PR DESCRIPTION
# Description

Adding protections at function level for gems speeding up above desert island

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
