### PR TITLE
[FIX] Remove Player from Player Selection Modal when they leave the plaza

### DIFF
--- a/src/features/world/ui/PlayerSelectionList.tsx
+++ b/src/features/world/ui/PlayerSelectionList.tsx
@@ -13,8 +13,10 @@ import { ITEM_DETAILS } from "features/game/types/images";
 
 class PlayerSelectionListManager {
   private listener?: (players: PlayerModalPlayer[]) => void;
+  private currentPlayers: PlayerModalPlayer[] = [];
 
   public open(players: PlayerModalPlayer[]) {
+    this.currentPlayers = players;
     if (this.listener) {
       this.listener(players);
     }
@@ -22,6 +24,13 @@ class PlayerSelectionListManager {
 
   public listen(cb: (players: PlayerModalPlayer[]) => void) {
     this.listener = cb;
+  }
+
+  public removePlayer(playerId: number) {
+    this.currentPlayers = this.currentPlayers.filter((p) => p.id !== playerId);
+    if (this.listener) {
+      this.listener(this.currentPlayers);
+    }
   }
 }
 
@@ -36,6 +45,20 @@ export const PlayerSelectionList: React.FC = () => {
     playerSelectionListManager.listen((players) => {
       setPlayers(players);
     });
+
+    // Listen for player leave events
+    const handlePlayerLeave = (event: CustomEvent) => {
+      playerSelectionListManager.removePlayer(event.detail.playerId);
+    };
+
+    window.addEventListener("player_leave", handlePlayerLeave as EventListener);
+
+    return () => {
+      window.removeEventListener(
+        "player_leave",
+        handlePlayerLeave as EventListener,
+      );
+    };
   }, []);
 
   const closeModal = () => {


### PR DESCRIPTION
# Description

This PR fixes an issue where the player modal isn't automatically removed from the list when they leave the plaza.

This allows players potentially to continue to claim stream rewards from player with Streamer Hat, if they didn't remove the hat.

Fixes #issue

# What needs to be tested by the reviewer?

- Go to plaza with more than 2 bumpkin
- Click on a stack of bumpkins to trigger the selection modal
- leave the plaza on the other account
- Player should be removed from list

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
