### PR TITLE
[FIX] Coins Balance Overlaps & Blocks Earn Button on Mobile

### DIFF
--- a/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
+++ b/src/features/game/expansion/components/temperateSeason/GameCalendar.tsx
@@ -25,6 +25,7 @@ import {
 } from "features/game/lib/temperateSeason";
 import { SeasonsIntroduction } from "./SeasonsIntroduction";
 import { RoundButton } from "components/ui/RoundButton";
+import { isMobile } from "mobile-device-detect";
 
 export type LocalCalendarDetails = {
   dateNumber: number;
@@ -126,8 +127,8 @@ const GameCalendarButton: React.FC<GameCalendarButtonProps> = ({
   <div
     className="absolute"
     style={{
-      top: `${PIXEL_SCALE * 38}px`,
-      left: `${PIXEL_SCALE * 5}px`,
+      top: `${PIXEL_SCALE * (isMobile ? 37 : 38)}px`,
+      left: `${PIXEL_SCALE * (isMobile ? 4 : 5)}px`,
     }}
   >
     <RoundButton
@@ -135,15 +136,15 @@ const GameCalendarButton: React.FC<GameCalendarButtonProps> = ({
         e.stopPropagation();
         onClick();
       }}
-      buttonSize={18}
+      buttonSize={isMobile ? 15 : 18}
     >
       <img
         src={calendarIcon}
         className="absolute group-active:translate-y-[2px]"
         style={{
-          width: `${PIXEL_SCALE * 10}px`,
-          left: `${PIXEL_SCALE * 3.5}px`,
-          top: `${PIXEL_SCALE * 3}px`,
+          width: `${PIXEL_SCALE * (isMobile ? 9 : 10)}px`,
+          left: `${PIXEL_SCALE * (isMobile ? 2.5 : 3.5)}px`,
+          top: `${PIXEL_SCALE * (isMobile ? 2 : 3)}px`,
         }}
       />
       {showTutorial && (
@@ -152,9 +153,9 @@ const GameCalendarButton: React.FC<GameCalendarButtonProps> = ({
           src={SUNNYSIDE.icons.click_icon}
           onClick={() => onClick()}
           style={{
-            width: `${PIXEL_SCALE * 15}px`,
-            left: `${PIXEL_SCALE * 12}px`,
-            top: `${PIXEL_SCALE * 12}px`,
+            width: `${PIXEL_SCALE * (isMobile ? 12 : 15)}px`,
+            left: `${PIXEL_SCALE * (isMobile ? 10 : 12)}px`,
+            top: `${PIXEL_SCALE * (isMobile ? 10 : 12)}px`,
           }}
         />
       )}

--- a/src/features/island/hud/components/bumpkinProfile/CodexButton.tsx
+++ b/src/features/island/hud/components/bumpkinProfile/CodexButton.tsx
@@ -13,6 +13,7 @@ import { getBumpkinLevel } from "features/game/lib/level";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useSelector } from "@xstate/react";
 import { RoundButton } from "components/ui/RoundButton";
+import { isMobile } from "mobile-device-detect";
 
 const _delivery = (state: MachineState) => state.context.state.delivery;
 const _level = (state: MachineState) =>
@@ -38,8 +39,8 @@ export const CodexButton: React.FC = () => {
     <div
       className="absolute"
       style={{
-        top: `${PIXEL_SCALE * 29}px`,
-        left: `${PIXEL_SCALE * 28}px`,
+        top: `${PIXEL_SCALE * (isMobile ? 33.5 : 29)}px`,
+        left: `${PIXEL_SCALE * (isMobile ? 23.5 : 28)}px`,
       }}
     >
       <RoundButton
@@ -48,19 +49,19 @@ export const CodexButton: React.FC = () => {
           e.preventDefault();
           setIsOpen(true);
         }}
-        buttonSize={18}
+        buttonSize={isMobile ? 15 : 18}
       >
         <div
           className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
           style={{
-            width: `${PIXEL_SCALE * 12}px`,
+            width: `${PIXEL_SCALE * (isMobile ? 10 : 12)}px`,
           }}
         >
           <img
             src={codex}
             className="group-active:translate-y-[2px]"
             style={{
-              width: `${PIXEL_SCALE * 12}px`,
+              width: `${PIXEL_SCALE * (isMobile ? 10 : 12)}px`,
             }}
           />
         </div>
@@ -133,7 +134,7 @@ export const CodexButton: React.FC = () => {
               src={SUNNYSIDE.ui.coins}
               className="absolute animate-pulsate sm:hidden"
               style={{
-                width: "30px",
+                width: "27px",
                 top: "-2px",
                 right: "-10px",
               }}

--- a/src/features/island/hud/components/bumpkinProfile/RewardsButton.tsx
+++ b/src/features/island/hud/components/bumpkinProfile/RewardsButton.tsx
@@ -10,6 +10,7 @@ import {
 import { getKeys } from "features/game/types/decorations";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { isMobile } from "mobile-device-detect";
 
 export const RewardsButton: React.FC = () => {
   const { gameState } = useGame();
@@ -43,19 +44,30 @@ export const RewardsButton: React.FC = () => {
 
   return (
     <div
-      className="absolute"
-      style={{ top: `${PIXEL_SCALE * 5}px`, left: `${PIXEL_SCALE * 32}px` }}
+      className="absolute z-10"
+      style={{
+        top: `${PIXEL_SCALE * (isMobile ? 15 : 5)}px`,
+        left: `${PIXEL_SCALE * (isMobile ? 34 : 32)}px`,
+      }}
     >
-      <RoundButton buttonSize={18} onClick={() => openModal("EARN")}>
-        <img
-          src={ITEM_DETAILS["Love Charm"].image}
-          className="absolute group-active:translate-y-[2px]"
+      <RoundButton
+        buttonSize={isMobile ? 15 : 18}
+        onClick={() => openModal("EARN")}
+      >
+        <div
+          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
           style={{
-            width: `${PIXEL_SCALE * 14}px`,
-            left: `${PIXEL_SCALE * 2}px`,
-            top: `${PIXEL_SCALE * 5}px`,
+            width: `${PIXEL_SCALE * (isMobile ? 12 : 14)}px`,
           }}
-        />
+        >
+          <img
+            src={ITEM_DETAILS["Love Charm"].image}
+            className="group-active:translate-y-[2px]"
+            style={{
+              width: `${PIXEL_SCALE * (isMobile ? 12 : 14)}px`,
+            }}
+          />
+        </div>
         {(isAnyTaskCompleted || isChestLocked) && (
           <img
             src={SUNNYSIDE.icons.expression_alerted}


### PR DESCRIPTION
# Description

On certain mobile screen sizes, large coins/gem balances visually overlapped the Earn button, making it unclickable.

This PR applies the following changes _**on mobile only**_:

- Reduces the size of the Earn button and adjacent buttons(Calendar & Codex)

- Adjusts their positions to prevent overlap with the coins balance

These changes improve interface accessibility and ensure a smoother user experience on small displays.

| Before | After |
|--------|--------|
| <img width="406" height="833" alt="image" src="https://github.com/user-attachments/assets/25923f8c-a16c-4072-9e1f-4042d2d43d9a" /> | <img width="406" height="833" alt="image" src="https://github.com/user-attachments/assets/1cd6dd5a-9496-4d35-a05b-8ae9517d1eef" /> | 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
