### PR TITLE
[FEAT] Include more marketplace details

### DIFF
--- a/src/features/marketplace/components/PriceHistory.tsx
+++ b/src/features/marketplace/components/PriceHistory.tsx
@@ -103,13 +103,13 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
                         <div className="flex items-center gap-1">
                           <p className="text-xxs">
                             {seller.username}{" "}
-                            {`(${source === "listing" ? t("marketplace.sold") : t("marketplace.madeOffer")})`}
+                            {`(${source === "listing" ? t("marketplace.soldListing") : t("marketplace.madeOffer")})`}
                           </p>
                         </div>
                         <div className="flex items-center gap-1">
                           <p className="text-xxs">
                             {buyer.username}{" "}
-                            {`(${source === "listing" ? t("marketplace.bought") : t("marketplace.acceptedOffer")})`}
+                            {`(${source === "listing" ? t("marketplace.boughtListing") : t("marketplace.acceptedOffer")})`}
                           </p>
                         </div>
                       </div>

--- a/src/features/marketplace/components/PriceHistory.tsx
+++ b/src/features/marketplace/components/PriceHistory.tsx
@@ -9,8 +9,6 @@ import classNames from "classnames";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { interpretTokenUri } from "lib/utils/tokenUriBuilder";
 import { getRelativeTime } from "lib/utils/time";
-import increaseRightArrow from "assets/icons/increase_right_arrow.webp";
-import decreaseLeftArrow from "assets/icons/decrease_left_arrow.webp";
 import { useNavigate } from "react-router";
 import { getTradeableDisplay } from "../lib/tradeables";
 import { INITIAL_FARM } from "features/game/lib/constants";
@@ -103,12 +101,16 @@ export const Sales: React.FC<{ sales: ISaleHistory["sales"] }> = ({
                       </div>
                       <div className="flex flex-col">
                         <div className="flex items-center gap-1">
-                          <img src={increaseRightArrow} className="h-3" />
-                          <p className="text-xxs">{buyer.username}</p>
+                          <p className="text-xxs">
+                            {seller.username}{" "}
+                            {`(${source === "listing" ? t("marketplace.sold") : t("marketplace.madeOffer")})`}
+                          </p>
                         </div>
                         <div className="flex items-center gap-1">
-                          <img src={decreaseLeftArrow} className="h-3" />
-                          <p className="text-xxs">{seller.username}</p>
+                          <p className="text-xxs">
+                            {buyer.username}{" "}
+                            {`(${source === "listing" ? t("marketplace.bought") : t("marketplace.acceptedOffer")})`}
+                          </p>
                         </div>
                       </div>
                     </div>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5740,5 +5740,9 @@
   "taskBoard.tasksDescription": "Complete tasks to earn Love Charm.",
   "taskBoard.tasksDescriptionTwo": "Love Charm can be used to purchase special items in the rewards shop",
   "taskBoard.otherWays": "Other ways to earn Love Charm",
-  "taskBoard.howToRefer": "How to refer a friend?"
+  "taskBoard.howToRefer": "How to refer a friend?",
+  "marketplace.bought": "Bought",
+  "marketplace.sold": "Sold",
+  "marketplace.madeOffer": "Made Offer",
+  "marketplace.acceptedOffer": "Accepted Offer"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5741,8 +5741,8 @@
   "taskBoard.tasksDescriptionTwo": "Love Charm can be used to purchase special items in the rewards shop",
   "taskBoard.otherWays": "Other ways to earn Love Charm",
   "taskBoard.howToRefer": "How to refer a friend?",
-  "marketplace.bought": "Bought",
-  "marketplace.sold": "Sold",
+  "marketplace.boughtListing": "Bought Listing",
+  "marketplace.soldListing": "Sold Listing",
   "marketplace.madeOffer": "Made Offer",
   "marketplace.acceptedOffer": "Accepted Offer"
 }


### PR DESCRIPTION
# Description

Included whether it was a listing or offer in the details. This will help understand the flow of items for players.

<img width="617" alt="Screenshot 2025-03-25 at 1 45 20 PM" src="https://github.com/user-attachments/assets/223f29a3-5a5c-4ddd-a0e8-49e707ab6222" />
<img width="254" alt="Screenshot 2025-03-25 at 1 45 34 PM" src="https://github.com/user-attachments/assets/b58df2ae-c8b9-406b-993e-e386d69c04f2" />
