### PR TITLE
[FIX] Doll Recipes not able to be selected from Recipes Tab

### DIFF
--- a/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
@@ -22,15 +22,14 @@ import {
 } from "features/game/lib/crafting";
 import { getImageUrl } from "lib/utils/getImageURLS";
 import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
-import Decimal from "decimal.js-light";
 import { RecipeInfoPanel } from "./RecipeInfoPanel";
-import { getKeys } from "features/game/types/decorations";
 import { CollectibleName } from "features/game/types/craftables";
 import { availableWardrobe } from "features/game/events/landExpansion/equip";
 import { getBoostedCraftingTime } from "features/game/events/landExpansion/startCrafting";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import lightningIcon from "assets/icons/lightning.png";
 import { InventoryItemName } from "features/game/types/game";
+import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
 
 const _state = (state: MachineState) => state.context.state;
 
@@ -75,22 +74,8 @@ export const RecipesTab: React.FC<Props> = ({
   }, [recipes, searchTerm]);
 
   const remainingInventory = useMemo(() => {
-    const updatedInventory = { ...inventory };
-
-    // Removed placed items
-    getKeys(updatedInventory).forEach((itemName) => {
-      const placedCount =
-        (gameService.getSnapshot().context.state.collectibles[
-          itemName as CollectibleName
-        ]?.length ?? 0) +
-        (gameService.getSnapshot().context.state.home?.collectibles[
-          itemName as CollectibleName
-        ]?.length ?? 0);
-
-      updatedInventory[itemName] = (
-        updatedInventory[itemName] ?? new Decimal(0)
-      ).minus(placedCount);
-    });
+    const chestItems = getChestItems(state);
+    const updatedInventory = { ...inventory, ...chestItems };
 
     return updatedInventory;
   }, [inventory]);


### PR DESCRIPTION
# Description

This PR Fixes an issue where you can't select a doll in the recipes tab even though you have enough ingredients

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
