### PR TITLE
[FEAT] Cancel Queued Recipe

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -441,6 +441,10 @@ import {
   exchangeObsidian,
   ObsidianExchangedAction,
 } from "./landExpansion/exchangeObsidian";
+import {
+  cancelQueuedRecipe,
+  CancelQueuedRecipeAction,
+} from "./landExpansion/cancelQueuedRecipe";
 
 export type PlayingEvent =
   | ObsidianExchangedAction
@@ -578,6 +582,7 @@ export type PlayingEvent =
   | AcknowledgeCalendarEventAction
   | CollectLavaPitAction
   | StartLavaPitAction
+  | CancelQueuedRecipeAction
   // To remove once December is finished
   | CollectCandyAction;
 
@@ -647,6 +652,7 @@ type Handlers<T> = {
 };
 
 export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
+  "recipe.cancelled": cancelQueuedRecipe,
   "obsidian.exchanged": exchangeObsidian,
   "resource.bought": buyResource,
   "vip.purchased": purchaseVIP,

--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.test.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.test.ts
@@ -1,0 +1,293 @@
+import { INITIAL_FARM } from "features/game/lib/constants";
+import {
+  cancelQueuedRecipe,
+  getCurrentCookingItem,
+} from "./cancelQueuedRecipe";
+import { BuildingProduct, PlacedItem } from "features/game/types/game";
+import { CookableName } from "features/game/types/consumables";
+
+describe("cancelQueuedRecipe", () => {
+  it("throws an error if the building does not exist", () => {
+    expect(() =>
+      cancelQueuedRecipe({
+        state: INITIAL_FARM,
+        action: {
+          type: "recipe.cancelled",
+          buildingName: "Bakery",
+          buildingId: "1",
+          queueItem: {
+            name: "Carrot Cake",
+            readyAt: 0,
+            amount: 1,
+          },
+        },
+      }),
+    ).toThrow("Building does not exist");
+  });
+
+  it("throws an error if there is no queue", () => {
+    expect(() =>
+      cancelQueuedRecipe({
+        state: {
+          ...INITIAL_FARM,
+          buildings: {
+            Bakery: [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                readyAt: 0,
+                createdAt: 0,
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipe.cancelled",
+          buildingName: "Bakery",
+          buildingId: "1",
+          queueItem: {
+            name: "Carrot Cake",
+            readyAt: 0,
+            amount: 1,
+          },
+        },
+      }),
+    ).toThrow("No queue exists");
+  });
+
+  it("throws an error if no recipe exists at the index", () => {
+    expect(() =>
+      cancelQueuedRecipe({
+        state: {
+          ...INITIAL_FARM,
+          buildings: {
+            Bakery: [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                readyAt: 0,
+                createdAt: 0,
+                crafting: [
+                  {
+                    name: "Carrot Cake",
+                    readyAt: 0,
+                    amount: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipe.cancelled",
+          buildingName: "Bakery",
+          buildingId: "1",
+          queueItem: {
+            name: "Sunflower Cake",
+            readyAt: 1000,
+            amount: 1,
+          },
+        },
+      }),
+    ).toThrow("Recipe does not exist");
+  });
+
+  it("throws an error if the recipe is currently being cooked", () => {
+    const now = new Date("2025-01-01").getTime();
+    const carrotCakeReadyAt = now + 60 * 1000;
+    const queueItem = {
+      name: "Carrot Cake",
+      readyAt: carrotCakeReadyAt,
+      amount: 1,
+    } as BuildingProduct;
+
+    expect(() =>
+      cancelQueuedRecipe({
+        state: {
+          ...INITIAL_FARM,
+          buildings: {
+            Bakery: [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                readyAt: 0,
+                createdAt: 0,
+                crafting: [
+                  {
+                    name: "Cornbread",
+                    readyAt: now - 1000,
+                    amount: 1,
+                  },
+                  queueItem,
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipe.cancelled",
+          buildingName: "Bakery",
+          buildingId: "1",
+          queueItem,
+        },
+        createdAt: now,
+      }),
+    ).toThrow(
+      `Recipe ${queueItem.name} with readyAt ${carrotCakeReadyAt} is currently being cooked`,
+    );
+  });
+
+  it("cancels the recipe", () => {
+    const now = new Date("2025-01-01").getTime();
+    const carrotCakeReadyAt = now + 60 * 1000;
+    const queueItem = {
+      name: "Carrot Cake",
+      readyAt: carrotCakeReadyAt,
+      amount: 1,
+    } as BuildingProduct;
+
+    const state = cancelQueuedRecipe({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          Bakery: [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+              crafting: [
+                {
+                  name: "Honey Cake",
+                  readyAt: now - 1000,
+                  amount: 1,
+                },
+                {
+                  name: "Cornbread",
+                  readyAt: now + 1000,
+                  amount: 1,
+                },
+                {
+                  name: "Carrot Cake",
+                  readyAt: carrotCakeReadyAt,
+                  amount: 1,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cancelled",
+        buildingName: "Bakery",
+        buildingId: "1",
+        queueItem,
+      },
+      createdAt: now,
+    });
+
+    expect(state.buildings?.Bakery?.[0]?.crafting).toEqual([
+      {
+        name: "Honey Cake",
+        readyAt: now - 1000,
+        amount: 1,
+      },
+      {
+        name: "Cornbread",
+        readyAt: now + 1000,
+        amount: 1,
+      },
+    ]);
+  });
+
+  it("increments the cancelled count for recipe", () => {
+    const now = new Date("2025-01-01").getTime();
+    const carrotCakeReadyAt = now + 60 * 1000;
+    const queueItem = {
+      name: "Carrot Cake",
+      readyAt: carrotCakeReadyAt,
+      amount: 1,
+    } as BuildingProduct;
+
+    const state = cancelQueuedRecipe({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          Bakery: [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+              crafting: [
+                {
+                  name: "Cornbread",
+                  readyAt: now + 1000,
+                  amount: 1,
+                },
+                queueItem,
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cancelled",
+        buildingName: "Bakery",
+        buildingId: "1",
+        queueItem,
+      },
+      createdAt: now,
+    });
+
+    expect(state.buildings?.Bakery?.[0]?.cancelled).toEqual({
+      "Carrot Cake": {
+        count: 1,
+        cancelledAt: now,
+      },
+    });
+  });
+});
+
+describe("getCurrentCookingItem", () => {
+  it("returns the current cooking item", () => {
+    const now = new Date("2025-01-01").getTime();
+    const cornbreadReadyAt = now - 1000;
+    const carrotCakeOneReadyAt = now + 60 * 1000;
+    const carrotCakeTwoReadyAt = now + 120 * 1000;
+
+    const building: PlacedItem = {
+      id: "1",
+      coordinates: { x: 0, y: 0 },
+      readyAt: 0,
+      createdAt: 0,
+      crafting: [
+        {
+          name: "Cornbread" as CookableName,
+          readyAt: cornbreadReadyAt,
+          amount: 1,
+        },
+        {
+          name: "Carrot Cake" as CookableName,
+          readyAt: carrotCakeOneReadyAt,
+          amount: 1,
+        },
+        {
+          name: "Carrot Cake" as CookableName,
+          readyAt: carrotCakeTwoReadyAt,
+          amount: 1,
+        },
+      ],
+    };
+    const item = getCurrentCookingItem({
+      building,
+      createdAt: now,
+    });
+
+    expect(item).toEqual({
+      name: "Carrot Cake",
+      readyAt: carrotCakeOneReadyAt,
+      amount: 1,
+    });
+  });
+});

--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
@@ -1,0 +1,96 @@
+import { BuildingName } from "features/game/types/buildings";
+import {
+  BuildingProduct,
+  Cancelled,
+  GameState,
+  PlacedItem,
+} from "features/game/types/game";
+import { produce } from "immer";
+
+export type CancelQueuedRecipeAction = {
+  type: "recipe.cancelled";
+  buildingName: BuildingName;
+  buildingId: string;
+  queueItem: BuildingProduct;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: CancelQueuedRecipeAction;
+  createdAt?: number;
+};
+
+export function getCurrentCookingItem({
+  building,
+  createdAt,
+}: {
+  building: PlacedItem;
+  createdAt: number;
+}) {
+  const queue = building.crafting;
+  const sortedByReadyAt = queue?.sort(
+    (a: BuildingProduct, b: BuildingProduct) => a.readyAt - b.readyAt,
+  );
+
+  if (!queue) return;
+
+  const cooking = sortedByReadyAt?.find((recipe) => recipe.readyAt > createdAt);
+
+  return cooking;
+}
+
+export function cancelQueuedRecipe({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options) {
+  return produce(state, (game) => {
+    const { queueItem, buildingName, buildingId } = action;
+    const buildings = game.buildings[buildingName];
+    const building = buildings?.find((b) => b.id === buildingId);
+
+    if (!building) {
+      throw new Error("Building does not exist");
+    }
+
+    const queue = building.crafting;
+
+    if (!queue) {
+      throw new Error("No queue exists");
+    }
+
+    const recipe = queue.find(
+      (r) => JSON.stringify(r) === JSON.stringify(queueItem),
+    );
+
+    if (!recipe) {
+      throw new Error("Recipe does not exist");
+    }
+
+    const currentCookingItem = getCurrentCookingItem({
+      building,
+      createdAt,
+    });
+
+    if (currentCookingItem?.readyAt === recipe.readyAt) {
+      throw new Error(
+        `Recipe ${queueItem.name} with readyAt ${recipe.readyAt} is currently being cooked`,
+      );
+    }
+
+    const newQueue = queue.filter((r) => r.readyAt !== recipe.readyAt);
+
+    building.crafting = newQueue;
+
+    const cancelled = building.cancelled || ({} as Cancelled);
+
+    cancelled[recipe.name] = {
+      count: (cancelled[recipe.name]?.count || 0) + 1,
+      cancelledAt: createdAt,
+    };
+
+    building.cancelled = cancelled;
+
+    return game;
+  });
+}

--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
@@ -80,6 +80,10 @@ export function cancelQueuedRecipe({
 
     const newQueue = queue.filter((r) => r.readyAt !== recipe.readyAt);
 
+    if (recipe.boost?.Oil) {
+      building.oil = (building.oil ?? 0) + recipe.boost.Oil;
+    }
+
     building.crafting = newQueue;
 
     const cancelled = building.cancelled || ({} as Cancelled);

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -22,6 +22,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     expiresAt: Date.now() + 31 * 24 * 60 * 60 * 1000,
   },
   inventory: {
+    "Golden Sheep": new Decimal(1),
     Potato: new Decimal(100),
     Rhubarb: new Decimal(100),
     "Sunpetal Seed": new Decimal(1),
@@ -351,6 +352,17 @@ export const STATIC_OFFLINE_FARM: GameState = {
   chickens: {},
   trades: {},
   buildings: {
+    Barn: [
+      {
+        id: "123",
+        readyAt: 0,
+        coordinates: {
+          x: -1,
+          y: -8,
+        },
+        createdAt: 0,
+      },
+    ],
     Mansion: [
       {
         id: "123",

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -452,17 +452,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
         createdAt: 0,
       },
     ],
-    Barn: [
-      {
-        id: "123",
-        readyAt: 0,
-        coordinates: {
-          x: 5,
-          y: -2,
-        },
-        createdAt: 0,
-      },
-    ],
   },
   crops: {
     "1": {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -623,11 +623,19 @@ export type BuildingProduce = {
   readyAt: number;
 };
 
+export type Cancelled = {
+  [key in InventoryItemName]: {
+    count: number;
+    cancelledAt: number;
+  };
+};
+
 export type PlacedItem = {
   id: string;
   coordinates: { x: number; y: number };
   readyAt: number;
   createdAt: number;
+  cancelled?: Cancelled;
   crafting?: BuildingProduct[];
   oil?: number;
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -623,12 +623,12 @@ export type BuildingProduce = {
   readyAt: number;
 };
 
-export type Cancelled = {
+export type Cancelled = Partial<{
   [key in InventoryItemName]: {
     count: number;
     cancelledAt: number;
   };
-};
+}>;
 
 export type PlacedItem = {
   id: string;

--- a/src/features/island/buildings/components/building/Queue.tsx
+++ b/src/features/island/buildings/components/building/Queue.tsx
@@ -11,11 +11,14 @@ import { useSelector } from "@xstate/react";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { BuildingProduct } from "features/game/types/game";
 import { VIPAccess } from "features/game/components/VipAccess";
+import { BuildingName } from "features/game/types/buildings";
 
 type Props = {
   cooking?: BuildingProduct;
   readyRecipes: BuildingProduct[];
   queue: BuildingProduct[];
+  buildingName: BuildingName;
+  buildingId: string;
   onClose: () => void;
 };
 
@@ -24,6 +27,8 @@ const _state = (state: MachineState) => state.context.state;
 export const Queue: React.FC<Props> = ({
   cooking,
   queue,
+  buildingName,
+  buildingId,
   readyRecipes,
   onClose,
 }) => {
@@ -55,16 +60,14 @@ export const Queue: React.FC<Props> = ({
         {Array(cooking ? 3 : 4)
           .fill(null)
           .map((_, index) => {
-            const isVIP = hasVipAccess({ game: state });
-            const availableSlots = isVIP ? 4 : cooking ? 0 : 1;
-
             const displayItems = [...queue, ...readyRecipes];
 
             return (
               <QueueSlot
                 key={`slot-${index}`}
+                buildingName={buildingName}
+                buildingId={buildingId}
                 item={displayItems[index]}
-                isLocked={!isVIP && index >= availableSlots}
                 readyRecipes={readyRecipes}
               />
             );

--- a/src/features/island/buildings/components/building/QueueSlot.tsx
+++ b/src/features/island/buildings/components/building/QueueSlot.tsx
@@ -1,32 +1,32 @@
-import React from "react";
+import React, { useContext, useState } from "react";
 import { BuildingProduct } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { Box } from "components/ui/Box";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { ModalOverlay } from "components/ui/ModalOverlay";
+import { useTranslation } from "react-i18next";
+import { Button } from "components/ui/Button";
+import { Context } from "features/game/GameProvider";
+import { BuildingName } from "features/game/types/buildings";
+import { Panel } from "components/ui/Panel";
 
 interface QueueSlotProps {
+  buildingName: BuildingName;
+  buildingId: string;
   item?: BuildingProduct;
   isLocked?: boolean;
   readyRecipes: BuildingProduct[];
 }
 
 export const QueueSlot: React.FC<QueueSlotProps> = ({
+  buildingName,
+  buildingId,
   item,
-  isLocked,
   readyRecipes,
 }) => {
-  if (isLocked) {
-    return (
-      <Box
-        showOverlay={true}
-        overlayIcon={
-          <div className="flex justify-center items-center">
-            <img src={SUNNYSIDE.icons.lock} alt="locked slot" className="w-5" />
-          </div>
-        }
-      />
-    );
-  }
+  const { gameService } = useContext(Context);
+  const { t } = useTranslation();
+  const [showConfirm, setShowConfirm] = useState(false);
 
   if (!item) return <Box />;
 
@@ -34,15 +34,57 @@ export const QueueSlot: React.FC<QueueSlotProps> = ({
     (recipe) => recipe.name === item.name && recipe.readyAt === item.readyAt,
   );
 
+  const handleCancel = () => {
+    gameService.send("recipe.cancelled", {
+      buildingName,
+      buildingId,
+      queueItem: item,
+    });
+  };
+
   return (
-    <div className="relative">
-      {isReady && (
-        <img
-          className="absolute top-1 right-1 w-4 z-10"
-          src={SUNNYSIDE.icons.confirm}
-        />
-      )}
-      <Box image={ITEM_DETAILS[item.name].image} />
-    </div>
+    <>
+      <div className="relative">
+        {isReady && (
+          <img
+            className="absolute top-1 right-1 w-4 z-10"
+            src={SUNNYSIDE.icons.confirm}
+          />
+        )}
+        {!isReady && (
+          <img
+            className="absolute top-1 right-1 w-4 z-10"
+            src={SUNNYSIDE.icons.cancel}
+          />
+        )}
+        <div
+          className={!isReady ? "cursor-pointer" : ""}
+          onClick={!isReady ? () => setShowConfirm(true) : undefined}
+        >
+          <Box image={ITEM_DETAILS[item.name].image} />
+        </div>
+      </div>
+      <ModalOverlay
+        show={showConfirm}
+        onBackdropClick={() => setShowConfirm(false)}
+      >
+        <Panel>
+          <p className="p-1.5 mb-1.5">
+            {t("recipes.confirmCancel", { recipe: item.name })}
+          </p>
+          <div className="flex space-x-1 justify-end">
+            <Button onClick={() => setShowConfirm(false)}>{t("cancel")}</Button>
+            <Button
+              onClick={() => {
+                setShowConfirm(false);
+                handleCancel();
+              }}
+            >
+              {t("confirm")}
+            </Button>
+          </div>
+        </Panel>
+      </ModalOverlay>
+    </>
   );
 };

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -223,6 +223,8 @@ export const Recipes: React.FC<Props> = ({
 
             {cooking && isVIP && (
               <Queue
+                buildingName={buildingName}
+                buildingId={buildingId as string}
                 cooking={cooking}
                 queue={queue}
                 readyRecipes={readyRecipes}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5485,6 +5485,7 @@
   "recipes.upNext": "Up Next",
   "recipes.addToQueue": "Add to queue",
   "recipes.queue": "Queue",
+  "recipes.confirmCancel": "Are you sure you want to remove this {{recipe}} from the queue?",
   "recipes.vipCookingQueue": "Become a VIP member and unlock the ability to cook up to 4 recipes at once! Upgrade now to supercharge your cooking.",
   "recipes.confirmAddToQueue": "Are you sure you want to add {{recipe}} to the queue?",
   "whatsOn.ticketsEnd": "No more timeshards",


### PR DESCRIPTION
# Description

This PR adds the functionality to be able to cancel a queued recipe.

<img width="500" alt="Screenshot 2025-02-12 at 3 35 32 PM" src="https://github.com/user-attachments/assets/c2a7cba0-a385-469f-9439-f202bb9c2ae6" />
<img width="450" alt="Screenshot 2025-02-12 at 3 35 39 PM" src="https://github.com/user-attachments/assets/7ab64566-faeb-40b7-a697-22a4b3b4abb9" />


Fixes #issue

# What needs to be tested by the reviewer?

- Add recipe to the queue
- Cancel item

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
