### PR TITLE
[FIX] Medic Apron with 0.5 Barn Delight

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -35,6 +35,7 @@ import { WakesIn } from "features/game/expansion/components/animals/WakesIn";
 import Decimal from "decimal.js-light";
 import { InfoPopover } from "features/island/common/InfoPopover";
 import {
+  getBarnDelightCost,
   handleFoodXP,
   REQUIRED_FOOD_QTY,
 } from "features/game/events/landExpansion/feedAnimal";
@@ -255,7 +256,9 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
 
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
-    const hasEnoughMedicine = medicineCount.gte(1);
+    const hasEnoughMedicine = medicineCount.gte(
+      getBarnDelightCost({ state: game }),
+    );
 
     if (hasOracleSyringeEquipped) {
       playCureAnimal();

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -35,6 +35,7 @@ import { WakesIn } from "features/game/expansion/components/animals/WakesIn";
 import { InfoPopover } from "features/island/common/InfoPopover";
 import Decimal from "decimal.js-light";
 import {
+  getBarnDelightCost,
   handleFoodXP,
   REQUIRED_FOOD_QTY,
 } from "features/game/events/landExpansion/feedAnimal";
@@ -219,7 +220,9 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
 
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
-    const hasEnoughMedicine = medicineCount.gte(1);
+    const hasEnoughMedicine = medicineCount.gte(
+      getBarnDelightCost({ state: game }),
+    );
 
     if (hasOracleSyringeEquipped) {
       playCureAnimal();

--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -702,7 +702,7 @@ describe("feedAnimal", () => {
         },
         inventory: {
           ...INITIAL_FARM.inventory,
-          "Barn Delight": new Decimal(1),
+          "Barn Delight": new Decimal(0.5),
         },
         henHouse: {
           ...INITIAL_FARM.henHouse,
@@ -730,7 +730,7 @@ describe("feedAnimal", () => {
     });
 
     expect(state.henHouse.animals[chickenId].state).toBe("idle");
-    expect(state.inventory["Barn Delight"]).toStrictEqual(new Decimal(0.5));
+    expect(state.inventory["Barn Delight"]).toStrictEqual(new Decimal(0));
     expect(state.henHouse.animals[chickenId].experience).toBe(0);
   });
 

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -35,6 +35,7 @@ import { WakesIn } from "features/game/expansion/components/animals/WakesIn";
 import { InfoPopover } from "features/island/common/InfoPopover";
 import Decimal from "decimal.js-light";
 import {
+  getBarnDelightCost,
   handleFoodXP,
   REQUIRED_FOOD_QTY,
 } from "features/game/events/landExpansion/feedAnimal";
@@ -265,7 +266,9 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
 
   const onSickClick = async () => {
     const medicineCount = inventory["Barn Delight"] ?? new Decimal(0);
-    const hasEnoughMedicine = medicineCount.gte(1);
+    const hasEnoughMedicine = medicineCount.gte(
+      getBarnDelightCost({ state: game }),
+    );
 
     if (hasOracleSyringeEquipped) {
       playCureAnimal();


### PR DESCRIPTION
When inventory supply of Barn Delight is 0.5 and Medic Apron is equipped, curing animals should be allowed.