### PR TITLE
[FIX] Stream Time Display

### DIFF
--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -37,6 +37,13 @@ export const STREAMS_CONFIG = {
   } as StreamConfig,
 };
 
+export const NO_STREAM_DATES = [
+  "2025-04-25", // ANZAC Day
+  "2025-12-26", // Boxing Day
+  "2026-04-03", // Easter Friday
+  "2026-12-25", // Christmas Day
+];
+
 export const getNextStreamTime = (schedule: StreamSchedule): Date => {
   // Get current time in Sydney timezone
   const now = new Date();
@@ -84,6 +91,13 @@ export const getNextStreamTime = (schedule: StreamSchedule): Date => {
   const nextStreamTime = new Date(now);
   nextStreamTime.setDate(nextStreamTime.getDate() + daysUntilStream);
   nextStreamTime.setHours(schedule.hour, schedule.minute, 0, 0);
+
+  // Check if the next stream time falls on a skipped date
+  const nextStreamDate = nextStreamTime.toISOString().split("T")[0];
+  if (NO_STREAM_DATES.includes(nextStreamDate)) {
+    // If it's a skipped date, add 7 days to get the following week
+    nextStreamTime.setDate(nextStreamTime.getDate() + 7);
+  }
 
   return nextStreamTime;
 };
@@ -137,6 +151,12 @@ export function getStream(): {
       // Create a Date object for the stream start time in Sydney timezone
       const startTime = new Date(now);
       startTime.setHours(stream.startHour, stream.startMinute, 0, 0);
+
+      // Check if the stream time falls on a skipped date
+      const streamDate = startTime.toISOString().split("T")[0];
+      if (NO_STREAM_DATES.includes(streamDate)) {
+        continue; // Skip this stream and check the next one
+      }
 
       // Convert to local time for display
       const localStartTime = new Date(


### PR DESCRIPTION
# Description

This PR fixes the following issues regarding the stream time
- Players in timezones where the day would be different from sydney should now show the time correctly
- fix edge case for DST
- Add NO_STREAM_DATES array for Australian public holidays

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
