### PR TITLE
[FIX] Crop Machine not showing previous generated amount

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -260,7 +260,7 @@ export const CropMachineModalContent: React.FC<Props> = ({
 
   const allowedSeeds = ALLOWED_SEEDS(state.bumpkin, inventory);
   const cropYield = selectedPack
-    ? getPackYieldAmount(state, selectedPack).amount
+    ? selectedPack.amount ?? getPackYieldAmount(state, selectedPack).amount
     : 0;
 
   return (


### PR DESCRIPTION
# Description

Crop Machine was showing the wrong amount if yield was generated prior to the yield calculation changes

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
