### PR TITLE
[FEAT] Only Show Reward Tabs in Phaser

### DIFF
--- a/src/features/social/PlayerModal.tsx
+++ b/src/features/social/PlayerModal.tsx
@@ -35,6 +35,7 @@ interface Props {
   loggedInFarmId: number;
   token: string;
   hasAirdropAccess: boolean;
+  showSpecialTabs?: boolean;
 }
 
 type Tab =
@@ -57,6 +58,7 @@ export const PlayerModal: React.FC<Props> = ({
   loggedInFarmId,
   token,
   hasAirdropAccess,
+  showSpecialTabs,
 }) => {
   const { t } = useAppTranslation();
   const [tab, setTab] = useState<Tab>("Player");
@@ -107,15 +109,17 @@ export const PlayerModal: React.FC<Props> = ({
   const player = data?.data;
 
   const setInitialTab = useCallback((equipped?: Equipped) => {
-    if (
-      equipped?.hat === "Streamer Hat" &&
-      loggedInFarmId !== currentPlayerId
-    ) {
-      setTab("Stream");
-    } else if (equipped?.shirt === "Gift Giver") {
-      setTab("Reward");
-    } else {
-      setTab("Player");
+    if (showSpecialTabs) {
+      if (
+        equipped?.hat === "Streamer Hat" &&
+        loggedInFarmId !== currentPlayerId
+      ) {
+        setTab("Stream");
+      } else if (equipped?.shirt === "Gift Giver") {
+        setTab("Reward");
+      } else {
+        setTab("Player");
+      }
     }
   }, []);
 
@@ -240,7 +244,7 @@ export const PlayerModal: React.FC<Props> = ({
               id: "Following",
             },
 
-            ...(playerHasGift
+            ...(playerHasGift && showSpecialTabs
               ? [
                   {
                     icon: giftIcon,
@@ -249,7 +253,7 @@ export const PlayerModal: React.FC<Props> = ({
                   },
                 ]
               : []),
-            ...(playerHasStreamReward && notCurrentPlayer
+            ...(playerHasStreamReward && notCurrentPlayer && showSpecialTabs
               ? [
                   {
                     icon: ITEM_DETAILS["Love Charm"].image,

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -521,6 +521,7 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
           loggedInFarmId={loggedInFarmId}
           token={rawToken}
           hasAirdropAccess={hasFeatureAccess(state, "AIRDROP_PLAYER")}
+          showSpecialTabs
         />
       ) : (
         <PlayerModals game={state} farmId={loggedInFarmId} />


### PR DESCRIPTION
# Description

There's a current bug where if streamer/gift giver is wearing their shirt and the player is following them, they would be able to access gift modal outside of the plaza

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
