### PR TITLE
[FEAT] Remove Mint NFT screen from multiple places.

### DIFF
--- a/src/features/goblins/bank/components/Deposit.tsx
+++ b/src/features/goblins/bank/components/Deposit.tsx
@@ -382,7 +382,7 @@ const DepositOptions: React.FC<Props> = ({
         </div>
       )}
       {status === "loaded" && !emptyWallet && (
-        <>
+        <GameWallet action="confirmDeposit">
           <div className="p-2 mb-1">
             <div className="flex justify-between sm:flex-row flex-col">
               <Label
@@ -622,7 +622,7 @@ const DepositOptions: React.FC<Props> = ({
           >
             {t("deposit.sendToFarm")}
           </Button>
-        </>
+        </GameWallet>
       )}
     </>
   );

--- a/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
@@ -8,7 +8,6 @@ import { Context as GameContext } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { ContentComponentProps } from "../GameOptions";
-import { GameWallet } from "features/wallet/Wallet";
 import { hasFeatureAccess } from "lib/flags";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress ?? "";
@@ -25,35 +24,35 @@ export const BlockchainSettings: React.FC<ContentComponentProps> = ({
 
   const farmAddress = useSelector(gameService, _farmAddress);
   const state = useSelector(gameService, _state);
-  const isFullUser = farmAddress !== undefined;
+  const isFullUser = farmAddress !== "";
   const storeOnChain = async () => {
     openModal("STORE_ON_CHAIN");
     onClose();
   };
 
   return (
-    <GameWallet action="connectWallet">
-      <div className="flex flex-col gap-1">
-        <Button onClick={() => onSubMenuClick("deposit")}>
-          {t("deposit")}
-        </Button>
+    <div className="flex flex-col gap-1">
+      <Button onClick={() => onSubMenuClick("deposit")}>{t("deposit")}</Button>
+      {isFullUser && (
         <Button onClick={storeOnChain}>
           {t("gameOptions.blockchainSettings.storeOnChain")}
         </Button>
-        {!hasFeatureAccess(state, "DISABLE_BLOCKCHAIN_ACTIONS") && (
-          <Button onClick={() => onSubMenuClick("swapSFL")}>
-            {t("gameOptions.blockchainSettings.swapPOLForSFL")}
-          </Button>
-        )}
+      )}
+      {!hasFeatureAccess(state, "DISABLE_BLOCKCHAIN_ACTIONS") && (
+        <Button onClick={() => onSubMenuClick("swapSFL")}>
+          {t("gameOptions.blockchainSettings.swapPOLForSFL")}
+        </Button>
+      )}
+      {isFullUser && (
         <Button onClick={() => onSubMenuClick("dequip")}>
           {t("dequipper.dequip")}
         </Button>
-        {isFullUser && (
-          <Button onClick={() => onSubMenuClick("transfer")}>
-            {t("gameOptions.blockchainSettings.transferOwnership")}
-          </Button>
-        )}
-      </div>
-    </GameWallet>
+      )}
+      {isFullUser && (
+        <Button onClick={() => onSubMenuClick("transfer")}>
+          {t("gameOptions.blockchainSettings.transferOwnership")}
+        </Button>
+      )}
+    </div>
   );
 };

--- a/src/features/wallet/walletMachine.ts
+++ b/src/features/wallet/walletMachine.ts
@@ -47,20 +47,21 @@ export type WalletAction =
   | "specialEvent"
   | "login"
   | "deposit"
+  | "confirmDeposit" // Only used if the player has items in their wallet
   | "withdraw"
   | "purchase"
+  | "confirmPurchase" // Only used if the player has POL
   | "donate"
   | "dailyReward"
   | "sync"
   | "dequip"
-  | "wishingWell"
-  | "connectWallet"
-  | "marketplace"
-  | "refresh";
+  | "marketplace";
 
 // Certain actions do not require an NFT to perform
 const NON_NFT_ACTIONS: WalletAction[] = [
   "login",
+  "deposit",
+  "purchase",
   "donate",
   "dailyReward",
   "specialEvent",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5801,5 +5801,6 @@
   "rewards.daily.claimed": "Claimed",
   "rewards.vip.title": "VIP Reward",
   "rewards.vip.description": "A monthly reward for VIP members",
-  "rewards.vip.claimed": "Claimed"
+  "rewards.vip.claimed": "Claimed",
+  "error.insufficientMatic": "POL required"
 }


### PR DESCRIPTION
# Description

Updates the requirements for showing Mint NFT screen.

1. Blockchain Settings: Removes Mint NFT Wall from Blockchain Settings.
2. Sync: First Sync option only available when you first hit hoarder.
3. Marketplace: Marketplace will mint an NFT on demand as required.
4. Buy Gems: Only requires NFT if you actually have POL on your POL wallet.
5. Deposit: Only requires NFT if you actually have items on your POL wallet.

# What needs to be tested by the reviewer?

Please describe how this can be tested.

Load game on non NFT, and click around.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]