### PR TITLE
[FIX] Skip Axe Shortcut for Fruit Patches if No Axe No Worries is Enabled

### DIFF
--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -180,7 +180,10 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
   const removeTree = async () => {
     if (!hasAxes) return;
 
-    if (!isCollectibleBuilt({ name: "Foreman Beaver", game }))
+    if (
+      !isCollectibleBuilt({ name: "Foreman Beaver", game }) &&
+      !game.bumpkin?.skills["No Axe No Worries"]
+    )
       shortcutItem("Axe");
 
     const newState = gameService.send("fruitTree.removed", {


### PR DESCRIPTION
# Description

This PR fixes an issue where, with the 'No Axe No Worries' skill enabled, the axe is still added to the shortcut when chopping stems or branches on fruit patches.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
