### PR TITLE
[FIX] Cooking Pots Hitbox Size

### DIFF
--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -2714,7 +2714,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
     <Project
       {...props}
       divStyle={{
-        width: `${PIXEL_SCALE * 48}px`,
+        width: `${PIXEL_SCALE * 32}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
         left: `${PIXEL_SCALE * 0}px`,
       }}
@@ -2729,7 +2729,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
     <Project
       {...props}
       divStyle={{
-        width: `${PIXEL_SCALE * 48}px`,
+        width: `${PIXEL_SCALE * 32}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
         left: `${PIXEL_SCALE * 0}px`,
       }}
@@ -2744,7 +2744,7 @@ export const COLLECTIBLE_COMPONENTS: Record<
     <Project
       {...props}
       divStyle={{
-        width: `${PIXEL_SCALE * 48}px`,
+        width: `${PIXEL_SCALE * 32}px`,
         bottom: `${PIXEL_SCALE * 0}px`,
         left: `${PIXEL_SCALE * 0}px`,
       }}


### PR DESCRIPTION
# Description

Fixes an issue where cooking pots could be clicked to open their popover outside their dedicated horizontal size (2 tiles), due to extra width in their divStyle. One result of this issue was that, when pots were positioned horizontally next to each other, clicking a pot could open the popover for the adjacent cooking pot instead of the one clicked.

### Resolves #6066 
