### PR TITLE
[FIX] Codex Crash

### DIFF
--- a/src/components/animation/SpriteAnimator.tsx
+++ b/src/components/animation/SpriteAnimator.tsx
@@ -79,6 +79,8 @@ export interface Props {
 }
 
 class Spritesheet extends React.Component<Props> {
+  private spriteRef = React.createRef<HTMLDivElement>();
+
   constructor(props: Props) {
     super(props);
 
@@ -180,6 +182,7 @@ class Spritesheet extends React.Component<Props> {
     const elSprite = React.createElement(
       "div",
       {
+        ref: this.spriteRef,
         className: `react-responsive-spritesheet ${this.id} ${className}`,
         style,
         onClick: () => onClick(this.setInstance()),
@@ -205,7 +208,9 @@ class Spritesheet extends React.Component<Props> {
     const imgLoadSprite = new Image();
     imgLoadSprite.src = image;
 
-    this.spriteEl = document.querySelector(`.${this.id}`);
+    this.spriteEl = this.spriteRef.current;
+    if (!this.spriteEl) return;
+
     this.spriteElContainer = this.spriteEl.querySelector(
       ".react-responsive-spritesheet-container",
     );

--- a/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
+++ b/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
@@ -201,10 +201,10 @@ export const MegaBountyBoardContent: React.FC<{ readonly?: boolean }> = ({
               <p className="text-sm">{t("bounties.board.empty")}</p>
             ) : (
               getObjectEntries(bountiesByCategory).map(
-                ([category, { categoryName, bounties }]) => {
+                ([category, { categoryName, bounties }], index) => {
                   if (bounties.length === 0) return null;
                   return (
-                    <div key={category}>
+                    <div key={`${category}-${index}`}>
                       <Label type="default" className="mb-2">
                         {categoryName}
                       </Label>


### PR DESCRIPTION
# Description

There was a problem where the codex was crashing when reopening after closing.

This was happening because the `SpriteAnimator` component was failing on subsequent renders when trying to access its DOM element. This was causing errors in components that use the `SpriteAnimator`, particularly in the `NPC` component when the Codex was reopened.

The component was using `document.querySelector` to find its element in `componentDidMount`, but this could run before React had finished rendering the element to the DOM. This timing issue was especially apparent on subsequent renders.

## Solution
Replaced the direct DOM query with React's ref system:
- Added a `spriteRef`
- Updated the element access to use `this.spriteRef.current`
- Added a safety check to handle cases where the ref might not be available

Fixes #issue

# What needs to be tested by the reviewer?

- Replace your local `tickets.json` leaderboard with the prod version.
- Open the codex and clock on the season tab
- Close the codex
- Open the codex again. Confirm there is no crash. 

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
