### PR TITLE
[FEAT] Auction Boosts

### DIFF
--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -305,6 +305,43 @@ describe("drillOilReserve", () => {
     );
   });
 
+  it("gives a +5 boost with Oil Gallon equipped", () => {
+    const now = Date.now();
+
+    const game = drillOilReserve({
+      action: {
+        id: "1",
+        type: "oilReserve.drilled",
+      },
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Oil Drill": new Decimal(2),
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            createdAt: now,
+            drilled: 0,
+            oil: {
+              drilledAt: 0,
+            },
+          },
+        },
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            secondaryTool: "Oil Gallon",
+          },
+        },
+      },
+    });
+
+    expect(game.inventory.Oil).toEqual(new Decimal(BASE_OIL_DROP_AMOUNT + 5));
+  });
+
   it("gives a +0.1 Bonus with Knight Chicken", () => {
     const boost = 0.1;
     const now = Date.now();

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -54,6 +54,11 @@ export function getOilDropAmount(game: GameState, reserve: OilReserve) {
     boostsUsed.push("Oil Extraction");
   }
 
+  if (isWearableActive({ game, name: "Oil Gallon" })) {
+    amount = amount.add(5);
+    boostsUsed.push("Oil Gallon");
+  }
+
   return { amount: amount.toDecimalPlaces(4).toNumber(), boostsUsed };
 }
 

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -1138,6 +1138,52 @@ describe("harvest", () => {
       expect(state.inventory.Artichoke).toEqual(new Decimal(3));
     });
 
+    it("gives +3 to the yield of Onion when Giant Onion is placed and ready", () => {
+      const state = harvest({
+        state: {
+          ...GAME_STATE,
+          bumpkin: TEST_BUMPKIN,
+          inventory: {
+            "Onion Seed": new Decimal(1),
+          },
+          season: {
+            season: "spring",
+            startedAt: 0,
+          },
+          collectibles: {
+            "Giant Onion": [
+              {
+                id: "123",
+                createdAt: dateNow,
+                coordinates: { x: 1, y: 1 },
+                readyAt: dateNow - 5 * 60 * 1000,
+              },
+            ],
+          },
+          crops: {
+            [firstId]: {
+              ...GAME_STATE.crops[firstId],
+              crop: {
+                name: "Onion",
+                plantedAt:
+                  dateNow - (CROPS["Onion"].harvestSeconds ?? 0) * 1000,
+              },
+            },
+          },
+        },
+        createdAt: dateNow,
+        action: {
+          type: "crop.harvested",
+          index: firstId,
+        },
+      });
+
+      const crops = state.crops;
+
+      expect(crops[firstId].crop).toBeUndefined();
+      expect(state.inventory.Onion).toEqual(new Decimal(4));
+    });
+
     it("gives +0.2 to the yield of Cabbage in AOE range when Scary Mike is placed and ready", () => {
       const state = harvest({
         state: {

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -787,6 +787,16 @@ export function getCropYieldAmount({
     boostsUsed.push("Hectare Farm");
   }
 
+  if (isCollectibleBuilt({ game, name: "Giant Onion" }) && crop === "Onion") {
+    amount += 3;
+    boostsUsed.push("Giant Onion");
+  }
+
+  /**
+   * All boosts should be applied above this comment
+   * Calendar events should be applied below this comment
+   */
+
   // Insect plague
   const isInsectPlagueActive =
     getActiveCalendarEvent({ game }) === "insectPlague";

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -657,6 +657,48 @@ describe("plant", () => {
       dateNow - 0.1 * CROPS.Parsnip.harvestSeconds * 1000,
     );
   });
+  it("grows turnip twice as fast with Giant Turnip placed.", () => {
+    const state = plant({
+      state: {
+        ...GAME_STATE,
+        bumpkin: TEST_BUMPKIN,
+        inventory: {
+          "Turnip Seed": new Decimal(1),
+          "Giant Turnip": new Decimal(1),
+        },
+        season: {
+          season: "winter",
+          startedAt: 0,
+        },
+        collectibles: {
+          "Giant Turnip": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              coordinates: { x: 1, y: 1 },
+              readyAt: dateNow - 100,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      action: {
+        type: "seed.planted",
+        cropId: "123",
+        index: Object.keys(GAME_STATE.crops)[0],
+        item: "Turnip Seed",
+      },
+    });
+
+    const turnipTime = CROPS.Turnip.harvestSeconds * 1000;
+
+    const crops = state.crops;
+
+    expect(crops).toBeDefined();
+    const plantedAt = crops[firstId].crop?.plantedAt || 0;
+
+    expect(plantedAt).toBe(dateNow - turnipTime * 0.5);
+  });
 
   describe("getCropTime", () => {
     const plot = GAME_STATE.crops[firstId];

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -373,6 +373,10 @@ export const getCropPlotTime = ({
     boostsUsed.push("Giant Zucchini");
   }
 
+  if (isCollectibleBuilt({ name: "Giant Turnip", game }) && crop === "Turnip") {
+    seconds = seconds * 0.5;
+  }
+
   const isSunshower = getActiveCalendarEvent({ game }) === "sunshower";
 
   if (isSunshower) {

--- a/src/features/game/events/landExpansion/startLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.test.ts
@@ -68,6 +68,30 @@ describe("startLavaPit", () => {
     expect(result.inventory.Oil).toEqual(new Decimal(0));
   });
 
+  it("subtracts the required resources with lava swimwear", () => {
+    const result = startLavaPit({
+      state: {
+        ...TEST_FARM,
+        bumpkin: {
+          ...TEST_FARM.bumpkin,
+          equipped: {
+            ...TEST_FARM.bumpkin.equipped,
+            dress: "Lava Swimwear",
+          },
+        },
+        lavaPits: {
+          1: { x: 0, y: 0, createdAt: 0 },
+        },
+      },
+      action: { type: "lavaPit.started", id: "1" },
+      createdAt: now,
+    });
+
+    expect(result.inventory.Oil).toEqual(new Decimal(50));
+    expect(result.inventory.Pepper).toEqual(new Decimal(375));
+    expect(result.inventory.Zucchini).toEqual(new Decimal(500));
+  });
+
   it("starts the lava pit", () => {
     const result = startLavaPit({
       state: {

--- a/src/features/game/events/landExpansion/supplyCropMachine.test.ts
+++ b/src/features/game/events/landExpansion/supplyCropMachine.test.ts
@@ -1822,7 +1822,7 @@ describe("supplyCropMachine", () => {
 
 describe("calculateCropTime", () => {
   it("calculates the time to harvest 10 Sunflower Seeds", () => {
-    const result = calculateCropTime(
+    const { milliSeconds: result } = calculateCropTime(
       { type: "Sunflower Seed", amount: 10 },
       GAME_STATE,
     );
@@ -1830,7 +1830,7 @@ describe("calculateCropTime", () => {
   });
 
   it("reduces crop machine growth time by 5% with Crop Processor Unit", () => {
-    const result = calculateCropTime(
+    const { milliSeconds: result } = calculateCropTime(
       { type: "Sunflower Seed", amount: 10 },
       {
         ...GAME_STATE,
@@ -1849,7 +1849,7 @@ describe("calculateCropTime", () => {
   });
 
   it("reduces crop machine growth time by 20% with Rapid Rig", () => {
-    const result = calculateCropTime(
+    const { milliSeconds: result } = calculateCropTime(
       { type: "Sunflower Seed", amount: 10 },
       {
         ...GAME_STATE,
@@ -1866,8 +1866,32 @@ describe("calculateCropTime", () => {
       (60 * 10 * 1000 * 0.8) / CROP_MACHINE_PLOTS(GAME_STATE),
     );
   });
+
+  it("reduces crop machine growth time by 50% with Groovy Gramophone", () => {
+    const { milliSeconds: result } = calculateCropTime(
+      { type: "Sunflower Seed", amount: 10 },
+      {
+        ...GAME_STATE,
+        collectibles: {
+          "Groovy Gramophone": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+              id: "0",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result).toBe(
+      (60 * 10 * 1000 * 0.5) / CROP_MACHINE_PLOTS(GAME_STATE),
+    );
+  });
+
   it("reduces crop machine growth time by 24% with Crop Processor Unit and Rapid Rig", () => {
-    const result = calculateCropTime(
+    const { milliSeconds: result } = calculateCropTime(
       { type: "Sunflower Seed", amount: 10 },
       {
         ...GAME_STATE,

--- a/src/features/game/expansion/components/lavaPit/LavaPitModalContent.tsx
+++ b/src/features/game/expansion/components/lavaPit/LavaPitModalContent.tsx
@@ -3,7 +3,7 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Label } from "components/ui/Label";
 import { useTranslation } from "react-i18next";
 import { getKeys } from "features/game/types/craftables";
-import { LAVA_PIT_REQUIREMENTS } from "features/game/events/landExpansion/startLavaPit";
+import { getLavaPitRequirements } from "features/game/events/landExpansion/startLavaPit";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
@@ -59,7 +59,9 @@ export const LavaPitModalContent: React.FC<Props> = ({ onClose, id }) => {
     gameService.send("lavaPit.collected", { id });
   };
 
-  const requirements = LAVA_PIT_REQUIREMENTS[season.season];
+  const { requirements } = getLavaPitRequirements(
+    gameService.state.context.state,
+  );
 
   const hasIngredients = getKeys(requirements).every((itemName) =>
     (inventory[itemName] ?? new Decimal(0)).gte(


### PR DESCRIPTION
# Description

This PR implements the Auction Boosts

- Groovy Gramophone - 2x Speed in Crop Machine
- Lava Swimwear - -50% resources required for Lava Pit
* Due to this boost, we are changing the Autumn Lava Pit Requirements to breakdown the Royal Ornament Ingredients since we can't burn 0.5 Royal Ornaments
- Oil Gallon - +5 Oil
- Giant Onion - +3 Onion
- Giant Turnip - 2x Turnip Growth Speed


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
