### PR TITLE
[FIX] FarmHelped not Triggers for Projects

### DIFF
--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -521,7 +521,7 @@ export const Project: React.FC<ProjectProps> = (input) => {
       project: input.project,
     });
 
-    if (isHelpComplete({ game: state })) {
+    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
       setShowHelped(true);
     }
   };


### PR DESCRIPTION
# Description
Fixes an issue where, if players cheer a cooking pot or big fruit as the last item to help a farm, the "helped farm" modal overlay does not appear, preventing them from confirming their help and successfully assisting the farm. Testing shows that monuments and clutters work fine when cheered/cleaned as the last item.

Originally reported on Discord: https://discord.com/channels/880987707214544966/950508604207796325/1405215849706422414
