### PR TITLE
[FIX] Animals instantly sorting after feeding

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -110,7 +110,7 @@ export const BarnInside: React.FC = () => {
     });
   }, [
     getKeys(barn.animals).length,
-    getValues(barn.animals).map((animal) => animal.state),
+    getValues(barn.animals).filter((animal) => animal.state === "sick").length,
     floorWidth,
   ]);
 

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -90,7 +90,8 @@ export const HenHouseInside: React.FC = () => {
     });
   }, [
     getKeys(henHouse.animals).length,
-    getValues(henHouse.animals).map((animal) => animal.state),
+    getValues(henHouse.animals).filter((animal) => animal.state === "sick")
+      .length,
     floorWidth,
   ]);
 


### PR DESCRIPTION
# Description

#5415 made barn/henhouse animals update on any state change, which makes feeding animals look weird as they instantly get sorted:

![before1](https://github.com/user-attachments/assets/f4e2defa-4639-40e4-b51b-393c1af1c338)
![before2](https://github.com/user-attachments/assets/9c930c74-cc01-4c47-ba77-f75cfc20e9a5)

This PR fixes this so that the animal order only changes if the amount of sick animals changes.
![after1](https://github.com/user-attachments/assets/e935fcc5-35f5-4afc-a5ca-9b9f3138ba1b)
![after2](https://github.com/user-attachments/assets/8d05f008-ef7b-4e93-9f0a-307360ab73a2)


Please describe how this can be tested.
* Feed barn animals and chickens -> expect normal behavior
* Trying to fulfill bounty with sick animal should give the reduced bounty message
* Healing the animal and immediately fulfilling bounty with same animal should work as expected now.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
- [X] I have read the contributing guidelines and agree to the T&Cs
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
