### PR TITLE
[FEAT] Non trade-able items

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -384,6 +384,10 @@ export const BUMPKIN_RELEASES: Partial<Record<BumpkinItem, Releases>> = {
     tradeAt: SEASONS["Great Bloom"].endDate,
     withdrawAt: SEASONS["Great Bloom"].endDate,
   },
+  "Flower Mask": {
+    tradeAt: SEASONS["Great Bloom"].endDate,
+    withdrawAt: SEASONS["Great Bloom"].endDate,
+  },
   "Amberfall Suit": {
     tradeAt: SEASONS["Great Bloom"].endDate,
     withdrawAt: SEASONS["Great Bloom"].endDate,
@@ -1115,10 +1119,8 @@ export const INVENTORY_RELEASES: Partial<Record<InventoryItemName, Releases>> =
       tradeAt: SEASONS["Better Together"].endDate,
       withdrawAt: SEASONS["Better Together"].endDate,
     },
-    "Double Bed": {
-      tradeAt: SEASONS["Better Together"].endDate,
-      withdrawAt: SEASONS["Better Together"].endDate,
-    },
+    // Double bed is not tradeable - explicitly set her to avoid accidental trade
+    "Double Bed": undefined,
     "Giant Artichoke": {
       tradeAt: SEASONS["Better Together"].endDate,
       withdrawAt: SEASONS["Better Together"].endDate,

--- a/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/seasonalstore_components/ItemDetail.tsx
@@ -40,6 +40,12 @@ import {
 } from "features/game/events/landExpansion/buySeasonalItem";
 import { REWARD_BOXES } from "features/game/types/rewardBoxes";
 import { secondsToString } from "lib/utils/time";
+import {
+  BUMPKIN_RELEASES,
+  INVENTORY_RELEASES,
+} from "features/game/types/withdrawables";
+
+import lockIcon from "assets/icons/lock.png";
 
 interface ItemOverlayProps {
   item: SeasonalStoreItem | null;
@@ -320,6 +326,11 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
 
     return currencyItem;
   };
+
+  const isTradeable = isWearable
+    ? (item as SeasonalStoreWearable)?.wearable in BUMPKIN_RELEASES
+    : (item as SeasonalStoreCollectible)?.collectible in INVENTORY_RELEASES;
+
   return (
     <InnerPanel className="shadow">
       {isVisible && (
@@ -415,6 +426,17 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
                         })}
                       </Label>
                     )}
+
+                    {!isTradeable && (
+                      <Label
+                        type="formula"
+                        icon={lockIcon}
+                        className="text-xxs"
+                      >
+                        {t("season.megastore.nonTradeable")}
+                      </Label>
+                    )}
+
                     {itemReq &&
                       (sfl !== 0 ? (
                         <div className="flex flex-1 content-start flex-col flex-wrap">

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6416,5 +6416,6 @@
   "cheers.guide.description": "Use Cheers to support your community! Cheer a farm to boost its Social Points, or cheer a monument or project to help speed up its progress.",
   "cheers.guide.description2": "You get 3 free Cheers every day at 12:00 AM UTC.",
   "cheers.guide.description3": "Clean up trash to exchange for bonus Cheers! Visit Garbo and toss trash, weeds, dung, or pests into the Incinerator to trade for extra Cheers.",
-  "cheers.progress": "Cheer Progress: {{progress}}"
+  "cheers.progress": "Cheer Progress: {{progress}}",
+  "season.megastore.nonTradeable": "Non tradeable"
 }


### PR DESCRIPTION
# Description

Additional info on the Megastore for visibility for items cannot be traded. The Chapter beds will fall under this.

Fixes: Flower Mask was not marked as tradeable at end of Chapter.