### PR TITLE
[FIX] Panel and campaign link

### DIFF
--- a/src/features/game/components/modal/components/Merkl.tsx
+++ b/src/features/game/components/modal/components/Merkl.tsx
@@ -6,17 +6,13 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Button } from "components/ui/Button";
 import flowerIcon from "assets/icons/flower_token.webp";
 import giftIcon from "assets/icons/gift.png";
+import { Panel } from "components/ui/Panel";
 
 export const Merkl: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { t } = useAppTranslation();
 
-  const CAMPAIGN_ID =
-    Date.now() > new Date("2025-05-15T00:00:00Z").getTime()
-      ? "0xabce6aa5c2d11a0609450db0410af89add01f8fb1047bd1317b67e26b3cdf433"
-      : "0x89dd96c10c739800b241a2e77fc44b5c0766766d437501dd9dcfb0e4314e6de3";
-
   return (
-    <>
+    <Panel>
       <div className="p-1">
         <div className="flex flex-row justify-between">
           <Label
@@ -54,13 +50,13 @@ export const Merkl: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       <Button
         onClick={() =>
           window.open(
-            `https://app.merkl.xyz/opportunities/base/CLAMM/0xafE30319a948F322585faFC1Cab1671A47eB3786/leaderboard?campaignId=${CAMPAIGN_ID}&page=1`,
+            `https://app.merkl.xyz/opportunities/base/CLAMM/0xafE30319a948F322585faFC1Cab1671A47eB3786`,
             "_blank",
           )
         }
       >
         {t("read.more")}
       </Button>
-    </>
+    </Panel>
   );
 };


### PR DESCRIPTION
# Description

Merkl rewards panel was missing and the Read more was pointing to the wrong link.



<img width="528" height="309" alt="Screenshot 2025-07-21 at 10 20 03 AM" src="https://github.com/user-attachments/assets/214ae91f-d2bb-4d96-981c-3a2d175379f7" />


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
