### PR TITLE
[FIX] Stream Time Display

### DIFF
--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -23,10 +23,10 @@ type StreamConfig = {
 export const STREAMS_CONFIG = {
   tuesday: {
     day: 2,
-    startHour: 18,
+    startHour: 15,
     startMinute: 30,
     durationMinutes: 60,
-    notifyMinutesBefore: 20,
+    notifyMinutesBefore: 10,
   } as StreamConfig,
   friday: {
     day: 5,

--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -20,6 +20,11 @@ type StreamConfig = {
   notifyMinutesBefore: number;
 };
 
+const NO_STREAM_DATES = [
+  "2025-04-25", // ANZAC Day
+  "2025-12-26", // Boxing Day
+];
+
 export const STREAMS_CONFIG = {
   tuesday: {
     day: 2,
@@ -71,6 +76,16 @@ export const getNextStreamTime = (schedule: StreamSchedule): number => {
       daysUntilStream * 24 * 60 + // Days in minutes
       (schedule.hour * 60 + schedule.minute) - // Stream time
       (currentHour * 60 + currentMinute); // Current time
+  }
+
+  const nextStreamDate = new Date(
+    sydneyTime.getTime() + minutesUntilStream * 60000,
+  )
+    .toISOString()
+    .split("T")[0];
+
+  if (NO_STREAM_DATES.includes(nextStreamDate)) {
+    minutesUntilStream += 7 * 24 * 60;
   }
 
   // Create the next stream time by adding minutes to current time

--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -90,6 +90,9 @@ export function getStream(): {
   endAt: number;
   notifyAt: number;
 } | null {
+  let nextStream = null;
+  let nextStreamTime = Infinity;
+
   for (const stream of Object.values(STREAMS_CONFIG)) {
     const streamStartTime = getNextStreamTime({
       day: stream.day,
@@ -97,14 +100,17 @@ export function getStream(): {
       minute: stream.startMinute,
     });
 
-    return {
-      startAt: streamStartTime,
-      endAt: streamStartTime + stream.durationMinutes * 60 * 1000,
-      notifyAt: streamStartTime - stream.notifyMinutesBefore * 60 * 1000,
-    };
+    if (streamStartTime < nextStreamTime) {
+      nextStreamTime = streamStartTime;
+      nextStream = {
+        startAt: streamStartTime,
+        endAt: streamStartTime + stream.durationMinutes * 60 * 1000,
+        notifyAt: streamStartTime - stream.notifyMinutesBefore * 60 * 1000,
+      };
+    }
   }
 
-  return null;
+  return nextStream;
 }
 
 export const Streams: React.FC<{ onClose: () => void }> = ({ onClose }) => {

--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -85,12 +85,14 @@ export const getNextStreamTime = (schedule: StreamSchedule): number => {
   return nextStreamTime.getTime();
 };
 
-export function getStream(): {
+export type StreamNotification = {
   startAt: number;
   endAt: number;
   notifyAt: number;
-} | null {
-  let nextStream = null;
+};
+
+export function getStream(): StreamNotification | null {
+  let nextStream: StreamNotification | null = null;
   let nextStreamTime = Infinity;
 
   for (const stream of Object.values(STREAMS_CONFIG)) {

--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -103,9 +103,9 @@ export function getStream(): {
     if (streamStartTime < nextStreamTime) {
       nextStreamTime = streamStartTime;
       nextStream = {
-        startAt: streamStartTime,
-        endAt: streamStartTime + stream.durationMinutes * 60 * 1000,
-        notifyAt: streamStartTime - stream.notifyMinutesBefore * 60 * 1000,
+        startAt: nextStreamTime,
+        endAt: nextStreamTime + stream.durationMinutes * 60 * 1000,
+        notifyAt: nextStreamTime - stream.notifyMinutesBefore * 60 * 1000,
       };
     }
   }

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -108,9 +108,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Iron: new Decimal(1000),
     Gold: new Decimal(1000),
   },
-  wardrobe: {
-    Halo: 1,
-  },
+  wardrobe: {},
   previousWardrobe: {},
   bank: { taxFreeSFL: 0 },
   beehives: {},

--- a/src/features/island/hud/components/StreamCountdown.tsx
+++ b/src/features/island/hud/components/StreamCountdown.tsx
@@ -18,10 +18,6 @@ const Countdown: React.FC<{
   const end = useCountdown(endAt);
   const { t } = useAppTranslation();
 
-  if (endAt < Date.now()) {
-    return null;
-  }
-
   if (Date.now() < startAt && Date.now() > notifyAt) {
     return (
       <div>
@@ -85,7 +81,14 @@ export const StreamCountdown: React.FC = () => {
     return () => clearInterval(interval);
   }, []);
 
-  if (!stream || hide) return null;
+  if (
+    !stream ||
+    hide ||
+    Date.now() < stream.notifyAt ||
+    Date.now() > stream.endAt
+  ) {
+    return null;
+  }
 
   return (
     <ButtonPanel

--- a/src/features/island/hud/components/StreamCountdown.tsx
+++ b/src/features/island/hud/components/StreamCountdown.tsx
@@ -3,7 +3,10 @@ import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { Label } from "components/ui/Label";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { getStream } from "features/game/components/modal/components/Streams";
+import {
+  getStream,
+  StreamNotification,
+} from "features/game/components/modal/components/Streams";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
 import { ButtonPanel } from "components/ui/Panel";
 import promoteIcon from "assets/icons/promote.webp";
@@ -65,11 +68,7 @@ const Countdown: React.FC<{
 
 export const StreamCountdown: React.FC = () => {
   const [hide, setHide] = useState(false);
-  const [stream, setStream] = useState<{
-    startAt: number;
-    endAt: number;
-    notifyAt: number;
-  } | null>(getStream());
+  const [stream, setStream] = useState<StreamNotification | null>(getStream());
 
   const navigate = useNavigate();
 

--- a/src/features/island/hud/components/StreamCountdown.tsx
+++ b/src/features/island/hud/components/StreamCountdown.tsx
@@ -11,8 +11,9 @@ import { useNavigate } from "react-router";
 const Countdown: React.FC<{
   startAt: number;
   endAt: number;
+  notifyAt: number;
   onHide: () => void;
-}> = ({ startAt, endAt, onHide }) => {
+}> = ({ startAt, endAt, notifyAt, onHide }) => {
   const start = useCountdown(startAt);
   const end = useCountdown(endAt);
   const { t } = useAppTranslation();
@@ -21,7 +22,7 @@ const Countdown: React.FC<{
     return null;
   }
 
-  if (Date.now() < startAt && Date.now() > startAt - 1000 * 60 * 10) {
+  if (Date.now() < startAt && Date.now() > notifyAt) {
     return (
       <div>
         <div className="h-6 flex justify-center">
@@ -71,6 +72,7 @@ export const StreamCountdown: React.FC = () => {
   const [stream, setStream] = useState<{
     startAt: number;
     endAt: number;
+    notifyAt: number;
   } | null>(getStream());
 
   const navigate = useNavigate();
@@ -95,6 +97,7 @@ export const StreamCountdown: React.FC = () => {
       <Countdown
         startAt={stream.startAt}
         endAt={stream.endAt}
+        notifyAt={stream.notifyAt}
         onHide={() => setHide(true)}
       />
     </ButtonPanel>


### PR DESCRIPTION
# Description

This PR fixes the issue of the start time being wrong for the opposite timezones

- rewrote getNextStreamTime to calculate the next stream time
- reused getNextStreamTime to calculate getStream()

Times in the below screenshot is in Pacific Time (GMT-8)
|Before (Discord Stream time showing wrongly) | After(taking to effect no stream on anzac day)|
|---|---|
|![image](https://github.com/user-attachments/assets/aaf2d7bb-688e-4f12-88c3-fa571b387687)|![image](https://github.com/user-attachments/assets/37752b17-53ed-4cb1-84f1-c8ffc90c97fb)|

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
