### PR TITLE
[FEAT] Claim Cheers Daily

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -513,6 +513,10 @@ import {
 } from "./landExpansion/removeBeehive";
 import { removeAll, RemoveAllAction } from "./landExpansion/removeAll";
 import { wakeAnimal, WakeUpAnimalAction } from "./landExpansion/wakeUpAnimal";
+import {
+  ClaimCheersAction,
+  claimDailyCheers,
+} from "./landExpansion/claimDailyCheers";
 
 export type PlayingEvent =
   | ObsidianExchangedAction
@@ -657,7 +661,8 @@ export type PlayingEvent =
   | InstantCraftAction
   | BuyBiomeAction
   | ApplyBiomeAction
-  | WakeUpAnimalAction;
+  | WakeUpAnimalAction
+  | ClaimCheersAction;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -883,6 +888,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "biome.bought": buyBiome,
   "biome.applied": applyBiome,
   "animal.wakeUp": wakeAnimal,
+  "cheers.claimed": claimDailyCheers,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/landExpansion/claimDailyCheers.test.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.test.ts
@@ -1,0 +1,73 @@
+import { claimDailyCheers } from "./claimDailyCheers";
+import { INITIAL_FARM } from "features/game/lib/constants";
+
+describe("claimDailyCheers", () => {
+  it("should claim daily free cheers", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: INITIAL_FARM,
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.socialFarming.cheers.cheersUsed).toBe(0);
+    expect(game?.socialFarming.cheers.freeCheersClaimedAt).toBe(now);
+  });
+
+  it("should prevent claiming a daily cheers twice in one day", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: INITIAL_FARM,
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(() =>
+      claimDailyCheers({
+        state: game,
+        action: { type: "cheers.claimed" },
+        createdAt: now,
+      }),
+    ).toThrow("Already claimed your daily free cheers");
+  });
+
+  it("gives three free cheers to the player", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: INITIAL_FARM,
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.inventory.Cheer?.toNumber()).toBe(3);
+  });
+
+  it("should only give bonus cheers if the player has used their free cheers", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: {
+        ...INITIAL_FARM,
+        socialFarming: {
+          points: 0,
+          villageProjects: {},
+          cheeredProjects: {
+            date: new Date(now).toISOString().split("T")[0],
+            projects: {},
+          },
+          cheers: {
+            freeCheersClaimedAt: now - 24 * 60 * 60 * 1000,
+            cheersUsed: 2,
+          },
+        },
+      },
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.inventory.Cheer?.toNumber()).toBe(1);
+  });
+});

--- a/src/features/game/events/landExpansion/claimDailyCheers.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.ts
@@ -1,0 +1,56 @@
+import Decimal from "decimal.js-light";
+import { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+export type ClaimCheersAction = {
+  type: "cheers.claimed";
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: ClaimCheersAction;
+  createdAt?: number;
+};
+
+export function claimDailyCheers({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options) {
+  return produce(state, (draft) => {
+    const {
+      socialFarming: { cheers },
+    } = draft;
+
+    const today = new Date(createdAt).toISOString().split("T")[0];
+    const yesterday = new Date(createdAt - 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+
+    if (cheers.freeCheersClaimedAt >= new Date(today).getTime()) {
+      throw new Error("Already claimed your daily free cheers");
+    }
+
+    const dayFreeCheersClaimed = new Date(cheers.freeCheersClaimedAt)
+      .toISOString()
+      .split("T")[0];
+
+    const cheersUsedYesterday =
+      dayFreeCheersClaimed === yesterday ? cheers.cheersUsed : 0;
+
+    const newCheerCount = 3 - cheersUsedYesterday;
+
+    if (newCheerCount <= 0) {
+      throw new Error("Not enough cheers to claim");
+    }
+
+    draft.inventory.Cheer = new Decimal(newCheerCount);
+
+    if (cheers.freeCheersClaimedAt < new Date(today).getTime()) {
+      cheers.freeCheersClaimedAt = createdAt;
+      cheers.cheersUsed = 0;
+    }
+
+    return draft;
+  });
+}

--- a/src/features/game/events/landExpansion/claimDailyCheers.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import { produce } from "immer";
+import { hasFeatureAccess } from "lib/flags";
 
 export type ClaimCheersAction = {
   type: "cheers.claimed";
@@ -18,6 +19,10 @@ export function claimDailyCheers({
   createdAt = Date.now(),
 }: Options) {
   return produce(state, (draft) => {
+    if (!hasFeatureAccess(draft, "CHEERS")) {
+      throw new Error("Cheers feature is not enabled");
+    }
+
     const {
       socialFarming: { cheers },
     } = draft;

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -92,6 +92,7 @@ import { ClaimReferralRewards } from "./components/ClaimReferralRewards";
 import { SoftBan } from "features/retreat/components/personhood/SoftBan";
 import { RewardBox } from "features/rewardBoxes/RewardBox";
 import { ClaimBlessingReward } from "features/loveIsland/blessings/ClaimBlessing";
+import { Cheering } from "./components/Cheering";
 
 function camelToDotCase(str: string): string {
   return str.replace(/([a-z])([A-Z])/g, "$1.$2").toLowerCase() as string;
@@ -180,6 +181,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   jinAirdrop: true,
   investigating: true,
   blessing: true,
+  cheers: true,
 };
 
 // State change selectors
@@ -267,6 +269,7 @@ const isRoninWelcomePack = (state: MachineState) =>
   state.matches("roninWelcomePack");
 const isRoninAirdrop = (state: MachineState) => state.matches("roninAirdrop");
 const isJinAirdrop = (state: MachineState) => state.matches("jinAirdrop");
+const isCheers = (state: MachineState) => state.matches("cheers");
 
 const GameContent: React.FC<{ isVisiting: boolean }> = ({ isVisiting }) => {
   const { gameService } = useContext(Context);
@@ -442,6 +445,7 @@ export const GameWrapper: React.FC<React.PropsWithChildren> = ({
   const showPWAInstallPrompt = useSelector(authService, _showPWAInstallPrompt);
   const investigating = useSelector(gameService, isInvestigating);
   const blessing = useSelector(gameService, isBlessing);
+  const cheers = useSelector(gameService, isCheers);
 
   const { t } = useAppTranslation();
   useInterval(() => {
@@ -644,6 +648,7 @@ export const GameWrapper: React.FC<React.PropsWithChildren> = ({
                 onClose={() => gameService.send("ACKNOWLEDGE")}
               />
             )}
+            {cheers && <Cheering />}
           </Panel>
         </Modal>
 

--- a/src/features/game/expansion/components/Cheering.tsx
+++ b/src/features/game/expansion/components/Cheering.tsx
@@ -1,0 +1,32 @@
+import { Button } from "components/ui/Button";
+
+import React, { useContext } from "react";
+import { Context } from "features/game/GameProvider";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { Label } from "components/ui/Label";
+import cheer from "assets/icons/cheer.webp";
+import chest from "assets/icons/chest.png";
+
+export const Cheering: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const { t } = useAppTranslation();
+  return (
+    <div>
+      <Label type="warning" icon={cheer} secondaryIcon={chest} className="ml-2">
+        {t("cheers")}
+      </Label>
+      <div className="flex flex-col p-2 text-xs space-y-1">
+        <span>{t("cheering.free.description")}</span>
+        <span>{t("cheering.free.description2")}</span>
+      </div>
+      <Button
+        onClick={() => {
+          gameService.send("cheers.claimed");
+          gameService.send("ACKNOWLEDGE");
+        }}
+      >
+        {t("cheering.free.claim")}
+      </Button>
+    </div>
+  );
+};

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -684,6 +684,10 @@ export const INITIAL_FARM: GameState = {
       date: "",
       projects: {},
     },
+    cheers: {
+      cheersUsed: 0,
+      freeCheersClaimedAt: 0,
+    },
   },
 };
 
@@ -998,6 +1002,10 @@ export const TEST_FARM: GameState = {
       date: new Date().toISOString().split("T")[0],
       projects: {},
     },
+    cheers: {
+      cheersUsed: 0,
+      freeCheersClaimedAt: 0,
+    },
   },
 };
 
@@ -1160,6 +1168,10 @@ export const EMPTY: GameState = {
     cheeredProjects: {
       date: new Date().toISOString().split("T")[0],
       projects: {},
+    },
+    cheers: {
+      cheersUsed: 0,
+      freeCheersClaimedAt: 0,
     },
   },
 };

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -1174,6 +1174,8 @@ export function startGame(authContext: AuthContext) {
             {
               target: "cheers",
               cond: (context) => {
+                if (!hasFeatureAccess(context.state, "CHEERS")) return false;
+
                 const now = Date.now();
 
                 const today = new Date(now).toISOString().split("T")[0];
@@ -1185,7 +1187,7 @@ export function startGame(authContext: AuthContext) {
                   context.state.socialFarming.cheers.freeCheersClaimedAt >=
                   new Date(today).getTime()
                 ) {
-                  throw new Error("Already claimed your daily free cheers");
+                  return false;
                 }
 
                 const dayFreeCheersClaimed = new Date(

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -1099,5 +1099,9 @@ export const STATIC_OFFLINE_FARM: GameState = {
       date: new Date().toISOString().split("T")[0],
       projects: {},
     },
+    cheers: {
+      cheersUsed: 0,
+      freeCheersClaimedAt: 0,
+    },
   },
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1793,6 +1793,10 @@ export interface GameState {
       date: string;
       projects: Partial<Record<VillageProjectName, number[]>>;
     };
+    cheers: {
+      cheersUsed: number;
+      freeCheersClaimedAt: number;
+    };
   };
 }
 

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -132,6 +132,7 @@ const FEATURE_FLAGS = {
       start: new Date(COMPETITION_POINTS.PEGGYS_COOKOFF.startAt),
       end: new Date(COMPETITION_POINTS.PEGGYS_COOKOFF.endAt),
     })(),
+  CHEERS: timeBasedFeatureFlag(new Date("2025-08-04T00:00:00Z")),
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6358,5 +6358,9 @@
   "sleepingAnimal.wakeUp": "Wake up",
   "removeAll.description.one": "This action will remove all items from the {{location}}.",
   "removeAll.description.two": "Are you sure you want to continue?",
-  "removeAll.title": "Remove All Items"
+  "removeAll.title": "Remove All Items",
+  "cheers": "Cheers",
+  "cheering.free.description": "Every day you can claim up to 3 free cheers.",
+  "cheering.free.description2": "Cheers can be given to your fellow farmers to support their farms.",
+  "cheering.free.claim": "Claim Cheers"
 }


### PR DESCRIPTION
# Description

Introduces the ability to claim cheers. You can get a max of 3 cheers per day. If you don't use 2 cheers, the next day you will only receive one free cheer. However additional cheers, such as those acquired via garbo will not be part of this count.

<img width="590" height="235" alt="1" src="https://github.com/user-attachments/assets/c2e673a9-1699-46ab-860b-db0481864063" />


# What needs to be tested by the reviewer?

1. Load the game
2. Claim your cheers

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes