### PR TITLE
[FIX] Daily Cheers

### DIFF
--- a/src/features/game/events/landExpansion/claimDailyCheers.test.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.test.ts
@@ -60,6 +60,33 @@ describe("claimDailyCheers", () => {
     expect(game?.inventory.Cheer?.toNumber()).toBe(3);
   });
 
+  it("gives three free cheers to the player if they didn't claim yesterday", () => {
+    const now = Date.now();
+
+    const game = claimDailyCheers({
+      state: {
+        ...INITIAL_FARM,
+        socialFarming: {
+          points: 0,
+          villageProjects: {},
+          cheersGiven: {
+            date: new Date(now).toISOString().split("T")[0],
+            projects: {},
+            farms: [],
+          },
+          cheers: {
+            freeCheersClaimedAt: now - 48 * 60 * 60 * 1000,
+            cheersUsed: 0,
+          },
+        },
+      },
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.inventory.Cheer?.toNumber()).toBe(3);
+  });
+
   it("should only give bonus cheers if the player has used their free cheers", () => {
     const now = Date.now();
 
@@ -112,5 +139,35 @@ describe("claimDailyCheers", () => {
     });
 
     expect(game?.inventory.Cheer?.toNumber()).toBe(3);
+  });
+
+  it("should give 3 free cheers to player on 4th August 2025, regardless of previous day's value", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-08-04T00:00:00.000Z"));
+    const now = Date.now();
+    const game = claimDailyCheers({
+      state: {
+        ...INITIAL_FARM,
+        socialFarming: {
+          points: 0,
+          villageProjects: {},
+          cheersGiven: {
+            date: new Date(now).toISOString().split("T")[0],
+            projects: {},
+            farms: [],
+          },
+          cheers: {
+            freeCheersClaimedAt: now - 24 * 60 * 60 * 1000,
+            cheersUsed: 0,
+          },
+        },
+      },
+      action: { type: "cheers.claimed" },
+      createdAt: now,
+    });
+
+    expect(game?.inventory.Cheer?.toNumber()).toBe(3);
+
+    jest.useRealTimers();
   });
 });

--- a/src/features/game/events/landExpansion/claimDailyCheers.ts
+++ b/src/features/game/events/landExpansion/claimDailyCheers.ts
@@ -40,10 +40,14 @@ export function claimDailyCheers({
       .toISOString()
       .split("T")[0];
 
-    const cheersUsedYesterday = Math.min(
-      dayFreeCheersClaimed === yesterday ? cheers.cheersUsed : 0,
-      3,
-    );
+    const isBetterTogetherStartDate =
+      new Date(today).getTime() === new Date("2025-08-04").getTime();
+
+    // If today is the start date, give 3 regardless of previous day's value
+    const cheersUsedYesterday = isBetterTogetherStartDate
+      ? 3
+      : // Otherwise, give the amount of cheers used yesterday, or 3 if cheers wasn't claimed yesterday
+        Math.min(dayFreeCheersClaimed === yesterday ? cheers.cheersUsed : 3, 3);
 
     if (cheersUsedYesterday < 0) {
       throw new Error("Not enough cheers to claim");


### PR DESCRIPTION
# Description

This PR fixes 2 edge cases with daily cheers

1. For beta testers, if they only were impacted by the bug where they were getting less than 3 cheers, and they used less than 3 cheers , they would be less cheers for subsequent days. To make sure they get 3 on the first day, we hardcode that they would get 3 on the first day of the release to reset their cheers playing field

2. for players who didn't claim their free cheers yesterday, the code is erronously coded that they would get 0 cheers if they didn't claim yesterday. They should be getting 3. this has been patched

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
