### PR TITLE
[FIX] Hide Season End timer in Composter Modal if in basic island

### DIFF
--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -518,15 +518,17 @@ const ComposterModalContent: React.FC<{
           >
             {t(`season.${state.season.season}`)}
           </Label>
-          <Label
-            icon={SUNNYSIDE.icons.stopwatch}
-            type="transparent"
-            className="mb-1"
-          >
-            {`${secondsToString(secondsTillWeekReset(), {
-              length: "short",
-            })} ${t("time.left")}`}
-          </Label>
+          {state.island.type !== "basic" && (
+            <Label
+              icon={SUNNYSIDE.icons.stopwatch}
+              type="transparent"
+              className="mb-1"
+            >
+              {`${secondsToString(secondsTillWeekReset(), {
+                length: "short",
+              })} ${t("time.left")}`}
+            </Label>
+          )}
         </div>
 
         <div className="flex flex-col h-full px-1 py-0">


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
