### PR TITLE
[FIX] Translations Description for Oil Rig Skill 

### DIFF
--- a/src/lib/i18n/dictionaries/de.json
+++ b/src/lib/i18n/dictionaries/de.json
@@ -6576,5 +6576,5 @@
   "skill.merinoWhispererDebuff": "-0,35 Ergiebigkeit bei Leder und Federn",
   "skill.leathercraftMasteryBuff": "+0.25 Lederausbeute",
   "skill.leathercraftMasteryDebuff": "-0,35 Ertrag aus Federn- und Merinowolle",
-  "skill.oilRig.buff": "Für die Herstellung einer Ölbohrmaschine werden 20% Wolle statt Leder benötigt."
+  "skill.oilRig.buff": "Für die Herstellung einer Ölbohrmaschine werden 20 Wolle statt Leder benötigt."
 }

--- a/src/lib/i18n/dictionaries/es.json
+++ b/src/lib/i18n/dictionaries/es.json
@@ -6576,5 +6576,5 @@
   "skill.merinoWhispererDebuff": "-0,35 Rendimiento en piel y plumas",
   "skill.leathercraftMasteryBuff": "+0,25 Rendimiento en piel",
   "skill.leathercraftMasteryDebuff": "-0,35 Rendimiento en plumas y lana merino",
-  "skill.oilRig.buff": "Para fabricar un taladro petrolífero se necesita un 20% de lana en lugar de cuero"
+  "skill.oilRig.buff": "Para fabricar un taladro petrolífero se necesita 20 de lana en lugar de cuero"
 }

--- a/src/lib/i18n/dictionaries/fr.json
+++ b/src/lib/i18n/dictionaries/fr.json
@@ -6576,5 +6576,5 @@
   "skill.merinoWhispererDebuff": "-0,35 Rendement en cuir et en plumes",
   "skill.leathercraftMasteryBuff": "+0,25 Rendement en cuir",
   "skill.leathercraftMasteryDebuff": "-0,35 Rendement en plumes et en laine mérinos",
-  "skill.oilRig.buff": "La perceuse à huile nécessite 20 % de laine au lieu de cuir pour être fabriquée"
+  "skill.oilRig.buff": "La perceuse à huile nécessite 20 de laine au lieu de cuir pour être fabriquée"
 }

--- a/src/lib/i18n/dictionaries/pt-BR.json
+++ b/src/lib/i18n/dictionaries/pt-BR.json
@@ -6576,5 +6576,5 @@
   "skill.merinoWhispererDebuff": "-0,35 Rendimento de couro e penas",
   "skill.leathercraftMasteryBuff": "+0.25 Rendimento de couro",
   "skill.leathercraftMasteryDebuff": "-0,35 Rendimento de lã de penas e merino",
-  "skill.oilRig.buff": "A perfuratriz de óleo requer 20% de lã em vez de couro para ser fabricada."
+  "skill.oilRig.buff": "A broca de óleo requer 20 de lã em vez de couro para ser fabricada."
 }


### PR DESCRIPTION
# Description

Multiple automatic translations got a % symbol wrongly added to the description, making the skill hard to understand.

Fixes #issue

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] I have read the contributing guidelines and agree to the T&Cs
