### PR TITLE
[FIX] Swap out long offset for short

### DIFF
--- a/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
+++ b/src/features/island/hud/components/codex/components/SeasonalAuctions.tsx
@@ -139,7 +139,7 @@ const NextDrop: React.FC<{ auctions: AuctionItems; game: GameState }> = ({
       : BUMPKIN_ITEM_BUFF_LABELS[nextDrop.wearable as BumpkinItem];
 
   const nextDropTime = new Date(nextDrop.startAt).toLocaleString("en-AU", {
-    timeZoneName: "longOffset",
+    timeZoneName: "shortOffset",
     day: "2-digit",
     month: "2-digit",
     year: "2-digit",
@@ -357,7 +357,7 @@ const Drops: React.FC<{
                       />
                       <span className="text-xs">
                         {new Date(drop.startAt).toLocaleString("en-AU", {
-                          timeZoneName: "longOffset",
+                          timeZoneName: "shortOffset",
                           day: "2-digit",
                           month: "2-digit",
                           year: "2-digit",

--- a/src/features/retreat/components/auctioneer/Auctions.tsx
+++ b/src/features/retreat/components/auctioneer/Auctions.tsx
@@ -101,7 +101,7 @@ export const Auctions: React.FC<Props> = ({ auctionService, onSelect }) => {
                   <img src={SUNNYSIDE.icons.stopwatch} className="h-5 mr-1" />
                   <span className="text-xs">
                     {new Date(auction.startAt).toLocaleString("en-AU", {
-                      timeZoneName: "longOffset",
+                      timeZoneName: "shortOffset",
                       day: "2-digit",
                       month: "2-digit",
                       year: "2-digit",


### PR DESCRIPTION
# Description

Its "appears" that `longOffset` doesn't work on some older browsers used by some players. Replacing with `shortOffset`.


<img width="300" alt="Screenshot 2025-06-05 at 4 04 47 PM" src="https://github.com/user-attachments/assets/5464acff-2a93-4874-a40d-6215d0a45bb1" />

Fixes #issue

# What needs to be tested by the reviewer?

- Open the auctions. All should be well

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
