### PR TITLE
[FEAT] Add Quick Follow From Interaction

### DIFF
--- a/src/features/game/actions/effect.ts
+++ b/src/features/game/actions/effect.ts
@@ -57,7 +57,6 @@ export type StateMachineEffectName = Exclude<
   | "moderation.kicked"
   | "moderation.muted"
   | "moderation.unmuted"
-  | "farm.followed"
   | "farm.unfollowed"
   | "message.sent"
 >;
@@ -91,7 +90,8 @@ export type StateMachineStateName =
   | "marketplaceBulkOffersCancelling"
   | "linkingWallet"
   | "assigningNFT"
-  | "cheeringFarm";
+  | "cheeringFarm"
+  | "followingFarm";
 
 export type StateMachineVisitStateName =
   | "cheeringVillageProject"
@@ -135,6 +135,7 @@ export const STATE_MACHINE_EFFECTS: Record<
   "wallet.linked": "linkingWallet",
   "nft.assigned": "assigningNFT",
   "farm.cheered": "cheeringFarm",
+  "farm.followed": "followingFarm",
 };
 
 export const STATE_MACHINE_VISIT_EFFECTS: Record<

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -11,6 +11,7 @@ import volcanoIsland from "assets/icons/islands/volcano.webp";
 import flowerIcon from "assets/icons/flower_token.webp";
 import cheer from "assets/icons/cheer.webp";
 import socialPointsIcon from "assets/icons/social_score.webp";
+import followingIcon from "assets/icons/following.webp";
 
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -83,10 +84,6 @@ const _hasCheeredToday = (farmId: number) => (state: MachineState) => {
     ).socialFarming.cheersGiven.farms.includes(farmId)
   );
 };
-const _haveCleanedToday = (playerId: number) => (state: MachineState) => {
-  return !!(state.context.visitorState ?? state.context.state).socialFarming
-    .dailyCollections?.[playerId]?.pointGivenAt;
-};
 
 export const PlayerDetails: React.FC<Props> = ({
   data,
@@ -141,6 +138,21 @@ export const PlayerDetails: React.FC<Props> = ({
         <PlayerDetailsSkeleton />
         {!isMobile && <FollowerFeedSkeleton />}
       </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <InnerPanel className="flex gap-1 w-full max-h-[400px]">
+        <div className="flex flex-col justify-center mr-2 mb-1 gap-2">
+          <Label type="default" className="relative">
+            {t("player.notFound")}
+          </Label>
+          <span className="text-xs p-1">
+            {t("player.notFound.description")}
+          </span>
+        </div>
+      </InnerPanel>
     );
   }
 
@@ -353,6 +365,10 @@ export const PlayerDetails: React.FC<Props> = ({
                 disabled={playerLoading || followLoading || !!error || isSelf}
                 onClick={onFollow}
               >
+                <img
+                  src={iAmFollowing ? SUNNYSIDE.icons.drag : followingIcon}
+                  className="w-4 h-4 mr-1 pt-0.5 object-contain"
+                />
                 <span className="text-xs">
                   {followLoading ? `...` : iAmFollowing ? `Unfollow` : `Follow`}
                 </span>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6194,10 +6194,10 @@
   "description.solarDoll": "A once-thought impossible dream to craft.",
   "crafting.undiscovered": "Craft more items to discover new ingredients.",
   "description.cheer": "Give a cheer to your fellow farmers!",
-  "cheering.village.project": "Cheering Project",
-  "cheering.village.project.success": "Cheering Success!",
-  "cheering.village.project.failed": "Cheering Failed!",
-  "cheer.village.project": "Cheer Project",
+  "cheering.village.project": "Cheering project",
+  "cheering.village.project.success": "Cheering success!",
+  "cheering.village.project.failed": "Cheering failed!",
+  "cheer.village.project": "Cheer project",
   "cheer.village.project.description": "You can cheer the {{project}} to help {{username}} complete it!",
   "cheer.village.project.confirm": "Are you sure you want to cheer the {{project}}?",
   "cheer": "Cheer",
@@ -6332,5 +6332,10 @@
   "bin.increaseLimit.description": "Are you sure you want to increase the limit? This will reset every day.",
   "incinerator.welcome": "Welcome to the Incinerator!",
   "incinerator.description": "The Incinerator is a place where you can burn clutter to get extra Cheers",
-  "incinerator.burn": "Burn {{number}}"
+  "incinerator.burn": "Burn {{number}}",
+  "following.farm": "Following farm",
+  "following.farm.success": "You are now following this farm",
+  "following.farm.error": "Failed to follow this farm",
+  "player.notFound": "Player not found",
+  "player.notFound.description": "We were unable to find this player. Please try again later."
 }


### PR DESCRIPTION
# Description

Allow a player to quick follow from a notification that someone has followed you.

<img width="295" height="138" alt="Screenshot 2025-08-06 at 11 08 21 AM" src="https://github.com/user-attachments/assets/d8fd4118-f091-467f-9b3c-68139d94032c" />

Fixes #issue

# What needs to be tested by the reviewer?

- Have two players who aren't following each other. 
- Have one follow the other
- View the "Started following you!" message in the feed.
- Click on the follow icon
- Confirm you're following the player

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
