### PR TITLE
[FEAT] Change Old Deposit To In Game Items Only

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -226,7 +226,6 @@ type BuySFLEvent = {
 
 type DepositEvent = {
   type: "DEPOSIT";
-  sfl: string;
   itemIds: number[];
   itemAmounts: string[];
   wearableIds: number[];
@@ -1824,7 +1823,6 @@ export function startGame(authContext: AuthContext) {
               if (!wallet.getAccount()) throw new Error("No account");
 
               const {
-                sfl,
                 itemAmounts,
                 itemIds,
                 wearableIds,
@@ -1833,9 +1831,9 @@ export function startGame(authContext: AuthContext) {
               } = event as DepositEvent;
 
               await depositToFarm({
+                sfl: "0", // Hardcoded to 0 for now. SFL is retired.
                 account: wallet.getAccount() as `0x${string}`,
                 farmId: context.nftId as number,
-                sfl: sfl,
                 itemIds: itemIds,
                 itemAmounts: itemAmounts,
                 wearableAmounts,

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -8,7 +8,7 @@ import { Inventory } from "./components/inventory/Inventory";
 import { BumpkinProfile } from "./components/BumpkinProfile";
 import { Save } from "./components/Save";
 import { DepositArgs } from "lib/blockchain/Deposit";
-import { DepositModal } from "features/goblins/bank/components/Deposit";
+import { DepositGameItemsModal } from "features/goblins/bank/components/DepositGameItems";
 import { placeEvent } from "features/game/expansion/placeable/landscapingMachine";
 import { TravelButton } from "./components/deliveries/TravelButton";
 import { CodexButton } from "./components/codex/CodexButton";
@@ -52,7 +52,7 @@ const HudComponent: React.FC<{
   const autosaving = gameState.matches("autosaving");
 
   const handleDeposit = (
-    args: Pick<DepositArgs, "sfl" | "itemIds" | "itemAmounts">,
+    args: Pick<DepositArgs, "itemIds" | "itemAmounts">,
   ) => {
     gameService.send("DEPOSIT", args);
   };
@@ -140,7 +140,7 @@ const HudComponent: React.FC<{
         <CodexButton />
         <RewardsButton />
 
-        <DepositModal
+        <DepositGameItemsModal
           farmAddress={farmAddress ?? ""}
           linkedWallet={linkedWallet ?? ""}
           handleClose={() => setShowDepositModal(false)}

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -8,7 +8,7 @@ import Decimal from "decimal.js-light";
 import { DepositArgs } from "lib/blockchain/Deposit";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { Deposit } from "features/goblins/bank/components/Deposit";
+import { Deposit } from "features/goblins/bank/components/DepositGameItems";
 import { placeEvent } from "features/game/expansion/placeable/landscapingMachine";
 import { Save } from "./components/Save";
 import { PIXEL_SCALE } from "features/game/lib/constants";

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -8,7 +8,7 @@ import Decimal from "decimal.js-light";
 import { DepositArgs } from "lib/blockchain/Deposit";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import { Deposit } from "features/goblins/bank/components/DepositGameItems";
+import { DepositGameItems } from "features/goblins/bank/components/DepositGameItems";
 import { placeEvent } from "features/game/expansion/placeable/landscapingMachine";
 import { Save } from "./components/Save";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -56,7 +56,7 @@ const HudComponent: React.FC = () => {
   };
 
   const handleDeposit = (
-    args: Pick<DepositArgs, "sfl" | "itemIds" | "itemAmounts">,
+    args: Pick<DepositArgs, "itemIds" | "itemAmounts">,
   ) => {
     gameService.send("DEPOSIT", args);
   };
@@ -154,7 +154,7 @@ const HudComponent: React.FC = () => {
                 },
               ]}
             >
-              <Deposit
+              <DepositGameItems
                 farmAddress={farmAddress}
                 linkedWallet={linkedWallet}
                 onDeposit={handleDeposit}

--- a/src/features/island/hud/components/settings-menu/GameOptions.tsx
+++ b/src/features/island/hud/components/settings-menu/GameOptions.tsx
@@ -37,7 +37,7 @@ import { Share } from "./general-settings/Share";
 import { PlazaSettings } from "./plaza-settings/PlazaSettingsModal";
 import { DeveloperOptions } from "./developer-options/DeveloperOptions";
 import { Discord } from "./general-settings/DiscordModal";
-import { DepositWrapper } from "features/goblins/bank/components/Deposit";
+import { DepositWrapper } from "features/goblins/bank/components/DepositGameItems";
 import { useSound } from "lib/utils/hooks/useSound";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
 import lockIcon from "assets/icons/lock.png";

--- a/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/blockchain-settings/BlockchainSettings.tsx
@@ -73,7 +73,9 @@ export const BlockchainSettings: React.FC<ContentComponentProps> = ({
         )}
       </div>
 
-      <Button onClick={() => onSubMenuClick("deposit")}>{t("deposit")}</Button>
+      <Button onClick={() => onSubMenuClick("deposit")}>
+        {t("deposit.items")}
+      </Button>
       {isFullUser && (
         <Button onClick={storeOnChain}>
           {t("gameOptions.blockchainSettings.storeOnChain")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6033,7 +6033,11 @@
   "current.timezone": "Current timezone: {{timeZone}}",
   "transaction.whalePack": "Whale pack can only be bought with FLOWER.",
   "deposit.flower.guide": "To deposit, switch to the {{network}} network in your personal wallet and send FLOWER to the address shown below.",
+<<<<<<< HEAD
   "flower.launch.one": "$FLOWER ERC20 is live on BASE",
   "flower.launch.two": "Deposits are enabled",
   "flower.launch.three": "Liquidity rewards and withdrawals starting soon"
+=======
+  "deposit.items": "Deposit Game Items"
+>>>>>>> d9c1224a7 ([FEAT] Convert old deposit to in game items only)
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6033,11 +6033,8 @@
   "current.timezone": "Current timezone: {{timeZone}}",
   "transaction.whalePack": "Whale pack can only be bought with FLOWER.",
   "deposit.flower.guide": "To deposit, switch to the {{network}} network in your personal wallet and send FLOWER to the address shown below.",
-<<<<<<< HEAD
   "flower.launch.one": "$FLOWER ERC20 is live on BASE",
   "flower.launch.two": "Deposits are enabled",
-  "flower.launch.three": "Liquidity rewards and withdrawals starting soon"
-=======
+  "flower.launch.three": "Liquidity rewards and withdrawals starting soon",
   "deposit.items": "Deposit Game Items"
->>>>>>> d9c1224a7 ([FEAT] Convert old deposit to in game items only)
 }


### PR DESCRIPTION
# Description

Change the wording on the Game Options -> Blockchain Settings -> Deposit button. It is now in-game items only. 

Remove the old sfl code.

<img width="348" alt="Screenshot 2025-05-08 at 2 31 09 PM" src="https://github.com/user-attachments/assets/a76e31c2-0195-420e-a7c3-658a0ce75506" />

<img width="358" alt="Screenshot 2025-05-08 at 2 31 17 PM" src="https://github.com/user-attachments/assets/6a1bfb71-5c4a-49ab-9165-601225527010" />

Fixes #issue

# What needs to be tested by the reviewer?


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
