### PR TITLE
[Fix] Players not being able to buy unlimited attempts at the event portal

### DIFF
--- a/src/features/game/events/minigames/purchaseMinigameItem.test.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.test.ts
@@ -51,7 +51,7 @@ describe("minigame.itemPurchased", () => {
         action: {
           id: "chicken-rescue",
           type: "minigame.itemPurchased",
-          sfl: 101,
+          sfl: 201,
           items: {},
         },
       }),

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -12,7 +12,7 @@ import { produce } from "immer";
 
 export type MinigameCurrency = CropName | PatchFruitName | CommodityName;
 
-const SFL_LIMIT = 100;
+const SFL_LIMIT = 200;
 
 export const MINIGAME_CURRENCY_LIMITS: Record<MinigameCurrency, number> = {
   ...getKeys(COMMODITIES).reduce(


### PR DESCRIPTION
# Description
 
This PR changes the SFL limit that can be used to buy stuff inside portals. This is to enable the unlimited attempts at the new event portal.
