### PR TITLE
[FIX] setDepth Layering Issue

### DIFF
--- a/src/assets/map/seasonal_plaza.json
+++ b/src/assets/map/seasonal_plaza.json
@@ -9203,12 +9203,23 @@
           "width": 16,
           "x": 32,
           "y": 297.6
+        },
+        {
+          "height": 16,
+          "id": 302,
+          "name": "",
+          "rotation": 0,
+          "type": "",
+          "visible": true,
+          "width": 16,
+          "x": 80,
+          "y": 9.6
         }
       ],
       "opacity": 1,
       "tintcolor": "#ff0000",
       "type": "objectgroup",
-      "visible": false,
+      "visible": true,
       "x": 0,
       "y": 0
     },
@@ -9535,7 +9546,7 @@
     }
   ],
   "nextlayerid": 159,
-  "nextobjectid": 302,
+  "nextobjectid": 303,
   "orientation": "orthogonal",
   "renderorder": "right-down",
   "tiledversion": "1.11.0",

--- a/src/features/world/scenes/Kingdom.ts
+++ b/src/features/world/scenes/Kingdom.ts
@@ -236,7 +236,8 @@ export class KingdomScene extends BaseScene {
 
           // Set depth for elements that should be drawn on top
           if (topElementsSet.has(element)) {
-            layer.setDepth(1000000);
+            const activeLayerName = `${element}/${capitalize(season)} ${element}`;
+            this.layers[activeLayerName]?.setDepth(1000000);
           }
         });
       });

--- a/src/features/world/scenes/PlazaScene.ts
+++ b/src/features/world/scenes/PlazaScene.ts
@@ -510,7 +510,8 @@ export class PlazaScene extends BaseScene {
 
           // Set depth for elements that should be drawn on top
           if (topElementsSet.has(element)) {
-            layer.setDepth(1000000);
+            const activeLayerName = `${element}/${capitalize(season)} ${element}`;
+            this.layers[activeLayerName]?.setDepth(1000000);
           }
         });
       });

--- a/src/features/world/scenes/WoodlandsScene.ts
+++ b/src/features/world/scenes/WoodlandsScene.ts
@@ -115,7 +115,8 @@ export class WoodlandsScene extends BaseScene {
 
           // Set depth for elements that should be drawn on top
           if (topElementsSet.has(element)) {
-            layer.setDepth(1000000);
+            const activeLayerName = `${element}/${capitalize(season)} ${element}`;
+            this.layers[activeLayerName]?.setDepth(1000000);
           }
         });
       });


### PR DESCRIPTION
# Description

This PR fixes the layering issue in Plaza,Kingdom, and Woodlands. the Depth of the layer for the active season is not being set properly as the season name is filtered in the top level of the iteration.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
