### PR TITLE
[FEAT] Marketplace Updates

### DIFF
--- a/src/features/game/events/claimPurchase.ts
+++ b/src/features/game/events/claimPurchase.ts
@@ -52,7 +52,8 @@ export function claimPurchase({
       const amount = listing?.items[item] ?? 0;
 
       let sfl = new Decimal(listing?.sfl ?? 0);
-      sfl = sfl.mul(1 - MARKETPLACE_TAX);
+      const tax = listing?.tax ?? sfl.mul(MARKETPLACE_TAX);
+      sfl = sfl.minus(tax);
 
       game.balance = game.balance.plus(sfl);
 

--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -70,7 +70,9 @@ export const MarketplaceSalesPopup: React.FC = () => {
             state: state.context.state,
           });
           const amount = listing.items[itemName as InventoryItemName];
-          const sfl = new Decimal(listing.sfl).mul(1 - MARKETPLACE_TAX);
+
+          const tax = listing.tax ?? listing.sfl * MARKETPLACE_TAX;
+          const sfl = new Decimal(listing.sfl).mul(1 - tax);
           const estTradePoints = calculateTradePoints({
             sfl: listing.sfl,
             points: !listing.signature ? 1 : 3,

--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -72,7 +72,7 @@ export const MarketplaceSalesPopup: React.FC = () => {
           const amount = listing.items[itemName as InventoryItemName];
 
           const tax = listing.tax ?? listing.sfl * MARKETPLACE_TAX;
-          const sfl = new Decimal(listing.sfl).mul(1 - tax);
+          const sfl = new Decimal(listing.sfl).sub(tax);
           const estTradePoints = calculateTradePoints({
             sfl: listing.sfl,
             points: !listing.signature ? 1 : 3,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -251,7 +251,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
   },
 
   island: {
-    type: "desert",
+    type: "spring",
   },
 
   home: {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1089,6 +1089,7 @@ export type Minigame = {
 export type TradeListing = {
   items: Partial<Record<MarketplaceTradeableName, number>>;
   sfl: number;
+  tax?: number; // Defaults to 10% of the sfl
   createdAt: number;
   collection: CollectionName;
   boughtAt?: number;
@@ -1103,6 +1104,7 @@ export type TradeListing = {
 export type TradeOffer = {
   items: Partial<Record<MarketplaceTradeableName, number>>;
   sfl: number;
+  tax?: number; // Defaults to 10% of the sfl
   collection: CollectionName;
   createdAt: number;
   fulfilledAt?: number;

--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -1,7 +1,8 @@
 import { BumpkinItem } from "./bumpkin";
-import { GameState, InventoryItemName } from "./game";
+import { GameState, InventoryItemName, IslandType } from "./game";
 import { KNOWN_ITEMS } from ".";
 import { TRADE_LIMITS } from "../actions/tradeLimits";
+import { hasVipAccess } from "../lib/vipAccess";
 
 // 10% tax on sales
 export const MARKETPLACE_TAX = 0.1;
@@ -285,4 +286,21 @@ export function getMarketPrice({
   }
 
   return price;
+}
+
+const ISLAND_RESOURCE_TAXES: Record<IslandType, number> = {
+  basic: 1,
+  spring: 0.5,
+  desert: 0.2,
+  volcano: 0.75,
+};
+
+export function getResourceTax({ game }: { game: GameState }): number {
+  let tax = ISLAND_RESOURCE_TAXES[game.island.type];
+
+  if (hasVipAccess({ game })) {
+    tax = tax * 0.5;
+  }
+
+  return tax;
 }

--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -23,6 +23,7 @@ export type Tradeable = {
   supply: number;
   collection: CollectionName;
   isActive: boolean;
+  isVip: boolean;
   expiresAt?: number;
 };
 

--- a/src/features/marketplace/actions/loadTradeable.ts
+++ b/src/features/marketplace/actions/loadTradeable.ts
@@ -23,6 +23,7 @@ export async function loadTradeable({
       supply: 0,
       collection: type,
       isActive: false,
+      isVip: false,
       lastSalePrice: 0,
       offers: [],
       listings: [],

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -2,7 +2,11 @@ import React, { useContext } from "react";
 
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
-import { Offer } from "features/game/types/marketplace";
+import {
+  getResourceTax,
+  MARKETPLACE_TAX,
+  Offer,
+} from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import { useSelector } from "@xstate/react";
@@ -129,6 +133,11 @@ const AcceptOfferContent: React.FC<{
     );
   }
 
+  let tax = offer.sfl * MARKETPLACE_TAX;
+  if (display.type === "resources") {
+    tax = offer.sfl * getResourceTax({ game: state });
+  }
+
   return (
     <>
       <div className="p-2">
@@ -143,6 +152,7 @@ const AcceptOfferContent: React.FC<{
         <TradeableSummary
           display={display}
           sfl={offer.sfl}
+          tax={tax}
           quantity={offer.quantity}
           estTradePoints={estTradePoints}
         />

--- a/src/features/marketplace/components/AcceptOffer.tsx
+++ b/src/features/marketplace/components/AcceptOffer.tsx
@@ -134,7 +134,10 @@ const AcceptOfferContent: React.FC<{
   }
 
   let tax = offer.sfl * MARKETPLACE_TAX;
-  if (display.type === "resources") {
+  if (
+    display.type === "collectibles" &&
+    isTradeResource(display.name as InventoryItemName)
+  ) {
     tax = offer.sfl * getResourceTax({ game: state });
   }
 

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -9,6 +9,7 @@ import tradeIcon from "assets/icons/trade.png";
 import trade_point from "src/assets/icons/trade_points_coupon.webp";
 import flowerIcon from "assets/icons/flower_token.webp";
 import crownIcon from "assets/icons/vip.webp";
+import lockIcon from "assets/icons/lock.png";
 
 import {
   Route,
@@ -44,6 +45,8 @@ import {
   hasReputation,
   Reputation,
 } from "features/game/lib/reputation";
+import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+import { pixelGreenBorderStyle } from "features/game/lib/style";
 
 const _hasTradeReputation = (state: MachineState) =>
   hasReputation({

--- a/src/features/marketplace/components/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/MarketplaceHome.tsx
@@ -9,7 +9,6 @@ import tradeIcon from "assets/icons/trade.png";
 import trade_point from "src/assets/icons/trade_points_coupon.webp";
 import flowerIcon from "assets/icons/flower_token.webp";
 import crownIcon from "assets/icons/vip.webp";
-import lockIcon from "assets/icons/lock.png";
 
 import {
   Route,
@@ -45,8 +44,6 @@ import {
   hasReputation,
   Reputation,
 } from "features/game/lib/reputation";
-import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
-import { pixelGreenBorderStyle } from "features/game/lib/style";
 
 const _hasTradeReputation = (state: MachineState) =>
   hasReputation({

--- a/src/features/marketplace/components/ResourceList.tsx
+++ b/src/features/marketplace/components/ResourceList.tsx
@@ -18,6 +18,8 @@ import { formatNumber, setPrecision } from "lib/utils/formatNumber";
 import lockIcon from "assets/icons/lock.png";
 import sflIcon from "assets/icons/flower_token.webp";
 import tradeIcon from "assets/icons/trade.png";
+import { useGame } from "features/game/GameProvider";
+import { getResourceTax } from "features/game/types/marketplace";
 
 type Props = {
   inventoryCount: Decimal;
@@ -50,6 +52,7 @@ export const ResourceList: React.FC<Props> = ({
   onList,
 }) => {
   const { t } = useAppTranslation();
+  const { gameState } = useGame();
 
   const unitPrice = new Decimal(quantity).equals(0)
     ? new Decimal(0)
@@ -71,6 +74,25 @@ export const ResourceList: React.FC<Props> = ({
 
   // For now, keep offchain
   const maxSFL = new Decimal(price).greaterThan(MAX_SFL);
+
+  const tax = getResourceTax({
+    game: gameState.context.state,
+  });
+
+  if (gameState.context.state.island.type === "basic") {
+    return (
+      <div>
+        <Label type="danger" className="mb-1">
+          Grow your farm
+        </Label>
+        <p className="text-sm">
+          You must upgrade your island to Petal Paradise to begin selling
+          resources.
+        </p>
+        <Button onClick={onCancel}>Ok</Button>
+      </div>
+    );
+  }
 
   return (
     <>
@@ -264,7 +286,7 @@ export const ResourceList: React.FC<Props> = ({
         >
           <span className="text-xs"> {t("bumpkinTrade.tradingFee")}</span>
           <p className="text-xs font-secondary">{`${formatNumber(
-            new Decimal(price).mul(0.1),
+            new Decimal(price).mul(tax),
             {
               decimalPlaces: 4,
               showTrailingZeros: true,
@@ -279,7 +301,7 @@ export const ResourceList: React.FC<Props> = ({
         >
           <span className="text-xs"> {t("bumpkinTrade.youWillReceive")}</span>
           <p className="text-xs font-secondary">{`${formatNumber(
-            new Decimal(price).mul(0.9),
+            new Decimal(price).mul(1 - tax),
             {
               decimalPlaces: 4,
               showTrailingZeros: true,

--- a/src/features/marketplace/components/ResourceList.tsx
+++ b/src/features/marketplace/components/ResourceList.tsx
@@ -83,13 +83,12 @@ export const ResourceList: React.FC<Props> = ({
     return (
       <div>
         <Label type="danger" className="mb-1">
-          Grow your farm
+          {t("marketplace.growFarm.title")}
         </Label>
-        <p className="text-sm">
-          You must upgrade your island to Petal Paradise to begin selling
-          resources.
+        <p className="text-sm p-1 mb-1">
+          {t("marketplace.growFarm.description")}
         </p>
-        <Button onClick={onCancel}>Ok</Button>
+        <Button onClick={onCancel}>{t("marketplace.ok")}</Button>
       </div>
     );
   }
@@ -99,7 +98,7 @@ export const ResourceList: React.FC<Props> = ({
       <div>
         <Label type="default" className="my-1 ml-2" icon={tradeIcon}>
           {t("marketplace.listItem", {
-            type: "Resource",
+            type: t("marketplace.resource"),
           })}
         </Label>
         <div className="flex justify-between">
@@ -256,7 +255,7 @@ export const ResourceList: React.FC<Props> = ({
           <p className="text-xs font-secondary">{`${formatNumber(price, {
             decimalPlaces: 4,
             showTrailingZeros: true,
-          })} FLOWER`}</p>
+          })} ${t("marketplace.flower")}`}</p>
         </div>
         <div
           className="flex justify-between"
@@ -270,11 +269,11 @@ export const ResourceList: React.FC<Props> = ({
           </span>
           <p className="text-xs font-secondary">
             {new Decimal(quantity).equals(0)
-              ? "0.0000 FLOWER"
+              ? `0.0000 ${t("marketplace.flower")}`
               : `${formatNumber(unitPrice, {
                   decimalPlaces: 4,
                   showTrailingZeros: true,
-                })} FLOWER`}
+                })} ${t("marketplace.flower")}`}
           </p>
         </div>
         <div
@@ -291,7 +290,7 @@ export const ResourceList: React.FC<Props> = ({
               decimalPlaces: 4,
               showTrailingZeros: true,
             },
-          )} FLOWER`}</p>
+          )} ${t("marketplace.flower")}`}</p>
         </div>
         <div
           className="flex justify-between"
@@ -306,7 +305,7 @@ export const ResourceList: React.FC<Props> = ({
               decimalPlaces: 4,
               showTrailingZeros: true,
             },
-          )} FLOWER`}</p>
+          )} ${t("marketplace.flower")}`}</p>
         </div>
         <div className="flex mt-2">
           <Button onClick={onCancel} className="mr-1">

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -31,6 +31,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import Decimal from "decimal.js-light";
 import { getRemainingTrades, Reputation } from "features/game/lib/reputation";
 import { hasReputation } from "features/game/lib/reputation";
+import { hasVipAccess } from "features/game/lib/vipAccess";
 
 type TradeableHeaderProps = {
   authToken: string;
@@ -108,10 +109,17 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
     isTradeResource(KNOWN_ITEMS[Number(params.id)]) &&
     params.collection === "collectibles";
 
+  const vipIsRequired =
+    tradeable?.isVip &&
+    !hasVipAccess({
+      game: gameService.getSnapshot().context.state,
+    });
+
   const showBuyNow =
     !isResources &&
     cheapestListing &&
     tradeable?.isActive &&
+    !vipIsRequired &&
     // Don't show buy now if the listing is mine
     cheapestListing.listedById !== farmId;
   // const showFreeListing = !isVIP && dailyListings === 0;
@@ -246,7 +254,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                     {t("marketplace.buyNow")}
                   </Button>
                 )}
-                {tradeable?.isActive && (
+                {tradeable?.isActive && !vipIsRequired && (
                   <Button
                     disabled={
                       !count ||
@@ -281,7 +289,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 {t("marketplace.buyNow")}
               </Button>
             )}
-            {tradeable?.isActive && (
+            {tradeable?.isActive && !vipIsRequired && (
               <Button
                 onClick={onListClick}
                 disabled={

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -200,7 +200,8 @@ export const TradeableInfo: React.FC<{
     <>
       <TradeableImage display={display} supply={tradeable?.supply} />
       <TradeableDescription display={display} tradeable={tradeable} />
-      <ResourceTaxes />
+      {display.type === "collectibles" &&
+        isTradeResource(display.name as InventoryItemName) && <ResourceTaxes />}
     </>
   );
 };
@@ -237,36 +238,34 @@ export const ResourceTaxes: React.FC = () => {
       <Modal show={showModal} onHide={() => setShowModal(false)}>
         <CloseButtonPanel onClose={() => setShowModal(false)}>
           <Label type="default" className="mb-1">
-            Market Economy
+            {t("marketplace.economy.title")}
           </Label>
           <div className="p-1">
             <p className="text-sm mb-1">
-              Progress through the game to pay less resource fees when selling.
+              {t("marketplace.economy.description")}
             </p>
           </div>
           <NoticeboardItems
             items={[
               {
                 icon: SUNNYSIDE.icons.cancel,
-                text: "Tutorial Island - Cannot sell resources",
+                text: t("marketplace.economy.tutorialIsland"),
               },
               {
                 icon: SUNNYSIDE.icons.heart,
-                text: "Petal Paradise - 50% resource tax",
+                text: t("marketplace.economy.petalParadise"),
               },
               {
                 icon: SUNNYSIDE.icons.heart,
-                text: "Desert Island - 20% resource tax",
+                text: t("marketplace.economy.desertIsland"),
               },
               {
                 icon: SUNNYSIDE.icons.heart,
-                text: "Volcano Island - 15% resource tax",
+                text: t("marketplace.economy.volcanoIsland"),
               },
             ]}
           />
-          <p className="text-xs p-1">
-            Resource taxes protect the deflationary market economy.
-          </p>
+          <p className="text-xs p-1">{t("marketplace.economy.protection")}</p>
         </CloseButtonPanel>
         <div
           className={classNames(
@@ -300,7 +299,9 @@ export const ResourceTaxes: React.FC = () => {
           <div className="flex items-center ">
             <img src={lockIcon} className="w-4 mr-1" />
             <div>
-              <p className="text-xs">Resource Fee = {tax * 100}%</p>
+              <p className="text-xs">
+                {t("marketplace.resourceFee", { tax: tax * 100 })}
+              </p>
             </div>
           </div>
         </div>

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext, useState } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { InnerPanel } from "components/ui/Panel";
 import {
   getMarketPrice,
+  getResourceTax,
   TradeableDetails,
 } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -12,6 +13,7 @@ import { TradeableDisplay } from "../lib/tradeables";
 import grassBg from "assets/ui/3x3_bg.png";
 import brownBg from "assets/brand/brown_background.png";
 import lockIcon from "assets/icons/lock.png";
+import crownIcon from "assets/icons/vip.webp";
 
 import { InventoryItemName } from "features/game/types/game";
 import { isTradeResource } from "features/game/actions/tradeLimits";
@@ -23,6 +25,13 @@ import {
   INVENTORY_RELEASES,
 } from "features/game/types/withdrawables";
 import { BUMPKIN_ITEM_PART, BumpkinItem } from "features/game/types/bumpkin";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { Modal } from "components/ui/Modal";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+import classNames from "classnames";
+import { pixelGreenBorderStyle } from "features/game/lib/style";
+import { useGame } from "features/game/GameProvider";
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString("en-US", {
@@ -115,7 +124,7 @@ export const TradeableDescription: React.FC<{
   const isResource = isTradeResource(display.name as InventoryItemName);
 
   return (
-    <InnerPanel>
+    <InnerPanel className="mb-1">
       <div className="p-2">
         <Label type="default" className="mb-1" icon={SUNNYSIDE.icons.search}>
           {t("marketplace.description")}
@@ -191,6 +200,7 @@ export const TradeableInfo: React.FC<{
     <>
       <TradeableImage display={display} supply={tradeable?.supply} />
       <TradeableDescription display={display} tradeable={tradeable} />
+      <ResourceTaxes />
     </>
   );
 };
@@ -210,6 +220,94 @@ export const TradeableMobileInfo: React.FC<{
         />
       </div>
       <TradeableDescription display={display} tradeable={tradeable} />
+    </>
+  );
+};
+
+export const ResourceTaxes: React.FC = () => {
+  const { t } = useAppTranslation();
+  const [showModal, setShowModal] = useState(false);
+  const { openModal } = useContext(ModalContext);
+  const { gameState } = useGame();
+
+  const tax = getResourceTax({ game: gameState.context.state });
+
+  return (
+    <>
+      <Modal show={showModal} onHide={() => setShowModal(false)}>
+        <CloseButtonPanel onClose={() => setShowModal(false)}>
+          <Label type="default" className="mb-1">
+            Market Economy
+          </Label>
+          <div className="p-1">
+            <p className="text-sm mb-1">
+              Progress through the game to pay less resource fees when selling.
+            </p>
+          </div>
+          <NoticeboardItems
+            items={[
+              {
+                icon: SUNNYSIDE.icons.cancel,
+                text: "Tutorial Island - Cannot sell resources",
+              },
+              {
+                icon: SUNNYSIDE.icons.heart,
+                text: "Petal Paradise - 50% resource tax",
+              },
+              {
+                icon: SUNNYSIDE.icons.heart,
+                text: "Desert Island - 20% resource tax",
+              },
+              {
+                icon: SUNNYSIDE.icons.heart,
+                text: "Volcano Island - 15% resource tax",
+              },
+            ]}
+          />
+          <p className="text-xs p-1">
+            Resource taxes protect the deflationary market economy.
+          </p>
+        </CloseButtonPanel>
+        <div
+          className={classNames(
+            `w-full items-center flex  text-xs p-1 pr-4 mt-1 relative`,
+          )}
+          style={{
+            background: "#3e8948",
+            color: "#ffffff",
+            ...pixelGreenBorderStyle,
+          }}
+        >
+          <img src={crownIcon} className="w-8 mr-2" />
+          <div>
+            <p className="text-xs flex-1">
+              {t("marketplace.vip.resourceDiscount")}
+            </p>
+            <span
+              onClick={() => openModal("VIP_ITEMS")}
+              className="underline text-xxs pb-1 pt-0.5 hover:text-blue-500 mb-2 text-white"
+            >
+              {t("read.more")}
+            </span>
+          </div>
+        </div>
+      </Modal>
+      <InnerPanel
+        className="mb-1 cursor-pointer"
+        onClick={() => setShowModal(true)}
+      >
+        <div className="flex justify-between items-center px-1 relative">
+          <div className="flex items-center ">
+            <img src={lockIcon} className="w-4 mr-1" />
+            <div>
+              <p className="text-xs">Resource Fee = {tax * 100}%</p>
+            </div>
+          </div>
+        </div>
+        <p className="text-xxs italic underline mb-0.5 pl-1">
+          {t("marketplace.unlocks.perks")}
+        </p>
+      </InnerPanel>
     </>
   );
 };

--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -171,6 +171,14 @@ export const TradeableDescription: React.FC<{
               <Label type="danger">{t("marketplace.notForSale")}</Label>
             </div>
           )}
+
+        {tradeable?.isVip && (
+          <div className="p-2 pl-0 pb-0">
+            <Label type="danger" icon={crownIcon}>
+              {t("marketplace.vipOnly")}
+            </Label>
+          </div>
+        )}
         {!canTrade && !!tradeAt && (
           <div className="p-2 pl-0 pb-0 flex items-center justify-between  flex-wrap">
             <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -3,10 +3,7 @@ import { useActor, useSelector } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { Label } from "components/ui/Label";
 import { Context } from "features/game/GameProvider";
-import {
-  getResourceTax,
-  MARKETPLACE_TAX,
-} from "features/game/types/marketplace";
+import { MARKETPLACE_TAX } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import tradeIcon from "assets/icons/trade.png";
@@ -238,6 +235,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
             <TradeableSummary
               display={display}
               sfl={price}
+              tax={price * MARKETPLACE_TAX}
               quantity={Math.max(1, quantity)}
               estTradePoints={estTradePoints}
             />
@@ -274,6 +272,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
           <TradeableSummary
             display={display}
             sfl={price}
+            tax={price * MARKETPLACE_TAX}
             quantity={Math.max(1, quantity)}
             estTradePoints={estTradePoints}
           />

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -3,7 +3,10 @@ import { useActor, useSelector } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { Label } from "components/ui/Label";
 import { Context } from "features/game/GameProvider";
-import { MARKETPLACE_TAX } from "features/game/types/marketplace";
+import {
+  getResourceTax,
+  MARKETPLACE_TAX,
+} from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import tradeIcon from "assets/icons/trade.png";
@@ -95,7 +98,8 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
 
   const dailyListings = getDailyListings();
 
-  const hasAccess = hasTradeReputation || dailyListings < 1;
+  const hasAccess =
+    state.island.type !== "basic" && (hasTradeReputation || dailyListings < 1);
 
   const tradeType = getTradeType({
     collection: display.type,
@@ -378,7 +382,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
             >
               <span className="text-xs"> {t("bumpkinTrade.tradingFee")}</span>
               <p className="text-xs font-secondary">{`${formatNumber(
-                price * 0.1,
+                price * MARKETPLACE_TAX,
                 {
                   decimalPlaces: 4,
                   showTrailingZeros: true,

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -3,7 +3,10 @@ import { useActor, useSelector } from "@xstate/react";
 import { Box } from "components/ui/Box";
 import { Label } from "components/ui/Label";
 import { Context } from "features/game/GameProvider";
-import { MARKETPLACE_TAX } from "features/game/types/marketplace";
+import {
+  getResourceTax,
+  MARKETPLACE_TAX,
+} from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 import tradeIcon from "assets/icons/trade.png";
@@ -257,6 +260,11 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
       );
     }
 
+    let tax = price * MARKETPLACE_TAX;
+    if (isResource) {
+      tax = price * getResourceTax({ game: state });
+    }
+
     return (
       <>
         <div className="p-2">
@@ -272,7 +280,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
           <TradeableSummary
             display={display}
             sfl={price}
-            tax={price * MARKETPLACE_TAX}
+            tax={tax}
             quantity={Math.max(1, quantity)}
             estTradePoints={estTradePoints}
           />

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -98,9 +98,6 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
 
   const dailyListings = getDailyListings();
 
-  const hasAccess =
-    state.island.type !== "basic" && (hasTradeReputation || dailyListings < 1);
-
   const tradeType = getTradeType({
     collection: display.type,
     id,
@@ -112,6 +109,8 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
   const isResource =
     isTradeResource(display.name as InventoryItemName) &&
     display.type === "collectibles";
+
+  const hasReputation = hasTradeReputation || dailyListings < 1;
 
   // Check inventory count
   const getCount = () => {
@@ -330,7 +329,7 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
           })}
         </Label>
 
-        {!hasAccess && (
+        {!hasReputation && (
           <RequiredReputation reputation={Reputation.Cropkeeper} />
         )}
       </div>

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -168,7 +168,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
             onClose={onListClose}
           />
         </Panel>
-        <ResourceTaxes />
+        {isResource && <ResourceTaxes />}
       </Modal>
       <InnerPanel className="mb-1">
         <div className="p-2">

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -31,6 +31,7 @@ import { KNOWN_ITEMS } from "features/game/types";
 import { KeyedMutator } from "swr";
 import { isTradeResource } from "features/game/actions/tradeLimits";
 import { MAX_LIMITED_SALES } from "./Tradeable";
+import { ResourceTaxes } from "./TradeableInfo";
 
 type TradeableListingsProps = {
   authToken: string;
@@ -157,7 +158,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
         </Panel>
       </Modal>
       <Modal show={showListItem} onHide={!isListing ? onListClose : undefined}>
-        <Panel>
+        <Panel className="mb-1">
           <TradeableListItem
             authToken={authToken}
             display={display}
@@ -167,6 +168,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
             onClose={onListClose}
           />
         </Panel>
+        <ResourceTaxes />
       </Modal>
       <InnerPanel className="mb-1">
         <div className="p-2">

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -36,6 +36,7 @@ import Decimal from "decimal.js-light";
 import { useParams } from "react-router";
 import { KeyedMutator } from "swr";
 import { MAX_LIMITED_PURCHASES } from "./Tradeable";
+import { ResourceTaxes } from "./TradeableInfo";
 
 const _hasPendingOfferEffect = (state: MachineState) =>
   state.matches("marketplaceOffering") || state.matches("marketplaceAccepting");
@@ -163,7 +164,7 @@ export const TradeableOffers: React.FC<{
         </Panel>
       </Modal>
       <Modal show={showAcceptOffer} onHide={handleHide}>
-        <Panel>
+        <Panel className="mb-1">
           <AcceptOffer
             authToken={authToken}
             itemId={itemId}
@@ -173,6 +174,7 @@ export const TradeableOffers: React.FC<{
             onOfferAccepted={reload}
           />
         </Panel>
+        {isResource && <ResourceTaxes />}
       </Modal>
       {!isResource && (
         <InnerPanel className="mb-1">

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -37,6 +37,7 @@ import { useParams } from "react-router";
 import { KeyedMutator } from "swr";
 import { MAX_LIMITED_PURCHASES } from "./Tradeable";
 import { ResourceTaxes } from "./TradeableInfo";
+import { hasVipAccess } from "features/game/lib/vipAccess";
 
 const _hasPendingOfferEffect = (state: MachineState) =>
   state.matches("marketplaceOffering") || state.matches("marketplaceAccepting");
@@ -150,6 +151,12 @@ export const TradeableOffers: React.FC<{
   const loading = !tradeable;
   const isResource = isTradeResource(KNOWN_ITEMS[Number(id)]);
 
+  const vipIsRequired =
+    tradeable?.isVip &&
+    !hasVipAccess({
+      game: gameService.getSnapshot().context.state,
+    });
+
   return (
     <>
       <Modal show={showMakeOffer} onHide={handleHide}>
@@ -209,7 +216,7 @@ export const TradeableOffers: React.FC<{
               )}
               {!loading && (
                 <div className="flex items-center w-full sm:w-fit">
-                  {tradeable?.isActive && (
+                  {tradeable?.isActive && !vipIsRequired && (
                     <Button
                       className="w-full sm:w-fit mr-1"
                       disabled={
@@ -225,7 +232,7 @@ export const TradeableOffers: React.FC<{
                     </Button>
                   )}
 
-                  {topOffer && tradeable?.isActive && (
+                  {topOffer && tradeable?.isActive && !vipIsRequired && (
                     <Button
                       disabled={
                         topOffer.offeredBy.id === farmId ||
@@ -294,7 +301,7 @@ export const TradeableOffers: React.FC<{
                   id={farmId}
                   tableType="offers"
                   onClick={
-                    tradeable.isActive
+                    tradeable.isActive && !vipIsRequired
                       ? (offerId) => {
                           handleSelectOffer(offerId);
                           setShowAcceptOffer(true);

--- a/src/features/marketplace/components/TradeableSummary.tsx
+++ b/src/features/marketplace/components/TradeableSummary.tsx
@@ -7,7 +7,6 @@ import { TradeableDisplay } from "../lib/tradeables";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { formatNumber } from "lib/utils/formatNumber";
 import Decimal from "decimal.js-light";
-import { MARKETPLACE_TAX } from "features/game/types/marketplace";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { TRADE_LIMITS } from "features/game/actions/tradeLimits";
 
@@ -66,9 +65,10 @@ export const TradeableItemDetails: React.FC<{
 export const TradeableSummary: React.FC<{
   display: TradeableDisplay;
   sfl: number;
+  tax: number;
   quantity: number;
   estTradePoints?: number;
-}> = ({ display, sfl, quantity, estTradePoints }) => {
+}> = ({ display, sfl, tax, quantity, estTradePoints }) => {
   const { t } = useAppTranslation();
 
   const isResource = display.name in TRADE_LIMITS;
@@ -99,7 +99,7 @@ export const TradeableSummary: React.FC<{
       >
         <span className="text-xs"> {t("bumpkinTrade.tradingFee")}</span>
         <p className="text-xs font-secondary">{`${formatNumber(
-          new Decimal(sfl).mul(MARKETPLACE_TAX),
+          new Decimal(tax),
           {
             decimalPlaces: 4,
             showTrailingZeros: true,
@@ -116,7 +116,7 @@ export const TradeableSummary: React.FC<{
       >
         <span className="text-xs"> {t("bumpkinTrade.youWillReceive")}</span>
         <p className="text-xs font-secondary">{`${formatNumber(
-          new Decimal(sfl).mul(1 - MARKETPLACE_TAX),
+          new Decimal(sfl).minus(tax),
           {
             decimalPlaces: 4,
             showTrailingZeros: true,

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -20,6 +20,7 @@ import { RemoveListing } from "../RemoveListing";
 import { tradeToId } from "features/marketplace/lib/offers";
 import { isTradeResource } from "features/game/actions/tradeLimits";
 import { MyTableRow } from "./MyTableRow";
+import { MARKETPLACE_TAX } from "features/game/types/marketplace";
 
 const _isCancellingOffer = (state: MachineState) =>
   state.matches("marketplaceListingCancelling");
@@ -165,6 +166,7 @@ export const MyListings: React.FC = () => {
                       usdPrice={usd}
                       isFulfilled={!!listing.fulfilledAt || !!listing.boughtAt}
                       isResource={isResource}
+                      fee={listing.tax ?? listing.sfl * MARKETPLACE_TAX}
                       onCancel={() => setRemoveListingId(id)}
                       onRowClick={() =>
                         navigate(

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -180,6 +180,7 @@ export const MyOffers: React.FC = () => {
                       isFulfilled={!!offer.fulfilledAt}
                       isResource={isResource}
                       onCancel={() => setRemoveId(id)}
+                      fee={0}
                       onRowClick={() =>
                         navigate(
                           `${isWorldRoute ? "/world" : ""}/marketplace/${details.type}/${itemId}`,

--- a/src/features/marketplace/components/profile/MyTableRow.tsx
+++ b/src/features/marketplace/components/profile/MyTableRow.tsx
@@ -24,6 +24,7 @@ type MyTableRowProps = {
   unitPrice: number;
   usdPrice: number;
   isFulfilled: boolean;
+  fee: number;
   isResource: boolean;
   onCancel: (id: string) => void;
   onClaim: (id: string) => void;
@@ -42,6 +43,7 @@ export const MyTableRow: React.FC<MyTableRowProps> = ({
   usdPrice,
   isResource,
   isFulfilled,
+  fee,
   onCancel,
   onRowClick,
   onClaim,
@@ -98,6 +100,9 @@ export const MyTableRow: React.FC<MyTableRowProps> = ({
                     price: formatNumber(unitPrice, { decimalPlaces: 4 }),
                   })}
                 </div>
+              )}
+              {!!fee && (
+                <div className="text-[16px] sm:text-xxs w-full">{`${fee} fee`}</div>
               )}
             </div>
           </div>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6118,5 +6118,6 @@
   "marketplace.growFarm.title": "Grow your farm",
   "marketplace.growFarm.description": "Upgrade your island to Petal Paradise to begin selling resources.",
   "marketplace.ok": "Ok",
-  "marketplace.flower": "FLOWER"
+  "marketplace.flower": "FLOWER",
+  "marketplace.vipOnly": "VIP only"
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6104,5 +6104,7 @@
   "blessing.noResults": "No results found for this date",
   "blessing.donated": "{amount} x {item} donated",
   "blessing.winners": "{count} winners",
-  "blessing.maxAmount": "Insufficient {name}."
+  "blessing.maxAmount": "Insufficient {name}.",
+  "marketplace.unlocks.perks": "Grow your land to unlock discounts.",
+  "marketplace.vip.resourceDiscount": "Unlock VIP for half the resource taxes."
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6106,5 +6106,17 @@
   "blessing.winners": "{count} winners",
   "blessing.maxAmount": "Insufficient {name}.",
   "marketplace.unlocks.perks": "Grow your land to unlock discounts.",
-  "marketplace.vip.resourceDiscount": "Unlock VIP for half the resource taxes."
+  "marketplace.vip.resourceDiscount": "Unlock VIP for half the resource taxes.",
+  "marketplace.economy.title": "Market Economy",
+  "marketplace.economy.description": "Progress through the game to pay less resource fees when selling.",
+  "marketplace.economy.tutorialIsland": "Tutorial Island - Cannot sell resources",
+  "marketplace.economy.petalParadise": "Petal Paradise - 50% resource tax",
+  "marketplace.economy.desertIsland": "Desert Island - 20% resource tax",
+  "marketplace.economy.volcanoIsland": "Volcano Island - 15% resource tax",
+  "marketplace.economy.protection": "Resource taxes protect the deflationary market economy.",
+  "marketplace.resourceFee": "Resource Fee = {{tax}}%",
+  "marketplace.growFarm.title": "Grow your farm",
+  "marketplace.growFarm.description": "Upgrade your island to Petal Paradise to begin selling resources.",
+  "marketplace.ok": "Ok",
+  "marketplace.flower": "FLOWER"
 }


### PR DESCRIPTION
# Description

This PR introduces the following improvements to the marketplace to mitigate bots + multiaccounters + encourage positive trading behaviour.

1. Cannot list resources on tutorial island
2. Progressive tax system for resources (50% on spring, 20% on desert, 15% on volcano)
3. 50% of resource tax for VIP
4. Mark VIP items

## How to test?

1. List and sell resources on spring island versus desert island - observe tax
2. List and sell resources with VIP - observe half off tax
3. Accept offer on resources - observe tax

_Note: Items with less than 20 listings will be marked as VIP only 🔒_

<img width="517" alt="Screenshot 2025-05-23 at 10 59 54 AM" src="https://github.com/user-attachments/assets/5bee66df-6f4d-498e-8b3b-f416bcf5b712" />
<img width="515" alt="Screenshot 2025-05-23 at 10 53 10 AM" src="https://github.com/user-attachments/assets/99780443-7590-4b78-9741-8b2a34290b5c" />
<img width="518" alt="Screenshot 2025-05-23 at 10 46 46 AM" src="https://github.com/user-attachments/assets/f46b3d79-f3e3-46b2-85c5-426e36bc7af8" />
<img width="314" alt="Screenshot 2025-05-23 at 11 09 33 AM" src="https://github.com/user-attachments/assets/2ee746e3-6c69-402a-85b6-e856cd108ecf" />
<img width="540" alt="Screenshot 2025-05-23 at 11 09 36 AM" src="https://github.com/user-attachments/assets/62cb96cc-d5a7-468b-a7db-584b8e19c2fb" />
