### PR TITLE
[FEAT] Default minigame leaderboard to past 7 days

### DIFF
--- a/src/features/world/ui/portals/FruitDash.tsx
+++ b/src/features/world/ui/portals/FruitDash.tsx
@@ -155,7 +155,6 @@ export const FruitDash: React.FC<Props> = ({ onClose }) => {
         jwt={authService.getSnapshot().context.user.rawToken as string}
         onBack={() => setPage("play")}
         name={"fruit-dash"}
-        startDate={new Date(2024, 6, 2)}
       />
     );
   }

--- a/src/features/world/ui/portals/MineWhack.tsx
+++ b/src/features/world/ui/portals/MineWhack.tsx
@@ -155,7 +155,6 @@ export const MineWhack: React.FC<Props> = ({ onClose }) => {
         jwt={authService.getSnapshot().context.user.rawToken as string}
         onBack={() => setPage("play")}
         name={"mine-whack"}
-        startDate={new Date(2024, 6, 2)}
       />
     );
   }


### PR DESCRIPTION
# Description

Leaderboards can only be processed for the last 30 days. This PR removes the old from dates, defaulting the leaderboards to the past 7 days.