### PR TITLE
[FIX] Remove Network Requirement from Daily Box

### DIFF
--- a/src/features/game/expansion/components/dailyReward/DailyReward.tsx
+++ b/src/features/game/expansion/components/dailyReward/DailyReward.tsx
@@ -128,8 +128,6 @@ export const DailyRewardContent: React.FC<{
 }) => {
   const { t } = useAppTranslation();
 
-  const network = useSelector(gameService, _network);
-
   useEffect(() => {
     chestService.send("UPDATE_BUMPKIN_LEVEL", { bumpkinLevel });
   }, [bumpkinLevel]);
@@ -218,10 +216,7 @@ export const DailyRewardContent: React.FC<{
               }}
             />
           </div>
-          <Button
-            onClick={() => chestService.send("UNLOCK")}
-            disabled={!network}
-          >
+          <Button onClick={() => chestService.send("UNLOCK")}>
             {t("reward.unlock")}
           </Button>
         </>


### PR DESCRIPTION
# Description

The network requirement is now handled by the wallet wall. The network in the game state is no longer needed here.

# What needs to be tested by the reviewer?

Ensure daily box can be clicked.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
