### PR TITLE
[FEAT] Close Marketplace modal by pressing Escape key

### DIFF
--- a/src/features/marketplace/Marketplace.tsx
+++ b/src/features/marketplace/Marketplace.tsx
@@ -1,5 +1,5 @@
 import { SUNNYSIDE } from "assets/sunnyside";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import sflIcon from "assets/icons/sfl.webp";
 import { MarketplaceNavigation } from "./components/MarketplaceHome";
 import { useLocation, useNavigate } from "react-router";
@@ -28,6 +28,21 @@ export const Marketplace: React.FC = () => {
 
     fromRoute ? navigate(fromRoute) : navigate(defaultRoute);
   };
+
+  // exit marketplace if Escape key is pressed
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        handleClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleClose]);
 
   return (
     <>


### PR DESCRIPTION
# Description

It's kinda annoying that all other modals are closeable by pressing ESC, but Marketplace was not so I fixed it.

# What needs to be tested by the reviewer?

Open Marketplace. Press ESC

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
