### PR TITLE
[FIX] Daily Chest Level Requirement Bug

### DIFF
--- a/src/features/game/expansion/components/dailyReward/DailyReward.tsx
+++ b/src/features/game/expansion/components/dailyReward/DailyReward.tsx
@@ -42,7 +42,7 @@ export const DailyReward: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
   const { gameService, showAnimations } = useContext(Context);
   const bumpkinLevel = useSelector(gameService, (state) =>
-    getBumpkinLevel(state.context.state.bumpkin.experience),
+    getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0),
   );
   const dailyRewards = useSelector(
     gameService,
@@ -61,7 +61,7 @@ export const DailyReward: React.FC = () => {
   });
   const [chestState] = useActor(chestService);
 
-  if (hasReferralAccess) {
+  if (hasReferralAccess || bumpkinLevel <= 5) {
     return <></>;
   }
 

--- a/src/features/island/hud/components/referral/Rewards.tsx
+++ b/src/features/island/hud/components/referral/Rewards.tsx
@@ -79,7 +79,14 @@ export const Rewards: React.FC<Props> = ({
       <CloseButtonPanel
         tabs={[
           { icon: SUNNYSIDE.ui.board, name: "Task Board" },
-          { icon: SUNNYSIDE.decorations.treasure_chest, name: "Daily Reward" },
+          ...(bumpkinLevel > 5
+            ? [
+                {
+                  icon: SUNNYSIDE.decorations.treasure_chest,
+                  name: "Daily Reward",
+                },
+              ]
+            : []),
           { icon: giftIcon, name: "Rewards Shop" },
         ]}
         currentTab={tab}

--- a/src/features/island/hud/components/referral/RewardsButton.tsx
+++ b/src/features/island/hud/components/referral/RewardsButton.tsx
@@ -19,6 +19,7 @@ import {
 import { rewardChestMachine } from "features/game/expansion/components/dailyReward/rewardChestMachine";
 import { useInterpret, useActor } from "@xstate/react";
 import Decimal from "decimal.js-light";
+import { getBumpkinLevel } from "features/game/lib/level";
 
 export const RewardsButton: React.FC = () => {
   const [showRewardsModal, setShowRewardsModal] = useState(false);
@@ -31,7 +32,7 @@ export const RewardsButton: React.FC = () => {
     (state) => state.context.state.dailyRewards,
   );
   const bumpkinLevel = useSelector(gameService, (state) =>
-    state.context.state.bumpkin ? state.context.state.bumpkin.experience : 0,
+    getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0),
   );
   const isRevealed = useSelector(gameService, (state) =>
     state.matches("revealed"),


### PR DESCRIPTION
# Description

- Fix the issue where the daily chest is displayed to players without checking the minimum required level. If they haven't reached level 6, clicking on it results in a blank modal.
- Add a condition to show the dedicated tab for `DailyRewardContent` in `Rewards.tsx`, only if players have reached the required level.
- Fix the issue in `RewardsButton.tsx` that causes `bumpkinLevel` to return experience instead of level.

Fixes #issue

# What needs to be tested by the reviewer?

- Try to check the visibility of the Daily Chest with and without the required level.
- On the testnet, check the Rewards Button in the top left to verify the visibility of Daily Reward both with and without the required level.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
