### PR TITLE
Fix/z index 2

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -42,7 +42,6 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Outlet, useLocation } from "react-router";
 import { createPortal } from "react-dom";
 import { NON_COLLIDING_OBJECTS } from "./placeable/lib/collisionDetection";
-import { getZIndex } from "./placeable/lib/collisionDetection";
 
 import {
   isBuildingUpgradable,
@@ -149,7 +148,7 @@ const getIslandElements = ({
 
             return (
               <MapPlacement
-                key={`building-${nameIndex}-${itemIndex}`}
+                key={`building-${nameIndex}-${x}-${y}`}
                 x={x}
                 y={y}
                 height={height}
@@ -184,17 +183,16 @@ const getIslandElements = ({
 
         return items
           .filter((collectible) => collectible.coordinates)
-          .map((collectible, itemIndex) => {
+          .map((collectible) => {
             const { readyAt, createdAt, coordinates, id } = collectible;
             const { x, y } = coordinates!;
             const { width, height } = COLLECTIBLES_DIMENSIONS[name];
 
             return (
               <MapPlacement
-                key={`collectible-${nameIndex}-${itemIndex}`}
+                key={`collectible-${nameIndex}-${x}-${y}`}
                 x={x}
                 y={y}
-                z={getZIndex(y, name)}
                 height={height}
                 width={width}
                 canCollide={NON_COLLIDING_OBJECTS.includes(name) ? false : true}
@@ -210,7 +208,7 @@ const getIslandElements = ({
                   y={coordinates!.y}
                   grid={grid}
                   game={game}
-                  z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : "unset"}
+                  // z={NON_COLLIDING_OBJECTS.includes(name) ? 0 : "unset"}
                   flipped={collectible.flipped}
                 />
               </MapPlacement>
@@ -756,6 +754,48 @@ export const Land: React.FC = () => {
     return gameGridValue;
   }, [JSON.stringify(gameGridValue)]);
 
+  const islandElements = getIslandElements({
+    game: state,
+    expansionConstruction,
+    buildings,
+    collectibles,
+    chickens,
+    trees,
+    stones,
+    iron,
+    gold,
+    crimstones,
+    sunstones,
+    fruitPatches,
+    flowerBeds,
+    crops,
+    showTimers: showTimers,
+    grid: gameGrid,
+    mushrooms: mushrooms?.mushrooms,
+    isFirstRender,
+    buds,
+    airdrops,
+    beehives,
+    oilReserves,
+    lavaPits,
+    isVisiting: visiting,
+    clutter: socialFarming?.clutter,
+    landscaping,
+    loggedInFarmState,
+  });
+  const sortedIslandElements = islandElements.sort((a, b) => {
+    // Non-colliding objects (like tiles, rugs) should be at the beginning
+    if (a.props.canCollide === false && b.props.canCollide !== false) {
+      return -1; // a should be before b
+    }
+    if (b.props.canCollide === false && a.props.canCollide !== false) {
+      return 1; // b should be before a
+    }
+
+    // For all other elements, sort by y position (higher y values first)
+    return b.props.y - a.props.y;
+  });
+
   return (
     <>
       <div
@@ -815,49 +855,7 @@ export const Land: React.FC = () => {
             />
 
             {/* Sort island elements by y axis */}
-            {!paused &&
-              getIslandElements({
-                game: state,
-                expansionConstruction,
-                buildings,
-                collectibles,
-                chickens,
-                trees,
-                stones,
-                iron,
-                gold,
-                crimstones,
-                sunstones,
-                fruitPatches,
-                flowerBeds,
-                crops,
-                showTimers: showTimers,
-                grid: gameGrid,
-                mushrooms: mushrooms?.mushrooms,
-                isFirstRender,
-                buds,
-                airdrops,
-                beehives,
-                oilReserves,
-                lavaPits,
-                isVisiting: visiting,
-                clutter: socialFarming?.clutter,
-                landscaping,
-                loggedInFarmState,
-              }).sort((a, b) => {
-                if (a.props.canCollide === false) {
-                  return -1;
-                }
-
-                if (b.props.y > a.props.y) {
-                  return 1;
-                }
-                if (a.props.y > b.props.y) {
-                  return -1;
-                }
-
-                return 0;
-              })}
+            {!paused && sortedIslandElements.map((element) => element)}
           </div>
 
           {landscaping && <Placeable location="farm" />}

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -785,9 +785,20 @@ export const Land: React.FC = () => {
   });
   const sortedIslandElements = islandElements.sort((a, b) => {
     // Non-colliding objects (like tiles, rugs) should be at the beginning
+    if (a.props.canCollide === false && b.props.canCollide === false) {
+      if (a.props.children.props.name.includes("Tile")) {
+        return -1; // a should be before b
+      }
+
+      if (b.props.children.props.name.includes("Tile")) {
+        return 1; // b should be before a
+      }
+    }
+
     if (a.props.canCollide === false && b.props.canCollide !== false) {
       return -1; // a should be before b
     }
+
     if (b.props.canCollide === false && a.props.canCollide !== false) {
       return 1; // b should be before a
     }

--- a/src/features/game/expansion/components/MapPlacement.tsx
+++ b/src/features/game/expansion/components/MapPlacement.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { GRID_WIDTH_PX } from "../../lib/constants";
 import classNames from "classnames";
-import { getZIndex } from "../placeable/lib/collisionDetection";
 
 export type Coordinates = {
   x: number;
@@ -34,7 +33,7 @@ export const MapPlacement: React.FC<React.PropsWithChildren<Props>> = ({
   height,
   width,
   children,
-  z,
+  z = "unset",
   canCollide = true,
   className,
 }) => {
@@ -46,7 +45,7 @@ export const MapPlacement: React.FC<React.PropsWithChildren<Props>> = ({
         left: `calc(50% + ${GRID_WIDTH_PX * x}px)`,
         height: height ? `${GRID_WIDTH_PX * height}px` : "auto",
         width: width ? `${GRID_WIDTH_PX * width}px` : "auto",
-        zIndex: z ?? getZIndex(y),
+        zIndex: z,
       }}
     >
       {children}

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -232,7 +232,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
         id="bg-overlay "
         className=" bg-black opacity-40 fixed inset-0"
         style={{
-          zIndex: 1999,
+          zIndex: 99,
           height: "200%",
           right: "-1000px",
           left: "-1000px",
@@ -241,7 +241,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
           bottom: "1000px",
         }}
       />
-      <div className="fixed left-1/2 top-1/2" style={{ zIndex: 2000 }}>
+      <div className="fixed left-1/2 top-1/2" style={{ zIndex: 100 }}>
         <Draggable
           key={`${origin?.x}-${origin?.y}`}
           nodeRef={nodeRef}

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -335,19 +335,6 @@ export const NON_COLLIDING_OBJECTS: InventoryItemName[] = [
   "Long Rug",
 ];
 
-export function getZIndex(y: number, name?: InventoryItemName) {
-  if (name && NON_COLLIDING_OBJECTS.includes(name)) {
-    // Tiles are underneath everything
-    if (name.includes("Tile")) return 0;
-
-    // Rugs sit on top of tiles
-    return 1;
-  }
-
-  // Everything else is based on it y position
-  return -y + 1000;
-}
-
 function detectHomeCollision({
   state,
   position,

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -65,6 +65,7 @@ import { WorldHud } from "features/island/hud/WorldHud";
 import { PlayerModal } from "features/social/PlayerModal";
 import { MachineState as GameMachineState } from "features/game/lib/gameMachine";
 import { RewardModal } from "features/social/RewardModal";
+import { Discovery } from "features/social/Discovery";
 
 const _roomState = (state: MachineState) => state.value;
 const _scene = (state: MachineState) => state.context.sceneId;
@@ -489,6 +490,7 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
         token={rawToken}
         hasAirdropAccess={hasFeatureAccess(state, "AIRDROP_PLAYER")}
       />
+      <Discovery />
       <RewardModal />
       <CommunityModals />
       <InteractableModals id={loggedInFarmId} scene={scene} key={scene} />


### PR DESCRIPTION
# Description

The z index of things was messed up during a fix for Tiles z index. Fixes tile and rug ordering.

This PR fixes that issue.

Its also fixes player search and social leaderboard opening in the mmo.

| Before | After |
|--------|--------|
|<img width="251" height="149" alt="Screenshot 2025-09-05 at 3 34 00 PM" src="https://github.com/user-attachments/assets/16e046ad-46bf-4c6f-a6e9-6478cc04cb5b" />|<img width="224" height="151" alt="Screenshot 2025-09-05 at 3 28 33 PM" src="https://github.com/user-attachments/assets/e62c071f-7d70-42c6-92e4-942c4876e859" />|


Fixes #issue

# What needs to be tested by the reviewer?

- Just confirm that everything has rendered correctly. Popovers should be on top and also when harvesting, harvest amounts should not be rendering under neighbouring plots etc. Tiles should render under rugs and everything else.  
- Basically all should look and work right.
- Search already tested


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
