### PR TITLE
[FEAT] Wire Up New Queries

### DIFF
--- a/src/features/game/actions/loadGameStateForVisit.ts
+++ b/src/features/game/actions/loadGameStateForVisit.ts
@@ -30,6 +30,8 @@ export async function loadGameStateForVisit(
   isBanned: boolean;
   visitorId: number;
   visitedFarmState: VisitGameState;
+  hasHelpedPlayerToday: boolean;
+  totalHelpedToday: number;
 }> {
   // Go and fetch the state for the farm you are trying to visit
   const url = `${API_URL}/visit/${id}`;

--- a/src/features/game/events/landExpansion/increaseHelpLimit.ts
+++ b/src/features/game/events/landExpansion/increaseHelpLimit.ts
@@ -27,15 +27,6 @@ export const HELP_LIMIT_COST: Inventory = {
 
 export const HELP_LIMIT = 5;
 
-export function getHelpedToday({ game }: { game: GameState }) {
-  const today = new Date().toISOString().split("T")[0];
-
-  return getKeys(game.socialFarming.helped ?? {}).filter((farmId) => {
-    const helpedAt = game.socialFarming.helped![farmId]?.helpedAt ?? 0;
-    return new Date(helpedAt).toISOString().split("T")[0] === today;
-  }).length;
-}
-
 export function getHelpLimit({
   game,
   now = new Date(),
@@ -103,6 +94,12 @@ export function increaseHelpLimit({
   });
 }
 
-export function hasHitHelpLimit({ game }: { game: GameState }) {
-  return getHelpedToday({ game }) >= getHelpLimit({ game });
+export function hasHitHelpLimit({
+  game,
+  totalHelpedToday,
+}: {
+  game: GameState;
+  totalHelpedToday: number;
+}) {
+  return totalHelpedToday >= getHelpLimit({ game });
 }

--- a/src/features/game/events/visiting/collectGarbage.ts
+++ b/src/features/game/events/visiting/collectGarbage.ts
@@ -6,6 +6,7 @@ import { hasHitHelpLimit } from "../landExpansion/increaseHelpLimit";
 export type CollectGarbageAction = {
   type: "garbage.collected";
   id: string;
+  totalHelpedToday: number;
 };
 
 type Options = {
@@ -32,7 +33,12 @@ export function collectGarbage({
     }
 
     // If over help limit, throw error
-    if (hasHitHelpLimit({ game: visitorGame })) {
+    if (
+      hasHitHelpLimit({
+        game: visitorGame,
+        totalHelpedToday: action.totalHelpedToday,
+      })
+    ) {
       throw new Error("Help limit reached");
     }
 

--- a/src/features/game/events/visiting/helpProject.ts
+++ b/src/features/game/events/visiting/helpProject.ts
@@ -6,6 +6,7 @@ import { hasHitHelpLimit } from "../landExpansion/increaseHelpLimit";
 export type HelpProjectAction = {
   type: "project.helped";
   project: MonumentName;
+  totalHelpedToday: number;
 };
 
 type Options = {
@@ -39,7 +40,12 @@ export function helpProject({
     }
 
     // If over help limit, throw error
-    if (hasHitHelpLimit({ game: visitorGame })) {
+    if (
+      hasHitHelpLimit({
+        game: visitorGame,
+        totalHelpedToday: action.totalHelpedToday,
+      })
+    ) {
       throw new Error("Help limit reached");
     }
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -173,6 +173,8 @@ export interface Context {
   rawToken?: string;
   visitorId?: number;
   visitorState?: GameState;
+  hasHelpedPlayerToday?: boolean;
+  totalHelpedToday?: number;
 }
 
 export type Moderation = {
@@ -602,9 +604,11 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
             transactionId: context.transactionId as string,
           });
 
+          const { visitedFarmState, ...rest } = data;
+
           return {
-            state: makeGame(data.visitedFarmState),
-            data,
+            state: makeGame(visitedFarmState),
+            data: rest,
             visitorState: gameState,
           };
         },
@@ -615,6 +619,9 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
               !event.data.state.transaction,
             actions: [
               assign((context: Context, event: DoneInvokeEvent<any>) => {
+                const { hasHelpedPlayerToday, totalHelpedToday, ...rest } =
+                  event.data.data;
+
                 return {
                   actions: [],
                   state: event.data.state,
@@ -623,8 +630,10 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
                   nftId: event.data.data?.nftId ?? context.nftId,
                   farmAddress:
                     event.data.data?.farmAddress ?? context.farmAddress,
-                  data: { ...context.data, [stateName]: event.data.data },
+                  data: { ...context.data, [stateName]: rest },
                   visitorState: event.data.visitorState,
+                  hasHelpedPlayerToday,
+                  totalHelpedToday,
                 };
               }),
             ],
@@ -636,6 +645,11 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
                 actions: [],
                 state: event.data.state,
                 visitorState: event.data.visitorState,
+                hasHelpedPlayerToday:
+                  event.data.data?.hasHelpedPlayerToday ??
+                  context.hasHelpedPlayerToday,
+                totalHelpedToday:
+                  event.data.data?.totalHelpedToday ?? context.totalHelpedToday,
               })),
             ],
           },
@@ -995,15 +1009,22 @@ export function startGame(authContext: AuthContext) {
                 farmId = (event as VisitEvent).landId;
               }
 
-              const { visitedFarmState, visitorFarmState, visitorId } =
-                await loadGameStateForVisit(
-                  Number(farmId),
-                  authContext.user.rawToken as string,
-                );
+              const {
+                visitedFarmState,
+                visitorFarmState,
+                hasHelpedPlayerToday,
+                totalHelpedToday,
+                visitorId,
+              } = await loadGameStateForVisit(
+                Number(farmId),
+                authContext.user.rawToken as string,
+              );
 
               return {
                 state: makeGame(visitedFarmState),
                 farmId,
+                hasHelpedPlayerToday,
+                totalHelpedToday,
                 visitorId,
                 visitorState: makeGame(visitorFarmState),
               };
@@ -1015,6 +1036,9 @@ export function startGame(authContext: AuthContext) {
                 farmId: (_, event) => event.data.farmId,
                 visitorId: (_, event) => event.data.visitorId,
                 visitorState: (_, event) => event.data.visitorState,
+                hasHelpedPlayerToday: (_, event) =>
+                  event.data.hasHelpedPlayerToday,
+                totalHelpedToday: (_, event) => event.data.totalHelpedToday,
                 actions: (_, event) => [],
               }),
             },
@@ -1048,6 +1072,8 @@ export function startGame(authContext: AuthContext) {
               actions: assign((context) => ({
                 visitorId: undefined,
                 visitorState: undefined,
+                hasHelpedPlayerToday: undefined,
+                totalHelpedToday: undefined,
                 state: context.visitorState,
                 farmId: context.visitorId,
                 actions: [],

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1511,30 +1511,10 @@ type ClutterCoordinates = {
   type: ClutterName;
 } & Coordinates;
 
-type ClutterCollection = {
-  collectedAt: number;
-  type: ClutterName;
-};
-
-type DailyCollection = {
-  pointGivenAt?: number;
-  clutter: { [clutterId: string]: ClutterCollection };
-};
-
 type VillageProject = {
   cheers: number;
   winnerId?: number;
   helpedAt?: number; // Local only field
-};
-
-export type HelpedFarm = {
-  count: number;
-  helpedAt: number;
-
-  streak?: {
-    updatedAt: number;
-    count: number;
-  };
 };
 
 export type SocialFarming = {
@@ -1551,7 +1531,6 @@ export type SocialFarming = {
   };
   cheers: { freeCheersClaimedAt: number };
   helpIncrease?: { boughtAt: number[] };
-  helped?: { [farmId: number]: HelpedFarm };
   clutter?: {
     spawnedAt: number;
     locations: { [clutterId: string]: ClutterCoordinates };

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import { Decoration, getKeys } from "./decorations";
-import { GameState, HelpedFarm, InventoryItemName } from "./game";
+import { GameState, InventoryItemName } from "./game";
 import { FARM_GARBAGE } from "./clutter";
 
 type LoveCharmMonumentName =
@@ -219,46 +219,6 @@ export function getHelpRequired({ game }: { game: GameState }) {
   );
 
   return clutter.length + pendingProjects.length;
-}
-
-export function hasHelpedFarmToday({
-  game,
-  farmId,
-}: {
-  game: GameState;
-  farmId: number;
-}) {
-  const helpedAt = game.socialFarming?.helped?.[farmId]?.helpedAt ?? 0;
-
-  return (
-    new Date(helpedAt).toISOString().slice(0, 10) ===
-    new Date().toISOString().slice(0, 10)
-  );
-}
-
-/**
- * If the last help was older than the previous day, the streak expires and returns 0.
- */
-export function getHelpStreak({
-  farm,
-  now = Date.now(),
-}: {
-  farm?: HelpedFarm;
-  now?: number;
-}) {
-  if (!farm?.streak?.updatedAt) return 0;
-
-  const streakDate = new Date(farm.streak.updatedAt);
-  const currentDate = new Date(now);
-
-  // Calculate the difference in days
-  const timeDiff = currentDate.getTime() - streakDate.getTime();
-  const daysDiff = Math.floor(timeDiff / (1000 * 3600 * 24));
-
-  // Streak expires if it's 2 or more days old (older than previous day)
-  if (daysDiff >= 2) return 0;
-
-  return farm.streak.count;
 }
 
 export const RAFFLE_REWARDS: Partial<

--- a/src/features/island/clutter/Clutter.tsx
+++ b/src/features/island/clutter/Clutter.tsx
@@ -8,10 +8,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import sparkle from "public/world/sparkle2.gif";
-import {
-  hasHelpedFarmToday,
-  isHelpComplete,
-} from "features/game/types/monuments";
+import { isHelpComplete } from "features/game/types/monuments";
 import { FarmHelped } from "../hud/components/FarmHelped";
 import { GameState } from "features/game/types/game";
 import { MapPlacement } from "features/game/expansion/components/MapPlacement";
@@ -22,6 +19,8 @@ interface Props {
 }
 
 const _farmId = (state: MachineState) => state.context.farmId;
+const _hasHelpedPlayerToday = (state: MachineState) =>
+  state.context.hasHelpedPlayerToday;
 
 export const Clutter: React.FC<{
   clutter: GameState["socialFarming"]["clutter"];
@@ -29,12 +28,9 @@ export const Clutter: React.FC<{
   const { gameService } = useContext(Context);
   const [showHelped, setShowHelped] = useState(false);
 
-  const hasHelpedToday = hasHelpedFarmToday({
-    game: gameService.state.context.visitorState!,
-    farmId: gameService.state.context.farmId,
-  });
+  const hasHelpedPlayerToday = useSelector(gameService, _hasHelpedPlayerToday);
 
-  if (hasHelpedToday) {
+  if (hasHelpedPlayerToday) {
     return null;
   }
 
@@ -74,6 +70,9 @@ export const Clutter: React.FC<{
   );
 };
 
+const _totalHelpedToday = (state: MachineState) =>
+  state.context.totalHelpedToday;
+
 export const ClutterItem: React.FC<
   Props & {
     onComplete: () => void;
@@ -81,12 +80,14 @@ export const ClutterItem: React.FC<
 > = ({ id, type, onComplete }) => {
   const { gameService } = useContext(Context);
   const farmId = useSelector(gameService, _farmId);
+  const totalHelpedToday = useSelector(gameService, _totalHelpedToday);
 
   // V2 - local only event
   const handleHelpFarm = async () => {
     gameService.send("garbage.collected", {
       id,
       visitedFarmId: farmId,
+      totalHelpedToday,
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {

--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -123,6 +123,10 @@ export const Monument: React.FC<MonumentProps> = (input) => {
   const { t } = useAppTranslation();
 
   const state = useSelector(gameService, (state) => state.context.state);
+  const totalHelpedToday = useSelector(
+    gameService,
+    (state) => state.context.totalHelpedToday,
+  );
 
   const projectCheers = useSelector(gameService, _cheers(input.project));
   const cheersAvailable = useSelector(gameService, _cheersAvailable);
@@ -145,6 +149,7 @@ export const Monument: React.FC<MonumentProps> = (input) => {
   const handleHelpProject = async () => {
     gameService.send("project.helped", {
       project: input.project,
+      totalHelpedToday: totalHelpedToday ?? 0,
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -22,7 +22,6 @@ import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import classNames from "classnames";
 import {
-  hasHelpedFarmToday,
   isHelpComplete,
   MonumentName,
   RAFFLE_REWARDS,
@@ -447,14 +446,9 @@ export const _hasCheeredToday =
     const today = new Date().toISOString().split("T")[0];
 
     if (state.context.visitorState) {
-      const hasHelpedToday = hasHelpedFarmToday({
-        game: state.context.visitorState,
-        farmId: state.context.farmId,
-      });
+      const hasHelpedToday = state.context.hasHelpedPlayerToday ?? false;
 
-      if (hasHelpedToday) {
-        return true;
-      }
+      if (hasHelpedToday) return true;
 
       if (
         state.context.state?.socialFarming.villageProjects[project]?.helpedAt
@@ -488,6 +482,10 @@ export const Project: React.FC<ProjectProps> = (input) => {
     gameService,
     _hasCheeredToday(input.project),
   );
+  const totalHelpedToday = useSelector(
+    gameService,
+    (state) => state.context.totalHelpedToday ?? 0,
+  );
   const state = useSelector(gameService, (state) => state.context.state);
 
   const requiredCheers = REQUIRED_CHEERS[input.project];
@@ -519,6 +517,7 @@ export const Project: React.FC<ProjectProps> = (input) => {
   const handleHelpProject = async () => {
     gameService.send("project.helped", {
       project: input.project,
+      totalHelpedToday: totalHelpedToday ?? 0,
     });
 
     if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -25,10 +25,7 @@ import choreIcon from "assets/icons/chores.webp";
 import { VisitorGuide } from "./components/VisitorGuide";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
-import {
-  getHelpRequired,
-  hasHelpedFarmToday,
-} from "features/game/types/monuments";
+import { getHelpRequired } from "features/game/types/monuments";
 import { hasHitHelpLimit } from "features/game/events/landExpansion/increaseHelpLimit";
 import { Feed } from "features/social/Feed";
 import { WorldFeedButton } from "features/social/components/WorldFeedButton";
@@ -49,21 +46,14 @@ export const VisitingHud: React.FC = () => {
 
   const [gameState] = useActor(gameService);
 
-  const hasHelpedToday = hasHelpedFarmToday({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    game: gameState.context.visitorState!,
-    farmId: gameState.context.farmId,
-  });
-
   const [showVisitorGuide, setShowVisitorGuide] = useState(() => {
     const hasHitLimit = hasHitHelpLimit({
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       game: gameState.context.visitorState!,
+      totalHelpedToday: gameState.context.totalHelpedToday ?? 0,
     });
 
-    if (hasHitLimit) {
-      return true;
-    }
+    if (hasHitLimit) return true;
 
     // Check if user has already acknowledged the visitor guide
     const hasAcknowledged =
@@ -136,7 +126,7 @@ export const VisitingHud: React.FC = () => {
             </div>
           </div>
           <div className="w-px h-[36px] bg-gray-300 mx-3 self-center" />
-          {hasHelpedToday ? (
+          {gameState.context.hasHelpedPlayerToday ?? false ? (
             <div className="flex justify-center items-center flex-grow">
               <img src={SUNNYSIDE.icons.confirm} className="w-5" />
             </div>

--- a/src/features/island/hud/components/VisitorGuide.tsx
+++ b/src/features/island/hud/components/VisitorGuide.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getKeys } from "features/game/lib/crafting";
 import {
-  hasHelpedFarmToday,
   RAFFLE_REWARDS,
   REQUIRED_CHEERS,
   WORKBENCH_MONUMENTS,
@@ -58,10 +57,7 @@ export const VisitorGuide: React.FC<VisitorGuideProps> = ({ onClose }) => {
     {} as Record<ClutterName, number>,
   );
 
-  const hasHelpedToday = hasHelpedFarmToday({
-    game: gameState.context.visitorState!,
-    farmId: gameState.context.farmId,
-  });
+  const hasHelpedToday = gameState.context.hasHelpedPlayerToday ?? false;
 
   const handleIncreaseLimit = () => {
     gameService.send("helpLimit.increased");
@@ -122,6 +118,7 @@ export const VisitorGuide: React.FC<VisitorGuideProps> = ({ onClose }) => {
 
   const hasHitLimit = hasHitHelpLimit({
     game: gameState.context.visitorState!,
+    totalHelpedToday: gameState.context.totalHelpedToday ?? 0,
   });
 
   if (hasHitLimit) {

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -542,7 +542,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
         <div
           ref={setRefs}
           id="loading-more"
-          className="bg-green-500 text-xs flex justify-center py-1 h-6"
+          className="text-xs flex justify-center py-1 h-6"
         >
           {hasMore ? <Loading dotsOnly /> : t("playerModal.noMoreMessages")}
         </div>

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -17,6 +17,7 @@ import { getRelativeTime } from "lib/utils/time";
 
 import promote from "assets/icons/promote.webp";
 import followIcon from "assets/icons/follow.webp";
+import helpIcon from "assets/icons/help.webp";
 
 import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
@@ -502,7 +503,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
                       />
                     )}
                   </div>
-                  <div className="flex flex-col gap-1">
+                  <div className="flex flex-col w-full gap-1">
                     <span className="flex items-center gap-1">
                       {interaction.type === "announcement" ? (
                         <img src={promote} />
@@ -511,13 +512,18 @@ const FeedContent: React.FC<FeedContentProps> = ({
                       )}
                       {`${getRelativeTime(interaction.createdAt)}`}
                     </span>
-                    <div
-                      className="text-xs break-words"
-                      style={{
-                        lineHeight: 1,
-                      }}
-                    >
-                      {interaction.message}
+                    <div className="flex justify-between items-center w-full">
+                      <div
+                        className="text-xs break-words"
+                        style={{
+                          lineHeight: 1,
+                        }}
+                      >
+                        {interaction.message}
+                      </div>
+                      {interaction.helpedThemToday && (
+                        <img src={helpIcon} className="w-4 h-4" />
+                      )}
                     </div>
                   </div>
                   <div className="flex items-center justify-end flex-grow cursor-pointer">

--- a/src/features/social/actions/getFollowNetworkDetails.ts
+++ b/src/features/social/actions/getFollowNetworkDetails.ts
@@ -5,17 +5,22 @@ type Request = {
   token: string;
   farmId: number;
   networkFarmId: number;
-  nextCursor: number | null;
+  nextCursor?: FollowNetworkMember;
   networkType: "followers" | "following";
 };
 
-export type Detail = {
+export type FollowNetworkMember = {
   id: number;
+  socialPoints: number;
+  helpStreak: number;
+};
+
+export type Detail = FollowNetworkMember & {
   clothing: Equipped;
   username: string;
   lastUpdatedAt: number;
-  socialPoints: number;
-  helpedYouToday?: boolean;
+  helpedYouToday: boolean;
+  helpedThemToday: boolean;
   hasCookingPot: boolean;
 };
 
@@ -23,7 +28,7 @@ export type FollowNetworkDetails = {
   data: {
     id: number;
     network: Detail[];
-    nextCursor: number | null;
+    nextCursor?: FollowNetworkMember;
   };
 };
 
@@ -34,7 +39,16 @@ export const getFollowNetworkDetails = async ({
   nextCursor,
   networkType,
 }: Request): Promise<FollowNetworkDetails> => {
-  const url = `${CONFIG.API_URL}/data?type=followNetworkDetails&networkFarmId=${networkFarmId}&networkType=${networkType}&farmId=${farmId}&nextCursor=${nextCursor}`;
+  const url = new URL(`${CONFIG.API_URL}/data`);
+
+  url.searchParams.set("type", "followNetworkDetails");
+  url.searchParams.set("networkFarmId", networkFarmId.toString());
+  url.searchParams.set("networkType", networkType);
+  url.searchParams.set("farmId", farmId.toString());
+
+  if (nextCursor !== undefined) {
+    url.searchParams.set("nextCursor", JSON.stringify(nextCursor));
+  }
 
   const res = await fetch(url, {
     headers: {

--- a/src/features/social/components/FollowDetailPanel.tsx
+++ b/src/features/social/components/FollowDetailPanel.tsx
@@ -18,13 +18,13 @@ type Props = {
   playerId: number;
   clothing: Equipped;
   username: string;
-  haveHelpedToday: boolean;
-  haveTheyHelpedYouToday: boolean;
+  helpedThemToday: boolean;
+  helpedYouToday: boolean;
   socialPoints: number;
   lastOnlineAt: number;
   hasCookingPot: boolean;
   navigateToPlayer: (playerId: number) => void;
-  friendStreak: number;
+  helpStreak: number;
 };
 
 export const FollowDetailPanel: React.FC<Props> = ({
@@ -32,13 +32,13 @@ export const FollowDetailPanel: React.FC<Props> = ({
   playerId,
   clothing,
   username,
-  haveHelpedToday,
-  haveTheyHelpedYouToday,
+  helpedThemToday,
+  helpedYouToday,
   socialPoints,
   lastOnlineAt,
   hasCookingPot,
   navigateToPlayer,
-  friendStreak,
+  helpStreak,
 }: Props) => {
   const { t } = useTranslation();
   const lastOnline = getRelativeTime(lastOnlineAt, "short");
@@ -88,16 +88,14 @@ export const FollowDetailPanel: React.FC<Props> = ({
             )}
             <div className="flex items-center justify-between w-full">
               <div className="flex items-center gap-1 flex-wrap">
-                {haveHelpedToday && <img src={helpIcon} className="w-4 h-4" />}
-                {haveTheyHelpedYouToday && (
-                  <img src={helpedIcon} className="w-4 h-4" />
-                )}
+                {helpedThemToday && <img src={helpIcon} className="w-4 h-4" />}
+                {helpedYouToday && <img src={helpedIcon} className="w-4 h-4" />}
                 {hasCookingPot && <img src={potIcon} className="w-4 h-4" />}
               </div>
-              {friendStreak > 0 && (
+              {helpStreak > 0 && (
                 <Label type="vibrant" icon={SUNNYSIDE.icons.heart}>
                   {t("friendStreak.short", {
-                    days: friendStreak,
+                    days: helpStreak,
                   })}
                 </Label>
               )}

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -9,7 +9,6 @@ import { useFollowNetwork } from "../hooks/useFollowNetwork";
 import { useInView } from "react-intersection-observer";
 import { Loading } from "features/auth/components";
 import { useGame } from "features/game/GameProvider";
-import { getHelpStreak } from "features/game/types/monuments";
 
 type Props = {
   loggedInFarmId: number;
@@ -144,20 +143,6 @@ export const FollowList: React.FC<Props> = ({
       </div>
       <div className="flex flex-col gap-1">
         {network.map((detail) => {
-          const friendStreak = getHelpStreak({
-            farm: gameService.state.context.state.socialFarming.helped?.[
-              detail.id
-            ],
-          });
-
-          const helpedToday =
-            gameService.getSnapshot().context.state.socialFarming.helped?.[
-              detail.id
-            ]?.helpedAt ?? 0;
-          const hasHelpedToday =
-            new Date(helpedToday).toISOString().split("T")[0] ===
-            new Date().toISOString().split("T")[0];
-
           return (
             <FollowDetailPanel
               key={`flw-${detail.id}`}
@@ -169,13 +154,14 @@ export const FollowList: React.FC<Props> = ({
               navigateToPlayer={navigateToPlayer}
               hasCookingPot={detail.hasCookingPot}
               socialPoints={detail.socialPoints ?? 0}
-              haveHelpedToday={hasHelpedToday}
-              haveTheyHelpedYouToday={detail.helpedYouToday ?? false}
-              friendStreak={friendStreak}
+              helpedThemToday={detail.helpedThemToday}
+              helpedYouToday={detail.helpedYouToday}
+              helpStreak={detail.helpStreak}
             />
           );
         })}
       </div>
+
       <div
         ref={intersectionRef}
         className="text-xs flex justify-center py-1 h-5"

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -45,7 +45,6 @@ import { getKeys } from "features/game/lib/crafting";
 import { ProgressBar } from "components/ui/ProgressBar";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
-import { getHelpStreak } from "features/game/types/monuments";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 
 const ISLAND_ICONS: Record<IslandType, string> = {
@@ -207,12 +206,6 @@ export const PlayerDetails: React.FC<Props> = ({
       (projectB.receivedCheers / projectB.requiredCheers) * 100;
 
     return projectBProgress - projectAProgress;
-  });
-
-  const friendStreak = getHelpStreak({
-    farm: gameService.state.context.state.socialFarming.helped?.[
-      player?.id ?? 0
-    ],
   });
 
   return (
@@ -438,14 +431,14 @@ export const PlayerDetails: React.FC<Props> = ({
               </div>
             </div>
           )}
-          {friendStreak > 0 && (
+          {player.helpStreak > 0 && (
             <div className="flex justify-start w-full">
               <Label
                 type="vibrant"
                 className="ml-2"
                 icon={SUNNYSIDE.icons.heart}
               >
-                {t("friendStreak", { days: friendStreak })}
+                {t("friendStreak", { days: player.helpStreak })}
               </Label>
             </div>
           )}

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -13,6 +13,8 @@ import cheer from "assets/icons/cheer.webp";
 import socialPointsIcon from "assets/icons/social_score.webp";
 import followIcon from "assets/icons/follow.webp";
 import unfollowIcon from "assets/icons/unfollow.webp";
+import helpIcon from "assets/icons/help.webp";
+import helpedIcon from "assets/icons/helped.webp";
 
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { PIXEL_SCALE } from "features/game/lib/constants";
@@ -431,17 +433,25 @@ export const PlayerDetails: React.FC<Props> = ({
               </div>
             </div>
           )}
-          {player.helpStreak > 0 && (
-            <div className="flex justify-start w-full">
-              <Label
-                type="vibrant"
-                className="ml-2"
-                icon={SUNNYSIDE.icons.heart}
-              >
-                {t("friendStreak", { days: player.helpStreak })}
-              </Label>
-            </div>
-          )}
+          <div className="flex w-full px-1 gap-1">
+            {player.helpedThemToday && (
+              <img src={helpIcon} className="w-4 h-4" />
+            )}
+            {player.helpedYouToday && (
+              <img src={helpedIcon} className="w-4 h-4" />
+            )}
+            {player.helpStreak > 0 && (
+              <div className="flex justify-start w-full">
+                <Label
+                  type="vibrant"
+                  className="ml-2"
+                  icon={SUNNYSIDE.icons.heart}
+                >
+                  {t("friendStreak", { days: player.helpStreak })}
+                </Label>
+              </div>
+            )}
+          </div>
         </InnerPanel>
 
         <InnerPanel className="flex flex-1 flex-col gap-1 max-h-[121px] overflow-y-auto scrollable">

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -53,6 +53,7 @@ export type Player = {
     projects: ActiveProjects;
     youHelpedThemCount: number;
     theyHelpedYouCount: number;
+    helpStreak: number;
   };
 };
 

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -53,6 +53,8 @@ export type Player = {
     projects: ActiveProjects;
     youHelpedThemCount: number;
     theyHelpedYouCount: number;
+    helpedYouToday: boolean;
+    helpedThemToday: boolean;
     helpStreak: number;
   };
 };

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -24,6 +24,7 @@ export type Interaction = {
   createdAt: number;
   readAt?: number; // Timestamp when the message was read by the recipient
   id?: string; // Unique identifier for the message
+  helpedThemToday?: boolean;
 };
 
 export type Milestone = Interaction & {


### PR DESCRIPTION
# Description

Helped data has been moved off the gameState. There are new queries set up in the BE to get the data where needed.

Helped details between a player and the player they're visiting will now be stored in the game machine context during a visit. 

Follow lists should be sorted correctly `streak -> points -> farmId`

Cursor based fetching/lazy loading of follow lists is still in place.

Adds helped icon to "help" notifications
<img width="258" height="64" alt="Screenshot 2025-08-21 at 3 38 11 PM" src="https://github.com/user-attachments/assets/ae4d1b78-b5d6-464b-8806-3395c7906e21" />

Fixes #issue

# What needs to be tested by the reviewer?

- Everything related to social farming needs to be tested. 
- Helping farms
- Visiting other farms from visiting and helping them
- Loading follow lists and scrolling
- Increasing helps and helping again
- Try to confirm everything is as it should be
- Helped today icons will now show on the player modal
- You see a helped icon on "help" notifications if you helped that person today

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
