### PR TITLE
[CHORE] Use ClaimReward for RoninWelcomePack instead of AirdropModal

### DIFF
--- a/src/features/game/expansion/components/Airdrop.tsx
+++ b/src/features/game/expansion/components/Airdrop.tsx
@@ -14,7 +14,25 @@ export const AirdropModal: React.FC<{
   onClose?: () => void;
   onClaimed: () => void;
 }> = ({ airdrop, onClose, onClaimed }) => {
-  return <ClaimReward reward={airdrop} onClaim={onClaimed} onClose={onClose} />;
+  const { gameService } = useContext(Context);
+
+  const claim = () => {
+    gameService.send("airdrop.claimed", {
+      id: airdrop.id,
+    });
+
+    if (airdrop.items["Time Warp Totem"]) {
+      gameService.send("LANDSCAPE", {
+        placeable: "Time Warp Totem",
+        action: "collectible.placed",
+        location: "farm",
+      });
+    }
+
+    onClaimed();
+  };
+
+  return <ClaimReward reward={airdrop} onClaim={claim} onClose={onClose} />;
 };
 
 interface Props {
@@ -23,7 +41,6 @@ interface Props {
 export const Airdrop: React.FC<Props> = ({ airdrop }) => {
   const { showAnimations } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
-  const { gameService } = useContext(Context);
 
   return (
     <>
@@ -31,12 +48,7 @@ export const Airdrop: React.FC<Props> = ({ airdrop }) => {
         <CloseButtonPanel onClose={() => setShowModal(false)}>
           <AirdropModal
             airdrop={airdrop}
-            onClaimed={() => {
-              gameService.send("airdrop.claimed", {
-                id: airdrop.id,
-              });
-              setShowModal(false);
-            }}
+            onClaimed={() => setShowModal(false)}
           />
         </CloseButtonPanel>
       </Modal>
@@ -92,9 +104,6 @@ export const AirdropPopup: React.FC = () => {
     <AirdropModal
       airdrop={airdrop}
       onClaimed={() => {
-        gameService.send("airdrop.claimed", {
-          id: airdrop.id,
-        });
         gameService.send("CLOSE");
       }}
       onClose={() => {

--- a/src/features/game/expansion/components/Airdrop.tsx
+++ b/src/features/game/expansion/components/Airdrop.tsx
@@ -21,14 +21,6 @@ export const AirdropModal: React.FC<{
       id: airdrop.id,
     });
 
-    if (airdrop.items["Time Warp Totem"]) {
-      gameService.send("LANDSCAPE", {
-        placeable: "Time Warp Totem",
-        action: "collectible.placed",
-        location: "farm",
-      });
-    }
-
     onClaimed();
   };
 

--- a/src/features/game/expansion/components/RoninWelcomePack.tsx
+++ b/src/features/game/expansion/components/RoninWelcomePack.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { AirdropModal } from "./Airdrop";
 import { useGame } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { SpecialEventName } from "features/game/types/specialEvents";
 import { Airdrop } from "features/game/types/game";
+import { ClaimReward } from "./ClaimReward";
 
 const _specialEvents = (state: MachineState) =>
   state.context.state.specialEvents;
@@ -42,9 +42,9 @@ export const RoninWelcomePack: React.FC = () => {
   };
 
   return (
-    <AirdropModal
-      airdrop={roninAirdropDetails}
-      onClaimed={() => {
+    <ClaimReward
+      reward={roninAirdropDetails}
+      onClaim={() => {
         gameService.send("specialEvent.taskCompleted", {
           event: roninWelcomePack,
           task: 1,
@@ -52,6 +52,7 @@ export const RoninWelcomePack: React.FC = () => {
         gameService.send("CLOSE");
       }}
       onClose={() => gameService.send("CLOSE")}
+      label={roninWelcomePack}
     />
   );
 };

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -1267,14 +1267,24 @@ export const COLLECTIBLE_COMPONENTS: Record<
       alt="Scarab Beetle"
     />
   ),
-  "Basic Bed": (props: CollectibleProps) => <Bed name="Basic Bed" />,
-  "Fisher Bed": (props: CollectibleProps) => <Bed name="Fisher Bed" />,
-  "Floral Bed": (props: CollectibleProps) => <Bed name="Floral Bed" />,
-  "Sturdy Bed": (props: CollectibleProps) => <Bed name="Sturdy Bed" />,
-  "Desert Bed": (props: CollectibleProps) => <Bed name="Desert Bed" />,
-  "Cow Bed": (props: CollectibleProps) => <Bed name="Cow Bed" />,
-  "Pirate Bed": (props: CollectibleProps) => <Bed name="Pirate Bed" />,
-  "Royal Bed": (props: CollectibleProps) => <Bed name="Royal Bed" />,
+  "Basic Bed": (props: CollectibleProps) => <Bed {...props} name="Basic Bed" />,
+  "Fisher Bed": (props: CollectibleProps) => (
+    <Bed {...props} name="Fisher Bed" />
+  ),
+  "Floral Bed": (props: CollectibleProps) => (
+    <Bed {...props} name="Floral Bed" />
+  ),
+  "Sturdy Bed": (props: CollectibleProps) => (
+    <Bed {...props} name="Sturdy Bed" />
+  ),
+  "Desert Bed": (props: CollectibleProps) => (
+    <Bed {...props} name="Desert Bed" />
+  ),
+  "Cow Bed": (props: CollectibleProps) => <Bed {...props} name="Cow Bed" />,
+  "Pirate Bed": (props: CollectibleProps) => (
+    <Bed {...props} name="Pirate Bed" />
+  ),
+  "Royal Bed": (props: CollectibleProps) => <Bed {...props} name="Royal Bed" />,
   "Cow Scratcher": (props: CollectibleProps) => (
     <ImageStyle
       {...props}


### PR DESCRIPTION
# Description

This PR reverts a change that I did in #5278 where I refactored `AirdropModal` to use in `RoninWelcomePack`, but I realised I could use `ClaimReward` directly since it's the same component used in AirdropModal

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
