### PR TITLE
[FEAT] Remove VIP Offer

### DIFF
--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -283,16 +283,6 @@ export const VIPItems: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
                   disableVipPurchase || (roninVip && isRoninVipOnCooldown)
                 }
               >
-                {name === "3_MONTHS" && (
-                  <>
-                    <Label type="info" className="absolute -top-5 -right-2">
-                      {t("vip.3Months.discount")}
-                    </Label>
-                    <p className="text-xs absolute bottom-5 line-through right-0">
-                      {`1500`}
-                    </p>
-                  </>
-                )}
                 <span className="whitespace-nowrap mb-2 mt-0.5">
                   {t(VIP_NAME[name])}
                 </span>

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -47,7 +47,7 @@ export type VipBundle = "1_MONTH" | "3_MONTHS" | "2_YEARS";
 
 export const VIP_PRICES: Record<VipBundle, number> = {
   "1_MONTH": 800,
-  "3_MONTHS": 1200, // 20% off - 1500 normally
+  "3_MONTHS": 1500,
   "2_YEARS": 11500,
 };
 


### PR DESCRIPTION
# Description

Removes the middle tier VIP offer (20% off). This was only meant to last the first 2 weeks, but we extended it due to the large intake of Ronin players.