### PR TITLE
[FIX] Boosted Monuments Popover Condition

### DIFF
--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -237,7 +237,10 @@ export const Monument: React.FC<MonumentProps> = (input) => {
           )}
         </PopoverButton>
 
-        <PopoverPanel anchor={{ to: "left start" }} className="flex">
+        <PopoverPanel
+          anchor={{ to: "left start" }}
+          className={classNames("flex", { hidden: isProjectComplete })}
+        >
           <SFTDetailPopoverInnerPanel>
             <SFTDetailPopoverLabel name={input.name} />
             <Label type="info" icon={helpIcon} className="ml-2 sm:ml-0">


### PR DESCRIPTION
# Description
Fixes the issue shown in the image below, where the popover containing help progress appears when clicking a completed monument. After the fix, only the modal with the boost description will be shown.

<img width="565" height="333" alt="image" src="https://github.com/user-attachments/assets/9e47b55f-7c4b-4f3b-8f79-d528f48ea164" />

