### PR TITLE
[FIX] Landscaping Movement issues

### DIFF
--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -135,6 +135,8 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
       return;
     }
 
+    const state = gameService.getSnapshot().context.state;
+
     if (!placeable) return;
 
     const items = getChestItems(state);
@@ -207,8 +209,8 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
     }
   }, [
     child.state,
+    gameService,
     placeable,
-    state,
     requirements,
     maximum,
     previousPosition,

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -262,7 +262,6 @@ export const MoveableComponent: React.FC<
     x: 0,
     y: 0,
   });
-  const state = useSelector(gameService, (state) => state.context.state);
 
   const isActive = useRef(false);
   const [showRemoveConfirmation, setShowRemoveConfirmation] = useState(false);
@@ -370,7 +369,11 @@ export const MoveableComponent: React.FC<
           return;
         }
 
-        const game = removePlaceable({ state, id, name });
+        const game = removePlaceable({
+          state: gameService.getSnapshot().context.state,
+          id,
+          name,
+        });
         const collisionDetected = detectCollision({
           name: name as CollectibleName,
           state: game,
@@ -452,7 +455,7 @@ export const MoveableComponent: React.FC<
           id,
           location,
           dimensions,
-          state,
+          state: gameService.getSnapshot().context.state,
           setIsColliding,
         });
         onStop({
@@ -481,7 +484,7 @@ export const MoveableComponent: React.FC<
           id,
           location,
           dimensions,
-          state,
+          state: gameService.getSnapshot().context.state,
           setIsColliding,
         });
         onStop({
@@ -510,7 +513,7 @@ export const MoveableComponent: React.FC<
           id,
           location,
           dimensions,
-          state,
+          state: gameService.getSnapshot().context.state,
           setIsColliding,
         });
         onStop({
@@ -539,7 +542,7 @@ export const MoveableComponent: React.FC<
           id,
           location,
           dimensions,
-          state,
+          state: gameService.getSnapshot().context.state,
           setIsColliding,
         });
         onStop({
@@ -565,6 +568,7 @@ export const MoveableComponent: React.FC<
     coordinatesX,
     coordinatesY,
     dimensions,
+    gameService,
     id,
     isPlacing,
     isSelected,
@@ -572,7 +576,6 @@ export const MoveableComponent: React.FC<
     name,
     onStop,
     position,
-    state,
   ]);
 
   return (
@@ -609,7 +612,7 @@ export const MoveableComponent: React.FC<
           id,
           location,
           dimensions,
-          state,
+          state: gameService.getSnapshot().context.state,
           setIsColliding,
         });
       }}


### PR DESCRIPTION
# Description

This PR fixes an issue where you can't place on a spot that was previously occupied by another collectible that was moved away.

This issue was because we were using useSelector to access state, which doesn't update the state in real time in the moveable component

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
