### PR TITLE
[FEAT] Marketplace Limit Updates

### DIFF
--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1591,14 +1591,13 @@ export interface GameState {
     tradePoints?: number;
     dailyListings?: { date: number; count: number };
     dailyPurchases?: { date: number; count: number };
-    weeklySales?: Record<
-      string, // date in YYYY-MM-DD format
-      Partial<Record<MarketplaceTradeableName, number>>
-    >;
-    weeklyPurchases?: Record<
-      string, // date in YYYY-MM-DD format
-      Partial<Record<MarketplaceTradeableName, number>>
-    >;
+    weeklySales?: {
+      [date: string]: Partial<Record<MarketplaceTradeableName, number>>;
+    };
+
+    weeklyPurchases?: {
+      [date: string]: Partial<Record<MarketplaceTradeableName, number>>;
+    };
   };
 
   buds?: Record<number, Bud>;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1591,7 +1591,16 @@ export interface GameState {
     tradePoints?: number;
     dailyListings?: { date: number; count: number };
     dailyPurchases?: { date: number; count: number };
+    weeklySales?: Record<
+      string, // date in YYYY-MM-DD format
+      Partial<Record<MarketplaceTradeableName, number>>
+    >;
+    weeklyPurchases?: Record<
+      string, // date in YYYY-MM-DD format
+      Partial<Record<MarketplaceTradeableName, number>>
+    >;
   };
+
   buds?: Record<number, Bud>;
 
   christmas2024?: Christmas;

--- a/src/features/game/types/getItemBuffs.ts
+++ b/src/features/game/types/getItemBuffs.ts
@@ -5,7 +5,7 @@ import { BumpkinItem } from "./bumpkin";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "./bumpkinItemBuffs";
 import { COLLECTIBLE_BUFF_LABELS } from "./collectibleItemBuffs";
 import { GameState, InventoryItemName } from "./game";
-import { CollectionName } from "./marketplace";
+import { CollectionName, MarketplaceTradeableName } from "./marketplace";
 
 export function getItemBuffs({
   state,
@@ -13,7 +13,7 @@ export function getItemBuffs({
   collection,
 }: {
   state: GameState;
-  item: InventoryItemName | BumpkinItem | BudName;
+  item: MarketplaceTradeableName;
   collection: CollectionName;
 }): BuffLabel[] {
   if (collection === "buds") {

--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -147,7 +147,7 @@ export type MarketplaceProfile = {
   trades: Sale[];
 };
 
-type BudNFTName = `Bud #${number}`;
+export type BudNFTName = `Bud #${number}`;
 
 export type MarketplaceTradeableName =
   | InventoryItemName

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -4,7 +4,7 @@ import {
 } from "features/game/types/marketplace";
 import React, { useContext, useState } from "react";
 import * as Auth from "features/auth/lib/Provider";
-import { useActor } from "@xstate/react";
+import { useActor, useSelector } from "@xstate/react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { loadTradeable } from "../actions/loadTradeable";
 import { getTradeableDisplay } from "../lib/tradeables";
@@ -31,9 +31,13 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { TradeableStats } from "./TradeableStats";
 import { getKeys } from "features/game/types/decorations";
 import { tradeToId } from "../lib/offers";
-import { getDayOfYear } from "lib/utils/time";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import useSWR from "swr";
+import { getWeekKey } from "features/game/lib/factions";
+import { MachineState } from "features/game/lib/gameMachine";
+
+const _trades = (state: MachineState) => state.context.state.trades;
+export const MAX_LIMITED_SALES = 1;
 
 export const Tradeable: React.FC = () => {
   const { authService } = useContext(Auth.Context);
@@ -95,17 +99,19 @@ export const Tradeable: React.FC = () => {
         token,
       }),
   );
+
+  const trades = useSelector(gameService, _trades);
+  const currentWeek = getWeekKey({ date: new Date() });
+  const weeklySalesCount =
+    trades.weeklySales?.[currentWeek]?.[display.name] ?? 0;
+  const listingsCount = Object.values(trades.listings ?? {}).filter(
+    (listing) => listing.items[display.name],
+  ).length;
+  const isLimited = !!tradeable?.expiresAt;
+  const limitedTradesLeft = isLimited
+    ? MAX_LIMITED_SALES - weeklySalesCount - listingsCount
+    : Infinity;
   if (error) throw error;
-
-  const getDailyListings = () => {
-    const today = getDayOfYear(new Date());
-    const dailyListings = gameState.context.state.trades.dailyListings ?? {
-      date: 0,
-      count: 0,
-    };
-
-    return dailyListings.date === today ? dailyListings.count : 0;
-  };
 
   // TODO 404 view
   if (tradeable === null) {
@@ -122,7 +128,6 @@ export const Tradeable: React.FC = () => {
     }
   };
 
-  const trades = gameState.context.state.trades;
   const hasListings = getKeys(trades.listings ?? {}).some(
     (listing) =>
       tradeToId({ details: trades.listings![listing] }) === Number(id),
@@ -156,11 +161,10 @@ export const Tradeable: React.FC = () => {
       </div>
       <div className="w-full">
         <TradeableHeader
-          dailyListings={getDailyListings()}
           authToken={authToken}
           farmId={farmId}
+          limitedTradesLeft={limitedTradesLeft}
           collection={collection as CollectionName}
-          display={display}
           count={count}
           tradeable={tradeable}
           onBack={onBack}
@@ -181,6 +185,7 @@ export const Tradeable: React.FC = () => {
         <TradeableListings
           id={Number(id)}
           authToken={authState.context.user.rawToken as string}
+          limitedTradesLeft={limitedTradesLeft}
           tradeable={tradeable}
           display={display}
           farmId={farmId}
@@ -197,6 +202,7 @@ export const Tradeable: React.FC = () => {
 
         <TradeableOffers
           itemId={Number(id)}
+          limitedTradesLeft={limitedTradesLeft}
           tradeable={tradeable}
           display={display}
           farmId={farmId}

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -38,6 +38,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 
 const _trades = (state: MachineState) => state.context.state.trades;
 export const MAX_LIMITED_SALES = 1;
+export const MAX_LIMITED_PURCHASES = 3;
 
 export const Tradeable: React.FC = () => {
   const { authService } = useContext(Auth.Context);
@@ -102,6 +103,7 @@ export const Tradeable: React.FC = () => {
 
   const trades = useSelector(gameService, _trades);
   const currentWeek = getWeekKey({ date: new Date() });
+  // Weekly sales count
   const weeklySalesCount =
     trades.weeklySales?.[currentWeek]?.[display.name] ?? 0;
   const listingsCount = Object.values(trades.listings ?? {}).filter(
@@ -111,6 +113,17 @@ export const Tradeable: React.FC = () => {
   const limitedTradesLeft = isLimited
     ? MAX_LIMITED_SALES - weeklySalesCount - listingsCount
     : Infinity;
+
+  // Weekly purchases count
+  const weeklyPurchasesCount =
+    trades.weeklyPurchases?.[currentWeek]?.[display.name] ?? 0;
+  const offersCount = Object.values(trades.offers ?? {}).filter(
+    (offer) => offer.items[display.name],
+  ).length;
+  const limitedPurchasesLeft = isLimited
+    ? MAX_LIMITED_PURCHASES - weeklyPurchasesCount - offersCount
+    : Infinity;
+
   if (error) throw error;
 
   // TODO 404 view
@@ -164,6 +177,7 @@ export const Tradeable: React.FC = () => {
           authToken={authToken}
           farmId={farmId}
           limitedTradesLeft={limitedTradesLeft}
+          limitedPurchasesLeft={limitedPurchasesLeft}
           collection={collection as CollectionName}
           count={count}
           tradeable={tradeable}
@@ -203,6 +217,7 @@ export const Tradeable: React.FC = () => {
         <TradeableOffers
           itemId={Number(id)}
           limitedTradesLeft={limitedTradesLeft}
+          limitedPurchasesLeft={limitedPurchasesLeft}
           tradeable={tradeable}
           display={display}
           farmId={farmId}

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -43,6 +43,7 @@ type TradeableHeaderProps = {
   onBack: () => void;
   onListClick: () => void;
   reload: () => void;
+  limitedPurchasesLeft: number;
 };
 
 const _balance = (state: MachineState) => state.context.state.balance;
@@ -56,6 +57,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   authToken,
   farmId,
   limitedTradesLeft,
+  limitedPurchasesLeft,
   count,
   tradeable,
   onListClick,
@@ -235,7 +237,10 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 {showBuyNow && (
                   <Button
                     onClick={() => setShowPurchaseModal(true)}
-                    disabled={!balance.gt(cheapestListing.sfl)}
+                    disabled={
+                      !balance.gt(cheapestListing.sfl) ||
+                      limitedPurchasesLeft <= 0
+                    }
                     className="mr-1 w-full sm:w-auto"
                   >
                     {t("marketplace.buyNow")}

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -30,11 +30,13 @@ import { TradeableDisplay } from "../lib/tradeables";
 import { KNOWN_ITEMS } from "features/game/types";
 import { KeyedMutator } from "swr";
 import { isTradeResource } from "features/game/actions/tradeLimits";
+import { MAX_LIMITED_SALES } from "./Tradeable";
 
 type TradeableListingsProps = {
   authToken: string;
   tradeable?: TradeableDetails;
   display: TradeableDisplay;
+  limitedTradesLeft: number;
   farmId: number;
   id: number;
   showListItem: boolean;
@@ -50,6 +52,7 @@ const _balance = (state: MachineState) => state.context.state.balance;
 export const TradeableListings: React.FC<TradeableListingsProps> = ({
   authToken,
   tradeable,
+  limitedTradesLeft,
   farmId,
   display,
   id,
@@ -64,6 +67,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
 
   const isListing = useSelector(gameService, _isListing);
   const balance = useSelector(gameService, _balance);
+
   const [selectedListing, setSelectedListing] = useState<Listing>();
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
 
@@ -170,6 +174,11 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
             <Label icon={tradeIcon} type="default" className="mb-2">
               {t("marketplace.listings")}
             </Label>
+            {tradeable?.expiresAt && (
+              <Label type={limitedTradesLeft <= 0 ? "danger" : "warning"}>
+                {`${limitedTradesLeft}/${MAX_LIMITED_SALES} Listings left`}
+              </Label>
+            )}
           </div>
           <div className="mb-2">
             {loading && <Loading />}

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -35,6 +35,7 @@ import { isTradeResource } from "features/game/actions/tradeLimits";
 import Decimal from "decimal.js-light";
 import { useParams } from "react-router";
 import { KeyedMutator } from "swr";
+import { MAX_LIMITED_PURCHASES } from "./Tradeable";
 
 const _hasPendingOfferEffect = (state: MachineState) =>
   state.matches("marketplaceOffering") || state.matches("marketplaceAccepting");
@@ -46,11 +47,20 @@ const _inventory = (state: MachineState) => state.context.state.inventory;
 export const TradeableOffers: React.FC<{
   tradeable?: TradeableDetails;
   limitedTradesLeft: number;
+  limitedPurchasesLeft: number;
   farmId: number;
   display: TradeableDisplay;
   itemId: number;
   reload: KeyedMutator<TradeableDetails>;
-}> = ({ tradeable, limitedTradesLeft, farmId, display, itemId, reload }) => {
+}> = ({
+  tradeable,
+  limitedTradesLeft,
+  farmId,
+  display,
+  itemId,
+  reload,
+  limitedPurchasesLeft,
+}) => {
   const { authService } = useContext(Auth.Context);
   const { gameService, showAnimations } = useContext(Context);
   const { t } = useAppTranslation();
@@ -171,6 +181,11 @@ export const TradeableOffers: React.FC<{
               <Label type="default" icon={increaseArrow}>
                 {t("marketplace.offers")}
               </Label>
+              {tradeable?.expiresAt && (
+                <Label type={limitedPurchasesLeft <= 0 ? "danger" : "warning"}>
+                  {`${limitedPurchasesLeft}/${MAX_LIMITED_PURCHASES} Offers left`}
+                </Label>
+              )}
             </div>
             <div className="flex w-full flex-col sm:flex-row items-center justify-between">
               {topOffer ? (
@@ -195,7 +210,11 @@ export const TradeableOffers: React.FC<{
                   {tradeable?.isActive && (
                     <Button
                       className="w-full sm:w-fit mr-1"
-                      disabled={!tradeable || !tradeable?.isActive}
+                      disabled={
+                        !tradeable ||
+                        !tradeable?.isActive ||
+                        limitedPurchasesLeft <= 0
+                      }
                       onClick={() => setShowMakeOffer(true)}
                     >
                       <span className="whitespace-nowrap text-xs sm:text-sm">

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -42,17 +42,15 @@ const _authToken = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
 const _balance = (state: MachineState) => state.context.state.balance;
 const _inventory = (state: MachineState) => state.context.state.inventory;
-const _bertObsession = (state: MachineState) =>
-  state.context.state.bertObsession;
-const _npcs = (state: MachineState) => state.context.state.npcs;
 
 export const TradeableOffers: React.FC<{
   tradeable?: TradeableDetails;
+  limitedTradesLeft: number;
   farmId: number;
   display: TradeableDisplay;
   itemId: number;
   reload: KeyedMutator<TradeableDetails>;
-}> = ({ tradeable, farmId, display, itemId, reload }) => {
+}> = ({ tradeable, limitedTradesLeft, farmId, display, itemId, reload }) => {
   const { authService } = useContext(Auth.Context);
   const { gameService, showAnimations } = useContext(Context);
   const { t } = useAppTranslation();
@@ -80,8 +78,6 @@ export const TradeableOffers: React.FC<{
   const authToken = useSelector(authService, _authToken);
   const balance = useSelector(gameService, _balance);
   const inventory = useSelector(gameService, _inventory);
-  const bertObsession = useSelector(gameService, _bertObsession);
-  const npcs = useSelector(gameService, _npcs);
   const [showMakeOffer, setShowMakeOffer] = useState(false);
   const [showAcceptOffer, setShowAcceptOffer] = useState(false);
   const [selectedOffer, setSelectedOffer] = useState<Offer>();
@@ -142,15 +138,6 @@ export const TradeableOffers: React.FC<{
 
   const loading = !tradeable;
   const isResource = isTradeResource(KNOWN_ITEMS[Number(id)]);
-
-  // Check if the item is a bert obsession and whether the bert obsession is completed
-  const isItemBertObsession = bertObsession?.name === display.name;
-  const obsessionCompletedAt = npcs?.bert?.questCompletedAt;
-  const isBertsObesessionCompleted =
-    !!obsessionCompletedAt &&
-    bertObsession &&
-    obsessionCompletedAt >= bertObsession.startDate &&
-    obsessionCompletedAt <= bertObsession.endDate;
 
   return (
     <>
@@ -221,9 +208,7 @@ export const TradeableOffers: React.FC<{
                     <Button
                       disabled={
                         topOffer.offeredBy.id === farmId ||
-                        (isItemBertObsession &&
-                          isBertsObesessionCompleted &&
-                          !isResource)
+                        limitedTradesLeft <= 0
                       }
                       onClick={() => setShowAcceptOffer(true)}
                       className="w-full sm:w-fit"

--- a/src/features/marketplace/lib/tradeables.ts
+++ b/src/features/marketplace/lib/tradeables.ts
@@ -5,16 +5,16 @@ import { GameState, InventoryItemName } from "features/game/types/game";
 import { getItemBuffs } from "features/game/types/getItemBuffs";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
+  BudNFTName,
   CollectionName,
   MarketplaceTradeableName,
 } from "features/game/types/marketplace";
 import { budImageDomain } from "features/island/collectibles/components/Bud";
 import { OPEN_SEA_WEARABLES } from "metadata/metadata";
-import { BudName } from "features/game/types/buds";
 import { translate } from "lib/i18n/translate";
 
 export type TradeableDisplay = {
-  name: string;
+  name: MarketplaceTradeableName;
   description: string;
   image: string;
   type: CollectionName;
@@ -44,7 +44,7 @@ export function getTradeableDisplay({
   }
 
   if (type === "buds") {
-    const name = `Bud #${id}` as BudName;
+    const name = `Bud #${id}` as BudNFTName;
 
     return {
       name,


### PR DESCRIPTION
This PR adds restrictions for the bounties sales in marketplace

### Sales (1 per week)
- If Player has an active listing, they can't list again
- If Player has an active listing, they can't accept any offers
- If Player has sold item this week, they can't list again
- If Player has sold item this week, they can't accept any offers

### Purchases (3 per week)
- If sum of active offers + purchases this week more than 3, they can't offer again
- If sum of active offers + purchases this week more than 3, they can't buy any listings

Added labels to tell players how much listings and offers they have this week
![image](https://github.com/user-attachments/assets/a814ec20-10c0-4bd4-baa3-5c7bdb0dbc42)
