### PR TITLE
[FIX] Buildings not be able to be removed

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -487,9 +487,13 @@ export function isCookingBuildingWorking(
   buildingName: CookingBuildingName,
   game: GameState,
 ): Restriction {
-  const isBuildingCooking = !!game.buildings[buildingName]?.some(
-    (building) => !!building.crafting,
-  );
+  const isBuildingCooking = !!game.buildings[buildingName]?.some((building) => {
+    if (building.crafting) {
+      return building.crafting.length > 0;
+    }
+
+    return false;
+  });
 
   return [isBuildingCooking, "Building is in use"];
 }


### PR DESCRIPTION
# Description

Fixes an issue where buildings were blocked from being removed. Now buildings can be removed if they aren't cooking anything.

<img width="308" alt="Screenshot 2025-02-13 at 2 27 58 PM" src="https://github.com/user-attachments/assets/c9b15ded-6e95-453a-ab60-6916cce514e4" />


Fixes #issue

# What needs to be tested by the reviewer?

- Cook something and collect
- Remove building
- Confirm it works

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
