### PR TITLE
[FEAT] Show all players when clicking multiple bumpkins

### DIFF
--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -63,6 +63,7 @@ import { ToastContext } from "features/game/toast/ToastProvider";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import worldIcon from "assets/icons/world.png";
 import { InfernosScene } from "./scenes/InferniaScene";
+import { PlayerSelectionList } from "./ui/PlayerSelectionList";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -533,6 +534,7 @@ export const PhaserComponent: React.FC<Props> = ({
       )}
 
       <NPCModals id={farmId as number} scene={scene} />
+      <PlayerSelectionList />
       <PlayerModals game={state} />
       <TradeCompleted mmoService={mmoService} farmId={farmId as number} />
       <CommunityModals />

--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -45,6 +45,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
   public frontfx: Phaser.GameObjects.Sprite | undefined;
 
   public clothing: Player["clothing"];
+  public username: string | undefined;
+  public experience: number | undefined;
+  public farmId: number | undefined;
   public faction: FactionName | undefined;
   private ready = false;
 
@@ -68,6 +71,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     onClick,
     name,
     direction,
+    username,
+    experience,
+    farmId,
     faction,
   }: {
     scene: Phaser.Scene;
@@ -78,6 +84,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     onCollide?: () => void;
     name?: string;
     direction?: "left" | "right";
+    username?: string;
+    experience?: number;
+    farmId?: number;
     faction?: FactionName;
   }) {
     super(scene, x, y);
@@ -101,6 +110,9 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
 
     this.reaction = this.scene.add.group();
 
+    this.username = username;
+    this.experience = experience;
+    this.farmId = farmId;
     this.faction = faction;
 
     if (name) {

--- a/src/features/world/containers/DogContainer.ts
+++ b/src/features/world/containers/DogContainer.ts
@@ -100,7 +100,7 @@ export class DogContainer extends Phaser.GameObjects.Container {
       key: `dog_${this.dogNumber}-idle`,
       frames: this.sprite?.anims.generateFrameNumbers(`dog_${this.dogNumber}`, {
         start: 6,
-        end: 10,
+        end: 9,
       }),
       frameRate: 1000 / 280,
       repeat: -1,

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -20,7 +20,6 @@ import {
   SceneId,
 } from "../mmoMachine";
 import { Player, PlazaRoomState } from "../types/Room";
-import { playerModalManager } from "../ui/PlayerModals";
 import { FactionName, GameState } from "features/game/types/game";
 import { translate } from "lib/i18n/translate";
 import { Room } from "colyseus.js";
@@ -41,6 +40,8 @@ import {
   PlazaShaders,
   getPlazaShaderSetting,
 } from "lib/utils/hooks/usePlazaShader";
+import { playerSelectionListManager } from "../ui/PlayerSelectionList";
+import { playerModalManager } from "../ui/PlayerModals";
 
 export type NPCBumpkin = {
   x: number;
@@ -327,11 +328,47 @@ export abstract class BaseScene extends Phaser.Scene {
           ...(this.gameState.bumpkin?.equipped as BumpkinParts),
           updatedAt: 0,
         },
-        experience: 0,
-        sessionId: this.mmoServer?.sessionId ?? "",
+        experience: this.gameState.bumpkin?.experience ?? 0,
       });
 
       this.initialiseCamera();
+
+      // handles player modal
+      // get all player under the pointer click
+      this.input.on("pointerdown", (pointer: Phaser.Input.Pointer) => {
+        const clickedObjects = this.input.hitTestPointer(pointer);
+
+        // filter other players
+        const clickedBumpkins = clickedObjects.filter((clickedObject) => {
+          const isBumpkinContainer = clickedObject instanceof BumpkinContainer;
+          if (!isBumpkinContainer) return false;
+
+          const bumpkinContainer = clickedObject as BumpkinContainer;
+          return (
+            bumpkinContainer.farmId !== this.id &&
+            bumpkinContainer.farmId !== undefined
+          );
+        }) as BumpkinContainer[];
+
+        if (clickedBumpkins.length === 0) return;
+
+        const players = clickedBumpkins.map((clickedBumpkin) => {
+          const { farmId, clothing, experience, username } = clickedBumpkin;
+          return {
+            id: farmId!,
+            clothing,
+            experience: experience ?? 0,
+            username,
+          };
+        });
+
+        if (clickedBumpkins.length === 1) {
+          playerModalManager.open(players[0]);
+          return;
+        }
+
+        playerSelectionListManager.open(players);
+      });
 
       // this.physics.world.fixedStep = false; // activates sync
       // this.physics.world.fixedStep = true; // deactivates sync (default)
@@ -572,6 +609,7 @@ export abstract class BaseScene extends Phaser.Scene {
       removeReactionListener();
 
       window.removeEventListener(AUDIO_MUTED_EVENT as any, this.onAudioMuted);
+      this.input.off("pointerdown"); // clean up pointerdown event listener
     });
   }
 
@@ -667,8 +705,7 @@ export abstract class BaseScene extends Phaser.Scene {
     isCurrentPlayer,
     clothing,
     npc,
-    experience = 0,
-    sessionId,
+    experience,
   }: {
     isCurrentPlayer: boolean;
     x: number;
@@ -679,7 +716,6 @@ export abstract class BaseScene extends Phaser.Scene {
     clothing: Player["clothing"];
     npc?: NPCName;
     experience?: number;
-    sessionId: string;
   }): BumpkinContainer {
     const defaultClick = () => {
       const distance = Phaser.Math.Distance.BetweenPoints(
@@ -687,26 +723,14 @@ export abstract class BaseScene extends Phaser.Scene {
         this.currentPlayer as BumpkinContainer,
       );
 
+      if (!npc) return;
+
       if (distance > 50) {
         entity.speak(translate("base.far.away"));
         return;
       }
 
-      if (npc) {
-        npcModalManager.open(npc);
-      } else {
-        if (farmId !== this.id) {
-          playerModalManager.open({
-            id: farmId,
-            // Always get the latest clothing
-            clothing: this.playerEntities[sessionId]?.clothing ?? clothing,
-            experience,
-            username,
-          });
-        }
-      }
-
-      // TODO - open player modals
+      npcModalManager.open(npc);
     };
 
     const entity = new BumpkinContainer({
@@ -715,6 +739,9 @@ export abstract class BaseScene extends Phaser.Scene {
       y,
       clothing,
       name: npc,
+      username,
+      experience,
+      farmId,
       faction,
       onClick: defaultClick,
     });
@@ -1027,7 +1054,6 @@ export abstract class BaseScene extends Phaser.Scene {
           isCurrentPlayer: sessionId === server.sessionId,
           npc: player.npc,
           experience: player.experience,
-          sessionId,
         });
       }
     });

--- a/src/features/world/ui/NPCModals.tsx
+++ b/src/features/world/ui/NPCModals.tsx
@@ -89,11 +89,7 @@ export const NPCModals: React.FC<Props> = ({ scene, id }) => {
 
   return (
     <>
-      <Modal
-        // dialogClassName="npc-dialog"
-        show={!!npc && !isSeparateModal}
-        onHide={closeModal}
-      >
+      <Modal show={!!npc && !isSeparateModal} onHide={closeModal}>
         {npc === "chase" && (
           <SpeakingModal
             onClose={closeModal}

--- a/src/features/world/ui/PlayerSelectionList.tsx
+++ b/src/features/world/ui/PlayerSelectionList.tsx
@@ -45,11 +45,27 @@ export const PlayerSelectionList: React.FC = () => {
     playerModalManager.open(player);
   };
 
+  const playersSortedByGiftGiver = players.sort((a, b) => {
+    if (
+      a.clothing.shirt === "Gift Giver" &&
+      b.clothing.shirt !== "Gift Giver"
+    ) {
+      return -1;
+    }
+    if (
+      b.clothing.shirt === "Gift Giver" &&
+      a.clothing.shirt !== "Gift Giver"
+    ) {
+      return 1;
+    }
+    return 0;
+  });
+
   return (
     <Modal show={!!players.length} onHide={closeModal}>
       <CloseButtonPanel title={t("select.player")} onClose={closeModal}>
         <div className="overflow-y-auto max-h-[70vh] scrollable">
-          {players.map((player) => (
+          {playersSortedByGiftGiver.map((player) => (
             <ButtonPanel
               key={player.id}
               className="flex flex-row items-center gap-1 mx-1 text-xs"

--- a/src/features/world/ui/PlayerSelectionList.tsx
+++ b/src/features/world/ui/PlayerSelectionList.tsx
@@ -1,0 +1,73 @@
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import React, { useEffect, useState } from "react";
+import { Modal } from "components/ui/Modal";
+
+import { playerModalManager, PlayerModalPlayer } from "./PlayerModals";
+import { NPCIcon } from "features/island/bumpkin/components/NPC";
+import { ButtonPanel } from "components/ui/Panel";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { getBumpkinLevel } from "features/game/lib/level";
+
+class PlayerSelectionListManager {
+  private listener?: (players: PlayerModalPlayer[]) => void;
+
+  public open(players: PlayerModalPlayer[]) {
+    if (this.listener) {
+      this.listener(players);
+    }
+  }
+
+  public listen(cb: (players: PlayerModalPlayer[]) => void) {
+    this.listener = cb;
+  }
+}
+
+export const playerSelectionListManager = new PlayerSelectionListManager();
+
+export const PlayerSelectionList: React.FC = () => {
+  const { t } = useAppTranslation();
+
+  const [players, setPlayers] = useState<PlayerModalPlayer[]>([]);
+
+  useEffect(() => {
+    playerSelectionListManager.listen((players) => {
+      setPlayers(players);
+    });
+  }, []);
+
+  const closeModal = () => {
+    setPlayers([]);
+  };
+
+  const openPlayerModal = (player: PlayerModalPlayer) => {
+    playerModalManager.open(player);
+  };
+
+  return (
+    <Modal show={!!players.length} onHide={closeModal}>
+      <CloseButtonPanel title={t("select.player")} onClose={closeModal}>
+        <div className="overflow-y-auto max-h-[70vh] scrollable">
+          {players.map((player) => (
+            <ButtonPanel
+              key={player.id}
+              className="flex flex-row items-center gap-1 mx-1 text-xs"
+              onClick={() => openPlayerModal(player)}
+            >
+              <NPCIcon parts={player.clothing} />
+              <div className="flex flex-col ml-1">
+                {player.username && <div>{player.username}</div>}
+                <div>{`#${player.id}`}</div>
+              </div>
+              <div className="flex-grow" />
+              <div className="text-center">
+                {t("level.number", {
+                  level: getBumpkinLevel(player.experience),
+                })}
+              </div>
+            </ButtonPanel>
+          ))}
+        </div>
+      </CloseButtonPanel>
+    </Modal>
+  );
+};

--- a/src/features/world/ui/PlayerSelectionList.tsx
+++ b/src/features/world/ui/PlayerSelectionList.tsx
@@ -7,6 +7,8 @@ import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { ButtonPanel } from "components/ui/Panel";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getBumpkinLevel } from "features/game/lib/level";
+import giftIcon from "assets/icons/gift.png";
+import { SquareIcon } from "components/ui/SquareIcon";
 
 class PlayerSelectionListManager {
   private listener?: (players: PlayerModalPlayer[]) => void;
@@ -54,6 +56,13 @@ export const PlayerSelectionList: React.FC = () => {
               onClick={() => openPlayerModal(player)}
             >
               <NPCIcon parts={player.clothing} />
+              {player.clothing.shirt !== "Gift Giver" && (
+                <SquareIcon
+                  className="absolute -top-1 left-3.5"
+                  icon={giftIcon}
+                  width={7}
+                />
+              )}
               <div className="flex flex-col ml-1">
                 {player.username && <div>{player.username}</div>}
                 <div>{`#${player.id}`}</div>

--- a/src/features/world/ui/PlayerSelectionList.tsx
+++ b/src/features/world/ui/PlayerSelectionList.tsx
@@ -56,7 +56,7 @@ export const PlayerSelectionList: React.FC = () => {
               onClick={() => openPlayerModal(player)}
             >
               <NPCIcon parts={player.clothing} />
-              {player.clothing.shirt !== "Gift Giver" && (
+              {player.clothing.shirt === "Gift Giver" && (
                 <SquareIcon
                   className="absolute -top-1 left-3.5"
                   icon={giftIcon}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5554,5 +5554,6 @@
   "rocketman.flower.launch": "On April 1st, $FLOWER will be added to the game!",
   "rocketman.flower.compete": "Compete in monthly challenges to earn $FLOWER.",
   "rocketman.flower.social": "Complete social tasks, spread the word, and earn $FLOWER.",
-  "rocketman.flower.eligible": "Polygon, Ronin & BASE users are eligible."
+  "rocketman.flower.eligible": "Polygon, Ronin & BASE users are eligible.",
+  "select.player": "Select Player"
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -813,13 +813,6 @@ img {
   );
 }
 
-.npc-dialog {
-  position: absolute;
-  bottom: 0;
-  width: 66%;
-  left: 17.5%;
-}
-
 /* Expanding Full Screen Panel */
 #expanding-base {
   position: fixed;


### PR DESCRIPTION
# Description

- show a player list if clicking an area with multiple bumpkins overlapping each other
  - clicking each option shows the regular bumpkin modal
- show the regular bumpkin modal if only one bumpkin is clicked

![image](https://github.com/user-attachments/assets/d430d2e2-e9f2-4993-81fd-e370ef465ece)

# What needs to be tested by the reviewer?

- go to plaza, then
  - click nothing
  - click npcs
  - click yourself
  - click dogs, i.e. non bumpkins
  - click one other player
  - click area with multiple players overlapping each other

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
