### PR TITLE
[FIX] Duplicating following data on infinite load fetch in feed

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -75,6 +75,7 @@ export const Feed: React.FC<Props> = ({
   const { authService } = useContext(AuthProvider.Context);
 
   const [showFollowing, setShowFollowing] = useState(false);
+  const feedRef = useRef<HTMLDivElement>(null);
 
   const username = useSelector(gameService, _username);
   const token = useSelector(authService, _token);
@@ -92,6 +93,27 @@ export const Feed: React.FC<Props> = ({
     mutate,
   } = useFeedInteractions(token, farmId, type === "world");
   const { setUnreadCount, lastAcknowledged, clearUnread } = useFeed();
+
+  // Handle clicks outside the feed to close it
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        showFeed &&
+        feedRef.current &&
+        !feedRef.current.contains(event.target as Node)
+      ) {
+        handleCloseFeed();
+      }
+    };
+
+    if (showFeed) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showFeed]);
 
   // Find number of unread and set unread count when the feed loads
   useEffect(() => {
@@ -181,6 +203,7 @@ export const Feed: React.FC<Props> = ({
           "-translate-x-[110%]": hideMobileFeed,
         },
       )}
+      divRef={feedRef}
     >
       <div className="flex flex-col gap-2 h-full w-full">
         <div className="sticky top-0 flex flex-col z-10 bg-[#e4a672]">

--- a/src/features/social/hooks/useFeedInteractions.ts
+++ b/src/features/social/hooks/useFeedInteractions.ts
@@ -36,7 +36,8 @@ export function useFeedInteractions(
   );
 
   const feed = data ? data.flatMap((page) => page.feed).filter(Boolean) : [];
-  const following = data ? data.flatMap((page) => page.following) : [];
+  // Only take following from the first page since it should be consistent across all pages
+  const following = data && data.length > 0 ? data[0].following : [];
 
   return {
     feed,


### PR DESCRIPTION
# Description

Every time the feed fetched more data it was duplicating the following list.

This PR fixes the issue. We now just take the following data from the first fetch. If a follow happens in between a mutate is called which refreshes the list which updates the first fetch correctly.

I have also made it that the feed closes if you click outside of it.

Fixes #issue

# What needs to be tested by the reviewer?

- Scroll to the bottom of the feed to trigger a refetch. 
- Confirm the following list doesn't duplicate


- Open the feed, click outside to close it.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
