### PR TITLE
[FIX] Add abort controller to autosaving request

### DIFF
--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -93,8 +93,8 @@ export async function autosaveRequest(
       deviceTrackerId: request.deviceTrackerId,
     }),
     // Just in case the request takes too long, abort it. Some players have requests
-    // that can take a long, so use a conservative timeout of x2 the autosave interval.
-    signal: AbortSignal.timeout(AUTO_SAVE_INTERVAL * 2),
+    // that can take a long, so use a conservative timeout of the autosave interval.
+    signal: AbortSignal.timeout(AUTO_SAVE_INTERVAL),
   });
 }
 

--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -74,14 +74,6 @@ export async function autosaveRequest(
   // Useful for using cached results
   const cachedKey = getSessionId();
 
-  // Just in case the request takes too long, abort it. Some players have requests
-  // that can take a long, so use a conservative timeout of x2 the autosave interval.
-  const controller = new AbortController();
-  const timeoutId = setTimeout(
-    () => controller.abort(),
-    AUTO_SAVE_INTERVAL * 2,
-  );
-
   const response = await window.fetch(`${API_URL}/autosave/${request.farmId}`, {
     method: "POST",
     headers: {
@@ -100,10 +92,10 @@ export async function autosaveRequest(
       cachedKey,
       deviceTrackerId: request.deviceTrackerId,
     }),
-    signal: controller.signal,
+    // Just in case the request takes too long, abort it. Some players have requests
+    // that can take a long, so use a conservative timeout of x2 the autosave interval.
+    signal: AbortSignal.timeout(AUTO_SAVE_INTERVAL * 2),
   });
-
-  clearTimeout(timeoutId);
 
   return response;
 }

--- a/src/features/game/actions/autosave.ts
+++ b/src/features/game/actions/autosave.ts
@@ -74,7 +74,7 @@ export async function autosaveRequest(
   // Useful for using cached results
   const cachedKey = getSessionId();
 
-  const response = await window.fetch(`${API_URL}/autosave/${request.farmId}`, {
+  return await window.fetch(`${API_URL}/autosave/${request.farmId}`, {
     method: "POST",
     headers: {
       ...{
@@ -96,8 +96,6 @@ export async function autosaveRequest(
     // that can take a long, so use a conservative timeout of x2 the autosave interval.
     signal: AbortSignal.timeout(AUTO_SAVE_INTERVAL * 2),
   });
-
-  return response;
 }
 
 let autosaveErrors = 0;


### PR DESCRIPTION
# Description

Adds an abort controller to the autosaving request, in case fetch never resolves (possibly in bad network conditions). This throws an unhanded exception as we don't know if the server received the request or not - and if the autosave failed or not. This should only happen in bad network conditions.

# What needs to be tested by the reviewer?

Manual inspection

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
