### PR TITLE
[FIX] Chefs Hat Sync Bug

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -630,11 +630,14 @@ export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
   const { inventory, wardrobe } = newState;
   const auctionBid = newState.auctioneer.bid?.ingredients ?? {};
 
-  const listedItems = getActiveListedItems(newState);
-  const listedInventoryItemNames = getKeys(listedItems).filter(
+  const { collectibles: listedCollectibles, wearables: listedWearables } =
+    getActiveListedItems(newState);
+
+  const listedInventoryItemNames = getKeys(listedCollectibles).filter(
     (name) => name in KNOWN_IDS,
   ) as InventoryItemName[];
-  const listedWardrobeItemNames = getKeys(listedItems).filter(
+
+  const listedWardrobeItemNames = getKeys(listedWearables).filter(
     (name) => name in ITEM_IDS,
   ) as BumpkinItem[];
 
@@ -646,7 +649,7 @@ export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
     .every((name) => {
       const inventoryAmount = inventory[name] ?? new Decimal(0);
       const auctionAmount = auctionBid[name] ?? new Decimal(0);
-      const listingAmount = listedItems[name] ?? new Decimal(0);
+      const listingAmount = listedCollectibles[name] ?? new Decimal(0);
 
       const previousInventoryAmount =
         newState.previousInventory[name] || new Decimal(0);
@@ -674,7 +677,7 @@ export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
     .concat(listedWardrobeItemNames)
     .every((name) => {
       const wardrobeAmount = wardrobe[name] ?? 0;
-      const listedAmount = listedItems[name] ?? 0;
+      const listedAmount = listedWearables[name] ?? 0;
 
       const previousWardrobeAmount = newState.previousWardrobe[name] || 0;
 

--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -16,7 +16,10 @@ import {
   Inventory,
   InventoryItemName,
 } from "features/game/types/game";
-import { MarketplaceTradeableName } from "features/game/types/marketplace";
+import {
+  CollectionName,
+  MarketplaceTradeableName,
+} from "features/game/types/marketplace";
 import {
   RESOURCE_STATE_ACCESSORS,
   RESOURCE_DIMENSIONS,
@@ -32,9 +35,12 @@ const PLACEABLE_DIMENSIONS = {
 
 export const getActiveListedItems = (
   state: GameState,
-): Record<MarketplaceTradeableName, number> => {
+): Record<CollectionName, Record<MarketplaceTradeableName, number>> => {
   if (!state.trades.listings)
-    return {} as Record<MarketplaceTradeableName, number>;
+    return {} as Record<
+      CollectionName,
+      Record<MarketplaceTradeableName, number>
+    >;
 
   return Object.values(state.trades.listings).reduce(
     (acc, listing) => {
@@ -43,16 +49,16 @@ export const getActiveListedItems = (
       Object.entries(listing.items).forEach(([itemName, quantity]) => {
         const name = itemName as MarketplaceTradeableName;
 
-        if (acc[name]) {
-          acc[name] += quantity as number;
+        if (acc[listing.collection][name]) {
+          acc[listing.collection][name] += quantity as number;
         } else {
-          acc[name] = quantity as number;
+          acc[listing.collection][name] = quantity as number;
         }
       });
 
       return acc;
     },
-    {} as Record<MarketplaceTradeableName, number>,
+    {} as Record<CollectionName, Record<MarketplaceTradeableName, number>>,
   );
 };
 

--- a/src/features/world/ui/npcs/HalloweenNPC.tsx
+++ b/src/features/world/ui/npcs/HalloweenNPC.tsx
@@ -67,7 +67,7 @@ export const HalloweenNPC: React.FC<Props> = ({ onClose }) => {
   const [selectedItems, setSelectedItems] = useState<InventoryItemName[]>([]);
 
   const getChestBears = (state: GameState) => {
-    const listedItems = getActiveListedItems(state);
+    const { collectibles: listedCollectibles } = getActiveListedItems(state);
 
     const availableItems = getKeys(state.inventory).reduce((acc, itemName) => {
       if (typeof itemName === "string" && bears.includes(itemName)) {
@@ -78,7 +78,7 @@ export const HalloweenNPC: React.FC<Props> = ({ onClose }) => {
               ?.minus(
                 state.collectibles[itemName as CollectibleName]?.length ?? 0,
               )
-              ?.minus(listedItems[itemName] ?? 0)
+              ?.minus(listedCollectibles[itemName] ?? 0)
               ?.minus(
                 state.home.collectibles[itemName as CollectibleName]?.length ??
                   0,


### PR DESCRIPTION
# Description

Process event was not differentiating between collections when looking at active listings. I have changed the `getActiveListedItems` function to seperate by collection.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
