### PR TITLE
[FEAT] Move Mod Button above marketplace button

### DIFF
--- a/src/features/world/ui/moderationTools/ModerationTools.tsx
+++ b/src/features/world/ui/moderationTools/ModerationTools.tsx
@@ -63,7 +63,14 @@ export const ModerationTools: React.FC<Props> = ({
 
   return (
     <>
-      <div className="fixed bottom-2 left-20">
+      <div
+        className="fixed"
+        style={{
+          left: `${PIXEL_SCALE * 3}px`,
+          bottom: `${PIXEL_SCALE * 55}px`,
+          width: `${PIXEL_SCALE * 22}px`,
+        }}
+      >
         <RoundButton onClick={toggleModerationTool}>
           <img
             src={SUNNYSIDE.badges.discord}


### PR DESCRIPTION
# Description

Mod Button tends to block all the widgets in the plaza, moving it above the marketplace button makes it cleaner and less obstructive
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/238c0230-2179-4d05-b4bd-178d27d27044)|![image](https://github.com/user-attachments/assets/0951bea2-7d5a-48c9-8f70-9a08872c396d)|

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
