### PR TITLE
[CHORE] Add Copy Button for Discord ID

### DIFF
--- a/src/features/island/hud/components/settings-menu/developer-options/DEV_PlayerSearch.tsx
+++ b/src/features/island/hud/components/settings-menu/developer-options/DEV_PlayerSearch.tsx
@@ -63,7 +63,12 @@ export const DEV_PlayerSearch: React.FC<ContentComponentProps> = () => {
           )}
         </div>
         <p>{`NFT ID: ${farm.moderator?.nftId}`}</p>
-        <p>{`Discord ID: ${farm.moderator?.discordId}`}</p>
+        <div className="flex items-center">
+          <p className="mr-2">{`Discord ID:`}</p>
+          {farm.moderator?.discordId && (
+            <CopyAddress address={farm.moderator.discordId} />
+          )}
+        </div>
         <p>{`Face Recognition: ${farm.moderator?.isFaceRecognised}`}</p>
         <p>{`Login with: ${farm.moderator?.account}`}</p>
       </div>


### PR DESCRIPTION
# Description

I added the same Copy Address button to the Discord ID in the Players search menu, so it will be easier to check what is the Discord accout that is linked to that farm

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] I have read the contributing guidelines and agree to the T&Cs