### PR TITLE
[FIX] Expires At Time In VIP 

### DIFF
--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -143,13 +143,13 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   const vipExpiresAt = getExpiresAt();
   const hasRoninVip = (state.nfts?.ronin?.expiresAt ?? 0) > Date.now();
 
-  // Disable VIP purchase buttons if Ronin NFT is active and expires in more than 3 days
+  // Disable VIP purchase buttons if Ronin NFT is active and expires in more than 1 day
   const shouldDisableVipPurchase = () => {
     if (!hasRoninVip) return false;
 
     const roninExpiresAt = state.nfts?.ronin?.expiresAt ?? 0;
 
-    return roninExpiresAt > Date.now() + 1000 * 60 * 60 * 24 * 3;
+    return roninExpiresAt > Date.now() + 1000 * 60 * 60 * 24 * 1;
   };
 
   const disableVipPurchase = shouldDisableVipPurchase();

--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -104,7 +104,7 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   const gemBalance = inventory["Gem"] ?? new Decimal(0);
 
   const handlePurchase = () => {
-    const state = gameService.send("vip.purchased", {
+    gameService.send("vip.purchased", {
       name: selected,
     });
     gameAnalytics.trackSink({
@@ -143,7 +143,7 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   const vipExpiresAt = getExpiresAt();
   const hasRoninVip = (state.nfts?.ronin?.expiresAt ?? 0) > Date.now();
 
-  // Disable VIP purchase if Ronin NFT is active and expires in more than 3 days
+  // Disable VIP purchase buttons if Ronin NFT is active and expires in more than 3 days
   const shouldDisableVipPurchase = () => {
     if (!hasRoninVip) return false;
 
@@ -151,6 +151,8 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
 
     return roninExpiresAt > Date.now() + 1000 * 60 * 60 * 24 * 3;
   };
+
+  const disableVipPurchase = shouldDisableVipPurchase();
 
   return (
     <>
@@ -258,7 +260,7 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
             {t("expired")}
           </Label>
         )}
-        {shouldDisableVipPurchase() && (
+        {disableVipPurchase && (
           <Label type="info" className="ml-1 my-1">
             {t("vip.ronin.purchase.warning")}
           </Label>
@@ -268,9 +270,11 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
             <div className="w-1/3 pr-1" key={name}>
               <ButtonPanel
                 key={name}
-                className="flex flex-col items-center relative cursor-pointer hover:bg-brown-300"
-                onClick={() => setSelected(name)}
-                disabled={shouldDisableVipPurchase()}
+                className="flex flex-col items-center relative"
+                onClick={
+                  disableVipPurchase ? undefined : () => setSelected(name)
+                }
+                disabled={disableVipPurchase}
               >
                 {name === "3_MONTHS" && (
                   <>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5535,5 +5535,6 @@
   "news.winds.of.change.description": "The Winds of Change Chapter has begun. Compete for NFTs and rewards!",
   "news.title": "News",
   "news.whatsOn": "What's happening in Sunflower Land?",
-  "news.flowerSoon": "$FLOWER ERC20 is launching soon!"
+  "news.flowerSoon": "$FLOWER ERC20 is launching soon!",
+  "vip.ronin.purchase.warning": "Ronin NFT VIP active. Return 3 days before expiry to purchase VIP."
 }


### PR DESCRIPTION
# Description

The expires at time inside of the VIP screen was not considering the expire at time for Ronin NFT's. I have updated this.

- Shows the correct expiry time. 
- Shows the longest expiry time if a player has `vip` and also has an NFT or if a player has two passes. It will show the expiry of Platinum over Gold.
- Blocks the purchase of `vip` if the player still more than 1 day available on their Ronin VIP. This is because the purchased `vip` doesn't stack onto the Ronin VIP. We can't stack because the VIP is transferrable.
- Allows purchase of `vip` as normal for everyone else.

_Ronin VIP active_
<img width="400" alt="Screenshot 2025-02-25 at 1 23 08 PM" src="https://github.com/user-attachments/assets/93d4de42-9aff-4e42-a38e-c89c0dddc7eb" />


Fixes #issue

# What needs to be tested by the reviewer?

All the above statements hold true.
You will need to test this on a Ronin account with an NFT in your wallet.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
