### PR TITLE
[FIX] Disable Blockchain Box Button if Rewards Claimed

### DIFF
--- a/src/features/island/hud/components/referral/Rewards.tsx
+++ b/src/features/island/hud/components/referral/Rewards.tsx
@@ -221,8 +221,13 @@ export const RewardOptions: React.FC<Props> = ({
 
       {hasFeatureAccess(state, "BLOCKCHAIN_BOX") && (
         <ButtonPanel
-          onClick={() => setSelected("BLOCKCHAIN_BOX")}
+          onClick={
+            state.pumpkinPlaza.blockchainBox
+              ? undefined
+              : () => setSelected("BLOCKCHAIN_BOX")
+          }
           className="mb-1"
+          disabled={!!state.pumpkinPlaza.blockchainBox}
         >
           <div className="flex items-start">
             <img src={loveBox} className="w-10 mr-4" />


### PR DESCRIPTION
# Description

If players have already claimed the rewards from the blockchain box, they can still access it and see the list of their rewards each time they click the corresponding button, but they don't receive anything more than once. This PR addresses the issue by disabling the blockchain box button.

![image](https://github.com/user-attachments/assets/e99a1906-c023-48ad-acf4-e651828063f8)

Fixes #issue

# What needs to be tested by the reviewer?

Test the blockchain box button click event under both claimed and unclaimed conditions.
# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
