### PR TITLE
[FEAT] Move the mint farm prompt inside each withdraw button

### DIFF
--- a/src/features/game/components/bank/components/BankModal.tsx
+++ b/src/features/game/components/bank/components/BankModal.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 
 import { Withdraw } from "./Withdraw";
-import { GameWallet } from "features/wallet/Wallet";
-
 import withdrawIcon from "assets/icons/withdraw.png";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { CloseButtonPanel } from "../../CloseablePanel";
@@ -23,9 +21,7 @@ export const BankModal: React.FC<Props> = ({ onClose }) => {
         tabs={[{ icon: withdrawIcon, name: t("withdraw") }]}
         onClose={onClose}
       >
-        <GameWallet action="withdraw">
-          <Withdraw onClose={onClose} />
-        </GameWallet>
+        <Withdraw onClose={onClose} />
       </CloseButtonPanel>
     </>
   );

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -17,6 +17,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { translate } from "lib/i18n/translate";
 import { Transaction } from "features/island/hud/Transaction";
 import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
+import { GameWallet } from "features/wallet/Wallet";
 
 const getPageIcon = (page: Page) => {
   switch (page) {
@@ -220,13 +221,31 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
     <>
       {page === "main" && <MainMenu setPage={setPage} />}
       {page !== "main" && <NavigationMenu page={page} setPage={setPage} />}
-      {page === "tokens" && <WithdrawFlower onWithdraw={onWithdrawTokens} />}
-      {page === "items" && <WithdrawItems onWithdraw={onWithdrawItems} />}
-      {page === "resources" && <WithdrawResources onWithdraw={onClose} />}
-      {page === "wearables" && (
-        <WithdrawWearables onWithdraw={onWithdrawWearables} />
+      {page === "tokens" && (
+        <GameWallet action="withdraw">
+          <WithdrawFlower onWithdraw={onWithdrawTokens} />
+        </GameWallet>
       )}
-      {page === "buds" && <WithdrawBuds onWithdraw={onWithdrawBuds} />}
+      {page === "items" && (
+        <GameWallet action="withdraw">
+          <WithdrawItems onWithdraw={onWithdrawItems} />
+        </GameWallet>
+      )}
+      {page === "resources" && (
+        <GameWallet action="withdraw">
+          <WithdrawResources onWithdraw={onClose} />
+        </GameWallet>
+      )}
+      {page === "wearables" && (
+        <GameWallet action="withdraw">
+          <WithdrawWearables onWithdraw={onWithdrawWearables} />
+        </GameWallet>
+      )}
+      {page === "buds" && (
+        <GameWallet action="withdraw">
+          <WithdrawBuds onWithdraw={onWithdrawBuds} />
+        </GameWallet>
+      )}
       {page === "verify" && <FaceRecognition />}
     </>
   );


### PR DESCRIPTION
# Description

The new gasless farm mint in withdraw requires Seedling reputation but the UI is currently blocking access to `Verify` (Proof of Humanity) which, without doing that, makes it difficult to reach Seedling.

I have shifted the farm mint prompt one step down.

Fixes #issue

# What needs to be tested by the reviewer?

- Create new farm
- Give yourself 1000 xp
- Go to the bank
- You should be able to verify
- If you click on Collectibles you should be prompted to mint a farm

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]