### PR TITLE
Making the Festival of Colors event last for one more day

### DIFF
--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -103,7 +103,7 @@ const FEATURE_FLAGS = {
 
   FESTIVALOFCOLORS: (game) =>
     betaTimeBasedFeatureFlag(new Date("2025-06-30T00:00:00Z"))(game) &&
-    Date.now() < new Date("2025-07-07T00:00:00Z").getTime(),
+    Date.now() < new Date("2025-07-08T00:00:00Z").getTime(),
 
   STREAM_STAGE_ACCESS: adminFeatureFlag,
 


### PR DESCRIPTION
This changes the feature flag for the festival of colors event for it to last one more day since there were some problems where players could not buy the attempts at the portal on the first hours of the event