### PR TITLE
[FIX] Stream Widget not showing when stream is currently live

### DIFF
--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -35,14 +35,16 @@ export const STREAMS_CONFIG = {
   } as StreamConfig,
   friday: {
     day: 5,
-    startHour: 11,
-    startMinute: 0,
+    startHour: 12,
+    startMinute: 30,
     durationMinutes: 60,
-    notifyMinutesBefore: 10,
+    notifyMinutesBefore: 15,
   } as StreamConfig,
 };
 
-export const getNextStreamTime = (schedule: StreamSchedule): number => {
+export const getNextStreamTime = (
+  schedule: StreamSchedule,
+): { startTime: number; isOngoing: boolean } => {
   // Create a date object in Sydney timezone
   const sydneyTime = new Date();
   const sydneyDate = new Date(
@@ -56,17 +58,28 @@ export const getNextStreamTime = (schedule: StreamSchedule): number => {
 
   // Calculate minutes until next stream
   let minutesUntilStream = 0;
+  let isOngoing = false;
 
-  // If we're past the stream time today, calculate for next week
+  // Check if we're in the middle of a stream
   if (
     currentDay === schedule.day &&
     (currentHour > schedule.hour ||
       (currentHour === schedule.hour && currentMinute >= schedule.minute))
   ) {
-    minutesUntilStream =
-      7 * 24 * 60 - // Full week in minutes
-      (currentHour * 60 + currentMinute) + // Minutes passed today
-      (schedule.hour * 60 + schedule.minute); // Stream time
+    // We're past the start time today, check if we're still within stream duration
+    const minutesSinceStart =
+      (currentHour - schedule.hour) * 60 + (currentMinute - schedule.minute);
+    if (minutesSinceStart < 60) {
+      // Assuming 60 minute stream duration
+      isOngoing = true;
+      minutesUntilStream = -minutesSinceStart;
+    } else {
+      // Stream has ended, calculate for next week
+      minutesUntilStream =
+        7 * 24 * 60 - // Full week in minutes
+        (currentHour * 60 + currentMinute) + // Minutes passed today
+        (schedule.hour * 60 + schedule.minute); // Stream time
+    }
   } else {
     // Calculate days until next stream
     const daysUntilStream = (schedule.day - currentDay + 7) % 7;
@@ -97,7 +110,10 @@ export const getNextStreamTime = (schedule: StreamSchedule): number => {
   nextStreamTime.setSeconds(0);
   nextStreamTime.setMilliseconds(0);
 
-  return nextStreamTime.getTime();
+  return {
+    startTime: nextStreamTime.getTime(),
+    isOngoing,
+  };
 };
 
 export type StreamNotification = {
@@ -109,16 +125,26 @@ export type StreamNotification = {
 export function getStream(): StreamNotification | null {
   let nextStream: StreamNotification | null = null;
   let nextStreamTime = Infinity;
+  let ongoingStream: StreamNotification | null = null;
 
   for (const stream of Object.values(STREAMS_CONFIG)) {
-    const streamStartTime = getNextStreamTime({
+    const { startTime, isOngoing } = getNextStreamTime({
       day: stream.day,
       hour: stream.startHour,
       minute: stream.startMinute,
     });
 
-    if (streamStartTime < nextStreamTime) {
-      nextStreamTime = streamStartTime;
+    if (isOngoing) {
+      ongoingStream = {
+        startAt: startTime,
+        endAt: startTime + stream.durationMinutes * 60 * 1000,
+        notifyAt: startTime - stream.notifyMinutesBefore * 60 * 1000,
+      };
+      return ongoingStream;
+    }
+
+    if (startTime < nextStreamTime) {
+      nextStreamTime = startTime;
       nextStream = {
         startAt: nextStreamTime,
         endAt: nextStreamTime + stream.durationMinutes * 60 * 1000,
@@ -136,12 +162,12 @@ export const Streams: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     day: STREAMS_CONFIG.tuesday.day,
     hour: STREAMS_CONFIG.tuesday.startHour,
     minute: STREAMS_CONFIG.tuesday.startMinute,
-  }); // Tuesday 3:30 PM
+  }).startTime; // Tuesday 3:30 PM
   const fridayStream = getNextStreamTime({
     day: STREAMS_CONFIG.friday.day,
     hour: STREAMS_CONFIG.friday.startHour,
     minute: STREAMS_CONFIG.friday.startMinute,
-  }); // Friday 11:00 AM
+  }).startTime; // Friday 11:00 AM
   const timeOptions: Intl.DateTimeFormatOptions = {
     year: "numeric",
     month: "long",

--- a/src/features/game/components/modal/components/Streams.tsx
+++ b/src/features/game/components/modal/components/Streams.tsx
@@ -35,8 +35,8 @@ export const STREAMS_CONFIG = {
   } as StreamConfig,
   friday: {
     day: 5,
-    startHour: 12,
-    startMinute: 30,
+    startHour: 11,
+    startMinute: 0,
     durationMinutes: 60,
     notifyMinutesBefore: 15,
   } as StreamConfig,
@@ -158,16 +158,18 @@ export function getStream(): StreamNotification | null {
 
 export const Streams: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { t } = useAppTranslation();
-  const tuesdayStream = getNextStreamTime({
-    day: STREAMS_CONFIG.tuesday.day,
-    hour: STREAMS_CONFIG.tuesday.startHour,
-    minute: STREAMS_CONFIG.tuesday.startMinute,
-  }).startTime; // Tuesday 3:30 PM
-  const fridayStream = getNextStreamTime({
-    day: STREAMS_CONFIG.friday.day,
-    hour: STREAMS_CONFIG.friday.startHour,
-    minute: STREAMS_CONFIG.friday.startMinute,
-  }).startTime; // Friday 11:00 AM
+  const { startTime: tuesdayStream, isOngoing: tuesdayOngoing } =
+    getNextStreamTime({
+      day: STREAMS_CONFIG.tuesday.day,
+      hour: STREAMS_CONFIG.tuesday.startHour,
+      minute: STREAMS_CONFIG.tuesday.startMinute,
+    }); // Tuesday 3:30 PM
+  const { startTime: fridayStream, isOngoing: fridayOngoing } =
+    getNextStreamTime({
+      day: STREAMS_CONFIG.friday.day,
+      hour: STREAMS_CONFIG.friday.startHour,
+      minute: STREAMS_CONFIG.friday.startMinute,
+    }); // Friday 11:00 AM
   const timeOptions: Intl.DateTimeFormatOptions = {
     year: "numeric",
     month: "long",
@@ -195,6 +197,15 @@ export const Streams: React.FC<{ onClose: () => void }> = ({ onClose }) => {
               timeZone,
             })}
           </Label>
+          {(tuesdayOngoing || fridayOngoing) && (
+            <Label
+              type="success"
+              icon={SUNNYSIDE.icons.stopwatch}
+              className="mb-1"
+            >
+              {t(`streams.${tuesdayOngoing ? "tuesday" : "friday"}.ongoing`)}
+            </Label>
+          )}
           <Label
             type="transparent"
             icon={SUNNYSIDE.icons.stopwatch}

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -25,6 +25,7 @@ import { MarketplaceButton } from "./components/MarketplaceButton";
 import { GameCalendar } from "features/game/expansion/components/temperateSeason/GameCalendar";
 import { LandscapeButton } from "./components/LandscapeButton";
 import { RewardsButton } from "./components/referral/RewardsButton";
+import { StreamCountdown } from "./components/StreamCountdown";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _linkedWallet = (state: MachineState) => state.context.linkedWallet;
@@ -120,6 +121,7 @@ const HudComponent: React.FC<{
           }}
         >
           <TransactionCountdown />
+          <StreamCountdown />
           <AuctionCountdown />
         </div>
         <div

--- a/src/features/island/hud/components/StreamCountdown.tsx
+++ b/src/features/island/hud/components/StreamCountdown.tsx
@@ -42,7 +42,7 @@ const Countdown: React.FC<{
   return (
     <div>
       <div className="flex">
-        <Label type="default" className="ml-1" icon={promoteIcon}>
+        <Label type="info" className="ml-1" icon={promoteIcon}>
           <div
             className="sm:max-w-[350px] max-w-[150px]"
             style={{

--- a/src/features/island/hud/components/StreamCountdown.tsx
+++ b/src/features/island/hud/components/StreamCountdown.tsx
@@ -42,7 +42,7 @@ const Countdown: React.FC<{
   return (
     <div>
       <div className="flex">
-        <Label type="info" className="ml-1" icon={promoteIcon}>
+        <Label type="success" className="ml-1" icon={promoteIcon}>
           <div
             className="sm:max-w-[350px] max-w-[150px]"
             style={{

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5956,7 +5956,7 @@
   "easter-eggstravaganza.portal.rewardMessage": "Congratulations, you completed the mission! Here is your reward.",
   "maxPerPerson": "Max per player: {{max}}",
   "stream.beginsSoon": "Town Hall Starts In",
-  "stream.isLive": "Town Hall",
+  "stream.isLive": "Town Hall is Live!",
   "description.bronzeLoveBox": "A bronze love box",
   "description.silverLoveBox": "A silver love box",
   "description.goldLoveBox": "A gold love box",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5901,6 +5901,8 @@
   "streams.description": "Watch & listen to our team streams for alpha, updates & giveaways!",
   "streams.discord": "Discord",
   "streams.twitch": "Twitch",
+  "streams.tuesday.ongoing": "Discord Stream Ongoing",
+  "streams.friday.ongoing": "Twitch Stream Ongoing",
   "loveRush.dateRange": "April 7th - May 4th",
   "loveRush.description": "During Love Rush, help the Bumpkin NPCs and earn Love Charms!",
   "loveRush.deliveries": "Perform Bumpkin deliveries for Love Charms",


### PR DESCRIPTION
# Description

This PR fixes an issue where the stream widget is not showing when the stream is currently live. That is because the code currently returns the next stream time the moment the stream startAt time passes, instead of waiting until the end time to return the next stream time


![image](https://github.com/user-attachments/assets/ff04287e-96dd-4501-ba70-f53a755775b4)

Add a label in the streams modal when the stream is live
![image](https://github.com/user-attachments/assets/eaa0fef8-95d9-4c66-b795-1412db75e865)

Fixes #issue

# What needs to be tested by the reviewer?

- Set the friday stream time to current time (in sydney timezone)
- check if the widget appears when the stream is live


# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
