### PR TITLE
[FIX] Crimstone Resetting when expanding land

### DIFF
--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -16,6 +16,7 @@ import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisi
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { CropName } from "features/game/types/crops";
 import { produce } from "immer";
+import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
@@ -300,7 +301,9 @@ export function revealLand({
             ...game.crimstones[id],
             stone: {
               ...game.crimstones[id].stone,
-              minedAt: 1,
+              minedAt:
+                (game.crimstones[id].removedAt ?? createdAt) -
+                CRIMSTONE_RECOVERY_TIME,
             },
           },
         };


### PR DESCRIPTION
# Description

There's a bug when reveallling land after an expansion is completed, crimstone minesLeft resets. This is because we set the minedAt time to 1, which is way over the 24h time to keep the streak going for crimstone nodes.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
