### PR TITLE
[FIX] Timeshard Front-end Hoard Limit

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -290,6 +290,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   Scroll: new Decimal(1500),
   "Amber Fossil": new Decimal(1500),
   Horseshoe: new Decimal(1500),
+  Timeshard: new Decimal(1500),
   "Bud Ticket": new Decimal(1),
 
   // Potion House

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -10,7 +10,7 @@ import {
 import { LEGACY_BADGE_TREE } from "../types/skills";
 import { Announcements } from "../types/announcements";
 import { EXOTIC_CROPS } from "../types/beans";
-import { BASIC_DECORATIONS } from "../types/decorations";
+import { BASIC_DECORATIONS, getValues } from "../types/decorations";
 import { FISH } from "../types/fishing";
 import { LANDSCAPING_DECORATIONS } from "../types/decorations";
 import { getActiveListedItems } from "features/island/hud/components/inventory/utils/inventory";
@@ -18,6 +18,7 @@ import { KNOWN_IDS } from "../types";
 import { ANIMAL_FOODS } from "../types/animals";
 import { BumpkinItem, ITEM_IDS } from "../types/bumpkin";
 import { MaxedItem } from "./gameMachine";
+import { SEASON_TICKET_NAME } from "../types/seasons";
 
 export const MAX_INVENTORY_ITEMS: Inventory = {
   ...getKeys(EXOTIC_CROPS).reduce(
@@ -109,6 +110,20 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
     }),
     {},
   ),
+
+  // Max of 1500 Chapter tickets
+  ...getValues(SEASON_TICKET_NAME).reduce(
+    (acc, name) => ({
+      ...acc,
+      [name]: new Decimal(1500),
+    }),
+    {},
+  ),
+  "Solar Flare Ticket": new Decimal(350),
+  "Dawn Breaker Ticket": new Decimal(750),
+  "Crow Feather": new Decimal(750),
+  "Bud Ticket": new Decimal(1),
+
   Sunflower: new Decimal(30000),
   Potato: new Decimal(20000),
   Rhubarb: new Decimal(20000),
@@ -280,18 +295,6 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   "Dinosaur Bone": new Decimal(50),
   "Human Bear": new Decimal(50),
   "Whale Bear": new Decimal(50),
-
-  // Seasonal Tickets
-  "Solar Flare Ticket": new Decimal(350),
-  "Dawn Breaker Ticket": new Decimal(750),
-  "Crow Feather": new Decimal(750),
-  "Mermaid Scale": new Decimal(1500),
-  "Tulip Bulb": new Decimal(1500),
-  Scroll: new Decimal(1500),
-  "Amber Fossil": new Decimal(1500),
-  Horseshoe: new Decimal(1500),
-  Timeshard: new Decimal(1500),
-  "Bud Ticket": new Decimal(1),
 
   // Potion House
   "Potion Ticket": new Decimal(7500),


### PR DESCRIPTION
# Description

Add  Timeshard hoard limit to frontend , in order to show a user-friendly modal for syncing instead of "something went wrong" error.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
