### PR TITLE
[FEAT] Face Recognition on Withdraw (wearables + collectibles)

### DIFF
--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -25,6 +25,8 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { MachineState } from "features/game/lib/gameMachine";
 import { hasReputation, Reputation } from "features/game/lib/reputation";
 import { RequiredReputation } from "features/island/hud/components/reputation/Reputation";
+import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
+import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
 
 interface Props {
   onWithdraw: (ids: number[], amounts: string[]) => void;
@@ -127,6 +129,10 @@ export const WithdrawItems: React.FC<Props> = ({
 
   if (!hasAccess) {
     return <RequiredReputation reputation={Reputation.Seedling} />;
+  }
+
+  if (!isFaceVerified({ game: state })) {
+    return <FaceRecognition />;
   }
 
   return (

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -24,6 +24,8 @@ import { PIXEL_SCALE } from "features/game/lib/constants";
 import { canWithdrawBoostedWearable } from "features/game/types/wearableValidation";
 import { hasReputation, Reputation } from "features/game/lib/reputation";
 import { RequiredReputation } from "features/island/hud/components/reputation/Reputation";
+import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
+import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
 
 interface Props {
   onWithdraw: (ids: number[], amounts: number[]) => void;
@@ -107,6 +109,10 @@ export const WithdrawWearables: React.FC<Props> = ({ onWithdraw }) => {
 
   if (!hasAccess) {
     return <RequiredReputation reputation={Reputation.Seedling} />;
+  }
+
+  if (!isFaceVerified({ game: state })) {
+    return <FaceRecognition />;
   }
 
   return (


### PR DESCRIPTION
# Description

This PR adds face recognition requirement on withdraw of wearables and collectibles.

Fixes #issue

# What needs to be tested by the reviewer?

- Withdraw a collectible
- Withdraw a wearable
- Assert that both require face recognition

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
