### PR TITLE
[FEAT] Better Together Auctions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import ErrorBoundary from "features/auth/components/ErrorBoundary";
 import { Navigation } from "./Navigation";
 import "./lib/i18n";
 import { WalletProvider } from "features/wallet/WalletProvider";
-import { useServiceWorkerUpdate } from "lib/utils/hooks/useServiceWorkerUpdate";
 
 // Initialise Global Settings
 initialise();
@@ -39,7 +38,7 @@ const NoServiceWorker = () => {
 };
 
 const ServiceWorker = () => {
-  useServiceWorkerUpdate();
+  // useServiceWorkerUpdate();
   return null;
 };
 

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -923,6 +923,23 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<
       boostedItemIcon: ITEM_DETAILS["Rapid Root"].image,
     },
   ],
+  "Lava Swimwear": [
+    {
+      shortDescription: translate("bumpkinItemBuff.lava.swimwear.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS["Lava Pit"].image,
+    },
+  ],
+  "Oil Gallon": [
+    {
+      shortDescription: translate("bumpkinItemBuff.oil.gallon.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Oil"].image,
+    },
+  ],
+
   ...SPECIAL_ITEM_LABELS,
   ...Object.fromEntries(
     getObjectEntries(CHAPTER_TICKET_BOOST_ITEMS)

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -1553,5 +1553,29 @@ function getCollectibleBuffLabels(
         boostTypeIcon: powerup,
       },
     ],
+    "Groovy Gramophone": [
+      {
+        shortDescription: translate("description.groovy.gramophone.boost"),
+        labelType: "info",
+        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+        boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,
+      },
+    ],
+    "Giant Onion": [
+      {
+        shortDescription: translate("description.giantOnion.boost"),
+        labelType: "success",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS["Onion"].image,
+      },
+    ],
+    "Giant Turnip": [
+      {
+        shortDescription: translate("description.giantTurnip.boost"),
+        labelType: "info",
+        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+        boostedItemIcon: ITEM_DETAILS["Turnip"].image,
+      },
+    ],
   };
 }

--- a/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
@@ -189,6 +189,7 @@ export const AuctioneerContent: React.FC<Props> = ({
     <Auctions
       auctionService={auctionService}
       onSelect={(id) => setSelectedAuctionId(id)}
+      game={gameState}
     />
   );
 };

--- a/src/features/retreat/components/auctioneer/Auctions.tsx
+++ b/src/features/retreat/components/auctioneer/Auctions.tsx
@@ -14,12 +14,20 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { getImageUrl } from "lib/utils/getImageURLS";
 import classNames from "classnames";
 import { isMobile } from "mobile-device-detect";
+import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
+import { GameState } from "features/game/types/game";
 
 interface Props {
   auctionService: MachineInterpreter;
   onSelect: (id: string) => void;
+  game: GameState;
 }
-export const Auctions: React.FC<Props> = ({ auctionService, onSelect }) => {
+export const Auctions: React.FC<Props> = ({
+  auctionService,
+  onSelect,
+  game,
+}) => {
   const [auctioneerState] = useActor(auctionService);
   const { t } = useAppTranslation();
 
@@ -42,6 +50,11 @@ export const Auctions: React.FC<Props> = ({ auctionService, onSelect }) => {
           auction.type === "collectible"
             ? ITEM_DETAILS[auction.collectible].image
             : getImageUrl(ITEM_IDS[auction.wearable]);
+
+        const hasBuff =
+          auction.type === "collectible"
+            ? !!COLLECTIBLE_BUFF_LABELS(game)[auction.collectible]
+            : !!BUMPKIN_ITEM_BUFF_LABELS[auction.wearable];
 
         return (
           <ButtonPanel
@@ -70,6 +83,12 @@ export const Auctions: React.FC<Props> = ({ auctionService, onSelect }) => {
                     auction.type !== "collectible",
                 })}
               />
+              {hasBuff && (
+                <img
+                  src={"/erc1155/images/small_boost.png"}
+                  className="absolute top-[1px] right-[1px] z-20"
+                />
+              )}
               <Label type="default" className="absolute bottom-1 right-1 z-20">
                 {auction.supply}
               </Label>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -519,6 +519,8 @@
   "bumpkinItemBuff.goblin.medallion.boost": "-25% Cooking Time",
   "bumpkinItemBuff.nightshade.medallion.boost": "-25% Cooking Time",
   "bumpkinItemBuff.sunflorian.medallion.boost": "-25% Cooking Time",
+  "bumpkinItemBuff.lava.swimwear.boost": "-50% Lava Pit resources",
+  "bumpkinItemBuff.oil.gallon.boost": "+5 Oil",
   "equip.background": "Background",
   "equip.hair": "Hair",
   "equip.body": "Body",
@@ -6363,5 +6365,8 @@
   "cheering.free.description": "Every day you can claim up to 3 free cheers.",
   "cheering.free.description2": "Cheers can be given to your fellow farmers to support their farms.",
   "cheering.free.claim": "Claim Cheers",
-  "description.turdTopper.boost": "+1 Fertiliser from Composters"
+  "description.turdTopper.boost": "+1 Fertiliser from Composters",
+  "description.giantOnion.boost": "+3 Onions",
+  "description.giantTurnip.boost": "2x Turnip Growth Speed",
+  "description.groovy.gramophone.boost": "+100% Growth Speed on Crop Machine"
 }


### PR DESCRIPTION
# Description

- Adds the Auctions for the Better together season.
- Also programmatically adds boost label in top right corner of auction list.

<img width="500" height="372" alt="1" src="https://github.com/user-attachments/assets/68898cce-c139-4956-8026-082a7fe6b401" />

# What needs to be tested by the reviewer?

1. Load BE and FE
2. Browse auction list, check for conflicts
3. Compare auctions to the auctions master list

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes