### PR TITLE
[FIX] VIP Expired Condition

### DIFF
--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -27,6 +27,7 @@ import { acknowledgeVIP } from "features/announcements/announcementsStorage";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
   hasVipAccess,
+  RONIN_FARM_CREATION_CUTOFF,
   VIP_DURATIONS,
   VIP_PRICES,
   VipBundle,
@@ -124,13 +125,16 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   const expiresSoon =
     vip && vip.expiresAt < Date.now() + 1000 * 60 * 60 * 24 * 7;
 
-  const hasExpired = vip && vip.expiresAt < Date.now();
-
   const hasOneYear =
     vip && vip.expiresAt > Date.now() + 1000 * 60 * 60 * 24 * 365;
 
+  const isRoninFarmCreatedAfterCutOff =
+    state.createdAt > RONIN_FARM_CREATION_CUTOFF;
+
+  const roninVip = state.nfts?.ronin && isRoninFarmCreatedAfterCutOff;
+
   const getExpiresAt = () => {
-    if (!vip && !state.nfts?.ronin) return 0;
+    if (!vip && !roninVip) return 0;
 
     const paidVipExpiresAt = vip?.expiresAt ?? 0;
     const roninVipExpiresAt = state.nfts?.ronin?.expiresAt ?? 0;
@@ -141,13 +145,13 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
   };
 
   const vipExpiresAt = getExpiresAt();
-  const hasRoninVip =
+  const activeRoninVip =
     (state.nfts?.ronin?.expiresAt ?? 0) > Date.now() &&
-    state.createdAt > new Date("2025-02-01").getTime();
+    isRoninFarmCreatedAfterCutOff;
 
   // Disable VIP purchase buttons if Ronin NFT is active and expires in more than 1 day
   const shouldDisableVipPurchase = () => {
-    if (!hasRoninVip) return false;
+    if (!activeRoninVip) return false;
 
     const roninExpiresAt = state.nfts?.ronin?.expiresAt ?? 0;
 
@@ -232,7 +236,7 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
           </a>
         </div>
         <p className="text-xs px-1 mt-2">{t("season.vip.description")}</p>
-        {hasVip && (
+        {hasVip ? (
           <>
             <div className="flex justify-between my-2">
               <Label
@@ -252,15 +256,16 @@ export const VIPItems: React.FC<Props> = ({ onClose, onSkip }) => {
               )}
             </div>
           </>
-        )}
-        {hasExpired && (
-          <Label
-            icon={SUNNYSIDE.icons.stopwatch}
-            type="danger"
-            className="ml-2"
-          >
-            {t("expired")}
-          </Label>
+        ) : (
+          (vip || roninVip) && (
+            <Label
+              icon={SUNNYSIDE.icons.stopwatch}
+              type="danger"
+              className="ml-2"
+            >
+              {t("expired")}
+            </Label>
+          )
         )}
         {disableVipPurchase && (
           <Label type="info" className="ml-1 my-1">

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -2,6 +2,10 @@ import Decimal from "decimal.js-light";
 import { GameState } from "../types/game";
 import { getSeasonalBanner } from "../types/seasons";
 
+export const RONIN_FARM_CREATION_CUTOFF = new Date(
+  "2025-02-01T00:00:00Z",
+).getTime();
+
 export const hasVipAccess = ({
   game,
   now = Date.now(),
@@ -26,9 +30,6 @@ export const hasVipAccess = ({
   // Has Ronin NFT VIP Access
   const nft = game.nfts?.ronin;
   if (nft && nft.expiresAt > now && !hasValidInGameVIP) {
-    const RONIN_FARM_CREATION_CUTOFF = new Date(
-      "2025-02-01T00:00:00Z",
-    ).getTime();
     return game.createdAt > RONIN_FARM_CREATION_CUTOFF;
   }
 


### PR DESCRIPTION
# Description

- **Fix VIP Expiration Condition for expired label:** Some players benefit from both purchased VIP and Ronin NFT VIP. There is a scenario where the purchased VIP expires sooner than the Ronin VIP (e.g., a player bought 1 month of VIP before obtaining 3 months of active Ronin VIP). The game uses outdated code and will incorrectly show that the VIP has expired. However, these players cannot purchase VIP until 1 day before their Ronin VIP expiration.
- Fix `onBackdropClick` event that causes the whole `VIPitems` modal to close instead of confirm purchase modal.
- **Correct typo in `dictionary.json`:** Change VIP purchase wait time from "3 days" to "1 day" before Ronin NFT VIP expiration.
- Improve the code

Fixes #issue

# What needs to be tested by the reviewer?

- Try to test the changes in VIPItems and confirm purchase modals.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
