### PR TITLE
[FIX] Prevent Multiple Help Info Popovers from Opening at Once

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -366,6 +366,49 @@ export const Feed: React.FC<Props> = ({
   );
 };
 
+const HelpIconWithPopover: React.FC<{
+  helpedThemToday: boolean;
+}> = ({ helpedThemToday }) => {
+  const [showPopover, setShowPopover] = useState(false);
+
+  return (
+    <div
+      className="relative flex h-8 w-10 cursor-pointer items-center justify-center"
+      onPointerOver={(e) => {
+        if (e.pointerType === "mouse") {
+          setShowPopover(true);
+        }
+      }}
+      onPointerOut={(e) => {
+        if (e.pointerType === "mouse") {
+          setShowPopover(false);
+        }
+      }}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        setShowPopover(!showPopover);
+        setTimeout(() => {
+          setShowPopover(false);
+        }, 1500);
+      }}
+      onClickCapture={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <img src={helpIcon} className="w-5 h-5" />
+      <HelpInfoPopover
+        className="absolute right-0 -top-6 z-20 w-max text-black"
+        showPopover={showPopover}
+        onHide={() => setShowPopover(false)}
+        helpedThemToday={helpedThemToday}
+      />
+    </div>
+  );
+};
+
 type FeedContentProps = {
   feed: Interaction[];
   following: number[];
@@ -396,7 +439,6 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const { t } = useAppTranslation();
 
   const [canPaginate, setCanPaginate] = useState(false);
-  const [showPopover, setShowPopover] = useState(false);
 
   // Intersection observer to load more interactions when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -523,41 +565,10 @@ const FeedContent: React.FC<FeedContentProps> = ({
                       >
                         {interaction.message}
                       </div>
-                      {interaction.helpedThemToday && (
-                        <div
-                          className="relative flex h-8 w-10 cursor-pointer items-center justify-center"
-                          onPointerOver={(e) => {
-                            if (e.pointerType === "mouse") {
-                              setShowPopover(true);
-                            }
-                          }}
-                          onPointerOut={(e) => {
-                            if (e.pointerType === "mouse") {
-                              setShowPopover(false);
-                            }
-                          }}
-                          onPointerDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-
-                            setShowPopover(!showPopover);
-                            setTimeout(() => {
-                              setShowPopover(false);
-                            }, 1500);
-                          }}
-                          onClickCapture={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                        >
-                          <img src={helpIcon} className="w-5 h-5" />
-                          <HelpInfoPopover
-                            className="absolute right-0 -top-6 z-20 w-max text-black"
-                            showPopover={showPopover}
-                            onHide={() => setShowPopover(false)}
-                            helpedThemToday={interaction.helpedThemToday}
-                          />
-                        </div>
+                      {!!interaction.helpedThemToday && (
+                        <HelpIconWithPopover
+                          helpedThemToday={interaction.helpedThemToday}
+                        />
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
# Description

- Currently, the help info popovers in the Feed component share a single state variable (`showPopover`), causing all popovers to appear simultaneously when any help icon is hovered over or clicked. 
The popover implementation has been refactored by creating a dedicated `HelpIconWithPopover` component that encapsulates its own state. This ensures that each help icon maintains an independent popover state, preventing the unintended behavior of all popovers appearing at once:

<img width="336" height="386" alt="image" src="https://github.com/user-attachments/assets/bb9eabf8-a57c-4882-9432-71aa28fb9d8b" />

---

- When a player helps you for the first time but you haven’t helped them yet, `interaction.helpedThemToday` renders as `0` in the UI:

<img width="335" height="72" alt="image" src="https://github.com/user-attachments/assets/ab61a4fe-78ba-4df6-80ed-9bf36c221bee" />

With these changes, `interaction.helpedThemToday` was wrapped with `!!` to ensure it always evaluates to a boolean, preventing this issue.
