### PR TITLE
[FIX] Player didn't get any cheers when using 3 the previous day

### DIFF
--- a/src/features/game/events/landExpansion/claimDailyCheers.test.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.test.ts
@@ -37,7 +37,22 @@ describe("claimDailyCheers", () => {
     const now = Date.now();
 
     const game = claimDailyCheers({
-      state: INITIAL_FARM,
+      state: {
+        ...INITIAL_FARM,
+        socialFarming: {
+          points: 0,
+          villageProjects: {},
+          cheersGiven: {
+            date: new Date(now).toISOString().split("T")[0],
+            projects: {},
+            farms: [],
+          },
+          cheers: {
+            freeCheersClaimedAt: now - 24 * 60 * 60 * 1000,
+            cheersUsed: 3,
+          },
+        },
+      },
       action: { type: "cheers.claimed" },
       createdAt: now,
     });
@@ -70,5 +85,32 @@ describe("claimDailyCheers", () => {
     });
 
     expect(game?.inventory.Cheer?.toNumber()).toBe(2);
+  });
+
+  it("should only give a maximum of 3 bonus cheers if the player has used more than 3 cheers yesterday", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: {
+        ...INITIAL_FARM,
+        socialFarming: {
+          points: 0,
+          villageProjects: {},
+          cheersGiven: {
+            date: new Date(now).toISOString().split("T")[0],
+            projects: {},
+            farms: [],
+          },
+          cheers: {
+            freeCheersClaimedAt: now - 24 * 60 * 60 * 1000,
+            cheersUsed: 4,
+          },
+        },
+      },
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.inventory.Cheer?.toNumber()).toBe(3);
   });
 });

--- a/src/features/game/events/landExpansion/claimDailyCheers.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.ts
@@ -45,7 +45,7 @@ export function claimDailyCheers({
       3,
     );
 
-    if (cheersUsedYesterday <= 0) {
+    if (cheersUsedYesterday < 0) {
       throw new Error("Not enough cheers to claim");
     }
 


### PR DESCRIPTION
# Description

Currently, a player who got 3 cheers yesterday and all 3 cheers yesterday would not get any cheers today.

This player ensures that the player gets the 3 daily cheers if they used their cheers. If a player didn't use their cheers yesterday, they wouldn't get any cheers

Player would get up to 3 cheers if they somehow managed to use more than 3 cheers 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
