### PR TITLE
[FIX] Hide the Discord Boat on Visit

### DIFF
--- a/src/features/game/expansion/components/Water.tsx
+++ b/src/features/game/expansion/components/Water.tsx
@@ -48,8 +48,6 @@ export const WaterComponent: React.FC<Props> = ({
     >
       {/* Decorations */}
 
-      {CONFIG.NETWORK === "mainnet" && <DiscordBoat />}
-
       {season !== "winter" && (
         <>
           {/* Goblin swimming */}
@@ -257,6 +255,7 @@ export const WaterComponent: React.FC<Props> = ({
 
       {!isVisiting && (
         <>
+          {CONFIG.NETWORK === "mainnet" && <DiscordBoat />}
           <SeasonTeaser offset={offset} />
           <TravelTeaser />
           <IslandUpgrader gameState={gameState} offset={offset} />


### PR DESCRIPTION
# Description

Hides the boat to prevent visitors from clicking on it, which results in showing the corresponding modal.

Originally reported on Discord: https://discord.com/channels/880987707214544966/1399972586552823929/1413563769451184159
