### PR TITLE
[FIX] Not Following Anyone Text

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6264,7 +6264,7 @@
   "playerModal.followers": "Followers ({{count}})",
   "playerModal.following": "Following ({{count}})",
   "playerModal.no.followers": "This player currently has no followers.",
-  "playerModal.no.following": "This player currently has no one following them.",
+  "playerModal.no.following": "This player is currently not following anyone.",
   "playerModal.dailyStreak": "Daily streak: {{streak}}",
   "playerModal.noFollowers": "No followers",
   "playerModal.noMoreMessages": "No more messages",


### PR DESCRIPTION
# Description

The Following tab is the tab that shows who the player is following atm. The text when they are not following anyone is inaccurate

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
