### PR TITLE
[FIX] Deliveries Skip Button onClick Event

### DIFF
--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -352,6 +352,7 @@ export const DeliveryOrders: React.FC<Props> = ({
 
   const skip = () => {
     setShowSkipDialog(false);
+    onSelect(undefined);
     gameService.send("order.skipped", { id: previewOrder?.id });
     gameService.send("SAVE");
   };


### PR DESCRIPTION
# Description

This PR fixes an issue on small screens (screen sizes below the Tailwind md breakpoint) where tapping the **Skip Order** button for an NPC order displayed another NPC’s available order.

With this change, skipping an order now directly navigates the player back to the deliveries list, making it easier for them to select their desired order:

https://github.com/user-attachments/assets/0a465094-730b-4e87-be84-94da4acdeea8





