### PR TITLE
[FIX] useCountdown infinite render loop

### DIFF
--- a/src/lib/utils/hooks/useCountdown.ts
+++ b/src/lib/utils/hooks/useCountdown.ts
@@ -12,22 +12,24 @@ export const getReturnValues = (timeLeft: number) => {
   return { days, hours, minutes, seconds };
 };
 
-export const useCountdown = (targetDate: number) => {
-  const timeRemaining = Math.max(targetDate - Date.now(), 0);
+const getTimeRemaining = (targetDate: number) => {
+  return Math.max(targetDate - Date.now(), 0);
+};
 
-  const [countDown, setCountDown] = useState<number>(timeRemaining);
+export const useCountdown = (targetDate: number) => {
+  const [countDown, setCountDown] = useState<number>(
+    getTimeRemaining(targetDate),
+  );
 
   useEffect(() => {
+    setCountDown(getTimeRemaining(targetDate));
+
     const interval = setInterval(() => {
-      setCountDown(timeRemaining);
+      setCountDown(getTimeRemaining(targetDate));
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [timeRemaining]);
-
-  useEffect(() => {
-    setCountDown(timeRemaining);
-  }, [timeRemaining]);
+  }, [targetDate]);
 
   return getReturnValues(countDown);
 };


### PR DESCRIPTION
# Description

There is a circular dependency, between two useEffects in `useCountdown`. Causing them to call each other ad nasuem.

This is breaking mobile devices when opening the `ChoreBoard.tsx`.

# What needs to be tested by the reviewer?

1. Open `main`
2. View performance on ChoreBoard.tsx using `react-scan` react profile or web dev tools.
3. Checkout this PR
4. Check performance again

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]