### PR TITLE
[FIX] Wrong VIP Access Check Instead of Using the Reputation System for Some SFL Deliveries

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -160,6 +160,41 @@ describe("deliver", () => {
     ).toThrow("Insufficient ingredient: coins");
   });
 
+  it("requires player has the reputation", () => {
+    expect(() =>
+      deliverOrder({
+        state: {
+          ...TEST_FARM,
+          vip: {
+            bundles: [],
+            expiresAt: Date.now() - 1000 * 60,
+          },
+          coins: 50,
+          delivery: {
+            ...TEST_FARM.delivery,
+            orders: [
+              {
+                id: "123",
+                createdAt: 0,
+                readyAt: MID_SEASON,
+                from: "gambit",
+                items: {
+                  coins: 50,
+                },
+                reward: {},
+              },
+            ],
+          },
+        },
+        action: {
+          id: "123",
+          type: "order.delivered",
+        },
+        createdAt: MID_SEASON,
+      }),
+    ).toThrow("You do not have the required reputation");
+  });
+
   it("takes sfl from player is required in delivery", () => {
     const balance = new Decimal(100);
     const game = deliverOrder({

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1797,6 +1797,10 @@ describe("deliver", () => {
           Orange: new Decimal(5),
           Grape: new Decimal(2),
         },
+        vip: {
+          bundles: [],
+          expiresAt: Date.now() + 1000 * 60 * 60 * 24 * 365,
+        },
         delivery: {
           ...TEST_FARM.delivery,
           orders: [

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -28,6 +28,7 @@ import { FISH } from "features/game/types/fishing";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { getActiveCalendarEvent } from "features/game/types/calendar";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { hasReputation, Reputation } from "features/game/lib/reputation";
 
 export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   "pumpkin' pete": 1,
@@ -366,6 +367,14 @@ export function getOrderSellPrice<T>(
   return ((order.reward.coins ?? 0) * mul) as T;
 }
 
+export const GOBLINS_REQUIRING_SEASON_PASS: NPCName[] = [
+  "grimtooth",
+  "grubnuk",
+  "gordo",
+  "guria",
+  "gambit",
+];
+
 export function deliverOrder({
   state,
   action,
@@ -386,6 +395,19 @@ export function deliverOrder({
 
     if (order.readyAt > createdAt) {
       throw new Error("Order has not started");
+    }
+
+    const hasCropkeeperReputation = hasReputation({
+      game,
+      reputation: Reputation.Cropkeeper,
+    });
+
+    const requiresReputation = GOBLINS_REQUIRING_SEASON_PASS.includes(
+      order.from,
+    );
+
+    if (requiresReputation && !hasCropkeeperReputation) {
+      throw new Error("You do not have the required reputation");
     }
 
     if (order.completedAt) {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -367,7 +367,7 @@ export function getOrderSellPrice<T>(
   return ((order.reward.coins ?? 0) * mul) as T;
 }
 
-export const GOBLINS_REQUIRING_SEASON_PASS: NPCName[] = [
+export const GOBLINS_REQUIRING_REPUTATION: NPCName[] = [
   "grimtooth",
   "grubnuk",
   "gordo",
@@ -402,7 +402,7 @@ export function deliverOrder({
       reputation: Reputation.Cropkeeper,
     });
 
-    const requiresReputation = GOBLINS_REQUIRING_SEASON_PASS.includes(
+    const requiresReputation = GOBLINS_REQUIRING_REPUTATION.includes(
       order.from,
     );
 

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { Label } from "components/ui/Label";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Context } from "features/game/GameProvider";
-import { useActor } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { Airdrop, GameState, Order } from "features/game/types/game";
 import { Button } from "components/ui/Button";
 
@@ -42,8 +42,6 @@ import {
   getCountAndTypeForDelivery,
   getOrderSellPrice,
 } from "features/game/events/landExpansion/deliver";
-import { hasVipAccess } from "features/game/lib/vipAccess";
-import { VIPAccess } from "features/game/components/VipAccess";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { getBumpkinHoliday } from "lib/utils/getSeasonWeek";
 import { SquareIcon } from "components/ui/SquareIcon";
@@ -53,6 +51,9 @@ import { TranslationKeys } from "lib/i18n/dictionaries/types";
 import { calculateRelationshipPoints } from "features/game/events/landExpansion/giftFlowers";
 import { FriendshipInfoPanel } from "components/ui/FriendshipInfoPanel";
 import { getActiveCalendarEvent } from "features/game/types/calendar";
+import { RequiredReputation } from "features/island/hud/components/reputation/Reputation";
+import { hasReputation, Reputation } from "features/game/lib/reputation";
+import { MachineState } from "features/game/lib/gameMachine";
 
 export const OrderCard: React.FC<{
   order: Order;
@@ -628,6 +629,12 @@ const GOBLINS_REQUIRING_SEASON_PASS: Partial<NPCName[]> = [
   "guria",
 ];
 
+const _hasReputation = (state: MachineState) =>
+  hasReputation({
+    game: state.context.state,
+    reputation: Reputation.Cropkeeper,
+  });
+
 export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
@@ -680,6 +687,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
   };
 
   const requiresSeasonPass = GOBLINS_REQUIRING_SEASON_PASS.includes(npc);
+  const hasCropkeeperReputation = useSelector(gameService, _hasReputation);
 
   const dialogue = npcDialogues[npc] || defaultDialogue;
   const intro = useRandomItem(dialogue.intro);
@@ -714,16 +722,15 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
     message = noOrder;
   }
 
-  const hasVIP = hasVipAccess({ game: gameState.context.state });
-
-  if (requiresSeasonPass && !hasVIP) {
-    message = t("goblinTrade.vipDelivery");
+  if (requiresSeasonPass && !hasCropkeeperReputation) {
+    message = t("goblinTrade.missingReputation.sflDelivery");
   }
 
   const missingLevels =
     (NPC_DELIVERY_LEVELS[npc as DeliveryNpcName] ?? 0) -
     getBumpkinLevel(game.bumpkin?.experience ?? 0);
-  const missingVIPAccess = requiresSeasonPass && !hasVIP;
+  const missingRequiredReputation =
+    requiresSeasonPass && !hasCropkeeperReputation;
   const isLocked = missingLevels >= 1;
   const isTicketOrder = tickets > 0;
   const deliveryFrozen = isHoliday && isTicketOrder;
@@ -793,7 +800,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
             </div>
           </InnerPanel>
 
-          <InnerPanel>
+          <InnerPanel className="mb-1">
             <div className="px-2 ">
               <div className="flex flex-col justify-between items-stretch mb-2 gap-1">
                 <div className="flex flex-row justify-between w-full">
@@ -810,6 +817,15 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
                       {t("delivery")}
                     </Label>
                   )}
+
+                  {isLocked && (
+                    <Label type="danger" secondaryIcon={SUNNYSIDE.icons.player}>
+                      {t("warning.level.required", {
+                        lvl: NPC_DELIVERY_LEVELS[npc as DeliveryNpcName],
+                      })}
+                    </Label>
+                  )}
+
                   {delivery?.completedAt && (
                     <Label
                       style={{ whiteSpace: "nowrap" }}
@@ -817,22 +833,6 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
                       secondaryIcon={SUNNYSIDE.icons.confirm}
                     >
                       {t("completed")}
-                    </Label>
-                  )}
-                </div>
-                <div className="flex flex-row justify-between w-full">
-                  {!delivery?.completedAt && requiresSeasonPass && (
-                    <VIPAccess
-                      isVIP={hasVIP}
-                      onUpgrade={() => {
-                        onClose && onClose();
-                        openModal("BUY_BANNER");
-                      }}
-                    />
-                  )}
-                  {isLocked && (
-                    <Label type="danger" secondaryIcon={SUNNYSIDE.icons.lock}>
-                      {`Lvl ${NPC_DELIVERY_LEVELS[npc as DeliveryNpcName]} required`}
                     </Label>
                   )}
                 </div>
@@ -868,7 +868,9 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
               )}
             </div>
           </InnerPanel>
-
+          {requiresSeasonPass && !hasCropkeeperReputation && (
+            <RequiredReputation reputation={Reputation.Cropkeeper} />
+          )}
           <div className="flex mt-1">
             {acceptGifts && (
               <Button className="mr-1" onClick={() => setShowFlowers(true)}>
@@ -882,7 +884,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
                 !hasDelivery ||
                 !!delivery?.completedAt ||
                 isLocked ||
-                missingVIPAccess ||
+                missingRequiredReputation ||
                 (isTicketOrder && isHoliday)
               }
               onClick={deliver}

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -41,6 +41,7 @@ import {
   generateDeliveryTickets,
   getCountAndTypeForDelivery,
   getOrderSellPrice,
+  GOBLINS_REQUIRING_SEASON_PASS,
 } from "features/game/events/landExpansion/deliver";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { getBumpkinHoliday } from "lib/utils/getSeasonWeek";
@@ -622,13 +623,6 @@ interface Props {
   npc: NPCName;
 }
 
-const GOBLINS_REQUIRING_SEASON_PASS: Partial<NPCName[]> = [
-  "grimtooth",
-  "grubnuk",
-  "gordo",
-  "guria",
-];
-
 const _hasReputation = (state: MachineState) =>
   hasReputation({
     game: state.context.state,
@@ -686,7 +680,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
     });
   };
 
-  const requiresSeasonPass = GOBLINS_REQUIRING_SEASON_PASS.includes(npc);
+  const requiresReputation = GOBLINS_REQUIRING_SEASON_PASS.includes(npc);
   const hasCropkeeperReputation = useSelector(gameService, _hasReputation);
 
   const dialogue = npcDialogues[npc] || defaultDialogue;
@@ -721,16 +715,16 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
   if (!delivery || (!!tickets && isHoliday)) {
     message = noOrder;
   }
+  const missingRequiredReputation =
+    requiresReputation && !hasCropkeeperReputation;
 
-  if (requiresSeasonPass && !hasCropkeeperReputation) {
+  if (missingRequiredReputation) {
     message = t("goblinTrade.missingReputation.sflDelivery");
   }
 
   const missingLevels =
     (NPC_DELIVERY_LEVELS[npc as DeliveryNpcName] ?? 0) -
     getBumpkinLevel(game.bumpkin?.experience ?? 0);
-  const missingRequiredReputation =
-    requiresSeasonPass && !hasCropkeeperReputation;
   const isLocked = missingLevels >= 1;
   const isTicketOrder = tickets > 0;
   const deliveryFrozen = isHoliday && isTicketOrder;
@@ -868,7 +862,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
               )}
             </div>
           </InnerPanel>
-          {requiresSeasonPass && !hasCropkeeperReputation && (
+          {missingRequiredReputation && (
             <RequiredReputation reputation={Reputation.Cropkeeper} />
           )}
           <div className="flex mt-1">

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -41,7 +41,7 @@ import {
   generateDeliveryTickets,
   getCountAndTypeForDelivery,
   getOrderSellPrice,
-  GOBLINS_REQUIRING_SEASON_PASS,
+  GOBLINS_REQUIRING_REPUTATION,
 } from "features/game/events/landExpansion/deliver";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { getBumpkinHoliday } from "lib/utils/getSeasonWeek";
@@ -680,7 +680,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
     });
   };
 
-  const requiresReputation = GOBLINS_REQUIRING_SEASON_PASS.includes(npc);
+  const requiresReputation = GOBLINS_REQUIRING_REPUTATION.includes(npc);
   const hasCropkeeperReputation = useSelector(gameService, _hasReputation);
 
   const dialogue = npcDialogues[npc] || defaultDialogue;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2133,7 +2133,7 @@
   "goblinTrade.select": "Select resource to sell",
   "goblinTrade.hoarding": "Oh no! You've reached the max SFL.",
   "goblinTrade.vipRequired": "VIP Required",
-  "goblinTrade.vipDelivery": "Hmmm, looks like you are a basic Bumpkin. I only trade with VIPs.",
+  "goblinTrade.missingReputation.sflDelivery": "Hmmm, looks like you are a basic Bumpkin. I only trade with a Cropkeeper.",
   "goldTooth.intro.part1": "Arrr, me hearties! The treasure-diggin' area be teemin' with wealth and adventure, and it be openin' its gates soon for ye daring farmers!",
   "goldTooth.intro.part2": "Be ready to join me crew, for the hunt for riches begins shortly!",
   "greenhouse.oilDescription": "The greenhouse needs oil to grow plants.",


### PR DESCRIPTION
# Description

Since introducing the reputation system, the `Unlock all SFL Deliveries` perk in the `Cropkeeper` tier has not been implemented yet.

![image](https://github.com/user-attachments/assets/58716d80-bd56-46fd-b257-c9966b47a4a5)


So the game still uses VIP access restriction for some SFL deliveries (season pass goblins). This PR addresses the issue by using the reputation system instead.

| Before | After |
|--------|--------|
| <img width="323" alt="before" src="https://github.com/user-attachments/assets/8d85858a-1a65-433b-9f4b-07f38a2264ff" /> | <img width="322" alt="after" src="https://github.com/user-attachments/assets/8b2c0e19-42e5-4d9e-8793-71e0c9863297" /> | 

Fixes #issue

# What needs to be tested by the reviewer?

- Complete SFL deliveries

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
