### PR TITLE
[FIX] Only hide competition leaderboard

### DIFF
--- a/src/features/competition/CompetitionBoard.tsx
+++ b/src/features/competition/CompetitionBoard.tsx
@@ -130,7 +130,8 @@ export const CompetitionModal: React.FC<{
 export const CompetitionDetails: React.FC<{
   competitionName: CompetitionName;
   state: GameState;
-}> = ({ competitionName, state }) => {
+  hideLeaderboard?: boolean;
+}> = ({ competitionName, state, hideLeaderboard }) => {
   const { t } = useAppTranslation();
 
   const [task, setTask] = useState<CompetitionTaskName>();
@@ -239,7 +240,7 @@ export const CompetitionDetails: React.FC<{
           </div>
         </InnerPanel>
 
-        <CompetitionLeaderboard name={competitionName} />
+        {hideLeaderboard && <CompetitionLeaderboard name={competitionName} />}
 
         <InnerPanel>
           <div className="p-1">

--- a/src/features/island/hud/components/codex/Codex.tsx
+++ b/src/features/island/hud/components/codex/Codex.tsx
@@ -165,15 +165,11 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
           },
         ]
       : []),
-    ...(Date.now() < new Date("2025-07-17T00:00:00Z").getTime()
-      ? [
-          {
-            name: "Competition" as const,
-            icon: chefIcon,
-            count: 0,
-          },
-        ]
-      : []),
+    {
+      name: "Competition" as const,
+      icon: chefIcon,
+      count: 0,
+    },
   ];
 
   return (
@@ -284,6 +280,9 @@ export const Codex: React.FC<Props> = ({ show, onHide }) => {
                 <CompetitionDetails
                   competitionName="PEGGYS_COOKOFF"
                   state={state}
+                  hideLeaderboard={
+                    Date.now() < new Date("2025-07-17T00:00:00Z").getTime()
+                  }
                 />
               </div>
             )}


### PR DESCRIPTION
# Description

Hide Leaderboard instead of the whole comp tab

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
