### PR TITLE
[FEAT] Ronin NFT VIP Access 👑 

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -449,6 +449,10 @@ import {
   speedUpUpgrade,
   SpeedUpUpgradeAction,
 } from "./landExpansion/speedUpUpgrade";
+import {
+  acknowledgeOnChainAirdrop,
+  AcknowledgeOnChainAirdropAction,
+} from "./landExpansion/acknowledgeOnChainAirdrop";
 
 export type PlayingEvent =
   | ObsidianExchangedAction
@@ -586,6 +590,7 @@ export type PlayingEvent =
   | CollectLavaPitAction
   | StartLavaPitAction
   | CancelQueuedRecipeAction
+  | AcknowledgeOnChainAirdropAction
   // To remove once December is finished
   | CollectCandyAction;
 
@@ -655,6 +660,7 @@ type Handlers<T> = {
 };
 
 export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
+  "onChainAirdrop.acknowledged": acknowledgeOnChainAirdrop,
   "recipe.cancelled": cancelQueuedRecipe,
   "obsidian.exchanged": exchangeObsidian,
   "resource.bought": buyResource,

--- a/src/features/game/events/landExpansion/acknowledgeOnChainAirdrop.test.ts
+++ b/src/features/game/events/landExpansion/acknowledgeOnChainAirdrop.test.ts
@@ -1,0 +1,40 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { GameState } from "features/game/types/game";
+import { acknowledgeOnChainAirdrop } from "./acknowledgeOnChainAirdrop";
+
+describe("acknowledgeOnChainAirdrop", () => {
+  it("throws an error if nft is found", () => {
+    expect(() =>
+      acknowledgeOnChainAirdrop({
+        state: TEST_FARM,
+        action: { type: "onChainAirdrop.acknowledged", chain: "ronin" },
+      }),
+    ).toThrow();
+  });
+
+  it("should set the nft as acknowledged", () => {
+    const state: GameState = {
+      ...TEST_FARM,
+      nfts: {
+        ronin: {
+          tokenId: 1,
+          name: "Ronin NFT",
+          expiresAt: Date.now() + 1000 * 60 * 60 * 24 * 30,
+        },
+      },
+    };
+
+    const acknowledgedAt = Date.now();
+
+    const newGame = acknowledgeOnChainAirdrop({
+      state,
+      action: {
+        type: "onChainAirdrop.acknowledged",
+        chain: "ronin",
+      },
+      createdAt: acknowledgedAt,
+    });
+
+    expect(newGame.nfts?.ronin?.acknowledgedAt).toBe(acknowledgedAt);
+  });
+});

--- a/src/features/game/events/landExpansion/acknowledgeOnChainAirdrop.ts
+++ b/src/features/game/events/landExpansion/acknowledgeOnChainAirdrop.ts
@@ -1,0 +1,31 @@
+import { Chain, GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+export type AcknowledgeOnChainAirdropAction = {
+  type: "onChainAirdrop.acknowledged";
+  chain: Chain;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: AcknowledgeOnChainAirdropAction;
+  createdAt?: number;
+};
+
+export function acknowledgeOnChainAirdrop({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (stateCopy) => {
+    const nft = stateCopy.nfts?.[action.chain];
+
+    if (!nft) {
+      throw new Error("NFT not found");
+    }
+
+    nft.acknowledgedAt = createdAt;
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/events/landExpansion/cook.test.ts
+++ b/src/features/game/events/landExpansion/cook.test.ts
@@ -1209,6 +1209,181 @@ describe("getCookingOilBoost", () => {
 
     expect(eggRecipe?.readyAt).toEqual(now + expectedTimeMs);
   });
+
+  it("applies the 50% cooking boost for valid Ronin NFTs", () => {
+    const now = Date.now();
+    const cookTimeMs = COOKABLES["Boiled Eggs"].cookingSeconds * 1000;
+
+    const state = cook({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Egg: new Decimal(100),
+        },
+        nfts: {
+          ronin: {
+            tokenId: 1,
+            name: "Sunflower Land Platinum Pass",
+            expiresAt: now + 31 * 24 * 60 * 60 * 1000,
+          },
+        },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cooked",
+        item: "Boiled Eggs",
+        buildingId: "1",
+      },
+      createdAt: now,
+    });
+
+    const building = state.buildings["Fire Pit"]?.[0];
+    const eggRecipe = building?.crafting?.find((r) => r.name === "Boiled Eggs");
+
+    expect(eggRecipe?.readyAt).toEqual(now + cookTimeMs * 0.5);
+  });
+
+  it("does not apply the 50% cooking boost for Bronze Season Pass (Ronin NFT)", () => {
+    const now = Date.now();
+    const cookTimeMs = COOKABLES["Boiled Eggs"].cookingSeconds * 1000;
+
+    const state = cook({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Egg: new Decimal(100),
+        },
+        nfts: {
+          ronin: {
+            tokenId: 1,
+            name: "Sunflower Land Bronze Pass",
+            expiresAt: now + 31 * 24 * 60 * 60 * 1000,
+          },
+        },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cooked",
+        item: "Boiled Eggs",
+        buildingId: "1",
+      },
+      createdAt: now,
+    });
+
+    const building = state.buildings["Fire Pit"]?.[0];
+    const eggRecipe = building?.crafting?.find((r) => r.name === "Boiled Eggs");
+
+    expect(eggRecipe?.readyAt).toEqual(now + cookTimeMs);
+  });
+
+  it("does not apply the 50% cooking boost to a queue item that starts after the Ronin NFT expires", () => {
+    const now = Date.now();
+    const cookTimeMs = COOKABLES["Boiled Eggs"].cookingSeconds * 1000;
+
+    const state = cook({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Egg: new Decimal(100),
+        },
+        nfts: {
+          ronin: {
+            tokenId: 1,
+            name: "Sunflower Land Platinum Pass",
+            expiresAt: now + cookTimeMs,
+          },
+        },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+              crafting: [
+                {
+                  name: "Boiled Eggs",
+                  readyAt: now + cookTimeMs,
+                  amount: 1,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cooked",
+        item: "Boiled Eggs",
+        buildingId: "1",
+      },
+      createdAt: now,
+    });
+
+    const building = state.buildings["Fire Pit"]?.[0];
+    const eggRecipe = building?.crafting?.find((r) => r.name === "Boiled Eggs");
+
+    expect(eggRecipe?.readyAt).toEqual(now + cookTimeMs);
+  });
+
+  it("does not apply the 50% cooking boost on an expired Ronin NFT", () => {
+    const now = Date.now();
+    const cookTimeMs = COOKABLES["Boiled Eggs"].cookingSeconds * 1000;
+
+    const state = cook({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          Egg: new Decimal(100),
+        },
+        nfts: {
+          ronin: {
+            tokenId: 1,
+            name: "Sunflower Land Platinum Pass",
+            expiresAt: now - cookTimeMs,
+          },
+        },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cooked",
+        item: "Boiled Eggs",
+        buildingId: "1",
+      },
+      createdAt: now,
+    });
+
+    const building = state.buildings["Fire Pit"]?.[0];
+    const eggRecipe = building?.crafting?.find((r) => r.name === "Boiled Eggs");
+
+    expect(eggRecipe?.readyAt).toEqual(now + cookTimeMs);
+  });
 });
 
 describe("getOilConsumption", () => {

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -79,6 +79,7 @@ import { SeasonChanged } from "./components/temperateSeason/SeasonChanged";
 import { CalendarEvent } from "./components/temperateSeason/CalendarEvent";
 import { DailyReset } from "../components/DailyReset";
 import { RoninWelcomePack } from "./components/RoninWelcomePack";
+import { ClaimRoninAirdrop } from "./components/onChainAirdrops/ClaimRoninAirdrop";
 
 function camelToDotCase(str: string): string {
   return str.replace(/([a-z])([A-Z])/g, "$1.$2").toLowerCase() as string;
@@ -151,6 +152,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   somethingArrived: true,
   seasonChanged: false,
   roninWelcomePack: true,
+  roninAirdrop: true,
 };
 
 // State change selectors
@@ -226,7 +228,7 @@ const isSeasonChanged = (state: MachineState) => state.matches("seasonChanged");
 const isCalendarEvent = (state: MachineState) => state.matches("calendarEvent");
 const isRoninWelcomePack = (state: MachineState) =>
   state.matches("roninWelcomePack");
-
+const isRoninAirdrop = (state: MachineState) => state.matches("roninAirdrop");
 const GameContent: React.FC = () => {
   const { gameService } = useContext(Context);
   useSound("desert", true);
@@ -392,6 +394,8 @@ export const GameWrapper: React.FC = ({ children }) => {
   const seasonChanged = useSelector(gameService, isSeasonChanged);
   const calendarEvent = useSelector(gameService, isCalendarEvent);
   const roninWelcomePack = useSelector(gameService, isRoninWelcomePack);
+  const roninAirdrop = useSelector(gameService, isRoninAirdrop);
+
   const showPWAInstallPrompt = useSelector(authService, _showPWAInstallPrompt);
 
   const { t } = useAppTranslation();
@@ -599,6 +603,7 @@ export const GameWrapper: React.FC = ({ children }) => {
             {hasSomethingArrived && <SomethingArrived />}
             {hasBBs && <Gems />}
             {roninWelcomePack && <RoninWelcomePack />}
+            {roninAirdrop && <ClaimRoninAirdrop />}
           </Panel>
         </Modal>
 
@@ -606,7 +611,6 @@ export const GameWrapper: React.FC = ({ children }) => {
         {refundAuction && <RefundAuction />}
         {seasonChanged && <SeasonChanged />}
         {calendarEvent && <CalendarEvent />}
-
         {competition && (
           <Modal show onHide={() => gameService.send("ACKNOWLEDGE")}>
             <CompetitionModal

--- a/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
+++ b/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
@@ -49,14 +49,6 @@ export const ClaimRoninAirdrop: React.FC = () => {
                 <span>{t("ronin.nft.perkTwo")}</span>
               </div>
             )}
-            <div className="flex items-center gap-2">
-              <img src={ITEM_DETAILS.Gem.image} className="w-6" />
-              <span>{t("ronin.nft.perkThree")}</span>
-            </div>
-            <div className="flex items-center gap-2 pb-1">
-              <img src={SUNNYSIDE.decorations.treasure_chest} className="h-6" />
-              <span>{t("ronin.nft.perkFour")}</span>
-            </div>
           </div>
           <p>{t("ronin.nft.expires")}</p>
           <Label

--- a/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
+++ b/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useSelector } from "@xstate/react";
+import { Label } from "components/ui/Label";
+import { useGame } from "features/game/GameProvider";
+import { MachineState } from "features/game/lib/gameMachine";
+import vipIcon from "assets/icons/vip.webp";
+import { useTranslation } from "react-i18next";
+import { Button } from "components/ui/Button";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { getTimeUntil } from "lib/utils/time";
+
+const _nft = (state: MachineState) => state.context.state.nfts?.ronin;
+
+export const ClaimRoninAirdrop: React.FC = () => {
+  const { gameService } = useGame();
+  const nft = useSelector(gameService, _nft);
+
+  const { t } = useTranslation();
+
+  const handleAcknowledge = () => {
+    gameService.send({ type: "onChainAirdrop.acknowledged", chain: "ronin" });
+    gameService.send("ACKNOWLEDGE");
+  };
+
+  const showCookingPerk = !nft?.name.includes("Bronze");
+
+  return (
+    <div className="flex flex-col space-y-2">
+      <div className="p-2">
+        <Label type="default" icon={vipIcon} className="mb-2">
+          {nft?.name}
+        </Label>
+        <div className="flex flex-col space-y-2 -mb-2">
+          <p className="text-base">
+            {t("ronin.nft.welcome", { nftName: nft?.name })}
+          </p>
+          <p className="pb-1">
+            {t("ronin.nft.description", { nftName: nft?.name })}
+          </p>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <img src={vipIcon} className="w-6" />
+              <span>{t("ronin.nft.perkOne")}</span>
+            </div>
+            {showCookingPerk && (
+              <div className="flex items-center gap-2">
+                <img src={ITEM_DETAILS["Pumpkin Soup"].image} className="w-6" />
+                <span>{t("ronin.nft.perkTwo")}</span>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <img src={ITEM_DETAILS.Gem.image} className="w-6" />
+              <span>{t("ronin.nft.perkThree")}</span>
+            </div>
+            <div className="flex items-center gap-2 pb-1">
+              <img src={SUNNYSIDE.decorations.treasure_chest} className="h-6" />
+              <span>{t("ronin.nft.perkFour")}</span>
+            </div>
+          </div>
+          <p>{t("ronin.nft.expires")}</p>
+          <Label
+            type="info"
+            icon={SUNNYSIDE.icons.stopwatch}
+          >{`Expires in ${getTimeUntil(new Date(nft?.expiresAt as number))}`}</Label>
+        </div>
+      </div>
+      <Button onClick={handleAcknowledge}>{t("lets.go")}</Button>
+    </div>
+  );
+};

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -162,6 +162,16 @@ const applyTempCollectibleBoost = ({
   return new Decimal(boostedTimeWithBoost + remainingTime);
 };
 
+const hasValidRoninNFT = (game: GameState, cookStartAt: number) => {
+  if (!game.nfts?.ronin) return false;
+
+  const { name, expiresAt } = game.nfts.ronin;
+
+  const hasCookBoost = !name.includes("Bronze");
+
+  return expiresAt > cookStartAt && hasCookBoost;
+};
+
 export const getCookingTime = ({
   seconds,
   item,
@@ -234,6 +244,10 @@ export const getCookingTime = ({
 
   if (isCollectibleBuilt({ name: "Desert Gnome", game })) {
     reducedSecs = reducedSecs.mul(0.9);
+  }
+
+  if (hasValidRoninNFT(game, cookStartAt)) {
+    reducedSecs = reducedSecs.mul(0.5);
   }
 
   // 10% reduction on Fire Pit with Fast Feasts skill

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -541,6 +541,7 @@ export type BlockchainState = {
     | "randomising"
     | "competition"
     | "roninWelcomePack"
+    | "roninAirdrop"
     | StateName
     | StateNameWithStatus; // TEST ONLY
   context: Context;
@@ -912,7 +913,8 @@ export function startGame(authContext: AuthContext) {
               target: "roninAirdrop",
               cond: (context) =>
                 !!context.state.nfts?.ronin &&
-                !context.state.nfts.ronin.acknowledgedAt,
+                !context.state.nfts.ronin.acknowledgedAt &&
+                context.state.nfts.ronin.expiresAt > Date.now(),
             },
             {
               target: "somethingArrived",
@@ -1040,13 +1042,13 @@ export function startGame(authContext: AuthContext) {
             },
           ],
         },
-        onChainAirdrop: {
+        roninAirdrop: {
           on: {
             "onChainAirdrop.acknowledged": (GAME_EVENT_HANDLERS as any)[
-              "roninAirdrop.claimed"
+              "onChainAirdrop.acknowledged"
             ],
-            CLOSE: {
-              target: "playing",
+            ACKNOWLEDGE: {
+              target: "notifying",
             },
           },
         },

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -909,6 +909,12 @@ export function startGame(authContext: AuthContext) {
               },
             },
             {
+              target: "roninAirdrop",
+              cond: (context) =>
+                !!context.state.nfts?.ronin &&
+                !context.state.nfts.ronin.acknowledgedAt,
+            },
+            {
               target: "somethingArrived",
               cond: (context) => !!context.revealed,
             },
@@ -1033,6 +1039,16 @@ export function startGame(authContext: AuthContext) {
               target: "playing",
             },
           ],
+        },
+        onChainAirdrop: {
+          on: {
+            "onChainAirdrop.acknowledged": (GAME_EVENT_HANDLERS as any)[
+              "roninAirdrop.claimed"
+            ],
+            CLOSE: {
+              target: "playing",
+            },
+          },
         },
         vip: {
           on: {

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -128,5 +128,6 @@ export function makeGame(farm: any): GameState {
     craftingBox: farm.craftingBox,
     season: farm.season,
     lavaPits: farm.lavaPits,
+    nfts: farm.nfts,
   };
 }

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -21,6 +21,10 @@ export const hasVipAccess = ({
 
   if (hasSeasonPass || hasLifetimePass) return true;
 
+  // Has Ronin NFT VIP Access
+  const nft = game.nfts?.ronin;
+  if (nft && nft.expiresAt > now) return true;
+
   // New Code
   return !!game.vip?.expiresAt && game.vip?.expiresAt > now;
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1571,6 +1571,7 @@ export interface GameState {
         name: string;
         tokenId: number;
         expiresAt: number;
+        acknowledgedAt?: number;
       }
     >
   >;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1358,6 +1358,8 @@ export type VIP = {
   expiresAt: number;
 };
 
+export type Chain = "ronin";
+
 export interface GameState {
   home: Home;
   bank: Bank;
@@ -1562,6 +1564,16 @@ export interface GameState {
   };
   season: Season;
   lavaPits: Record<string, LavaPit>;
+  nfts?: Partial<
+    Record<
+      Chain,
+      {
+        name: string;
+        tokenId: number;
+        expiresAt: number;
+      }
+    >
+  >;
 }
 
 export interface Context {

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5521,7 +5521,5 @@
   "ronin.nft.description": "Your {{nftName}} comes with exclusive perks!",
   "ronin.nft.perkOne": "VIP Access",
   "ronin.nft.perkTwo": "50% Faster Cooking",
-  "ronin.nft.perkThree": "Bonus Items",
-  "ronin.nft.perkFour": "Exclusive Ronin Collectible",
   "ronin.nft.expires": "These perks won't last forever, so make the most of them while they last!"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5520,6 +5520,6 @@
   "ronin.nft.welcome": "Welcome Ronin Player!",
   "ronin.nft.description": "Your {{nftName}} comes with exclusive perks!",
   "ronin.nft.perkOne": "VIP Access",
-  "ronin.nft.perkTwo": "50% Faster Cooking",
+  "ronin.nft.perkTwo": "2x Faster Cooking",
   "ronin.nft.expires": "These perks won't last forever, so make the most of them while they last!"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5512,10 +5512,16 @@
   "whatsOn.ticketPaused": "The Bumpkins are on holidays - No more timeshards from chores & bounties.",
   "whatsOn.mysterySeasonText2": "No more timeshards from deliveries.",
   "whatsOn.mysterySeasonText3": "No more ancient clocks while digging.",
-
   "polygon.required": "Polygon Required",
   "polygon.requiredDescription": "This interaction requires a connection to the Polygon network.",
   "polygon.roninDescription": "Ronin support will be available for this interaction in April 2025.",
   "polygon.continueDescription": "Switch to Polygon to continue. This may require POL on the Polygon Network.",
-  "polygon.cantContinueDescription": "Unfortunately, your wallet does not support Polygon. Please stay tuned for Ronin support in April 2025."
+  "polygon.cantContinueDescription": "Unfortunately, your wallet does not support Polygon. Please stay tuned for Ronin support in April 2025.",
+  "ronin.nft.welcome": "Welcome Ronin Player!",
+  "ronin.nft.description": "Your {{nftName}} comes with exclusive perks!",
+  "ronin.nft.perkOne": "VIP Access",
+  "ronin.nft.perkTwo": "50% Faster Cooking",
+  "ronin.nft.perkThree": "Bonus Items",
+  "ronin.nft.perkFour": "Exclusive Ronin Collectible",
+  "ronin.nft.expires": "These perks won't last forever, so make the most of them while they last!"
 }


### PR DESCRIPTION
# Description

If a players enters the game with an unacknowledged Ronin NFT then show them a welcome modal explaining their boost and the expiry time.

<img width="505" alt="Screenshot 2025-02-20 at 9 43 10 AM" src="https://github.com/user-attachments/assets/994d3bfc-2f8e-427c-9db9-bbafb5e1e757" />

```
Add VIP access for Ronin players:

Platinum = 6 Months VIP
Gold = 3 Months VIP
Silver = 1 Month VIP
Bronze = 7 days VIP Access

Add Cooking time buff for ronin players

Platinum = 6 months -50% Cooking time
Gold= 3 months -50% Cooking time
Silver = 1 months -50% Cooking time
```

Fixes #issue

# What needs to be tested by the reviewer?

**Confirm NFT Boost**

- Airdrop yourself an NFT on Ronin (saigon)
- Start a new farm
- Confirm you see the intro message
- Enter the game
- Confirm you have VIP and confirm the relevant cooking boost is applied

**Confirm NFT Boost Removed**

- Remove the NFT from your wallet
- Load the game
- Confirm you don't have VIP or cooking boost

**Confirm NFT Boost Transferrable**

- Send NFT to another wallet
- Start a new farm
- Confirm you see the intro message
- Enter the game
- Confirm you have VIP and confirm the relevant cooking boost is applied

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
