### PR TITLE
[FIX] Composter Sizing

### DIFF
--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -113,13 +113,13 @@ export const COMPOSTER_IMAGES: Record<
     composting: SUNNYSIDE.building.basicComposting,
     idle: SUNNYSIDE.building.basicComposter,
     ready: SUNNYSIDE.building.basicReady,
-    width: 24,
+    width: 20,
   },
   "Turbo Composter": {
     composting: SUNNYSIDE.building.advancedComposting,
     idle: SUNNYSIDE.building.advancedComposter,
     ready: SUNNYSIDE.building.advancedReady,
-    width: 27,
+    width: 28,
   },
   "Premium Composter": {
     composting: SUNNYSIDE.building.expertComposting,


### PR DESCRIPTION
# Description

This Fixes overlapping of sizes of the Composter New Designs.
BEFORE:
<img width="467" height="251" alt="image" src="https://github.com/user-attachments/assets/6579d101-224e-4ac8-a927-e775143e4592" />
AFTER:
<img width="475" height="266" alt="image" src="https://github.com/user-attachments/assets/ad3f9b12-6034-4eb2-ad8e-5ec1475cd103" />
<img width="440" height="221" alt="image" src="https://github.com/user-attachments/assets/e0a00162-1ed4-45b4-aa49-1dbfd036a3be" />

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
