### PR TITLE
[FIX] Temp Boosts For Queued Recipes

### DIFF
--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -102,6 +102,7 @@ export const getReadyAt = ({
     seconds: withOilBoost,
     item,
     game,
+    cookStartAt: createdAt,
   });
 
   return createdAt + seconds * 1000;

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -11,6 +11,7 @@ import {
 import { INITIAL_REWARDS } from "../types/rewards";
 import { Equipped } from "../types/bumpkin";
 import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
+import { EXPIRY_COOLDOWNS } from "./collectibleBuilt";
 
 export const STATIC_OFFLINE_FARM: GameState = {
   username: "Local Hero",
@@ -482,6 +483,20 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   collectibles: {
+    "Gourmet Hourglass": [
+      {
+        id: "1",
+        createdAt:
+          Date.now() -
+          (EXPIRY_COOLDOWNS["Gourmet Hourglass"] as number) +
+          30 * 60 * 1000,
+        coordinates: {
+          x: 3,
+          y: -5,
+        },
+        readyAt: 0,
+      },
+    ],
     Bale: [
       {
         id: "1",

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -90,15 +90,23 @@ export const Recipes: React.FC<Props> = ({
       amount.greaterThan(inventory[name as InventoryItemName] ?? 0),
     );
 
-  const latestRecipeCompletionTime = queue.sort(
-    (a, b) => b.readyAt - a.readyAt,
-  )[0].readyAt;
+  const getNewRecipeStartAt = () => {
+    let latestRecipeCompletionTime = cooking?.readyAt ?? Date.now();
+
+    if (queue.length > 0) {
+      latestRecipeCompletionTime = queue.sort(
+        (a, b) => b.readyAt - a.readyAt,
+      )[0]?.readyAt;
+    }
+
+    return latestRecipeCompletionTime;
+  };
 
   const cookingTime = getCookingTime({
     seconds: getCookingOilBoost(selected.name, state, buildingId).timeToCook,
     item: selected.name,
     game: state,
-    cookStartAt: latestRecipeCompletionTime,
+    cookStartAt: getNewRecipeStartAt(),
   });
 
   const cook = () => {

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -90,10 +90,15 @@ export const Recipes: React.FC<Props> = ({
       amount.greaterThan(inventory[name as InventoryItemName] ?? 0),
     );
 
+  const latestRecipeCompletionTime = queue.sort(
+    (a, b) => b.readyAt - a.readyAt,
+  )[0].readyAt;
+
   const cookingTime = getCookingTime({
     seconds: getCookingOilBoost(selected.name, state, buildingId).timeToCook,
     item: selected.name,
     game: state,
+    cookStartAt: latestRecipeCompletionTime,
   });
 
   const cook = () => {


### PR DESCRIPTION
# Description

Account for temp boost item expiry time when calculating cook time for queued item.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
