### PR TITLE
[FIX] Daily Reward Level Requirement

### DIFF
--- a/src/features/island/hud/components/referral/Rewards.tsx
+++ b/src/features/island/hud/components/referral/Rewards.tsx
@@ -252,7 +252,13 @@ export const RewardOptions: React.FC<Props> = ({
         </ButtonPanel>
       )}
 
-      <ButtonPanel onClick={() => setSelected("DAILY_REWARD")} className="mb-1">
+      <ButtonPanel
+        onClick={
+          bumpkinLevel < 6 ? undefined : () => setSelected("DAILY_REWARD")
+        }
+        disabled={bumpkinLevel < 6}
+        className="mb-1"
+      >
         <div className="flex items-start">
           <img
             src={SUNNYSIDE.decorations.treasure_chest}
@@ -267,6 +273,16 @@ export const RewardOptions: React.FC<Props> = ({
           {hasOpenedDaily && (
             <Label className="absolute top-0 right-0" type="success">
               {t("rewards.daily.claimed")}
+            </Label>
+          )}
+          {bumpkinLevel < 6 && (
+            <Label
+              icon={lockIcon}
+              secondaryIcon={SUNNYSIDE.icons.player}
+              className="absolute top-0 right-1"
+              type="formula"
+            >
+              {`${t("lvl")} 6`}
             </Label>
           )}
         </div>


### PR DESCRIPTION
# Description

Recently, after changing the newly added rewards tabs to button panels in `Rewards.tsx`, the level restriction for the daily reward that had been added there was removed. However, the level requirement still exists in `DailyRewardContent`, which results in a blank screen if the condition is met:
https://github.com/sunflower-land/sunflower-land/blob/4c88155980590ba7b653b1f64ffd01dc54c16e9f/src/features/game/expansion/components/dailyReward/DailyReward.tsx#L141


So you could either approve this PR, or could remove the level restriction from the main component, allowing players to access the daily reward regardless of their bumpkin level.

- after addressing the issue in this PR:

![image](https://github.com/user-attachments/assets/640f8052-2945-4a5b-bceb-dc692989a5eb)


Fixes #issue

# What needs to be tested by the reviewer?

- test daily reward with and without required level

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
