### PR TITLE
[FIX] Send cheers to feed

### DIFF
--- a/src/features/social/components/InteractionBubble.tsx
+++ b/src/features/social/components/InteractionBubble.tsx
@@ -44,7 +44,7 @@ export const InteractionBubble: React.FC<Props> = ({
     );
   }
 
-  if (type === "milestone" || type === "announcement") {
+  if (type === "milestone" || type === "announcement" || type === "cheer") {
     return (
       <div
         className={classNames("relative min-h-[57px]", {

--- a/src/features/social/hooks/useSocial.ts
+++ b/src/features/social/hooks/useSocial.ts
@@ -127,6 +127,14 @@ const onMilestone = (update: Milestone) => {
   });
 };
 
+const onCheer = (update: Cheer) => {
+  [...subscribers.values()].forEach((subscriber) => {
+    if (subscriber.callbacks?.onCheer) {
+      subscriber.callbacks.onCheer(update);
+    }
+  });
+};
+
 const clearListeners = () => {
   room?.removeAllListeners();
   heartBeatTimeout && clearInterval(heartBeatTimeout);
@@ -148,6 +156,7 @@ const setupListeners = (
   room.onMessage("unfollow", onUnfollow);
   room.onMessage("interaction", onInteraction);
   room.onMessage("milestone", onMilestone);
+  room.onMessage("cheers", onCheer);
 };
 
 const updateFollowing = () => {

--- a/src/features/social/hooks/useSocial.ts
+++ b/src/features/social/hooks/useSocial.ts
@@ -127,14 +127,6 @@ const onMilestone = (update: Milestone) => {
   });
 };
 
-const onCheer = (update: Cheer) => {
-  [...subscribers.values()].forEach((subscriber) => {
-    if (subscriber.callbacks?.onCheer) {
-      subscriber.callbacks.onCheer(update);
-    }
-  });
-};
-
 const clearListeners = () => {
   room?.removeAllListeners();
   heartBeatTimeout && clearInterval(heartBeatTimeout);
@@ -156,7 +148,6 @@ const setupListeners = (
   room.onMessage("unfollow", onUnfollow);
   room.onMessage("interaction", onInteraction);
   room.onMessage("milestone", onMilestone);
-  room.onMessage("cheers", onCheer);
 };
 
 const updateFollowing = () => {

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -7,7 +7,12 @@ export type ParticipantInfo = {
   clothing?: Equipped;
 };
 
-export type InteractionType = "chat" | "follow" | "milestone" | "announcement";
+export type InteractionType =
+  | "chat"
+  | "follow"
+  | "milestone"
+  | "announcement"
+  | "cheer";
 
 export type Interaction = {
   type: InteractionType;


### PR DESCRIPTION
# Description

Displays cheers sent to the farm in the feed

# What needs to be tested by the reviewer?

1. Load up two farms in plaza
2. Have one farm cheer another via the player modal
3. Check the receiving player knows the cheer came in

<img width="281" height="261" alt="cheerbuddy" src="https://github.com/user-attachments/assets/f92804b4-2f68-45c1-bcf5-1ee6c8b51d36" />


# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
