### PR TITLE
[FEAT] Add Better Together Megastore

### DIFF
--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -93,9 +93,9 @@ export const CHAPTER_TICKET_BOOST_ITEMS: Record<
 
   // TODO: Add Better Together items
   "Better Together": {
-    basic: "Cow Scratcher",
-    rare: "Cow Scratcher",
-    epic: "Cow Scratcher",
+    basic: "Garbage Bin Hat",
+    rare: "Raccoon Onesie",
+    epic: "Recycle Shirt",
   },
 };
 

--- a/src/features/game/types/bumpkinItemBuffs.ts
+++ b/src/features/game/types/bumpkinItemBuffs.ts
@@ -939,7 +939,28 @@ export const BUMPKIN_ITEM_BUFF_LABELS: Partial<
       boostedItemIcon: ITEM_DETAILS["Oil"].image,
     },
   ],
-
+  "Architect Ruler": [
+    {
+      shortDescription: translate("description.architectRuler.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Crafting Box"].image,
+    },
+  ],
+  "Pickaxe Shark": [
+    {
+      shortDescription: translate("description.pickaxeShark.boost.1"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Gold"].image,
+    },
+    {
+      shortDescription: translate("description.pickaxeShark.boost.2"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Gold"].image,
+    },
+  ],
   ...SPECIAL_ITEM_LABELS,
   ...Object.fromEntries(
     getObjectEntries(CHAPTER_TICKET_BOOST_ITEMS)

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -1593,5 +1593,35 @@ function getCollectibleBuffLabels(
         boostedItemIcon: SUNNYSIDE.animals.chickenAsleep,
       },
     ],
+    "Reelmaster's Chair": [
+      {
+        shortDescription: translate("description.reelmastersChair.boost"),
+        labelType: "success",
+        boostTypeIcon: powerup,
+      },
+    ],
+    "Music Box": [
+      {
+        shortDescription: translate("description.musicBox.boost"),
+        labelType: "info",
+        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+        boostedItemIcon: ITEM_DETAILS["Fruit Patch"].image,
+      },
+    ],
+    "Double Bed": [
+      {
+        shortDescription: translate("description.doubleBed.boost"),
+        labelType: "vibrant",
+        boostTypeIcon: lightning,
+      },
+    ],
+    "Giant Artichoke": [
+      {
+        shortDescription: translate("description.giantArtichoke.boost"),
+        labelType: "success",
+        boostTypeIcon: powerup,
+        boostedItemIcon: ITEM_DETAILS["Artichoke"].image,
+      },
+    ],
   };
 }

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -747,7 +747,7 @@ const BETTER_TOGETHER_ITEMS: SeasonalStore = {
       },
       {
         wearable: "Raccoon Onesie",
-        cost: { sfl: 0, items: { Geniseed: 700 } },
+        cost: { sfl: 0, items: { Bracelet: 700 } },
       },
     ],
     requirement: 4,

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -71,6 +71,13 @@ export type SeasonalWearableName = Extract<
   | "Love Charm Shirt"
   | "Frost Sword"
   | "Oracle Syringe"
+
+  // Better Together
+  | "Garbage Bin Hat"
+  | "Architect Ruler"
+  | "Raccoon Onesie"
+  | "Recycle Shirt"
+  | "Pickaxe Shark"
 >;
 
 export type MegastoreKeys = "Treasure Key" | "Rare Key" | "Luxury Key";
@@ -687,6 +694,112 @@ const GREAT_BLOOM_ITEMS: SeasonalStore = {
   },
 };
 
+const BETTER_TOGETHER_ITEMS: SeasonalStore = {
+  basic: {
+    items: [
+      {
+        collectible: "Floor Mirror",
+        cost: { sfl: 5, items: {} },
+      },
+      {
+        collectible: "Long Rug",
+        cost: { sfl: 0, items: { Bracelet: 50 } },
+      },
+      {
+        collectible: "Garbage Bin",
+        cost: { sfl: 0, items: { Coprolite: 25 } },
+      },
+      {
+        collectible: "Bronze Flower Box",
+        cost: { sfl: 0, items: { Bracelet: 450 } },
+      },
+      {
+        collectible: "Treasure Key",
+        cost: { sfl: 0, items: { Bracelet: 250 } },
+      },
+      {
+        wearable: "Garbage Bin Hat",
+        cost: { sfl: 0, items: { Bracelet: 300 } },
+      },
+    ],
+  },
+  rare: {
+    items: [
+      {
+        collectible: "Wheelbarrow",
+        cost: { sfl: 60, items: {} },
+      },
+      {
+        collectible: "Snail King",
+        cost: { sfl: 0, items: { Coprolite: 85 } },
+      },
+      {
+        collectible: "Silver Flower Box",
+        cost: { sfl: 0, items: { Bracelet: 1000 } },
+      },
+      {
+        collectible: "Rare Key",
+        cost: { sfl: 0, items: { Bracelet: 500 } },
+      },
+      {
+        wearable: "Architect Ruler",
+        cost: { sfl: 0, items: { Bracelet: 2500 } },
+      },
+      {
+        wearable: "Raccoon Onesie",
+        cost: { sfl: 0, items: { Geniseed: 700 } },
+      },
+    ],
+    requirement: 4,
+  },
+  epic: {
+    items: [
+      {
+        collectible: "Reelmaster's Chair",
+        cost: { sfl: 0, items: { Coprolite: 160 } },
+      },
+      {
+        collectible: "Rat King",
+        cost: { sfl: 0, items: { Bracelet: 1250 } },
+      },
+      {
+        collectible: "Fruit Tune Box",
+        cost: { sfl: 0, items: { Bracelet: 3500 } },
+      },
+      {
+        collectible: "Gold Flower Box",
+        cost: { sfl: 0, items: { Bracelet: 2000 } },
+      },
+      {
+        collectible: "Luxury Key",
+        cost: { sfl: 0, items: { Bracelet: 1000 } },
+      },
+      {
+        collectible: "Double Bed",
+        cost: { sfl: 0, items: { Wool: 5000, Gem: 2500, Bracelet: 1250 } },
+      },
+      {
+        wearable: "Recycle Shirt",
+        cost: { sfl: 400, items: {} },
+      },
+    ],
+    requirement: 4,
+  },
+  mega: {
+    items: [
+      {
+        collectible: "Giant Artichoke",
+        cost: { sfl: 0, items: { Bracelet: 5500 } },
+      },
+      {
+        wearable: "Pickaxe Shark",
+        cost: { sfl: 0, items: { Bracelet: 8000 } },
+      },
+    ],
+    requirement: 4,
+  },
+};
+
 export const MEGASTORE: Record<SeasonName, SeasonalStore> = {
   "Catch the Kraken": EMPTY_SEASONAL_STORE,
   "Clash of Factions": EMPTY_SEASONAL_STORE,
@@ -748,5 +861,5 @@ export const MEGASTORE: Record<SeasonName, SeasonalStore> = {
   "Great Bloom": GREAT_BLOOM_ITEMS,
 
   // TODO: To add Better Together items
-  "Better Together": EMPTY_SEASONAL_STORE,
+  "Better Together": BETTER_TOGETHER_ITEMS,
 };

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -69,12 +69,10 @@ export const SEASONS: Record<SeasonName, SeasonDates> = {
   },
   "Great Bloom": {
     startDate: new Date("2025-05-01T00:00:00.000Z"),
-    // TODO DO NOT COMMIT
-    endDate: new Date("2025-07-30T00:00:00.000Z"),
+    endDate: new Date("2025-08-04T00:00:00.000Z"),
   },
   "Better Together": {
-    // TODO DO NOT COMMIT
-    startDate: new Date("2025-07-30T00:00:00.000Z"),
+    startDate: new Date("2025-08-04T00:00:00.000Z"),
     endDate: new Date("2025-11-03T00:00:00.000Z"),
   },
 };

--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -69,10 +69,12 @@ export const SEASONS: Record<SeasonName, SeasonDates> = {
   },
   "Great Bloom": {
     startDate: new Date("2025-05-01T00:00:00.000Z"),
-    endDate: new Date("2025-08-04T00:00:00.000Z"),
+    // TODO DO NOT COMMIT
+    endDate: new Date("2025-07-30T00:00:00.000Z"),
   },
   "Better Together": {
-    startDate: new Date("2025-08-04T00:00:00.000Z"),
+    // TODO DO NOT COMMIT
+    startDate: new Date("2025-07-30T00:00:00.000Z"),
     endDate: new Date("2025-11-03T00:00:00.000Z"),
   },
 };

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6392,5 +6392,13 @@
   "description.venusBumpkinTrap": "Never turn your back on this snappy plant!",
   "sleepingAnimal.favouriteFood": "Favourite food:",
   "sleepingAnimal.every": "Every",
-  "sleepingAnimal.missing": "Missing"
+  "sleepingAnimal.missing": "Missing",
+  "description.bonusBracelet.boost": "+1 Bracelet",
+  "description.architectRuler.boost": "+25% Crafting Box Speed",
+  "description.reelmastersChair.boost": "+5 Fishing Attempts",
+  "description.musicBox.boost": "+20% Fruit Patch Growth Speed",
+  "description.doubleBed.boost": "+2 Farmhands",
+  "description.giantArtichoke.boost": "+2 Artichokes",
+  "description.pickaxeShark.boost.1": "+15% Gold Recovery Time",
+  "description.pickaxeShark.boost.2": "10% chance of Instant Gold"
 }


### PR DESCRIPTION
# Description

- Add Better Together Megastore Items
- Adds Boost Labels to the items in game

<img width="505" height="406" alt="1" src="https://github.com/user-attachments/assets/4ae88f3a-12c1-4c2b-b892-83545c0c46fe" />


# What needs to be tested by the reviewer?

1. Set your season dates in the frontend and backend to:

```ts
  "Great Bloom": {
    startDate: new Date("2025-05-01T00:00:00.000Z"),
    endDate: new Date("2025-07-30T00:00:00.000Z"),
  },
  "Better Together": {
    startDate: new Date("2025-07-30T00:00:00.000Z"),
    endDate: new Date("2025-11-03T00:00:00.000Z"),
  },
```
2. Browse the megastore
3. Give yourself each megastore item and assert you can save the game

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]