### PR TITLE
[FEAT] Display Cheer Progress in Monument Popovers

### DIFF
--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -17,6 +17,11 @@ import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import classNames from "classnames";
 import { MonumentName } from "features/game/types/monuments";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
+import {
+  SFTDetailPopoverInnerPanel,
+  SFTDetailPopoverLabel,
+} from "components/ui/SFTDetailPopover";
 
 export const REQUIRED_CHEERS: Record<MonumentName, number> = {
   "Big Orange": 50,
@@ -116,6 +121,7 @@ type MonumentProps = React.ComponentProps<typeof ImageStyle> & {
 export const Monument: React.FC<MonumentProps> = (input) => {
   const { isVisiting } = useVisiting();
   const { gameService } = useContext(Context);
+  const { t } = useAppTranslation();
 
   const projectCheers = useSelector(gameService, _cheers(input.project));
   const cheersAvailable = useSelector(gameService, _cheersAvailable);
@@ -159,58 +165,77 @@ export const Monument: React.FC<MonumentProps> = (input) => {
 
   return (
     <>
-      <ImageStyle {...input} />
-      {isVisiting && !hasCheeredProjectToday && (
-        <div
-          className={classNames(
-            "absolute -top-4 -right-4 pointer-events-auto cursor-pointer hover:img-highlight",
-            {
-              "animate-pulsate": hasCheers,
-            },
-          )}
-          onClick={() => setIsCheering(true)}
-        >
-          <div
-            className="relative mr-2"
-            style={{ width: `${PIXEL_SCALE * 20}px` }}
-          >
-            <img className="w-full" src={SUNNYSIDE.icons.disc} />
-            <img
-              className={classNames("absolute")}
-              src={cheer}
-              style={{
-                width: `${PIXEL_SCALE * 17}px`,
-                right: `${PIXEL_SCALE * 2}px`,
-                top: `${PIXEL_SCALE * 2}px`,
-              }}
-            />
+      <Popover>
+        <PopoverButton as="div">
+          <div className="absolute" style={input.divStyle}>
+            <img src={input.image} style={input.imgStyle} alt={input.alt} />
           </div>
-        </div>
-      )}
-      <div
-        className="absolute bottom-2 left-1/2"
-        style={{
-          width: `${PIXEL_SCALE * 20}px`,
-        }}
-      >
-        {!hasCheeredProjectToday && (
-          <ProgressBar
-            type="quantity"
-            percentage={projectPercentage}
-            formatLength="full"
-            className="ml-1 -translate-x-1/2"
-          />
-        )}
-        {hasCheeredProjectToday && (
-          <LiveProgressBar
-            startAt={new Date(today).getTime()}
-            endAt={new Date(tomorrow).getTime()}
-            formatLength="short"
-            onComplete={() => setRender((r) => r + 1)}
-            className="ml-1 -translate-x-1/2"
-          />
-        )}
-      </div>
+
+          {isVisiting && !hasCheeredProjectToday && (
+            <div
+              className={classNames(
+                "absolute -top-4 -right-4 pointer-events-auto cursor-pointer hover:img-highlight",
+                {
+                  "animate-pulsate": hasCheers,
+                },
+              )}
+              onClick={() => setIsCheering(true)}
+            >
+              <div
+                className="relative mr-2"
+                style={{ width: `${PIXEL_SCALE * 20}px` }}
+              >
+                <img className="w-full" src={SUNNYSIDE.icons.disc} />
+                <img
+                  className={classNames("absolute")}
+                  src={cheer}
+                  style={{
+                    width: `${PIXEL_SCALE * 17}px`,
+                    right: `${PIXEL_SCALE * 2}px`,
+                    top: `${PIXEL_SCALE * 2}px`,
+                  }}
+                />
+              </div>
+            </div>
+          )}
+          <div
+            className="absolute bottom-2 left-1/2"
+            style={{
+              width: `${PIXEL_SCALE * 20}px`,
+            }}
+          >
+            {!hasCheeredProjectToday && (
+              <ProgressBar
+                type="quantity"
+                percentage={projectPercentage}
+                formatLength="full"
+                className="ml-1 -translate-x-1/2"
+              />
+            )}
+            {hasCheeredProjectToday && (
+              <LiveProgressBar
+                startAt={new Date(today).getTime()}
+                endAt={new Date(tomorrow).getTime()}
+                formatLength="short"
+                onComplete={() => setRender((r) => r + 1)}
+                className="ml-1 -translate-x-1/2"
+              />
+            )}
+          </div>
+        </PopoverButton>
+
+        <PopoverPanel anchor={{ to: "left start" }} className="flex">
+          <SFTDetailPopoverInnerPanel>
+            <SFTDetailPopoverLabel name={input.name} />
+            <Label type="info" icon={cheer} className="ml-2 sm:ml-0">
+              {t("cheers.progress", {
+                progress: `${projectCheers}/${REQUIRED_CHEERS[input.project]}`,
+              })}
+            </Label>
+          </SFTDetailPopoverInnerPanel>
+        </PopoverPanel>
+      </Popover>
+
       <Modal show={isCheering} onHide={() => setIsCheering(false)}>
         <CheerModal
           project={input.project}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6406,5 +6406,6 @@
   "description.pickaxeShark.boost.2": "10% chance of Instant Gold",
   "cheers.guide.description": "Use Cheers to support your community! Cheer a farm to boost its Social Points, or cheer a monument or project to help speed up its progress.",
   "cheers.guide.description2": "You get 3 free Cheers every day at 12:00 AM UTC.",
-  "cheers.guide.description3": "Clean up trash to exchange for bonus Cheers! Visit Garbo and toss trash, weeds, dung, or pests into the Incinerator to trade for extra Cheers."
+  "cheers.guide.description3": "Clean up trash to exchange for bonus Cheers! Visit Garbo and toss trash, weeds, dung, or pests into the Incinerator to trade for extra Cheers.",
+  "cheers.progress": "Cheer Progress: {{progress}}"
 }


### PR DESCRIPTION
# Description

Displays current cheer progress in monument popovers when clicked, allowing farm owners to track the progress more clearly.

<img width="380" height="131" alt="image" src="https://github.com/user-attachments/assets/47aeb664-d5a2-4708-bdf5-2a4d3abce26f" />


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
