### PR TITLE
[FIX] Correct onHide and onClose event handling in AnimalDeal for the Barn

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -131,10 +131,9 @@ export const BarnInside: React.FC = () => {
         onClose={() => setShowUpgradeModal(false)}
       />
 
-      <Modal show={!!selected} onHide={() => setDeal(undefined)}>
+      <Modal show={!!selected} onHide={() => setSelected(undefined)}>
         <AnimalDeal
           onClose={() => {
-            setDeal(undefined);
             setSelected(undefined);
           }}
           onSold={() => {


### PR DESCRIPTION
# Description

There is an issue when clicking outside of the `animalDeal` confirmation modal (only for the Barn), that causes players stuck in that situation. This PR addresses this issue and additionally updates `onClose` event to act the same as how it works inside the Hen House.

### Before
![Before_Conf_Sell_Animal_Modal](https://github.com/user-attachments/assets/488f4a97-9d3c-4c38-b89b-a9ee2384663f)

### After

![After_Conf_Sell_Animal_Modal](https://github.com/user-attachments/assets/3d08d2f8-4258-40cf-ab51-a5f2cf593406)

---
# Other PRs, ready for review:
- [[FIX] Hide Fisherman Events for Unqualified Farms](https://github.com/sunflower-land/sunflower-land/pull/5277)
- [[CHORE] Update Descriptions](https://github.com/sunflower-land/sunflower-land/pull/5296)