### PR TITLE
[FIX] Remaining Queue Ready Times

### DIFF
--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.test.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.test.ts
@@ -4,9 +4,8 @@ import {
   getCurrentCookingItem,
 } from "./cancelQueuedRecipe";
 import { BuildingProduct, PlacedItem } from "features/game/types/game";
-import { CookableName } from "features/game/types/consumables";
+import { CookableName, COOKABLES } from "features/game/types/consumables";
 import { getOilConsumption } from "./cook";
-import Decimal from "decimal.js-light";
 
 describe("cancelQueuedRecipe", () => {
   it("throws an error if the building does not exist", () => {
@@ -202,51 +201,6 @@ describe("cancelQueuedRecipe", () => {
     ]);
   });
 
-  it("returns resources consumed by the recipe", () => {
-    const now = new Date("2025-01-01").getTime();
-    const carrotCakeReadyAt = now + 60 * 1000;
-    const queueItem = {
-      name: "Carrot Cake",
-      readyAt: carrotCakeReadyAt,
-      amount: 1,
-    } as BuildingProduct;
-
-    const state = cancelQueuedRecipe({
-      state: {
-        ...INITIAL_FARM,
-        buildings: {
-          Bakery: [
-            {
-              id: "1",
-              coordinates: { x: 0, y: 0 },
-              readyAt: 0,
-              createdAt: 0,
-              crafting: [
-                {
-                  name: "Cornbread",
-                  readyAt: now + 1000,
-                  amount: 1,
-                },
-                queueItem,
-              ],
-            },
-          ],
-        },
-      },
-      action: {
-        type: "recipe.cancelled",
-        buildingName: "Bakery",
-        buildingId: "1",
-        queueItem,
-      },
-      createdAt: now,
-    });
-
-    expect(state.inventory.Egg).toEqual(new Decimal(30));
-    expect(state.inventory.Wheat).toEqual(new Decimal(10));
-    expect(state.inventory.Carrot).toEqual(new Decimal(120));
-  });
-
   it("returns the oil consumed by the queued recipe", () => {
     const now = new Date("2025-01-01").getTime();
     const itemName = "Carrot Cake" as CookableName;
@@ -345,6 +299,74 @@ describe("cancelQueuedRecipe", () => {
         count: 1,
         cancelledAt: now,
       },
+    });
+  });
+
+  it("adjusts the readyAt times for the recipes still in the queue", () => {
+    const now = new Date("2025-01-01").getTime();
+    const totalCookingTime = COOKABLES["Mashed Potato"].cookingSeconds * 1000;
+    const mpReadyAt = now + totalCookingTime;
+    const mpOneReadyAt = mpReadyAt + totalCookingTime;
+    const mpTwoReadyAt = mpOneReadyAt + totalCookingTime;
+    const mpThreeReadyAt = mpTwoReadyAt + totalCookingTime;
+    const queueItem = {
+      name: "Mashed Potato",
+      readyAt: mpOneReadyAt,
+      amount: 1,
+    } as BuildingProduct;
+
+    const state = cancelQueuedRecipe({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Fire Pit": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+              crafting: [
+                {
+                  name: "Mashed Potato",
+                  readyAt: mpReadyAt,
+                  amount: 1,
+                },
+                queueItem,
+                {
+                  name: "Mashed Potato",
+                  readyAt: mpTwoReadyAt,
+                  amount: 1,
+                },
+                {
+                  name: "Mashed Potato",
+                  readyAt: mpThreeReadyAt,
+                  amount: 1,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cancelled",
+        buildingName: "Fire Pit",
+        buildingId: "1",
+        queueItem,
+      },
+      createdAt: now,
+    });
+
+    const building = state.buildings?.["Fire Pit"]?.[0];
+
+    expect(building?.crafting?.[1]).toEqual({
+      name: "Mashed Potato",
+      readyAt: mpTwoReadyAt - totalCookingTime,
+      amount: 1,
+    });
+    expect(building?.crafting?.[2]).toEqual({
+      name: "Mashed Potato",
+      readyAt: mpThreeReadyAt - totalCookingTime,
+      amount: 1,
     });
   });
 });

--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
@@ -126,14 +126,6 @@ export function cancelQueuedRecipe({
 
     building.cancelled = cancelled;
 
-    // console.log(
-    //   "New Queue:",
-    //   newQueue.map((item) => ({
-    //     ...item,
-    //     totalCookingTime: (item.readyAt - createdAt) / 1000, // Convert to seconds
-    //   })),
-    // );
-
     return game;
   });
 }

--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
@@ -98,11 +98,12 @@ export function cancelQueuedRecipe({
       game.inventory,
     );
 
+    const cancelledCookingTime =
+      recipe.readyAt - queue[recipeIndex - 1].readyAt;
+
     const newQueue = queue
       .map((r, index) => {
         if (index < recipeIndex) return r;
-
-        const cancelledCookingTime = r.readyAt - queue[index - 1].readyAt;
 
         return {
           ...r,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -22,6 +22,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     expiresAt: Date.now() + 31 * 24 * 60 * 60 * 1000,
   },
   inventory: {
+    Egg: new Decimal(100),
     Oil: new Decimal(50),
     "Golden Sheep": new Decimal(1),
     Potato: new Decimal(100),

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -22,6 +22,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     expiresAt: Date.now() + 31 * 24 * 60 * 60 * 1000,
   },
   inventory: {
+    Oil: new Decimal(50),
     "Golden Sheep": new Decimal(1),
     Potato: new Decimal(100),
     Rhubarb: new Decimal(100),


### PR DESCRIPTION
# Description

- Update the correct ready at times for the remaining queue items once a recipe is removed

Fixes #issue

# What needs to be tested by the reviewer?

- Add multiple mashed potatos to the queue
- Cancel the first in the queue
- Ensure the next one cooked has the correct cooking time

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
