### PR TITLE
[FIX] cook.test.ts

### DIFF
--- a/src/features/game/events/landExpansion/cook.test.ts
+++ b/src/features/game/events/landExpansion/cook.test.ts
@@ -426,7 +426,7 @@ describe("cook", () => {
         },
         vip: {
           bundles: [{ name: "1_MONTH", boughtAt: Date.now() }],
-          expiresAt: Date.now() + 31 * 24 * 60 * 60 * 1000,
+          expiresAt: now + 31 * 24 * 60 * 60 * 1000,
         },
         buildings: {
           "Fire Pit": [
@@ -452,6 +452,7 @@ describe("cook", () => {
         item: "Mashed Potato",
         buildingId: "blah",
       },
+      createdAt: now,
     });
 
     expect(state.buildings["Fire Pit"]?.[0].crafting?.[1].readyAt).toBeCloseTo(


### PR DESCRIPTION
```
FAIL src/features/game/events/landExpansion/cook.test.ts
  ● cook › adds the correct readyAt for the second recipe when a recipe is already cooked
    expect(received).toBeCloseTo(expected)
    Expected: 1740532845645
    Received: 1740532845646
```
<https://github.com/sunflower-land/sunflower-land/actions/runs/13534401225/job/37823276707?pr=5320>