### PR TITLE
[FIX] Fruitful Bounty Skill

### DIFF
--- a/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
+++ b/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
@@ -41,7 +41,7 @@ export function fertiliseFruitPatch({
   createdAt = Date.now(),
 }: Options): GameState {
   return produce(state, (stateCopy) => {
-    const { fruitPatches, inventory } = stateCopy;
+    const { fruitPatches, inventory, bumpkin } = stateCopy;
 
     const fruitPatch = fruitPatches[action.patchID];
 
@@ -78,7 +78,12 @@ export function fertiliseFruitPatch({
 
     // Apply boost to already planted
     if (fruitPatch.fruit) {
-      fruitPatch.fruit.amount += 0.1;
+      const fruitfulBlendBuff = 0.1;
+      if (bumpkin.skills["Fruitful Bounty"]) {
+        fruitPatch.fruit.amount += fruitfulBlendBuff * 2;
+      } else {
+        fruitPatch.fruit.amount += fruitfulBlendBuff;
+      }
     }
 
     inventory[action.fertiliser] = fertiliserAmount.minus(1);

--- a/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
+++ b/src/features/game/events/landExpansion/fertiliseFruitPatch.ts
@@ -3,7 +3,7 @@ import {
   FRUIT_COMPOST,
   FruitCompostName,
 } from "features/game/types/composters";
-import { GameState, PlantedFruit } from "features/game/types/game";
+import { GameState } from "features/game/types/game";
 import { produce } from "immer";
 
 export enum FERTILISE_FRUIT_ERRORS {
@@ -27,12 +27,13 @@ type Options = {
   createdAt?: number;
 };
 
-const getYield = (fruitDetails: PlantedFruit, fertiliser: FruitCompostName) => {
-  if (fertiliser === "Fruitful Blend") {
-    return fruitDetails.amount + 0.25;
+export const getFruitfulBlendBuff = (state: GameState) => {
+  const fruitfulBlendBuff = 0.1;
+  if (state.bumpkin?.skills["Fruitful Bounty"]) {
+    return fruitfulBlendBuff * 2;
+  } else {
+    return fruitfulBlendBuff;
   }
-
-  return fruitDetails.amount;
 };
 
 export function fertiliseFruitPatch({
@@ -41,7 +42,7 @@ export function fertiliseFruitPatch({
   createdAt = Date.now(),
 }: Options): GameState {
   return produce(state, (stateCopy) => {
-    const { fruitPatches, inventory, bumpkin } = stateCopy;
+    const { fruitPatches, inventory } = stateCopy;
 
     const fruitPatch = fruitPatches[action.patchID];
 
@@ -78,12 +79,7 @@ export function fertiliseFruitPatch({
 
     // Apply boost to already planted
     if (fruitPatch.fruit) {
-      const fruitfulBlendBuff = 0.1;
-      if (bumpkin.skills["Fruitful Bounty"]) {
-        fruitPatch.fruit.amount += fruitfulBlendBuff * 2;
-      } else {
-        fruitPatch.fruit.amount += fruitfulBlendBuff;
-      }
+      fruitPatch.fruit.amount += getFruitfulBlendBuff(stateCopy);
     }
 
     inventory[action.fertiliser] = fertiliserAmount.minus(1);

--- a/src/features/game/events/landExpansion/fruitHarvested.test.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.test.ts
@@ -950,5 +950,20 @@ describe("fruitHarvested", () => {
 
       expect(amount).toEqual(1.2);
     });
+    it("gives +0.2 fruit yield when Fruitful Bounty is claimed and Fruitful Blend is applied", () => {
+      const amount = getFruitYield({
+        game: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Fruitful Bounty": 1 },
+          },
+        },
+        fertiliser: "Fruitful Blend",
+        name: "Apple",
+      });
+
+      expect(amount).toEqual(1.2);
+    });
   });
 });

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -25,6 +25,7 @@ import { isGreenhouseFruit } from "./plantGreenhouse";
 import { FACTION_ITEMS } from "features/game/lib/factions";
 import { produce } from "immer";
 import { getActiveCalendarEvent } from "features/game/types/calendar";
+import { getFruitfulBlendBuff } from "./fertiliseFruitPatch";
 
 export type HarvestFruitAction = {
   type: "fruit.harvested";
@@ -160,12 +161,7 @@ export function getFruitYield({ name, game, fertiliser }: FruitYield) {
   }
 
   if (fertiliser === "Fruitful Blend") {
-    const fruitfulBlendBuff = 0.1;
-    if (bumpkin.skills["Fruitful Bounty"]) {
-      amount += fruitfulBlendBuff * 2;
-    } else {
-      amount += fruitfulBlendBuff;
-    }
+    amount += getFruitfulBlendBuff(game);
   }
 
   if (name === "Banana" && isWearableActive({ name: "Banana Amulet", game })) {


### PR DESCRIPTION
# Description

Fixes an issue where Fruitful Bounty does not work as intended (i.e., applying the Fruitful Blend after planting the fruit patch plants does not grant the skill boost on the first harvest but instead applies it to subsequent harvests).

Fixes #issue

# What needs to be tested by the reviewer?

Apply Fruitful Blend to fruit patches both before and after planting a fruit, with and without the Fruitful Bounty skill.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
