### PR TITLE
[CHORE] Allow Town Hall Countdown Hide

### DIFF
--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -25,7 +25,7 @@ import { MarketplaceButton } from "./components/MarketplaceButton";
 import { GameCalendar } from "features/game/expansion/components/temperateSeason/GameCalendar";
 import { LandscapeButton } from "./components/LandscapeButton";
 import { RewardsButton } from "./components/referral/RewardsButton";
-import { StreamCountdown } from "./components/StreamCountdown";
+import { StreamCountdown } from "./components/streamCountdown/StreamCountdown";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _linkedWallet = (state: MachineState) => state.context.linkedWallet;

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -27,7 +27,7 @@ import { GameCalendar } from "features/game/expansion/components/temperateSeason
 
 import chest from "assets/icons/chest.png";
 import { RewardsButton } from "./components/referral/RewardsButton";
-import { StreamCountdown } from "./components/StreamCountdown";
+import { StreamCountdown } from "./components/streamCountdown/StreamCountdown";
 import { FloatingIslandCountdown } from "./components/FloatingIslandCountdown";
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.

--- a/src/features/island/hud/components/streamCountdown/acknowledgeStreamCountdown.tsx
+++ b/src/features/island/hud/components/streamCountdown/acknowledgeStreamCountdown.tsx
@@ -1,0 +1,11 @@
+export function getStreamCountdownLastRead(): string | null {
+  const value = localStorage.getItem(`streamCountdownAcknowledged`);
+
+  if (!value) return null;
+
+  return value;
+}
+
+export function acknowledgeStreamCountdown(today: string) {
+  return localStorage.setItem("streamCountdownAcknowledged", today);
+}

--- a/src/features/retreat/components/auctioneer/AuctionCountdown.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionCountdown.tsx
@@ -10,6 +10,10 @@ import { Context } from "features/game/GameProvider";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { loadUpcomingAuction } from "./actions/loadUpcomingAuction";
+import {
+  acknowledgeAuctionCountdown,
+  getAuctionCountdownLastRead,
+} from "./auctionCountdownStorage";
 
 const Countdown: React.FC<{ auction: Auction; onComplete: () => void }> = ({
   auction,
@@ -93,7 +97,7 @@ export const AuctionCountdown: React.FC = () => {
         transactionId: gameState.context.transactionId as string,
       });
 
-      if (upcoming) {
+      if (upcoming && getAuctionCountdownLastRead() !== upcoming.auctionId) {
         setAuction(upcoming);
       }
     };
@@ -101,13 +105,20 @@ export const AuctionCountdown: React.FC = () => {
     load();
   }, []);
 
+  const handleClick = () => {
+    if (auction) {
+      acknowledgeAuctionCountdown(auction.auctionId);
+      setAuction(undefined);
+    }
+  };
+
   if (!auction) {
     return null;
   }
 
   return (
     <InnerPanel className="flex justify-center" id="test-auction">
-      <Countdown auction={auction} onComplete={() => setAuction(undefined)} />
+      <Countdown auction={auction} onComplete={handleClick} />
     </InnerPanel>
   );
 };

--- a/src/features/retreat/components/auctioneer/auctionCountdownStorage.tsx
+++ b/src/features/retreat/components/auctioneer/auctionCountdownStorage.tsx
@@ -1,0 +1,11 @@
+export function getAuctionCountdownLastRead(): string | null {
+  const value = localStorage.getItem(`auctionCountdownAcknowledged`);
+
+  if (!value) return null;
+
+  return value;
+}
+
+export function acknowledgeAuctionCountdown(auctionId: string) {
+  return localStorage.setItem("auctionCountdownAcknowledged", auctionId);
+}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5980,7 +5980,7 @@
   "easter-eggstravaganza.portal.rewardMessage": "Congratulations, you completed the mission! Here is your reward.",
   "maxPerPerson": "Max per player: {{max}}",
   "stream.beginsSoon": "Town Hall Starts In",
-  "stream.isLive": "Town Hall is Live!",
+  "stream.isLive": "Town Hall is live!",
   "description.bronzeLoveBox": "A bronze love box",
   "description.silverLoveBox": "A silver love box",
   "description.goldLoveBox": "A gold love box",


### PR DESCRIPTION
# Description

This PR fixes an issue where the Town Hall Countdown was unable to be closed due to the on click wrapping the whole component just taking you to the town hall. 

This PR also adds the acknowledgement of these countdowns to local storage so if you close this countdown then it won't reopen for that particular stream. This will also apply for auction countdowns. If you close the countdown it will not reopen again for that particular auction.

Fixes #issue

# What needs to be tested by the reviewer?

***Town Hall Countdown***
- Create a stream for now in `StreamCountdown`
- Confirm you can navigate to the Town Hall by clicking on the countdown
- Go back
- Confirm you can close the countdown
- Navigate to barn/hen house.. anywhere
- Confirm you do not see the countdown again

***Auction Countdown***
- Create an auction for now in the BE
- Close the auction countdown
- Navigate to barn/hen house.. anywhere
- Confirm you do not see the auction countdown again
- Change the auction to be a different one in the BE
- Confirm you see the Auction Countdown show on load

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
