### PR TITLE
[FIX] Prevent Flower Bed from colliding with itself when moved

### DIFF
--- a/src/features/game/events/landExpansion/moveFlowerBed.ts
+++ b/src/features/game/events/landExpansion/moveFlowerBed.ts
@@ -40,6 +40,12 @@ export function moveFlowerBed({
         height: dimensions.height,
         width: dimensions.width,
       },
+      ignore: {
+        x: flowerBed.x,
+        y: flowerBed.y,
+        width: dimensions.width,
+        height: dimensions.height,
+      },
     });
 
     if (collides) {

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -97,6 +97,7 @@ function detectPlaceableCollision(
   state: GameState,
   boundingBox: BoundingBox,
   name: InventoryItemName,
+  ignore?: BoundingBox,
 ) {
   const {
     collectibles,
@@ -180,9 +181,20 @@ function detectPlaceableCollision(
     ...budsBoundingBox,
   ];
 
-  return boundingBoxes.some((resourceBoundingBox) =>
-    isOverlapping(boundingBox, resourceBoundingBox),
-  );
+  return boundingBoxes.some((resourceBoundingBox) => {
+    // Skip if this is the same as the item we're trying to move
+    if (
+      ignore &&
+      resourceBoundingBox.x === ignore.x &&
+      resourceBoundingBox.y === ignore.y &&
+      resourceBoundingBox.width === ignore.width &&
+      resourceBoundingBox.height === ignore.height
+    ) {
+      return false;
+    }
+
+    return isOverlapping(boundingBox, resourceBoundingBox);
+  });
 }
 
 export const HOME_BOUNDS: Record<IslandType, BoundingBox> = {
@@ -527,11 +539,13 @@ export function detectCollision({
   position,
   location,
   name,
+  ignore,
 }: {
   location: PlaceableLocation;
   state: GameState;
   position: Position;
   name: InventoryItemName | AnimalType;
+  ignore?: Position;
 }) {
   const item = name as InventoryItemName;
 
@@ -543,7 +557,7 @@ export function detectCollision({
 
   return (
     detectWaterCollision(expansions, position) ||
-    detectPlaceableCollision(state, position, item) ||
+    detectPlaceableCollision(state, position, item, ignore) ||
     detectLandCornerCollision(expansions, position) ||
     detectChickenCollision(state, position) ||
     detectMushroomCollision(state, position) ||


### PR DESCRIPTION
## Description

This PR fixes an issue where repositioning an already placed flower bed would incorrectly trigger a collision with itself. The `detectCollision` and `detectPlaceableCollision` functions have been updated to support an `ignore` parameter, allowing the system to skip the object's current position during collision checks.

Fixes #5512

## What needs to be tested by the reviewer?

1. Place a flower bed on the map.
2. Drag it to a new location (overlapping with its old position).
3. Ensure that collision detection no longer blocks the move.
4. Confirm that it still collides properly with other structures/resources.

## Checklist:

- [x] Title of the PR is relevant and is prefixed with [FIX]
- [x ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


https://github.com/user-attachments/assets/4e32931b-0b8c-4bbf-956e-c76b9e9a2834


