### PR TITLE
[FIX] Bounties not sellable

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1886,9 +1886,7 @@ describe("deliver", () => {
       createdAt: now,
     });
 
-    expect(
-      state.inventory[getSeasonalTicket(new Date("2024-05-10T16:00:00Z"))],
-    ).toEqual(new Decimal(10));
+    expect(state.inventory[getSeasonalTicket()]).toEqual(new Decimal(10));
   });
 
   it("can deliver items from the wardrobe", () => {

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -27,7 +27,6 @@ import {
   BeachBountyTreasure,
 } from "features/game/types/treasure";
 import { produce } from "immer";
-import { getSeasonChangeover } from "lib/utils/getSeasonWeek";
 import { isCollectible } from "./garbageSold";
 import { CHAPTER_TICKET_BOOST_ITEMS } from "./completeNPCChore";
 
@@ -116,7 +115,6 @@ export function sellBounty({
   state,
   action,
   createdAt = Date.now(),
-  farmId = 0,
 }: Options): GameState {
   return produce(state, (draft) => {
     const request = draft.bounties.requests.find(
@@ -134,21 +132,10 @@ export function sellBounty({
       throw new Error("Bounty already completed");
     }
 
-    const { ticketTasksAreFrozen } = getSeasonChangeover({
-      now: createdAt,
-      id: farmId as number,
-    });
-
     const tickets = generateBountyTicket({
       game: draft,
       bounty: request,
     });
-
-    const isTicketOrder = tickets > 0;
-
-    if (isTicketOrder && ticketTasksAreFrozen) {
-      throw new Error("Ticket tasks are frozen");
-    }
 
     // Remove the item from the inventory
     const item = draft.inventory[request.name];


### PR DESCRIPTION
# Description

The season changeover condition is preventing players from completing their bounties. Since we only generate them to start at the start of the week, this check is no longer needed

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
