### PR TITLE
[FEAT] Differentiate Follow Requests by List Type

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -292,7 +292,7 @@ export const Feed: React.FC<Props> = ({
               networkList={following}
               networkCount={following.length}
               showLabel={false}
-              type="following"
+              networkType="following"
               scrollContainerRef={scrollContainerRef}
               navigateToPlayer={handleFollowingClick}
             />

--- a/src/features/social/PlayerModal.tsx
+++ b/src/features/social/PlayerModal.tsx
@@ -245,7 +245,7 @@ export const PlayerModal: React.FC<Props> = ({
                   networkList={player?.followedBy ?? []}
                   networkCount={player?.followedBy?.length ?? 0}
                   playerLoading={playerLoading}
-                  type="followers"
+                  networkType="followers"
                   navigateToPlayer={navigateToPlayer}
                   scrollContainerRef={scrollContainerRef}
                 />
@@ -263,7 +263,7 @@ export const PlayerModal: React.FC<Props> = ({
                   networkCount={player?.following?.length ?? 0}
                   networkList={player?.following ?? []}
                   playerLoading={playerLoading}
-                  type="following"
+                  networkType="following"
                   navigateToPlayer={navigateToPlayer}
                   scrollContainerRef={scrollContainerRef}
                 />

--- a/src/features/social/actions/getFollowNetworkDetails.ts
+++ b/src/features/social/actions/getFollowNetworkDetails.ts
@@ -7,6 +7,7 @@ type Request = {
   farmId: number;
   networkFarmId: number;
   nextCursor: number | null;
+  networkType: "followers" | "following";
 };
 
 export type Detail = {
@@ -32,8 +33,9 @@ export const getFollowNetworkDetails = async ({
   farmId,
   networkFarmId,
   nextCursor,
+  networkType,
 }: Request): Promise<FollowNetworkDetails> => {
-  const url = `${CONFIG.API_URL}/data?type=followNetworkDetails&networkFarmId=${networkFarmId}&farmId=${farmId}&nextCursor=${nextCursor}`;
+  const url = `${CONFIG.API_URL}/data?type=followNetworkDetails&networkFarmId=${networkFarmId}&networkType=${networkType}&farmId=${farmId}&nextCursor=${nextCursor}`;
 
   const res = await fetch(url, {
     headers: {

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -17,9 +17,9 @@ type Props = {
   networkFarmId: number;
   networkList: number[];
   networkCount: number;
+  networkType: "followers" | "following";
   playerLoading?: boolean;
   showLabel?: boolean;
-  type: "followers" | "following";
   scrollContainerRef: React.RefObject<HTMLDivElement>;
   navigateToPlayer: (playerId: number) => void;
 };
@@ -32,7 +32,7 @@ export const FollowList: React.FC<Props> = ({
   networkCount,
   playerLoading,
   showLabel = true,
-  type,
+  networkType,
   scrollContainerRef,
   navigateToPlayer,
 }) => {
@@ -59,7 +59,7 @@ export const FollowList: React.FC<Props> = ({
     error,
     loadMore,
     mutate,
-  } = useFollowNetwork(token, loggedInFarmId, networkFarmId);
+  } = useFollowNetwork(token, loggedInFarmId, networkFarmId, networkType);
 
   useEffect(() => {
     const el = scrollContainerRef.current;
@@ -90,7 +90,7 @@ export const FollowList: React.FC<Props> = ({
         <div className="sticky top-0 bg-brown-200 z-10 pb-1">
           {showLabel && (
             <Label type="default">
-              {t(`playerModal.${type}`, { count: networkCount })}
+              {t(`playerModal.${networkType}`, { count: networkCount })}
             </Label>
           )}
         </div>
@@ -107,7 +107,7 @@ export const FollowList: React.FC<Props> = ({
           <div className="sticky top-0 bg-brown-200 z-10 pb-1">
             {showLabel && (
               <Label type="default">
-                {t(`playerModal.${type}`, { count: networkCount })}
+                {t(`playerModal.${networkType}`, { count: networkCount })}
               </Label>
             )}
           </div>
@@ -124,11 +124,11 @@ export const FollowList: React.FC<Props> = ({
         <div className="sticky top-0 bg-brown-200 z-10 pb-1">
           {showLabel && (
             <Label type="default">
-              {t(`playerModal.${type}`, { count: networkCount })}
+              {t(`playerModal.${networkType}`, { count: networkCount })}
             </Label>
           )}
         </div>
-        <div className="text-xs">{t(`playerModal.no.${type}`)}</div>
+        <div className="text-xs">{t(`playerModal.no.${networkType}`)}</div>
       </div>
     );
   }
@@ -138,34 +138,30 @@ export const FollowList: React.FC<Props> = ({
       <div className="sticky -top-1 bg-brown-200 z-10 pb-1 pt-1">
         {showLabel && (
           <Label type="default">
-            {t(`playerModal.${type}`, { count: networkCount })}
+            {t(`playerModal.${networkType}`, { count: networkCount })}
           </Label>
         )}
       </div>
       <div className="flex flex-col gap-1">
-        {networkList.map((followId) => {
-          const details = network.find((detail) => detail.id === followId);
-
-          if (!details) return null;
-
+        {network.map((detail) => {
           const friendStreak = getHelpStreak({
             farm: gameService.state.context.state.socialFarming.helped?.[
-              followId
+              detail.id
             ],
           });
 
           return (
             <FollowDetailPanel
-              key={`flw-${details.id}`}
+              key={`flw-${detail.id}`}
               loggedInFarmId={loggedInFarmId}
-              playerId={details.id}
-              clothing={details.clothing as Equipped}
-              username={details.username ?? ""}
-              lastOnlineAt={details.lastUpdatedAt ?? 0}
+              playerId={detail.id}
+              clothing={detail.clothing as Equipped}
+              username={detail.username ?? ""}
+              lastOnlineAt={detail.lastUpdatedAt ?? 0}
               navigateToPlayer={navigateToPlayer}
-              projects={details.projects ?? {}}
-              socialPoints={details.socialPoints ?? 0}
-              haveCleanedToday={!!details.cleanedToday}
+              projects={detail.projects ?? {}}
+              socialPoints={detail.socialPoints ?? 0}
+              haveCleanedToday={!!detail.cleanedToday}
               friendStreak={friendStreak}
             />
           );

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -385,7 +385,7 @@ export const PlayerDetails: React.FC<Props> = ({
           <div className="flex flex-col gap-1 px-1 w-full ml-1 pt-0">
             <div className="flex items-center justify-between">
               <FollowsIndicator
-                count={data?.data?.followedByCount ?? 0}
+                count={data?.data?.followedBy?.length ?? 0}
                 onClick={onFollowersClick}
                 type="followers"
               />

--- a/src/features/social/hooks/useFollowNetwork.ts
+++ b/src/features/social/hooks/useFollowNetwork.ts
@@ -8,23 +8,25 @@ export const useFollowNetwork = (
   token: string,
   loggedInFarmId: number,
   networkFarmId: number,
+  networkType: "followers" | "following",
 ) => {
   const getKey = (
     pageIndex: number,
     previousPageData: FollowNetworkDetails | null,
   ) => {
-    if (pageIndex === 0) return `followNetworkDetails-${networkFarmId}-0`;
+    if (pageIndex === 0)
+      return `followNetworkDetails-${networkType}-${networkFarmId}-0`;
 
     if (!previousPageData?.data?.nextCursor) return null;
 
-    return `followNetworkDetails-${networkFarmId}-${previousPageData.data.nextCursor}`;
+    return `followNetworkDetails-${networkType}-${networkFarmId}-${previousPageData.data.nextCursor}`;
   };
 
   const { data, size, error, setSize, isValidating, mutate } = useSWRInfinite(
     getKey,
     (key) => {
       const parts = key.split("-");
-      const cursor = parts[2];
+      const cursor = parts[3];
       const nextCursor = cursor === "0" ? 0 : Number(cursor);
 
       return getFollowNetworkDetails({
@@ -32,6 +34,7 @@ export const useFollowNetwork = (
         farmId: loggedInFarmId,
         networkFarmId,
         nextCursor,
+        networkType,
       });
     },
     {

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -39,22 +39,17 @@ export type Player = {
   data?: {
     id: number;
     following: number[];
-    followingCount: number;
     followedBy: number[];
-    followedByCount: number;
     username: string;
     level: number;
     farmCreatedAt: number;
     marketValue: number;
     island: IslandType;
-    dailyStreak: number;
-    totalDeliveries: number;
     isVip: boolean;
     clothing: Equipped;
     faction?: FactionName;
     lastUpdatedAt: number;
     socialPoints: number;
-    hasCleanedToday: boolean;
     projects: ActiveProjects;
     cleaning: {
       youCleanedThemCount: number;


### PR DESCRIPTION
# Description

Add `networkType` to the followers requests so we can return only followers or followedby. This is required for the cursor pagination to work correctly.

Fixes #issue

# What needs to be tested by the reviewer?

- Check followers and following lists work correctly and are ordered by social point.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
