### PR TITLE
[FIX] Prevent selling ready animals that are lower level than the bounty request

### DIFF
--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -119,6 +119,49 @@ describe("animal.sold", () => {
     ).toThrow("Animal does not meet requirements");
   });
 
+  it("allows chicken to be sold if they are above the current level, even if they are ready", () => {
+    expect(() =>
+      sellAnimal({
+        state: {
+          ...INITIAL_FARM,
+          henHouse: {
+            level: 1,
+            animals: {
+              "1": {
+                id: "1",
+                type: "Chicken",
+                state: "ready",
+                asleepAt: 0,
+                experience: 2160,
+                createdAt: Date.now(),
+                item: "Petting Hand",
+                lovedAt: 0,
+                awakeAt: 0,
+              },
+            },
+          },
+          bounties: {
+            bonusClaimedAt: 0,
+            completed: [],
+            requests: [
+              {
+                id: "123",
+                coins: 100,
+                level: 12,
+                name: "Chicken",
+              },
+            ],
+          },
+        },
+        action: {
+          requestId: "123",
+          animalId: "1",
+          type: "animal.sold",
+        },
+      }),
+    ).not.toThrow("Animal does not meet requirements");
+  });
+
   it("requires chicken is correct level", () => {
     expect(() =>
       sellAnimal({

--- a/src/features/game/events/landExpansion/sellAnimal.test.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.test.ts
@@ -76,6 +76,49 @@ describe("animal.sold", () => {
     ).toThrow("Animal does not exist");
   });
 
+  it("requires chicken is not ready even if they are at the correct level", () => {
+    expect(() =>
+      sellAnimal({
+        state: {
+          ...INITIAL_FARM,
+          henHouse: {
+            level: 1,
+            animals: {
+              "1": {
+                id: "1",
+                type: "Chicken",
+                state: "ready",
+                asleepAt: 0,
+                experience: 1920,
+                createdAt: Date.now(),
+                item: "Petting Hand",
+                lovedAt: 0,
+                awakeAt: 0,
+              },
+            },
+          },
+          bounties: {
+            bonusClaimedAt: 0,
+            completed: [],
+            requests: [
+              {
+                id: "123",
+                coins: 100,
+                level: 12,
+                name: "Chicken",
+              },
+            ],
+          },
+        },
+        action: {
+          requestId: "123",
+          animalId: "1",
+          type: "animal.sold",
+        },
+      }),
+    ).toThrow("Animal does not meet requirements");
+  });
+
   it("requires chicken is correct level", () => {
     expect(() =>
       sellAnimal({

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -18,7 +18,14 @@ export function isValidDeal({
     return false;
   }
 
-  if (animal.state === "ready") {
+  /**
+   * If animal is ready, it would normally show its previous level until they claim yield.
+   * Hence we should check their effective level to be the previous level.
+   */
+  if (
+    animal.state === "ready" &&
+    getAnimalLevel(animal.experience, animal.type) - 1 < deal.level
+  ) {
     return false;
   }
 

--- a/src/features/game/events/landExpansion/sellAnimal.ts
+++ b/src/features/game/events/landExpansion/sellAnimal.ts
@@ -18,6 +18,10 @@ export function isValidDeal({
     return false;
   }
 
+  if (animal.state === "ready") {
+    return false;
+  }
+
   if (getAnimalLevel(animal.experience, animal.type) < deal.level) {
     return false;
   }


### PR DESCRIPTION
# Description

Animals now require not to be ready before selling them

Fixes #issue
This PR fixes an bug where a player can feed an animal to the next level, don't claim the yield, but be able to sell their animal to a bounty of that new level.

# What needs to be tested by the reviewer?

Test the bug first:
- Feed animal to next level
- Don't collect yield
- Exit barn (Important!!)
- Enter Barn
- Initiaite sell modal
- The animal that's ready is able to be sold at the next level

Now test the fix
- Feed animal to next level
- Don't collect yield
- Exit barn
- Enter Barn
- Initiaite sell modal
- The animal that's ready shouldn't be able to be sold

Edge case test:
Animal that's ready and shows that it's above the bounty level should be sold
- Set animal that fulfills bounty req to ready
- Attempt to sell the animal

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
