### PR TITLE
[FIX] Bert Start Time Calculation

### DIFF
--- a/src/features/game/events/landExpansion/completeBertObsession.test.ts
+++ b/src/features/game/events/landExpansion/completeBertObsession.test.ts
@@ -209,4 +209,37 @@ describe("completeBertObsession", () => {
       }),
     ).toThrow("This obsession is already completed");
   });
+
+  it("throws an error if obsession is in the future", () => {
+    const now = new Date("2023-08-17T00:00:00.000Z");
+    jest.setSystemTime(now);
+
+    expect(() =>
+      completeBertObsession({
+        state: {
+          ...TEST_FARM,
+          bumpkin: INITIAL_BUMPKIN,
+          bertObsession: {
+            name: "Halo",
+            type: "wearable",
+            startDate: now.getTime() + 10000,
+            endDate: now.getTime() + 20000,
+            reward: 3,
+          },
+          wardrobe: {
+            Halo: 1,
+          },
+          npcs: {
+            bert: {
+              deliveryCount: 0,
+            },
+          },
+        },
+        action: {
+          type: "bertObsession.completed",
+        },
+        createdAt: now.getTime(),
+      }),
+    ).toThrow("This obsession is not available");
+  });
 });

--- a/src/features/game/events/landExpansion/completeBertObsession.ts
+++ b/src/features/game/events/landExpansion/completeBertObsession.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { BumpkinItem } from "features/game/types/bumpkin";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 import { GameState, InventoryItemName } from "features/game/types/game";
 import { getSeasonalTicket } from "features/game/types/seasons";
 import { produce } from "immer";
@@ -39,6 +40,14 @@ export function completeBertObsession({
       throw new Error(translate("error.noDiscoveryAvailable"));
     }
 
+    const isObsessionAvailable =
+      createdAt >= currentObsession.startDate &&
+      createdAt <= currentObsession.endDate;
+
+    if (!isObsessionAvailable) {
+      throw new Error("This obsession is not available");
+    }
+
     if (stateCopy.npcs.bert.questCompletedAt) {
       const obsessionAlreadyCompleted =
         stateCopy.npcs.bert.questCompletedAt >= currentObsession.startDate &&
@@ -71,6 +80,11 @@ export function completeBertObsession({
       stateCopy.inventory[getSeasonalTicket()] || new Decimal(0);
     stateCopy.inventory[getSeasonalTicket()] = currentTickets.add(
       currentObsession.reward,
+    );
+
+    stateCopy.farmActivity = trackFarmActivity(
+      "Obsession Completed",
+      stateCopy.farmActivity,
     );
 
     stateCopy.npcs.bert.questCompletedAt = createdAt;

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -654,6 +654,14 @@ export const STATIC_OFFLINE_FARM: GameState = {
       total: 10,
     },
   },
+  bertObsession: {
+    type: "collectible",
+    name: "Axe",
+    startDate: Date.now() - 5 * 60 * 1000,
+    endDate: Date.now() + 10 * 60 * 1000,
+    reward: 3,
+  },
+  npcs: {},
   farmActivity: {},
   milestones: {},
   specialEvents: {

--- a/src/features/game/types/farmActivity.ts
+++ b/src/features/game/types/farmActivity.ts
@@ -18,7 +18,8 @@ export type FarmActivityName =
   | BountiedEvent
   | CraftedEvent
   | ResourceBought
-  | "Obsidian Exchanged";
+  | "Obsidian Exchanged"
+  | "Obsession Completed";
 
 export function trackFarmActivity(
   activityName: FarmActivityName,

--- a/src/features/world/ui/npcs/Bert.tsx
+++ b/src/features/world/ui/npcs/Bert.tsx
@@ -168,7 +168,12 @@ export const BertObsession: React.FC<{
   const resetSeconds = (endDate - new Date().getTime()) / 1000;
   const reward = currentObsession?.reward ?? 0;
 
-  if (!currentObsession) {
+  const now = Date.now();
+  const isObsessionAvailable =
+    now >= (currentObsession?.startDate ?? 0) &&
+    now <= (currentObsession?.endDate ?? 0);
+
+  if (!currentObsession || !isObsessionAvailable) {
     return (
       <div className="w-full flex flex-col items-center pt-0.5">
         <div className="flex flex-row justify-between w-full my-1">


### PR DESCRIPTION
# Description

Updates the Bert to check the player `createdAt` time when displaying and claiming the Bert Obession.

Test instructions in B.E.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
