### PR TITLE
[FEAT] Harvest Full Beehive Immediately on click

### DIFF
--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -127,7 +127,10 @@ export const Beehive: React.FC<Props> = ({ id }) => {
 
   const handleHiveClick = () => {
     if (!honeyProduced) return;
-
+    if (honeyReady) {
+      handleHarvestHoney();
+      return;
+    }
     setShowHoneyLevelModal(true);
   };
 

--- a/src/features/game/expansion/components/resources/beehive/beehiveMachine.ts
+++ b/src/features/game/expansion/components/resources/beehive/beehiveMachine.ts
@@ -231,7 +231,8 @@ export const beehiveMachine = createMachine<
         hive: (_, event) => {
           return (event as UpdateHive).updatedHive;
         },
-        honeyProduced: ({ hive }) => hive.honey.produced,
+        honeyProduced: (_, event) =>
+          (event as UpdateHive).updatedHive.honey.produced,
       }),
       removeActiveFlower: assign((_) => ({
         attachedFlower: undefined,


### PR DESCRIPTION
# Description

This PR allows players to harvest the beehive immediately when they click on a full beehive, skipping the beehive modal

This PR also fixes the issue where the beehive machine state didn't change when harvesting a full beehive

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
