### PR TITLE
[FEAT] Move Chapter Ticket to OFFCHAIN_ITEMS

### DIFF
--- a/src/features/game/lib/offChainItems.ts
+++ b/src/features/game/lib/offChainItems.ts
@@ -1,4 +1,5 @@
 import { getKeys, TOOLS } from "../types/craftables";
+import { SEASON_TICKET_NAME } from "../types/seasons";
 import { SEEDS } from "../types/seeds";
 import { TREASURE_TOOLS } from "../types/tools";
 
@@ -12,4 +13,5 @@ export const OFFCHAIN_ITEMS = [
   ...getKeys(SEEDS),
   ...getKeys(TOOLS),
   ...getKeys(TREASURE_TOOLS),
+  ...Object.values(SEASON_TICKET_NAME),
 ];


### PR DESCRIPTION
# Description

Since Chapter Tickets can't be traded anyways, no point in having it storing on chain.

This PR removes the hoard limit for chapter tickets

Fixes #issue
Edge Case: Player places bid for 5000 tickets, stores on chain, refunds bid, but because 5000 is above the 1500 hoard limit it won't let them claim it

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
