### PR TITLE
[FEAT] Expose player farm ID when visiting

### DIFF
--- a/src/features/game/actions/loadGameStateForVisit.ts
+++ b/src/features/game/actions/loadGameStateForVisit.ts
@@ -28,6 +28,8 @@ export async function loadGameStateForVisit(
 ): Promise<{
   state: VisitGameState;
   isBanned: boolean;
+  visitorId: number;
+  visitedFarmState: GameState;
 }> {
   // Go and fetch the state for the farm you are trying to visit
   const url = `${API_URL}/visit/${id}`;

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -167,6 +167,7 @@ export interface Context {
   oauthNonce: string;
   data: Partial<Record<StateMachineStateName, any>>;
   rawToken?: string;
+  visitorId?: number;
 }
 
 export type Moderation = {
@@ -648,10 +649,6 @@ export function startGame(authContext: AuthContext) {
           id: "loading",
           always: [
             {
-              target: "loadLandToVisit",
-              cond: () => window.location.href.includes("visit"),
-            },
-            {
               target: "error",
               cond: () => !!getError(),
               actions: assign({
@@ -709,6 +706,11 @@ export function startGame(authContext: AuthContext) {
             },
             onDone: [
               {
+                target: "loadLandToVisit",
+                cond: () => window.location.href.includes("visit"),
+                actions: ["assignGame"],
+              },
+              {
                 target: "blacklisted",
                 cond: (_, event) => {
                   return event.data.state.ban.status === "permanent";
@@ -763,33 +765,36 @@ export function startGame(authContext: AuthContext) {
         loadLandToVisit: {
           invoke: {
             src: async (_, event) => {
-              let landId: number;
+              let farmId: number;
 
               // We can enter this state two ways
               // 1. Directly on load if the url has a visit path (/visit)
               // 2. From a VISIT event passed back to the machine which will include a farmId in the payload
 
               if (!(event as VisitEvent).landId) {
-                landId = Number(window.location.href.split("/").pop());
+                farmId = Number(window.location.href.split("/").pop());
               } else {
-                landId = (event as VisitEvent).landId;
+                farmId = (event as VisitEvent).landId;
               }
 
-              const { state } = await loadGameStateForVisit(
-                Number(landId),
-                authContext.user.rawToken as string,
-              );
+              const { visitedFarmState, visitorId } =
+                await loadGameStateForVisit(
+                  Number(farmId),
+                  authContext.user.rawToken as string,
+                );
 
               return {
-                state: makeGame(state),
-                farmId: landId,
+                state: makeGame(visitedFarmState),
+                farmId,
+                visitorId,
               };
             },
             onDone: {
               target: "visiting",
               actions: assign({
-                state: (_context, event) => event.data.state,
-                farmId: (_context, event) => event.data.farmId,
+                state: (_, event) => event.data.state,
+                farmId: (_, event) => event.data.farmId,
+                visitorId: (_, event) => event.data.visitorId,
               }),
             },
             onError: {
@@ -809,6 +814,9 @@ export function startGame(authContext: AuthContext) {
         },
         visiting: {
           on: {
+            SAVE: {
+              target: "autosaving",
+            },
             VISIT: {
               target: "loadLandToVisit",
             },
@@ -1450,10 +1458,11 @@ export function startGame(authContext: AuthContext) {
           },
           invoke: {
             src: async (context, event) => {
+              const farmId = context.visitorId ?? context.farmId;
               const data = await saveGame(
                 context,
                 event,
-                context.farmId as number,
+                farmId as number,
                 authContext.user.rawToken as string,
               );
 
@@ -1498,6 +1507,15 @@ export function startGame(authContext: AuthContext) {
                     game.calendar[activeEvent].acknowledgedAt;
 
                   return !isAcknowledged;
+                },
+                actions: assign((context: Context, event) =>
+                  handleSuccessfulSave(context, event),
+                ),
+              },
+              {
+                target: "visiting",
+                cond: (context) => {
+                  return !!context.visitorId;
                 },
                 actions: assign((context: Context, event) =>
                   handleSuccessfulSave(context, event),


### PR DESCRIPTION
# Description

Added `visitorId` to the gameMachine in order to have access to the player's farm ID when visiting

# What needs to be tested by the reviewer?

Visit a farm, your farm ID should be in `context.visitorId` and the farm you're visiting is still `context.farmId`

