### PR TITLE
[FIX] Digby Dialogue Condition

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -1011,7 +1011,39 @@ export const STATIC_OFFLINE_FARM: GameState = {
   },
   desert: {
     digging: {
-      grid: [],
+      streak: {
+        count: 0,
+        collectedAt: Date.now() - 1000 * 60 * 60 * 1,
+        totalClaimed: 0,
+      },
+      grid: [
+        [
+          {
+            x: 0,
+            y: 0,
+            dugAt: 0,
+            items: { Coprolite: 1 },
+            tool: "Sand Shovel",
+          },
+        ],
+        [
+          {
+            x: 1,
+            y: 0,
+            dugAt: 0,
+            items: { Coprolite: 1 },
+            tool: "Sand Shovel",
+          },
+
+          {
+            x: 2,
+            y: 0,
+            dugAt: 0,
+            items: { Coprolite: 1 },
+            tool: "Sand Shovel",
+          },
+        ],
+      ],
       patterns: [],
     },
   },

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -1329,7 +1329,7 @@ export class BeachScene extends BaseScene {
   public handleDigbyWarnings = () => {
     if (!this.currentPlayer) return;
 
-    if (this.percentageTreasuresFound >= 100) {
+    if (this.percentageTreasuresFound >= 100 && !this.hasClaimedStreakReward) {
       if (this.alreadyNotifiedOfClaim) return;
 
       this.npcs.digby?.speak(translate("digby.claimPrize"));


### PR DESCRIPTION
# Description

Fixes the issue where the following dialogue appears when all 3 artefacts of the day are found and the reward has already been claimed. With this update, the dialogue no longer appears once the reward is claimed.

<img width="419" height="213" alt="image" src="https://github.com/user-attachments/assets/9b77fc24-3d4d-4235-bf6f-09e59b793eff" />

