### PR TITLE
[FEAT] Add Power Skills Ready Indicator

### DIFF
--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -3,9 +3,37 @@ import lightning from "assets/icons/lightning.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PowerSkills } from "./PowerSkills";
+import { useGame } from "features/game/GameProvider";
+import {
+  BumpkinSkillRevamp,
+  getPowerSkills,
+} from "features/game/types/bumpkinSkills";
+import { BumpkinRevampSkillName } from "features/game/types/bumpkinSkills";
+import { useSelector } from "@xstate/react";
 
 export const PowerSkillsButton: React.FC = () => {
   const [show, setShow] = useState(false);
+  const { gameService } = useGame();
+  const bumpkin = useSelector(
+    gameService,
+    (state) => state.context.state.bumpkin,
+  );
+  const { skills, previousPowerUseAt } = bumpkin;
+
+  const powerSkills = getPowerSkills();
+  const powerSkillsUnlocked = powerSkills.filter(
+    (skill) => !!skills[skill.name as BumpkinRevampSkillName],
+  );
+
+  const powerSkillsReady = powerSkillsUnlocked.some(
+    (skill: BumpkinSkillRevamp) => {
+      const nextSkillUse =
+        (previousPowerUseAt?.[skill.name as BumpkinRevampSkillName] ?? 0) +
+        (skill.requirements.cooldown ?? 0);
+      return nextSkillUse < Date.now();
+    },
+  );
+
   return (
     <div className="relative">
       <div
@@ -44,6 +72,17 @@ export const PowerSkillsButton: React.FC = () => {
             width: `${PIXEL_SCALE * 8}px`,
           }}
         />
+        {powerSkillsReady && (
+          <img
+            src={SUNNYSIDE.icons.expression_alerted}
+            className="absolute animate-pulsate"
+            style={{
+              width: `${PIXEL_SCALE * 4}px`,
+              top: `-${PIXEL_SCALE * 2}px`,
+              right: `-${PIXEL_SCALE * 2}px`,
+            }}
+          />
+        )}
       </div>
       <PowerSkills show={show} onHide={() => setShow(false)} />
     </div>

--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import lightning from "assets/icons/lightning.png";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PowerSkills } from "./PowerSkills";
-import { useGame } from "features/game/GameProvider";
+import { Context } from "features/game/GameProvider";
 import {
   BumpkinSkillRevamp,
   getPowerSkills,
@@ -13,7 +13,7 @@ import { useSelector } from "@xstate/react";
 
 export const PowerSkillsButton: React.FC = () => {
   const [show, setShow] = useState(false);
-  const { gameService } = useGame();
+  const { gameService } = useContext(Context);
   const bumpkin = useSelector(
     gameService,
     (state) => state.context.state.bumpkin,

--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -25,14 +25,21 @@ export const PowerSkillsButton: React.FC = () => {
     (skill) => !!skills[skill.name as BumpkinRevampSkillName],
   );
 
-  const powerSkillsReady = powerSkillsUnlocked.some(
-    (skill: BumpkinSkillRevamp) => {
+  const powerSkillsReady = powerSkillsUnlocked
+    .filter((skill: BumpkinSkillRevamp) => {
+      const fertiliserSkill: BumpkinRevampSkillName[] = [
+        "Sprout Surge",
+        "Root Rocket",
+        "Blend-tastic",
+      ];
+      return !fertiliserSkill.includes(skill.name as BumpkinRevampSkillName);
+    })
+    .some((skill: BumpkinSkillRevamp) => {
       const nextSkillUse =
         (previousPowerUseAt?.[skill.name as BumpkinRevampSkillName] ?? 0) +
         (skill.requirements.cooldown ?? 0);
       return nextSkillUse < Date.now();
-    },
-  );
+    });
 
   return (
     <div className="relative">


### PR DESCRIPTION
# Description

Add exclamation when at least 1 power skill is ready to be used
![image](https://github.com/user-attachments/assets/02d5d11f-4b67-4305-b8df-f0830146a5c3)
Doesn't include fertiliser power skills

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
