### PR TITLE
[FIX] Love Rush Streaks bug

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -2078,7 +2078,7 @@ describe("deliver", () => {
 
       expect(state.inventory["Love Charm"]).toEqual(new Decimal(15));
     });
-    it("resets the streak if the player has not delivered for more than 24 hours", () => {
+    it("resets the streak if the player has not delivered for more than 2 days", () => {
       const state = deliverOrder({
         state: {
           ...INITIAL_FARM,
@@ -2091,7 +2091,7 @@ describe("deliver", () => {
               deliveryCount: 1,
               streaks: {
                 streak: 6,
-                lastClaimedAt: eventTime - 36 * 60 * 60 * 1000,
+                lastClaimedAt: eventTime - 48 * 60 * 60 * 1000,
               },
             },
           },

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -2161,5 +2161,49 @@ describe("deliver", () => {
 
       expect(state.inventory["Love Charm"]).toEqual(new Decimal(0));
     });
+
+    it("doesn't break the streak if the player delivers on consecutive days", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2025-05-01T20:00:00Z").getTime()); // More than 24 hours apart but still consecutive days
+      const state = deliverOrder({
+        state: {
+          ...INITIAL_FARM,
+          inventory: {
+            "Love Charm": new Decimal(0),
+            Sunflower: new Decimal(1),
+          },
+          npcs: {
+            betty: {
+              deliveryCount: 1,
+              streaks: {
+                streak: 6,
+                lastClaimedAt: new Date("2025-04-30T15:00:00Z").getTime(),
+              },
+            },
+          },
+          delivery: {
+            ...INITIAL_FARM.delivery,
+            orders: [
+              {
+                id: "123",
+                createdAt: eventTime,
+                readyAt: eventTime,
+                from: "betty",
+                items: { Sunflower: 1 },
+                reward: {},
+              },
+            ],
+          },
+        },
+        action: {
+          id: "123",
+          type: "order.delivered",
+        },
+        createdAt: new Date("2025-05-01T20:00:00Z").getTime(),
+      });
+
+      expect(state.inventory["Love Charm"]).toEqual(new Decimal(15));
+      expect(state.npcs?.betty?.streaks?.streak).toEqual(7);
+    });
   });
 });

--- a/src/features/game/types/loveRushDeliveries.ts
+++ b/src/features/game/types/loveRushDeliveries.ts
@@ -106,34 +106,31 @@ export function getLoveRushStreaks({
   streaks?: { streak: number; lastClaimedAt: number };
   createdAt?: number;
 }): { currentStreak: number; newStreak: number } {
-  const currentStreak = streaks?.streak ?? 0;
-  const lastClaimedAt = new Date(streaks?.lastClaimedAt ?? 0);
-  const currentDate = new Date(createdAt);
+  let currentStreak: number = streaks?.streak ?? 0;
+  let newStreak: number = currentStreak + 1;
+  const lastClaimedAt = streaks?.lastClaimedAt ?? 0;
 
-  // Convert to UTC dates at midnight
-  const lastClaimedDay = Date.UTC(
-    lastClaimedAt.getUTCFullYear(),
-    lastClaimedAt.getUTCMonth(),
-    lastClaimedAt.getUTCDate(),
-  );
-  const currentDay = Date.UTC(
-    currentDate.getUTCFullYear(),
-    currentDate.getUTCMonth(),
-    currentDate.getUTCDate(),
-  );
-  const previousDay = currentDay - 24 * 60 * 60 * 1000;
+  // Get the date in YYYY-MM-DD format
+  const lastClaimAtDate = new Date(lastClaimedAt).toISOString().split("T")[0];
+  const currentDate = new Date(createdAt).toISOString().split("T")[0];
 
-  // Check if same day or consecutive days
-  if (lastClaimedDay === currentDay) {
-    return { currentStreak, newStreak: currentStreak };
+  // Calculate the difference in days between the last claim and the current date from 00:00:00 UTC
+  const dayDifference =
+    (new Date(currentDate).getTime() - new Date(lastClaimAtDate).getTime()) /
+    (1000 * 60 * 60 * 24);
+
+  // If the difference is greater than 1, reset the streak
+  if (dayDifference > 1) {
+    currentStreak = 0;
+    newStreak = 1;
   }
 
-  if (lastClaimedDay === previousDay) {
-    return { currentStreak, newStreak: currentStreak + 1 };
+  // If the last claim is the same as the current date, set the new streak to the current streak
+  if (lastClaimAtDate === currentDate) {
+    newStreak = currentStreak;
   }
 
-  // Reset streak if not consecutive
-  return { currentStreak: 0, newStreak: 1 };
+  return { currentStreak, newStreak };
 }
 
 export function getLoveRushDeliveryRewards({

--- a/src/features/game/types/loveRushDeliveries.ts
+++ b/src/features/game/types/loveRushDeliveries.ts
@@ -106,27 +106,34 @@ export function getLoveRushStreaks({
   streaks?: { streak: number; lastClaimedAt: number };
   createdAt?: number;
 }): { currentStreak: number; newStreak: number } {
-  let currentStreak: number = streaks?.streak ?? 0;
-  let newStreak: number = currentStreak + 1;
+  const currentStreak = streaks?.streak ?? 0;
   const lastClaimedAt = new Date(streaks?.lastClaimedAt ?? 0);
   const currentDate = new Date(createdAt);
 
-  const dayDifference =
-    (currentDate.getTime() - lastClaimedAt.getTime()) / (1000 * 60 * 60 * 24);
+  // Convert to UTC dates at midnight
+  const lastClaimedDay = Date.UTC(
+    lastClaimedAt.getUTCFullYear(),
+    lastClaimedAt.getUTCMonth(),
+    lastClaimedAt.getUTCDate(),
+  );
+  const currentDay = Date.UTC(
+    currentDate.getUTCFullYear(),
+    currentDate.getUTCMonth(),
+    currentDate.getUTCDate(),
+  );
+  const previousDay = currentDay - 24 * 60 * 60 * 1000;
 
-  if (dayDifference > 1) {
-    currentStreak = 0;
-    newStreak = 1;
+  // Check if same day or consecutive days
+  if (lastClaimedDay === currentDay) {
+    return { currentStreak, newStreak: currentStreak };
   }
 
-  const lastClaimAtDate = lastClaimedAt.toISOString().split("T")[0];
-  const currentDateString = currentDate.toISOString().split("T")[0];
-
-  if (lastClaimAtDate === currentDateString) {
-    newStreak = currentStreak;
+  if (lastClaimedDay === previousDay) {
+    return { currentStreak, newStreak: currentStreak + 1 };
   }
 
-  return { currentStreak, newStreak };
+  // Reset streak if not consecutive
+  return { currentStreak: 0, newStreak: 1 };
 }
 
 export function getLoveRushDeliveryRewards({


### PR DESCRIPTION
# Description

There's a bug with the streaks where if the player completes the delivery 24h since the time of the last delivery, even if the dates are consecutive, the streaks will break. For example last claimed time is 4th April 2025 0800 UTC, and current time is 5th April 2025 1200 UTC, because it's 24h since the last delivery, the streak will break, 

This PR addresses this issue by following a similar implementation to the daily chest, where it takes the time from the start of the day as reference

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
