### PR TITLE
[FEAT] Allow Bee Swarm to apply on empty Plot

### DIFF
--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -145,7 +145,7 @@ export function harvest({
 
     // Remove crop data for plot
     delete plot.crop;
-
+    delete plot.beeSwarm;
     delete plot.fertiliser;
 
     const cropCount = stateCopy.inventory[cropName] || new Decimal(0);

--- a/src/features/game/events/landExpansion/harvestBeehive.test.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.test.ts
@@ -1,6 +1,10 @@
 import { Beehive, CropPlot, FlowerBed } from "features/game/types/game";
 import { HARVEST_BEEHIVE_ERRORS, harvestBeehive } from "./harvestBeehive";
-import { TEST_FARM, INITIAL_BUMPKIN } from "features/game/lib/constants";
+import {
+  TEST_FARM,
+  INITIAL_BUMPKIN,
+  INITIAL_FARM,
+} from "features/game/lib/constants";
 import Decimal from "decimal.js-light";
 import { DEFAULT_HONEY_PRODUCTION_TIME } from "features/game/lib/updateBeehives";
 
@@ -236,7 +240,7 @@ describe("harvestBeehive", () => {
     expect(state.crops?.["987"].crop?.amount).toEqual(1.2);
   });
 
-  it("[BEE SWARM] Does not affect crop plots that are not planted", () => {
+  it("Adds to the swarm counter when there is no crop planted", () => {
     const crops: Record<string, CropPlot> = {
       "1": {
         x: 0,
@@ -249,10 +253,9 @@ describe("harvestBeehive", () => {
         createdAt: 0,
       },
     };
-
     const state = harvestBeehive({
       state: {
-        ...TEST_FARM,
+        ...INITIAL_FARM,
         beehives: {
           "1234": {
             ...DEFAULT_BEEHIVE,
@@ -269,9 +272,94 @@ describe("harvestBeehive", () => {
         type: "beehive.harvested",
         id: "1234",
       },
+      createdAt: now,
     });
 
-    expect(state.crops).toEqual(crops);
+    expect(state.crops).toEqual({
+      "1": {
+        x: 0,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 1,
+          swarmActivatedAt: now,
+        },
+      },
+      "2": {
+        x: 1,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 1,
+          swarmActivatedAt: now,
+        },
+      },
+    });
+  });
+
+  it("Stacks the swarm counter when there is no crop planted", () => {
+    const crops: Record<string, CropPlot> = {
+      "1": {
+        x: 0,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 1,
+          swarmActivatedAt: now,
+        },
+      },
+      "2": {
+        x: 1,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 1,
+          swarmActivatedAt: now,
+        },
+      },
+    };
+    const state = harvestBeehive({
+      state: {
+        ...INITIAL_FARM,
+        beehives: {
+          "1234": {
+            ...DEFAULT_BEEHIVE,
+            swarm: true,
+            honey: {
+              updatedAt: 0,
+              produced: DEFAULT_HONEY_PRODUCTION_TIME,
+            },
+          },
+        },
+        crops,
+      },
+      action: {
+        type: "beehive.harvested",
+        id: "1234",
+      },
+      createdAt: now,
+    });
+
+    expect(state.crops).toEqual({
+      "1": {
+        x: 0,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 2,
+          swarmActivatedAt: now,
+        },
+      },
+      "2": {
+        x: 1,
+        y: -2,
+        createdAt: 0,
+        beeSwarm: {
+          noOfSwarms: 2,
+          swarmActivatedAt: now,
+        },
+      },
+    });
   });
 
   it("sets the swarm to false after activating the swarm", () => {

--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -60,10 +60,7 @@ const applySwarmBoostToCrops = (
         swarmActivatedAt: createdAt,
       };
 
-      return {
-        ...acc,
-        [cropId]: updatedPlot,
-      };
+      return { ...acc, [cropId]: updatedPlot };
     },
     {} as GameState["crops"],
   );

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -3894,6 +3894,72 @@ describe("getCropYield", () => {
       expect(state.crops[index].crop?.amount).toEqual(1.25);
     });
   });
+  it("gives a +0.2 boost if the plot has a beeswarm attached to it", () => {
+    const now = Date.now();
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Sunflower Seed": new Decimal(1),
+        },
+        crops: {
+          "1": {
+            createdAt: now,
+            beeSwarm: {
+              noOfSwarms: 1,
+              swarmActivatedAt: now,
+            },
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "1",
+        item: "Sunflower Seed",
+      },
+      createdAt: now,
+    });
+
+    expect(state.crops["1"].crop?.amount).toEqual(1.2);
+  });
+  it("gives a +0.3 boost if the plot has a beeswarm attached to it with Pollen Power Up skill", () => {
+    const now = Date.now();
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...GAME_STATE.bumpkin,
+          skills: { "Pollen Power Up": 1 },
+        },
+        inventory: {
+          "Sunflower Seed": new Decimal(1),
+        },
+        crops: {
+          "1": {
+            createdAt: now,
+            beeSwarm: {
+              noOfSwarms: 1,
+              swarmActivatedAt: now,
+            },
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "1",
+        item: "Sunflower Seed",
+      },
+      createdAt: now,
+    });
+
+    expect(state.crops["1"].crop?.amount).toEqual(1.3);
+  });
 
   describe("getPlantedAt", () => {
     it("returns normal planted at if time wrap is expired", () => {

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -3925,6 +3925,39 @@ describe("getCropYield", () => {
 
     expect(state.crops["1"].crop?.amount).toEqual(1.2);
   });
+
+  it("gives a +0.4 boost if the plot has 2 beeswarms attached to it", () => {
+    const now = Date.now();
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Sunflower Seed": new Decimal(1),
+        },
+        crops: {
+          "1": {
+            createdAt: now,
+            beeSwarm: {
+              noOfSwarms: 2,
+              swarmActivatedAt: now,
+            },
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+      action: {
+        type: "seed.planted",
+        cropId: "1",
+        index: "1",
+        item: "Sunflower Seed",
+      },
+      createdAt: now,
+    });
+
+    expect(state.crops["1"].crop?.amount).toEqual(1.4);
+  });
+
   it("gives a +0.3 boost if the plot has a beeswarm attached to it with Pollen Power Up skill", () => {
     const now = Date.now();
     const state = plant({

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -790,6 +790,14 @@ export function getCropYieldAmount({
     amount += 0.2;
   }
 
+  if (plot?.beeSwarm) {
+    let beeSwarmBonus = 0.2;
+    if (skills["Pollen Power Up"]) {
+      beeSwarmBonus += 0.1;
+    }
+    amount += beeSwarmBonus * plot.beeSwarm.noOfSwarms;
+  }
+
   // Greenhouse Crops
   // Rice
   if (crop === "Rice" && isWearableActive({ name: "Non La Hat", game })) {

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -795,7 +795,9 @@ export function getCropYieldAmount({
     if (skills["Pollen Power Up"]) {
       beeSwarmBonus += 0.1;
     }
-    amount += beeSwarmBonus * plot.beeSwarm.noOfSwarms;
+    // Multiply by the amount of stacked beeswarms
+    beeSwarmBonus *= plot.beeSwarm.noOfSwarms;
+    amount += beeSwarmBonus;
   }
 
   // Greenhouse Crops

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -11,6 +11,7 @@ import {
 import { Equipped } from "../types/bumpkin";
 import { tokenUriBuilder } from "lib/utils/tokenUriBuilder";
 import { EXPIRY_COOLDOWNS } from "./collectibleBuilt";
+import { DEFAULT_HONEY_PRODUCTION_TIME } from "./updateBeehives";
 
 export const STATIC_OFFLINE_FARM: GameState = {
   settings: {},
@@ -119,7 +120,15 @@ export const STATIC_OFFLINE_FARM: GameState = {
   wardrobe: {},
   previousWardrobe: {},
   bank: { taxFreeSFL: 0, withdrawnAmount: 0 },
-  beehives: {},
+  beehives: {
+    "123": {
+      swarm: true,
+      honey: { updatedAt: 0, produced: DEFAULT_HONEY_PRODUCTION_TIME },
+      flowers: [],
+      x: 0,
+      y: 0,
+    },
+  },
   crimstones: {},
   flowers: {
     discovered: {

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -27,6 +27,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Town Center": new Decimal(1),
     House: new Decimal(1),
     Mansion: new Decimal(1),
+    "Crop Plot": new Decimal(66),
     "Love Charm": new Decimal(1000),
     "Great Bloom Banner": new Decimal(1),
     "Winds of Change Banner": new Decimal(1),

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -622,6 +622,10 @@ export type CropPlot = {
   crop?: PlantedCrop;
   fertiliser?: CropFertiliser;
   createdAt: number;
+  beeSwarm?: {
+    noOfSwarms: number;
+    swarmActivatedAt: number;
+  };
 } & Coordinates;
 
 export type GreenhousePlant = {

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -9,6 +9,7 @@ import { Bar, LiveProgressBar } from "components/ui/ProgressBar";
 import powerup from "assets/icons/level_up.png";
 import locust from "assets/icons/locust.webp";
 import sunshower from "assets/icons/sunshower.webp";
+import bee from "assets/icons/bee.webp";
 
 import { TimerPopover } from "../../common/TimerPopover";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
@@ -166,6 +167,19 @@ const FertilePlotComponent: React.FC<Props> = ({
             width: `${PIXEL_SCALE * 6}px`,
             bottom: `${PIXEL_SCALE * 9}px`,
             right: `${PIXEL_SCALE * 0}px`,
+          }}
+        />
+      )}
+
+      {/* Bee Swarm */}
+      {plot.beeSwarm && (
+        <img
+          className="absolute z-10 pointer-events-none"
+          src={bee}
+          style={{
+            width: `${PIXEL_SCALE * 10}px`,
+            top: `${PIXEL_SCALE * -4}px`,
+            left: `${PIXEL_SCALE * -3}px`,
           }}
         />
       )}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -177,9 +177,9 @@ const FertilePlotComponent: React.FC<Props> = ({
           className="absolute z-10 pointer-events-none"
           src={bee}
           style={{
-            width: `${PIXEL_SCALE * 10}px`,
-            top: `${PIXEL_SCALE * -4}px`,
-            left: `${PIXEL_SCALE * -3}px`,
+            width: `${PIXEL_SCALE * 8}px`,
+            top: `${PIXEL_SCALE * -2}px`,
+            left: `${PIXEL_SCALE * 0}px`,
           }}
         />
       )}


### PR DESCRIPTION
# Description

The bee swarm popup can sometimes catch players off guard if they weren't expecting it, and if they didn't have anything planting they would lose their boost. This makes it confusing for players new to beehives to be confused between what's said on screen and what actually happened.

Allow Bee Swarm to apply to empty plots

Add Icon to plots when Bee Swarm activated
![image](https://github.com/user-attachments/assets/f8a48289-5730-4f78-80f4-acd68938a4a2)

Fixes #issue

# What needs to be tested by the reviewer?

Run FE + BE

1. Test to check if swarm would apply to empty crops
- Edit gameState.beehives and set the swarm to true and set the beehive.honey.produced to be of this value `86400000`
- In the game, ensure that the plots are empty and the beehives are full
- claim one beehive
- plant sunflowers
- sunflowers should yield the beeswarm boost

2. Test to check if swarm would stack
- Edit gameState.beehives and set the swarm to true for at least 2 beehives and set the beehive.honey.produced to be of this value `86400000`
- In the game, ensure that the plots are empty and the beehives are full
- claim 2 beehives
- plant sunflowers
- sunflowers should yield 2x beeswarm boost


# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
