### PR TITLE
[FIX] Beehives not filtering finished flowers

### DIFF
--- a/src/features/game/events/landExpansion/instaGrowFlower.test.ts
+++ b/src/features/game/events/landExpansion/instaGrowFlower.test.ts
@@ -2,6 +2,7 @@ import { instaGrowFlower } from "./instaGrowFlower";
 import { GameState } from "../../types/game";
 import { FLOWER_SEEDS, FLOWERS, FlowerName } from "../../types/flowers";
 import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
 
 const GAME_STATE: GameState = {
   flowers: {
@@ -166,5 +167,58 @@ describe("instaGrowFlower", () => {
       growTime -
       Date.now();
     expect(newTimeLeft).toBeLessThanOrEqual(0);
+  });
+
+  it("updates the beehives after a flower is instagrown", () => {
+    const flowerBedId = "123";
+    const now = Date.now();
+    const growTime =
+      FLOWER_SEEDS[FLOWERS["Red Pansy"].seed].plantSeconds * 1000;
+
+    const state: GameState = {
+      ...INITIAL_FARM,
+      inventory: {
+        Obsidian: new Decimal(1),
+      },
+      beehives: {
+        "123": {
+          swarm: false,
+          honey: {
+            updatedAt: 0,
+            produced: 0,
+          },
+          x: 0,
+          y: 0,
+          flowers: [
+            {
+              id: flowerBedId,
+              attachedAt: now,
+              attachedUntil: now + growTime,
+            },
+          ],
+        },
+      },
+      flowers: {
+        discovered: {},
+        flowerBeds: {
+          [flowerBedId]: {
+            createdAt: 0,
+            x: 0,
+            y: 0,
+            flower: {
+              name: "Red Pansy",
+              plantedAt: now,
+            },
+          },
+        },
+      },
+    };
+
+    const result = instaGrowFlower({
+      state,
+      action: { type: "flower.instaGrown", id: flowerBedId },
+    });
+
+    expect(result.beehives["123"].flowers).toEqual([]);
   });
 });

--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -2,6 +2,7 @@ import { INITIAL_FARM } from "features/game/lib/constants";
 import { skillUse } from "./skillUsed";
 import { CROPS } from "features/game/types/crops";
 import { COOKABLES } from "features/game/types/consumables";
+import { FLOWER_SEEDS, FLOWERS } from "features/game/types/flowers";
 
 describe("skillUse", () => {
   const dateNow = Date.now();
@@ -552,11 +553,137 @@ describe("skillUse", () => {
         createdAt: dateNow,
       });
 
-      expect(state.flowers.flowerBeds["123"].flower?.plantedAt).toEqual(1);
-      expect(state.flowers.flowerBeds["456"].flower?.plantedAt).toEqual(1);
-      expect(state.flowers.flowerBeds["789"].flower?.plantedAt).toEqual(1);
+      const expectedTime =
+        dateNow -
+        FLOWER_SEEDS[FLOWERS["Yellow Carnation"].seed].plantSeconds * 1000;
+
+      expect(state.flowers.flowerBeds["123"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["456"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["789"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+    });
+
+    it("updates the beehives after a flower is instagrown", () => {
+      const now = Date.now();
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Petal Blessed": 1 },
+          },
+          flowers: {
+            flowerBeds: {
+              "123": {
+                x: 1,
+                createdAt: 1715650356584,
+                y: -10,
+                flower: {
+                  plantedAt: 1733412398960,
+                  name: "Yellow Carnation",
+                },
+              },
+              "456": {
+                x: 1,
+                createdAt: 1715650403667,
+                y: -9,
+                flower: {
+                  plantedAt: 1733412401734,
+                  name: "Yellow Carnation",
+                },
+              },
+              "789": {
+                x: 1,
+                createdAt: 1715649513672,
+                y: -11,
+                flower: {
+                  plantedAt: 1733412395200,
+                  name: "Yellow Carnation",
+                },
+              },
+            },
+            discovered: {},
+          },
+          beehives: {
+            "123": {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "123",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+            456: {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "456",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+            789: {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "789",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+          },
+        },
+        action: { type: "skill.used", skill: "Petal Blessed" },
+        createdAt: dateNow,
+      });
+
+      const expectedTime =
+        dateNow -
+        FLOWER_SEEDS[FLOWERS["Yellow Carnation"].seed].plantSeconds * 1000;
+
+      expect(state.flowers.flowerBeds["123"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["456"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["789"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+
+      expect(state.beehives["123"].flowers).toEqual([]);
+      expect(state.beehives["456"].flowers).toEqual([]);
+      expect(state.beehives["789"].flowers).toEqual([]);
     });
   });
+
   describe("useGreaseLightning", () => {
     it("activates Grease Lightning", () => {
       const state = skillUse({

--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -682,6 +682,113 @@ describe("skillUse", () => {
       expect(state.beehives["456"].flowers).toEqual([]);
       expect(state.beehives["789"].flowers).toEqual([]);
     });
+
+    it("does not update the beehives if the flower beds are not active", () => {
+      const now = Date.now();
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Petal Blessed": 1 },
+          },
+          flowers: {
+            flowerBeds: {
+              "123": {
+                x: 1,
+                createdAt: now,
+                y: -10,
+                flower: {
+                  plantedAt: now,
+                  name: "Yellow Carnation",
+                },
+              },
+              "456": {
+                x: 1,
+                createdAt: now,
+                y: -9,
+                flower: {
+                  plantedAt: now,
+                  name: "Yellow Carnation",
+                },
+              },
+              "789": {
+                createdAt: now,
+                flower: {
+                  plantedAt: now,
+                  name: "Yellow Carnation",
+                },
+              },
+            },
+            discovered: {},
+          },
+          beehives: {
+            "123": {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "123",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+            456: {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "456",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+            789: {
+              swarm: false,
+              honey: {
+                updatedAt: 0,
+                produced: 0,
+              },
+              flowers: [
+                {
+                  id: "789",
+                  attachedAt: now,
+                  attachedUntil: now + 1000 * 60 * 60 * 24,
+                },
+              ],
+              x: 0,
+              y: 0,
+            },
+          },
+        },
+        action: { type: "skill.used", skill: "Petal Blessed" },
+        createdAt: dateNow,
+      });
+
+      const expectedTime =
+        dateNow -
+        FLOWER_SEEDS[FLOWERS["Yellow Carnation"].seed].plantSeconds * 1000;
+
+      expect(state.flowers.flowerBeds["123"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["456"].flower?.plantedAt).toEqual(
+        expectedTime,
+      );
+      expect(state.flowers.flowerBeds["789"].flower?.plantedAt).toEqual(now);
+    });
   });
 
   describe("useGreaseLightning", () => {

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -121,14 +121,16 @@ function usePetalBlessed({
   flowerBeds: FlowerBeds;
   createdAt?: number;
 }): FlowerBeds {
-  getKeys(flowerBeds).forEach((bed) => {
-    const { flower } = flowerBeds[bed];
-    if (flower) {
-      const growTime =
-        FLOWER_SEEDS[FLOWERS[flower.name].seed].plantSeconds * 1000;
-      flower.plantedAt = createdAt - growTime;
-    }
-  });
+  Object.values(flowerBeds)
+    .filter((bed) => bed.x !== undefined && bed.y !== undefined)
+    .forEach((bed) => {
+      const { flower } = bed;
+      if (flower) {
+        const growTime =
+          FLOWER_SEEDS[FLOWERS[flower.name].seed].plantSeconds * 1000;
+        flower.plantedAt = createdAt - growTime;
+      }
+    });
   return flowerBeds;
 }
 

--- a/src/features/game/lib/updateBeehives.test.ts
+++ b/src/features/game/lib/updateBeehives.test.ts
@@ -839,7 +839,9 @@ describe("updateBeehives", () => {
       now + DEFAULT_HONEY_PRODUCTION_TIME / 4,
     );
     expect(finalBeehives["abc"].flowers[1].attachedUntil).toEqual(
-      now + DEFAULT_HONEY_PRODUCTION_TIME,
+      now +
+        DEFAULT_HONEY_PRODUCTION_TIME / 4 +
+        DEFAULT_HONEY_PRODUCTION_TIME / 2,
     );
   });
 

--- a/src/features/game/lib/updateBeehives.ts
+++ b/src/features/game/lib/updateBeehives.ts
@@ -188,9 +188,10 @@ const removeInactiveFlowers = ({
 
   Object.values(activeBeehives).forEach((hive) => {
     hive.flowers = hive.flowers.filter((flower) => {
+      console.log({ flowerId: flower.id });
       const flowerDetails = activeFlowerBeds[flower.id];
 
-      if (!flowerDetails.flower) return false;
+      if (!flowerDetails || !flowerDetails.flower) return false;
       const flowerName = flowerDetails.flower.name;
 
       const growTime =


### PR DESCRIPTION
# Description

There's an issue with the beehives where it wasn't taking into account which flowers are currently growing when updating beehives. hence when a flower is instantly finished, the beehives weren't filtering that out properly in the assignment of bees to flowers.

This PR also fixes an issue where the beehives weren't updating when using petal blessed (skill that instantly grows all flowers)

Fixes #issue

# What needs to be tested by the reviewer?

Run FE + BE

- Plant Flower
- Check beehives are updated

- Instantly grow flower using obsidian
- Check beehives are updated

- Instantly grow flower using petal blessed
- check beehives are updated

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
