### PR TITLE
[FEAT] Bring Back Daily Chest

### DIFF
--- a/src/features/game/components/modal/ModalProvider.tsx
+++ b/src/features/game/components/modal/ModalProvider.tsx
@@ -17,6 +17,7 @@ import { CloseButtonPanel } from "../CloseablePanel";
 import { DiscordBonus } from "features/game/expansion/components/DiscordBoat";
 import { Streams } from "./components/Streams";
 import { Merkl } from "./components/Merkl";
+import { Rewards } from "features/island/hud/components/referral/Rewards";
 type GlobalModal =
   | "BUY_GEMS"
   | "DISCORD"
@@ -35,7 +36,9 @@ type GlobalModal =
   | "REFERRAL"
   | "STREAMS"
   | "MERKL"
-  | "DEPOSIT";
+  | "DEPOSIT"
+  | "DAILY_REWARD"
+  | "EARN";
 
 export const ModalContext = createContext<{
   openModal: (type: GlobalModal) => void;
@@ -214,6 +217,12 @@ export const ModalProvider: FC = ({ children }) => {
           bumpkinParts={NPC_WEARABLES["pumpkin' pete"]}
         />
       </Modal>
+
+      <Rewards
+        show={opened === "DAILY_REWARD" || opened === "EARN"}
+        onHide={handleClose}
+        tab={opened === "DAILY_REWARD" ? "Rewards" : "Earn"}
+      />
     </ModalContext.Provider>
   );
 };

--- a/src/features/game/expansion/components/dailyReward/DailyReward.tsx
+++ b/src/features/game/expansion/components/dailyReward/DailyReward.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/ui/Button";
-import { PIXEL_SCALE } from "features/game/lib/constants";
-import React, { useEffect } from "react";
+import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
+import React, { useContext, useEffect } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { GameWallet } from "features/wallet/Wallet";
 import { useSelector } from "@xstate/react";
@@ -33,6 +33,9 @@ import { NetworkOption } from "features/island/hud/components/DepositFlower";
 import baseIcon from "assets/icons/chains/base.png";
 import { CONFIG } from "lib/config";
 import { NetworkName } from "features/game/events/landExpansion/updateNetwork";
+import { Context } from "features/game/GameProvider";
+import { getBumpkinLevel } from "features/game/lib/level";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
 
 const _network = (state: MachineState) => state.context.state.settings.network;
 
@@ -131,12 +134,15 @@ export const DailyRewardContent: React.FC<{
     }
 
     gameService.send("network.updated", { network: networkName });
-    chestService.send("UPDATE_NETWORK", { network: networkName });
   };
 
   useEffect(() => {
     chestService.send("UPDATE_BUMPKIN_LEVEL", { bumpkinLevel });
   }, [bumpkinLevel]);
+
+  useEffect(() => {
+    chestService.send("UPDATE_NETWORK", { network });
+  }, [network]);
 
   if (bumpkinLevel <= 5) {
     return null;
@@ -318,5 +324,71 @@ export const DailyRewardContent: React.FC<{
     >
       <Content />
     </GameWallet>
+  );
+};
+
+const _bumpkinLevel = (state: MachineState) =>
+  getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0);
+
+const _chestCollectedAt = (state: MachineState) =>
+  state.context.state.dailyRewards?.chest?.collectedAt ?? 0;
+
+export const DailyReward: React.FC = () => {
+  const { gameService, showAnimations } = useContext(Context);
+
+  const bumpkinLevel = useSelector(gameService, _bumpkinLevel);
+  const chestCollectedAt = useSelector(gameService, _chestCollectedAt);
+
+  const { openModal } = useContext(ModalContext);
+
+  if (bumpkinLevel <= 5) {
+    return <></>;
+  }
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  const isChestCollected = chestCollectedAt > today.getTime();
+
+  return (
+    <>
+      <div
+        className="absolute z-20"
+        style={{
+          width: `${PIXEL_SCALE * 16}px`,
+
+          height: `${PIXEL_SCALE * 16}px`,
+
+          left: `${GRID_WIDTH_PX * 1.5}px`,
+
+          top: `${GRID_WIDTH_PX * 1}px`,
+        }}
+      >
+        <img
+          id="daily-reward"
+          src={
+            isChestCollected
+              ? SUNNYSIDE.decorations.treasure_chest_opened
+              : SUNNYSIDE.decorations.treasure_chest
+          }
+          className="cursor-pointer hover:img-highlight w-full absolute bottom-0"
+          onClick={() => openModal("DAILY_REWARD")}
+        />
+
+        {!isChestCollected && (
+          <img
+            src={SUNNYSIDE.icons.expression_alerted}
+            className={"absolute" + (showAnimations ? " animate-float" : "")}
+            style={{
+              width: `${PIXEL_SCALE * 4}px`,
+
+              top: `${PIXEL_SCALE * -14}px`,
+
+              left: `${PIXEL_SCALE * 6}px`,
+            }}
+          />
+        )}
+      </div>
+    </>
   );
 };

--- a/src/features/island/buildings/components/building/house/House.tsx
+++ b/src/features/island/buildings/components/building/house/House.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router";
 import { Section } from "lib/utils/hooks/useScrollIntoView";
 import { HomeBumpkins } from "./HomeBumpkins";
 import { MANOR_VARIANTS } from "features/island/lib/alternateArt";
+import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 
 export const House: React.FC<BuildingProps> = ({ isBuilt, island, season }) => {
   const { gameService, showAnimations } = useContext(Context);
@@ -63,6 +64,13 @@ export const House: React.FC<BuildingProps> = ({ isBuilt, island, season }) => {
           }}
         />
       </BuildingImageWrapper>
+
+      <div
+        className="absolute"
+        style={{ left: `${PIXEL_SCALE * 7}px`, top: `${PIXEL_SCALE * -16}px` }}
+      >
+        <DailyReward />
+      </div>
 
       <div
         className="absolute w-full"

--- a/src/features/island/buildings/components/building/manor/Manor.tsx
+++ b/src/features/island/buildings/components/building/manor/Manor.tsx
@@ -13,6 +13,7 @@ import { Section } from "lib/utils/hooks/useScrollIntoView";
 import { HomeBumpkins } from "../house/HomeBumpkins";
 import { MANOR_VARIANTS } from "features/island/lib/alternateArt";
 import { MachineState } from "features/game/lib/gameMachine";
+import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 const _season = (state: MachineState) => state.context.state.season.season;
 
 export const Manor: React.FC<BuildingProps> = ({ isBuilt, island }) => {
@@ -67,6 +68,16 @@ export const Manor: React.FC<BuildingProps> = ({ isBuilt, island }) => {
           }}
         />
       </BuildingImageWrapper>
+      <div
+        className="absolute"
+        style={{
+          left: `${PIXEL_SCALE * -12}px`,
+
+          top: `${PIXEL_SCALE * -16}px`,
+        }}
+      >
+        <DailyReward />
+      </div>
 
       <div
         className="absolute w-full"

--- a/src/features/island/buildings/components/building/mansion/Mansion.tsx
+++ b/src/features/island/buildings/components/building/mansion/Mansion.tsx
@@ -13,6 +13,7 @@ import { Section } from "lib/utils/hooks/useScrollIntoView";
 import { HomeBumpkins } from "../house/HomeBumpkins";
 import { MANOR_VARIANTS } from "features/island/lib/alternateArt";
 import { MachineState } from "features/game/lib/gameMachine";
+import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 const _season = (state: MachineState) => state.context.state.season.season;
 
 const _state = (state: MachineState) => {
@@ -71,6 +72,16 @@ export const Mansion: React.FC<BuildingProps> = ({ isBuilt, island }) => {
           }}
         />
       </BuildingImageWrapper>
+      <div
+        className="absolute"
+        style={{
+          left: `${PIXEL_SCALE * -4.3}px`,
+
+          top: `${PIXEL_SCALE}px`,
+        }}
+      >
+        <DailyReward />
+      </div>
 
       <div
         className="absolute w-fit"

--- a/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
+++ b/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
@@ -10,6 +10,7 @@ import { Bumpkin } from "features/game/types/game";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { useNavigate } from "react-router";
 import { HomeBumpkins } from "../house/HomeBumpkins";
+import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 
 export const TownCenter: React.FC<BuildingProps> = ({ isBuilt }) => {
   const { gameService, showAnimations } = useContext(Context);
@@ -59,6 +60,12 @@ export const TownCenter: React.FC<BuildingProps> = ({ isBuilt }) => {
           }}
         />
       </BuildingImageWrapper>
+      <div
+        className="absolute"
+        style={{ left: `${PIXEL_SCALE * 16}px`, top: `${PIXEL_SCALE * 14}px` }}
+      >
+        <DailyReward />
+      </div>
 
       <div
         className="absolute w-full"

--- a/src/features/island/hud/components/referral/RewardsButton.tsx
+++ b/src/features/island/hud/components/referral/RewardsButton.tsx
@@ -1,58 +1,26 @@
 import { RoundButton } from "components/ui/RoundButton";
 import { PIXEL_SCALE } from "features/game/lib/constants";
-import React, { useCallback, useContext, useState, useEffect } from "react";
-import { Rewards } from "./Rewards";
+import React, { useCallback, useContext } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { Context } from "features/game/GameProvider";
-import { useSelector } from "@xstate/react";
+import { useGame } from "features/game/GameProvider";
 import {
   InGameTaskName,
   IN_GAME_TASKS,
 } from "features/game/events/landExpansion/completeSocialTask";
-import { rewardChestMachine } from "features/game/expansion/components/dailyReward/rewardChestMachine";
-import { useInterpret, useActor } from "@xstate/react";
-import Decimal from "decimal.js-light";
-import { getBumpkinLevel } from "features/game/lib/level";
 import { getKeys } from "features/game/types/decorations";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
 
 export const RewardsButton: React.FC = () => {
-  const [showRewardsModal, setShowRewardsModal] = useState(false);
-  const { gameService } = useContext(Context);
-  const state = useSelector(gameService, (state) => state.context.state);
-
-  // Get daily rewards data for chest state
-  const dailyRewards = useSelector(
-    gameService,
-    (state) => state.context.state.dailyRewards,
-  );
-  const bumpkinLevel = useSelector(gameService, (state) =>
-    getBumpkinLevel(state.context.state.bumpkin?.experience ?? 0),
-  );
-  const isRevealed = useSelector(gameService, (state) =>
-    state.matches("revealed"),
-  );
-
-  // Initialize chest service to check if chest is locked
-  const chestService = useInterpret(rewardChestMachine, {
-    context: {
-      lastUsedCode: dailyRewards?.chest?.code ?? 0,
-      openedAt: dailyRewards?.chest?.collectedAt ?? 0,
-      bumpkinLevel,
-      network: state.settings.network,
-    },
-  });
-  const [chestState] = useActor(chestService);
-
-  // Load the chest state when component mounts
-  useEffect(() => {
-    chestService.send("LOAD");
-  }, [chestService]);
+  const { gameState } = useGame();
+  const { openModal } = useContext(ModalContext);
 
   const isTaskCompleted = useCallback(
-    (task: InGameTaskName) => IN_GAME_TASKS[task].requirement(state),
-    [state],
+    (task: InGameTaskName) =>
+      IN_GAME_TASKS[task].requirement(gameState.context.state),
+    [gameState.context.state],
   );
+
   const isAnyTaskCompleted = getKeys(IN_GAME_TASKS)
     .filter(
       (task) =>
@@ -63,18 +31,22 @@ export const RewardsButton: React.FC = () => {
     .some(
       (task) =>
         isTaskCompleted(task) &&
-        !state.socialTasks?.completed[task]?.completedAt,
+        !gameState.context.state.socialTasks?.completed[task]?.completedAt,
     );
 
-  // Check if chest is locked or can be unlocked
-  const isChestLocked = !chestState.matches("opened");
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  const isChestLocked =
+    (gameState.context.state.dailyRewards?.chest?.collectedAt ?? 0) >
+    today.getTime();
 
   return (
     <div
       className="absolute"
       style={{ top: `${PIXEL_SCALE * 5}px`, left: `${PIXEL_SCALE * 32}px` }}
     >
-      <RoundButton buttonSize={18} onClick={() => setShowRewardsModal(true)}>
+      <RoundButton buttonSize={18} onClick={() => openModal("EARN")}>
         <img
           src={ITEM_DETAILS["Love Charm"].image}
           className="absolute group-active:translate-y-[2px]"
@@ -95,20 +67,6 @@ export const RewardsButton: React.FC = () => {
           />
         )}
       </RoundButton>
-      <Rewards
-        show={showRewardsModal}
-        onHide={() => setShowRewardsModal(false)}
-        gameService={gameService}
-        state={state}
-        isRevealed={isRevealed}
-        bumpkinLevel={bumpkinLevel}
-        chestService={chestService}
-        chestState={chestState}
-        loveCharmCount={state.inventory["Love Charm"] ?? new Decimal(0)}
-        socialTasks={state.socialTasks}
-        isChestLocked={isChestLocked}
-        isAnyTaskCompleted={isAnyTaskCompleted}
-      />
     </div>
   );
 };


### PR DESCRIPTION
# Description

Brings back the daily chest. It now opens the same page as the `RewardsButton`.

![chest](https://github.com/user-attachments/assets/c3cbf000-79b9-43f6-b794-04218cc0f2ac)

# What needs to be tested by the reviewer?

Claim Daily Chest

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes