### PR TITLE
[FEAT] Withdraw and Trade Rocket Onesie

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -496,6 +496,11 @@ export const BUMPKIN_RELEASES: Partial<Record<BumpkinItem, Releases>> = {
     tradeAt: SEASONS["Better Together"].endDate,
     withdrawAt: SEASONS["Better Together"].endDate,
   },
+  "Rocket Onesie": {
+    tradeAt: new Date("2025-09-12"),
+    withdrawAt: new Date("2025-09-12"),
+  },
+  // writing a manual date so that it shows up in what's new section
 };
 
 export const INVENTORY_RELEASES: Partial<Record<InventoryItemName, Releases>> =


### PR DESCRIPTION
# Description

Rocket Onesie was a wearable that was auctioned a while back using SFL (before flower migration), but the whole time it was not withdrawable or tradable.

Setting the rocket onesie to be tradable

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
