### PR TITLE
[FIX] Daily Chest State Issue

### DIFF
--- a/src/features/game/components/modal/ModalProvider.tsx
+++ b/src/features/game/components/modal/ModalProvider.tsx
@@ -216,7 +216,11 @@ export const ModalProvider: FC<React.PropsWithChildren> = ({ children }) => {
 
       <Rewards show={opened === "EARN"} onHide={handleClose} tab={"Earn"} />
 
-      <DailyRewardChest show={opened === "DAILY_REWARD"} onHide={handleClose} />
+      <DailyRewardChest
+        show={opened === "DAILY_REWARD"}
+        onHide={handleClose}
+        tab={0}
+      />
     </ModalContext.Provider>
   );
 };

--- a/src/features/island/hud/components/referral/Rewards.tsx
+++ b/src/features/island/hud/components/referral/Rewards.tsx
@@ -143,7 +143,9 @@ export const Rewards: React.FC<Props> = ({ show, onHide, tab }) => {
 
 export type RewardType = "DAILY_REWARD" | "VIP" | "BLOCKCHAIN_BOX";
 
-export const RewardOptions: React.FC = () => {
+export const RewardOptions: React.FC<{ selectedButton?: RewardType }> = ({
+  selectedButton,
+}) => {
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, (state) => state.context.state);
 
@@ -174,7 +176,9 @@ export const RewardOptions: React.FC = () => {
     chestService.send("LOAD");
   }, [chestService]);
 
-  const [selected, setSelected] = useState<RewardType>();
+  const [selected, setSelected] = useState<RewardType | undefined>(
+    selectedButton,
+  );
   const { t } = useAppTranslation();
 
   if (selected === "DAILY_REWARD") {


### PR DESCRIPTION
# Description

Fixes the state issue where accessing DailyRewardContent via the daily chest shows reward as unclaimed after it was already claimed.

resolves #5875 


https://github.com/user-attachments/assets/c02c0597-8c32-4483-8510-9b144c8af445


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
