### PR TITLE
[FIX] Floating point artifact in bee swarm modal

### DIFF
--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -428,7 +428,7 @@ export const Beehive: React.FC<Props> = ({ id }) => {
             message={[
               {
                 text: t("beehive.pollinationCelebration", {
-                  amount: Number(calculateSwarmBoost(0, gameState).toFixed(2)),
+                  amount: formatNumber(calculateSwarmBoost(0, gameState)),
                 }),
               },
             ]}

--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -428,7 +428,7 @@ export const Beehive: React.FC<Props> = ({ id }) => {
             message={[
               {
                 text: t("beehive.pollinationCelebration", {
-                  amount: calculateSwarmBoost(0, gameState),
+                  amount: Number(calculateSwarmBoost(0, gameState).toFixed(2)),
                 }),
               },
             ]}


### PR DESCRIPTION
# Description

With "Pollen Power Up" Skill, the pollination boost displays a floating point artifact. This fixes it.
**Before:**
![before](https://github.com/user-attachments/assets/3f1fc7f0-9498-4504-899e-71301cd9faf6)

**After:**
![after](https://github.com/user-attachments/assets/47b754b3-c651-480e-9e2c-bb849d83197c)

# What needs to be tested by the reviewer?
Please describe how this can be tested.
* Observe correct text "+0.2" on regular bee swarm
* Observe correct text "+0.3" on bee swarm with "Pollen Power Up" skill
# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
