### PR TITLE
[FEAT] Fruitful Blend Description with Fruitful Bounty Skill

### DIFF
--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -23,6 +23,7 @@ import {
 } from "features/game/events/landExpansion/upgradeBuilding";
 import { makeUpgradableBuildingKey } from "features/game/events/landExpansion/upgradeBuilding";
 import { BuildingName } from "features/game/types/buildings";
+import { BumpkinRevampSkillName } from "features/game/types/bumpkinSkills";
 
 /**
  * The props for the details for items.
@@ -104,7 +105,10 @@ export const InventoryItemDetails: React.FC<Props> = ({
           isCollectibleBuilt({
             name: boostedDescription.name as CollectibleName,
             game,
-          })
+          }) ||
+          game.bumpkin?.skills[
+            boostedDescription.name as BumpkinRevampSkillName
+          ]
         ) {
           description = boostedDescription.description;
         }

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -3163,6 +3163,12 @@ export const ITEM_DETAILS: Items = {
     description: translate("compost.sproutMix"),
   },
   "Fruitful Blend": {
+    boostedDescriptions: [
+      {
+        name: "Fruitful Bounty",
+        description: translate("compost.fruitfulBlendBoosted"),
+      },
+    ],
     image: fruitfulBlend,
     description: translate("compost.fruitfulBlend"),
   },

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -43,6 +43,7 @@ import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
 import { SEASON_ICONS } from "../market/SeasonalSeeds";
 import { RecipeInfoPanel } from "../craftingBox/components/RecipeInfoPanel";
 import { secondsTillWeekReset } from "features/game/lib/factions";
+import { getFruitfulBlendBuff } from "features/game/events/landExpansion/fertiliseFruitPatch";
 
 const WORM_OUTPUT: Record<ComposterName, { min: number; max: number }> = {
   "Compost Bin": { min: 2, max: 4 },
@@ -196,7 +197,7 @@ const FertiliserLabel: React.FC<{
         type="success"
         className="text-xs whitespace-pre-line"
       >
-        {"+0.1"} {t("fruit")}
+        {`+${getFruitfulBlendBuff(state)}`} {t("fruit")}
       </Label>
     );
   }

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -39,7 +39,7 @@ import {
   getSpeedUpCost,
   getSpeedUpTime,
 } from "features/game/events/landExpansion/accelerateComposter";
-import { isCollectibleActive } from "features/game/lib/collectibleBuilt";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { SEASON_ICONS } from "../market/SeasonalSeeds";
 import { RecipeInfoPanel } from "../craftingBox/components/RecipeInfoPanel";
 import { secondsTillWeekReset } from "features/game/lib/factions";
@@ -181,7 +181,7 @@ const FertiliserLabel: React.FC<{
         type="success"
         className="text-xs whitespace-pre-line"
       >
-        {isCollectibleActive({ name: "Knowledge Crab", game: state })
+        {isCollectibleBuilt({ name: "Knowledge Crab", game: state })
           ? "+0.4"
           : "+0.2"}{" "}
         {t("crops")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -658,6 +658,7 @@
   "community.url": "Enter your repo URL",
   "comunity.Travel": "Travel to community built islands",
   "compost.fruitfulBlend": "Fruitful Blend boosts the yield of each fruit growing on fruit patches by +0.1",
+  "compost.fruitfulBlendBoosted": "Fruitful Blend boosts the yield of each fruit growing on fruit patches by +0.2",
   "compost.sproutMix": "Sprout Mix increases your crop yield from plots by +0.2",
   "compost.sproutMixBoosted": "Sprout Mix increases your crop yield from plots by +0.4",
   "compost.rapidRoot": "Rapid Root reduces crop growth time from plots by 50%",


### PR DESCRIPTION
# When Fruitful Bounty skill is active:

- **Description in Inventory:** 

![image](https://github.com/user-attachments/assets/63cb671a-0915-43a8-b6ba-6121211155f9)

- **Boost Label in Turbo Composter:**

![image](https://github.com/user-attachments/assets/65a41710-dd29-4b46-829e-6aa6fb1315bc)

Fixes #issue

# What needs to be tested by the reviewer?

- Check Fruitful Blend description/boost-label in Inventory/Turbo Composter

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
