### PR TITLE
[FIX] Team work monument

### DIFF
--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -135,6 +135,35 @@ describe("Place Collectible", () => {
     });
   });
 
+  it("adds monument to village projects", () => {
+    const state = placeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Teamwork Monument": new Decimal(1),
+        },
+        collectibles: {},
+        buildings: {},
+        trees: {},
+        stones: {},
+      },
+      action: {
+        id: "123",
+        type: "collectible.placed",
+        name: "Teamwork Monument",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+        location: "farm",
+      },
+    });
+
+    expect(state.socialFarming.villageProjects["Teamwork Monument"]).toEqual({
+      cheers: 0,
+    });
+  });
+
   it("Cannot place a building", () => {
     expect(() =>
       placeCollectible({

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -7,6 +7,7 @@ import { trackActivity } from "features/game/types/bumpkinActivity";
 import { PlaceableLocation } from "features/game/types/collectibles";
 import { produce } from "immer";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
+import { MonumentName, REQUIRED_CHEERS } from "features/game/types/monuments";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -44,6 +45,17 @@ export function placeCollectible({
 
     if (!(collectible in COLLECTIBLES_DIMENSIONS)) {
       throw new Error("You cannot place this item");
+    }
+
+    const isMonument = action.name in REQUIRED_CHEERS;
+
+    if (
+      isMonument &&
+      !stateCopy.socialFarming.villageProjects[action.name as MonumentName]
+    ) {
+      stateCopy.socialFarming.villageProjects[action.name as MonumentName] = {
+        cheers: 0,
+      };
     }
 
     // Search for existing collectible in current location

--- a/src/features/game/events/landExpansion/upgradeNode.ts
+++ b/src/features/game/events/landExpansion/upgradeNode.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+
 import { produce } from "immer";
 import { ADVANCED_RESOURCES, RockName } from "features/game/types/resources";
 import { GameState, InventoryItemName, Rock } from "features/game/types/game";


### PR DESCRIPTION
# Description

Fixes the issue where Team Work Monument was not increasing it's helped amount.

**How to tests?**

1. Place a teamwork monument
2. Get someone else to cheers it

Also worth testing digging up other monuments, placing them again and helping.