### PR TITLE
[FIX] speedUpRecipe.test.ts

### DIFF
--- a/src/features/game/events/landExpansion/speedUpRecipe.test.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.test.ts
@@ -311,6 +311,7 @@ describe("instantCook", () => {
         buildingName: "Fire Pit",
         type: "recipe.spedUp",
       },
+      createdAt: now,
     });
 
     const building = state.buildings["Fire Pit"]?.[0];


### PR DESCRIPTION
```
FAIL src/features/game/events/landExpansion/speedUpRecipe.test.ts
  ● instantCook › updates all the recipes readyAt times correctly
    expect(received).toBeCloseTo(expected)
    Expected: 1740533873681
    Received: 1740533873682
```
<https://github.com/sunflower-land/sunflower-land/actions/runs/13534610207/job/37823843562?pr=5322>