### PR TITLE
[FIX] Event Portal linking to wrong URL

### DIFF
--- a/src/features/world/ui/portals/FestivalOfColors2025.tsx
+++ b/src/features/world/ui/portals/FestivalOfColors2025.tsx
@@ -146,7 +146,7 @@ export const FestivalOfColors2025: React.FC<Props> = ({ onClose }) => {
   if (isPlaying) {
     return (
       <div>
-        <Portal portalName={PORTAL_NAME} onClose={onClose} />
+        <Portal portalName={"festival-of-colors"} onClose={onClose} />
       </div>
     );
   }


### PR DESCRIPTION
# Description

This will fix the portal minigame for the next event and enable beta testers to test it before the event starts.
