### PR TITLE
[FIX] Realign Box Selector Location in Deliveries Modal

### DIFF
--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -274,10 +274,10 @@ export const OrderCard: React.FC<OrderCardProps> = ({
           <div id="select-box" className="hidden md:block">
             <img
               className="absolute pointer-events-none"
-              src={SUNNYSIDE.ui.selectBoxTL}
+              src={SUNNYSIDE.ui.selectBoxBR}
               style={{
-                top: `${PIXEL_SCALE * -3}px`,
-                left: `${PIXEL_SCALE * -3}px`,
+                bottom: `${PIXEL_SCALE * -3}px`,
+                right: `${PIXEL_SCALE * -3}px`,
                 width: `${PIXEL_SCALE * 8}px`,
               }}
             />


### PR DESCRIPTION
# Description

This PR fixes the issue where, on large screens, the Love Charm amount is not displayed properly when selecting orders and is covered by the box selector.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7e3026d7-7fb7-477d-b066-c9ac945b2485) | ![image](https://github.com/user-attachments/assets/95fc1cd8-c241-46b3-b43d-009853ffb3db) | 

Fixes #issue

# What needs to be tested by the reviewer?

Select delivery orders through Codex on large screens.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
