### PR TITLE
[FIX] Instant Cook Bug

### DIFF
--- a/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedRecipe.ts
@@ -105,13 +105,11 @@ export function recalculateQueue({
   buildingName,
   game,
   isInstantCook,
-  keepReadyRecipes = false,
 }: {
   queue: BuildingProduct[];
   createdAt: number;
   buildingName: CookingBuildingName;
   isInstantCook?: boolean;
-  keepReadyRecipes?: boolean;
   game: GameState;
 }): BuildingProduct[] {
   // Keep only ready recipes
@@ -136,12 +134,7 @@ export function recalculateQueue({
       return [...recipes, { ...recipe, readyAt }];
     }, [] as BuildingProduct[]);
 
-    // Instant Gratification Skill - keep ready recipes
-    if (keepReadyRecipes) {
-      return [...readyRecipes, ...updatedRecipes];
-    }
-
-    return updatedRecipes;
+    return [...readyRecipes, ...updatedRecipes];
   }
 
   // Currently cooking

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -140,7 +140,6 @@ function useInstantGratification({
       buildingName,
       game,
       isInstantCook: true,
-      keepReadyRecipes: true,
     });
   });
 

--- a/src/features/game/events/landExpansion/speedUpRecipe.test.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.test.ts
@@ -486,4 +486,51 @@ describe("getInstantGems", () => {
       }),
     ).toEqual(10);
   });
+
+  it("doesn't remove other ready recipes when speeding up the current recipe", () => {
+    const now = Date.now();
+
+    const state = speedUpRecipe({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Fire Pit": [
+            {
+              id: "123",
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+              crafting: [
+                {
+                  name: "Mashed Potato", // Ready recipe
+                  readyAt: now - 1000,
+                  amount: 1,
+                },
+                {
+                  name: "Radish Cake",
+                  readyAt: now + 30000 + 2000,
+                  amount: 1,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.spedUp",
+        buildingId: "123",
+        buildingName: "Fire Pit",
+      },
+      createdAt: now,
+    });
+
+    expect(state.buildings["Fire Pit"]?.[0].crafting).toMatchObject([
+      {
+        name: "Mashed Potato",
+        readyAt: expect.any(Number),
+        amount: 1,
+      },
+    ]);
+    expect(state.inventory["Radish Cake"]).toEqual(new Decimal(1));
+  });
 });

--- a/src/features/game/events/landExpansion/speedUpRecipe.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.ts
@@ -129,11 +129,12 @@ export function speedUpRecipe({
       game.inventory[recipe.name] ?? new Decimal(0)
     ).add(recipe.amount ?? 1);
 
-    // Set the current cooking item to be ready now
-    recipe.readyAt = createdAt;
+    const queueWithoutSpedUpRecipe = queue.filter(
+      (item) => item.readyAt !== recipe.readyAt,
+    );
 
     building.crafting = recalculateQueue({
-      queue,
+      queue: queueWithoutSpedUpRecipe,
       createdAt,
       buildingName: action.buildingName as CookingBuildingName,
       isInstantCook: true,


### PR DESCRIPTION
# Description

This PR fixes a bug where instant cook clears food that are in the queue and ready.

- Cook and queue,
- let food complete but don't collect,
- use gems,
- the food that was ready disappears?

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
