### PR TITLE
[FEAT] VIP Ronin Cooldown

### DIFF
--- a/src/features/game/events/landExpansion/cook.test.ts
+++ b/src/features/game/events/landExpansion/cook.test.ts
@@ -1305,6 +1305,7 @@ describe("getCookingOilBoost", () => {
             tokenId: 1,
             name: "Sunflower Land Platinum Pass",
             expiresAt: now + cookTimeMs,
+            acknowledgedAt: new Date("2025-03-02T00:00:00Z").getTime(),
           },
         },
         buildings: {

--- a/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
+++ b/src/features/game/expansion/components/onChainAirdrops/ClaimRoninAirdrop.tsx
@@ -50,6 +50,7 @@ export const ClaimRoninAirdrop: React.FC = () => {
               </div>
             )}
           </div>
+          <p className="my-1">{t("ronin.nft.activates")}</p>
           <p>{t("ronin.nft.expires")}</p>
           <Label
             type="info"

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -6,6 +6,9 @@ export const RONIN_FARM_CREATION_CUTOFF = new Date(
   "2025-02-01T00:00:00Z",
 ).getTime();
 
+// Prevents people sharing VIP across their farms
+const RONIN_VIP_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
 export const hasVipAccess = ({
   game,
   now = Date.now(),
@@ -29,7 +32,16 @@ export const hasVipAccess = ({
 
   // Has Ronin NFT VIP Access
   const nft = game.nfts?.ronin;
-  if (nft && nft.expiresAt > now && !hasValidInGameVIP) {
+  if (
+    nft &&
+    nft.expiresAt > now &&
+    !hasValidInGameVIP &&
+    nft.acknowledgedAt &&
+    // They acknowledged the NFT before the 24 hour cooldown cutover rule
+    (nft.acknowledgedAt < new Date("2025-03-03T00:00:00Z").getTime() ||
+      // Ensure they have had the NFT for 24 hours
+      nft.acknowledgedAt > now - RONIN_VIP_COOLDOWN_MS)
+  ) {
     return game.createdAt > RONIN_FARM_CREATION_CUTOFF;
   }
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5531,6 +5531,7 @@
   "ronin.nft.perkOne": "VIP Access (Farm created after February 1st, 2025)",
   "ronin.nft.perkTwo": "2x Faster Cooking",
   "ronin.nft.expires": "These perks won't last forever, so make the most of them while they last!",
+  "ronin.nft.activates": "Your VIP Access will be activated in 24 hours.",
   "news.flower.launch": "$FLOWER Launch",
   "news.flower.launch.description": "A new $ERC20 is coming to Sunflower Land. Learn about the new utility & how to earn.",
   "news.ronin.network": "Ronin Network",


### PR DESCRIPTION
# Description

This PR adds a 24 hour cooldown before Ronin VIP Access is activated (after claiming the NFT).

This prevents multi-accounters sharing VIP across their farms.