### PR TITLE
[FEAT] Selected Seed Details in Obsidian Shrine Modal

### DIFF
--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -178,10 +178,10 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
           )}
         </CloseButtonPanel>
 
-        <div className="absolute -top-8 -mt-[2px] right-0">
+        <div className="absolute -top-8 -mt-[2px] right-0 mr-[5.5px]">
           <Label
             type="info"
-            icon={SUNNYSIDE.icons.stopwatch}
+            secondaryIcon={SUNNYSIDE.icons.stopwatch}
             className="mt-2 mb-2"
           >
             <span className="text-xs">


### PR DESCRIPTION
# Description

Display Selected Seed name and growing time in the UI:

<img width="581" height="413" alt="image" src="https://github.com/user-attachments/assets/8f697f74-be8f-472e-8c5f-5c8aba8c8858" />


