### PR TITLE
[FIX] Pathname while visiting

### DIFF
--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -77,7 +77,11 @@ export const VisitingHud: React.FC = () => {
   const navigate = useNavigate();
 
   const handleEndVisit = () => {
-    navigate(fromRoute ?? "/");
+    if (fromRoute && !fromRoute.includes("visit")) {
+      navigate(fromRoute);
+    } else {
+      navigate("/");
+    }
     gameService.send("END_VISIT");
   };
 

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -164,7 +164,9 @@ export const PlayerDetails: React.FC<Props> = ({
     if (!player) return;
 
     // Setting from route to navigate back to the correct page after visit
-    setFromRoute(location.pathname);
+    if (!isVisiting) {
+      setFromRoute(location.pathname);
+    }
 
     gameService.send("VISIT", { landId: player.id });
     navigate(`/visit/${player.id}`);


### PR DESCRIPTION
Co-authored-by: Spencer Dezart-Smith <17863697+spencerdezartsmith@users.noreply.github.com>

# Description

This PR fixes the issue where the pathname was set to the previous farm when you visit another farm from another farm, making the back path the visit path of the previous farm

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
