### PR TITLE
[FIX] Adjust mission texts from portal

### DIFF
--- a/src/features/world/ui/portals/FruitDash.tsx
+++ b/src/features/world/ui/portals/FruitDash.tsx
@@ -178,7 +178,9 @@ export const FruitDash: React.FC<Props> = ({ onClose }) => {
         <MinigamePrizeUI
           prize={prize}
           history={dailyAttempt}
-          mission={`Mission: Rescue ${prize?.score} chickens`}
+          mission={t("fruit-dash.portal.missionObjectives", {
+            targetScore: prize?.score ?? 0,
+          })}
         />
       </div>
       <div className="flex">

--- a/src/features/world/ui/portals/MineWhack.tsx
+++ b/src/features/world/ui/portals/MineWhack.tsx
@@ -178,7 +178,9 @@ export const MineWhack: React.FC<Props> = ({ onClose }) => {
         <MinigamePrizeUI
           prize={prize}
           history={dailyAttempt}
-          mission={`Mission: Rescue ${prize?.score} chickens`}
+          mission={t("mine-whack.portal.missionObjectives", {
+            targetScore: prize?.score ?? 0,
+          })}
         />
       </div>
       <div className="flex">


### PR DESCRIPTION
# Description

Mission objectives from Fruit Dash and Mine Whack are copied from Chicken Recue.

Fixes #issue

# What needs to be tested by the reviewer?

Mission objectives from Fruit Dash and Mine Whack are not mentioning chickens.

# Checklist:

- [x ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]