### PR TITLE
[FEAT] Burn temp items on upgrade

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -302,193 +302,45 @@ describe("upgradeFarm", () => {
     expect(state.island.previousExpansions).toEqual(16);
   });
 
-  it("removes items which have expired on the land", () => {
-    const createdAt = Date.now();
+  it.only("removes all temporary collectibles", () => {
+    const now = Date.now();
 
     const state = upgrade({
       action: {
         type: "farm.upgraded",
       },
       state: {
-        ...TEST_FARM,
+        ...INITIAL_FARM,
         inventory: {
           "Basic Land": new Decimal(16),
           Gold: new Decimal(15),
           "Time Warp Totem": new Decimal(1),
+          "Super Totem": new Decimal(1),
         },
         collectibles: {
           "Time Warp Totem": [
             {
               id: "1",
-              readyAt: Date.now() - 48 * 60 * 60 * 1000,
-              createdAt: Date.now() - 48 * 60 * 60 * 1000,
+              readyAt: now + 1 * 60 * 60 * 1000,
+              createdAt: now + 1 * 60 * 60 * 1000,
               coordinates: { x: 0, y: 0 },
+            },
+          ],
+          "Super Totem": [
+            {
+              id: "1",
+              readyAt: now + 1 * 60 * 60 * 1000,
+              createdAt: now + 1 * 60 * 60 * 1000,
+              coordinates: { x: 1, y: 2 },
             },
           ],
         },
       },
-      createdAt,
+      createdAt: now,
     });
 
     expect(state.inventory["Time Warp Totem"]).toEqual(new Decimal(0));
-  });
-
-  it("it does not remove items that have not yet expired", () => {
-    const createdAt = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...TEST_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Time Warp Totem": new Decimal(1),
-        },
-        collectibles: {
-          "Time Warp Totem": [
-            {
-              id: "1",
-              // Still active
-              readyAt: Date.now() - 1 * 60 * 60 * 1000,
-              createdAt: Date.now() - 1 * 60 * 60 * 1000,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-        },
-      },
-      createdAt,
-    });
-
-    expect(state.inventory["Time Warp Totem"]).toEqual(new Decimal(1));
-  });
-
-  it("removes Super Totem which have expired on the land", () => {
-    const createdAt = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...TEST_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Super Totem": new Decimal(1),
-        },
-        collectibles: {
-          "Super Totem": [
-            {
-              id: "1",
-              readyAt: Date.now() - 7 * 25 * 60 * 60 * 1000,
-              createdAt: Date.now() - 7 * 25 * 60 * 60 * 1000,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-        },
-      },
-      createdAt,
-    });
-
     expect(state.inventory["Super Totem"]).toEqual(new Decimal(0));
-  });
-
-  it("it does not remove Super Totem that have not yet expired", () => {
-    const createdAt = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...TEST_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Super Totem": new Decimal(1),
-        },
-        collectibles: {
-          "Super Totem": [
-            {
-              id: "1",
-              // Still active
-              readyAt: Date.now() - 1 * 60 * 60 * 1000,
-              createdAt: Date.now() - 1 * 60 * 60 * 1000,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-        },
-      },
-      createdAt,
-    });
-
-    expect(state.inventory["Super Totem"]).toEqual(new Decimal(1));
-  });
-
-  it("removes hourglasses which have expired on the land", () => {
-    const createdAt = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...INITIAL_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Orchard Hourglass": new Decimal(1),
-        },
-        collectibles: {
-          "Orchard Hourglass": [
-            {
-              id: "1",
-              readyAt: createdAt - 6 * 60 * 60 * 1000,
-              createdAt: createdAt - 6 * 60 * 60 * 1000 - 1,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-        },
-      },
-      createdAt,
-    });
-
-    expect(state.inventory["Orchard Hourglass"]).toEqual(new Decimal(0));
-  });
-
-  it("it does not remove hourglasses that have not yet expired", () => {
-    const createdAt = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...INITIAL_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Super Totem": new Decimal(1),
-        },
-        collectibles: {
-          "Super Totem": [
-            {
-              id: "1",
-              // Still active
-              readyAt: Date.now() - 1 * 60 * 60 * 1000,
-              createdAt: Date.now() - 1 * 60 * 60 * 1000,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-        },
-      },
-      createdAt,
-    });
-
-    expect(state.inventory["Super Totem"]).toEqual(new Decimal(1));
   });
 
   it("does not remove sunstones", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -302,7 +302,7 @@ describe("upgradeFarm", () => {
     expect(state.island.previousExpansions).toEqual(16);
   });
 
-  it.only("removes all temporary collectibles", () => {
+  it("removes all temporary collectibles", () => {
     const now = Date.now();
 
     const state = upgrade({

--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -15,7 +15,7 @@ import { Label } from "components/ui/Label";
 import { Panel } from "components/ui/Panel";
 import { useActor } from "@xstate/react";
 import { ISLAND_UPGRADE } from "features/game/events/landExpansion/upgradeFarm";
-import { getKeys } from "features/game/types/craftables";
+import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { createPortal } from "react-dom";
 import confetti from "canvas-confetti";
 import { GameState, IslandType } from "features/game/types/game";
@@ -25,6 +25,7 @@ import { Transition } from "@headlessui/react";
 import { formatDateTime } from "lib/utils/time";
 import { translate } from "lib/i18n/translate";
 import { Loading } from "features/auth/components";
+import { EXPIRY_COOLDOWNS } from "features/game/lib/collectibleBuilt";
 
 const UPGRADE_DATES: Record<IslandType, number | null> = {
   basic: new Date(0).getTime(),
@@ -70,7 +71,7 @@ const IslandUpgraderModal: React.FC<{
 
   const [showConfirmation, setShowConfirmation] = useState(false);
 
-  const { island, inventory } = gameState.context.state;
+  const { island, inventory, collectibles, home } = gameState.context.state;
   const upgrade = ISLAND_UPGRADE[island.type];
   const { t } = useAppTranslation();
 
@@ -105,6 +106,29 @@ const IslandUpgraderModal: React.FC<{
       </Panel>
     );
   }
+
+  const hasUnexpiredItemsPlaced = () => {
+    const temporaryCollectibles = getKeys(EXPIRY_COOLDOWNS).reduce(
+      (acc, name) => {
+        const items = collectibles[name as CollectibleName] ?? [];
+        const homeItems = home.collectibles[name as CollectibleName] ?? [];
+
+        const count = [...items, ...homeItems].length;
+
+        if (count > 0) {
+          return {
+            ...acc,
+            [name]: count,
+          };
+        }
+
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    return getKeys(temporaryCollectibles).length > 0;
+  };
 
   const upgradeDate = UPGRADE_DATES[island.type];
   const hasUpgrade = upgradeDate !== null;
@@ -162,6 +186,15 @@ const IslandUpgraderModal: React.FC<{
                 </Label>
               )}
 
+              {isReady && hasUnexpiredItemsPlaced() && (
+                <Label
+                  icon={SUNNYSIDE.icons.expression_alerted}
+                  type="danger"
+                  className="mr-3 mb-1"
+                >
+                  {t("islandupgrade.tempItemWarning")}
+                </Label>
+              )}
               {getKeys(upgrade.items).map((name) => (
                 <Label
                   key={name}

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -54,7 +54,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Town Center": new Decimal(1),
     Market: new Decimal(1),
     Workbench: new Decimal(1),
-    "Basic Land": new Decimal(10),
+    "Basic Land": new Decimal(25),
     "Lava Pit": new Decimal(1),
     Bush: new Decimal(3),
     Axe: new Decimal(10),
@@ -313,7 +313,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
   },
 
   island: {
-    type: "volcano",
+    type: "desert",
   },
 
   home: {
@@ -338,6 +338,14 @@ export const STATIC_OFFLINE_FARM: GameState = {
             y: 2,
           },
           readyAt: Date.now(),
+        },
+      ],
+      "Super Totem": [
+        {
+          id: "1",
+          createdAt: Date.now() - 1 * 60 * 60 * 1000,
+          coordinates: { x: 0, y: 0 },
+          readyAt: Date.now() - 1 * 60 * 60 * 1000,
         },
       ],
     },

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2341,6 +2341,7 @@
   "islandupgrade.warning": "Make sure you do not have any crops, fruit, buildings, chickens, crimstone, flowers or honey in progress. These will not be able to be harvested and will be returned to your inventory. Sunstones, House, Market, Fire Pit and Workbench will remain placed on your land.",
   "islandupgrade.upgradeIsland": "Upgrade Island",
   "islandupgrade.newOpportunities": "An exotic island awaits you with new resources and opportunities to grow your farm.",
+  "islandupgrade.tempItemWarning": "Active totems/hourglasses will be burned",
   "islandupgrade.confirmation": "Would you like to upgrade? You will start on a small island with all of your items.",
   "islandupgrade.locked": "Locked",
   "islandupgrade.exploring": "Exploring",


### PR DESCRIPTION
# Description

All temporary items will be burned on island upgrade.

<img width="499" alt="Screenshot 2025-03-20 at 10 57 35 AM" src="https://github.com/user-attachments/assets/371e0848-23d6-49f8-a95b-f3306a377e9c" />

# What needs to be tested by the reviewer?

- Upgrade with an active Super Totem. It should be burned.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
