### PR TITLE
[CHORE] Tweak Lava Pit Requirements

### DIFF
--- a/src/features/game/events/landExpansion/startLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.test.ts
@@ -9,8 +9,9 @@ const TEST_FARM: GameState = {
   ...INITIAL_FARM,
   inventory: {
     ...INITIAL_FARM.inventory,
-    Oil: new Decimal(120),
-    Pepper: new Decimal(1000),
+    Oil: new Decimal(100),
+    Pepper: new Decimal(750),
+    Zucchini: new Decimal(1000),
   },
   season: {
     season: "summer",

--- a/src/features/game/events/landExpansion/startLavaPit.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.ts
@@ -11,21 +11,26 @@ import { hasFeatureAccess } from "lib/flags";
 export const LAVA_PIT_REQUIREMENTS: Record<TemperateSeasonName, Inventory> = {
   autumn: {
     "Royal Ornament": new Decimal(1),
-    Broccoli: new Decimal(1500),
+    Artichoke: new Decimal(30),
+    Broccoli: new Decimal(750),
+    Yam: new Decimal(1000),
   },
   winter: {
-    Onion: new Decimal(1000),
     "Merino Wool": new Decimal(200),
+    Onion: new Decimal(400),
+    Turnip: new Decimal(200),
   },
   spring: {
     Celestine: new Decimal(2),
-    Duskberry: new Decimal(2),
     Lunara: new Decimal(2),
-    Rhubarb: new Decimal(3000),
+    Duskberry: new Decimal(2),
+    Rhubarb: new Decimal(2000),
+    Kale: new Decimal(100),
   },
   summer: {
-    Oil: new Decimal(120),
-    Pepper: new Decimal(1000),
+    Oil: new Decimal(100),
+    Pepper: new Decimal(750),
+    Zucchini: new Decimal(1000),
   },
 };
 


### PR DESCRIPTION
# Lava Pit Requirements Update

## Changes
This PR adjusts the resource requirements for the Lava Pit across all seasons to better balance gameplay and resource gathering.

### Autumn
- Added: 30 Artichoke
- Reduced: Broccoli from 1500 to 750
- Added: 1000 Yam

### Winter
- Reduced: Onion from 1000 to 400
- Added: 200 Turnip

### Spring
- Reduced: Rhubarb from 3000 to 2000
- Added: 100 Kale

### Summer
- Reduced: Oil from 120 to 100
- Reduced: Pepper from 1000 to 750
- Added: 1000 Zucchini

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]