### PR TITLE
[FIX] Replace Shovel Icon in the Remove All button

### DIFF
--- a/src/features/island/collectibles/RemoveAllConfirmation.tsx
+++ b/src/features/island/collectibles/RemoveAllConfirmation.tsx
@@ -5,7 +5,7 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Button } from "components/ui/Button";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { ITEM_DETAILS } from "features/game/types/images";
+import cleanBroom from "assets/icons/clean_broom.webp";
 import { PlaceableLocation } from "features/game/types/collectibles";
 
 interface Props {
@@ -25,7 +25,7 @@ export const RemoveAllConfirmation: React.FC<Props> = ({
       <CloseButtonPanel title={t("removeAll.title")} onClose={onClose}>
         <div className="flex flex-col items-center p-2 w-full text-center text-sm">
           <img
-            src={ITEM_DETAILS["Rusty Shovel"].image}
+            src={cleanBroom}
             className="mb-4"
             style={{
               width: `${PIXEL_SCALE * 20}px`,

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -10,6 +10,7 @@ import chest from "assets/icons/chest.png";
 import shopIcon from "assets/icons/shop.png";
 import flipped from "assets/icons/flipped.webp";
 import flipIcon from "assets/icons/flip.webp";
+import cleanBroom from "assets/icons/clean_broom.webp";
 
 import { isMobile } from "mobile-device-detect";
 
@@ -210,7 +211,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
               </RoundButton>
               <RoundButton className="mb-3.5" onClick={removeAll}>
                 <img
-                  src={ITEM_DETAILS["Rusty Shovel"].image}
+                  src={cleanBroom}
                   className="absolute group-active:translate-y-[2px]"
                   style={{
                     top: `${PIXEL_SCALE * 5}px`,


### PR DESCRIPTION
# Description

I replaced the Rusty Shovel icon for a Broom one in the Landscaping UI and the confirmation modal to avoid confusion, some players click this option thinking that is the option to just remove things from their land.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] I have read the contributing guidelines and agree to the T&Cs