### PR TITLE
[FEAT] Add Inventory Counts For Fish/Flowers Codex

### DIFF
--- a/src/features/island/hud/components/codex/SimpleBox.tsx
+++ b/src/features/island/hud/components/codex/SimpleBox.tsx
@@ -4,6 +4,7 @@ import { pixelDarkBorderStyle } from "features/game/lib/style";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SquareIcon } from "components/ui/SquareIcon";
 import classNames from "classnames";
+import { Label } from "components/ui/Label";
 
 const INNER_CANVAS_WIDTH = 14;
 
@@ -11,6 +12,7 @@ export interface BoxProps {
   image: string;
   silhouette: boolean;
   className?: string;
+  inventoryCount?: number;
   onClick: () => void;
 }
 
@@ -19,6 +21,7 @@ export const SimpleBox: React.FC<BoxProps> = ({
   silhouette,
   className,
   children,
+  inventoryCount,
   onClick,
 }) => {
   return (
@@ -35,6 +38,18 @@ export const SimpleBox: React.FC<BoxProps> = ({
           ...pixelDarkBorderStyle,
         }}
       >
+        {inventoryCount && (
+          <Label
+            className="absolute z-10 -top-3 -right-3"
+            type="default"
+            style={{
+              padding: "0 2.5",
+              height: "24px",
+            }}
+          >
+            {inventoryCount}
+          </Label>
+        )}
         <div className="absolute flex justify-center items-center w-full h-full">
           <SquareIcon
             icon={image}

--- a/src/features/island/hud/components/codex/components/Milestone.tsx
+++ b/src/features/island/hud/components/codex/components/Milestone.tsx
@@ -50,7 +50,7 @@ export const MilestonePanel: React.FC<{
   ];
 
   return (
-    <InnerPanel>
+    <InnerPanel className="mx-2">
       <div
         className="flex items-center mt-1"
         style={{

--- a/src/features/island/hud/components/codex/components/Milestone.tsx
+++ b/src/features/island/hud/components/codex/components/Milestone.tsx
@@ -31,7 +31,9 @@ export const MilestonePanel: React.FC<{
 }> = ({ milestone, farmActivity, onClaim, onBack, isClaimed }) => {
   const { t } = useAppTranslation();
 
-  const percentageComplete = milestone.percentageComplete(farmActivity);
+  if (!milestone) return null;
+
+  const percentageComplete = milestone?.percentageComplete(farmActivity);
 
   // Currently only supporting one reward per milestone
   const reward = getKeys(milestone.reward)[0];

--- a/src/features/island/hud/components/codex/pages/Fish.tsx
+++ b/src/features/island/hud/components/codex/pages/Fish.tsx
@@ -9,7 +9,6 @@ import {
   FISH_MILESTONES,
   MILESTONES,
   MilestoneName,
-  getExperienceLevelForMilestones,
 } from "features/game/types/milestones";
 import { getFishByType } from "../lib/utils";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -24,6 +23,7 @@ import { ResizableBar } from "components/ui/ProgressBar";
 import { Context } from "features/game/GameProvider";
 import { SEASON_ICONS } from "features/island/buildings/components/building/market/SeasonalSeeds";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { ModalOverlay } from "components/ui/ModalOverlay";
 
 const FISH_BY_TYPE = getFishByType();
 
@@ -32,15 +32,8 @@ type Props = {
   state: GameState;
 };
 
-function getTotalFishCaught(farmActivity: GameState["farmActivity"]) {
-  return getKeys(FISH).reduce((total, fish) => {
-    return total + (farmActivity[`${fish} Caught`] ?? 0);
-  }, 0);
-}
-
 export const Fish: React.FC<Props> = ({ onMilestoneReached, state }) => {
   const { gameService } = useContext(Context);
-  const [expandedIndex, setExpandedIndex] = useState<number>();
   const [selectedFish, setSelectedFish] = useState<
     FishName | MarineMarvelName
   >();
@@ -50,35 +43,13 @@ export const Fish: React.FC<Props> = ({ onMilestoneReached, state }) => {
 
   const { farmActivity, milestones } = state;
 
-  const [caughtFishCount] = useState<number>(() =>
-    getTotalFishCaught(farmActivity),
-  );
-
-  const handleMilestoneExpand = (milestoneIndex: number) => {
-    if (expandedIndex === milestoneIndex) {
-      setExpandedIndex(undefined);
-    } else {
-      setExpandedIndex(milestoneIndex);
-    }
-  };
-
   const handleClaimReward = (milestone: MilestoneName) => {
     gameService.send("milestone.claimed", { milestone });
-    setExpandedIndex(undefined);
     onMilestoneReached(milestone);
     setSelectedMilestone(undefined);
   };
 
   const milestoneNames = getKeys(FISH_MILESTONES);
-  const unclaimedMilestones = milestoneNames.filter(
-    (milestone) => !milestones[milestone],
-  );
-  const claimedMilestoneCount =
-    milestoneNames.length - unclaimedMilestones.length;
-  const experienceLevel = getExperienceLevelForMilestones(
-    claimedMilestoneCount,
-    milestoneNames.length,
-  );
 
   if (selectedFish) {
     const hasCaught = (farmActivity[`${selectedFish} Caught`] ?? 0) > 0;
@@ -146,113 +117,114 @@ export const Fish: React.FC<Props> = ({ onMilestoneReached, state }) => {
     );
   }
 
-  if (selectedMilestone) {
-    return (
-      <MilestonePanel
-        milestone={MILESTONES[selectedMilestone]}
-        farmActivity={farmActivity}
-        onClaim={() => handleClaimReward(selectedMilestone)}
-        onBack={() => setSelectedMilestone(undefined)}
-        isClaimed={!!milestones[selectedMilestone]}
-      />
-    );
-  }
-
   return (
-    <div
-      className={classNames(
-        "flex flex-col h-full overflow-y-auto scrollable pr-1",
-      )}
-    >
-      <InnerPanel className="space-y-2 mt-1 mb-1">
-        <div className="flex flex-col space-y-2">
-          {/* Claimed Milestones */}
-          <div className="flex justify-between px-1.5">
-            <Label
-              icon={SUNNYSIDE.tools.fishing_rod}
-              type="default"
-            >{`Fishing`}</Label>
-            <MilestoneTracker
-              milestones={milestoneNames}
-              claimedMilestones={milestones}
-            />
-          </div>
+    <>
+      <div
+        className={classNames(
+          "flex flex-col h-full overflow-y-auto scrollable pr-1",
+        )}
+      >
+        <InnerPanel className="space-y-2 mt-1 mb-1">
+          <div className="flex flex-col space-y-2">
+            {/* Claimed Milestones */}
+            <div className="flex justify-between px-1.5">
+              <Label
+                icon={SUNNYSIDE.tools.fishing_rod}
+                type="default"
+              >{`Fishing`}</Label>
+              <MilestoneTracker
+                milestones={milestoneNames}
+                claimedMilestones={milestones}
+              />
+            </div>
 
-          <div className="px-1.5 py-2 flex overflow-x-auto scrollable">
-            {milestoneNames.map((name, index) => {
-              const milestone = MILESTONES[name];
-              const percentageComplete =
-                milestone.percentageComplete(farmActivity);
+            <div className="px-1.5 py-2 flex overflow-x-auto scrollable">
+              {milestoneNames.map((name) => {
+                const milestone = MILESTONES[name];
+                const percentageComplete =
+                  milestone.percentageComplete(farmActivity);
 
-              const claimed = milestones[name];
-              return (
-                <ButtonPanel
-                  key={name}
-                  style={{
-                    height: "80px",
-                    width: "100px",
-                    zIndex: 100 - index,
-                  }}
-                  className="flex mr-2 flex-col items-center justify-center relative"
-                  onClick={() => setSelectedMilestone(name)}
-                >
-                  <span
-                    className="text-xs text-center w-full"
-                    style={{
-                      textOverflow: "ellipsis",
-                      overflowX: "clip",
-                    }}
+                const claimed = milestones[name];
+                return (
+                  <ButtonPanel
+                    key={name}
+                    className="flex mr-2 flex-col items-center justify-center relative w-[100px] h-[80px] shrink-0"
+                    onClick={() => setSelectedMilestone(name)}
                   >
-                    {name}
-                  </span>
-                  <img
-                    src={claimed ? SUNNYSIDE.icons.confirm : giftIcon}
-                    className="h-6 absolute -top-4 -right-4"
-                  />
-                  <div
-                    className="absolute w-full left-0 right-0 flex justify-center"
-                    style={{ bottom: "-12px" }}
-                  >
-                    <ResizableBar
-                      percentage={percentageComplete}
-                      type="progress"
+                    <span
+                      className="text-xs text-center w-full"
+                      style={{
+                        textOverflow: "ellipsis",
+                        overflowX: "clip",
+                      }}
+                    >
+                      {name}
+                    </span>
+                    <img
+                      src={claimed ? SUNNYSIDE.icons.confirm : giftIcon}
+                      className="h-6 absolute -top-4 -right-4"
                     />
+                    <div
+                      className="absolute w-full left-0 right-0 flex justify-center"
+                      style={{ bottom: "-12px" }}
+                    >
+                      <ResizableBar
+                        percentage={percentageComplete}
+                        type="progress"
+                      />
+                    </div>
+                  </ButtonPanel>
+                );
+              })}
+            </div>
+          </div>
+        </InnerPanel>
+        <InnerPanel>
+          <div className="flex flex-col">
+            {getKeys(FISH_BY_TYPE).map((type) => {
+              const typeIcon = ITEM_DETAILS[FISH_BY_TYPE[type][0]].image;
+
+              return (
+                <div key={type} className="flex flex-col mb-2">
+                  <Label
+                    type="default"
+                    className="capitalize ml-3"
+                    icon={typeIcon}
+                  >
+                    {type !== "marine marvel"
+                      ? `${type} Fish`
+                      : "Marine Marvels"}
+                  </Label>
+                  <div className="flex flex-wrap">
+                    {FISH_BY_TYPE[type].map((name) => (
+                      <SimpleBox
+                        silhouette={!farmActivity[`${name} Caught`]}
+                        onClick={() => setSelectedFish(name)}
+                        key={name}
+                        inventoryCount={state.inventory[name]?.toNumber()}
+                        image={ITEM_DETAILS[name].image}
+                      />
+                    ))}
                   </div>
-                </ButtonPanel>
+                </div>
               );
             })}
           </div>
-        </div>
-      </InnerPanel>
-      <InnerPanel>
-        <div className="flex flex-col">
-          {getKeys(FISH_BY_TYPE).map((type) => {
-            const typeIcon = ITEM_DETAILS[FISH_BY_TYPE[type][0]].image;
-
-            return (
-              <div key={type} className="flex flex-col mb-2">
-                <Label
-                  type="default"
-                  className="capitalize ml-3"
-                  icon={typeIcon}
-                >
-                  {type !== "marine marvel" ? `${type} Fish` : "Marine Marvels"}
-                </Label>
-                <div className="flex flex-wrap">
-                  {FISH_BY_TYPE[type].map((name) => (
-                    <SimpleBox
-                      silhouette={!farmActivity[`${name} Caught`]}
-                      onClick={() => setSelectedFish(name)}
-                      key={name}
-                      image={ITEM_DETAILS[name].image}
-                    />
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </InnerPanel>
-    </div>
+        </InnerPanel>
+      </div>
+      <ModalOverlay
+        show={!!selectedMilestone}
+        className="z-auto"
+        onBackdropClick={() => setSelectedMilestone(undefined)}
+      >
+        <MilestonePanel
+          milestone={MILESTONES[selectedMilestone as MilestoneName]}
+          farmActivity={farmActivity}
+          onClaim={() => handleClaimReward(selectedMilestone as MilestoneName)}
+          onBack={() => setSelectedMilestone(undefined)}
+          isClaimed={!!milestones[selectedMilestone as MilestoneName]}
+        />
+      </ModalOverlay>
+    </>
   );
 };

--- a/src/features/island/hud/components/codex/pages/Flowers.tsx
+++ b/src/features/island/hud/components/codex/pages/Flowers.tsx
@@ -1,13 +1,9 @@
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { SimpleBox } from "../SimpleBox";
 import { Label } from "components/ui/Label";
 import { getKeys } from "features/game/types/craftables";
 import { ITEM_DETAILS } from "features/game/types/images";
-import {
-  FLOWER_MILESTONES,
-  MilestoneName,
-  getExperienceLevelForMilestones,
-} from "features/game/types/milestones";
+import { MilestoneName } from "features/game/types/milestones";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { GameState } from "features/game/types/game";
 import { FLOWERS, FlowerName } from "features/game/types/flowers";
@@ -16,7 +12,6 @@ import { Detail } from "../components/Detail";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { InnerPanel } from "components/ui/Panel";
 import classNames from "classnames";
-import { Context } from "features/game/GameProvider";
 
 const FLOWERS_BY_SEED = getFlowerBySeed();
 
@@ -31,44 +26,17 @@ function getTotalFlowersFound(farmActivity: GameState["farmActivity"]) {
   }, 0);
 }
 
-export const Flowers: React.FC<Props> = ({ onMilestoneReached, state }) => {
-  const { gameService } = useContext(Context);
-  const [expandedIndex, setExpandedIndex] = useState<number>();
+export const Flowers: React.FC<Props> = ({ state }) => {
   const [selectedFlower, setSelectedFlower] = useState<FlowerName>();
   const { t } = useAppTranslation();
 
-  const { farmActivity, milestones, flowers } = state;
+  const { farmActivity, flowers } = state;
   const { discovered } = flowers;
 
   const crossBreeds = (selectedFlower && discovered[selectedFlower]) ?? [];
 
   const [foundFlowersCount] = useState<number>(() =>
     getTotalFlowersFound(farmActivity),
-  );
-
-  const handleMilestoneExpand = (milestoneIndex: number) => {
-    if (expandedIndex === milestoneIndex) {
-      setExpandedIndex(undefined);
-    } else {
-      setExpandedIndex(milestoneIndex);
-    }
-  };
-
-  const handleClaimReward = (milestone: MilestoneName) => {
-    gameService.send("milestone.claimed", { milestone });
-    setExpandedIndex(undefined);
-    onMilestoneReached(milestone);
-  };
-
-  const milestoneNames = getKeys(FLOWER_MILESTONES);
-  const unclaimedMilestones = milestoneNames.filter(
-    (milestone) => !milestones[milestone],
-  );
-  const claimedMilestoneCount =
-    milestoneNames.length - unclaimedMilestones.length;
-  const experienceLevel = getExperienceLevelForMilestones(
-    claimedMilestoneCount,
-    milestoneNames.length,
   );
 
   if (selectedFlower) {
@@ -122,28 +90,6 @@ export const Flowers: React.FC<Props> = ({ onMilestoneReached, state }) => {
           <Label type="formula" className="ml-1.5">
             {`${t("flowers.found")}: ${foundFlowersCount}`}
           </Label>
-          {/* Milestones disabled for spring bloom launch */}
-          {/* Claimed Milestones */}
-          {/* <div className="flex flex-wrap gap-1 px-1.5">
-            <MilestoneTracker
-              milestones={milestoneNames}
-              experienceLabelText={`${experienceLevel} Gardener`}
-              labelType="default"
-              labelIcon={SUNNYSIDE.icons.seedling}
-            />
-          </div>
-          <div className="space-y-1.5 px-1.5">
-            {unclaimedMilestones.map((milestone, index) => (
-              <MilestonePanel
-                key={milestone}
-                milestone={MILESTONES[milestone]}
-                isExpanded={expandedIndex === index}
-                farmActivity={farmActivity}
-                onClick={() => handleMilestoneExpand(index)}
-                onClaim={() => handleClaimReward(milestone)}
-              />
-            ))}
-          </div> */}
         </div>
         <div className="flex flex-col">
           {getKeys(FLOWERS_BY_SEED).map((type) => {
@@ -165,6 +111,7 @@ export const Flowers: React.FC<Props> = ({ onMilestoneReached, state }) => {
                         !farmActivity[`${name} Harvested`] &&
                         (discovered[name] ?? []).length < 1
                       }
+                      inventoryCount={state.inventory[name]?.toNumber()}
                       onClick={() => setSelectedFlower(name)}
                       key={name}
                       image={ITEM_DETAILS[name].image}


### PR DESCRIPTION
# Description

I have added inventory counts for Fish and Flowers inside of the codex screen. This is to help players plan better when viewing the codex. I have also refactored the milestone UI to use the Modal Overlay component.

<img width="772" alt="Screenshot 2025-02-10 at 3 44 08 PM" src="https://github.com/user-attachments/assets/67833020-77b3-4a9a-a1f7-4ad9b42abe11" />

<img width="288" alt="Screenshot 2025-02-10 at 3 46 11 PM" src="https://github.com/user-attachments/assets/18bfb974-a04f-4b69-aff1-a780ec7918b5" />

Fixes #[issue](https://discord.com/channels/880987707214544966/1338209047991812239/1338209047991812239)

# What needs to be tested by the reviewer?

- Check your inventory count is shown inside of codex for fish and flowers
- Open the milestones in Fish. All should work.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
