### PR TITLE
[FEAT] Help farm

### DIFF
--- a/src/features/game/actions/effect.ts
+++ b/src/features/game/actions/effect.ts
@@ -43,9 +43,13 @@ type EffectName =
   | "farm.unfollowed"
   | "message.sent"
   | "farm.cheered"
-  | "project.completed";
+  | "project.completed"
+  | "farm.helped";
 
-type VisitEffectName = "villageProject.cheered" | "farm.cleaned";
+type VisitEffectName =
+  | "villageProject.cheered"
+  | "farm.cleaned"
+  | "farm.helped";
 
 // IMPORTANT: If your effect does not go via a state in the state machine then exclude it here!
 // Create a type that excludes the events that are not individual state machine states
@@ -93,11 +97,13 @@ export type StateMachineStateName =
   | "assigningNFT"
   | "cheeringFarm"
   | "followingFarm"
-  | "completingProject";
+  | "completingProject"
+  | "helpingFarm";
 
 export type StateMachineVisitStateName =
   | "cheeringVillageProject"
-  | "cleaningFarm";
+  | "cleaningFarm"
+  | "helpingFarm";
 
 export type StateNameWithStatus =
   | `${StateMachineStateName}Success`
@@ -139,6 +145,7 @@ export const STATE_MACHINE_EFFECTS: Record<
   "farm.cheered": "cheeringFarm",
   "farm.followed": "followingFarm",
   "project.completed": "completingProject",
+  "farm.helped": "helpingFarm",
 };
 
 export const STATE_MACHINE_VISIT_EFFECTS: Record<
@@ -147,6 +154,7 @@ export const STATE_MACHINE_VISIT_EFFECTS: Record<
 > = {
   "villageProject.cheered": "cheeringVillageProject",
   "farm.cleaned": "cleaningFarm",
+  "farm.helped": "helpingFarm",
 };
 
 export interface Effect {

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -527,6 +527,13 @@ import {
 } from "./landExpansion/flipCollectible";
 import { CatchPestAction, catchPest } from "./landExpansion/catchPest";
 
+// Visiting local events
+import {
+  collectGarbage,
+  CollectGarbageAction,
+} from "./visiting/collectGarbage";
+import { helpProject, HelpProjectAction } from "./visiting/helpProject";
+
 import {
   increaseBinLimit,
   IncreaseBinLimitAction,
@@ -680,10 +687,13 @@ export type PlayingEvent =
   | ClaimCheersAction
   | BurnClutterAction;
 
+export type LocalVisitingEvent = CollectGarbageAction | HelpProjectAction;
+
 export type VisitingEvent =
   | CollectClutterAction
   | CatchPestAction
-  | IncreaseBinLimitAction;
+  | IncreaseBinLimitAction
+  | LocalVisitingEvent;
 
 export type PlacementEvent =
   | ConstructBuildingAction
@@ -743,6 +753,7 @@ export type PlacementEvent =
   | FlipCollectibleAction;
 
 export type GameEvent = PlayingEvent | PlacementEvent | VisitingEvent;
+
 export type GameEventName<T> = Extract<T, { type: string }>["type"];
 
 export function isEventType<T extends PlayingEvent>(
@@ -915,10 +926,16 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "clutter.burned": burnClutter,
 };
 
+export const LOCAL_VISITING_EVENTS: Handlers<LocalVisitingEvent> = {
+  "garbage.collected": collectGarbage,
+  "project.helped": helpProject,
+};
+
 export const VISITING_EVENTS: Handlers<VisitingEvent> = {
   "clutter.collected": collectClutter,
   "pest.caught": catchPest,
   "binLimit.increased": increaseBinLimit,
+  ...LOCAL_VISITING_EVENTS,
 };
 
 export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {

--- a/src/features/game/events/visiting/collectGarbage.ts
+++ b/src/features/game/events/visiting/collectGarbage.ts
@@ -24,6 +24,7 @@ export function collectGarbage({
   createdAt = Date.now(),
 }: Options): [GameState, GameState] {
   return produce([state, visitorState!], ([game, visitorGame]) => {
+    console.log({ CleanGame: visitorGame });
     const clutters = game.socialFarming?.clutter?.locations;
 
     if (!clutters || !clutters[action.id]) {
@@ -35,6 +36,8 @@ export function collectGarbage({
     visitorGame.inventory[type] = (
       visitorState?.inventory[type] ?? new Decimal(0)
     ).plus(1);
+
+    console.log("locally collected", type, visitorGame.inventory[type]);
 
     delete clutters[action.id];
   });

--- a/src/features/game/events/visiting/collectGarbage.ts
+++ b/src/features/game/events/visiting/collectGarbage.ts
@@ -1,0 +1,41 @@
+import { produce } from "immer";
+import { GameState } from "features/game/types/game";
+import Decimal from "decimal.js-light";
+
+export type CollectGarbageAction = {
+  type: "garbage.collected";
+  id: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: CollectGarbageAction;
+  createdAt?: number;
+  visitorState?: GameState;
+};
+
+/**
+ * Local only event to collect garbage
+ */
+export function collectGarbage({
+  state,
+  action,
+  visitorState,
+  createdAt = Date.now(),
+}: Options): [GameState, GameState] {
+  return produce([state, visitorState!], ([game, visitorGame]) => {
+    const clutters = game.socialFarming?.clutter?.locations;
+
+    if (!clutters || !clutters[action.id]) {
+      throw new Error("No clutter found");
+    }
+
+    const type = clutters[action.id].type;
+
+    visitorGame.inventory[type] = (
+      visitorState?.inventory[type] ?? new Decimal(0)
+    ).plus(1);
+
+    delete clutters[action.id];
+  });
+}

--- a/src/features/game/events/visiting/collectGarbage.ts
+++ b/src/features/game/events/visiting/collectGarbage.ts
@@ -24,7 +24,6 @@ export function collectGarbage({
   createdAt = Date.now(),
 }: Options): [GameState, GameState] {
   return produce([state, visitorState!], ([game, visitorGame]) => {
-    console.log({ CleanGame: visitorGame });
     const clutters = game.socialFarming?.clutter?.locations;
 
     if (!clutters || !clutters[action.id]) {
@@ -36,8 +35,6 @@ export function collectGarbage({
     visitorGame.inventory[type] = (
       visitorState?.inventory[type] ?? new Decimal(0)
     ).plus(1);
-
-    console.log("locally collected", type, visitorGame.inventory[type]);
 
     delete clutters[action.id];
   });

--- a/src/features/game/events/visiting/helpProject.ts
+++ b/src/features/game/events/visiting/helpProject.ts
@@ -27,17 +27,13 @@ export function helpProject({
     if (!visitorGame) {
       throw new Error("No visitor game");
     }
-    console.log("locally helped project", action.project, visitorGame);
-    console.log({ helpProjectGame: visitorGame });
     const project = game.socialFarming.villageProjects[action.project];
-
-    console.log({ project });
 
     if (!project) {
       throw new Error("Project not found");
     }
 
-    if (!!project.helpedAt) {
+    if (project.helpedAt) {
       throw new Error("Already helped");
     }
 

--- a/src/features/game/events/visiting/helpProject.ts
+++ b/src/features/game/events/visiting/helpProject.ts
@@ -1,0 +1,44 @@
+import { produce } from "immer";
+import { GameState } from "features/game/types/game";
+import { MonumentName } from "features/game/types/monuments";
+
+export type HelpProjectAction = {
+  type: "project.helped";
+  project: MonumentName;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: HelpProjectAction;
+  createdAt?: number;
+  visitorState?: GameState;
+  visitedFarmId: number;
+};
+
+/**
+ * Local only event to check when helped
+ */
+export function helpProject({
+  state,
+  action,
+  visitorState,
+  createdAt = Date.now(),
+  visitedFarmId,
+}: Options): [GameState, GameState] {
+  return produce([state, visitorState!], ([game, visitorGame]) => {
+    const project = visitorGame.socialFarming.villageProjects[action.project];
+
+    if (!project) {
+      throw new Error("Project not found");
+    }
+
+    project.helpedAt = createdAt;
+
+    // TODO: remove these once using helpedAt
+    project.cheers += 1;
+    visitorGame.socialFarming.cheersGiven.projects[action.project] = [
+      ...(visitorGame.socialFarming.cheersGiven.projects[action.project] ?? []),
+      visitedFarmId,
+    ];
+  });
+}

--- a/src/features/game/events/visiting/helpProject.ts
+++ b/src/features/game/events/visiting/helpProject.ts
@@ -12,7 +12,6 @@ type Options = {
   action: HelpProjectAction;
   createdAt?: number;
   visitorState?: GameState;
-  visitedFarmId: number;
 };
 
 /**
@@ -23,22 +22,26 @@ export function helpProject({
   action,
   visitorState,
   createdAt = Date.now(),
-  visitedFarmId,
 }: Options): [GameState, GameState] {
   return produce([state, visitorState!], ([game, visitorGame]) => {
-    const project = visitorGame.socialFarming.villageProjects[action.project];
+    if (!visitorGame) {
+      throw new Error("No visitor game");
+    }
+    console.log("locally helped project", action.project, visitorGame);
+    console.log({ helpProjectGame: visitorGame });
+    const project = game.socialFarming.villageProjects[action.project];
+
+    console.log({ project });
 
     if (!project) {
       throw new Error("Project not found");
     }
 
-    project.helpedAt = createdAt;
+    if (!!project.helpedAt) {
+      throw new Error("Already helped");
+    }
 
-    // TODO: remove these once using helpedAt
+    project.helpedAt = createdAt;
     project.cheers += 1;
-    visitorGame.socialFarming.cheersGiven.projects[action.project] = [
-      ...(visitorGame.socialFarming.cheersGiven.projects[action.project] ?? []),
-      visitedFarmId,
-    ];
   });
 }

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -601,35 +601,8 @@ const getIslandElements = ({
       );
   }
 
-  {
-    clutter &&
-      isVisiting &&
-      mapPlacements.push(
-        ...Object.keys(clutter.locations).flatMap((id) => {
-          const { x, y } = clutter.locations[id];
-          const isPest = clutter.locations[id].type in FARM_PEST;
-
-          return (
-            <MapPlacement
-              key={`clutter-${id}`}
-              x={x}
-              y={y}
-              height={1}
-              width={1}
-              z={isPest ? 999999 : 99999999}
-              className={classNames({
-                "pointer-events-none": !isVisiting,
-              })}
-            >
-              <Clutter
-                key={`clutter-${id}`}
-                id={id}
-                type={clutter.locations[id].type}
-              />
-            </MapPlacement>
-          );
-        }),
-      );
+  if (clutter && isVisiting) {
+    mapPlacements.push(<Clutter clutter={clutter} />);
   }
 
   {

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -53,7 +53,6 @@ import { getCurrentBiome } from "features/island/biomes/biomes";
 import { useVisiting } from "lib/utils/visitUtils";
 import { getObjectEntries } from "./lib/utils";
 import { Clutter } from "features/island/clutter/Clutter";
-import { FARM_PEST } from "../types/clutter";
 
 export const LAND_WIDTH = 6;
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -16,6 +16,7 @@ import {
   GameEventName,
   VISITING_EVENTS,
   VisitingEvent,
+  LOCAL_VISITING_EVENTS,
 } from "../events";
 
 import {
@@ -347,13 +348,19 @@ const playingEventHandler = (eventName: string) => {
               visitorState: context.visitorState,
             });
 
-            const actions = [
+            let actions = [
               ...context.actions,
               {
                 ...event,
                 createdAt: new Date(),
               },
             ];
+
+            // Filter out any local only actions so we don't persist them
+            actions = actions.filter(
+              (action) =>
+                !Object.keys(LOCAL_VISITING_EVENTS).includes(action.type),
+            );
 
             if (Array.isArray(result)) {
               const [state, visitorState] = result;

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -317,19 +317,16 @@ const playingEventHandler = (eventName: string) => {
       {
         target: "hoarding",
         cond: (context: Context, event: PlayingEvent | VisitingEvent) => {
-          console.log("CHECKING?");
           const { valid } = checkProgress({
             state: context.state as GameState,
             action: event,
             farmId: context.farmId,
           });
-          console.log("Done chekcing?");
 
           return !valid;
         },
         actions: assign(
           (context: Context, event: PlayingEvent | VisitingEvent) => {
-            console.log("CHECKING again?");
             const { maxedItem } = checkProgress({
               state: context.state as GameState,
               action: event,
@@ -343,7 +340,6 @@ const playingEventHandler = (eventName: string) => {
       {
         actions: assign(
           (context: Context, event: PlayingEvent | VisitingEvent) => {
-            console.log("YEET?");
             const result = processEvent({
               state: context.state,
               action: event,
@@ -359,8 +355,6 @@ const playingEventHandler = (eventName: string) => {
                 createdAt: new Date(),
               },
             ];
-
-            console.log("actions", actions);
 
             // Filter out any local only actions so we don't persist them
             actions = actions.filter(

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -317,16 +317,19 @@ const playingEventHandler = (eventName: string) => {
       {
         target: "hoarding",
         cond: (context: Context, event: PlayingEvent | VisitingEvent) => {
+          console.log("CHECKING?");
           const { valid } = checkProgress({
             state: context.state as GameState,
             action: event,
             farmId: context.farmId,
           });
+          console.log("Done chekcing?");
 
           return !valid;
         },
         actions: assign(
           (context: Context, event: PlayingEvent | VisitingEvent) => {
+            console.log("CHECKING again?");
             const { maxedItem } = checkProgress({
               state: context.state as GameState,
               action: event,
@@ -340,6 +343,7 @@ const playingEventHandler = (eventName: string) => {
       {
         actions: assign(
           (context: Context, event: PlayingEvent | VisitingEvent) => {
+            console.log("YEET?");
             const result = processEvent({
               state: context.state,
               action: event,
@@ -355,6 +359,8 @@ const playingEventHandler = (eventName: string) => {
                 createdAt: new Date(),
               },
             ];
+
+            console.log("actions", actions);
 
             // Filter out any local only actions so we don't persist them
             actions = actions.filter(

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -611,6 +611,7 @@ export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
   try {
     newState = processEvent({ state, action, farmId }) as GameState;
   } catch {
+    console.log("Error processing event", action);
     // Not our responsibility to catch events, pass on to the next handler
     return { valid: true };
   }

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -611,7 +611,6 @@ export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
   try {
     newState = processEvent({ state, action, farmId }) as GameState;
   } catch {
-    console.log("Error processing event", action);
     // Not our responsibility to catch events, pass on to the next handler
     return { valid: true };
   }

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1545,6 +1545,13 @@ export type SocialFarming = {
     spawnedAt: number;
     locations: { [clutterId: string]: ClutterCoordinates };
   };
+  helped?: Record<
+    number,
+    {
+      count: number;
+      helpedAt: number;
+    }
+  >;
 };
 
 export interface GameState {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1518,11 +1518,15 @@ type DailyCollection = {
   clutter: { [clutterId: string]: ClutterCollection };
 };
 
+type VillageProject = {
+  cheers: number;
+  winnerId?: number;
+  helpedAt?: number; // Local only field
+};
+
 export type SocialFarming = {
   points: number;
-  villageProjects: Partial<
-    Record<MonumentName, { cheers: number; winnerId?: number }>
-  >;
+  villageProjects: Partial<Record<MonumentName, VillageProject>>;
   cheersGiven: {
     date: string;
     projects: Partial<Record<MonumentName, number[]>>;

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -1,8 +1,9 @@
 import Decimal from "decimal.js-light";
-import { Decoration } from "./decorations";
+import { Decoration, getKeys } from "./decorations";
 import { GameState, InventoryItemName } from "./game";
 import cloneDeep from "lodash.clonedeep";
 import { hasFeatureAccess } from "lib/flags";
+import { FARM_GARBAGE } from "./clutter";
 
 type LoveCharmMonumentName =
   | "Farmer's Monument"
@@ -245,4 +246,26 @@ export function getMonumentBoostedAmount({
   }
 
   return base;
+}
+
+export function isHelpComplete({ game }: { game: GameState }) {
+  const isClean = getKeys(game.socialFarming.clutter?.locations ?? {}).every(
+    (id) => {
+      const type = game.socialFarming.clutter?.locations[id].type;
+
+      // There are no garbage items left
+      return !type || !(type in FARM_GARBAGE);
+    },
+  );
+
+  const areProjectsHelped = getKeys(game.socialFarming.villageProjects).every(
+    (project) => {
+      const isComplete =
+        !!game.socialFarming.villageProjects[project]?.helpedAt;
+
+      return isComplete;
+    },
+  );
+
+  return isClean && areProjectsHelped;
 }

--- a/src/features/island/clutter/Clutter.tsx
+++ b/src/features/island/clutter/Clutter.tsx
@@ -18,6 +18,8 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { FarmCleaned } from "../hud/components/FarmCleaned";
 import { getBinLimit } from "features/game/events/landExpansion/increaseBinLimit";
 import sparkle from "public/world/sparkle2.gif";
+import { isHelpComplete } from "features/game/types/monuments";
+import { hasFeatureAccess } from "lib/flags";
 
 interface Props {
   id: string;
@@ -57,6 +59,13 @@ export const Clutter: React.FC<Props> = ({ id, type }) => {
       });
     }
 
+    if (
+      hasFeatureAccess(gameService.state.context.visitorState!, "CHEERS_V2")
+    ) {
+      handleHelpFarm();
+      return;
+    }
+
     gameService.send("clutter.collected", {
       id,
       visitedFarmId: farmId,
@@ -76,6 +85,23 @@ export const Clutter: React.FC<Props> = ({ id, type }) => {
       !hasCleanedToday(gameService.state)
     ) {
       setShowComplete(true);
+    }
+  };
+
+  // V2 - local only event
+  const handleHelpFarm = async () => {
+    gameService.send("garbage.collected", {
+      id,
+      visitedFarmId: farmId,
+    });
+
+    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+      gameService.send("farm.helped", {
+        effect: {
+          type: "farm.helped",
+          farmId: gameService.getSnapshot().context.farmId,
+        },
+      });
     }
   };
 

--- a/src/features/island/clutter/Clutter.tsx
+++ b/src/features/island/clutter/Clutter.tsx
@@ -18,8 +18,14 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { FarmCleaned } from "../hud/components/FarmCleaned";
 import { getBinLimit } from "features/game/events/landExpansion/increaseBinLimit";
 import sparkle from "public/world/sparkle2.gif";
-import { isHelpComplete } from "features/game/types/monuments";
+import {
+  hasHelpedFarmToday,
+  isHelpComplete,
+} from "features/game/types/monuments";
 import { hasFeatureAccess } from "lib/flags";
+import { FarmHelped } from "../hud/components/FarmHelped";
+import { GameState } from "features/game/types/game";
+import { MapPlacement } from "features/game/expansion/components/MapPlacement";
 
 interface Props {
   id: string;
@@ -34,7 +40,64 @@ const _caughtPests = (state: MachineState) =>
 const _inventory = (state: MachineState) =>
   state.context.visitorState?.inventory;
 
-export const Clutter: React.FC<Props> = ({ id, type }) => {
+export const Clutter: React.FC<{
+  clutter: GameState["socialFarming"]["clutter"];
+}> = ({ clutter }) => {
+  const { gameService } = useContext(Context);
+  const [showHelped, setShowHelped] = useState(false);
+
+  console.log({ clutter });
+
+  const hasHelpedToday = hasHelpedFarmToday({
+    game: gameService.state.context.visitorState!,
+    farmId: gameService.state.context.farmId,
+  });
+
+  if (hasHelpedToday) {
+    return null;
+  }
+
+  return (
+    <>
+      <Modal show={showHelped}>
+        <CloseButtonPanel
+          bumpkinParts={gameService.state.context.state.bumpkin.equipped}
+        >
+          <FarmHelped />
+        </CloseButtonPanel>
+      </Modal>
+
+      {...Object.keys(clutter?.locations ?? {}).flatMap((id) => {
+        const { x, y } = clutter!.locations[id];
+        const isPest = clutter!.locations[id].type in FARM_PEST;
+
+        return (
+          <MapPlacement
+            key={`clutter-${id}`}
+            x={x}
+            y={y}
+            height={1}
+            width={1}
+            z={isPest ? 999999 : 99999999}
+          >
+            <ClutterItem
+              onComplete={() => setShowHelped(true)}
+              key={`clutter-${id}`}
+              id={id}
+              type={clutter!.locations[id].type}
+            />
+          </MapPlacement>
+        );
+      })}
+    </>
+  );
+};
+
+export const ClutterItem: React.FC<
+  Props & {
+    onComplete: () => void;
+  }
+> = ({ id, type, onComplete }) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const farmId = useSelector(gameService, _farmId);
@@ -96,12 +159,8 @@ export const Clutter: React.FC<Props> = ({ id, type }) => {
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
-      gameService.send("farm.helped", {
-        effect: {
-          type: "farm.helped",
-          farmId: gameService.getSnapshot().context.farmId,
-        },
-      });
+      console.log("HELP COMPLETE");
+      onComplete();
     }
   };
 
@@ -123,6 +182,7 @@ export const Clutter: React.FC<Props> = ({ id, type }) => {
           <FarmCleaned />
         </CloseButtonPanel>
       </Modal>
+
       <div
         className="relative w-full h-full"
         onMouseEnter={() =>

--- a/src/features/island/clutter/Clutter.tsx
+++ b/src/features/island/clutter/Clutter.tsx
@@ -46,8 +46,6 @@ export const Clutter: React.FC<{
   const { gameService } = useContext(Context);
   const [showHelped, setShowHelped] = useState(false);
 
-  console.log({ clutter });
-
   const hasHelpedToday = hasHelpedFarmToday({
     game: gameService.state.context.visitorState!,
     farmId: gameService.state.context.farmId,
@@ -159,7 +157,6 @@ export const ClutterItem: React.FC<
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
-      console.log("HELP COMPLETE");
       onComplete();
     }
   };

--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -18,7 +18,6 @@ import Decimal from "decimal.js-light";
 import classNames from "classnames";
 import {
   isHelpComplete,
-  isHelpComplete,
   MonumentName,
   REQUIRED_CHEERS,
 } from "features/game/types/monuments";
@@ -27,9 +26,11 @@ import {
   SFTDetailPopoverInnerPanel,
   SFTDetailPopoverLabel,
 } from "components/ui/SFTDetailPopover";
-import { CheerModal, PROJECT_IMAGES } from "./Project";
+import { _hasCheeredToday, CheerModal, PROJECT_IMAGES } from "./Project";
 import powerup from "assets/icons/level_up.png";
 import { hasFeatureAccess } from "lib/flags";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { FarmHelped } from "features/island/hud/components/FarmHelped";
 
 const BOOST_LABELS: Partial<
   Record<
@@ -106,21 +107,6 @@ const _cheersAvailable = (state: MachineState) => {
   return state.context.visitorState?.inventory["Cheer"] ?? new Decimal(0);
 };
 
-export const _hasCheeredToday =
-  (project: MonumentName) => (state: MachineState) => {
-    const today = new Date().toISOString().split("T")[0];
-
-    if (state.context.visitorState?.socialFarming.cheersGiven.date !== today) {
-      return false;
-    }
-
-    return (
-      state.context.visitorState?.socialFarming.cheersGiven.projects[
-        project
-      ]?.includes(state.context.farmId) ?? false
-    );
-  };
-
 const MonumentImage = (
   input: MonumentProps & {
     open: boolean;
@@ -172,6 +158,7 @@ export const Monument: React.FC<MonumentProps> = (input) => {
 
   const [isCheering, setIsCheering] = useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
+  const [showHelped, setShowHelped] = useState(false);
 
   const [, setRender] = useState<number>(0);
 
@@ -200,12 +187,7 @@ export const Monument: React.FC<MonumentProps> = (input) => {
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
-      gameService.send("farm.helped", {
-        effect: {
-          type: "farm.helped",
-          farmId: gameService.getSnapshot().context.farmId,
-        },
-      });
+      setShowHelped(true);
     }
   };
 
@@ -238,6 +220,14 @@ export const Monument: React.FC<MonumentProps> = (input) => {
 
   return (
     <>
+      <Modal show={showHelped}>
+        <CloseButtonPanel
+          bumpkinParts={gameService.state.context.state.bumpkin.equipped}
+        >
+          <FarmHelped />
+        </CloseButtonPanel>
+      </Modal>
+
       <Popover>
         <PopoverButton as="div">
           {({ open }) => (
@@ -282,7 +272,14 @@ export const Monument: React.FC<MonumentProps> = (input) => {
                       <img className="w-full" src={SUNNYSIDE.icons.disc} />
                       <img
                         className={classNames("absolute")}
-                        src={cheer}
+                        src={
+                          hasFeatureAccess(
+                            gameService.getSnapshot().context.visitorState!,
+                            "CHEERS_V2",
+                          )
+                            ? SUNNYSIDE.icons.drag
+                            : cheer
+                        }
                         style={{
                           width: `${PIXEL_SCALE * 17}px`,
                           right: `${PIXEL_SCALE * 2}px`,

--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -16,7 +16,12 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import classNames from "classnames";
-import { MonumentName, REQUIRED_CHEERS } from "features/game/types/monuments";
+import {
+  isHelpComplete,
+  isHelpComplete,
+  MonumentName,
+  REQUIRED_CHEERS,
+} from "features/game/types/monuments";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   SFTDetailPopoverInnerPanel,
@@ -188,6 +193,22 @@ export const Monument: React.FC<MonumentProps> = (input) => {
     }
   };
 
+  // V2 - local only event
+  const handleHelpProject = async () => {
+    gameService.send("project.helped", {
+      project: input.project,
+    });
+
+    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+      gameService.send("farm.helped", {
+        effect: {
+          type: "farm.helped",
+          farmId: gameService.getSnapshot().context.farmId,
+        },
+      });
+    }
+  };
+
   const onClick = () => {
     if (isProjectComplete || hasCheeredProjectToday) {
       setIsCheering(true);
@@ -201,7 +222,7 @@ export const Monument: React.FC<MonumentProps> = (input) => {
       )
     ) {
       // New version doesn't need modal
-      handleCheer();
+      handleHelpProject();
     } else {
       setIsCheering(true);
     }

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -370,7 +370,7 @@ export const _hasCheeredToday =
       }
 
       if (
-        !!state.context.state?.socialFarming.villageProjects[project]?.helpedAt
+        state.context.state?.socialFarming.villageProjects[project]?.helpedAt
       ) {
         return true;
       }

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -19,6 +19,7 @@ import classNames from "classnames";
 import {
   getMonumentBoostedAmount,
   getMonumentRewards,
+  isHelpComplete,
   MonumentName,
   REQUIRED_CHEERS,
 } from "features/game/types/monuments";
@@ -452,6 +453,22 @@ export const Project: React.FC<ProjectProps> = (input) => {
     }
   };
 
+  // V2 - local only event
+  const handleHelpProject = async () => {
+    gameService.send("project.helped", {
+      project: input.project,
+    });
+
+    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+      gameService.send("farm.helped", {
+        effect: {
+          type: "farm.helped",
+          farmId: gameService.getSnapshot().context.farmId,
+        },
+      });
+    }
+  };
+
   const onClick = () => {
     if (isProjectComplete || hasCheeredProjectToday) {
       setIsCheering(true);
@@ -464,8 +481,7 @@ export const Project: React.FC<ProjectProps> = (input) => {
         "CHEERS_V2",
       )
     ) {
-      // New version doesn't need modal
-      handleCheer();
+      handleHelpProject();
     } else {
       setIsCheering(true);
     }

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -22,7 +22,7 @@ import { getTrashBinItems, hasCleanedToday } from "../clutter/Clutter";
 import {
   getCollectedGarbage,
   TRASH_BIN_FARM_LIMIT,
-} from "features/game/events/visiting/collectClutter";
+} from "features/game/events/landExpansion/collectClutter";
 import garbageBin from "assets/sfts/garbage_bin.webp";
 import socialPointsIcon from "assets/icons/social_score.webp";
 import loadingIcon from "assets/icons/timer.gif";
@@ -34,6 +34,11 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { FarmCleaned } from "./components/FarmCleaned";
 import { BinGuide } from "./components/BinGuide";
 import { getBinLimit } from "features/game/events/landExpansion/increaseBinLimit";
+import { hasFeatureAccess } from "lib/flags";
+import {
+  getHelpRequired,
+  hasHelpedFarmToday,
+} from "features/game/types/monuments";
 
 const _cheers = (state: MachineState) => {
   return state.context.visitorState?.inventory["Cheer"] ?? new Decimal(0);
@@ -67,9 +72,16 @@ export const VisitingHud: React.FC = () => {
   const { gameService, shortcutItem, selectedItem, fromRoute } =
     useContext(Context);
 
-  const [showVisitorGuide, setShowVisitorGuide] = useState(true);
-  const [showBinGuide, setShowBinGuide] = useState(false);
   const [gameState] = useActor(gameService);
+
+  const hasHelpedToday = hasHelpedFarmToday({
+    game: gameState.context.visitorState!,
+    farmId: gameState.context.farmId,
+  });
+
+  const [showVisitorGuide, setShowVisitorGuide] = useState(!hasHelpedToday);
+
+  const [showBinGuide, setShowBinGuide] = useState(false);
   const cheers = useSelector(gameService, _cheers);
   const socialPoints = useSelector(gameService, _socialPoints);
   const saving = useSelector(gameService, _autosaving);
@@ -99,6 +111,15 @@ export const VisitingHud: React.FC = () => {
     game: gameState.context.visitorState!,
   });
 
+  const hasCheersV2 = hasFeatureAccess(
+    gameState.context.visitorState!,
+    "CHEERS_V2",
+  );
+
+  const helpRequired = getHelpRequired({
+    game: gameState.context.state,
+  });
+
   return (
     <HudContainer>
       <Modal show={showVisitorGuide} onHide={() => setShowVisitorGuide(false)}>
@@ -118,7 +139,7 @@ export const VisitingHud: React.FC = () => {
       <Modal show={showBinGuide} onHide={() => setShowBinGuide(false)}>
         <BinGuide onClose={() => setShowBinGuide(false)} />
       </Modal>
-      {!gameState.matches("landToVisitNotFound") && (
+      {!gameState.matches("landToVisitNotFound") && !hasCheersV2 && (
         <InnerPanel className="absolute px-2 pt-1 pb-2 bottom-2 left-1/2 -translate-x-1/2 z-50 flex flex-row">
           <div className="flex flex-col p-0.5">
             <div className="flex items-center space-x-1">
@@ -140,6 +161,36 @@ export const VisitingHud: React.FC = () => {
             <span className="text-md">{`${collectedClutter}/${TRASH_BIN_FARM_LIMIT}`}</span>
             <img src={garbageBin} style={{ width: `20px`, margin: `2px` }} />
           </div>
+        </InnerPanel>
+      )}
+
+      {!gameState.matches("landToVisitNotFound") && hasCheersV2 && (
+        <InnerPanel className="absolute px-2 pt-1 pb-2 bottom-2 left-1/2 -translate-x-1/2 z-50 flex flex-row">
+          <div className="flex flex-col p-0.5 items-center justify-center">
+            <div className="flex items-center space-x-1">
+              <NPCIcon
+                parts={gameState.context.state.bumpkin?.equipped}
+                width={20}
+              />
+              <span className="text-xs whitespace-nowrap">
+                {t("visiting.farmId", { farmId: displayId })}
+              </span>
+            </div>
+          </div>
+          <div className="w-px h-[36px] bg-gray-300 mx-3 self-center" />
+          {hasHelpedToday ? (
+            <div className="flex flex-col sm:flex-row items-center space-x-1">
+              <img
+                src={SUNNYSIDE.icons.confirm}
+                style={{ width: `20px`, margin: `2px` }}
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col sm:flex-row items-center space-x-1">
+              <span className="text-md">{`${helpRequired}`}</span>
+              <img src={choreIcon} style={{ width: `20px`, margin: `2px` }} />
+            </div>
+          )}
         </InnerPanel>
       )}
       <div className="absolute right-0 top-0 p-2.5">

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -22,7 +22,7 @@ import { getTrashBinItems, hasCleanedToday } from "../clutter/Clutter";
 import {
   getCollectedGarbage,
   TRASH_BIN_FARM_LIMIT,
-} from "features/game/events/landExpansion/collectClutter";
+} from "features/game/events/visiting/collectClutter";
 import garbageBin from "assets/sfts/garbage_bin.webp";
 import socialPointsIcon from "assets/icons/social_score.webp";
 import loadingIcon from "assets/icons/timer.gif";

--- a/src/features/island/hud/components/FarmHelped.tsx
+++ b/src/features/island/hud/components/FarmHelped.tsx
@@ -1,0 +1,73 @@
+import { Button } from "components/ui/Button";
+import { Label } from "components/ui/Label";
+import { useGame } from "features/game/GameProvider";
+import { NPCIcon } from "features/island/bumpkin/components/NPC";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import React from "react";
+import socialScoreIcon from "assets/icons/social_score.webp";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { hasFeatureAccess } from "lib/flags";
+
+export const FarmHelped: React.FC = () => {
+  const { gameService, gameState } = useGame();
+
+  const { t } = useAppTranslation();
+
+  const handleClean = () => {
+    gameService.send("farm.helped", {
+      effect: {
+        type: "farm.helped",
+        visitedFarmId: gameService.state.context.farmId,
+      },
+    });
+  };
+
+  return (
+    <>
+      <div className="p-1">
+        <Label type="default">{t("visiting.helped")}</Label>
+        <p className="text-sm my-1">{t("visiting.helped.thanks")} </p>
+        <div className="flex items-center flex-wrap">
+          <div className="flex items-center mr-4">
+            <NPCIcon parts={gameState.context.state.bumpkin.equipped} />
+            <div className="ml-1">
+              <p className="text-sm">{gameState.context.state.username}</p>
+            </div>
+          </div>
+          <Label type="warning" className="mr-2" icon={socialScoreIcon}>
+            {t("socialPoints", { points: 1 })}
+          </Label>
+          {hasFeatureAccess(
+            gameService.getSnapshot().context.visitorState!,
+            "CHEERS_V2",
+          ) && (
+            <Label type="warning" icon={ITEM_DETAILS["Love Charm"].image}>
+              {`+1 Love Charm`}
+            </Label>
+          )}
+        </div>
+
+        {/* <div className="flex items-center flex-wrap">
+          <div className="flex items-center mr-4">
+            <NPCIcon
+              parts={
+                gameState.context.visitorState?.bumpkin
+                  ?.equipped as BumpkinParts
+              }
+            />
+            <div className="ml-1">
+              <p className="text-sm">
+                {gameState.context.visitorState?.username as string}
+              </p>
+            </div>
+          </div>
+          <Label type="transparent" icon={socialScoreIcon}>
+            {t("socialPoints", { points: 2 })}
+          </Label>
+        </div> */}
+      </div>
+
+      <Button onClick={handleClean}>{t("ok")}</Button>
+    </>
+  );
+};

--- a/src/features/island/hud/components/VisitorGuide.tsx
+++ b/src/features/island/hud/components/VisitorGuide.tsx
@@ -11,7 +11,7 @@ import { _hasCheeredToday } from "features/island/collectibles/components/Monume
 import { hasCleanedToday } from "features/island/clutter/Clutter";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import Decimal from "decimal.js-light";
-import { getCollectedGarbage } from "features/game/events/landExpansion/collectClutter";
+import { getCollectedGarbage } from "features/game/events/visiting/collectClutter";
 import { ClutterName, FARM_PEST } from "features/game/types/clutter";
 
 interface VisitorGuideProps {

--- a/src/features/island/hud/components/VisitorGuide.tsx
+++ b/src/features/island/hud/components/VisitorGuide.tsx
@@ -4,15 +4,18 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import React from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getKeys } from "features/game/lib/crafting";
-import { WORKBENCH_MONUMENTS } from "features/game/types/monuments";
+import {
+  hasHelpedFarmToday,
+  WORKBENCH_MONUMENTS,
+} from "features/game/types/monuments";
 import { useGame } from "features/game/GameProvider";
 import { Button } from "components/ui/Button";
-import { _hasCheeredToday } from "features/island/collectibles/components/Monument";
 import { hasCleanedToday } from "features/island/clutter/Clutter";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import Decimal from "decimal.js-light";
-import { getCollectedGarbage } from "features/game/events/visiting/collectClutter";
+import { getCollectedGarbage } from "features/game/events/landExpansion/collectClutter";
 import { ClutterName, FARM_PEST } from "features/game/types/clutter";
+import { _hasCheeredToday } from "features/island/collectibles/components/Project";
 
 interface VisitorGuideProps {
   onClose: () => void;
@@ -44,6 +47,28 @@ export const VisitorGuide: React.FC<VisitorGuideProps> = ({ onClose }) => {
     {} as Record<ClutterName, number>,
   );
 
+  const hasHelpedToday = hasHelpedFarmToday({
+    game: gameState.context.visitorState!,
+    farmId: gameState.context.farmId,
+  });
+
+  if (hasHelpedToday) {
+    return (
+      <div className="max-h-[300px] overflow-y-auto scrollable pr-0.5">
+        <Label type="default">
+          {t("visitorGuide.farmTitle", {
+            username:
+              gameState.context.state.username ??
+              `#${gameState.context.farmId}`,
+          })}
+        </Label>
+        <p className="text-xs sm:text-sm mb-2 p-1">
+          {t("visitorGuide.alreadyHelped")}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="max-h-[300px] overflow-y-auto scrollable pr-0.5">
       <Label type="default">
@@ -55,7 +80,9 @@ export const VisitorGuide: React.FC<VisitorGuideProps> = ({ onClose }) => {
       <p className="text-xs sm:text-sm mb-2 p-1">
         {t("visitorGuide.welcomeMessage")}
       </p>
+
       <Label type="default">{t("taskBoard.tasks")}</Label>
+
       {getKeys(clutter).map((type) => {
         const isPest = type in FARM_PEST;
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6273,6 +6273,8 @@
   "visitorGuide.netRequired": "Net required",
   "visiting.cleaned": "Cleaned",
   "visiting.thanks": "Thanks for cleaning my farm!",
+  "visiting.helped": "Helped",
+  "visiting.helped.thanks": "Thanks for helping my farm!",
   "visitorGuide.clutter": "Find the hidden item on the farm.",
   "visitorGuide.pest": "Catch the pest.",
   "visitorGuide.pets": "Catch the cheeky pests",
@@ -6359,7 +6361,10 @@
   "whatsOn.newChapterDate": "November 3rd",
   "whatsOn.newChapter.description": "The new chapter is coming soon!",
   "completing.project": "Completing project",
+  "visitorGuide.alreadyHelped": "Thanks for helping me today. Come back tomorrow to help again!",
   "completing.project.success": "Yeehaw, enjoy your reward!",
   "project.friendBonus": "Friend bonus",
-  "project.friendBonus.description": "A random helper has been selected to also receive the prize!"
+  "project.friendBonus.description": "A random helper has been selected to also receive the prize!",
+  "helping.farm": "Notfying Bumpkin",
+  "helping.farm.success": "Thanks for your help!"
 }


### PR DESCRIPTION
# Description

1. Makes all of the visiting actions instant - i.e. helping projects.
2. Max help 5 friends per day > unless limit increased

**Tech changes**

We now store visiting events locally and only submit them once all of them are complete. This avoids all of the loading modals after each monuments.