### PR TITLE
[FEAT] Persist Visit Guide Acknowledgement

### DIFF
--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -79,8 +79,12 @@ export const VisitingHud: React.FC = () => {
     farmId: gameState.context.farmId,
   });
 
-  const [showVisitorGuide, setShowVisitorGuide] = useState(true);
-
+  const [showVisitorGuide, setShowVisitorGuide] = useState(() => {
+    // Check if user has already acknowledged the visitor guide
+    const hasAcknowledged =
+      localStorage.getItem("visitorGuideAcknowledged") === "true";
+    return !hasAcknowledged;
+  });
   const [showBinGuide, setShowBinGuide] = useState(false);
   const cheers = useSelector(gameService, _cheers);
   const socialPoints = useSelector(gameService, _socialPoints);
@@ -120,14 +124,21 @@ export const VisitingHud: React.FC = () => {
     game: gameState.context.state,
   });
 
+  const handleCloseVisitorGuide = () => {
+    // Store acknowledgment in local storage
+    localStorage.setItem("visitorGuideAcknowledged", "true");
+    setShowVisitorGuide(false);
+    gameService.send("SAVE");
+  };
+
   return (
     <HudContainer>
-      <Modal show={showVisitorGuide} onHide={() => setShowVisitorGuide(false)}>
+      <Modal show={showVisitorGuide} onHide={handleCloseVisitorGuide}>
         <CloseButtonPanel
           bumpkinParts={gameState.context.state.bumpkin?.equipped}
           container={OuterPanel}
         >
-          <VisitorGuide onClose={() => setShowVisitorGuide(false)} />
+          <VisitorGuide onClose={handleCloseVisitorGuide} />
         </CloseButtonPanel>
       </Modal>
       <Modal show={showCleanedModal}>


### PR DESCRIPTION
# Description

When you acknowledge the visitor guide for the first time its persisted in local storage so it doesn't show again. 

Players have access to the task list through the hud.

Fixes #issue

- Visit and acknowledge the modal
- Visit another farm, modal shouldn't show

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
