### PR TITLE
[FEAT] Change Lava Pit Requirements

### DIFF
--- a/src/features/game/events/landExpansion/startLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.test.ts
@@ -7,8 +7,8 @@ const TEST_FARM: GameState = {
   ...INITIAL_FARM,
   inventory: {
     ...INITIAL_FARM.inventory,
-    Oil: new Decimal(100),
-    Cobia: new Decimal(10),
+    Oil: new Decimal(120),
+    Pepper: new Decimal(1000),
   },
   season: {
     season: "summer",
@@ -57,7 +57,7 @@ describe("startLavaPit", () => {
       createdAt: now,
     });
 
-    expect(result.inventory.Oil).toEqual(new Decimal(40));
+    expect(result.inventory.Oil).toEqual(new Decimal(0));
   });
 
   it("starts the lava pit", () => {

--- a/src/features/game/events/landExpansion/startLavaPit.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.ts
@@ -10,21 +10,21 @@ import {
 export const LAVA_PIT_REQUIREMENTS: Record<TemperateSeasonName, Inventory> = {
   autumn: {
     "Royal Ornament": new Decimal(1),
-    "Celestial Frostbloom": new Decimal(1),
+    Broccoli: new Decimal(1500),
   },
   winter: {
-    "Merino Wool": new Decimal(50),
-    Crimsteel: new Decimal(1),
+    Onion: new Decimal(1000),
+    "Merino Wool": new Decimal(200),
   },
   spring: {
-    Gold: new Decimal(10),
-    Duskberry: new Decimal(1),
-    Lunara: new Decimal(1),
-    Celestine: new Decimal(1),
+    Celestine: new Decimal(2),
+    Duskberry: new Decimal(2),
+    Lunara: new Decimal(2),
+    Rhubarb: new Decimal(3000),
   },
   summer: {
-    Oil: new Decimal(60),
-    Cobia: new Decimal(5),
+    Oil: new Decimal(120),
+    Pepper: new Decimal(1000),
   },
 };
 


### PR DESCRIPTION
# Description

This PR introduces a change to the lava pit requirements. This aims to utilise more of the newer resources.

```
Spring:
Celestine - 2
Lunara - 2
Duskberry - 2
Rhubarb - 3000

Summer:
Oil - 120
Pepper - 1000

Autumn:
Royal Ornament - 1
Broccoli - 1500

Winter:
Merino Wool - 200
Onion - 1000
```

Fixes #issue

# What needs to be tested by the reviewer?

- Lava pit requests new resources

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
