### PR TITLE
[FIX] Crafting Box ReadyAt time calculation

### DIFF
--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -3,6 +3,7 @@ import { LEVEL_EXPERIENCE } from "features/game/lib/level";
 import { INITIAL_BUMPKIN, TEST_FARM } from "../../lib/constants";
 import { GameState } from "../../types/game";
 import { placeBuilding } from "./placeBuilding";
+import { RECIPES } from "features/game/lib/crafting";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -378,6 +379,49 @@ describe("Place building", () => {
     expect(state.henHouse.animals["123"].asleepAt).toEqual(dateNow - 60000);
     expect(state.henHouse.animals["123"].awakeAt).toEqual(
       dateNow - 60000 + 24 * 60 * 60 * 1000,
+    );
+  });
+
+  it("adjusts the new readyAt for crafting box", () => {
+    const state = placeBuilding({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Crafting Box": new Decimal(1),
+          "Basic Land": new Decimal(10),
+        },
+        buildings: {
+          "Crafting Box": [
+            {
+              id: "123",
+              createdAt: dateNow,
+              readyAt: dateNow,
+              removedAt: dateNow - 120000,
+            },
+          ],
+        },
+        craftingBox: {
+          item: {
+            collectible: "Doll",
+          },
+          startedAt: dateNow - 180000,
+          readyAt: dateNow - 180000 + (RECIPES(GAME_STATE)["Doll"]?.time ?? 0),
+          status: "crafting",
+          recipes: {},
+        },
+      },
+      action: {
+        type: "building.placed",
+        name: "Crafting Box",
+        id: "123",
+        coordinates: { x: 0, y: 1 },
+      },
+      createdAt: dateNow,
+    });
+
+    expect(state.craftingBox.startedAt).toEqual(dateNow - 60000);
+    expect(state.craftingBox.readyAt).toEqual(
+      dateNow - 60000 + (RECIPES(GAME_STATE)["Doll"]?.time ?? 0),
     );
   });
 });

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -160,7 +160,7 @@ export function placeBuilding({
                 game: stateCopy,
                 time: RECIPES(stateCopy)[craftingBox.item.wearable]?.time ?? 0,
               });
-          craftingBox.readyAt = createdAt + recipeTime;
+          craftingBox.readyAt = craftingBox.startedAt + recipeTime;
         }
       }
 


### PR DESCRIPTION
# Description

This PR fixes an issue where placing crafting box would calculate the readyAt time from current time instead of the new startedAt time

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
