### PR TITLE
[FIX] Broken Offers

### DIFF
--- a/src/features/game/events/landExpansion/cook.test.ts
+++ b/src/features/game/events/landExpansion/cook.test.ts
@@ -1245,7 +1245,7 @@ describe("getCookingOilBoost", () => {
     const building = state.buildings["Fire Pit"]?.[0];
     const eggRecipe = building?.crafting?.find((r) => r.name === "Boiled Eggs");
 
-    expect(eggRecipe?.readyAt).toEqual(now + cookTimeMs * 0.5);
+    expect(eggRecipe?.readyAt).toBeCloseTo(now + cookTimeMs * 0.5, 0);
   });
 
   it("does not apply the 50% cooking boost for Bronze Season Pass (Ronin NFT)", () => {

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -62,7 +62,8 @@ export const MakeOffer: React.FC<{
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [needsSync, setNeedsSync] = useState(false);
 
-  const isResource = isTradeResource(KNOWN_ITEMS[Number(itemId)]);
+  const isResource =
+    display.type === "collectibles" && isTradeResource(KNOWN_ITEMS[itemId]);
 
   const tradeType = getTradeType({
     collection: display.type,

--- a/src/features/marketplace/components/MakeOffer.tsx
+++ b/src/features/marketplace/components/MakeOffer.tsx
@@ -63,7 +63,8 @@ export const MakeOffer: React.FC<{
   const [needsSync, setNeedsSync] = useState(false);
 
   const isResource =
-    display.type === "collectibles" && isTradeResource(KNOWN_ITEMS[itemId]);
+    display.type === "collectibles" &&
+    isTradeResource(KNOWN_ITEMS[Number(itemId)]);
 
   const tradeType = getTradeType({
     collection: display.type,

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -36,8 +36,6 @@ import Decimal from "decimal.js-light";
 import { useParams } from "react-router";
 import { KeyedMutator } from "swr";
 
-// JWT TOKEN
-
 const _hasPendingOfferEffect = (state: MachineState) =>
   state.matches("marketplaceOffering") || state.matches("marketplaceAccepting");
 const _authToken = (state: AuthMachineState) =>


### PR DESCRIPTION
# Description

This PR fixes an issue where `Make an Offer` was breaking for wearables. The reason being is we were not considering the collection type when checking if something was a resource. So `Banana Onesie` for example had the same id as `Soybean` so `isResource` was evaluating to true. This broke the game.

Fixes #issue

# What needs to be tested by the reviewer?

- Try to make an offer on a Banana Onesie

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
