### PR TITLE
[CHORE] Update Discord Guide

### DIFF
--- a/src/features/island/hud/components/reputation/Reputation.tsx
+++ b/src/features/island/hud/components/reputation/Reputation.tsx
@@ -28,7 +28,7 @@ import walletIcon from "assets/icons/wallet.png";
 import hammerinHarry from "assets/npcs/hammerin_harry.webp";
 import salesIcon from "assets/icons/sale.webp";
 import { UPGRADE_RAFTS } from "features/game/expansion/components/IslandUpgrader";
-import boat from "assets/decorations/isles_boat.png";
+import settings from "assets/icons/settings_disc.png";
 import bank from "assets/icons/withdraw.png";
 import bud from "assets/icons/bud.png";
 
@@ -383,7 +383,7 @@ export const ReputationGuide: React.FC<Props> = ({ onClose }) => {
     },
     {
       content: t("reputation.guide.connectDiscord"),
-      icon: boat,
+      icon: settings,
     },
     {
       content: t("reputation.guide.proofOfHumanity"),

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5475,7 +5475,7 @@
   "reputation.earnPoints": "Earn points",
   "reputation.guide.upgrade": "Unlock all the expansions on your current island, and then click the goblin on the raft to reach the next island. (Basic -> Spring -> Desert -> Volcano)",
   "reputation.guide.levelUp": "To level up your Bumpkin, cook food in the cooking buildings, and click on the Bumpkin in front of the tent or house to feed it.",
-  "reputation.guide.connectDiscord": "Connect the Discord Account through the boat at the top of your island and receive the 'Companion Cap' as a reward.",
+  "reputation.guide.connectDiscord": "Connect your Discord account by clicking the gear icon in the bottom right corner, selecting General Settings, and then clicking the Discord button.",
   "reputation.guide.proofOfHumanity": "Complete the Proof of Humanity by traveling to Retreat Island and locating the bank.",
   "reputation.guide.ownBud": "Own a Bud by purchasing it through the in-game or third-party marketplaces.",
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5475,7 +5475,7 @@
   "reputation.earnPoints": "Earn points",
   "reputation.guide.upgrade": "Unlock all the expansions on your current island, and then click the goblin on the raft to reach the next island. (Basic -> Spring -> Desert -> Volcano)",
   "reputation.guide.levelUp": "To level up your Bumpkin, cook food in the cooking buildings, and click on the Bumpkin in front of the tent or house to feed it.",
-  "reputation.guide.connectDiscord": "Connect your Discord account by clicking the gear icon in the bottom right corner, selecting General Settings, and then clicking the Discord button.",
+  "reputation.guide.connectDiscord": "Connect your Discord account by clicking the gear icon, selecting General Settings, and clicking the Discord button.",
   "reputation.guide.proofOfHumanity": "Complete the Proof of Humanity by traveling to Retreat Island and locating the bank.",
   "reputation.guide.ownBud": "Own a Bud by purchasing it through the in-game or third-party marketplaces.",
 


### PR DESCRIPTION
# Description

The condition for earning reputation points by connecting Discord have recently changed. Some players have farms that are not linked to Discord and already have the Companion Cap in their inventory, so they don’t see the Discord boat or know how to connect their Discord. The text will be updated to resolve this issue.

![image](https://github.com/user-attachments/assets/10a6ea0e-2282-41ef-8208-c69b5e4e58ff)


Fixes #issue

# What needs to be tested by the reviewer?

- check the reputation guide

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
