### PR TITLE
[FIX] Uniswap Link

### DIFF
--- a/src/features/game/components/FLOWERTeaser.tsx
+++ b/src/features/game/components/FLOWERTeaser.tsx
@@ -69,7 +69,7 @@ export const FLOWERTeaserContent: React.FC = () => {
         <Button
           onClick={() => {
             window.open(
-              "https://app.uniswap.org/swap?chain=base&inputCurrency=0x3e12b9d6a4d12cd9b4a6d613872d0eb32f68b380&outputCurrency=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&value=1&field=input",
+              "https://app.uniswap.org/swap?chain=base&inputCurrency=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&outputCurrency=0x3e12b9d6a4d12cd9b4a6d613872d0eb32f68b380&value=1&field=input",
               "_blank",
             );
           }}


### PR DESCRIPTION
# Description

Uniswap link currently points to Sell FLOWER and Buy USDC,

It should point to Sell USDC and Buy FLOWER

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
