### PR TITLE
[FIX] Animals resorted when curing animals

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -79,35 +79,39 @@ export const BarnInside: React.FC = () => {
     width: floorWidth,
   } = ANIMAL_HOUSE_BOUNDS.barn[level];
 
-  // Organise the animals neatly in the barn
-  const organizedAnimals = useMemo(() => {
-    // First, group animals by type and sort within each group
-    const animals = getKeys(barn.animals)
-      .map((id) => ({
-        ...barn.animals[id],
-      }))
-      // Group by type first (Cow, then Sheep)
-      .sort((a, b) => {
-        if (a.type === b.type) {
-          return b.experience - a.experience;
-        }
-        return a.type === "Cow" ? -1 : 1;
-      });
+  // Sort order will remain the same as long as animals are not added or removed
+  // Group animals by type (Cow, then Sheep) first, then sort by experience
+  const sortedAnimalIds = useMemo(
+    () =>
+      getKeys(barn.animals)
+        .map((id) => barn.animals[id])
+        .sort((a, b) =>
+          a.type === b.type
+            ? b.experience - a.experience
+            : a.type.localeCompare(b.type),
+        )
+        .map((animal) => animal.id),
+    [getKeys(barn.animals).length],
+  );
 
+  // Organize the animals neatly in the barn
+  const organizedAnimals = useMemo(() => {
     const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Cow.width);
     const verticalGap = 0.5; // Add a 0.5 grid unit gap between rows
 
-    return animals.map((animal, index) => {
-      const row = Math.floor(index / maxAnimalsPerRow);
-      const col = index % maxAnimalsPerRow;
-      return {
-        ...animal,
-        coordinates: {
-          x: col * ANIMALS.Cow.width,
-          y: row * (ANIMALS.Cow.height + verticalGap),
-        },
-      };
-    });
+    return sortedAnimalIds
+      .map((id) => barn.animals[id])
+      .map((animal, index) => {
+        const row = Math.floor(index / maxAnimalsPerRow);
+        const col = index % maxAnimalsPerRow;
+        return {
+          ...animal,
+          coordinates: {
+            x: col * ANIMALS.Cow.width,
+            y: row * (ANIMALS.Cow.height + verticalGap),
+          },
+        };
+      });
   }, [
     getKeys(barn.animals).length,
     getValues(barn.animals).filter((animal) => animal.state === "sick").length,

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -65,29 +65,34 @@ export const HenHouseInside: React.FC = () => {
     width: floorWidth,
   } = ANIMAL_HOUSE_BOUNDS.henHouse[level];
 
-  // Organise the animals neatly in the barn
-  const organizedAnimals = useMemo(() => {
-    // First, group animals by type and sort within each group
-    const animals = getKeys(henHouse.animals)
-      .map((id) => ({
-        ...henHouse.animals[id],
-      }))
-      .sort((a, b) => b.experience - a.experience);
+  // Sort order will remain the same as long as animals are not added or removed
+  const sortedAnimalIds = useMemo(
+    () =>
+      getKeys(henHouse.animals)
+        .map((id) => henHouse.animals[id])
+        .sort((a, b) => b.experience - a.experience)
+        .map((animal) => animal.id),
+    [getKeys(henHouse.animals).length],
+  );
 
+  // Organize the animals neatly in the hen house
+  const organizedAnimals = useMemo(() => {
     const maxAnimalsPerRow = Math.floor(floorWidth / ANIMALS.Cow.width);
     const verticalGap = 0.5; // Add a 0.5 grid unit gap between rows
 
-    return animals.map((animal, index) => {
-      const row = Math.floor(index / maxAnimalsPerRow);
-      const col = index % maxAnimalsPerRow;
-      return {
-        ...animal,
-        coordinates: {
-          x: col * ANIMALS.Cow.width,
-          y: row * (ANIMALS.Cow.height + verticalGap),
-        },
-      };
-    });
+    return sortedAnimalIds
+      .map((id) => henHouse.animals[id])
+      .map((animal, index) => {
+        const row = Math.floor(index / maxAnimalsPerRow);
+        const col = index % maxAnimalsPerRow;
+        return {
+          ...animal,
+          coordinates: {
+            x: col * ANIMALS.Cow.width,
+            y: row * (ANIMALS.Cow.height + verticalGap),
+          },
+        };
+      });
   }, [
     getKeys(henHouse.animals).length,
     getValues(henHouse.animals).filter((animal) => animal.state === "sick")


### PR DESCRIPTION
# Description

Fix bug where curing animals will resort animal positions.  With the fix, the animals will only be resorted if animals are bought or sold.

![image](https://github.com/user-attachments/assets/6e0318f6-04ed-4895-8f32-c6dc8b3497aa)

# What needs to be tested by the reviewer?

- Feed some animals randomly, then
  - Buy animals
  - Sell animals
  - Cure animals
- Cure some animals, then
  - Sell animals

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
