### PR TITLE
[FIX] Ticket Items Lightning Label

### DIFF
--- a/src/features/bumpkins/components/BumpkinEquip.tsx
+++ b/src/features/bumpkins/components/BumpkinEquip.tsx
@@ -236,7 +236,7 @@ export const BumpkinEquip: React.FC<Props> = ({ equipment, onEquip, game }) => {
                 <div className="w-full grid grid-cols-5 sm:grid-cols-4 py-1 px-1 gap-2">
                   {filteredWardrobeNames.map((name) => {
                     const boostLabel =
-                      BUMPKIN_ITEM_BUFF_LABELS[name] &&
+                      BUMPKIN_ITEM_BUFF_LABELS[name]?.[0] &&
                       !SPECIAL_ITEM_LABELS[name];
 
                     const specialItem = SPECIAL_ITEM_LABELS[name];

--- a/src/features/bumpkins/components/BumpkinPartGroup.tsx
+++ b/src/features/bumpkins/components/BumpkinPartGroup.tsx
@@ -37,7 +37,7 @@ export const BumpkinPartGroup: React.FC<Props> = ({
       {bumpkinParts.map((name) => {
         const bumpkinItem = equipped[name];
         const boostLabel = bumpkinItem
-          ? (BUMPKIN_ITEM_BUFF_LABELS[bumpkinItem] &&
+          ? (BUMPKIN_ITEM_BUFF_LABELS[bumpkinItem]?.[0] &&
               !SPECIAL_ITEM_LABELS[bumpkinItem]) ??
             ""
           : "";


### PR DESCRIPTION
# Description

When the corresponding chapter (formerly called season) has ended, hide the lightning label in the top-right corner of the ticket items' icon in the wardrobe.

![image](https://github.com/user-attachments/assets/5d503c43-4dc2-4722-9f97-7b4c3d5e34ba)

Fixes #issue

# What needs to be tested by the reviewer?

- Check for the existence of the lightning label on the previous season's ticket items in the wardrobe

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
