### PR TITLE
[CHORE] Add farm creation restriction

### DIFF
--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -23,7 +23,12 @@ export const hasVipAccess = ({
 
   // Has Ronin NFT VIP Access
   const nft = game.nfts?.ronin;
-  if (nft && nft.expiresAt > now) return true;
+  if (nft && nft.expiresAt > now) {
+    const RONIN_FARM_CREATION_CUTOFF = new Date(
+      "2025-02-01T00:00:00Z",
+    ).getTime();
+    return game.createdAt > RONIN_FARM_CREATION_CUTOFF;
+  }
 
   // New Code
   return !!game.vip?.expiresAt && game.vip?.expiresAt > now;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5524,7 +5524,7 @@
   "polygon.cantContinueDescription": "Unfortunately, your wallet does not support Polygon. Please stay tuned for Ronin support in April 2025.",
   "ronin.nft.welcome": "Welcome Ronin Player!",
   "ronin.nft.description": "Your {{nftName}} comes with exclusive perks!",
-  "ronin.nft.perkOne": "VIP Access",
+  "ronin.nft.perkOne": "VIP Access (Farm created after February 1st, 2025)",
   "ronin.nft.perkTwo": "2x Faster Cooking",
   "ronin.nft.expires": "These perks won't last forever, so make the most of them while they last!"
 }


### PR DESCRIPTION
# Description

Ronin VIP is only valid if farm was created AFTER 1st Feb 2025

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
