### PR TITLE
[FIX] Fruit patch quick select not working after buying seeds

### DIFF
--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -54,6 +54,18 @@ const HasAxes = (
   return (inventory.Axe ?? new Decimal(0)).gte(axesNeeded);
 };
 
+//Update inventory selector if player buys fruit seeds
+const HasFruitSeeds = (
+  inventory: Partial<Record<InventoryItemName, Decimal>>,
+) => {
+  return Object.fromEntries(
+    Object.keys(PATCH_FRUIT_SEEDS).map((seed) => [
+      seed,
+      inventory[seed as PatchFruitSeedName] ?? new Decimal(0),
+    ]),
+  );
+};
+
 const selectInventory = (state: MachineState) => state.context.state.inventory;
 const selectGame = (state: MachineState) => state.context.state;
 const compareFruit = (prev?: Patch, next?: Patch) =>
@@ -92,7 +104,10 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
   const inventory = useSelector(
     gameService,
     selectInventory,
-    (prev, next) => HasAxes(prev, game, fruit) === HasAxes(next, game, fruit),
+    (prev, next) =>
+      HasAxes(prev, game, fruit) === HasAxes(next, game, fruit) &&
+      JSON.stringify(HasFruitSeeds(prev)) ===
+        JSON.stringify(HasFruitSeeds(next)),
   );
   const island = useSelector(gameService, _island);
 


### PR DESCRIPTION
# Description

The fruit patch quick select currently makes it impossible to plant a seed if you had 0 in your inventory, then bought some at Betty, and tried again. The quick selector would get in the way of planting your newly bought seeds. This commit fixes the issue.

**Before (Cannot plant seed even if seed is already selected)**
![before](https://github.com/user-attachments/assets/e1938f37-8740-4c5b-9418-d16b892c9de0)

**After**
![after](https://github.com/user-attachments/assets/b02d7ff2-657c-4fb6-bf8e-cab1c2912f2e)

# What needs to be tested by the reviewer?

* Start with 0 of any kind of seed
* Buy seeds at Betty
* Plant those seeds normally and through quick select

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
