### PR TITLE
[FEAT] Player Search

### DIFF
--- a/src/features/social/Discovery.tsx
+++ b/src/features/social/Discovery.tsx
@@ -8,21 +8,27 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { discoveryModalManager } from "./lib/discoveryModalManager";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { SearchPlayers } from "./components/SearchPlayers";
+import { hasFeatureAccess } from "lib/flags";
 
-type Tab = "Leaderboard" | "Discovery";
+export type DiscoveryTab = "leaderboard" | "search";
 
 const _farmId = (state: MachineState) => state.context.farmId;
 
 export const Discovery: React.FC = () => {
   const { gameService } = useContext(Context);
+
   const { t } = useAppTranslation();
+
   const [showDiscoveryModal, setShowDiscoveryModal] = useState(false);
-  const [tab, setTab] = useState<Tab>("Leaderboard");
+  const [tab, setTab] = useState<DiscoveryTab>("leaderboard");
 
   const farmId = useSelector(gameService, _farmId);
 
   useEffect(() => {
-    discoveryModalManager.listen(() => {
+    discoveryModalManager.listen((tab: DiscoveryTab) => {
+      setTab(tab);
       setShowDiscoveryModal(true);
     });
   }, []);
@@ -37,20 +43,27 @@ export const Discovery: React.FC = () => {
         currentTab={tab}
         setCurrentTab={setTab}
         tabs={[
-          // {
-          //   icon: SUNNYSIDE.icons.search,
-          //   name: t("discovery"),
-          //   id: "Discovery",
-          // },
           {
             icon: socialPointsIcon,
             name: t("leaderboard"),
-            id: "Leaderboard",
+            id: "leaderboard",
           },
+          ...(hasFeatureAccess(
+            gameService.getSnapshot().context.state,
+            "PLAYER_SEARCH",
+          )
+            ? [
+                {
+                  icon: SUNNYSIDE.icons.search,
+                  name: t("playerSearch.searchPlayer"),
+                  id: "search",
+                },
+              ]
+            : []),
         ]}
       >
-        {/* {tab === "Discovery" && <div>{`Discovery`}</div>} */}
-        {tab === "Leaderboard" && (
+        {tab === "search" && <SearchPlayers />}
+        {tab === "leaderboard" && (
           <SocialLeaderboard
             id={farmId}
             onClose={() => setShowDiscoveryModal(false)}

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -45,12 +45,10 @@ import socialPointsIcon from "assets/icons/social_score.webp";
 import { discoveryModalManager } from "./lib/discoveryModalManager";
 import { FeedFilters } from "./components/FeedFilters";
 import { getFilter, storeFilter } from "./lib/persistFilter";
-<<<<<<< HEAD
 import { HelpInfoPopover } from "./components/HelpInfoPopover";
-=======
-import { PlayerSearch } from "./components/PlayerSearch";
+import { SearchBar } from "./components/SearchBar";
 import { Detail } from "./actions/getFollowNetworkDetails";
->>>>>>> a7e656832 ([FEAT] Add search to follow list)
+import { hasFeatureAccess } from "lib/flags";
 
 type Props = {
   type: "world" | "local";
@@ -303,7 +301,7 @@ export const Feed: React.FC<Props> = ({
               onClick={() => {
                 setShowFollowing(false);
                 setShowFeed(false);
-                discoveryModalManager.open();
+                discoveryModalManager.open("leaderboard");
               }}
             >
               <img
@@ -312,6 +310,22 @@ export const Feed: React.FC<Props> = ({
               />
               {t("leaderboard")}
             </div>
+            {hasFeatureAccess(
+              gameService.getSnapshot().context.state,
+              "PLAYER_SEARCH",
+            ) && (
+              <div
+                className="flex ml-1.5 mr-1 items-center gap-1 text-xs underline cursor-pointer whitespace-nowrap"
+                onClick={() => {
+                  setShowFollowing(false);
+                  setShowFeed(false);
+                  discoveryModalManager.open("search");
+                }}
+              >
+                {t("playerSearch.searchPlayer")}
+                <img src={SUNNYSIDE.icons.search} className="w-4" />
+              </div>
+            )}
           </div>
         </div>
         {!showFollowing && (
@@ -336,10 +350,7 @@ export const Feed: React.FC<Props> = ({
 
         {showFollowing && (
           <>
-            <PlayerSearch
-              context="following"
-              onSearchResults={setSearchResults}
-            />
+            <SearchBar context="following" onSearchResults={setSearchResults} />
             <div
               ref={scrollContainerRef}
               className="flex flex-col gap-2 overflow-hidden overflow-y-auto scrollable"

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -45,7 +45,12 @@ import socialPointsIcon from "assets/icons/social_score.webp";
 import { discoveryModalManager } from "./lib/discoveryModalManager";
 import { FeedFilters } from "./components/FeedFilters";
 import { getFilter, storeFilter } from "./lib/persistFilter";
+<<<<<<< HEAD
 import { HelpInfoPopover } from "./components/HelpInfoPopover";
+=======
+import { PlayerSearch } from "./components/PlayerSearch";
+import { Detail } from "./actions/getFollowNetworkDetails";
+>>>>>>> a7e656832 ([FEAT] Add search to follow list)
 
 type Props = {
   type: "world" | "local";
@@ -96,6 +101,7 @@ export const Feed: React.FC<Props> = ({
   const [showFollowing, setShowFollowing] = useState(false);
   const feedRef = useRef<HTMLDivElement>(null);
   const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(getFilter());
+  const [searchResults, setSearchResults] = useState<Detail[]>([]);
 
   const username = useSelector(gameService, _username);
   const token = useSelector(authService, _token);
@@ -329,22 +335,29 @@ export const Feed: React.FC<Props> = ({
         )}
 
         {showFollowing && (
-          <div
-            ref={scrollContainerRef}
-            className="flex flex-col gap-2 -mt-2 h-full overflow-hidden overflow-y-auto scrollable"
-          >
-            <FollowList
-              loggedInFarmId={farmId}
-              token={token}
-              networkFarmId={farmId}
-              networkList={following}
-              networkCount={following.length}
-              showLabel={false}
-              networkType="following"
-              scrollContainerRef={scrollContainerRef}
-              navigateToPlayer={handleFollowingClick}
+          <>
+            <PlayerSearch
+              context="following"
+              onSearchResults={setSearchResults}
             />
-          </div>
+            <div
+              ref={scrollContainerRef}
+              className="flex flex-col gap-2 overflow-hidden overflow-y-auto scrollable"
+            >
+              <FollowList
+                loggedInFarmId={farmId}
+                token={token}
+                searchResults={searchResults}
+                networkFarmId={farmId}
+                networkList={following}
+                networkCount={following.length}
+                showLabel={false}
+                networkType="following"
+                scrollContainerRef={scrollContainerRef}
+                navigateToPlayer={handleFollowingClick}
+              />
+            </div>
+          </>
         )}
 
         {!showFollowing && (

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -289,10 +289,11 @@ export const Feed: React.FC<Props> = ({
               {t("myProfile")}
             </div>
             <FollowsIndicator
+              showSingleBumpkin
               count={following.length}
               onClick={() => setShowFollowing(!showFollowing)}
               type="following"
-              className="ml-1"
+              className="ml-1 -mr-3.5"
             />
           </div>
           <div className="flex items-center justify-between gap-1 w-full">

--- a/src/features/social/actions/searchPlayerByUsername.ts
+++ b/src/features/social/actions/searchPlayerByUsername.ts
@@ -1,0 +1,35 @@
+import { CONFIG } from "lib/config";
+import { Detail } from "./getFollowNetworkDetails";
+
+type Request = {
+  token: string;
+  farmId: number;
+  searchTerm: string;
+  context: "following" | "all" | "followers";
+  signal?: AbortSignal;
+};
+
+export const searchPlayerByUsername = async ({
+  token,
+  farmId,
+  searchTerm,
+  context,
+  signal,
+}: Request): Promise<{ data: Detail[] }> => {
+  const url = new URL(`${CONFIG.API_URL}/data`);
+  url.searchParams.set("type", "playerSearch");
+  url.searchParams.set("farmId", farmId.toString());
+  url.searchParams.set("searchTerm", searchTerm);
+  url.searchParams.set("context", context);
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    signal,
+  });
+
+  const response = await res.json();
+
+  return response;
+};

--- a/src/features/social/components/FollowDetailPanel.tsx
+++ b/src/features/social/components/FollowDetailPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback } from "react";
 import { ButtonPanel } from "components/ui/Panel";
 import { NPCIcon } from "features/island/bumpkin/components/NPC";
 import { OnlineStatus } from "./OnlineStatus";
@@ -12,8 +12,6 @@ import helpIcon from "assets/icons/help.webp";
 import helpedIcon from "assets/icons/helped.webp";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { shortenCount } from "lib/utils/formatNumber";
-import classNames from "classnames";
-import { HelpInfoPopover } from "./HelpInfoPopover";
 
 type Props = {
   loggedInFarmId: number;
@@ -25,8 +23,8 @@ type Props = {
   socialPoints: number;
   lastOnlineAt: number;
   hasCookingPot: boolean;
-  helpStreak: number;
   navigateToPlayer: (playerId: number) => void;
+  helpStreak: number;
 };
 
 export const FollowDetailPanel: React.FC<Props> = ({
@@ -43,8 +41,6 @@ export const FollowDetailPanel: React.FC<Props> = ({
   helpStreak,
 }: Props) => {
   const { t } = useTranslation();
-  const [showPopover, setShowPopover] = useState(false);
-  const [mounted, setMounted] = useState(false);
   const lastOnline = getRelativeTime(lastOnlineAt, "short");
 
   const isOnline = lastOnlineAt > Date.now() - 30 * 60 * 1000;
@@ -55,22 +51,9 @@ export const FollowDetailPanel: React.FC<Props> = ({
     navigateToPlayer(playerId);
   }, [navigateToPlayer, playerId]);
 
-  useEffect(() => {
-    // Set mounted after a brief delay to prevent accidental triggers during mount
-    const timer = setTimeout(() => {
-      setMounted(true);
-    }, 50);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [playerId]);
-
   return (
     <ButtonPanel
-      className={classNames(
-        "flex gap-3 justify-between hover:bg-brown-300 transition-colors active:bg-brown-400",
-      )}
+      className="flex gap-3 justify-between hover:bg-brown-300 transition-colors active:bg-brown-400"
       onClick={handleClick}
     >
       <div className="flex items-center gap-2 w-full">
@@ -86,15 +69,7 @@ export const FollowDetailPanel: React.FC<Props> = ({
             />
           </div>
         </div>
-        <div className="flex flex-col gap-0.5 w-full relative">
-          <HelpInfoPopover
-            className="-top-1 left-4 w-max h-max z-20 absolute"
-            showPopover={showPopover}
-            onHide={() => setShowPopover(false)}
-            helpedThemToday={helpedThemToday}
-            helpedYouToday={helpedYouToday}
-            hasCookingPot={hasCookingPot}
-          />
+        <div className="flex flex-col gap-0.5 w-full">
           <div className="flex flex-col justify-center w-full">
             <div className="flex items-center justify-between w-full mb-0.5">
               <div className="text-xs">{isYou ? `${t("you")}` : username}</div>
@@ -112,49 +87,11 @@ export const FollowDetailPanel: React.FC<Props> = ({
               <div className="text-xxs mb-1.5">{t("social.farming")}</div>
             )}
             <div className="flex items-center justify-between w-full">
-              <div className="relative flex items-center gap-1 flex-wrap">
-                {(helpedThemToday || helpedYouToday || hasCookingPot) && (
-                  <>
-                    <div
-                      onPointerOver={(e) => {
-                        if (e.pointerType === "mouse" && mounted) {
-                          setShowPopover(true);
-                        }
-                      }}
-                      onPointerOut={(e) => {
-                        if (e.pointerType === "mouse" && mounted) {
-                          setShowPopover(false);
-                        }
-                      }}
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-
-                        if (mounted) {
-                          setShowPopover(!showPopover);
-                          setTimeout(() => {
-                            setShowPopover(false);
-                          }, 1500);
-                        }
-                      }}
-                      onClickCapture={(e) => {
-                        // Stop the additional synthetic event from from firing
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      className="absolute inset-0 min-w-8 h-8 bg-transparent z-20"
-                    />
-                    {helpedThemToday && (
-                      <img src={helpIcon} className="w-5 h-5" />
-                    )}
-                    {helpedYouToday && (
-                      <img src={helpedIcon} className="w-5 h-5" />
-                    )}
-                    {hasCookingPot && <img src={potIcon} className="w-5 h-5" />}
-                  </>
-                )}
+              <div className="flex items-center gap-1 flex-wrap">
+                {helpedThemToday && <img src={helpIcon} className="w-5 h-5" />}
+                {helpedYouToday && <img src={helpedIcon} className="w-5 h-5" />}
+                {hasCookingPot && <img src={potIcon} className="w-5 h-5" />}
               </div>
-
               {helpStreak > 0 && (
                 <Label type="vibrant" icon={SUNNYSIDE.icons.heart}>
                   {t("friendStreak.short", {

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -13,7 +13,7 @@ import { Detail } from "../actions/getFollowNetworkDetails";
 type Props = {
   loggedInFarmId: number;
   token: string;
-  searchResults: Detail[];
+  searchResults?: Detail[];
   networkFarmId: number;
   networkList: number[];
   networkCount: number;
@@ -28,13 +28,13 @@ export const FollowList: React.FC<Props> = ({
   loggedInFarmId,
   token,
   networkFarmId,
-  searchResults,
   networkList,
   networkCount,
   playerLoading,
   showLabel = true,
   networkType,
   scrollContainerRef,
+  searchResults = [],
   navigateToPlayer,
 }) => {
   useSocial({

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -8,11 +8,12 @@ import { Equipped } from "features/game/types/bumpkin";
 import { useFollowNetwork } from "../hooks/useFollowNetwork";
 import { useInView } from "react-intersection-observer";
 import { Loading } from "features/auth/components";
-import { useGame } from "features/game/GameProvider";
+import { Detail } from "../actions/getFollowNetworkDetails";
 
 type Props = {
   loggedInFarmId: number;
   token: string;
+  searchResults: Detail[];
   networkFarmId: number;
   networkList: number[];
   networkCount: number;
@@ -27,6 +28,7 @@ export const FollowList: React.FC<Props> = ({
   loggedInFarmId,
   token,
   networkFarmId,
+  searchResults,
   networkList,
   networkCount,
   playerLoading,
@@ -41,8 +43,6 @@ export const FollowList: React.FC<Props> = ({
   });
   const { t } = useTranslation();
   const [isScrollable, setIsScrollable] = useState(false);
-  const { gameService } = useGame();
-
   // Intersection observer to load more details when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
     root: scrollContainerRef.current,
@@ -120,29 +120,33 @@ export const FollowList: React.FC<Props> = ({
   if (networkCount === 0) {
     return (
       <div className="flex flex-col gap-1 pl-1 mb-1">
-        <div className="sticky top-0 bg-brown-200 z-10 pb-1">
-          {showLabel && (
+        {showLabel && (
+          <div className="sticky top-0 bg-brown-200 z-10 pb-1">
             <Label type="default">
               {t(`playerModal.${networkType}`, { count: networkCount })}
             </Label>
-          )}
-        </div>
+          </div>
+        )}
+
         <div className="text-xs">{t(`playerModal.no.${networkType}`)}</div>
       </div>
     );
   }
 
+  const data = searchResults.length > 0 ? searchResults : network;
+
   return (
     <div className="flex flex-col pr-0.5">
-      <div className="sticky -top-1 bg-brown-200 z-10 pb-1 pt-1">
-        {showLabel && (
+      {showLabel && (
+        <div className="sticky -top-1 bg-brown-200 z-10 pb-1 pt-1">
           <Label type="default">
             {t(`playerModal.${networkType}`, { count: networkCount })}
           </Label>
-        )}
-      </div>
+        </div>
+      )}
+
       <div className="flex flex-col gap-1">
-        {network.map((detail) => {
+        {data.map((detail) => {
           return (
             <FollowDetailPanel
               key={`flw-${detail.id}`}

--- a/src/features/social/components/FollowsIndicator.tsx
+++ b/src/features/social/components/FollowsIndicator.tsx
@@ -16,6 +16,7 @@ interface FollowsIndicatorProps {
   onClick: () => void;
   type: "followers" | "following";
   className?: string;
+  showSingleBumpkin?: boolean;
 }
 
 export const FollowsIndicator: React.FC<FollowsIndicatorProps> = ({
@@ -23,6 +24,7 @@ export const FollowsIndicator: React.FC<FollowsIndicatorProps> = ({
   onClick,
   type,
   className = "",
+  showSingleBumpkin = false,
 }) => {
   const { t } = useTranslation();
 
@@ -59,9 +61,11 @@ export const FollowsIndicator: React.FC<FollowsIndicatorProps> = ({
         <div className="absolute">
           <NPCIcon width={24} parts={defaultNPCParts} />
         </div>
-        <div className="absolute left-3.5">
-          <NPCIcon width={24} parts={secondNPCParts} />
-        </div>
+        {!showSingleBumpkin && (
+          <div className="absolute left-3.5">
+            <NPCIcon width={24} parts={secondNPCParts} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/social/components/PlayerSearch.tsx
+++ b/src/features/social/components/PlayerSearch.tsx
@@ -1,9 +1,148 @@
-import React from "react";
+import React, { useContext } from "react";
+import { useEffect, useRef, useState } from "react";
+import { MachineState } from "features/game/lib/gameMachine";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import * as AuthProvider from "features/auth/lib/Provider";
+import { Detail } from "../actions/getFollowNetworkDetails";
+import { searchPlayerByUsername } from "../actions/searchPlayerByUsername";
+import { TextInput } from "components/ui/TextInput";
 
-export const PlayerSearch: React.FC = () => {
+import loadingIcon from "assets/icons/timer.gif";
+import { SUNNYSIDE } from "assets/sunnyside";
+import classNames from "classnames";
+import { Label } from "components/ui/Label";
+import { useTranslation } from "react-i18next";
+
+const _farmId = (state: MachineState) =>
+  state.context.visitorId ?? state.context.farmId;
+const _token = (state: AuthMachineState) =>
+  state.context.user.rawToken as string;
+
+type Props = {
+  context: "following" | "all" | "followers";
+  onSearchResults: (results: Detail[]) => void;
+};
+
+const useDebouncedValue = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    if (value.length === 0) {
+      setDebouncedValue("");
+      return;
+    }
+
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+};
+
+export const PlayerSearch: React.FC<Props> = ({ onSearchResults, context }) => {
+  const { gameService } = useContext(Context);
+  const { authService } = useContext(AuthProvider.Context);
+
+  const { t } = useTranslation();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [results, setResults] = useState<Detail[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const controllerRef = useRef<AbortController>();
+  const currentRequestRef = useRef<string>("");
+
+  const farmId = useSelector(gameService, _farmId);
+  const token = useSelector(authService, _token);
+
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 200);
+
+  useEffect(() => {
+    if (debouncedSearchTerm.trim().length > 2) {
+      setLoading(true);
+
+      // Abort previous request if it exists
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+      }
+
+      // Create new abort controller for this request
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      // Track this specific request
+      const requestId = debouncedSearchTerm;
+      currentRequestRef.current = requestId;
+
+      searchPlayerByUsername({
+        token,
+        farmId,
+        searchTerm: debouncedSearchTerm,
+        context,
+        signal: controller.signal,
+      })
+        .then(({ data }) => {
+          // Only update results if this is still the current request
+          if (currentRequestRef.current === requestId) {
+            setResults(data);
+          }
+        })
+        .catch((error) => {
+          if (error.name === "AbortError") {
+            // eslint-disable-next-line no-console
+            console.log("Search aborted by the user.");
+          } else {
+            // eslint-disable-next-line no-console
+            console.error("Failed to search players:", error);
+          }
+        })
+        .finally(() => {
+          // Only update loading state if this is still the current request
+          if (currentRequestRef.current === requestId) {
+            setLoading(false);
+          }
+        });
+    } else {
+      setResults([]);
+      setLoading(false);
+    }
+  }, [debouncedSearchTerm, token, farmId, context]);
+
+  useEffect(() => {
+    onSearchResults(results);
+  }, [results, onSearchResults]);
+
+  const getIcon = () => {
+    if (!searchTerm || searchTerm.length < 3) return SUNNYSIDE.icons.search;
+    if (loading) return loadingIcon;
+
+    return SUNNYSIDE.icons.close;
+  };
+
   return (
-    <div>
-      <input type="text" placeholder="Search for a player" />
+    <div className="relative mt-1">
+      <div className="flex relative">
+        <TextInput
+          value={searchTerm}
+          onValueChange={(value) => setSearchTerm(value)}
+          placeholder="Search by username.."
+        />
+        <img
+          onClick={searchTerm ? () => setSearchTerm("") : undefined}
+          src={getIcon()}
+          className={classNames("absolute right-3 top-1/2 -translate-y-1/2", {
+            "h-4 w-auto": loading,
+            "w-4 h-auto cursor-pointer": !loading,
+          })}
+        />
+      </div>
+      {debouncedSearchTerm.length > 2 && !loading && results.length === 0 && (
+        <Label className="text-xs absolute -top-3 right-0" type="default">
+          {t("playerSearch.noResults")}
+        </Label>
+      )}
     </div>
   );
 };

--- a/src/features/social/components/SearchBar.tsx
+++ b/src/features/social/components/SearchBar.tsx
@@ -13,7 +13,7 @@ import loadingIcon from "assets/icons/timer.gif";
 import { SUNNYSIDE } from "assets/sunnyside";
 import classNames from "classnames";
 import { Label } from "components/ui/Label";
-import { useTranslation } from "react-i18next";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 const _farmId = (state: MachineState) =>
   state.context.visitorId ?? state.context.farmId;
@@ -41,11 +41,11 @@ const useDebouncedValue = (value: string, delay: number) => {
   return debouncedValue;
 };
 
-export const PlayerSearch: React.FC<Props> = ({ onSearchResults, context }) => {
+export const SearchBar: React.FC<Props> = ({ onSearchResults, context }) => {
   const { gameService } = useContext(Context);
   const { authService } = useContext(AuthProvider.Context);
 
-  const { t } = useTranslation();
+  const { t } = useAppTranslation();
 
   const [searchTerm, setSearchTerm] = useState("");
   const [results, setResults] = useState<Detail[]>([]);
@@ -112,7 +112,8 @@ export const PlayerSearch: React.FC<Props> = ({ onSearchResults, context }) => {
 
   useEffect(() => {
     onSearchResults(results);
-  }, [results, onSearchResults]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [results]);
 
   const getIcon = () => {
     if (!searchTerm || searchTerm.length < 3) return SUNNYSIDE.icons.search;
@@ -122,12 +123,13 @@ export const PlayerSearch: React.FC<Props> = ({ onSearchResults, context }) => {
   };
 
   return (
-    <div className="relative mt-1">
-      <div className="flex relative">
+    <div className="relative mt-1 w-full">
+      <div className="flex relative w-full">
         <TextInput
           value={searchTerm}
           onValueChange={(value) => setSearchTerm(value)}
-          placeholder="Search by username.."
+          placeholder={t("playerSearch.placeholderContext", { context })}
+          className="w-full"
         />
         <img
           onClick={searchTerm ? () => setSearchTerm("") : undefined}

--- a/src/features/social/components/SearchPlayers.tsx
+++ b/src/features/social/components/SearchPlayers.tsx
@@ -1,0 +1,58 @@
+import React, { useContext, useState } from "react";
+import { SearchBar } from "./SearchBar";
+import { Detail } from "../actions/getFollowNetworkDetails";
+import { FollowDetailPanel } from "./FollowDetailPanel";
+import { MachineState } from "features/game/lib/gameMachine";
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import { playerModalManager } from "../lib/playerModalManager";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+const _farmId = (state: MachineState) =>
+  state.context.visitorId ?? state.context.farmId;
+
+export const SearchPlayers: React.FC = () => {
+  const { gameService } = useContext(Context);
+
+  const { t } = useAppTranslation();
+
+  const [searchResults, setSearchResults] = useState<Detail[]>([]);
+  const farmId = useSelector(gameService, _farmId);
+
+  const handlePlayerClick = (playerId: number) => {
+    playerModalManager.open({
+      farmId: playerId,
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <SearchBar context="all" onSearchResults={setSearchResults} />
+      <div className="flex flex-col gap-1 h-80 mt-1 overflow-y-auto scrollable">
+        {searchResults.length === 0 && (
+          <div className="flex p-1 h-full">
+            <p className="text-sm">{t("playerSearch.startTyping")}</p>
+          </div>
+        )}
+        <div className="flex flex-col pr-0.5">
+          {searchResults.map((result) => (
+            <FollowDetailPanel
+              loggedInFarmId={farmId}
+              clothing={result.clothing}
+              playerId={result.id}
+              key={result.id}
+              username={result.username}
+              lastOnlineAt={result.lastUpdatedAt}
+              hasCookingPot={result.hasCookingPot}
+              helpedThemToday={result.helpedThemToday}
+              helpedYouToday={result.helpedYouToday}
+              socialPoints={result.socialPoints}
+              navigateToPlayer={handlePlayerClick}
+              helpStreak={result.helpStreak}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/social/components/SocialLeaderboard.tsx
+++ b/src/features/social/components/SocialLeaderboard.tsx
@@ -31,7 +31,7 @@ export const SocialLeaderboard: React.FC<LeaderboardProps> = ({
   const [showLeaderboard, setShowLeaderboard] = useState<"weekly" | "allTime">(
     "weekly",
   );
-  const [hovering, setHovering] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
 
   const { data, isLoading } = useSWR(
     id ? ["socialLeaderboard", id] : null,
@@ -63,8 +63,25 @@ export const SocialLeaderboard: React.FC<LeaderboardProps> = ({
         <div className="flex flex-col mb-1 gap-1 md:flex-row md:items-center justify-between p-1">
           <div
             className="relative"
-            onMouseEnter={() => setHovering(true)}
-            onMouseLeave={() => setHovering(false)}
+            onPointerEnter={(e) => {
+              if (e.pointerType === "touch") {
+                setShowTooltip(true);
+                setTimeout(() => {
+                  setShowTooltip(false);
+                }, 1000);
+              } else {
+                setShowTooltip(true);
+              }
+            }}
+            onPointerLeave={(e) => {
+              if (e.pointerType === "touch") {
+                return;
+              }
+
+              if (showTooltip) {
+                setShowTooltip(false);
+              }
+            }}
           >
             <Label
               type="default"
@@ -77,7 +94,7 @@ export const SocialLeaderboard: React.FC<LeaderboardProps> = ({
             >
               {t(`social.leaderboard.${showLeaderboard}`)}
             </Label>
-            {hovering && (
+            {showTooltip && (
               <Label type="info" className="absolute -bottom-7 -right-3">
                 <p className="text-xxs px-1">
                   {t("social.leaderboard.clickToView", {
@@ -191,7 +208,7 @@ export const SocialLeaderboardTable: React.FC<Props> = ({
 
               <td
                 style={{ border: "1px solid #b96f50" }}
-                className="p-1.5 w-1/5"
+                className="p-1.5 w-1/4"
               >
                 {count}
               </td>

--- a/src/features/social/components/skeletons/LeaderboardSkeleton.tsx
+++ b/src/features/social/components/skeletons/LeaderboardSkeleton.tsx
@@ -13,7 +13,7 @@ export const LeaderboardSkeleton: React.FC = () => {
         <Label type="default" icon={socialPointsIcon}>
           {t("social.leaderboard")}
         </Label>
-        <div className="h-3 bg-brown-300 animate-pulse w-24"></div>
+        <div className="h-3 mt-1 bg-brown-300 animate-pulse w-24"></div>
       </div>
 
       {/* Table skeleton */}

--- a/src/features/social/hooks/useFeedInteractions.ts
+++ b/src/features/social/hooks/useFeedInteractions.ts
@@ -38,18 +38,18 @@ export function useFeedInteractions(
     },
   );
 
-  const followingRef = useRef<number[] | null>([]);
+  const followingRef = useRef<number[] | null>(null);
 
   // Whatever SWR returned for page 0 this render
   const firstFollowing = data?.[0]?.following;
 
   useEffect(() => {
-    const hasNotInitialized = followingRef.current?.length === 0;
-    const hasDifferentLength =
-      followingRef.current?.length !== firstFollowing?.length;
-
-    if (hasNotInitialized || hasDifferentLength) {
-      followingRef.current = firstFollowing ?? [];
+    if (
+      firstFollowing &&
+      (followingRef.current === null ||
+        followingRef.current.length !== firstFollowing.length)
+    ) {
+      followingRef.current = firstFollowing;
     }
   }, [firstFollowing]);
 

--- a/src/features/social/lib/discoveryModalManager.ts
+++ b/src/features/social/lib/discoveryModalManager.ts
@@ -1,13 +1,15 @@
-class DiscoveryModalManager {
-  private listener?: () => void;
+import { DiscoveryTab } from "../Discovery";
 
-  public open() {
+class DiscoveryModalManager {
+  private listener?: (tab: DiscoveryTab) => void;
+
+  public open(tab: DiscoveryTab) {
     if (this.listener) {
-      this.listener();
+      this.listener(tab);
     }
   }
 
-  public listen(cb: () => void) {
+  public listen(cb: (tab: DiscoveryTab) => void) {
     this.listener = cb;
   }
 }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -119,12 +119,9 @@ const FEATURE_FLAGS = {
   OBSIDIAN_EXCHANGE: testnetFeatureFlag,
   GASLESS_AUCTIONS: () => true,
   NODE_FORGING: defaultFeatureFlag,
-<<<<<<< HEAD
   DEPOSIT_SFL: adminTimeBasedFeatureFlag(new Date("2025-08-28T00:00:00.000Z")),
-=======
 
   PLAYER_SEARCH: usernameFeatureFlag,
->>>>>>> 2db8582dd ([FEAT] Add search player and feature flag)
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -119,7 +119,12 @@ const FEATURE_FLAGS = {
   OBSIDIAN_EXCHANGE: testnetFeatureFlag,
   GASLESS_AUCTIONS: () => true,
   NODE_FORGING: defaultFeatureFlag,
+<<<<<<< HEAD
   DEPOSIT_SFL: adminTimeBasedFeatureFlag(new Date("2025-08-28T00:00:00.000Z")),
+=======
+
+  PLAYER_SEARCH: usernameFeatureFlag,
+>>>>>>> 2db8582dd ([FEAT] Add search player and feature flag)
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6495,5 +6495,9 @@
   "transaction.migrate.sfl.taxFree": "FLOWER migrated from SFL is tax-free for withdrawal.",
   "transaction.migrate.sfl.maxAmount": "Max Amount: {{maxAmount}} (Updates Daily)",
   "sfl.migrated": "SFL Migrated",
-  "playerSearch.noResults": "No results found"
+  "playerSearch.noResults": "No results found",
+  "playerSearch.placeholderContext": "Search {{context}}...",
+  "playerSearch.placeholderAll": "Search by username...",
+  "playerSearch.searchPlayer": "Search players",
+  "playerSearch.startTyping": "Start typing a username..."
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6488,12 +6488,12 @@
   "upgrade.success": "{{resource}} upgrade complete!",
   "upgrade.success.description": "You can now mine {{resource}}!",
   "pets.coming.soon": "Pets are coming soon - November 3rd.",
-
   "deposit.loadingBalance": "Loading balance...",
   "transaction.migrate.sfl": "Migrate SFL",
   "transaction.migrate.sfl.description": "This migration is for converting SFL to FLOWER. SFL can only be migrated from the linked wallet.",
   "transaction.migrate.sfl.limit": "The limit of SFL that can be migrated is update daily. The amount added to the limit increases by 1000 SFL each day.",
   "transaction.migrate.sfl.taxFree": "FLOWER migrated from SFL is tax-free for withdrawal.",
   "transaction.migrate.sfl.maxAmount": "Max Amount: {{maxAmount}} (Updates Daily)",
-  "sfl.migrated": "SFL Migrated"
+  "sfl.migrated": "SFL Migrated",
+  "playerSearch.noResults": "No results found"
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -207,6 +207,12 @@ input {
   color: #3e2731;
 }
 
+input::placeholder {
+  color: black;
+  opacity: 0.3;
+  padding-left: 2px;
+}
+
 button:disabled {
   cursor: not-allowed;
 }


### PR DESCRIPTION
# Description

This PR adds the ability for a player to be able to search their following list and also do a global search on players by username.

**NOTE** This is currently behind a feature flag just while I do some testing.
<img width="319" height="331" alt="Screenshot 2025-08-27 at 10 59 25 AM" src="https://github.com/user-attachments/assets/19e44614-d0ef-4938-a24b-c854552a3095" />

<img width="494" height="252" alt="Screenshot 2025-08-27 at 10 55 41 AM" src="https://github.com/user-attachments/assets/f7bbffb3-a2a2-45fc-a477-a3fb87bb93fc" />

Fixes #issue

# What needs to be tested by the reviewer?

- Click on the feed -> following and search your followers
- Click on the feed -> search players and search all players

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
