### PR TITLE
[FEAT] Add lock overlay on skills that hasn't been unlocked

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
@@ -298,10 +298,16 @@ export const SkillPathDetails: React.FC<Props> = ({
                               setSelectedSkill(skill);
                               setShowConfirmation(false);
                             }}
-                            showOverlay={hasSkill}
+                            showOverlay={hasSkill || !tierUnlocked}
                             overlayIcon={
                               <img
-                                src={SUNNYSIDE.icons.confirm}
+                                src={
+                                  hasSkill
+                                    ? SUNNYSIDE.icons.confirm
+                                    : !tierUnlocked
+                                      ? SUNNYSIDE.icons.lock
+                                      : undefined
+                                }
                                 alt="claimed"
                                 className="relative object-contain"
                                 style={{


### PR DESCRIPTION
# Description

Added overlay lock for skills that hasn't been unlocked
![image](https://github.com/user-attachments/assets/e69a5f72-8131-4a1e-bcc1-cda87fe547e6)


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
