### PR TITLE
[FEAT] Allow Follow From Visit

### DIFF
--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -10,8 +10,7 @@ import {
   cacheShortcuts,
   getShortcuts,
 } from "features/farming/hud/lib/shortcuts";
-
-import { startGame, MachineInterpreter, MachineState } from "./lib/gameMachine";
+import { startGame, MachineInterpreter } from "./lib/gameMachine";
 import { InventoryItemName } from "./types/game";
 import {
   cacheShowAnimationsSetting,
@@ -36,13 +35,11 @@ interface GameContext {
   toggleQuickSelect: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
-  fromRoute: string;
+  fromRoute?: string;
   setFromRoute: (route: string) => void;
 }
 
 export const Context = React.createContext<GameContext>({} as GameContext);
-
-const _visiting = (state: MachineState) => state.matches("visiting");
 
 export const GameProvider: React.FC<React.PropsWithChildren> = ({
   children,
@@ -88,7 +85,7 @@ export const GameProvider: React.FC<React.PropsWithChildren> = ({
     getEnableQuickSelectSetting(),
   );
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
-  const [fromRoute, setFromRoute] = useState<string>("");
+  const [fromRoute, setFromRoute] = useState<string | undefined>();
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
     const originalShortcuts = getShortcuts();

--- a/src/features/island/bumpkin/components/PlayerNPC.tsx
+++ b/src/features/island/bumpkin/components/PlayerNPC.tsx
@@ -38,6 +38,7 @@ export const PlayerNPC: React.FC<NPCProps> = ({ parts: bumpkinParts }) => {
 
   const { isVisiting } = useVisiting();
   const context = gameService.getSnapshot().context;
+  const loggedInFarmId = context.visitorId ?? context.farmId;
 
   const handleClick = () => {
     if (isVisiting) {
@@ -79,13 +80,13 @@ export const PlayerNPC: React.FC<NPCProps> = ({ parts: bumpkinParts }) => {
       {hasFeatureAccess(context.state, "SOCIAL_FARMING") ? (
         <PlayerModal
           game={context.state}
-          farmId={context.farmId}
+          loggedInFarmId={loggedInFarmId}
           token={token}
         />
       ) : (
         <PlayerModals
           game={context.state}
-          farmId={context.farmId}
+          farmId={loggedInFarmId}
           isOpen={open}
         />
       )}

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -114,14 +114,14 @@ export const VisitingHud: React.FC = () => {
           }}
         >
           <img
-            src={SUNNYSIDE.icons.worldIcon}
-            id="world-icon"
+            src={SUNNYSIDE.icons.arrow_left}
+            alt="End visit"
+            className="absolute"
             style={{
               width: `${PIXEL_SCALE * 12}px`,
               left: `${PIXEL_SCALE * 5}px`,
               top: `${PIXEL_SCALE * 4}px`,
             }}
-            className="absolute group-active:translate-y-[2px]"
           />
         </RoundButton>
       </div>

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -234,7 +234,7 @@ export const Feed: React.FC<Props> = ({
         {showFollowing && (
           <div className="flex flex-col gap-2 -mt-2">
             <FollowList
-              farmId={farmId}
+              loggedInFarmId={farmId}
               token={token}
               networkFarmId={farmId}
               networkList={following}

--- a/src/features/social/components/FollowDetailPanel.tsx
+++ b/src/features/social/components/FollowDetailPanel.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Equipped } from "features/game/types/bumpkin";
 
 type Props = {
-  farmId: number;
+  loggedInFarmId: number;
   playerId: number;
   clothing: Equipped;
   username: string;
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export const FollowDetailPanel: React.FC<Props> = ({
-  farmId,
+  loggedInFarmId,
   playerId,
   clothing,
   username,
@@ -27,7 +27,7 @@ export const FollowDetailPanel: React.FC<Props> = ({
   const lastOnline = getRelativeTime(lastOnlineAt);
 
   const isOnline = lastOnlineAt > Date.now() - 30 * 60 * 1000;
-  const isYou = farmId === playerId;
+  const isYou = loggedInFarmId === playerId;
 
   // Use useCallback to memoize the click handler
   const handleClick = useCallback(() => {
@@ -37,7 +37,6 @@ export const FollowDetailPanel: React.FC<Props> = ({
   return (
     <ButtonPanel
       className="flex gap-3 hover:bg-brown-300 transition-colors active:bg-brown-400"
-      disabled={isYou}
       onClick={handleClick}
     >
       <div className="relative">
@@ -46,7 +45,7 @@ export const FollowDetailPanel: React.FC<Props> = ({
         </div>
         <div className="absolute -top-1 -right-1">
           <OnlineStatus
-            farmId={farmId}
+            loggedInFarmId={loggedInFarmId}
             playerId={playerId}
             lastUpdatedAt={lastOnlineAt}
           />

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -9,7 +9,7 @@ import { Button } from "components/ui/Button";
 import { Equipped } from "features/game/types/bumpkin";
 
 type Props = {
-  farmId: number;
+  loggedInFarmId: number;
   token: string;
   networkFarmId: number;
   networkList: number[];
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const FollowList: React.FC<Props> = ({
-  farmId,
+  loggedInFarmId,
   token,
   networkFarmId,
   networkList,
@@ -41,7 +41,7 @@ export const FollowList: React.FC<Props> = ({
     [
       networkCount > 0 ? "followNetworkDetails" : null,
       token,
-      farmId,
+      loggedInFarmId,
       networkFarmId,
     ],
     ([, token, farmId, networkFarmId]) => {
@@ -127,7 +127,7 @@ export const FollowList: React.FC<Props> = ({
         return (
           <FollowDetailPanel
             key={`flw-${followerId}`}
-            farmId={farmId}
+            loggedInFarmId={loggedInFarmId}
             playerId={followerId}
             clothing={networkDetails?.[followerId]?.clothing as Equipped}
             username={networkDetails?.[followerId]?.username ?? ""}

--- a/src/features/social/components/FollowerFeed.tsx
+++ b/src/features/social/components/FollowerFeed.tsx
@@ -37,7 +37,7 @@ import { useFeed } from "../FeedContext";
 import silhouette from "assets/npcs/silhouette.webp";
 
 type Props = {
-  farmId: number;
+  loggedInFarmId: number;
   playerId: number;
   playerClothing?: Equipped;
   playerUsername?: string;
@@ -55,7 +55,7 @@ const _token = (state: AuthMachineState) =>
 
 export const FollowerFeed: React.FC<Props> = ({
   chatDisabled,
-  farmId,
+  loggedInFarmId,
   playerId,
   playerClothing,
   playerUsername,
@@ -92,7 +92,7 @@ export const FollowerFeed: React.FC<Props> = ({
     hasMore,
     loadMore,
     mutate,
-  } = useChatInteractions(token, farmId, playerId);
+  } = useChatInteractions(token, loggedInFarmId, playerId);
 
   useEffect(() => {
     // Always refetch when the component mounts
@@ -120,7 +120,7 @@ export const FollowerFeed: React.FC<Props> = ({
   }, [scrolledToBottom, newLocalMessagesCount]);
 
   useSocial({
-    farmId,
+    farmId: loggedInFarmId,
     callbacks: {
       onInteraction: async (update) => {
         if (update.sender.id !== playerId) return;
@@ -212,9 +212,9 @@ export const FollowerFeed: React.FC<Props> = ({
         username: playerUsername ?? `#${playerId}`,
       },
       sender: {
-        id: farmId,
+        id: loggedInFarmId,
         clothing: myClothing,
-        username: myUsername ?? `#${farmId}`,
+        username: myUsername ?? `#${loggedInFarmId}`,
       },
       createdAt: Date.now(),
     };
@@ -230,7 +230,7 @@ export const FollowerFeed: React.FC<Props> = ({
           },
           transactionId: randomID(),
           token: token as string,
-          farmId: farmId,
+          farmId: loggedInFarmId,
         });
 
         // Replace page 0 with latest messages. The rest will become invalid as the

--- a/src/features/social/components/OnlineStatus.tsx
+++ b/src/features/social/components/OnlineStatus.tsx
@@ -2,20 +2,20 @@ import React from "react";
 import { useSocial } from "../hooks/useSocial";
 
 type OnlineStatusProps = {
-  farmId: number;
+  loggedInFarmId: number;
   playerId: number;
   lastUpdatedAt: number;
   size?: number;
 };
 
 export const OnlineStatus: React.FC<OnlineStatusProps> = ({
-  farmId,
+  loggedInFarmId,
   playerId,
   lastUpdatedAt,
   size = 12,
 }) => {
   const { online } = useSocial({
-    farmId,
+    farmId: loggedInFarmId,
   });
 
   const lastOnlineAt = online[playerId] ?? lastUpdatedAt ?? 0;
@@ -33,7 +33,6 @@ export const OnlineStatus: React.FC<OnlineStatusProps> = ({
         border: "1px solid #000",
         boxShadow: "0 0 2px rgba(0,0,0,0.15)",
       }}
-      title={status}
     />
   );
 };

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -49,6 +49,7 @@ const ISLAND_ICONS: Record<IslandType, string> = {
 type Props = {
   data?: Player;
   error?: Error;
+  loggedInFarmId: number;
   playerLoading: boolean;
   playerValidating: boolean;
   followLoading: boolean;
@@ -61,7 +62,6 @@ type Props = {
   onGoBack?: () => void;
 };
 
-const _farmId = (state: MachineState) => state.context.farmId;
 const _cheersAvailable = (state: MachineState) => {
   return state.context.state.inventory["Cheer"] ?? new Decimal(0);
 };
@@ -79,6 +79,7 @@ export const PlayerDetails: React.FC<Props> = ({
   error,
   playerLoading,
   followLoading,
+  loggedInFarmId,
   iAmFollowing,
   isFollowMutual,
   mutate,
@@ -91,7 +92,6 @@ export const PlayerDetails: React.FC<Props> = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { isVisiting } = useVisiting();
-  const farmId = useSelector(gameService, _farmId);
   const cheersAvailable = useSelector(gameService, _cheersAvailable);
   const location = useLocation();
   const [showCheerModal, setShowCheerModal] = useState(false);
@@ -104,7 +104,7 @@ export const PlayerDetails: React.FC<Props> = ({
   );
 
   useSocial({
-    farmId,
+    farmId: loggedInFarmId,
     following: player?.followedBy ?? [],
     callbacks: {
       onFollow: () => mutate(),
@@ -150,7 +150,7 @@ export const PlayerDetails: React.FC<Props> = ({
     },
   );
 
-  const isSelf = player?.id === farmId;
+  const isSelf = player?.id === loggedInFarmId;
   const hasCheersAvailable = cheersAvailable.gt(0);
   const displayName = player?.username ?? `#${player?.id}`;
 
@@ -206,7 +206,7 @@ export const PlayerDetails: React.FC<Props> = ({
                     {player?.id && (
                       <OnlineStatus
                         playerId={player?.id}
-                        farmId={farmId}
+                        loggedInFarmId={loggedInFarmId}
                         lastUpdatedAt={player?.lastUpdatedAt ?? 0}
                       />
                     )}
@@ -340,7 +340,7 @@ export const PlayerDetails: React.FC<Props> = ({
       </div>
       {!isMobile && player && !isSelf && (
         <FollowerFeed
-          farmId={farmId}
+          loggedInFarmId={loggedInFarmId}
           playerId={player.id}
           playerClothing={player.clothing}
           playerUsername={player.username}


### PR DESCRIPTION
# Description

This PR allows a player to follow another player while visiting them. If a logged in player visits another player and clicks on their bumpkin, they are now able to click the "follow" button and follow them. 

The "follow" effect does not go through the game machine so it doesn't interfere with visitor context changes. 

I have also changed some naming from `farmId`
-> `loggedInFarmId` just so it is clear what we're referencing as the value could either be `farmId` or `visitorId` depending on whether they're visiting or not.

I have also changed the world button in the visitor hud to a back button so its clear that that button takes you back.

<img width="558" height="68" alt="Screenshot 2025-07-31 at 10 50 29 PM" src="https://github.com/user-attachments/assets/26505f77-552a-4819-bb49-0cad175baa15" />

# What needs to be tested by the reviewer?

- Visit a player either directly from the url or via a bumpkin in the mmo.
- Click on their little bumpkin by the house
- Click follow
- Click unfollow
- Click around back and forth, following and unfollowing players while visiting just to ensure everything flows as its supposed to

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
