### PR TITLE
[FEAT] Show Inventory Amount for Crafting Box Recipes

### DIFF
--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -426,6 +426,9 @@ export const CraftTab: React.FC<Props> = ({
   const recipeAmount = (recipeName: RecipeCollectibleName) =>
     remainingInventory[recipeName as RecipeCollectibleName] ?? new Decimal(0);
 
+  const isCraftingInProgress =
+    isCrafting && remainingTime !== null && remainingTime > 0;
+
   return (
     <>
       <div className="flex pl-1 pt-1">
@@ -491,7 +494,7 @@ export const CraftTab: React.FC<Props> = ({
             isPending={isPending}
             failedAttempt={failedAttempt}
             amount={
-              isCrafting && !isReady && (currentRecipe?.time ?? 0) > 0
+              isCraftingInProgress
                 ? new Decimal(0)
                 : recipeAmount(currentRecipe?.name as RecipeCollectibleName)
             }

--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -27,6 +27,7 @@ import {
   RecipeIngredient,
   DOLLS,
   RECIPES,
+  RecipeCollectibleName,
 } from "features/game/lib/crafting";
 import {
   findMatchingRecipe,
@@ -422,6 +423,9 @@ export const CraftTab: React.FC<Props> = ({
 
   const gems = getInstantGems({ readyAt: craftingReadyAt, game: state });
 
+  const recipeAmount = (recipeName: RecipeCollectibleName) =>
+    remainingInventory[recipeName as RecipeCollectibleName] ?? new Decimal(0);
+
   return (
     <>
       <div className="flex pl-1 pt-1">
@@ -486,6 +490,11 @@ export const CraftTab: React.FC<Props> = ({
             recipe={currentRecipe}
             isPending={isPending}
             failedAttempt={failedAttempt}
+            amount={
+              isCrafting && !isReady && (currentRecipe?.time ?? 0) > 0
+                ? new Decimal(0)
+                : recipeAmount(currentRecipe?.name as RecipeCollectibleName)
+            }
           />
           <CraftTimer
             state={state}
@@ -605,6 +614,7 @@ export const CraftTab: React.FC<Props> = ({
                 recipe={currentRecipe}
                 isPending={isPending}
                 failedAttempt={failedAttempt}
+                amount={new Decimal(1)}
               />
               <CraftTimer
                 state={state}
@@ -658,7 +668,8 @@ const CraftDetails: React.FC<{
   recipe: Recipe | null;
   isPending: boolean;
   failedAttempt: boolean;
-}> = ({ recipe, isPending, failedAttempt }) => {
+  amount: Decimal;
+}> = ({ recipe, isPending, failedAttempt, amount }) => {
   const { t } = useTranslation();
 
   if (!recipe) {
@@ -684,6 +695,7 @@ const CraftDetails: React.FC<{
         <Box
           image={SUNNYSIDE.icons.expression_confused}
           key={`box-${isPending}`}
+          count={amount}
         />
       </>
     );
@@ -700,7 +712,7 @@ const CraftDetails: React.FC<{
             ? ITEM_DETAILS[recipe.name as InventoryItemName].image
             : getImageUrl(ITEM_IDS[recipe.name as BumpkinItem])
         }
-        count={new Decimal(1)}
+        count={amount}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -486,7 +486,6 @@ export const CraftTab: React.FC<Props> = ({
             recipe={currentRecipe}
             isPending={isPending}
             failedAttempt={failedAttempt}
-            amount={new Decimal(1)}
           />
           <CraftTimer
             state={state}
@@ -606,7 +605,6 @@ export const CraftTab: React.FC<Props> = ({
                 recipe={currentRecipe}
                 isPending={isPending}
                 failedAttempt={failedAttempt}
-                amount={new Decimal(1)}
               />
               <CraftTimer
                 state={state}
@@ -660,8 +658,7 @@ const CraftDetails: React.FC<{
   recipe: Recipe | null;
   isPending: boolean;
   failedAttempt: boolean;
-  amount: Decimal;
-}> = ({ recipe, isPending, failedAttempt, amount }) => {
+}> = ({ recipe, isPending, failedAttempt }) => {
   const { t } = useTranslation();
 
   if (!recipe) {
@@ -687,7 +684,6 @@ const CraftDetails: React.FC<{
         <Box
           image={SUNNYSIDE.icons.expression_confused}
           key={`box-${isPending}`}
-          count={amount}
         />
       </>
     );
@@ -704,7 +700,7 @@ const CraftDetails: React.FC<{
             ? ITEM_DETAILS[recipe.name as InventoryItemName].image
             : getImageUrl(ITEM_IDS[recipe.name as BumpkinItem])
         }
-        count={amount}
+        count={new Decimal(1)}
       />
     </>
   );

--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -27,7 +27,6 @@ import {
   RecipeIngredient,
   DOLLS,
   RECIPES,
-  RecipeCollectibleName,
 } from "features/game/lib/crafting";
 import {
   findMatchingRecipe,
@@ -423,12 +422,6 @@ export const CraftTab: React.FC<Props> = ({
 
   const gems = getInstantGems({ readyAt: craftingReadyAt, game: state });
 
-  const recipeAmount = (recipeName: RecipeCollectibleName) =>
-    remainingInventory[recipeName as RecipeCollectibleName] ?? new Decimal(0);
-
-  const isCraftingInProgress =
-    isCrafting && remainingTime !== null && remainingTime > 0;
-
   return (
     <>
       <div className="flex pl-1 pt-1">
@@ -493,11 +486,7 @@ export const CraftTab: React.FC<Props> = ({
             recipe={currentRecipe}
             isPending={isPending}
             failedAttempt={failedAttempt}
-            amount={
-              isCraftingInProgress
-                ? new Decimal(0)
-                : recipeAmount(currentRecipe?.name as RecipeCollectibleName)
-            }
+            amount={new Decimal(1)}
           />
           <CraftTimer
             state={state}

--- a/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
@@ -15,6 +15,7 @@ import classNames from "classnames";
 import { SquareIcon } from "components/ui/SquareIcon";
 import {
   Recipe,
+  RecipeCollectibleName,
   RecipeIngredient,
   RECIPES,
   Recipes,
@@ -30,6 +31,7 @@ import lightningIcon from "assets/icons/lightning.png";
 import { InventoryItemName } from "features/game/types/game";
 import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
 import { getObjectEntries } from "features/game/expansion/lib/utils";
+import Decimal from "decimal.js-light";
 
 const _state = (state: MachineState) => state.context.state;
 
@@ -125,6 +127,9 @@ export const RecipesTab: React.FC<Props> = ({
     });
   };
 
+  const recipeAmount = (recipeName: RecipeCollectibleName) =>
+    remainingInventory[recipeName as RecipeCollectibleName] ?? new Decimal(0);
+
   return (
     <div className="flex flex-col">
       <Label type="default" className="mb-2">
@@ -215,6 +220,15 @@ export const RecipesTab: React.FC<Props> = ({
                             src={getImageUrl(ITEM_IDS[recipe.name])}
                             className="w-6 h-6 object-contain"
                           />
+                        )}
+                        {recipeAmount(recipe.name as RecipeCollectibleName).gt(
+                          0,
+                        ) && (
+                          <div className="absolute -top-4 -right-4">
+                            <Label type="default">
+                              <p className="text-xxs">{`${recipeAmount(recipe.name as RecipeCollectibleName)}`}</p>
+                            </Label>
+                          </div>
                         )}
                       </ButtonPanel>
                     </div>


### PR DESCRIPTION
# Description

Displays the inventory amount for known patterns in the Recipes tab and for the selected recipe in the Craft tab. This helps players who want to complete tasks requiring certain amounts of crafting items or for other use cases.

<img width="620" height="509" alt="image" src="https://github.com/user-attachments/assets/81298021-948d-4d43-8cec-339f59b80e31" />
<img width="626" height="357" alt="image" src="https://github.com/user-attachments/assets/9252fdd0-edf1-4f2a-9514-7c78fe2d435b" />


