### PR TITLE
[FIX] upgradeFarm.test.ts

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -446,8 +446,8 @@ describe("upgradeFarm", () => {
           "Orchard Hourglass": [
             {
               id: "1",
-              readyAt: Date.now() - 6 * 60 * 60 * 1000,
-              createdAt: Date.now() - 6 * 60 * 60 * 1000 - 1,
+              readyAt: createdAt - 6 * 60 * 60 * 1000,
+              createdAt: createdAt - 6 * 60 * 60 * 1000 - 1,
               coordinates: { x: 0, y: 0 },
             },
           ],


### PR DESCRIPTION
```
FAIL src/features/game/events/landExpansion/upgradeFarm.test.ts
  ● upgradeFarm › removes hourglasses which have expired on the land
    expect(received).toEqual(expected) // deep equality
    - Expected  - 1
    + Received  + 1
```
<https://github.com/sunflower-land/sunflower-land/actions/runs/13534610207/job/37823843562?pr=5322>