### PR TITLE
[FIX] Add Disconnect Wallet Button

### DIFF
--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -210,7 +210,10 @@ const WalletContent: React.FC<{ id?: number }> = ({ id }) => {
           <Label icon={walletIcon} type="default" className="mb-1">
             {t("wallet.signRequest")}
           </Label>
-          <p className="text-sm">{t("wallet.rejectedDescription")}</p>
+          <p className="text-sm">
+            {t("wallet.signRequestInWallet")}
+            {"."}
+          </p>
         </div>
         <div className="flex space-x-1">
           <Button onClick={() => walletService.send("BACK")}>
@@ -569,7 +572,10 @@ const PortalWalletContent: React.FC<Props> = ({ id, farmAddress, action }) => {
           <Label icon={walletIcon} type="default" className="mb-1">
             {t("wallet.signRequest")}
           </Label>
-          <p className="text-sm">{t("wallet.rejectedDescription")}</p>
+          <p className="text-sm">
+            {t("wallet.signRequestInWallet")}
+            {"."}
+          </p>
         </div>
         <div className="flex space-x-1">
           <Button onClick={() => walletService.send("BACK")}>

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -210,10 +210,7 @@ const WalletContent: React.FC<{ id?: number }> = ({ id }) => {
           <Label icon={walletIcon} type="default" className="mb-1">
             {t("wallet.signRequest")}
           </Label>
-          <p className="text-sm">
-            {t("wallet.signRequestInWallet")}
-            {"."}
-          </p>
+          <p className="text-sm">{t("wallet.rejectedDescription")}</p>
         </div>
         <div className="flex space-x-1">
           <Button onClick={() => walletService.send("BACK")}>
@@ -229,15 +226,27 @@ const WalletContent: React.FC<{ id?: number }> = ({ id }) => {
 
   if (walletState.matches("signing")) {
     return (
-      <div className="p-2">
-        <Label icon={walletIcon} type="default" className="mb-1">
-          {t("wallet.signRequest")}
-        </Label>
-        <p className="text-sm">
-          {t("wallet.signRequestInWallet")}
-          {"."}
-        </p>
-      </div>
+      <>
+        <div className="p-2">
+          <Label icon={walletIcon} type="default" className="mb-1">
+            {t("wallet.signRequest")}
+          </Label>
+          <p className="text-sm">
+            {t("wallet.signRequestInWallet")}
+            {"."}
+          </p>
+        </div>
+        <div className="flex space-x-1">
+          <Button onClick={() => walletService.send("BACK")}>
+            {t("back")}
+          </Button>
+          <Button onClick={() => walletService.send("DISCONNECT_WALLET")}>
+            <span className="whitespace-nowrap">
+              {t("wallet.disconnectWallet")}
+            </span>
+          </Button>
+        </div>
+      </>
     );
   }
 
@@ -560,10 +569,7 @@ const PortalWalletContent: React.FC<Props> = ({ id, farmAddress, action }) => {
           <Label icon={walletIcon} type="default" className="mb-1">
             {t("wallet.signRequest")}
           </Label>
-          <p className="text-sm">
-            {t("wallet.signRequestInWallet")}
-            {"."}
-          </p>
+          <p className="text-sm">{t("wallet.rejectedDescription")}</p>
         </div>
         <div className="flex space-x-1">
           <Button onClick={() => walletService.send("BACK")}>
@@ -579,15 +585,27 @@ const PortalWalletContent: React.FC<Props> = ({ id, farmAddress, action }) => {
 
   if (walletState.matches("signing")) {
     return (
-      <div className="p-2">
-        <Label icon={walletIcon} type="default" className="mb-1">
-          {t("wallet.signRequest")}
-        </Label>
-        <p className="text-sm">
-          {t("wallet.signRequestInWallet")}
-          {"."}
-        </p>
-      </div>
+      <>
+        <div className="p-2">
+          <Label icon={walletIcon} type="default" className="mb-1">
+            {t("wallet.signRequest")}
+          </Label>
+          <p className="text-sm">
+            {t("wallet.signRequestInWallet")}
+            {"."}
+          </p>
+        </div>
+        <div className="flex space-x-1">
+          <Button onClick={() => walletService.send("BACK")}>
+            {t("back")}
+          </Button>
+          <Button onClick={() => walletService.send("DISCONNECT_WALLET")}>
+            <span className="whitespace-nowrap">
+              {t("wallet.disconnectWallet")}
+            </span>
+          </Button>
+        </div>
+      </>
     );
   }
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3603,6 +3603,7 @@
   "wallet.signRequestInWallet": "Sign the request in your wallet to continue",
   "wallet.rejected": "Wallet Rejected",
   "wallet.rejectedDescription": "Wallet rejected the connection. Please try again.",
+  "wallet.disconnectWallet": "Disconnect Wallet",
   "warning.noAxe": "No Axe Selected!",
   "warning.chat.maxCharacters": "Max characters",
   "warning.chat.noSpecialCharacters": "No special characters",


### PR DESCRIPTION
# Description

Occasionally, wallets get stuck on signing. The only fix right now is uninstall the app and reinstall. This PR adds a disconnect wallet option.

![disconnect](https://github.com/user-attachments/assets/7f50dafe-dc50-4aef-95b9-aaddbc5435ec)


# What needs to be tested by the reviewer?

DIsconnect during signing

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]