### PR TITLE
[FIX] Update Wallet Error Handling to Continue Instead of Reset

### DIFF
--- a/src/features/auth/components/ErrorBoundary.tsx
+++ b/src/features/auth/components/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { BoundaryError } from "./SomethingWentWrong";
 import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
+import { translate } from "lib/i18n/translate";
 
 interface Props {
   children?: ReactNode;
@@ -23,6 +24,10 @@ class ErrorBoundary extends Component<Props, State> {
     return { error };
   }
 
+  public handleAcknowledge = () => {
+    window.location.reload();
+  };
+
   public render() {
     if (this.state.error !== null) {
       return (
@@ -40,6 +45,8 @@ class ErrorBoundary extends Component<Props, State> {
               <BoundaryError
                 error={this.state.error.message}
                 stack={this.state.error.stack}
+                onAcknowledge={this.handleAcknowledge}
+                onAcknowledgeText={translate("refresh")}
               />
             </Panel>
           </Modal>

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -97,6 +97,13 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
 
   const tsFileName = stack ? getFirstTsFileName(stack) : null;
 
+  const truncateError = (error: string, maxLength: number) => {
+    if (error.length > maxLength) {
+      return error.substring(0, maxLength) + "...";
+    }
+    return error;
+  };
+
   return showGetHelp ? (
     <div className="relative">
       <img
@@ -156,6 +163,13 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
       <div className="p-2 py-1 space-y-2 mb-2">
         <h1 className="mb-1 text-base text-center">{t("error.wentWrong")}</h1>
         <p>{t("error.connection.one")}</p>
+        {error && (
+          <p className="mb-1 text-xs">
+            {t("error")}
+            {": "}
+            {truncateError(error, 140)}
+          </p>
+        )}
         <p
           onClick={() => setShowGetHelp(true)}
           className="underline text-xs cursor-pointer"

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -170,16 +170,15 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
             {truncateError(error, 140)}
           </p>
         )}
-        <p
-          onClick={() => setShowGetHelp(true)}
-          className="underline text-xs cursor-pointer"
-        >
-          {t("error.connection.two")}
-        </p>
       </div>
-      {onAcknowledge && (
-        <Button onClick={onAcknowledge}>{t("try.again")}</Button>
-      )}
+      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0">
+        {onAcknowledge && (
+          <Button onClick={onAcknowledge}>{t("try.again")}</Button>
+        )}
+        <Button onClick={() => setShowGetHelp(true)}>
+          {t("error.connection.two")}
+        </Button>
+      </div>
     </>
   );
 };

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -43,6 +43,7 @@ interface BoundaryErrorProps {
   stack?: string;
   transactionId?: string;
   onAcknowledge?: () => void;
+  onAcknowledgeText?: string;
 }
 
 /*
@@ -54,6 +55,7 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
   error,
   transactionId,
   onAcknowledge,
+  onAcknowledgeText,
   stack,
 }) => {
   const [showGetHelp, setShowGetHelp] = useState(false);
@@ -171,9 +173,11 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
           </p>
         )}
       </div>
-      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0">
+      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0 ">
         {onAcknowledge && (
-          <Button onClick={onAcknowledge}>{t("try.again")}</Button>
+          <Button onClick={onAcknowledge}>
+            {onAcknowledgeText ?? t("try.again")}
+          </Button>
         )}
         <Button onClick={() => setShowGetHelp(true)}>
           {t("error.connection.two")}

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -81,14 +81,6 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
     );
   }
 
-  const handleGetSupport = () => {
-    window.open(
-      "https://sunflower-land.help/",
-      "_blank",
-      "noopener,noreferrer",
-    );
-  };
-
   const handleAskOnDiscord = () => {
     window.open(
       "https://discord.gg/sunflowerland",
@@ -156,7 +148,6 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
         </div>
       </div>
       <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0">
-        <Button onClick={handleGetSupport}>{t("error.contactSupport")}</Button>
         <Button onClick={handleAskOnDiscord}>{t("error.askOnDiscord")}</Button>
       </div>
     </div>

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -147,9 +147,7 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
           </p>
         </div>
       </div>
-      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0">
-        <Button onClick={handleAskOnDiscord}>{t("error.askOnDiscord")}</Button>
-      </div>
+      <Button onClick={handleAskOnDiscord}>{t("error.askOnDiscord")}</Button>
     </div>
   ) : (
     <>
@@ -164,7 +162,7 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
           </p>
         )}
       </div>
-      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0 ">
+      <div className="flex flex-col space-y-0.5 space-x-0 sm:flex-row sm:space-x-1 sm:space-y-0">
         {onAcknowledge && (
           <Button onClick={onAcknowledge}>
             {onAcknowledgeText ?? t("try.again")}
@@ -181,6 +179,7 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
 export const SomethingWentWrong: React.FC = () => {
   const { authService } = useContext(Auth.Context);
   const { gameService } = useContext(Context);
+  const { t } = useAppTranslation();
 
   // If we get a connecting error before the game has loaded then try to connect again via the authService
   const service = gameService ?? authService;
@@ -203,6 +202,7 @@ export const SomethingWentWrong: React.FC = () => {
       transactionId={transactionId}
       error={errorCode}
       onAcknowledge={onAcknowledge}
+      onAcknowledgeText={t("refresh")}
     />
   );
 };

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -149,10 +149,10 @@ const WalletContent: React.FC<{ id?: number }> = ({ id }) => {
             {t("wallet.uniqueFarmNFT")}
             {"."}
           </p>
-          <p className="text-xs mb-2">
+          <Label type="info" className="text-xs mb-1">
             {t("wallet.RequiresPol")}
             {"."}
-          </p>
+          </Label>
         </div>
         <Button onClick={() => walletService.send("MINT")}>
           {t("wallet.mintFreeNFT")}

--- a/src/features/wallet/components/WalletErrors.tsx
+++ b/src/features/wallet/components/WalletErrors.tsx
@@ -20,7 +20,7 @@ export const WalletErrorMessage: React.FC<Props> = ({
   const { walletService } = useContext(WalletContext);
 
   const onAcknowledge = () => {
-    walletService.send("RESET");
+    walletService.send("CONTINUE");
   };
 
   if (errorCode === ERRORS.NO_WEB3_PHANTOM) {

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1210,7 +1210,6 @@
   "error.Web3NotFound": "Web3 Not Found",
   "error.wentWrong": "Oops! Something went wrong!",
   "error.getHelp": "Get help",
-  "error.contactSupport": "Contact support",
   "error.askOnDiscord": "Ask on discord",
   "error.tooManyFarms": "Slow down Bumpkin! It looks like you have too many accounts on your network. Please try again later.",
   "error.clock.not.synced": "Clock not in sync",


### PR DESCRIPTION
# Description

- **Resolve accessing blockchain settings menu when the farm is not minted yet:** If players receive an error while minting the farm and click the "Try Again" button, the wallet status will be reset. This reset causes players to mistakenly see a modal prompting them to link a wallet, after which they can access the blockchain settings menu.

| Before | After |
|--------|--------|
| ![Before_Minting](https://github.com/user-attachments/assets/10da0763-6432-4ff5-a1c1-2efc19c76b52) | ![After_Minting](https://github.com/user-attachments/assets/c466a3a9-1475-460b-9c33-69a90adb8a66) | 
---
- **Add error code to main modal and truncate the code if it's too long:** This change could help us resolve players' issues faster. In most cases, it should eliminate the need to instruct players to click "Get Help" and send another screenshot.
- **Convert the "Get Help" link to a button to increase its visibility for players:** Make it even easier for them to see & click "Get Help", read the message, navigate to Discord, and send a screenshot of the error code.

![image](https://github.com/user-attachments/assets/0747a285-e777-4817-ac39-2a4a3eebb875)

---
-  **Add the "Refresh" Button to ErrorBoundary Modal**: If players encounter this kind of error, then they can refresh the page through this button.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c2542983-1cfb-4df8-b094-4983830dc6b6) | ![image](https://github.com/user-attachments/assets/a0f3bb04-b3b8-48bd-9a07-2e04979e2e53) | 
---
- Add a label to the POL requirement message, so for those who might not pay attention to some in-game texts, it could be more noticeable.

![image](https://github.com/user-attachments/assets/50d7634d-cc50-40ea-a532-4d5c064ac7b6)

Fixes #issue

# What needs to be tested by the reviewer?

- Try to Mint the farm, do something that game gives you errors and check the error modal.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
