### PR TITLE
[FIX] Tutorial Island Initial Plots

### DIFF
--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -2551,6 +2551,7 @@ describe("isPlotFertile", () => {
       y: 1,
     });
     const isFertile = isPlotFertile({
+      island: "spring",
       buildings: {
         "Water Well": [],
       },
@@ -2590,6 +2591,7 @@ describe("isPlotFertile", () => {
       y: 1,
     });
     const isFertile = isPlotFertile({
+      island: "spring",
       buildings: {
         "Water Well": [
           {
@@ -2643,6 +2645,7 @@ describe("isPlotFertile", () => {
       y: 1,
     };
     const isFertile = isPlotFertile({
+      island: "spring",
       crops: {
         0: fakePlot,
         1: fakePlot,

--- a/src/features/game/expansion/components/UpgradeBuildingModal.tsx
+++ b/src/features/game/expansion/components/UpgradeBuildingModal.tsx
@@ -95,11 +95,13 @@ export const UpgradeBuildingModal: React.FC<Props> = ({
   const currentSupportedPlots = getSupportedPlots({
     wellLevel: currentLevel,
     buildings: state.buildings,
+    island: state.island.type,
   });
 
   const nextSupportedPlots = getSupportedPlots({
     wellLevel: nextLevel,
     buildings: state.buildings,
+    island: state.island.type,
   });
 
   const nextLevelFertility = nextSupportedPlots - currentSupportedPlots;

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -126,6 +126,7 @@ export const Plot: React.FC<Props> = ({ id }) => {
     buildings: state.buildings,
     upgradeReadyAt: waterWell.upgradeReadyAt ?? 0,
     createdAt: Date.now(),
+    island: state.island.type,
   });
 
   if (!isFertile) return <NonFertilePlot />;


### PR DESCRIPTION
# Description

Tutorial Island will have a 17 default plots before they need to build a water well

Upon upgrading to petal paradise, players start with 18 default plots, those 18 plots will not require water well

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
