### PR TITLE
[FIX] Bumpkin Level Requirement Check in Water Well Upgrade Modal

### DIFF
--- a/src/features/game/expansion/components/UpgradeBuildingModal.tsx
+++ b/src/features/game/expansion/components/UpgradeBuildingModal.tsx
@@ -67,7 +67,7 @@ export const UpgradeBuildingModal: React.FC<Props> = ({
     const bumpkinLevel = getBumpkinLevel(state.bumpkin.experience);
 
     if (requirements.requiredLevel) {
-      return bumpkinLevel > requirements.requiredLevel;
+      return bumpkinLevel >= requirements.requiredLevel;
     }
 
     return true;

--- a/src/features/game/expansion/components/UpgradeBuildingModal.tsx
+++ b/src/features/game/expansion/components/UpgradeBuildingModal.tsx
@@ -64,7 +64,7 @@ export const UpgradeBuildingModal: React.FC<Props> = ({
   };
 
   const hasRequiredLevel = () => {
-    const bumpkinLevel = getBumpkinLevel(state.bumpkin.experience);
+    const bumpkinLevel = getBumpkinLevel(state.bumpkin?.experience ?? 0);
 
     if (requirements.requiredLevel) {
       return bumpkinLevel >= requirements.requiredLevel;

--- a/src/features/game/expansion/components/UpgradeBuildingModal.tsx
+++ b/src/features/game/expansion/components/UpgradeBuildingModal.tsx
@@ -26,6 +26,7 @@ import {
   WATER_WELL_VARIANTS,
 } from "features/island/lib/alternateArt";
 import { getSupportedPlots } from "features/game/events/landExpansion/plant";
+import { getBumpkinLevel } from "features/game/lib/level";
 
 interface Props {
   buildingName: UpgradableBuildingType;
@@ -62,7 +63,22 @@ export const UpgradeBuildingModal: React.FC<Props> = ({
     onClose();
   };
 
+  const hasRequiredLevel = () => {
+    const bumpkinLevel = getBumpkinLevel(state.bumpkin.experience);
+
+    if (requirements.requiredLevel) {
+      return bumpkinLevel > requirements.requiredLevel;
+    }
+
+    return true;
+  };
+
   const hasRequirements = () => {
+    // Check if player has enough bumpkin level
+    if (!hasRequiredLevel()) {
+      return false;
+    }
+
     // Check if player has enough coins
     if (state.coins < requirements.coins) {
       return false;
@@ -173,14 +189,28 @@ export const UpgradeBuildingModal: React.FC<Props> = ({
                 )}
               />
             </div>
-            <div className="flex flex-col items-start w-full mt-2">
-              <Label
-                type="default"
-                icon={SUNNYSIDE.icons.basket}
-                className="ml-2 mb-2"
-              >
-                {t("requirements")}
-              </Label>
+            <div className="flex flex-col w-full mt-2">
+              <div className="flex flex-wrap justify-between">
+                <Label
+                  type="default"
+                  icon={SUNNYSIDE.icons.basket}
+                  className="ml-2 mb-2"
+                >
+                  {t("requirements")}
+                </Label>
+
+                {requirements.requiredLevel && !hasRequiredLevel() && (
+                  <Label
+                    type="danger"
+                    secondaryIcon={SUNNYSIDE.icons.player}
+                    className="mr-2 mb-2"
+                  >
+                    {t("warning.level.required", {
+                      lvl: requirements.requiredLevel,
+                    })}
+                  </Label>
+                )}
+              </div>
               <InnerPanel className="flex flex-wrap gap-2 w-full">
                 {getKeys(requirements.items).map((itemName) => (
                   <div key={itemName} className="flex-shrink-0 gap-1">


### PR DESCRIPTION
# Description

- **Add a condition to check the required Bumpkin level and disable the upgrade button if the Bumpkin's level is insufficient.**

- **Display a label that shows the required level to upgrade the water well.**

These changes will help players better understand why they cannot upgrade the water well, even if they have sufficient resources.

| Before |
|--------|
| ![Before_Upgrade_Well_Modal](https://github.com/user-attachments/assets/a065f013-b005-417d-a548-d8f0b8d90037) |

| After |
|--------|
| ![After_Upgrade_Well_Modal](https://github.com/user-attachments/assets/bd0e96b8-15d0-49c2-9f59-e21650d3df96) | 

Fixes #issue

# What needs to be tested by the reviewer?

- try to upgrade the water well.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
