### PR TITLE
[FEAT] JSON Patch Autosave

### DIFF
--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -175,7 +175,8 @@ export async function autosave(request: Request, retries = 0) {
         applyPatches(
           draft,
           patches.map((patch: any) => {
-            // Remove leading slash and split by remaining slashes
+            // Remove leading slash and split by remaining slashes to format for immer
+            // https://immerjs.github.io/immer/patches/
             const path = patch.path.replace(/^\//, "").split("/");
             return { ...patch, path };
           }),

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -106,6 +106,9 @@ import { SpecialEventName } from "../types/specialEvents";
 import { getAccount } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
 import { hasFeatureAccess } from "lib/flags";
+import { enablePatches } from "immer";
+
+enablePatches();
 
 // Run at startup in case removed from query params
 const portalName = new URLSearchParams(window.location.search).get("portal");
@@ -436,6 +439,7 @@ const EFFECT_STATES = Object.values(EFFECT_EVENTS).reduce(
 
           if (context.actions.length > 0) {
             await autosave({
+              state: context.state,
               farmId: Number(context.farmId),
               sessionId: context.sessionId as string,
               actions: context.actions,
@@ -589,6 +593,7 @@ export const saveGame = async (
   }
 
   const { verified, farm, announcements } = await autosave({
+    state: context.state,
     farmId,
     sessionId: context.sessionId as string,
     actions: context.actions,
@@ -1522,6 +1527,7 @@ export function startGame(authContext: AuthContext) {
               // Autosave just in case
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -1641,6 +1647,7 @@ export function startGame(authContext: AuthContext) {
 
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -1652,6 +1659,7 @@ export function startGame(authContext: AuthContext) {
               }
 
               const { farm, changeset } = await autosave({
+                state: context.state,
                 farmId: Number(context.farmId),
                 sessionId: context.sessionId as string,
                 actions: [event],
@@ -1809,6 +1817,7 @@ export function startGame(authContext: AuthContext) {
 
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -1915,6 +1924,7 @@ export function startGame(authContext: AuthContext) {
 
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -1976,6 +1986,7 @@ export function startGame(authContext: AuthContext) {
 
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -2051,6 +2062,7 @@ export function startGame(authContext: AuthContext) {
 
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,
@@ -2144,6 +2156,7 @@ export function startGame(authContext: AuthContext) {
             src: async (context, e) => {
               if (context.actions.length > 0) {
                 await autosave({
+                  state: context.state,
                   farmId: Number(context.farmId),
                   sessionId: context.sessionId as string,
                   actions: context.actions,


### PR DESCRIPTION
# Description

Applies a JSON patch when you autosave - rather than returning the entire state (to save bandwidth)

![bandwith begone](https://github.com/user-attachments/assets/47383bce-6bfd-49e2-82b9-4e4b69defd34)

# What needs to be tested by the reviewer?

- Play the game
- Try to trigger state updates that operate on both objects and arrays

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes