### PR TITLE
[FEAT] Dynamic Megastore Chest Rewards

### DIFF
--- a/src/features/game/events/landExpansion/buySeasonalItem.ts
+++ b/src/features/game/events/landExpansion/buySeasonalItem.ts
@@ -10,6 +10,7 @@ import {
   SeasonalStoreCollectible,
   SeasonalStoreItem,
   SeasonalStoreTier,
+  SeasonalStoreWearable,
   SeasonalTierItemName,
 } from "features/game/types/megastore";
 import { SFLDiscount } from "features/game/lib/SFLDiscount";
@@ -19,6 +20,12 @@ export function isCollectible(
   item: SeasonalStoreItem,
 ): item is SeasonalStoreCollectible {
   return "collectible" in item;
+}
+
+export function isWearable(
+  item: SeasonalStoreItem,
+): item is SeasonalStoreWearable {
+  return "wearable" in item;
 }
 
 export type BuySeasonalItemAction = {
@@ -38,7 +45,7 @@ export type FlowerBox =
   | "Silver Flower Box"
   | "Gold Flower Box";
 
-export const FLOWER_BOXES: Record<string, true> = {
+export const FLOWER_BOXES: Record<FlowerBox, true> = {
   "Bronze Flower Box": true,
   "Silver Flower Box": true,
   "Gold Flower Box": true,

--- a/src/features/game/types/chests.test.ts
+++ b/src/features/game/types/chests.test.ts
@@ -1,44 +1,86 @@
-import { BASIC_REWARDS, LUXURY_REWARDS, RARE_REWARDS } from "./chests";
-import { SEASONS } from "./seasons";
+import {
+  isCollectible,
+  isWearable,
+} from "../events/landExpansion/buySeasonalItem";
+import {
+  ChestReward,
+  BASIC_REWARDS,
+  RARE_REWARDS,
+  LUXURY_REWARDS,
+  MEGASTORE_TIER_WEIGHTS,
+  MEGASTORE_RESTRICTED_ITEMS,
+  CHEST_MULTIPLIER,
+} from "./chests";
+import { MEGASTORE, SeasonalStore } from "./megastore";
+import { getCurrentSeason } from "./seasons";
 
 describe("SEASONAL_REWARDS", () => {
-  it("does not include Kite during Bull Run Chapter", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(SEASONS["Bull Run"].startDate);
+  it("includes seasonal megastore items in all reward types with correct tier-based weightings", () => {
+    const currentSeason = getCurrentSeason(new Date());
+    const store = MEGASTORE[currentSeason];
 
-    expect(BASIC_REWARDS()).not.toContainEqual({
-      items: { Kite: 1 },
-      weighting: 5,
-    });
-    expect(RARE_REWARDS()).not.toContainEqual({
-      items: { Kite: 1 },
-      weighting: 25,
-    });
-    expect(LUXURY_REWARDS()).not.toContainEqual({
-      items: { Kite: 1 },
-      weighting: 25,
-    });
+    // Test all reward types
+    const rewardTypes: {
+      rewards: ChestReward[];
+      weight: number;
+    }[] = [
+      { rewards: BASIC_REWARDS(), weight: 5 },
+      { rewards: RARE_REWARDS(), weight: 25 },
+      { rewards: LUXURY_REWARDS(), weight: 50 },
+    ];
 
-    jest.clearAllTimers();
-  });
+    rewardTypes.forEach(({ rewards, weight }) => {
+      // Test all tiers
+      Object.entries(MEGASTORE_TIER_WEIGHTS).forEach(([tier, tierWeight]) => {
+        const tierItems = store[tier as keyof SeasonalStore].items;
 
-  it("includes Kite during Winds of Change Chapter", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(SEASONS["Winds of Change"].startDate);
+        // For each item in the tier, verify it exists in rewards with correct weighting
+        tierItems.forEach((item) => {
+          if (
+            isCollectible(item) &&
+            !MEGASTORE_RESTRICTED_ITEMS.includes(item.collectible)
+          ) {
+            expect(rewards).toContainEqual({
+              items: { [item.collectible]: 1 },
+              weighting: weight * CHEST_MULTIPLIER * tierWeight,
+            });
+          }
+          if (
+            isWearable(item) &&
+            !MEGASTORE_RESTRICTED_ITEMS.includes(item.wearable)
+          ) {
+            expect(rewards).toContainEqual({
+              wearables: { [item.wearable]: 1 },
+              weighting: weight * CHEST_MULTIPLIER * tierWeight,
+            });
+          }
+        });
+      });
 
-    expect(BASIC_REWARDS()).toContainEqual({
-      items: { Kite: 1 },
-      weighting: 2250,
-    });
-    expect(RARE_REWARDS()).toContainEqual({
-      items: { Kite: 1 },
-      weighting: 11250,
-    });
-    expect(LUXURY_REWARDS()).toContainEqual({
-      items: { Kite: 1 },
-      weighting: 11250,
-    });
+      // Verify items from other seasons are not included
+      Object.entries(MEGASTORE).forEach(([season, seasonStore]) => {
+        if (season === currentSeason) return; // Skip current season
 
-    jest.clearAllTimers();
+        // Check all tiers in other seasons
+        Object.entries(MEGASTORE_TIER_WEIGHTS).forEach(([tier]) => {
+          const tierItems = seasonStore[tier as keyof SeasonalStore].items;
+
+          tierItems.forEach((item) => {
+            if (isCollectible(item)) {
+              expect(rewards).not.toContainEqual({
+                items: { [item.collectible]: 1 },
+                weighting: expect.any(Number),
+              });
+            }
+            if (isWearable(item)) {
+              expect(rewards).not.toContainEqual({
+                wearables: { [item.wearable]: 1 },
+                weighting: expect.any(Number),
+              });
+            }
+          });
+        });
+      });
+    });
   });
 });

--- a/src/features/game/types/chests.test.ts
+++ b/src/features/game/types/chests.test.ts
@@ -58,6 +58,17 @@ describe("SEASONAL_REWARDS", () => {
     });
   });
 
+  it("does not include restricted items", () => {
+    rewardTypes.forEach(({ rewards }) => {
+      MEGASTORE_RESTRICTED_ITEMS.forEach((item) => {
+        expect(rewards).not.toContainEqual({
+          items: { [item]: 1 },
+          weighting: expect.any(Number),
+        });
+      });
+    });
+  });
+
   it("does not include items from other seasons", () => {
     rewardTypes.forEach(({ rewards }) => {
       // Verify items from other seasons are not included

--- a/src/features/game/types/chests.test.ts
+++ b/src/features/game/types/chests.test.ts
@@ -15,19 +15,18 @@ import { MEGASTORE, SeasonalStore } from "./megastore";
 import { getCurrentSeason } from "./seasons";
 
 describe("SEASONAL_REWARDS", () => {
-  it("includes seasonal megastore items in all reward types with correct tier-based weightings", () => {
-    const currentSeason = getCurrentSeason(new Date());
-    const store = MEGASTORE[currentSeason];
+  const currentSeason = getCurrentSeason(new Date()); // Test all reward types
+  const rewardTypes: {
+    rewards: ChestReward[];
+    weight: number;
+  }[] = [
+    { rewards: BASIC_REWARDS(), weight: 5 },
+    { rewards: RARE_REWARDS(), weight: 25 },
+    { rewards: LUXURY_REWARDS(), weight: 50 },
+  ];
 
-    // Test all reward types
-    const rewardTypes: {
-      rewards: ChestReward[];
-      weight: number;
-    }[] = [
-      { rewards: BASIC_REWARDS(), weight: 5 },
-      { rewards: RARE_REWARDS(), weight: 25 },
-      { rewards: LUXURY_REWARDS(), weight: 50 },
-    ];
+  it("includes seasonal megastore items in all reward types with correct tier-based weightings", () => {
+    const store = MEGASTORE[currentSeason];
 
     rewardTypes.forEach(({ rewards, weight }) => {
       // Test all tiers
@@ -56,7 +55,11 @@ describe("SEASONAL_REWARDS", () => {
           }
         });
       });
+    });
+  });
 
+  it("does not include items from other seasons", () => {
+    rewardTypes.forEach(({ rewards }) => {
       // Verify items from other seasons are not included
       Object.entries(MEGASTORE).forEach(([season, seasonStore]) => {
         if (season === currentSeason) return; // Skip current season

--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -1,15 +1,20 @@
 import {
   FLOWER_BOXES,
+  FlowerBox,
   isCollectible,
   isWearable,
 } from "../events/landExpansion/buySeasonalItem";
 import { CHAPTER_TICKET_BOOST_ITEMS } from "../events/landExpansion/completeNPCChore";
 import { getObjectEntries } from "../expansion/lib/utils";
-import { BumpkinItem } from "./bumpkin";
 import { ARTEFACT_SHOP_KEYS } from "./collectibles";
 import { getKeys } from "./decorations";
-import { BB_TO_GEM_RATIO, InventoryItemName, Wardrobe } from "./game";
-import { MEGASTORE, SeasonalStore } from "./megastore";
+import { BB_TO_GEM_RATIO, InventoryItemName, Keys, Wardrobe } from "./game";
+import {
+  MEGASTORE,
+  SeasonalCollectibleName,
+  SeasonalStore,
+  SeasonalWearableName,
+} from "./megastore";
 import { getCurrentSeason } from "./seasons";
 
 export type ChestReward = {
@@ -30,7 +35,12 @@ export const MEGASTORE_TIER_WEIGHTS: Record<keyof SeasonalStore, number> = {
 };
 
 const currentSeason = getCurrentSeason(new Date());
-export const MEGASTORE_RESTRICTED_ITEMS: (InventoryItemName | BumpkinItem)[] = [
+export const MEGASTORE_RESTRICTED_ITEMS: (
+  | Keys
+  | SeasonalCollectibleName
+  | SeasonalWearableName
+  | FlowerBox
+)[] = [
   ...Object.values(CHAPTER_TICKET_BOOST_ITEMS[currentSeason]),
   ...getKeys(FLOWER_BOXES),
   ...getKeys(ARTEFACT_SHOP_KEYS),

--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -20,43 +20,43 @@ export type ChestReward = {
   weighting: number;
 };
 
-const multiplier = 900;
+export const CHEST_MULTIPLIER = 900;
+
+export const MEGASTORE_TIER_WEIGHTS: Record<keyof SeasonalStore, number> = {
+  basic: 0.5,
+  rare: 0.2,
+  epic: 0.1,
+  mega: 0.05,
+};
+
+const currentSeason = getCurrentSeason(new Date());
+export const MEGASTORE_RESTRICTED_ITEMS: (InventoryItemName | BumpkinItem)[] = [
+  ...Object.values(CHAPTER_TICKET_BOOST_ITEMS[currentSeason]),
+  ...getKeys(FLOWER_BOXES),
+  ...getKeys(ARTEFACT_SHOP_KEYS),
+];
 
 const SEASONAL_REWARDS: (weight: number) => ChestReward[] = (weight) => {
-  const currentSeason = getCurrentSeason(new Date());
-
-  /** Excludes:
-   * - Chapter Ticket Boost Items
-   * - Flower Boxes
-   * - Treasure Keys
-   */
-  const restrictedItems: (InventoryItemName | BumpkinItem)[] = [
-    ...Object.values(CHAPTER_TICKET_BOOST_ITEMS[currentSeason]),
-    ...getKeys(FLOWER_BOXES),
-    ...getKeys(ARTEFACT_SHOP_KEYS),
-  ];
-
   const store = MEGASTORE[currentSeason];
   const rewards: ChestReward[] = [];
 
-  const tierWeights: Record<keyof SeasonalStore, number> = {
-    basic: 0.5,
-    rare: 0.2,
-    epic: 0.1,
-    mega: 0.05,
-  };
-
-  getObjectEntries(tierWeights).forEach(([tier, tierWeight]) => {
+  getObjectEntries(MEGASTORE_TIER_WEIGHTS).forEach(([tier, tierWeight]) => {
     const items = store[tier].items;
 
     items.forEach((item) => {
-      if (isCollectible(item) && !restrictedItems.includes(item.collectible)) {
+      if (
+        isCollectible(item) &&
+        !MEGASTORE_RESTRICTED_ITEMS.includes(item.collectible)
+      ) {
         rewards.push({
           items: { [item.collectible]: 1 },
           weighting: weight * tierWeight,
         });
       }
-      if (isWearable(item) && !restrictedItems.includes(item.wearable)) {
+      if (
+        isWearable(item) &&
+        !MEGASTORE_RESTRICTED_ITEMS.includes(item.wearable)
+      ) {
         rewards.push({
           wearables: { [item.wearable]: 1 },
           weighting: weight * tierWeight,
@@ -69,82 +69,85 @@ const SEASONAL_REWARDS: (weight: number) => ChestReward[] = (weight) => {
 };
 
 export const BASIC_REWARDS: () => ChestReward[] = () => [
-  { coins: 1600, weighting: 100 * multiplier },
-  { coins: 3200, weighting: 50 * multiplier },
-  { coins: 8000, weighting: 20 * multiplier },
-  { items: { Gem: 1 * BB_TO_GEM_RATIO }, weighting: 100 * multiplier },
-  { items: { Gem: 2 * BB_TO_GEM_RATIO }, weighting: 50 * multiplier },
-  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 20 * multiplier },
-  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 5 * multiplier },
+  { coins: 1600, weighting: 100 * CHEST_MULTIPLIER },
+  { coins: 3200, weighting: 50 * CHEST_MULTIPLIER },
+  { coins: 8000, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { Gem: 1 * BB_TO_GEM_RATIO }, weighting: 100 * CHEST_MULTIPLIER },
+  { items: { Gem: 2 * BB_TO_GEM_RATIO }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 5 * CHEST_MULTIPLIER },
   {
     items: { Axe: 5, Pickaxe: 5, "Stone Pickaxe": 5 },
-    weighting: 100 * multiplier,
+    weighting: 100 * CHEST_MULTIPLIER,
   },
-  { items: { "Iron Pickaxe": 10 }, weighting: 10 * multiplier },
-  { items: { Rod: 10 }, weighting: 20 * multiplier },
-  { items: { "Rapid Root": 10, "Sprout Mix": 10 }, weighting: 50 * multiplier },
-  { items: { "Fishing Lure": 10 }, weighting: 10 * multiplier },
-  { items: { "Pirate Cake": 5 }, weighting: 5 * multiplier },
-  { items: { "Wheat Cake": 3 }, weighting: 20 * multiplier },
-  { items: { "Goblin Brunch": 3 }, weighting: 30 * multiplier },
-  { items: { "Bumpkin Roast": 3 }, weighting: 40 * multiplier },
-  { items: { "Fermented Carrots": 5 }, weighting: 50 * multiplier },
-  { items: { "Blueberry Jam": 3 }, weighting: 100 * multiplier },
-  { items: { Rug: 1 }, weighting: 25 * multiplier },
-  { items: { "Prize Ticket": 1 }, weighting: 5 * multiplier },
-  ...SEASONAL_REWARDS(5 * multiplier),
+  { items: { "Iron Pickaxe": 10 }, weighting: 10 * CHEST_MULTIPLIER },
+  { items: { Rod: 10 }, weighting: 20 * CHEST_MULTIPLIER },
+  {
+    items: { "Rapid Root": 10, "Sprout Mix": 10 },
+    weighting: 50 * CHEST_MULTIPLIER,
+  },
+  { items: { "Fishing Lure": 10 }, weighting: 10 * CHEST_MULTIPLIER },
+  { items: { "Pirate Cake": 5 }, weighting: 5 * CHEST_MULTIPLIER },
+  { items: { "Wheat Cake": 3 }, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { "Goblin Brunch": 3 }, weighting: 30 * CHEST_MULTIPLIER },
+  { items: { "Bumpkin Roast": 3 }, weighting: 40 * CHEST_MULTIPLIER },
+  { items: { "Fermented Carrots": 5 }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { "Blueberry Jam": 3 }, weighting: 100 * CHEST_MULTIPLIER },
+  { items: { Rug: 1 }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { "Prize Ticket": 1 }, weighting: 5 * CHEST_MULTIPLIER },
+  ...SEASONAL_REWARDS(5 * CHEST_MULTIPLIER),
 ];
 
 export const RARE_REWARDS: () => ChestReward[] = () => [
-  { coins: 1600, weighting: 50 * multiplier },
-  { coins: 3200, weighting: 100 * multiplier },
-  { coins: 8000, weighting: 50 * multiplier },
-  { coins: 16000, weighting: 20 * multiplier },
-  { items: { Gem: 1 * BB_TO_GEM_RATIO }, weighting: 50 * multiplier },
-  { items: { Gem: 2 * BB_TO_GEM_RATIO }, weighting: 100 * multiplier },
-  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 50 * multiplier },
-  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 20 * multiplier },
-  { items: { Gem: 25 * BB_TO_GEM_RATIO }, weighting: 10 * multiplier },
-  { items: { Gem: 50 * BB_TO_GEM_RATIO }, weighting: 5 * multiplier },
+  { coins: 1600, weighting: 50 * CHEST_MULTIPLIER },
+  { coins: 3200, weighting: 100 * CHEST_MULTIPLIER },
+  { coins: 8000, weighting: 50 * CHEST_MULTIPLIER },
+  { coins: 16000, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { Gem: 1 * BB_TO_GEM_RATIO }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { Gem: 2 * BB_TO_GEM_RATIO }, weighting: 100 * CHEST_MULTIPLIER },
+  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { Gem: 25 * BB_TO_GEM_RATIO }, weighting: 10 * CHEST_MULTIPLIER },
+  { items: { Gem: 50 * BB_TO_GEM_RATIO }, weighting: 5 * CHEST_MULTIPLIER },
   {
     items: { Axe: 15, Pickaxe: 15, "Stone Pickaxe": 15 },
-    weighting: 50 * multiplier,
+    weighting: 50 * CHEST_MULTIPLIER,
   },
-  { items: { "Gold Pickaxe": 3 }, weighting: 50 * multiplier },
-  { items: { "Oil Drill": 3 }, weighting: 25 * multiplier },
+  { items: { "Gold Pickaxe": 3 }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { "Oil Drill": 3 }, weighting: 25 * CHEST_MULTIPLIER },
   {
     items: { Rod: 5, Earthworm: 5, "Red Wiggler": 5, Grub: 5 },
-    weighting: 50 * multiplier,
+    weighting: 50 * CHEST_MULTIPLIER,
   },
-  { items: { "Fishing Lure": 25 }, weighting: 25 * multiplier },
-  { items: { "Pirate Cake": 5 }, weighting: 30 * multiplier },
-  { items: { "Wheat Cake": 3 }, weighting: 20 * multiplier },
-  { items: { "Goblin Brunch": 3 }, weighting: 50 * multiplier },
-  { items: { "Bumpkin Roast": 3 }, weighting: 40 * multiplier },
-  { items: { "Prize Ticket": 1 }, weighting: 20 * multiplier },
-  ...SEASONAL_REWARDS(25 * multiplier),
+  { items: { "Fishing Lure": 25 }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { "Pirate Cake": 5 }, weighting: 30 * CHEST_MULTIPLIER },
+  { items: { "Wheat Cake": 3 }, weighting: 20 * CHEST_MULTIPLIER },
+  { items: { "Goblin Brunch": 3 }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { "Bumpkin Roast": 3 }, weighting: 40 * CHEST_MULTIPLIER },
+  { items: { "Prize Ticket": 1 }, weighting: 20 * CHEST_MULTIPLIER },
+  ...SEASONAL_REWARDS(25 * CHEST_MULTIPLIER),
 ];
 
 export const LUXURY_REWARDS: () => ChestReward[] = () => [
-  { coins: 3200, weighting: 50 * multiplier },
-  { coins: 8000, weighting: 100 * multiplier },
-  { coins: 16000, weighting: 50 * multiplier },
-  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 50 * multiplier },
-  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 100 * multiplier },
-  { items: { Gem: 25 * BB_TO_GEM_RATIO }, weighting: 25 * multiplier },
-  { items: { Gem: 50 * BB_TO_GEM_RATIO }, weighting: 10 * multiplier },
-  { items: { "Gold Pickaxe": 10 }, weighting: 75 * multiplier },
-  { items: { "Oil Drill": 5 }, weighting: 50 * multiplier },
+  { coins: 3200, weighting: 50 * CHEST_MULTIPLIER },
+  { coins: 8000, weighting: 100 * CHEST_MULTIPLIER },
+  { coins: 16000, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { Gem: 5 * BB_TO_GEM_RATIO }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { Gem: 10 * BB_TO_GEM_RATIO }, weighting: 100 * CHEST_MULTIPLIER },
+  { items: { Gem: 25 * BB_TO_GEM_RATIO }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { Gem: 50 * BB_TO_GEM_RATIO }, weighting: 10 * CHEST_MULTIPLIER },
+  { items: { "Gold Pickaxe": 10 }, weighting: 75 * CHEST_MULTIPLIER },
+  { items: { "Oil Drill": 5 }, weighting: 50 * CHEST_MULTIPLIER },
   {
     items: { Rod: 10, Earthworm: 10, "Red Wiggler": 10, Grub: 10 },
-    weighting: 50 * multiplier,
+    weighting: 50 * CHEST_MULTIPLIER,
   },
-  { items: { "Fishing Lure": 25 }, weighting: 25 * multiplier },
-  { items: { "Pirate Cake": 10 }, weighting: 50 * multiplier },
-  { items: { "Goblin Brunch": 10 }, weighting: 25 * multiplier },
-  { items: { "Bumpkin Roast": 10 }, weighting: 25 * multiplier },
-  { items: { "Prize Ticket": 1 }, weighting: 50 * multiplier },
-  ...SEASONAL_REWARDS(25 * multiplier),
+  { items: { "Fishing Lure": 25 }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { "Pirate Cake": 10 }, weighting: 50 * CHEST_MULTIPLIER },
+  { items: { "Goblin Brunch": 10 }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { "Bumpkin Roast": 10 }, weighting: 25 * CHEST_MULTIPLIER },
+  { items: { "Prize Ticket": 1 }, weighting: 50 * CHEST_MULTIPLIER },
+  ...SEASONAL_REWARDS(50 * CHEST_MULTIPLIER),
 ];
 
 export const BUD_BOX_REWARDS: ChestReward[] = [

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -1,3 +1,4 @@
+import { FlowerBox } from "../events/landExpansion/buySeasonalItem";
 import { BumpkinItem } from "./bumpkin";
 import { InventoryItemName } from "./game";
 import { SeasonName } from "./seasons";
@@ -72,10 +73,10 @@ type SeasonalStoreBase = {
 };
 
 export type SeasonalStoreWearable = SeasonalStoreBase & {
-  wearable: BumpkinItem;
+  wearable: SeasonalWearableName;
 };
 export type SeasonalStoreCollectible = SeasonalStoreBase & {
-  collectible: InventoryItemName;
+  collectible: SeasonalCollectibleName | MegastoreKeys | FlowerBox;
 };
 
 export type SeasonalStoreItem =
@@ -123,14 +124,14 @@ const EMPTY_SEASONAL_STORE: SeasonalStore = {
 // Test only
 const PHARAOH_ITEMS: SeasonalStoreItem[] = [
   {
-    wearable: "Red Farmer Shirt",
+    wearable: "Red Farmer Shirt" as SeasonalWearableName,
     cost: {
       items: {},
       sfl: 5,
     },
   },
   {
-    collectible: "Basic Bear",
+    collectible: "Basic Bear" as SeasonalCollectibleName,
     cost: {
       items: {
         Wood: 1,
@@ -139,7 +140,7 @@ const PHARAOH_ITEMS: SeasonalStoreItem[] = [
     },
   },
   {
-    collectible: "Treasure Key",
+    collectible: "Treasure Key" as MegastoreKeys,
     cooldownMs: 24 * 60 * 60 * 1000,
     cost: {
       items: {
@@ -152,7 +153,7 @@ const PHARAOH_ITEMS: SeasonalStoreItem[] = [
 
 const RARE_PHARAOH_ITEMS: SeasonalStoreItem[] = [
   {
-    wearable: "Rancher Hair",
+    wearable: "Rancher Hair" as SeasonalWearableName,
     cost: {
       items: {
         Wood: 1,
@@ -162,7 +163,7 @@ const RARE_PHARAOH_ITEMS: SeasonalStoreItem[] = [
     },
   },
   {
-    wearable: "Axe",
+    wearable: "Axe" as SeasonalWearableName,
     cost: {
       items: {
         Wood: 1,
@@ -171,7 +172,7 @@ const RARE_PHARAOH_ITEMS: SeasonalStoreItem[] = [
     },
   },
   {
-    wearable: "Yellow Farmer Shirt",
+    wearable: "Yellow Farmer Shirt" as SeasonalWearableName,
     cost: {
       items: {
         Wood: 1,
@@ -192,7 +193,7 @@ const RARE_PHARAOH_ITEMS: SeasonalStoreItem[] = [
 ];
 const EPIC_PHARAOH_ITEMS: SeasonalStoreItem[] = [
   {
-    wearable: "Blue Farmer Shirt",
+    wearable: "Blue Farmer Shirt" as SeasonalWearableName,
     cost: {
       items: {
         Wood: 1,
@@ -201,7 +202,7 @@ const EPIC_PHARAOH_ITEMS: SeasonalStoreItem[] = [
     },
   },
   {
-    collectible: "Luxury Key",
+    collectible: "Luxury Key" as MegastoreKeys,
     cooldownMs: 24 * 60 * 60 * 1000,
     cost: {
       items: {


### PR DESCRIPTION
# Description

This PR adds Megastore items into chest rewards
Going forward, the Megastore Items will be automatically added to the chest as rewards and their weightage is determined based on their tier in the megastore:

- basic: 50%
- rare: 20%
- epic: 10%
- mega: 5%

Percentages are based on the **set weightage** that's set for each key so this will not be the actual chances of getting them

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
