### PR TITLE
[FIX] Template collectable blocking clicks

### DIFF
--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -359,12 +359,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
   ...getKeys(DECORATION_TEMPLATES).reduce(
     (previous, name) => ({
       ...previous,
-      [name]: () => (
-        <TemplateCollectible
-          name={name}
-          dimensions={DECORATION_TEMPLATES[name].dimensions}
-        />
-      ),
+      [name]: () => <TemplateCollectible name={name} />,
     }),
     {} as Record<TemplateDecorationName, React.FC<CollectibleProps>>,
   ),

--- a/src/features/island/collectibles/TemplateCollectible.tsx
+++ b/src/features/island/collectibles/TemplateCollectible.tsx
@@ -15,7 +15,7 @@ export const TemplateCollectible: React.FC<Props> = ({ name, dimensions }) => {
   return (
     <img
       src={ITEM_DETAILS[name].image}
-      className="absolute left-1/2 transform -translate-x-1/2"
+      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
       alt={name}
       style={{
         maxWidth: "none",

--- a/src/features/island/collectibles/TemplateCollectible.tsx
+++ b/src/features/island/collectibles/TemplateCollectible.tsx
@@ -2,16 +2,14 @@ import React from "react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { CollectibleName } from "features/game/types/craftables";
-import { Template } from "features/game/types/templates";
 import { setImageWidth } from "lib/images";
 import { ITEM_DETAILS } from "features/game/types/images";
 
 interface Props {
   name: CollectibleName;
-  dimensions: Template["dimensions"];
 }
 
-export const TemplateCollectible: React.FC<Props> = ({ name, dimensions }) => {
+export const TemplateCollectible: React.FC<Props> = ({ name }) => {
   return (
     <img
       src={ITEM_DETAILS[name].image}

--- a/src/features/island/collectibles/components/template/ImageStyle.tsx
+++ b/src/features/island/collectibles/components/template/ImageStyle.tsx
@@ -15,7 +15,7 @@ export const ImageStyle: React.FC<Props> = ({
   alt,
 }) => {
   return (
-    <div className="absolute" style={divStyle}>
+    <div className="absolute pointer-events-none" style={divStyle}>
       <img src={image} style={imgStyle} alt={alt} />
     </div>
   );


### PR DESCRIPTION
# Description

- Fix template collectable blocking clicks if the image is too large

# What needs to be tested by the reviewer?

Place Tornado Pinwheel on island and click any collectable above it

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
