### PR TITLE
[FIX] Coin Balance Overlap with New Love Charm Icon Button

### DIFF
--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -26,26 +26,15 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
           className="flex cursor-pointer items-center space-x-3 relative"
           onClick={onClick}
         >
-          <div className="h-9 w-full bg-black opacity-30 absolute coins-bb-hud-backdrop" />
-          {/* Coins */}
-          <div className="flex items-center space-x-2">
-            <span className="balance-text mt-0.5">{formatNumber(coins)}</span>
-            <img
-              src={coinsIcon}
-              alt="Coins"
-              style={{
-                width: 25,
-              }}
-            />
-          </div>
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-1 relative">
+            <div className="h-9 w-full bg-black opacity-30 absolute gem-flower-hud-backdrop -z-10" />
             <span className="balance-text mt-0.5">{formatNumber(gems)}</span>
             <img
               src={gemIcon}
               alt="Gems"
               style={{
                 marginTop: 2,
-                width: 28,
+                width: 26,
               }}
             />
           </div>
@@ -59,21 +48,33 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
             }}
           />
         </div>
+        {/* Coins */}
+        <div className="flex items-center space-x-1 relative">
+          <div className="h-9 w-full bg-black opacity-30 absolute coin-hud-backdrop -z-10" />
+          <span className="balance-text mt-0.5">{formatNumber(coins)}</span>
+          <img
+            src={coinsIcon}
+            alt="Coins"
+            style={{
+              width: 26,
+            }}
+          />
+        </div>
         {/* FLOWER */}
         <div
-          className={classNames("flex items-center space-x-2 relative", {
+          className={classNames("flex items-center space-x-1 relative", {
             // show cursor if balance has a decimal place
             "cursor-pointer": sfl.toNumber() % 1 !== 0,
           })}
           onClick={() => setShowFullBalance(!showFullBalance)}
         >
-          <div className="h-9 w-full bg-black opacity-25 absolute sfl-hud-backdrop -z-10" />
+          <div className="h-9 w-full bg-black opacity-30 absolute gem-flower-hud-backdrop -z-10" />
           <span className="balance-text">
-            {formatNumber(sfl, { decimalPlaces: showFullBalance ? 8 : 4 })}
+            {formatNumber(sfl, { decimalPlaces: showFullBalance ? 4 : 2 })}
           </span>
           <img
             src={flowerIcon}
-            alt="FLOWER "
+            alt="FLOWER"
             style={{
               width: 26,
             }}

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -23,18 +23,33 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
     <>
       <div className="flex flex-col absolute space-y-1 items-end z-50 right-3 top-3 !text-[28px] text-stroke">
         <div
-          className="flex cursor-pointer items-center space-x-3 relative"
+          className="flex relative cursor-pointer items-center space-x-1 sm:space-x-3 sm:-mb-0.5"
           onClick={onClick}
         >
-          <div className="flex items-center space-x-1 relative">
-            <div className="h-9 w-full bg-black opacity-30 absolute gem-flower-hud-backdrop -z-10" />
-            <span className="balance-text mt-0.5">{formatNumber(gems)}</span>
+          <div className="h-9 w-full bg-black opacity-30 absolute balances-hud-backdrop -z-10" />
+          {/* Coin */}
+          <div className="items-center space-x-1 hidden sm:flex">
+            <span className="balance-text mb-0.5">{formatNumber(coins)}</span>
+            <img
+              src={coinsIcon}
+              alt="Coins"
+              style={{
+                width: 27,
+              }}
+            />
+          </div>
+
+          {/* Gem */}
+          <div className="flex items-center space-x-1">
+            <span className="balance-text -mb-0.5 sm:mb-0.5">
+              {formatNumber(gems)}
+            </span>
             <img
               src={gemIcon}
               alt="Gems"
+              className="mt-0.5 sm:-mt-1"
               style={{
-                marginTop: 2,
-                width: 26,
+                width: 27,
               }}
             />
           </div>
@@ -48,18 +63,20 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
             }}
           />
         </div>
-        {/* Coins */}
-        <div className="flex items-center space-x-1 relative">
-          <div className="h-9 w-full bg-black opacity-30 absolute coin-hud-backdrop -z-10" />
+
+        {/* Coin Mobile */}
+        <div className="flex items-center space-x-1 relative sm:hidden">
+          <div className="h-9 w-full bg-black opacity-30 absolute coin-balance-mobile-hud-backdrop -z-10" />
           <span className="balance-text mt-0.5">{formatNumber(coins)}</span>
           <img
             src={coinsIcon}
             alt="Coins"
             style={{
-              width: 26,
+              width: 27,
             }}
           />
         </div>
+
         {/* FLOWER */}
         <div
           className={classNames("flex items-center space-x-1 relative", {
@@ -68,7 +85,7 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
           })}
           onClick={() => setShowFullBalance(!showFullBalance)}
         >
-          <div className="h-9 w-full bg-black opacity-30 absolute gem-flower-hud-backdrop -z-10" />
+          <div className="h-9 w-full bg-black opacity-30 absolute balances-hud-backdrop -z-10" />
           <span className="balance-text">
             {formatNumber(sfl, { decimalPlaces: showFullBalance ? 4 : 2 })}
           </span>
@@ -76,7 +93,7 @@ export const Balances: React.FC<Props> = ({ sfl, coins, gems, onClick }) => {
             src={flowerIcon}
             alt="FLOWER"
             style={{
-              width: 26,
+              width: 27,
             }}
           />
         </div>

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -129,7 +129,7 @@ const LandscapingHudComponent: React.FC<{
                 marginBottom: `${PIXEL_SCALE * 25}px`,
                 width: `${PIXEL_SCALE * 22}px`,
                 right: `${PIXEL_SCALE * 3}px`,
-                top: `${PIXEL_SCALE * 31}px`,
+                top: `${PIXEL_SCALE * 41}px`,
               }}
             >
               <RoundButton

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -123,13 +123,13 @@ const LandscapingHudComponent: React.FC<{
         {idle && (
           <>
             <div
-              className="absolute flex z-50 flex-col"
+              className="absolute flex z-50 flex-col sm:-mt-8"
               style={{
                 marginLeft: `${PIXEL_SCALE * 2}px`,
                 marginBottom: `${PIXEL_SCALE * 25}px`,
                 width: `${PIXEL_SCALE * 22}px`,
                 right: `${PIXEL_SCALE * 3}px`,
-                top: `${PIXEL_SCALE * 41}px`,
+                top: `${PIXEL_SCALE * 43}px`,
               }}
             >
               <RoundButton

--- a/src/features/island/hud/components/LandscapeButton.tsx
+++ b/src/features/island/hud/components/LandscapeButton.tsx
@@ -11,12 +11,12 @@ export const LandscapeButton: React.FC = () => {
 
   return (
     <div
-      className="absolute"
+      className="absolute sm:-mt-8"
       style={{
         marginLeft: `${PIXEL_SCALE * 2}px`,
         marginBottom: `${PIXEL_SCALE * 25}px`,
         right: `${PIXEL_SCALE * 3}px`,
-        top: `${PIXEL_SCALE * 41}px`,
+        top: `${PIXEL_SCALE * 43}px`,
       }}
     >
       <RoundButton

--- a/src/features/island/hud/components/LandscapeButton.tsx
+++ b/src/features/island/hud/components/LandscapeButton.tsx
@@ -16,7 +16,7 @@ export const LandscapeButton: React.FC = () => {
         marginLeft: `${PIXEL_SCALE * 2}px`,
         marginBottom: `${PIXEL_SCALE * 25}px`,
         right: `${PIXEL_SCALE * 3}px`,
-        top: `${PIXEL_SCALE * 31}px`,
+        top: `${PIXEL_SCALE * 41}px`,
       }}
     >
       <RoundButton

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -78,10 +78,10 @@ export const Inventory: React.FC<Props> = ({
   return (
     <>
       <div
-        className="flex flex-col items-center absolute z-50"
+        className="flex flex-col items-center absolute z-50 sm:-mt-8"
         style={{
           right: `${PIXEL_SCALE * 3}px`,
-          top: `${PIXEL_SCALE * (isFarming ? 67 : 40)}px`,
+          top: `${PIXEL_SCALE * (isFarming ? 69 : 42)}px`,
         }}
       >
         <BasketButton onClick={() => setIsOpen(true)} />

--- a/src/features/island/hud/components/inventory/Inventory.tsx
+++ b/src/features/island/hud/components/inventory/Inventory.tsx
@@ -81,7 +81,7 @@ export const Inventory: React.FC<Props> = ({
         className="flex flex-col items-center absolute z-50"
         style={{
           right: `${PIXEL_SCALE * 3}px`,
-          top: `${PIXEL_SCALE * (isFarming ? 58 : 31)}px`,
+          top: `${PIXEL_SCALE * (isFarming ? 67 : 40)}px`,
         }}
       >
         <BasketButton onClick={() => setIsOpen(true)} />
@@ -90,7 +90,8 @@ export const Inventory: React.FC<Props> = ({
           <div
             className="flex flex-col items-center"
             style={{
-              marginRight: `${PIXEL_SCALE * -3}px`,
+              marginRight: `${PIXEL_SCALE * -2}px`,
+              marginTop: `${PIXEL_SCALE * 1}px`,
             }}
           >
             {shortcuts.map((item, index) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -437,7 +437,7 @@ img {
   transition-timing-function: ease;
 }
 
-.gem-flower-hud-backdrop {
+.balances-hud-backdrop {
   height: 20px;
   width: 98%;
   right: 11px;
@@ -451,7 +451,7 @@ img {
   z-index: -1;
 }
 
-.coin-hud-backdrop {
+.coin-balance-mobile-hud-backdrop {
   height: 20px;
   width: 98%;
   right: 11px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -437,10 +437,24 @@ img {
   transition-timing-function: ease;
 }
 
-.coins-bb-hud-backdrop {
-  height: 19px;
-  width: 95%;
-  left: -1px;
+.gem-flower-hud-backdrop {
+  height: 20px;
+  width: 98%;
+  right: 11px;
+  top: 4px;
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 1) 22%
+  );
+  mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 22%);
+  z-index: -1;
+}
+
+.coin-hud-backdrop {
+  height: 20px;
+  width: 98%;
+  right: 11px;
   top: 6px;
   -webkit-mask-image: linear-gradient(
     90deg,
@@ -520,20 +534,6 @@ img {
     2px -2px 0 black,
     -2px 2px 0 black,
     2px 2px 0 black;
-}
-
-.sfl-hud-backdrop {
-  height: 21px;
-  width: 88%;
-  left: -1px;
-  top: 3px;
-  -webkit-mask-image: linear-gradient(
-    90deg,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 1) 22%
-  );
-  mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 22%);
-  z-index: -1;
 }
 
 @keyframes pointing {


### PR DESCRIPTION
# Description

- This PR fixes an issue where the coin balance could be overlapped by the newly added Love Charm icon button on smaller screens. The coin balance has been repositioned to ensure proper visibility across all screen sizes.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b5138dd7-64a1-455d-99f9-2fc99300935e) | ![image](https://github.com/user-attachments/assets/e2fc3fc0-cc1e-486c-91e9-9d7ccbfca8ff) | 

- Minor UI FIxes

Fixes #issue

# What needs to be tested by the reviewer?

Check the top-right corner of your game's screen to see how the balances for gems, flowers, and coins are displayed across different screen sizes. Click on those that have click events.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
