### PR TITLE
[FIX] Show resulting flower if flower has been discovered

### DIFF
--- a/src/features/game/events/landExpansion/plantFlower.ts
+++ b/src/features/game/events/landExpansion/plantFlower.ts
@@ -6,7 +6,7 @@ import {
   FLOWER_CROSS_BREED_AMOUNTS,
   FLOWER_SEEDS,
   FlowerCrossBreedName,
-  FlowerName,
+  FLOWERS,
   FlowerSeedName,
   isFlowerSeed,
 } from "features/game/types/flowers";
@@ -18,7 +18,7 @@ import {
 } from "features/game/lib/collectibleBuilt";
 import { produce } from "immer";
 import { SEASONAL_SEEDS } from "features/game/types/seeds";
-import { getObjectEntries } from "features/game/expansion/lib/utils";
+import { getKeys } from "features/game/types/decorations";
 
 export type PlantFlowerAction = {
   type: "flower.planted";
@@ -141,23 +141,12 @@ export function plantFlower({
     stateCopy.inventory[action.crossbreed] =
       crossBreedCount.minus(crossBreedAmount);
 
-    const { discovered } = flowers;
-
-    // Convert discovered map to get crossbreed -> flower mapping
-    const flowerCrossBreeds: Partial<Record<FlowerCrossBreedName, FlowerName>> =
-      {};
-
-    // Iterate through discovered flowers and their crossbreeds
-    getObjectEntries(discovered).forEach(([flowerName, crossbreeds]) => {
-      crossbreeds?.forEach((crossbreed) => {
-        flowerCrossBreeds[crossbreed] = flowerName;
-      });
-    });
-
-    let flower: FlowerName | undefined;
-    if (flowerCrossBreeds[action.crossbreed]) {
-      flower = flowerCrossBreeds[action.crossbreed];
-    }
+    const seedFlowers = getKeys(FLOWERS).filter(
+      (flowerName) => FLOWERS[flowerName].seed === action.seed,
+    );
+    const flower = seedFlowers.find((seedFlower) =>
+      (flowers.discovered[seedFlower] ?? []).includes(action.crossbreed),
+    );
 
     flowerBed.flower = {
       plantedAt: getPlantedAt({

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -23,6 +23,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     expiresAt: Date.now() + 31 * 24 * 60 * 60 * 1000,
   },
   inventory: {
+    Beetroot: new Decimal(100),
     Jin: new Decimal(1),
     Egg: new Decimal(100),
     Oil: new Decimal(50),
@@ -111,7 +112,9 @@ export const STATIC_OFFLINE_FARM: GameState = {
   beehives: {},
   crimstones: {},
   flowers: {
-    discovered: {},
+    discovered: {
+      "Red Balloon Flower": ["Beetroot"],
+    },
     flowerBeds: {
       "1": {
         createdAt: 0,


### PR DESCRIPTION
# Description

Set flower on FE if crossbreed has been discovered

Fixes #issue

# What needs to be tested by the reviewer?

Test 1: Discovered flower
- Plant a crossbreed that has been discovered
- Flower Bed should instantly show what flower will be growing

Test 2: Undiscovered flower
- Plant a crossbreed that hasn't been discovered
- Flower Bed should be dirty until after autosave

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
