### PR TITLE
[FIX] Do not update building if it's the second instance of building

### DIFF
--- a/src/features/game/events/landExpansion/placeBuilding.test.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.test.ts
@@ -424,4 +424,80 @@ describe("Place building", () => {
       dateNow - 60000 + (RECIPES(GAME_STATE)["Doll"]?.time ?? 0),
     );
   });
+
+  it("does not adjust the new readyAt for second instance of building", () => {
+    const state = placeBuilding({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Hen House": new Decimal(2),
+        },
+        buildings: {
+          "Hen House": [
+            {
+              id: "123",
+              readyAt: 0,
+              createdAt: 0,
+              coordinates: { x: 0, y: 0 },
+            },
+            {
+              id: "456",
+              readyAt: 0,
+              createdAt: 0,
+              removedAt: dateNow - 2 * 24 * 60 * 60 * 1000,
+            },
+          ],
+        },
+        henHouse: {
+          level: 1,
+          animals: {
+            123: {
+              id: "123",
+              type: "Chicken",
+              state: "idle",
+              createdAt: dateNow - 180000,
+              experience: 1000,
+              asleepAt: dateNow - 180000,
+              awakeAt: dateNow - 180000 + 24 * 60 * 60 * 1000,
+              lovedAt: 0,
+              item: "Brush",
+            },
+            456: {
+              id: "456",
+              type: "Chicken",
+              state: "idle",
+              createdAt: dateNow - 180000,
+              experience: 1000,
+              asleepAt: dateNow - 180000,
+              awakeAt: dateNow - 180000 + 24 * 60 * 60 * 1000,
+              lovedAt: 0,
+              item: "Brush",
+            },
+            789: {
+              id: "789",
+              type: "Chicken",
+              state: "idle",
+              createdAt: dateNow - 180000,
+              experience: 1000,
+              asleepAt: dateNow - 180000,
+              awakeAt: dateNow - 180000 + 24 * 60 * 60 * 1000,
+              lovedAt: 0,
+              item: "Brush",
+            },
+          },
+        },
+      },
+      action: {
+        type: "building.placed",
+        name: "Hen House",
+        id: "456",
+        coordinates: { x: 0, y: 3 },
+      },
+      createdAt: dateNow,
+    });
+
+    expect(state.henHouse.animals["123"].asleepAt).toEqual(dateNow - 180000);
+    expect(state.henHouse.animals["456"].asleepAt).toEqual(dateNow - 180000);
+    expect(state.henHouse.animals["789"].asleepAt).toEqual(dateNow - 180000);
+  });
 });


### PR DESCRIPTION
# Description

If a player somehow has a second instance of that building (ie 2 Hen Houses), the second hen house would cause the animal sleep times to be shifted forward, even though the first one is placed.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
