### PR TITLE
[FIX] Add back button when select crossbreed

### DIFF
--- a/src/features/island/flowers/FlowerBedContent.tsx
+++ b/src/features/island/flowers/FlowerBedContent.tsx
@@ -66,6 +66,12 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
     if (!seed) setSelecting("seed");
   };
 
+  const handleBack = () => {
+    setSelecting("seed");
+    setSeed(undefined);
+    setCrossBreed(undefined);
+  };
+
   const plant = () => {
     gameService.send({
       type: "flower.planted",
@@ -106,33 +112,53 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
   return (
     <>
       <div className="p-2">
-        {seed && crossbreed && (
-          <div className="flex items-center justify-center">
-            <img
-              src={
-                resultFlower
-                  ? ITEM_DETAILS[resultFlower].image
-                  : SUNNYSIDE.icons.search
-              }
-              className="h-4 mr-1"
-            />
-            <span className="text-xs">
-              {resultFlower ?? "Unknown combination"}
-            </span>
+        <div
+          className="flex items-center"
+          style={{ height: `${PIXEL_SCALE * 11}px` }}
+        >
+          {selecting === "crossbreed" && (
+            <div className="">
+              <img
+                src={SUNNYSIDE.icons.arrow_left}
+                className="cursor-pointer"
+                alt="back"
+                style={{
+                  width: `${PIXEL_SCALE * 11}px`,
+                  marginRight: `${PIXEL_SCALE * 4}px`,
+                }}
+                onClick={handleBack}
+              />
+            </div>
+          )}
+          <div className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap">
+            {seed && crossbreed && (
+              <div className="flex items-center justify-center">
+                <img
+                  src={
+                    resultFlower
+                      ? ITEM_DETAILS[resultFlower].image
+                      : SUNNYSIDE.icons.search
+                  }
+                  className="h-4 mr-1"
+                />
+                <span className="text-xs">
+                  {resultFlower ?? "Unknown combination"}
+                </span>
+              </div>
+            )}
+            {!(seed && crossbreed) && (
+              <div className="flex items-center justify-center">
+                <img
+                  src={SUNNYSIDE.icons.expression_confused}
+                  className="h-4 mr-1"
+                />
+                <span className="text-xs">
+                  {t("flowerBedContent.select.combination")}
+                </span>
+              </div>
+            )}
           </div>
-        )}
-        {!(seed && crossbreed) && (
-          <div className="flex items-center justify-center">
-            <img
-              src={SUNNYSIDE.icons.expression_confused}
-              className="h-4 mr-1"
-            />
-            <span className="text-xs">
-              {t("flowerBedContent.select.combination")}
-            </span>
-          </div>
-        )}
-
+        </div>
         <div
           className="relative mx-auto w-full mt-2"
           style={{


### PR DESCRIPTION
# Description

Add back button in the flower bed modal after selecting a flower seed, so you can go back and select a different seed.

**Before [large/small screen]**
<p>
<img src="https://github.com/user-attachments/assets/df4be2e7-a295-4f05-97e1-5a70eb10edaf" width="250"/>
<img src="https://github.com/user-attachments/assets/3310f456-1f25-456f-bea1-60a36ebddd25" width="250"/>
</p>

**After [large/small screen]**
<p>
<img src="https://github.com/user-attachments/assets/ec36ddc4-bb88-4539-b75f-70a963201cad" width="250"/>
<img src="https://github.com/user-attachments/assets/ed9c9eb1-dbde-41a7-abb4-42618fd2d0a8" width="250"/>
</p>


Fixes #issue

# What needs to be tested by the reviewer?

* Open flower bed
* Select seed
* Press back button and select a different seed

Please describe how this can be tested.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

