### PR TITLE
[FEAT] Add Label for Limited Withdrawal

### DIFF
--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -73,7 +73,9 @@ const MainMenu: React.FC<{ setPage: (page: Page) => void }> = ({ setPage }) => {
     <div className="p-2 flex flex-col justify-center space-y-1">
       <span className="mb-1">{translate("withdraw.sync")}</span>
       {/* Remove the following label once FLOWER is released for withdrawals */}
-      <Label type="info">{translate("withdraw.sfl.disabled")}</Label>
+      {!hasFeatureAccess(gameState.context.state, "FLOWER_WITHDRAW") && (
+        <Label type="info">{translate("withdraw.sfl.disabled")}</Label>
+      )}
 
       <div className="flex space-x-1">
         <Button

--- a/src/features/game/components/bank/components/WithdrawFlower.tsx
+++ b/src/features/game/components/bank/components/WithdrawFlower.tsx
@@ -93,14 +93,17 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
   return (
     <>
       <div className="p-2 mb-2">
-        <Label type="default" className="-ml-0.5">
-          {t("withdraw.choose")}
-        </Label>
-        <p className="text-xs mt-2">
-          {t("withdraw.sfl.available", {
-            flower: formatNumber(balance, { decimalPlaces: 4 }),
-          })}
-        </p>
+        <div className="flex flex-col items-start gap-2">
+          <Label type="default">{t("withdraw.choose")}</Label>
+          {hasFeatureAccess(state, "WITHDRAWAL_THRESHOLD") && (
+            <Label type="warning">{t("withdraw.flower.limited")}</Label>
+          )}
+          <p className="text-xs">
+            {t("withdraw.sfl.available", {
+              flower: formatNumber(balance, { decimalPlaces: 4 }),
+            })}
+          </p>
+        </div>
 
         <div>
           <div className="flex items-center mt-2 -ml-1">

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -120,6 +120,11 @@ const FEATURE_FLAGS = {
   FLOWER_BOXES: betaTimeBasedFeatureFlag(new Date("2025-05-01T00:00:00Z")),
 
   MEGA_BOUNTIES: betaTimeBasedFeatureFlag(new Date("2025-05-05T00:00:00Z")),
+
+  WITHDRAWAL_THRESHOLD: timePeriodFeatureFlag({
+    start: new Date("2025-05-08T00:00:00Z"),
+    end: new Date("2025-06-20T00:00:00.000Z"),
+  }),
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3678,6 +3678,7 @@
   "withdraw.bumpkin.wearing": "Your Bumpkin is currently wearing the following item(s) that can't be withdrawn. You will need to unequip them before you can withdraw.",
   "withdraw.buds": "Select Buds to withdraw",
   "withdraw.budRestricted": "Used in today's bud box",
+  "withdraw.flower.limited": "During the initial launch of $FLOWER, the amount of $FLOWER you can withdraw is limited.",
   "world.lvl.requirement": "Lvl {{lvl}}",
   "world.factionMembersOnly": "Faction members only",
   "world.newArea": "New",


### PR DESCRIPTION
# Description

- Added a label to tell players that the flower withdrawals will be limited for a short time
![image](https://github.com/user-attachments/assets/a9ed2f13-b4d1-49bb-bfa2-cd20b00254b0)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
