### PR TITLE
[FEAT] Show Global Data in Local Feed

### DIFF
--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -72,7 +72,7 @@ const HudComponent: React.FC<{
 
   return (
     <HudContainer>
-      <Feed type="local" showFeed={showFeed} setShowFeed={setShowFeed} />
+      <Feed type="world" showFeed={showFeed} setShowFeed={setShowFeed} />
       <div
         className={classNames(
           "absolute left-0 top-0 bottom-0 p-2.5 transition-transform duration-200",

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -102,7 +102,7 @@ export const VisitingHud: React.FC = () => {
 
   return (
     <HudContainer>
-      <Feed type="local" showFeed={showFeed} setShowFeed={setShowFeed} />
+      <Feed type="world" showFeed={showFeed} setShowFeed={setShowFeed} />
       <Modal show={showVisitorGuide} onHide={handleCloseVisitorGuide}>
         <CloseButtonPanel
           bumpkinParts={gameState.context.state.bumpkin?.equipped}

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -24,7 +24,6 @@ import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { isMobile } from "mobile-device-detect";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { capitalize } from "lib/utils/capitalize";
 import { useFeedInteractions } from "./hooks/useFeedInteractions";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import * as AuthProvider from "features/auth/lib/Provider";
@@ -261,9 +260,7 @@ export const Feed: React.FC<Props> = ({
                   onClick={() => setShowFollowing(false)}
                 />
               )}
-              <Label type="default">
-                {t("social.feed", { type: capitalize(type) })}
-              </Label>
+              <Label type="default">{t("feed")}</Label>
               {server && <span className="text-xxs">{server}</span>}
             </div>
             <img

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6169,6 +6169,7 @@
   "social.lastOnline": "Last online {{time}}",
   "social.farming": "Farming",
   "social.feed": "{{type}} Feed",
+  "feed": "Feed",
   "social.activeProjects": "{{count}} active projects",
   "chestRewardsList.desertReward.desc1": "Increase your Desert Daily Streak to earn rewards from higher tiers.",
   "chestRewardsList.desertReward.desc2": "Claiming the reward grants one chapter artefact.",


### PR DESCRIPTION
# Description

Changes the Feed on the farm and visit, to display the world data.

<img width="324" height="383" alt="hue" src="https://github.com/user-attachments/assets/75048b86-9358-4d0b-8b22-83fb905c0737" />

# What needs to be tested by the reviewer?

Ensure you see global changes on the milestones

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]