### PR TITLE
[FIX] Add Building Type to Bonus Animals Restriction Message

### DIFF
--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -480,7 +480,15 @@ function hasBonusAnimals(game: GameState, animalType: AnimalType): Restriction {
 
   const bonusAnimalCount = animalCount - baseCapacity;
 
-  return [bonusAnimalCount > 0, translate("restrictionReason.hasBonusAnimals")];
+  return [
+    bonusAnimalCount > 0,
+    translate("restrictionReason.hasBonusAnimals", {
+      building:
+        animalType === "Chicken"
+          ? translate("restrictionReason.hasBonusAnimals.henHouse")
+          : translate("restrictionReason.hasBonusAnimals.barn"),
+    }),
+  ];
 }
 
 export function isCookingBuildingWorking(

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3664,6 +3664,8 @@
   "worm.redWiggler": "An exotic worm that entices rare fish.",
   "restrictionReason.isGrowing": "{{item}} is growing",
   "restrictionReason.hasBonusAnimals": "Bonus animals in {{building}}",
+  "restrictionReason.hasBonusAnimals.barn": "barn",
+  "restrictionReason.hasBonusAnimals.henHouse": "hen house",
   "restrictionReason.beanPlanted": "Magic Bean is planted",
   "restrictionReason.cropsGrowing": "Crops are growing",
   "restrictionReason.?cropGrowing": "{{crop}} is growing",


### PR DESCRIPTION
# Description

Fixes the issue that bonus animals text shows {{building}} instead of the building type.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
