### PR TITLE
[FIX] Marketplace Price Change Arrows

### DIFF
--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -279,7 +279,11 @@ export function getMarketPrice({
       return listing.sfl < cheapest.sfl ? listing : cheapest;
     }, tradeable.listings[0]);
 
-    price = cheapestListing?.sfl ?? 0;
+    if (cheapestListing) {
+      price = cheapestListing.sfl / cheapestListing.quantity;
+    } else {
+      price = 0;
+    }
   } else if (tradeable?.history.sales.length) {
     // Set it to the latest sale
     price =


### PR DESCRIPTION
# Description

The calculation for resources was using the bundle price instead of the unit price.

I have fixed this.

<img width="300" alt="Screenshot 2025-06-26 at 3 18 11 PM" src="https://github.com/user-attachments/assets/bc7da565-a504-4a43-aa20-8d2344cc6f05" />

Fixes #issue

# What needs to be tested by the reviewer?

- Make some trades at different prices and confirm the changes

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
