### PR TITLE
[FEAT] Move NFT ID down a level

### DIFF
--- a/src/components/ui/WalletAddressLabel.tsx
+++ b/src/components/ui/WalletAddressLabel.tsx
@@ -25,7 +25,7 @@ export const WalletAddressLabel: React.FC<Props> = ({
   return (
     <Label
       type="formula"
-      className="mb-1 mr-4"
+      className="mb-1 mr-2"
       icon={walletIcon}
       popup={show}
       onClick={() => {

--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -41,11 +41,9 @@ import { Discord } from "./general-settings/DiscordModal";
 import { DepositWrapper } from "features/goblins/bank/components/Deposit";
 import { useSound } from "lib/utils/hooks/useSound";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
-import ticket from "assets/icons/ticket.png";
 import lockIcon from "assets/icons/lock.png";
 import telegramIcon from "assets/icons/telegram.webp";
 import { DEV_HoarderCheck } from "./developer-options/DEV_HoardingCheck";
-import { WalletAddressLabel } from "components/ui/WalletAddressLabel";
 import { PickServer } from "./plaza-settings/PickServer";
 import { PlazaShaderSettings } from "./plaza-settings/PlazaShaderSettings";
 import { Preferences } from "./general-settings/Preferences";
@@ -93,7 +91,6 @@ const GameOptions: React.FC<ContentComponentProps> = ({
 
   const [isConfirmLogoutModalOpen, showConfirmLogoutModal] = useState(false);
   const [showFarm, setShowFarm] = useState(false);
-  const [showNftId, setShowNftId] = useState(false);
 
   const copypaste = useSound("copypaste");
 
@@ -159,36 +156,6 @@ const GameOptions: React.FC<ContentComponentProps> = ({
               farmId: gameService.state?.context?.farmId,
             })}
           </Label>
-          {gameService.state?.context?.nftId !== undefined && (
-            <Label
-              type="default"
-              icon={ticket}
-              popup={showNftId}
-              className="mb-1 mr-4"
-              onClick={() => {
-                setShowNftId(true);
-                setTimeout(() => {
-                  setShowNftId(false);
-                }, 2000);
-                copypaste.play();
-                clipboard.copy(
-                  gameService.state?.context?.nftId?.toString() || "",
-                );
-              }}
-            >
-              {`NFT ID #${gameService.state?.context?.nftId}`}
-            </Label>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center justify-between mx-2">
-          {gameService.state?.context?.linkedWallet && (
-            <WalletAddressLabel
-              walletAddress={
-                (gameService.state?.context?.linkedWallet as string) || "XXXX"
-              }
-              showLabelTitle={true}
-            />
-          )}
         </div>
       </>
       <div className="flex flex-col gap-1">

--- a/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
@@ -1,7 +1,10 @@
-import React, { useContext } from "react";
+import clipboard from "clipboard";
+import React, { useContext, useState } from "react";
 import { useSelector } from "@xstate/react";
 
 import { Button } from "components/ui/Button";
+
+import ticket from "assets/icons/ticket.png";
 
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Context as GameContext } from "features/game/GameProvider";
@@ -9,6 +12,9 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
 import { ContentComponentProps } from "../GameOptions";
 import { hasFeatureAccess } from "lib/flags";
+import { Label } from "components/ui/Label";
+import { useSound } from "lib/utils/hooks/useSound";
+import { WalletAddressLabel } from "components/ui/WalletAddressLabel";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress ?? "";
 const _state = (state: MachineState) => state.context.state;
@@ -30,8 +36,44 @@ export const BlockchainSettings: React.FC<ContentComponentProps> = ({
     onClose();
   };
 
+  const [showNftId, setShowNftId] = useState(false);
+  const copypaste = useSound("copypaste");
+
   return (
     <div className="flex flex-col gap-1">
+      <div className="flex justify-between">
+        {gameService.state?.context?.nftId !== undefined ? (
+          <Label
+            type="default"
+            icon={ticket}
+            popup={showNftId}
+            className="mb-1 mr-4 ml-2"
+            onClick={() => {
+              setShowNftId(true);
+              setTimeout(() => {
+                setShowNftId(false);
+              }, 2000);
+              copypaste.play();
+              clipboard.copy(
+                gameService.state?.context?.nftId?.toString() || "",
+              );
+            }}
+          >
+            {`NFT ID #${gameService.state?.context?.nftId}`}
+          </Label>
+        ) : (
+          <div className="w-10" />
+        )}
+        {gameService.state?.context?.linkedWallet && (
+          <WalletAddressLabel
+            walletAddress={
+              (gameService.state?.context?.linkedWallet as string) || "XXXX"
+            }
+            showLabelTitle={false}
+          />
+        )}
+      </div>
+
       <Button onClick={() => onSubMenuClick("deposit")}>{t("deposit")}</Button>
       {isFullUser && (
         <Button onClick={storeOnChain}>


### PR DESCRIPTION
# Description

Players were consistently using the wrong ID for troubleshooting, socials + rewards. This PR moves Blockchain related labels into the Blockchain settings.

<img width="544" alt="Screenshot 2025-04-02 at 11 08 17 AM" src="https://github.com/user-attachments/assets/c11ed19e-7c55-4b10-9283-db6a22e641a5" />
<img width="525" alt="Screenshot 2025-04-02 at 11 08 52 AM" src="https://github.com/user-attachments/assets/5ff4a19a-3d24-40d7-b3b6-c83ccb978369" />

