### PR TITLE
[FIX] Some Placed Nodes not filtered in chest

### DIFF
--- a/src/features/island/hud/components/inventory/utils/inventory.ts
+++ b/src/features/island/hud/components/inventory/utils/inventory.ts
@@ -124,7 +124,10 @@ export const getChestItems = (state: GameState): Inventory => {
         ...acc,
         [itemName]: new Decimal(
           state.inventory[itemName]?.minus(
-            nodes.filter((resource) => resource.removedAt === undefined).length,
+            nodes.filter(
+              (resource) =>
+                resource.x !== undefined && resource.y !== undefined,
+            ).length,
           ) ?? 0,
         ),
       };


### PR DESCRIPTION
# Description

There was a bug where placed nodes without existing progress didn't have their removedAt field deleted. This has been fixed in #6103, however the getChestItems code is filtering based on the removedAt field, which implies that these placed nodes with the removedAt field still intact will not be filtered from chest. Reverting the filtering logic to use x and y instead

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
