### PR TITLE
[FIX] selectSeed Condition in Flowerbed Modal

### DIFF
--- a/src/features/island/flowers/FlowerBedContent.tsx
+++ b/src/features/island/flowers/FlowerBedContent.tsx
@@ -54,9 +54,11 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
 
   const selectSeed = (name: FlowerSeedName) => {
     setSeed(name);
-    if (!crossbreed) setSelecting("crossbreed");
+    const hasSelectedSeed = inventory[name]?.gte(1);
+
+    if (!crossbreed && hasSelectedSeed) setSelecting("crossbreed");
     if (crossbreed && !FLOWER_CROSS_BREED_AMOUNTS[name][crossbreed]) {
-      setSelecting("crossbreed");
+      if (hasSelectedSeed) setSelecting("crossbreed");
       setCrossBreed(undefined);
     }
   };


### PR DESCRIPTION
# Description

Fixes the issue where players are taken to the crossbreed selection if they select a flower seed with zero quantity in their inventory and haven't selected a related crossbreed beforehand.

For new players, this can be a bit challenging; after automatically switching to the crossbreed selection and selecting an available crossbreed, the "Plant Flower" button still remains disabled, leaving them unaware of the reason. The message informing them that they don't have that type of flower seed is displayed in seed selection, which can cause confusion at first glance.

This PR addresses this issue by preventing players from automatically switching to the crossbreed selection if they select a flower seed with zero quantity.

# After Fix
- ### [Test] Selecting seeds with zero quantity or more

![1](https://github.com/user-attachments/assets/54f1aad4-6dcf-4b2c-b6fd-7d6dbb7b2f81)

- ### [Test] Selecting crossbreeds for seasonal seeds and then selecting all season seeds(sunpetal-bloom-lily)
![2](https://github.com/user-attachments/assets/6064d284-cadd-4850-9471-8de2095005a4)


Fixes #issue

# What needs to be tested by the reviewer?
- Click a flowerbed and select a flower seed.
- Select crossbreeds for seasonal flower seeds and then choose all season seeds.
- Select crossbreeds for all season seeds, then choose seasonal flower seeds.
# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
