### PR TITLE
[FIX] Tiles Z Index 

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -41,16 +41,8 @@ import { BackgroundIslands } from "./components/BackgroundIslands";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Outlet, useLocation } from "react-router";
 import { createPortal } from "react-dom";
-<<<<<<< HEAD
 import { NON_COLLIDING_OBJECTS } from "./placeable/lib/collisionDetection";
-=======
-import {
-  getZIndex,
-  NON_COLLIDING_OBJECTS,
-  pickEmptyPosition,
-} from "./placeable/lib/collisionDetection";
-import { EXPANSION_ORIGINS, LAND_SIZE } from "./lib/constants";
->>>>>>> 95032b78a ([FIX] Tile positioning)
+import { getZIndex } from "./placeable/lib/collisionDetection";
 
 import {
   isBuildingUpgradable,

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -41,7 +41,16 @@ import { BackgroundIslands } from "./components/BackgroundIslands";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Outlet, useLocation } from "react-router";
 import { createPortal } from "react-dom";
+<<<<<<< HEAD
 import { NON_COLLIDING_OBJECTS } from "./placeable/lib/collisionDetection";
+=======
+import {
+  getZIndex,
+  NON_COLLIDING_OBJECTS,
+  pickEmptyPosition,
+} from "./placeable/lib/collisionDetection";
+import { EXPANSION_ORIGINS, LAND_SIZE } from "./lib/constants";
+>>>>>>> 95032b78a ([FIX] Tile positioning)
 
 import {
   isBuildingUpgradable,
@@ -182,6 +191,7 @@ const getIslandElements = ({
               key={`collectible-${nameIndex}-${itemIndex}`}
               x={x}
               y={y}
+              z={getZIndex(y, name)}
               height={height}
               width={width}
               canCollide={NON_COLLIDING_OBJECTS.includes(name) ? false : true}

--- a/src/features/game/expansion/components/MapPlacement.tsx
+++ b/src/features/game/expansion/components/MapPlacement.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { GRID_WIDTH_PX } from "../../lib/constants";
 import classNames from "classnames";
+import { getZIndex } from "../placeable/lib/collisionDetection";
 
 export type Coordinates = {
   x: number;
@@ -19,7 +20,7 @@ type Position = {
   y: number;
 };
 
-type Props = Position;
+type Props = Position & { id?: string };
 
 /**
  * This component is used to place items on the map. It uses the cartesian place coordinates
@@ -27,12 +28,13 @@ type Props = Position;
  * grid size up and one grid right. The item will be placed at 0,0 of this coordinate.
  */
 export const MapPlacement: React.FC<React.PropsWithChildren<Props>> = ({
+  id,
   x,
   y,
   height,
   width,
   children,
-  z = "unset",
+  z,
   canCollide = true,
   className,
 }) => {
@@ -44,7 +46,7 @@ export const MapPlacement: React.FC<React.PropsWithChildren<Props>> = ({
         left: `calc(50% + ${GRID_WIDTH_PX * x}px)`,
         height: height ? `${GRID_WIDTH_PX * height}px` : "auto",
         width: width ? `${GRID_WIDTH_PX * width}px` : "auto",
-        zIndex: z,
+        zIndex: z ?? getZIndex(y),
       }}
     >
       {children}

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -173,7 +173,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
         id="bg-overlay "
         className=" bg-black opacity-40 fixed inset-0"
         style={{
-          zIndex: 99,
+          zIndex: 1999,
           height: "200%",
           right: "-1000px",
           left: "-1000px",
@@ -182,7 +182,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
           bottom: "1000px",
         }}
       />
-      <div className="fixed left-1/2 top-1/2" style={{ zIndex: 100 }}>
+      <div className="fixed left-1/2 top-1/2" style={{ zIndex: 2000 }}>
         <Draggable
           key={`${origin?.x}-${origin?.y}`}
           defaultPosition={{ x: DEFAULT_POSITION_X, y: DEFAULT_POSITION_Y }}

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -325,6 +325,19 @@ export const NON_COLLIDING_OBJECTS: InventoryItemName[] = [
   "Long Rug",
 ];
 
+export function getZIndex(y: number, name?: InventoryItemName) {
+  if (name && NON_COLLIDING_OBJECTS.includes(name)) {
+    // Tiles are underneath everything
+    if (name.includes("Tile")) return 0;
+
+    // Rugs sit on top of tiles
+    return 1;
+  }
+
+  // Everything else is based on it y position
+  return -y + 1000;
+}
+
 function detectHomeCollision({
   state,
   position,

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -34,6 +34,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Geniseed: new Decimal(400),
     Wheat: new Decimal(400),
     Pickaxe: new Decimal(1),
+    "Blue Tile": new Decimal(1000),
     "Beta Pass": new Decimal(1),
     "Colors Token 2025": new Decimal(10000),
     "Magic Bean": new Decimal(1),


### PR DESCRIPTION
# Description

I have updated all items to have a z index based on their y position. Non colliding items which are currently tiles and rugs have 0 and 1 respectively. 

<img width="251" alt="Screenshot 2025-07-04 at 1 16 06 PM" src="https://github.com/user-attachments/assets/da59d3b9-42eb-4330-938c-0bcb70f5f13e" />

Fixes #issue

# What needs to be tested by the reviewer?

- Please test thoroughly placing, moving items both on your farm and in the house. 

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes