### PR TITLE
[CHORE] Show Trade Cake XP in Marketplace Rewards Shop

### DIFF
--- a/src/features/marketplace/components/rewards/ItemDetail.tsx
+++ b/src/features/marketplace/components/rewards/ItemDetail.tsx
@@ -20,6 +20,9 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import React, { useContext, useLayoutEffect, useState } from "react";
 
+import { getFoodExpBoost } from "features/game/expansion/lib/boosts";
+import { ConsumableName, CONSUMABLES } from "features/game/types/consumables";
+
 interface Props {
   onClose: () => void;
   itemName: TradeRewardsItem | TradeRewardPacks;
@@ -133,6 +136,23 @@ export const ItemDetail: React.FC<Props> = ({ onClose, itemName }) => {
                       {t("marketplace.reward.seedLimit")}
                     </span>
                   </Label>
+                )}
+                {itemName === "Trade Cake" && (
+                  <div className="flex flex-1 items-end">
+                    <RequirementLabel
+                      type="xp"
+                      xp={
+                        new Decimal(
+                          getFoodExpBoost(
+                            CONSUMABLES["Trade Cake" as ConsumableName],
+                            state.bumpkin,
+                            state,
+                            state.buds ?? {},
+                          ),
+                        )
+                      }
+                    />
+                  </div>
                 )}
                 <div className="flex flex-1 items-end">
                   <RequirementLabel


### PR DESCRIPTION
# Description

Show Trade Cake XP in Marketplace Rewards Shop

**Before**
![before](https://github.com/user-attachments/assets/cac67f58-be1c-4982-be3e-7812b24ca3f9)
**After**
![after](https://github.com/user-attachments/assets/4d2fb1aa-82c3-4592-8ef4-78fddfa93f1a)


# What needs to be tested by the reviewer?
* Go to market place rewards shop and select Trade Cake
* See xp that the cake gives
* Purchase cake, and consume it. Verify the XP shown in the marketplace modal is the gained XP

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
