### PR TITLE
[FIX] Harvest Count for Fruit Patch Seeds with Pear Turbocharge Skill

### DIFF
--- a/src/features/game/events/landExpansion/utils.ts
+++ b/src/features/game/events/landExpansion/utils.ts
@@ -16,7 +16,9 @@ export const getFruitHarvests = (
     harvests = [4, 4];
   }
   if (isCollectibleBuilt({ name: "Immortal Pear", game: state })) {
-    harvests = harvests.map((harvest) => harvest + 1);
+    harvests = harvests.map(
+      (harvest) => harvest + (state.bumpkin.skills["Pear Turbocharge"] ? 2 : 1),
+    );
   }
 
   return harvests;


### PR DESCRIPTION
# Description

Fixes harvest count for fruit patch seeds in the seeds shop and inventory when Pear Turbocharge skill is claimed and Immortal Pear is placed.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6fee8021-b81b-4c40-b53c-d54ddf7c4329) | ![image](https://github.com/user-attachments/assets/7ce8d5f1-0ffa-4676-84bc-83b26cea693a)| 

Fixes #issue

# What needs to be tested by the reviewer?

- Check fruit patch seeds' harvest count in the seeds shop and inventory, both with and without required conditions met

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes