### PR TITLE
[CHORE] Increase wool trade/max limits

### DIFF
--- a/src/features/game/actions/tradeLimits.ts
+++ b/src/features/game/actions/tradeLimits.ts
@@ -80,7 +80,7 @@ export const TRADE_LIMITS: Partial<Record<TradeResource, number>> = {
   Honey: 100,
   Milk: 100,
   Leather: 100,
-  Wool: 100,
+  Wool: 1000,
   "Merino Wool": 100,
   ...EMBLEM_TRADE_LIMITS,
 };

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -157,7 +157,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   Chicken: new Decimal(20),
   Egg: new Decimal(1700),
   Leather: new Decimal(1500),
-  Wool: new Decimal(2500),
+  Wool: new Decimal(3000),
   "Merino Wool": new Decimal(1500),
   Feather: new Decimal(3000),
   Milk: new Decimal(1500),

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -157,7 +157,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   Chicken: new Decimal(20),
   Egg: new Decimal(1700),
   Leather: new Decimal(1500),
-  Wool: new Decimal(1500),
+  Wool: new Decimal(2500),
   "Merino Wool": new Decimal(1500),
   Feather: new Decimal(3000),
   Milk: new Decimal(1500),


### PR DESCRIPTION
# Description

Will large amounts of wool being a requirement for biomes, it makes sense to increase the trade limits.

<img width="492" height="264" alt="Screenshot 2025-08-08 at 3 56 54 PM" src="https://github.com/user-attachments/assets/ee0c36f6-805e-41d6-b30f-fa461b56991a" />

Fixes #issue

# What needs to be tested by the reviewer?

- List wool amount > than 100

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
