### PR TITLE
[FIX] Reveal Land Setting minedAt/choppedAt/drilledAt needs to be earlier than removedAt

### DIFF
--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -681,7 +681,7 @@ describe("revealLand", () => {
     });
 
     expect(state.trees[1].wood.choppedAt).toBeLessThan(
-      state.trees[1].removedAt ?? 0,
+      state.trees[1].removedAt!,
     );
   });
 });

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -14,7 +14,6 @@ import { Airdrop, BoostName, GameState } from "features/game/types/game";
 import { getKeys } from "features/game/types/craftables";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
-import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { CropName } from "features/game/types/crops";
 import { produce } from "immer";
 
@@ -237,24 +236,21 @@ export function revealLand({
       land.lavaPits?.length ?? 0,
     );
 
-    // Refresh all basic resources
-    game.trees = getKeys(game.trees).reduce(
-      (acc, id) => {
-        return {
-          ...acc,
-          [id]: {
-            ...game.trees[id],
-            wood: {
-              ...game.trees[id].wood,
-              choppedAt: createdAt - 4 * 60 * 60 * 1000,
-            },
+    // Replenish all trees
+    game.trees = getKeys(game.trees).reduce<GameState["trees"]>((acc, id) => {
+      return {
+        ...acc,
+        [id]: {
+          ...game.trees[id],
+          wood: {
+            ...game.trees[id].wood,
+            choppedAt: 1,
           },
-        };
-      },
-      {} as GameState["trees"],
-    );
+        },
+      };
+    }, {});
 
-    game.stones = getKeys(game.stones).reduce(
+    game.stones = getKeys(game.stones).reduce<GameState["stones"]>(
       (acc, id) => {
         return {
           ...acc,
@@ -262,47 +258,41 @@ export function revealLand({
             ...game.stones[id],
             stone: {
               ...game.stones[id].stone,
-              minedAt: createdAt - 12 * 60 * 60 * 1000,
+              minedAt: 1,
             },
           },
         };
       },
-      {} as GameState["stones"],
+      {},
     );
 
-    game.iron = getKeys(game.iron).reduce(
-      (acc, id) => {
-        return {
-          ...acc,
-          [id]: {
-            ...game.iron[id],
-            stone: {
-              ...game.iron[id].stone,
-              minedAt: createdAt - 24 * 60 * 60 * 1000,
-            },
+    game.iron = getKeys(game.iron).reduce<GameState["iron"]>((acc, id) => {
+      return {
+        ...acc,
+        [id]: {
+          ...game.iron[id],
+          stone: {
+            ...game.iron[id].stone,
+            minedAt: 1,
           },
-        };
-      },
-      {} as GameState["iron"],
-    );
+        },
+      };
+    }, {});
 
-    game.gold = getKeys(game.gold).reduce(
-      (acc, id) => {
-        return {
-          ...acc,
-          [id]: {
-            ...game.gold[id],
-            stone: {
-              ...game.gold[id].stone,
-              minedAt: createdAt - 48 * 60 * 60 * 1000,
-            },
+    game.gold = getKeys(game.gold).reduce<GameState["gold"]>((acc, id) => {
+      return {
+        ...acc,
+        [id]: {
+          ...game.gold[id],
+          stone: {
+            ...game.gold[id].stone,
+            minedAt: 1,
           },
-        };
-      },
-      {} as GameState["gold"],
-    );
+        },
+      };
+    }, {});
 
-    game.crimstones = getKeys(game.crimstones).reduce(
+    game.crimstones = getKeys(game.crimstones).reduce<GameState["crimstones"]>(
       (acc, id) => {
         return {
           ...acc,
@@ -310,13 +300,28 @@ export function revealLand({
             ...game.crimstones[id],
             stone: {
               ...game.crimstones[id].stone,
-              minedAt: createdAt - CRIMSTONE_RECOVERY_TIME * 1000,
+              minedAt: 1,
             },
           },
         };
       },
-      {} as GameState["crimstones"],
+      {},
     );
+
+    game.oilReserves = getKeys(game.oilReserves).reduce<
+      GameState["oilReserves"]
+    >((acc, id) => {
+      return {
+        ...acc,
+        [id]: {
+          ...game.oilReserves[id],
+          oil: {
+            ...game.oilReserves[id].oil,
+            drilledAt: 1,
+          },
+        },
+      };
+    }, {});
 
     // Add fire pit on expansion 5
     if (landCount >= 5 && !game.inventory["Fire Pit"]) {


### PR DESCRIPTION
# Description

This PR Fixes the issue where the minedAt/choppedAt/drilledAt timing was set to a time that's later than the removedAt time.
It is important that the minedAt timing is removedAt timing due to the code in the place events

```ts
      if (updatedTree.wood && updatedTree.removedAt) {
        const existingProgress =
          updatedTree.removedAt - updatedTree.wood.choppedAt;
        updatedTree.wood.choppedAt = createdAt - existingProgress;
      }
```
Because it's calculating the existingProgress.
If existingProgress is negative, the choppedAt will be in the future, hence extending the time when the node will be ready

This PR sets that minedAt/choppedAt/drilledAt timing to be 1, essentially allowing them to mine instantly, and have no issues if those nodes are in their inventory

### Stealth Launch
Refresh Oil Reserve on Reveal Land

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
