### PR TITLE
[FIX] Missing Inventory after Selling Placed Treasure

### DIFF
--- a/src/features/game/events/landExpansion/treasureSold.test.ts
+++ b/src/features/game/events/landExpansion/treasureSold.test.ts
@@ -236,4 +236,32 @@ describe("treasureSold", () => {
     });
     expect(state.bumpkin?.activity?.["Clam Shell Sold"]).toEqual(amount);
   });
+
+  it("only sells one treasure even when they are placed", () => {
+    const state = sellTreasure({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Giant Apple": new Decimal(3),
+        },
+        collectibles: {
+          "Giant Apple": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "12",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "treasure.sold",
+        item: "Giant Apple",
+        amount: 1,
+      },
+    });
+
+    expect(state.inventory["Giant Apple"]).toEqual(new Decimal(2));
+  });
 });

--- a/src/features/game/events/landExpansion/treasureSold.ts
+++ b/src/features/game/events/landExpansion/treasureSold.ts
@@ -88,7 +88,9 @@ export function sellTreasure({ state, action }: Options) {
     );
 
     game.coins = coins + earned;
-    game.inventory[item] = setPrecision(count.sub(amount));
+    game.inventory[item] = setPrecision(
+      (game.inventory[item] ?? new Decimal(0)).sub(amount),
+    );
 
     game.boostsUsedAt = updateBoostUsed({
       game,


### PR DESCRIPTION
# Description

When selling treasure, that is placed, such as the Giant Apple, the inventory amount was incorrectly being calculated. The game removes more Giant Apples than the players had.

# What needs to be tested by the reviewer?

1. Checkout `main`
2. Place Giant Apple
3. Sell a different Giant Apple
4. See two apples disappear
5. Checkout the fix
6. Retest and assert only one apple is sold

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]