### PR TITLE
[FEAT] VIP Items Better Together

### DIFF
--- a/src/features/game/events/landExpansion/startComposter.test.ts
+++ b/src/features/game/events/landExpansion/startComposter.test.ts
@@ -938,4 +938,47 @@ describe("start Premium Composter", () => {
       newState.buildings["Premium Composter"]?.[0].producing?.readyAt,
     ).toBe(dateNow + 10.8 * 60 * 60 * 1000);
   });
+
+  it("gives +1 Rapid Root with Turd Topper", () => {
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        Onion: new Decimal(5),
+        Turnip: new Decimal(2),
+      },
+      wardrobe: {
+        "Turd Topper": 1,
+      },
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        equipped: {
+          ...INITIAL_BUMPKIN.equipped,
+          hat: "Turd Topper",
+        },
+      },
+      buildings: {
+        "Turbo Composter": [
+          {
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            id: "0",
+          },
+        ],
+      },
+    };
+
+    const newState = startComposter({
+      createdAt: dateNow,
+      state,
+      action: { type: "composter.started", building: "Turbo Composter" },
+    });
+
+    expect(
+      newState.buildings["Turbo Composter"]?.[0].producing?.items[
+        "Fruitful Blend"
+      ],
+    ).toBe(4);
+  });
 });

--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -11,11 +11,11 @@ import {
   CompostBuilding,
   GameState,
   InventoryItemName,
-  Skills,
 } from "features/game/types/game";
 import { translate } from "lib/i18n/translate";
 import { produce } from "immer";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+import { isWearableActive } from "features/game/lib/wearables";
 
 export type StartComposterAction = {
   type: "composter.started";
@@ -54,14 +54,15 @@ export function getReadyAt({
 }
 
 export function getCompostAmount({
-  skills,
+  game,
   building,
 }: {
-  skills: Skills;
+  game: GameState;
   building: ComposterName;
 }): { produceAmount: number; boostsUsed: BoostName[] } {
   let { produceAmount } = composterDetails[building];
   const boostsUsed: BoostName[] = [];
+  const { skills } = game.bumpkin;
 
   if (skills["Efficient Bin"] && building === "Compost Bin") {
     produceAmount += 5;
@@ -86,6 +87,10 @@ export function getCompostAmount({
   if (skills["Composting Revamp"]) {
     produceAmount += 5;
     boostsUsed.push("Composting Revamp");
+  }
+
+  if (isWearableActive({ game, name: "Turd Topper" })) {
+    produceAmount += 1;
   }
 
   if (produceAmount < 0) {
@@ -141,7 +146,7 @@ export function startComposter({
 
     const { produceAmount, boostsUsed: composterBoostsUsed } = getCompostAmount(
       {
-        skills,
+        game: stateCopy,
         building,
       },
     );

--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -91,6 +91,7 @@ export function getCompostAmount({
 
   if (isWearableActive({ game, name: "Turd Topper" })) {
     produceAmount += 1;
+    boostsUsed.push("Turd Topper");
   }
 
   if (produceAmount < 0) {

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -915,6 +915,14 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
     },
   ],
+  "Turd Topper": [
+    {
+      shortDescription: translate("description.turdTopper.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Rapid Root"].image,
+    },
+  ],
   ...SPECIAL_ITEM_LABELS,
   ...Object.fromEntries(
     getObjectEntries(CHAPTER_TICKET_BOOST_ITEMS)

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -248,7 +248,7 @@ const ComposterModalContent: React.FC<{
   const { resourceBoostRequirements } = getSpeedUpCost(state, composterName);
 
   const { produceAmount } = getCompostAmount({
-    skills: bumpkin.skills,
+    game: state,
     building: composterName,
   });
 

--- a/src/features/world/ui/VIPGift.tsx
+++ b/src/features/world/ui/VIPGift.tsx
@@ -71,7 +71,7 @@ export const VIPGiftContent: React.FC<Props> = ({ onClose }) => {
   const hasVip = hasVipAccess({ game: gameState.context.state });
   const rewardEntry = MONTHLY_REWARDS_DATES.sort(
     (a, b) => new Date(b).getTime() - new Date(a).getTime(),
-  ).find(([key]) => {
+  ).find((key) => {
     const rewardStartDate = new Date(key);
     return currentDate >= rewardStartDate;
   });

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6362,5 +6362,6 @@
   "cheers": "Cheers",
   "cheering.free.description": "Every day you can claim up to 3 free cheers.",
   "cheering.free.description2": "Cheers can be given to your fellow farmers to support their farms.",
-  "cheering.free.claim": "Claim Cheers"
+  "cheering.free.claim": "Claim Cheers",
+  "description.turdTopper.boost": "+1 Fertiliser from Composters"
 }


### PR DESCRIPTION
# Description

- Adds the VIP items into the VIP chest for the better together season 
- Adds the Turd Topper boost in game

# What needs to be tested by the reviewer?

1. Add the items to your inventory
2. Assert that they do not crash the game

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]