### PR TITLE
[FEAT] Great Bloom Megastore Boosts

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -41,6 +41,7 @@ import {
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export const ANIMAL_EMOTION_ICONS: Record<
   Exclude<TState["value"], "idle" | "needsLove" | "initial" | "sick">,
@@ -160,6 +161,11 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
     game,
   });
 
+  const hasOracleSyringeEquipped = isWearableActive({
+    name: "Oracle Syringe",
+    game,
+  });
+
   const { name: mutantName } = cow.reward?.items?.[0] ?? {};
 
   const feedCow = (item?: InventoryItemName) => {
@@ -250,6 +256,12 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
     const hasEnoughMedicine = medicineCount.gte(1);
+
+    if (hasOracleSyringeEquipped) {
+      playCureAnimal();
+      cureCow("Barn Delight");
+      return;
+    }
 
     if (hasEnoughMedicine) {
       playCureAnimal();

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -41,6 +41,7 @@ import {
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isWearableActive } from "features/game/lib/wearables";
 
 const _animalState = (state: AnimalMachineState) =>
   // Casting here because we know the value is always a string rather than an object
@@ -101,6 +102,11 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
 
   const hasGoldenSheep = isCollectibleBuilt({
     name: "Golden Sheep",
+    game,
+  });
+
+  const hasOracleSyringeEquipped = isWearableActive({
+    name: "Oracle Syringe",
     game,
   });
 
@@ -214,6 +220,12 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
     const hasEnoughMedicine = medicineCount.gte(1);
+
+    if (hasOracleSyringeEquipped) {
+      playCureAnimal();
+      cureSheep("Barn Delight");
+      return;
+    }
 
     if (hasEnoughMedicine) {
       playCureAnimal();

--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -597,6 +597,54 @@ describe("feedAnimal", () => {
     expect(state.henHouse.animals[chickenId].state).toBe("ready");
   });
 
+  it("cures a sick animal for Free when Oracle Syringe is equipped", () => {
+    const chickenId = "xyz";
+
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          equipped: {
+            ...INITIAL_FARM.bumpkin?.equipped,
+            wings: "Oracle Syringe",
+          },
+        },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Barn Delight": new Decimal(1),
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            [chickenId]: {
+              id: chickenId,
+              type: "Chicken",
+              createdAt: 0,
+              state: "sick",
+              experience: 0,
+              asleepAt: 0,
+              awakeAt: 0,
+              lovedAt: 0,
+              item: "Petting Hand",
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: chickenId,
+        item: "Barn Delight",
+      },
+    });
+
+    expect(state.henHouse.animals[chickenId].state).toBe("idle");
+    expect(state.inventory["Barn Delight"]).toStrictEqual(new Decimal(1));
+    expect(state.henHouse.animals[chickenId].experience).toBe(0);
+  });
+
   it("cures a sick animal with Barn Delight", () => {
     const chickenId = "xyz";
 

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -22,6 +22,7 @@ import {
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { getKeys } from "features/game/types/decorations";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export const ANIMAL_SLEEP_DURATION = 24 * 60 * 60 * 1000;
 
@@ -184,6 +185,22 @@ export function feedAnimal({
     if (action.item === "Barn Delight") {
       if (animal.state !== "sick") {
         throw new Error("Cannot cure a healthy animal");
+      }
+
+      const hasOracleSyringeEquipped = isWearableActive({
+        name: "Oracle Syringe",
+        game: copy,
+      });
+
+      if (hasOracleSyringeEquipped) {
+        //Free Medicine for Animals
+        animal.state = "idle";
+
+        copy.bumpkin.activity = trackActivity(
+          `${action.animal} Cured`,
+          copy.bumpkin.activity,
+        );
+        return copy;
       }
 
       const barnDelightAmount =

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -2473,6 +2473,45 @@ describe("getCropTime", () => {
     );
   });
 
+  it("gives +2 Kale when Giant Kale is placed and ready", () => {
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Kale Seed": new Decimal(1),
+        },
+        collectibles: {
+          "Giant Kale": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: dateNow - 10000,
+              readyAt: dateNow - 10000,
+              id: "123",
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "seed.planted",
+        cropId: "123",
+        index: "0",
+        item: "Kale Seed",
+      },
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+    expect((plots as Record<number, CropPlot>)[0].crop).toEqual(
+      expect.objectContaining({
+        name: "Kale",
+        plantedAt: expect.any(Number),
+        amount: 3,
+      }),
+    );
+  });
+
   it("applies a +5% speed boost with Green Thumb skill", () => {
     const baseHarvestSeconds = CROPS["Corn"].harvestSeconds;
     const time = getCropPlotTime({

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -2102,6 +2102,75 @@ describe("getCropTime", () => {
     expect(time).toEqual(baseHarvestSeconds * 0.75);
   });
 
+  it("gives +0.5 Yam when Giant Yam is placed and ready", () => {
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        island: {
+          type: "desert",
+        },
+        inventory: {
+          "Yam Seed": new Decimal(1),
+        },
+        season: {
+          season: "autumn",
+          startedAt: 0,
+        },
+        collectibles: {
+          "Giant Yam": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: dateNow - 10000,
+              readyAt: dateNow - 10000,
+              id: "123",
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "seed.planted",
+        cropId: "123",
+        index: "0",
+        item: "Yam Seed",
+      },
+    });
+
+    const plots = state.crops;
+
+    expect(plots).toBeDefined();
+    expect((plots as Record<number, CropPlot>)[0].crop).toEqual(
+      expect.objectContaining({
+        name: "Yam",
+        plantedAt: expect.any(Number),
+        amount: 1.5,
+      }),
+    );
+  });
+
+  it("applies a 2x speed boost with Giant Zucchini placed", () => {
+    const baseHarvestSeconds = CROPS["Zucchini"].harvestSeconds;
+    const time = getCropPlotTime({
+      crop: "Zucchini",
+      game: {
+        ...TEST_FARM,
+        collectibles: {
+          "Giant Zucchini": [
+            {
+              id: "123",
+              coordinates: { x: -1, y: -1 },
+              createdAt: dateNow - 100,
+              readyAt: dateNow - 100,
+            },
+          ],
+        },
+      },
+      plot,
+    });
+
+    expect(time).toEqual(baseHarvestSeconds * 0.5);
+  });
+
   it("applies a 20% speed boost with Basic Scarecrow placed, plot is within AOE and crop is Sunflower", () => {
     const sunflowerHarvestSeconds = CROPS["Sunflower"].harvestSeconds;
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -606,6 +606,10 @@ export function getCropYieldAmount({
     amount += 2;
   }
 
+  if (crop === "Kale" && isCollectibleBuilt({ name: "Giant Kale", game })) {
+    amount += 2;
+  }
+
   const collectibles = game.collectibles;
 
   if (

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -219,6 +219,13 @@ export function getCropTime({
   }
 
   if (
+    crop === "Zucchini" &&
+    isCollectibleBuilt({ name: "Giant Zucchini", game })
+  ) {
+    seconds = seconds * 0.5;
+  }
+
+  if (
     isSummerCrop(crop, game.season.season, SEASONAL_SEEDS) &&
     !isGreenhouseCrop(crop) &&
     isWearableActive({ name: "Solflare Aegis", game })
@@ -574,6 +581,10 @@ export function getCropYieldAmount({
     isWearableActive({ name: "Eggplant Onesie", game })
   ) {
     amount += 0.1;
+  }
+
+  if (crop === "Yam" && isCollectibleBuilt({ name: "Giant Yam", game })) {
+    amount += 0.5;
   }
 
   if (crop === "Soybean" && isWearableActive({ name: "Tofu Mask", game })) {

--- a/src/features/game/types/removeables.ts
+++ b/src/features/game/types/removeables.ts
@@ -282,6 +282,45 @@ function areAnyMineralsMined(game: GameState): Restriction {
   return areGoldsMined;
 }
 
+export function areAnyChickensHealthy(game: GameState): Restriction {
+  const chickensAreHealthy = Object.values(game.henHouse.animals).some(
+    (animal) => animal.state !== "sick",
+  );
+
+  return [chickensAreHealthy, "Chickens are healthy"];
+}
+
+export function areAnySheepsHealthy(game: GameState): Restriction {
+  const chickensAreHealthy = Object.values(game.barn.animals).some(
+    (animal) => animal.state !== "sick" && animal.type === "Sheep",
+  );
+
+  return [chickensAreHealthy, "Sheeps are healthy"];
+}
+
+export function areAnyCowsHealthy(game: GameState): Restriction {
+  const chickensAreHealthy = Object.values(game.barn.animals).some(
+    (animal) => animal.state !== "sick" && animal.type === "Cow",
+  );
+
+  return [chickensAreHealthy, "Cows are healthy"];
+}
+
+export function areAnyAnimalsHealthy(game: GameState): Restriction {
+  const areChickensHealthy = areAnyChickensHealthy(game);
+  const areSheepsHealthy = areAnySheepsHealthy(game);
+  const areCowsHealthy = areAnyCowsHealthy(game);
+
+  if (areChickensHealthy[0]) {
+    return areChickensHealthy;
+  }
+  if (areSheepsHealthy[0]) {
+    return areSheepsHealthy;
+  }
+
+  return areCowsHealthy;
+}
+
 export function areAnyChickensSleeping(game: GameState): Restriction {
   const chickensAreSleeping = Object.values(game.henHouse.animals).some(
     (animal) =>
@@ -767,6 +806,11 @@ export const REMOVAL_RESTRICTIONS: Partial<
   "Barn Blueprint": (game) =>
     hasBonusAnimals(game, "Cow") || hasBonusAnimals(game, "Sheep"),
   "Golden Sheep": (game) => areAnySheepSleeping(game),
+
+  // Great Bloom
+  "Giant Yam": (game) => cropIsGrowing({ item: "Yam", game }),
+  "Giant Zucchini": (game) => cropIsGrowing({ item: "Zucchini", game }),
+  "Giant Kale": (game) => cropIsGrowing({ item: "Kale", game }),
 };
 
 export const BUD_REMOVAL_RESTRICTIONS: Record<

--- a/src/features/game/types/wearableValidation.ts
+++ b/src/features/game/types/wearableValidation.ts
@@ -21,6 +21,7 @@ import {
   areAnyCookingBuildingWorking,
   isCraftingBoxWorking,
   areAnySeasonCropsorGHCropsGrowing,
+  areAnyAnimalsHealthy,
 } from "./removeables";
 import { GameState } from "./game";
 
@@ -95,6 +96,7 @@ const withdrawConditions: Partial<Record<BumpkinItem, isWithdrawable>> = {
     !areAnySeasonCropsorGHCropsGrowing(state, "autumn")[0],
   "Frozen Heart": (state) =>
     !areAnySeasonCropsorGHCropsGrowing(state, "winter")[0],
+  "Oracle Syringe": (state) => !areAnyAnimalsHealthy(state)[0],
 };
 
 export const canWithdrawBoostedWearable = (

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -41,6 +41,7 @@ import {
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export const CHICKEN_EMOTION_ICONS: Record<
   Exclude<TState["value"], "idle" | "needsLove" | "initial" | "sick">,
@@ -170,6 +171,11 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
     game,
   });
 
+  const hasOracleSyringeEquipped = isWearableActive({
+    name: "Oracle Syringe",
+    game,
+  });
+
   // Check if the chicken has a mutant
   const { name: mutantName } = chicken.reward?.items?.[0] ?? {};
 
@@ -260,6 +266,12 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
     const hasEnoughMedicine = medicineCount.gte(1);
+
+    if (hasOracleSyringeEquipped) {
+      playCureAnimal();
+      cureChicken("Barn Delight");
+      return;
+    }
 
     if (hasEnoughMedicine) {
       playCureAnimal();


### PR DESCRIPTION
# Description

This PR adds boost for the following Megastore Items:
Giant Yam - +0.5 Yam 🆕
Giant Zucchini- 2x Zucchini🆕
Oracle Syringe - Heal Animals for Free
Giant Kale - +2 Kale

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.


Connect FE to BE.
GIve yourself this Items/Wearables.
Place Items. 
Plant Yam and check Yield
Plant Zucchini and check Time Boost.
Plant Kale and check Yield.

Equip Oracle Syringe(wings)
Modify gamestate of Chicken and Barn Animals `state` to be `sick`.
Click on sick animal and check if they are cured.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
