### PR TITLE
[FEAT] Hide Progress Bar when Monument project is at 100%

### DIFF
--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -219,19 +219,21 @@ export const Monument: React.FC<MonumentProps> = (input) => {
                   </div>
                 </div>
               )}
-              <div
-                className="absolute bottom-2 left-1/2"
-                style={{
-                  width: `${PIXEL_SCALE * 20}px`,
-                }}
-              >
-                <ProgressBar
-                  type="quantity"
-                  percentage={projectPercentage}
-                  formatLength="full"
-                  className="ml-1 -translate-x-1/2"
-                />
-              </div>
+              {projectPercentage < 100 && (
+                <div
+                  className="absolute bottom-2 left-1/2"
+                  style={{
+                    width: `${PIXEL_SCALE * 20}px`,
+                  }}
+                >
+                  <ProgressBar
+                    type="quantity"
+                    percentage={projectPercentage}
+                    formatLength="full"
+                    className="ml-1 -translate-x-1/2"
+                  />
+                </div>
+              )}
             </>
           )}
         </PopoverButton>


### PR DESCRIPTION
# Description

This PR Hides the progress bar when the monuement is completed. Cooking Pots and Big Fruits will continue to have the progress bar enabled at 100%


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
