### PR TITLE
[FIX] Sick animal message showing after healing

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -9,7 +9,7 @@ import { Hud } from "features/island/hud/Hud";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { getKeys } from "features/game/types/decorations";
+import { getKeys, getValues } from "features/game/types/decorations";
 import { ANIMALS, AnimalType } from "features/game/types/animals";
 import { Cow } from "./components/Cow";
 import { Sheep } from "./components/Sheep";
@@ -108,7 +108,11 @@ export const BarnInside: React.FC = () => {
         },
       };
     });
-  }, [getKeys(barn.animals).length, floorWidth]);
+  }, [
+    getKeys(barn.animals).length,
+    getValues(barn.animals).map((animal) => animal.state),
+    floorWidth,
+  ]);
 
   return (
     <>

--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -11,6 +11,12 @@ import { Template } from "./templates";
 export const getKeys = Object.keys as <T extends object>(
   obj: T,
 ) => Array<keyof T>;
+/**
+ * getValues is a ref to Object.values, but the return is typed literally.
+ */
+export const getValues = Object.values as <T extends object>(
+  obj: T,
+) => Array<T[keyof T]>;
 
 export type AchievementDecorationName =
   | "Chef Bear"

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -9,7 +9,7 @@ import { Hud } from "features/island/hud/Hud";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { getKeys } from "features/game/types/decorations";
+import { getKeys, getValues } from "features/game/types/decorations";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 import { ANIMALS } from "features/game/types/animals";
 import { Chicken } from "./Chicken";
@@ -88,7 +88,11 @@ export const HenHouseInside: React.FC = () => {
         },
       };
     });
-  }, [getKeys(henHouse.animals).length, floorWidth]);
+  }, [
+    getKeys(henHouse.animals).length,
+    getValues(henHouse.animals).map((animal) => animal.state),
+    floorWidth,
+  ]);
 
   const nextLevel = Math.min(level + 1, 3);
   return (


### PR DESCRIPTION
# Description

When trying to fulfil a bounty of an animal that was just healed, it will show the message as if it was sick, even though it was just healed. This issue happens because the organizedAnimals objects in BarnInside and HenHouseInside are only updated when the number of animals changes. With this fix, the animals will also update if an animal's state updates (i.e. going from sick to idle) .

**Before (Barn)**
  <img src="https://github.com/user-attachments/assets/5d682ebe-832b-4ebf-8d9f-6172d70f4bc1" width="350" />
**Before (Hen House)**  
<img src="https://github.com/user-attachments/assets/92e73dfd-e0b8-497e-baab-d56ede1245d0" width="350" /> 

**After (Barn)**
<img src="https://github.com/user-attachments/assets/3af1c21b-3ad8-4bdc-bd44-06871625b504" width="350" /> 

**After (Hen House)**
<img src="https://github.com/user-attachments/assets/2fea3494-bb6a-473d-8f3d-3e6e0f27acce" width="350" /> 




# What needs to be tested by the reviewer?

* Heal sick cow/sheep and sell
* Heal sick chicken and sell
* Ensure correct message is shown depending on whether animal is sick or not

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
