### PR TITLE
[FIX] Ready In time for Guardian Blessings

### DIFF
--- a/src/features/loveIsland/blessings/ClaimBlessing.tsx
+++ b/src/features/loveIsland/blessings/ClaimBlessing.tsx
@@ -4,7 +4,10 @@ import { Label } from "components/ui/Label";
 import { useAuth } from "features/auth/lib/Provider";
 import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 import { useGame } from "features/game/GameProvider";
-import { blessingIsReady } from "features/game/lib/blessings";
+import {
+  blessingIsReady,
+  GUARDIAN_PENDING_MS,
+} from "features/game/lib/blessings";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { secondsToString } from "lib/utils/time";
 import React from "react";
@@ -68,7 +71,9 @@ export const ClaimBlessingReward: React.FC<Props> = ({ onClose }) => {
   if (!isReady) {
     const offeredDate = new Date(offered!.offeredAt).toISOString().slice(0, 10);
 
-    const readyIn = Date.now() - new Date(offeredDate).getTime();
+    const readyIn =
+      new Date(offeredDate).getTime() + GUARDIAN_PENDING_MS - Date.now();
+
     return (
       <div>
         <Label type="default" className="mb-1">


### PR DESCRIPTION
# Description

Ready In time was calculated wrongly. it was taking the current time minus the start of the day that the player offer the guardian. It should be taking the time that it's ready minus the current time

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
