### PR TITLE
[FIX] Shrines shouldn't be able to be picked up

### DIFF
--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -1,11 +1,11 @@
 import { trackActivity } from "features/game/types/bumpkinActivity";
-import { CollectibleName } from "features/game/types/craftables";
+import { CollectibleName, getKeys } from "features/game/types/craftables";
 import { GameState, PlacedItem, PlacedLamp } from "features/game/types/game";
 
 import { PlaceableLocation } from "features/game/types/collectibles";
 import { produce } from "immer";
-import { HourglassType } from "features/island/collectibles/components/Hourglass";
 import { HOURGLASSES } from "./burnCollectible";
+import { PET_SHRINES } from "features/game/types/pets";
 
 export enum REMOVE_COLLECTIBLE_ERRORS {
   INVALID_COLLECTIBLE = "This collectible does not exist",
@@ -27,6 +27,14 @@ type Options = {
   action: RemoveCollectibleAction;
   createdAt?: number;
 };
+
+export const LIMITED_ITEMS: CollectibleName[] = [
+  ...HOURGLASSES,
+  "Time Warp Totem",
+  "Super Totem",
+  ...getKeys(PET_SHRINES),
+  "Obsidian Shrine",
+];
 
 export function removeCollectible({
   state,
@@ -86,11 +94,7 @@ export function removeCollectible({
       }
     }
 
-    if (
-      HOURGLASSES.includes(action.name as HourglassType) ||
-      action.name === "Time Warp Totem" ||
-      action.name === "Super Totem"
-    ) {
+    if (LIMITED_ITEMS.includes(action.name)) {
       const collectible: PlacedItem = collectibleToRemove;
       if (collectible) {
         throw new Error(REMOVE_COLLECTIBLE_ERRORS.LIMITED_ITEM_IN_USE);

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -42,11 +42,10 @@ import { ZoomContext } from "components/ZoomProvider";
 import { RemoveKuebikoModal } from "./RemoveKuebikoModal";
 import { PlaceableLocation } from "features/game/types/collectibles";
 import { RemoveHungryCaterpillarModal } from "./RemoveHungryCaterpillarModal";
-import { HourglassType } from "./components/Hourglass";
-import { HOURGLASSES } from "features/game/events/landExpansion/burnCollectible";
 import flipped from "assets/icons/flipped.webp";
 import flipIcon from "assets/icons/flip.webp";
 import debounce from "lodash.debounce";
+import { LIMITED_ITEMS } from "features/game/events/landExpansion/removeCollectible";
 
 export const RESOURCE_MOVE_EVENTS: Record<
   ResourceName,
@@ -140,11 +139,7 @@ export function getRemoveAction(
     return "building.removed";
   }
 
-  if (
-    HOURGLASSES.includes(name as HourglassType) ||
-    name === "Time Warp Totem" ||
-    name === "Super Totem"
-  ) {
+  if (LIMITED_ITEMS.includes(name as CollectibleName)) {
     return null;
   }
 


### PR DESCRIPTION
# Description

Shrines, like hourglasses, are limited time items that will expire after a certain amount of time. To ensure that player doesn't exploit its boost duration, they can't be removed once placed down

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
