### PR TITLE
[FEAT] Live Progress Bar for Lava Pit

### DIFF
--- a/src/features/game/expansion/components/lavaPit/LavaPit.tsx
+++ b/src/features/game/expansion/components/lavaPit/LavaPit.tsx
@@ -11,6 +11,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import animatedLavaPit from "assets/resources/lava/lava_pit_animation.webp";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { getLavaPitTime } from "features/game/events/landExpansion/collectLavaPit";
+import { LiveProgressBar } from "components/ui/ProgressBar";
 
 const _lavaPit = (id: string) => (state: MachineState) =>
   state.context.state.lavaPits[id];
@@ -23,8 +24,8 @@ interface Props {
 
 export const LavaPit: React.FC<Props> = ({ id }) => {
   const [showModal, setShowModal] = useState(false);
-
-  const { gameService, showAnimations } = useContext(Context);
+  const [renderKey, setRender] = useState<number>(0);
+  const { gameService, showAnimations, showTimers } = useContext(Context);
   const lavaPit = useSelector(gameService, _lavaPit(id));
   const lavaPitTime = useSelector(gameService, _lavaPitTime);
 
@@ -36,6 +37,11 @@ export const LavaPit: React.FC<Props> = ({ id }) => {
   const lavaPitReady =
     (lavaPit?.startedAt ?? Infinity) + lavaPitTime < Date.now() &&
     !lavaPit?.collectedAt;
+
+  const width = 36;
+  const lavaPitStartedAt = lavaPit?.startedAt ?? 0;
+  const lavaPitEndAt = lavaPitStartedAt + lavaPitTime;
+  const isReadyWithinADay = lavaPitEndAt < Date.now() + 24 * 60 * 60 * 1000;
 
   return (
     <div className="relative w-full h-full">
@@ -57,14 +63,37 @@ export const LavaPit: React.FC<Props> = ({ id }) => {
           <img
             id={`lavapit-${id}`}
             src={animatedLavaPit}
-            width={36 * PIXEL_SCALE}
+            width={width * PIXEL_SCALE}
           />
         ) : (
           <img
             id={`lavapit-${id}`}
             src={ITEM_DETAILS["Lava Pit"].image}
-            width={36 * PIXEL_SCALE}
+            width={width * PIXEL_SCALE}
           />
+        )}
+
+        {lavaPitRunning && showTimers && (
+          <div
+            className="flex justify-center absolute bg-red-500"
+            style={{
+              bottom: "12px",
+              width: `${width * PIXEL_SCALE}px`,
+              left: `${PIXEL_SCALE * ((32 - width) / 2)}px`,
+            }}
+          >
+            <LiveProgressBar
+              key={renderKey}
+              startAt={lavaPitStartedAt}
+              endAt={lavaPitEndAt}
+              formatLength={isReadyWithinADay ? "short" : "medium"}
+              className="relative"
+              style={{
+                width: `${PIXEL_SCALE * 14}px`,
+              }}
+              onComplete={() => setRender((r) => r + 1)}
+            />
+          </div>
         )}
       </div>
 

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -192,7 +192,12 @@ export const STATIC_OFFLINE_FARM: GameState = {
     },
   },
   lavaPits: {
-    "1": { createdAt: 0, x: -4, y: -6 },
+    "1": {
+      createdAt: 0,
+      startedAt: Date.now() - 1000 * (60 * 60 * 48),
+      x: -4,
+      y: -6,
+    },
   },
 
   fruitPatches: {


### PR DESCRIPTION
# Description
Displays live Lava Pit progress bar when timers are enabled, so users can see remaining time without clicking. Enhances UX.

<img width="119" height="121" alt="image" src="https://github.com/user-attachments/assets/0d021038-f362-42f4-a8e2-ecba93618e2f" />

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
