### PR TITLE
[FIX] Add to queue button not disabled when queue is full

### DIFF
--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -160,7 +160,8 @@ export const Recipes: React.FC<Props> = ({
     (recipe) => recipe.readyAt <= Date.now(),
   );
   const isVIP = hasVipAccess({ game: state });
-  const isQueueFull = [...readyRecipes, ...queue].length >= availableSlots;
+  const isQueueFull =
+    [...readyRecipes, ...queue, selected].length >= availableSlots;
 
   return (
     <>


### PR DESCRIPTION
# Description

`isQueueFull` was not considering the current selected recipe being cooked so when queue was full the condition was always `3 >= 4` and never disabled the button.

Before:
![image](https://github.com/user-attachments/assets/c109ab05-b6e7-4414-aa4a-2fe01a3f9228)

After:
![image](https://github.com/user-attachments/assets/e874d442-23c4-4c19-b8bd-9c468b4b4579)


# What needs to be tested by the reviewer?

Fill the VIP queue and see the "Add to queue" button being disabled.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
