### PR TITLE
[FIX] Rewards Button Indicator

### DIFF
--- a/src/features/island/hud/components/referral/RewardsButton.tsx
+++ b/src/features/island/hud/components/referral/RewardsButton.tsx
@@ -53,10 +53,18 @@ export const RewardsButton: React.FC = () => {
     (task: InGameTaskName) => IN_GAME_TASKS[task].requirement(state),
     [state],
   );
-  const isAnyTaskCompleted = getKeys(IN_GAME_TASKS).some(
-    (task) =>
-      isTaskCompleted(task) && !state.socialTasks?.completed[task]?.completedAt,
-  );
+  const isAnyTaskCompleted = getKeys(IN_GAME_TASKS)
+    .filter(
+      (task) =>
+        !(
+          ["Link your Discord", "Link your Telegram"] as InGameTaskName[]
+        ).includes(task),
+    )
+    .some(
+      (task) =>
+        isTaskCompleted(task) &&
+        !state.socialTasks?.completed[task]?.completedAt,
+    );
 
   // Check if chest is locked or can be unlocked
   const isChestLocked = !chestState.matches("opened");


### PR DESCRIPTION
# Description

This PR fixes the issue where the Rewards Button indicator still includes the Link your Discord and Link your Telegram tasks, which has since been removed

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
