### PR TITLE
[FEAT] Help Visiting Pets

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -548,6 +548,7 @@ import { bulkFeedPets, BulkFeedPetsAction } from "./pets/bulkFeedPets";
 import { NeglectPetAction, neglectPet } from "./pets/neglectPet";
 import { petPet, PetPetAction } from "./pets/petPet";
 import { fetchPet, FetchPetAction } from "./pets/fetchPet";
+import { helpPets, HelpPetsAction } from "./visiting/helpPets";
 
 export type PlayingEvent =
   | ObsidianExchangedAction
@@ -704,7 +705,10 @@ export type PlayingEvent =
   | InstaGrowFlowerAction
   | UpgradeStoneAction;
 
-export type LocalVisitingEvent = CollectGarbageAction | HelpProjectAction;
+export type LocalVisitingEvent =
+  | CollectGarbageAction
+  | HelpProjectAction
+  | HelpPetsAction;
 
 export type VisitingEvent = IncreaseHelpLimitAction | LocalVisitingEvent;
 
@@ -950,6 +954,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
 export const LOCAL_VISITING_EVENTS: Handlers<LocalVisitingEvent> = {
   "garbage.collected": collectGarbage,
   "project.helped": helpProject,
+  "pet.visitingPets": helpPets,
 };
 
 export const VISITING_EVENTS: Handlers<VisitingEvent> = {

--- a/src/features/game/events/visiting/helpPets.ts
+++ b/src/features/game/events/visiting/helpPets.ts
@@ -1,0 +1,43 @@
+import { GameState } from "features/game/types/game";
+import { PetName } from "features/game/types/pets";
+import { produce } from "immer";
+import { hasHitHelpLimit } from "../landExpansion/increaseHelpLimit";
+
+export type HelpPetsAction = {
+  type: "pet.visitingPets";
+  pet: PetName;
+  totalHelpedToday: number;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: HelpPetsAction;
+  createdAt?: number;
+  visitorState?: GameState;
+};
+
+export function helpPets({
+  state,
+  action,
+  visitorState,
+  createdAt = Date.now(),
+}: Options): [GameState, GameState] {
+  return produce([state, visitorState!], ([game, visitorGame]) => {
+    if (
+      hasHitHelpLimit({
+        game: visitorGame,
+        totalHelpedToday: action.totalHelpedToday,
+      })
+    ) {
+      throw new Error("Help limit reached");
+    }
+
+    const pet = game.pets?.common?.[action.pet];
+
+    if (!pet) {
+      throw new Error("Pet not found");
+    }
+
+    pet.visitedAt = createdAt;
+  });
+}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -111,6 +111,7 @@ import { NetworkOption } from "features/island/hud/components/deposit/DepositFlo
 import { blessingIsReady } from "./blessings";
 import { hasReadNews } from "features/farming/mail/components/News";
 import { depositSFL } from "lib/blockchain/DepositSFL";
+import { hasFeatureAccess } from "lib/flags";
 
 // Run at startup in case removed from query params
 const portalName = new URLSearchParams(window.location.search).get("portal");
@@ -623,6 +624,12 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
 
           const { visitedFarmState, ...rest } = data;
 
+          // if you don't have access to pets, delete pets object from their gameState
+          const hasPetsAccess = hasFeatureAccess(gameState, "PETS");
+          if (!hasPetsAccess) {
+            visitedFarmState.pets = undefined;
+          }
+
           return {
             state: makeGame(visitedFarmState),
             data: rest,
@@ -1026,8 +1033,8 @@ export function startGame(authContext: AuthContext) {
               }
 
               const {
-                visitedFarmState,
-                visitorFarmState,
+                visitedFarmState, // Their gameState
+                visitorFarmState, // Your gameState
                 hasHelpedPlayerToday,
                 totalHelpedToday,
                 visitorId,
@@ -1035,6 +1042,12 @@ export function startGame(authContext: AuthContext) {
                 Number(farmId),
                 authContext.user.rawToken as string,
               );
+
+              const hasPetsAccess = hasFeatureAccess(visitorFarmState, "PETS");
+              // if you don't have access to pets, delete pets object from their gameState
+              if (!hasPetsAccess) {
+                visitedFarmState.pets = undefined;
+              }
 
               return {
                 state: makeGame(visitedFarmState),

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -218,7 +218,12 @@ export function getHelpRequired({ game }: { game: GameState }) {
     },
   );
 
-  return clutter.length + pendingProjects.length;
+  const pendingPets = getKeys(game.pets?.common ?? {}).filter((pet) => {
+    const hasVisited = !!game.pets?.common?.[pet]?.visitedAt;
+    return !hasVisited;
+  });
+
+  return clutter.length + pendingProjects.length + pendingPets.length;
 }
 
 export const RAFFLE_REWARDS: Partial<

--- a/src/features/game/types/pets.ts
+++ b/src/features/game/types/pets.ts
@@ -96,6 +96,7 @@ export type Pet = {
   energy: number;
   experience: number;
   pettedAt: number;
+  visitedAt?: number; // Local only field
 };
 
 export type Pets = {

--- a/src/features/game/types/pets.ts
+++ b/src/features/game/types/pets.ts
@@ -96,6 +96,9 @@ export type Pet = {
   energy: number;
   experience: number;
   pettedAt: number;
+  dailySocialXP?: {
+    [date: string]: number;
+  };
   visitedAt?: number; // Local only field
 };
 


### PR DESCRIPTION
# Description

This PR helps pets in visiting state

https://github.com/user-attachments/assets/2a857071-9c98-490b-88cb-9ed72ab15444

Feature flag will delete pets object from visiting farm's GameState if the visitor doesn't have access, so that the visitor doesn't need to pet pets to complete that farm

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
