### PR TITLE
[FEAT] Adjust Key Chests Rates for megastore items

### DIFF
--- a/src/components/ui/ChestRewardsList.tsx
+++ b/src/components/ui/ChestRewardsList.tsx
@@ -54,7 +54,7 @@ const RewardRow: React.FC<{
 };
 
 const isStoreChapterItem = (rewardName: string) => {
-  return SEASONAL_REWARDS(BASIC_SEASONAL_REWARDS_WEIGHT).some(
+  return SEASONAL_REWARDS(BASIC_SEASONAL_REWARDS_WEIGHT, "luxury").some(
     (reward) =>
       (reward.items && Object.keys(reward.items).includes(rewardName)) ||
       (reward.wearables && Object.keys(reward.wearables).includes(rewardName)),

--- a/src/features/game/types/chests.test.ts
+++ b/src/features/game/types/chests.test.ts
@@ -19,18 +19,24 @@ describe("SEASONAL_REWARDS", () => {
   const rewardTypes: {
     rewards: ChestReward[];
     weight: number;
+    chestTier: "basic" | "rare" | "luxury";
   }[] = [
-    { rewards: BASIC_REWARDS(), weight: 5 },
-    { rewards: RARE_REWARDS(), weight: 25 },
-    { rewards: LUXURY_REWARDS(), weight: 50 },
+    { rewards: BASIC_REWARDS(), weight: 20, chestTier: "basic" },
+    { rewards: RARE_REWARDS(), weight: 50, chestTier: "rare" },
+    { rewards: LUXURY_REWARDS(), weight: 50, chestTier: "luxury" },
   ];
 
   it("includes seasonal megastore items in all reward types with correct tier-based weightings", () => {
     const store = MEGASTORE[currentSeason];
 
-    rewardTypes.forEach(({ rewards, weight }) => {
-      // Test all tiers
+    rewardTypes.forEach(({ rewards, weight, chestTier }) => {
+      // Test tiers based on chest tier filtering
       Object.entries(MEGASTORE_TIER_WEIGHTS).forEach(([tier, tierWeight]) => {
+        // Apply the same filtering logic as SEASONAL_REWARDS
+        if (chestTier === "basic" && (tier === "mega" || tier === "epic"))
+          return;
+        if (chestTier === "rare" && tier === "mega") return;
+
         const tierItems = store[tier as keyof SeasonalStore].items;
 
         // For each item in the tier, verify it exists in rewards with correct weighting

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1125,6 +1125,7 @@ export const INVENTORY_RELEASES: Partial<Record<InventoryItemName, Releases>> =
     },
     // Double bed is not tradeable - explicitly set her to avoid accidental trade
     "Double Bed": undefined,
+    "Teamwork Monument": undefined,
     "Giant Artichoke": {
       tradeAt: SEASONS["Better Together"].endDate,
       withdrawAt: SEASONS["Better Together"].endDate,


### PR DESCRIPTION
# Description

This PR adjusts the rate for megastore items in chests

Key changes
- Mega Items are no longer included in Basic and Rare Chests
- Epic Items are no longer included in Basic Chest
- Drop rates for megastore items increased in basic and rare chests

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
