### PR TITLE
[FEAT] Show Modal automatically when player is in range of Streamer Hat

### DIFF
--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -101,7 +101,7 @@ const getModalStatesForEffects = () =>
     (states, stateName) => ({
       ...states,
       [stateName]: true,
-      [`${stateName}Failure`]: true,
+      [`${stateName}Failed`]: true,
       [`${stateName}Success`]: true,
     }),
     {} as Record<BlockchainState["value"], boolean>,
@@ -245,9 +245,9 @@ const isEffectSuccess = (state: MachineState) =>
   Object.values(EFFECT_EVENTS).some((stateName) =>
     state.matches(`${stateName}Success`),
   );
-const isEffectFailure = (state: MachineState) =>
+const isEffectFailed = (state: MachineState) =>
   Object.values(EFFECT_EVENTS).some((stateName) =>
-    state.matches(`${stateName}Failure`),
+    state.matches(`${stateName}Failed`),
   );
 const hasMarketplaceSales = (state: MachineState) =>
   state.matches("marketplaceSale");
@@ -419,7 +419,7 @@ export const GameWrapper: React.FC = ({ children }) => {
   const showReferralRewards = useSelector(gameService, _showReferralRewards);
   const effectPending = useSelector(gameService, isEffectPending);
   const effectSuccess = useSelector(gameService, isEffectSuccess);
-  const effectFailure = useSelector(gameService, isEffectFailure);
+  const effectFailed = useSelector(gameService, isEffectFailed);
   const showSales = useSelector(gameService, hasMarketplaceSales);
   const competition = useSelector(gameService, isCompetition);
   const seasonChanged = useSelector(gameService, isSeasonChanged);
@@ -600,7 +600,7 @@ export const GameWrapper: React.FC = ({ children }) => {
               (EFFECT_SUCCESS_COMPONENTS[stateValue as StateValues] ?? (
                 <EffectSuccess state={stateValue} />
               ))}
-            {effectFailure && (
+            {effectFailed && (
               <ErrorMessage errorCode={errorCode as ErrorCode} />
             )}
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -421,7 +421,7 @@ const EFFECT_STATES = Object.values(EFFECT_EVENTS).reduce(
         CONTINUE: { target: "playing" },
       },
     },
-    [`${stateName}Failure`]: {
+    [`${stateName}Failed`]: {
       on: {
         CONTINUE: { target: "playing" },
         REFRESH: { target: "playing" },
@@ -482,7 +482,7 @@ const EFFECT_STATES = Object.values(EFFECT_EVENTS).reduce(
           },
         ],
         onError: {
-          target: `${stateName}Failure`,
+          target: `${stateName}Failed`,
           actions: "assignErrorMessage",
         },
       },
@@ -514,7 +514,7 @@ export type BlockchainState = {
     | "beanRevealed"
     // | "effectPending"
     | "effectSuccess"
-    | "effectFailure"
+    | "effectFailed"
     | "error"
     | "refreshing"
     | "swarming"
@@ -1897,12 +1897,12 @@ export function startGame(authContext: AuthContext) {
         //       },
         //     ],
         //     onError: {
-        //       target: "effectFailure",
+        //       target: "effectFailed",
         //       actions: "assignErrorMessage",
         //     },
         //   },
         // },
-        effectFailure: {
+        effectFailed: {
           on: {
             ACKNOWLEDGE: "playing",
           },

--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -132,6 +132,29 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
       this.label = label;
     }
 
+    // For Debugging Purpose - Check player position
+    // Uncomment to see the coordinates
+    // const coordinatesText = this.scene.add.text(
+    //   x, // X position of the text
+    //   y, // Y position of the text (above the NPC and label)
+    //   `X: ${x}, Y: ${y}`, // Initial text content
+    //   {
+    //     fontSize: "4px",
+    //     fontFamily: "monospace",
+    //     resolution: 4,
+    //     color: "#00000",
+    //   }, // Style
+    // );
+    // coordinatesText.setOrigin(0.5);
+
+    // // Update the text whenever the NPC's position changes
+    // this.scene.events.on("update", () => {
+    //   coordinatesText.setPosition(this.x, this.y + 15); // Adjust to keep it above the NPC
+    //   coordinatesText.setText(
+    //     `x: ${Math.round(this.x)}, y: ${Math.round(this.y)}`,
+    //   ); // Update the coordinates
+    // });
+
     this.scene.add.existing(this);
 
     if (onClick) {
@@ -402,7 +425,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
       this.removeIcon();
     }
 
-    this.icon = this.scene.add.sprite(0, -12, "charm_icon").setOrigin(0.5);
+    this.icon = this.scene.add.sprite(0, -14, "charm_icon").setOrigin(0.5);
     this.add(this.icon);
 
     if (this.scene.textures.exists("sparkle")) {

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -1231,7 +1231,6 @@ export abstract class BaseScene extends Phaser.Scene {
           entity,
         );
         const now = Date.now();
-        // Only open if it's been more than 5 minutes since last open or if it's a different player
         if (
           now - this.lastModalOpenTime > STREAM_REWARD_COOLDOWN - 15 * 1000 &&
           distance < 75

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -1231,8 +1231,12 @@ export abstract class BaseScene extends Phaser.Scene {
           entity,
         );
         const now = Date.now();
+        const streamerHatLastClaimedAt =
+          this.gameService.state.context.state.pumpkinPlaza.streamerHat
+            ?.openedAt ?? 0;
+
         if (
-          now - this.lastModalOpenTime > STREAM_REWARD_COOLDOWN - 15 * 1000 &&
+          now - this.lastModalOpenTime > STREAM_REWARD_COOLDOWN &&
           distance < 75
         ) {
           playerModalManager.open({
@@ -1241,7 +1245,7 @@ export abstract class BaseScene extends Phaser.Scene {
             experience: player.experience,
             username: player.username,
           });
-          this.lastModalOpenTime = now;
+          this.lastModalOpenTime = streamerHatLastClaimedAt;
         }
       }
     });

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -42,6 +42,7 @@ import {
 } from "lib/utils/hooks/usePlazaShader";
 import { playerSelectionListManager } from "../ui/PlayerSelectionList";
 import { playerModalManager } from "../ui/player/PlayerModals";
+import { STREAM_REWARD_COOLDOWN } from "../ui/player/StreamReward";
 
 export type NPCBumpkin = {
   x: number;
@@ -97,6 +98,7 @@ export const FACTION_NAME_COLORS: Record<FactionName, string> = {
 export abstract class BaseScene extends Phaser.Scene {
   abstract sceneId: SceneId;
   eventListener?: (event: EventObject) => void;
+  private lastModalOpenTime = 0;
 
   public joystick?: VirtualJoystick;
   private switchToScene?: SceneId;
@@ -1220,6 +1222,28 @@ export abstract class BaseScene extends Phaser.Scene {
       // Check if player is in area as well
       if (hidden === entity.visible) {
         entity.setVisible(!hidden);
+      }
+
+      // Check for streamer hat
+      if (player.clothing?.hat === "Streamer Hat") {
+        const distance = Phaser.Math.Distance.BetweenPoints(
+          this.currentPlayer as BumpkinContainer,
+          entity,
+        );
+        const now = Date.now();
+        // Only open if it's been more than 5 minutes since last open or if it's a different player
+        if (
+          now - this.lastModalOpenTime > STREAM_REWARD_COOLDOWN - 15 * 1000 &&
+          distance < 75
+        ) {
+          playerModalManager.open({
+            id: player.farmId,
+            clothing: player.clothing,
+            experience: player.experience,
+            username: player.username,
+          });
+          this.lastModalOpenTime = now;
+        }
       }
     });
   }

--- a/src/features/world/ui/npcs/Mayor.tsx
+++ b/src/features/world/ui/npcs/Mayor.tsx
@@ -336,7 +336,14 @@ export const Mayor: React.FC<MayorProps> = ({ onClose }) => {
               })}
             </span>
           </div>
-          <Button onClick={onClose}>{t("close")}</Button>
+          <Button
+            onClick={() => {
+              onClose();
+              gameService.send("CONTINUE");
+            }}
+          >
+            {t("close")}
+          </Button>
         </CloseButtonPanel>
       )}
     </>

--- a/src/features/world/ui/player/PlayerModals.tsx
+++ b/src/features/world/ui/player/PlayerModals.tsx
@@ -118,10 +118,17 @@ export const PlayerModals: React.FC<Props> = ({ game, farmId }) => {
 
   useEffect(() => {
     playerModalManager.listen((npc) => {
-      setTab("Player");
       setPlayer(npc);
+      // Automatically set to Stream tab if player has Streamer Hat and is not current player
+      if (npc.clothing?.hat === "Streamer Hat" && farmId !== npc.id) {
+        setTab("Stream");
+      } else if (npc.clothing.shirt === "Gift Giver") {
+        setTab("Reward");
+      } else {
+        setTab("Player");
+      }
     });
-  }, []);
+  }, [farmId]);
 
   useEffect(() => {
     if (!player) return;

--- a/src/features/world/ui/player/StreamReward.tsx
+++ b/src/features/world/ui/player/StreamReward.tsx
@@ -8,6 +8,28 @@ import { millisecondsToString } from "lib/utils/time";
 import * as Auth from "features/auth/lib/Provider";
 import React, { useContext, useState, useEffect } from "react";
 import { Button } from "components/ui/Button";
+import { ErrorCode } from "lib/errors";
+import { ErrorMessage } from "features/auth/ErrorMessage";
+import { Loading } from "features/auth/components";
+
+export const STREAM_REWARD_COOLDOWN = 1000 * 60 * 5;
+
+const RewardHeader: React.FC<{ timeToNextClaim: number }> = ({
+  timeToNextClaim,
+}) => (
+  <div className="flex justify-between items-center px-1 mb-2">
+    <Label type="success" icon={ITEM_DETAILS["Love Charm"].image}>
+      {`Stream Reward`}
+    </Label>
+    {timeToNextClaim > 0 && (
+      <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+        {`Time to next claim - ${millisecondsToString(timeToNextClaim, {
+          length: "short",
+        })}`}
+      </Label>
+    )}
+  </div>
+);
 
 export const StreamReward: React.FC<{ streamerId: number }> = ({
   streamerId,
@@ -15,29 +37,30 @@ export const StreamReward: React.FC<{ streamerId: number }> = ({
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const { authService } = useContext(Auth.Context);
+
   const streamHatLastClaimed = useSelector(
     gameService,
     (state) => state.context.state.pumpkinPlaza.streamerHat?.openedAt ?? 0,
   );
-  const claiming = useSelector(gameService, (state) =>
-    state.matches("claimingStreamReward"),
-  );
+  const gameState = useSelector(gameService, (state) => ({
+    isClaiming: state.matches("claimingStreamReward"),
+    isSuccess: state.matches("claimingStreamRewardSuccess"),
+    isFailed: state.matches("claimingStreamRewardFailed"),
+    errorCode: state.context.errorCode,
+  }));
+
   const [timeToNextClaim, setTimeToNextClaim] = useState(0);
-  const hasOpened = timeToNextClaim > 0;
 
   useEffect(() => {
     const updateTime = () => {
       const timeSinceLastClaim = Date.now() - streamHatLastClaimed;
-      const nextClaim = 1000 * 60 * 5 - timeSinceLastClaim;
-      setTimeToNextClaim(Math.max(0, nextClaim));
+      setTimeToNextClaim(
+        Math.max(0, STREAM_REWARD_COOLDOWN - timeSinceLastClaim),
+      );
     };
 
-    // Update immediately
     updateTime();
-
-    // Update every second
     const interval = setInterval(updateTime, 1000);
-
     return () => clearInterval(interval);
   }, [streamHatLastClaimed]);
 
@@ -48,25 +71,41 @@ export const StreamReward: React.FC<{ streamerId: number }> = ({
     });
   };
 
+  const acknowledge = () => gameService.send("CONTINUE");
+
+  if (gameState.isClaiming) {
+    return (
+      <div className="ml-1 mb-2">
+        <RewardHeader timeToNextClaim={timeToNextClaim} />
+        <Loading text={t("claiming")} />
+      </div>
+    );
+  }
+
+  if (gameState.isSuccess) {
+    return (
+      <div>
+        <div className="ml-1 mb-2">
+          <RewardHeader timeToNextClaim={timeToNextClaim} />
+          <p className="text-sm">{`You have successfully claimed 5 Love Charms!`}</p>
+        </div>
+        <Button onClick={acknowledge}>{t("continue")}</Button>
+      </div>
+    );
+  }
+
+  if (gameState.isFailed) {
+    return <ErrorMessage errorCode={gameState.errorCode as ErrorCode} />;
+  }
+
   return (
     <div>
       <div className="ml-1 mb-2">
-        <div className="flex justify-between items-center px-1 mb-2">
-          <Label type="success" icon={ITEM_DETAILS["Love Charm"].image}>
-            {`Stream Reward`}
-          </Label>
-          {hasOpened && (
-            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-              {`Time to next claim - ${millisecondsToString(timeToNextClaim, {
-                length: "short",
-              })}`}
-            </Label>
-          )}
-        </div>
+        <RewardHeader timeToNextClaim={timeToNextClaim} />
         <p className="text-sm">{`You have found a streamer! Claim 5 Love Charms every 5 minutes.`}</p>
       </div>
-      <Button onClick={claimReward} disabled={hasOpened || claiming}>
-        {claiming ? t("claiming") : hasOpened ? t("claimed") : t("claim")}
+      <Button onClick={claimReward} disabled={timeToNextClaim > 0}>
+        {timeToNextClaim > 0 ? t("claimed") : t("claim")}
       </Button>
     </div>
   );

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5739,7 +5739,7 @@
   "socialTask.complete50Deliveries": "Complete 50 deliveries",
   "socialTask.complete50Deliveries.description": "Go to the plaza and complete deliveries with various NPCs 50 times",
   "socialTask.joinStream": "Join a stream",
-  "socialTask.joinStream.description": "Join a dev chat on discord or twitch stream to earn 1 Love Charm every 5 minutes from the host wearing a stream hat.",
+  "socialTask.joinStream.description": "Join a dev chat on discord or twitch stream to earn 5 Love Charm every 5 minutes from the host wearing a streamer hat.",
   "claimReferralRewards.title": "Referral Rewards",
   "claimReferralRewards.description": "Congratulations! {{totalUnclaimedReferrals}} new players have joined and bought VIP using your referral link. Here are your rewards!",
   "referral.vip": "25 Love Charms when your friend buys VIP",


### PR DESCRIPTION
# Description

This PR allows the streamer's player modal to appear in the following conditions:
- When they are get in range of the streamer
- 4 mins 45s after they claim the reward

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE twice with local BE
- Change/remove the cooldown in `claimStreamReward.ts` (for testing)
- Change `STREAM_REWARD_COOLDOWN` in `StreamReward.tsx` to around 20-30s
- Give yourself streamer hat on one account
- Bring both bumpkins to plaza
- station 1 bumpkin at an area away from the spawn point
- walk other bumpkin into the range of the streamer hat bumpkin
- modal should appear
- claim reward, close modal and wait around 10s in the range of the streamer
- modal should appear again approx 15s before the cooldown ends

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
