### PR TITLE
[FIX] Prevent resource nodes from colliding with itself when moved

### DIFF
--- a/src/features/game/events/landExpansion/moveFlowerBed.test.ts
+++ b/src/features/game/events/landExpansion/moveFlowerBed.test.ts
@@ -15,28 +15,6 @@ describe("moveFlowerBed", () => {
     ).toThrow("Flower bed does not exist");
   });
 
-  it("throws if a collision is detected", () => {
-    expect(() =>
-      moveFlowerBed({
-        state: {
-          ...TEST_FARM,
-          flowers: {
-            discovered: {},
-            flowerBeds: {
-              "1": { x: 1, y: 1, createdAt: 0 },
-              "2": { x: 0, y: 0, createdAt: 0 },
-            },
-          },
-        },
-        action: {
-          type: "flowerBed.moved",
-          coordinates: { x: 0, y: 0 },
-          id: "1",
-        },
-      }),
-    ).toThrow("Flower Bed collides");
-  });
-
   it("moves a patch", () => {
     const result = moveFlowerBed({
       state: {

--- a/src/features/game/events/landExpansion/moveFlowerBed.ts
+++ b/src/features/game/events/landExpansion/moveFlowerBed.ts
@@ -1,7 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { GameState } from "features/game/types/game";
-import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
 import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 
@@ -27,23 +25,6 @@ export function moveFlowerBed({
 
     if (!flowerBed) {
       throw new Error(translate("harvestflower.noFlowerBed"));
-    }
-
-    const dimensions = RESOURCE_DIMENSIONS["Flower Bed"];
-    const collides = detectCollision({
-      state: stateCopy,
-      name: "Flower Bed",
-      location: "farm",
-      position: {
-        x: action.coordinates.x,
-        y: action.coordinates.y,
-        height: dimensions.height,
-        width: dimensions.width,
-      },
-    });
-
-    if (collides) {
-      throw new Error("Flower Bed collides");
     }
 
     flowerBed.x = action.coordinates.x;

--- a/src/features/game/events/landExpansion/moveLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/moveLavaPit.test.ts
@@ -28,44 +28,6 @@ describe("moveLavaPit", () => {
     ).toThrow("Lava pit #2 does not exist");
   });
 
-  it("throws an error if the lava pit collides", () => {
-    expect(() =>
-      moveLavaPit({
-        action: {
-          coordinates: {
-            x: 1,
-            y: 1,
-          },
-          id: "1",
-          type: "lavaPit.moved",
-        },
-        state: {
-          ...INITIAL_FARM,
-          inventory: {
-            "Lava Pit": new Decimal(1),
-          },
-          stones: {
-            "123": {
-              createdAt: Date.now(),
-              stone: {
-                minedAt: 0,
-              },
-              x: 1,
-              y: 1,
-            },
-          },
-          lavaPits: {
-            "1": {
-              x: 1,
-              y: 1,
-              createdAt: 0,
-            },
-          },
-        },
-      }),
-    ).toThrow("Lava pit collides");
-  });
-
   it("moves a lava pit", () => {
     const state = moveLavaPit({
       action: {

--- a/src/features/game/events/landExpansion/moveLavaPit.ts
+++ b/src/features/game/events/landExpansion/moveLavaPit.ts
@@ -1,7 +1,5 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { GameState } from "features/game/types/game";
-import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
 import cloneDeep from "lodash.clonedeep";
 
 export type MoveLavaPitAction = {
@@ -27,23 +25,6 @@ export function moveLavaPit({
 
   if (!pit) {
     throw new Error(`Lava pit #${action.id} does not exist`);
-  }
-
-  const dimensions = RESOURCE_DIMENSIONS["Lava Pit"];
-  const collides = detectCollision({
-    state: game,
-    position: {
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      height: dimensions.height,
-      width: dimensions.width,
-    },
-    location: "farm",
-    name: "Lava Pit",
-  });
-
-  if (collides) {
-    throw new Error("Lava pit collides");
   }
 
   pit.x = action.coordinates.x;

--- a/src/features/game/events/landExpansion/placeFlowerBed.test.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.test.ts
@@ -56,38 +56,6 @@ describe("placeFlowerBed", () => {
     ).toThrow("No flower beds available");
   });
 
-  it("ensures flower bed does not collide", () => {
-    expect(() =>
-      placeFlowerBed({
-        action: {
-          coordinates: {
-            x: 2,
-            y: 2,
-          },
-          id: "1",
-          type: "flowerBed.placed",
-        },
-        state: {
-          ...TEST_FARM,
-          buildings: {},
-          inventory: {
-            "Flower Bed": new Decimal(2),
-          },
-          flowers: {
-            discovered: {},
-            flowerBeds: {
-              "123": {
-                createdAt: dateNow,
-                x: 2,
-                y: 2,
-              },
-            },
-          },
-        },
-      }),
-    ).toThrow("Flower Bed collides");
-  });
-
   it("ensures id does not exist", () => {
     expect(() =>
       placeFlowerBed({

--- a/src/features/game/events/landExpansion/placeFlowerBed.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { FlowerBed, GameState } from "features/game/types/game";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
-import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { produce } from "immer";
 
 export type PlaceFlowerBedAction = {
@@ -31,23 +30,6 @@ export function placeFlowerBed({
 
     if (available.lt(1)) {
       throw new Error("No flower beds available");
-    }
-
-    const dimensions = RESOURCE_DIMENSIONS["Flower Bed"];
-    const collides = detectCollision({
-      state,
-      name: "Flower Bed",
-      location: "farm",
-      position: {
-        x: action.coordinates.x,
-        y: action.coordinates.y,
-        height: dimensions.height,
-        width: dimensions.width,
-      },
-    });
-
-    if (collides) {
-      throw new Error("Flower Bed collides");
     }
 
     if (game.flowers.flowerBeds[action.id]) {

--- a/src/features/game/events/landExpansion/placeLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/placeLavaPit.test.ts
@@ -55,37 +55,6 @@ describe("placeLavaPit", () => {
     ).toThrow("No lava pit available");
   });
 
-  it("ensures lava pits do not collide", () => {
-    expect(() =>
-      placeLavaPit({
-        action: {
-          name: "Lava Pit",
-          coordinates: {
-            x: 2,
-            y: 2,
-          },
-          id: "1",
-
-          type: "lavaPit.placed",
-        },
-        state: {
-          ...INITIAL_FARM,
-          buildings: {},
-          inventory: {
-            "Lava Pit": new Decimal(2),
-          },
-          lavaPits: {
-            "123": {
-              createdAt: Date.now(),
-              x: 2,
-              y: 2,
-            },
-          },
-        },
-      }),
-    ).toThrow("Lava Pit collides");
-  });
-
   it("ensures id does not exist", () => {
     expect(() =>
       placeLavaPit({

--- a/src/features/game/events/landExpansion/placeLavaPit.ts
+++ b/src/features/game/events/landExpansion/placeLavaPit.ts
@@ -3,7 +3,6 @@ import cloneDeep from "lodash.clonedeep";
 import Decimal from "decimal.js-light";
 import { GameState, LavaPit } from "features/game/types/game";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
 
 export type PlaceLavaPitAction = {
@@ -33,23 +32,6 @@ export function placeLavaPit({
 
   if (available.lt(1)) {
     throw new Error("No lava pit available");
-  }
-
-  const dimensions = RESOURCE_DIMENSIONS["Lava Pit"];
-  const collides = detectCollision({
-    state: game,
-    position: {
-      x: action.coordinates.x,
-      y: action.coordinates.y,
-      height: dimensions.height,
-      width: dimensions.width,
-    },
-    location: "farm",
-    name: "Lava Pit",
-  });
-
-  if (collides) {
-    throw new Error("Lava Pit collides");
   }
 
   if (game.lavaPits[action.id]) {

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -112,7 +112,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
     .landscaping as MachineInterpreter;
 
   const [machine, send] = useActor(child);
-  const { placeable, collisionDetected, origin, coordinates } = machine.context;
+  const { placeable, collisionDetected, origin } = machine.context;
 
   const grid = getGameGrid(gameState.context.state);
 
@@ -145,13 +145,15 @@ export const Placeable: React.FC<Props> = ({ location }) => {
     getInitialCoordinates(origin);
 
   useEffect(() => {
-    const [startingX, startingY] = getInitialCoordinates({ x: 0, y: 0 });
+    if (!placeable) return;
+
+    const [startingX, startingY] = getInitialCoordinates(origin);
 
     detect({
       x: Math.round(startingX / GRID_WIDTH_PX),
       y: Math.round(-startingY / GRID_WIDTH_PX),
     });
-  }, []);
+  }, [placeable]);
 
   useEffect(() => {
     setShowHint(true);

--- a/src/features/game/types/resources.ts
+++ b/src/features/game/types/resources.ts
@@ -1,6 +1,7 @@
 import { Dimensions } from "./craftables";
 import { translate } from "lib/i18n/translate";
 import { AnimalResource } from "./game";
+import { GameState } from "features/game/types/game";
 
 export type CommodityName =
   | "Wood"
@@ -122,6 +123,25 @@ export const RESOURCES: Record<ResourceName, string> = {
   "Sunstone Rock": "Mine sunstone",
   "Oil Reserve": "Drill oil",
   "Lava Pit": "Craft obsidian",
+};
+
+export const RESOURCE_STATE_ACCESSORS: Record<
+  ResourceName,
+  (game: GameState) => any
+> = {
+  "Crop Plot": (game) => game.crops,
+  Tree: (game) => game.trees,
+  "Stone Rock": (game) => game.stones,
+  "Iron Rock": (game) => game.iron,
+  "Gold Rock": (game) => game.gold,
+  "Crimstone Rock": (game) => game.crimstones,
+  Boulder: () => undefined,
+  Beehive: (game) => game.beehives,
+  "Fruit Patch": (game) => game.fruitPatches,
+  "Flower Bed": (game) => game.flowers.flowerBeds,
+  "Sunstone Rock": (game) => game.sunstones,
+  "Oil Reserve": (game) => game.oilReserves,
+  "Lava Pit": (game) => game.lavaPits,
 };
 
 export const RESOURCE_DIMENSIONS: Record<ResourceName, Dimensions> = {

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -367,11 +367,13 @@ const _gameState = (state: MachineState) => state.context.state;
 const MoveableBuilding: React.FC<Prop> = (props) => {
   const { gameService } = useContext(Context);
   const gameState = useSelector(gameService, _gameState);
+  const BuildingPlaced = useMemo(
+    () => READONLY_BUILDINGS(gameState)[props.name],
+    [props.name],
+  );
 
   const landscaping = useSelector(gameService, isLandscaping);
   if (landscaping) {
-    const BuildingPlaced = READONLY_BUILDINGS(gameState)[props.name];
-
     const inProgress = props.readyAt > Date.now();
 
     // In Landscaping mode, use readonly building

--- a/src/features/island/collectibles/lib/placing.ts
+++ b/src/features/island/collectibles/lib/placing.ts
@@ -4,6 +4,10 @@ import { PlaceableName } from "features/game/types/buildings";
 import { CollectibleName } from "features/game/types/craftables";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import { GameState } from "features/game/types/game";
+import {
+  RESOURCE_STATE_ACCESSORS,
+  ResourceName,
+} from "features/game/types/resources";
 import cloneDeep from "lodash.clonedeep";
 
 /**
@@ -19,53 +23,10 @@ export function removePlaceable({
   name: PlaceableName | "Bud";
 }) {
   const game = cloneDeep(state);
-  if (name === "Crop Plot") {
-    delete game.crops[id];
-    return game;
-  }
 
-  if (name === "Tree") {
-    delete game.trees[id];
-    return game;
-  }
-
-  if (name === "Stone Rock") {
-    delete game.stones[id];
-    return game;
-  }
-
-  if (name === "Iron Rock") {
-    delete game.iron[id];
-    return game;
-  }
-
-  if (name === "Gold Rock") {
-    delete game.gold[id];
-    return game;
-  }
-
-  if (name === "Crimstone Rock") {
-    delete game.crimstones[id];
-    return game;
-  }
-
-  if (name === "Sunstone Rock") {
-    delete game.sunstones[id];
-    return game;
-  }
-
-  if (name === "Fruit Patch") {
-    delete game.fruitPatches[id];
-    return game;
-  }
-
-  if (name === "Beehive") {
-    delete game.beehives[id];
-    return game;
-  }
-
-  if (name === "Flower Bed") {
-    delete game.flowers.flowerBeds[id];
+  if (name in RESOURCE_STATE_ACCESSORS) {
+    const attributeMapping = RESOURCE_STATE_ACCESSORS[name as ResourceName];
+    delete attributeMapping(game)[id];
     return game;
   }
 

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -10,7 +10,11 @@ import {
 import { getKeys } from "features/game/types/craftables";
 import { GameState, Inventory } from "features/game/types/game";
 import { MarketplaceTradeableName } from "features/game/types/marketplace";
-import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
+import {
+  RESOURCE_STATE_ACCESSORS,
+  RESOURCE_DIMENSIONS,
+  ResourceName,
+} from "features/game/types/resources";
 import { setPrecision } from "lib/utils/formatNumber";
 
 const PLACEABLE_DIMENSIONS = {
@@ -71,128 +75,13 @@ export const getChestBuds = (
 
 export const getChestItems = (state: GameState): Inventory => {
   const availableItems = getKeys(state.inventory).reduce((acc, itemName) => {
-    if (itemName === "Tree") {
+    if (itemName in RESOURCE_STATE_ACCESSORS) {
+      const stateAccessor = RESOURCE_STATE_ACCESSORS[itemName as ResourceName];
       return {
         ...acc,
-        Tree: new Decimal(
-          state.inventory.Tree?.minus(Object.keys(state.trees).length) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Stone Rock") {
-      return {
-        ...acc,
-        "Stone Rock": new Decimal(
-          state.inventory["Stone Rock"]?.minus(
-            Object.keys(state.stones).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Iron Rock") {
-      return {
-        ...acc,
-        "Iron Rock": new Decimal(
-          state.inventory["Iron Rock"]?.minus(Object.keys(state.iron).length) ??
-            0,
-        ),
-      };
-    }
-
-    if (itemName === "Gold Rock") {
-      return {
-        ...acc,
-        "Gold Rock": new Decimal(
-          state.inventory["Gold Rock"]?.minus(Object.keys(state.gold).length) ??
-            0,
-        ),
-      };
-    }
-
-    if (itemName === "Crimstone Rock") {
-      return {
-        ...acc,
-        "Crimstone Rock": new Decimal(
-          state.inventory["Crimstone Rock"]?.minus(
-            Object.keys(state.crimstones).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Sunstone Rock") {
-      return {
-        ...acc,
-        "Sunstone Rock": new Decimal(
-          state.inventory["Sunstone Rock"]?.minus(
-            Object.keys(state.sunstones).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Crop Plot") {
-      return {
-        ...acc,
-        "Crop Plot": new Decimal(
-          state.inventory["Crop Plot"]?.minus(
-            Object.keys(state.crops).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Fruit Patch") {
-      return {
-        ...acc,
-        "Fruit Patch": new Decimal(
-          state.inventory["Fruit Patch"]?.minus(
-            Object.keys(state.fruitPatches).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Beehive") {
-      return {
-        ...acc,
-        Beehive: new Decimal(
-          state.inventory.Beehive?.minus(Object.keys(state.beehives).length) ??
-            0,
-        ),
-      };
-    }
-
-    if (itemName === "Flower Bed") {
-      return {
-        ...acc,
-        "Flower Bed": new Decimal(
-          state.inventory["Flower Bed"]?.minus(
-            Object.keys(state.flowers.flowerBeds).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Oil Reserve") {
-      return {
-        ...acc,
-        "Oil Reserve": new Decimal(
-          state.inventory["Oil Reserve"]?.minus(
-            Object.keys(state.oilReserves).length,
-          ) ?? 0,
-        ),
-      };
-    }
-
-    if (itemName === "Lava Pit") {
-      return {
-        ...acc,
-        "Lava Pit": new Decimal(
-          state.inventory["Lava Pit"]?.minus(
-            Object.keys(state.lavaPits).length,
+        [itemName]: new Decimal(
+          state.inventory[itemName]?.minus(
+            Object.keys(stateAccessor(state)).length,
           ) ?? 0,
         ),
       };


### PR DESCRIPTION
# Description

- Remove collision logic in flower bed and lava pit component because collision check is handled in the placeable component for all placeables.  Having the duplicate logic interfere with the drag and drop.
- Define new constant for mapping resource node to gamestate attribute so new resource types will not be missed/
- Fix initial collision detection when placing new placeable at the first time
  - Fix similar collision detection not activating when placing a second placeable after reentering edit mode

Properly fixes https://github.com/sunflower-land/sunflower-land/issues/5512 and addresses issues that arise from https://github.com/sunflower-land/sunflower-land/pull/5513 if merged

![image](https://github.com/user-attachments/assets/5472cab6-9e43-464a-9801-6013671afc0d)

# What needs to be tested by the reviewer?

- move resource nodes such as flower bed and lava pit
- in playing mode, select resource node and start placing resource node
  - do this more than one time by exiting edit mode and entering it again

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
