### PR TITLE
[FIX] Fishing Mini Challenge

### DIFF
--- a/src/features/game/events/landExpansion/missFish.ts
+++ b/src/features/game/events/landExpansion/missFish.ts
@@ -21,9 +21,5 @@ export function missFish({ state }: Options): GameState {
     delete game.fishing.wharf.castedAt;
     delete game.fishing.wharf.caught;
     delete game.fishing.wharf.chum;
-
-    return {
-      ...game,
-    };
   });
 }

--- a/src/features/game/events/landExpansion/startLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.test.ts
@@ -115,33 +115,4 @@ describe("startLavaPit", () => {
 
     expect(result.lavaPits[1].collectedAt).toBeUndefined();
   });
-
-  it("returns the old cobia and oil requirements if the date is prior to 2025-06-16", () => {
-    /**
-     * Old requirements:
-     * Oil: 60
-     * Cobia: 5
-     */
-    spy.mockReturnValue({ NETWORK: "mainnet" });
-
-    const now = new Date("2025-06-15T23:59:59Z").getTime();
-    const result = startLavaPit({
-      state: {
-        ...TEST_FARM,
-        inventory: {
-          ...TEST_FARM.inventory,
-          Oil: new Decimal(120),
-          Cobia: new Decimal(10),
-        },
-        lavaPits: {
-          1: { x: 0, y: 0, createdAt: 0 },
-        },
-      },
-      action: { type: "lavaPit.started", id: "1" },
-      createdAt: now,
-    });
-
-    expect(result.inventory.Oil).toEqual(new Decimal(60));
-    expect(result.inventory.Cobia).toEqual(new Decimal(5));
-  });
 });


### PR DESCRIPTION
# Description

This PR fixes the fishing mini game which was always showing that you had caught the fish even when you failed at the mini game.

This was due to an immer error being thrown from the `missFish` action as we were returning a new object from the `produce` function.

<img width="516" alt="Screenshot 2025-06-16 at 10 33 16 AM" src="https://github.com/user-attachments/assets/37c1745d-1bc4-4837-a8b9-6e99515daf0c" />


# What needs to be tested by the reviewer?

- You can set the `fishDifficulty` to true inside of `FishermanNPC` and go fishing.
- Fail the mini game
- Confirm you see the "got away" modal
- Try again and win the mini game
- Confirm you got the fish you caught

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
