### PR TITLE
[FIX] Player modal clicks interfere with joystick

### DIFF
--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -336,6 +336,9 @@ export abstract class BaseScene extends Phaser.Scene {
       // handles player modal
       // get all player under the pointer click
       this.input.on("pointerdown", (pointer: Phaser.Input.Pointer) => {
+        // ignore click if the joystick is active
+        if (this.joystick?.pointer) return;
+
         const clickedObjects = this.input.hitTestPointer(pointer);
 
         // filter other players


### PR DESCRIPTION
# Description

- Fix issue where the player clicks are interfering with touch screen joystick movements

caused by https://github.com/sunflower-land/sunflower-land/pull/5365

# What needs to be tested by the reviewer?

- Start dragging joystick when finger is on top of other players

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
