### PR TITLE
[FEAT] Display upcoming Animal Mutant

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -46,6 +46,7 @@ import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { OuterPanel } from "components/ui/Panel";
 import { SleepingAnimalModal } from "./SleepingAnimalModal";
+import { MutantBubble } from "features/game/expansion/components/animals/MutantBubble";
 
 export const ANIMAL_EMOTION_ICONS: Record<
   Exclude<TState["value"], "idle" | "needsLove" | "initial" | "sick">,
@@ -519,6 +520,8 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
           // Don't block level up UI with wakes in panel if accidentally clicked
           onLevelUp={() => setShowAnimalDetails(false)}
         />
+        {/* Mutant */}
+        {mutantName && <MutantBubble mutantName={mutantName as MutantAnimal} />}
         {/* Feed XP */}
         <Transition
           appear={true}

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -46,6 +46,7 @@ import { Modal } from "components/ui/Modal";
 import { SleepingAnimalModal } from "./SleepingAnimalModal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { OuterPanel } from "components/ui/Panel";
+import { MutantBubble } from "features/game/expansion/components/animals/MutantBubble";
 
 const _animalState = (state: AnimalMachineState) =>
   // Casting here because we know the value is always a string rather than an object
@@ -493,6 +494,8 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
           // Don't block level up UI with wakes in panel if accidentally clicked
           onLevelUp={() => setShowAnimalDetails(false)}
         />
+        {/* Mutant */}
+        {mutantName && <MutantBubble mutantName={mutantName as MutantAnimal} />}
         {/* Feed XP */}
         <Transition
           appear={true}

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -53,6 +53,8 @@ export const SleepingAnimalModal = ({
     onClose();
   };
 
+  const { name: mutantName } = animal.reward?.items?.[0] ?? {};
+
   if (showConfirm) {
     return (
       <InnerPanel>
@@ -145,6 +147,19 @@ export const SleepingAnimalModal = ({
             )}`}</span>
           </div>
         </div>
+
+        {mutantName && (
+          <div className="flex text-sm p-1 items-center w-[280px]">
+            <img
+              src={ITEM_DETAILS[mutantName]?.image}
+              alt="Mutant"
+              className="w-6 mr-2"
+            />
+            <span className="mr-2">
+              {t("sleepingAnimal.mutantDrop", { mutantName })}
+            </span>
+          </div>
+        )}
       </InnerPanel>
 
       {level < 15 && (

--- a/src/features/game/expansion/components/animals/MutantBubble.tsx
+++ b/src/features/game/expansion/components/animals/MutantBubble.tsx
@@ -1,0 +1,40 @@
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { AnimalType } from "features/game/types/animals";
+import { MutantAnimal } from "features/game/types/game";
+import { ITEM_DETAILS } from "features/game/types/images";
+import React from "react";
+
+export const MutantBubble: React.FC<{
+  mutantName: MutantAnimal;
+  animalType?: AnimalType;
+}> = ({ mutantName, animalType }) => {
+  return (
+    <div
+      className="absolute inline-flex justify-center items-center z-10 pointer-events-none"
+      style={{
+        top: `${PIXEL_SCALE * (animalType === "Chicken" ? 15 : 18)}px`,
+        right: `${PIXEL_SCALE * (animalType === "Chicken" ? 2 : 0)}px`,
+        borderImage: `url(${SUNNYSIDE.ui.speechBorder})`,
+        borderStyle: "solid",
+        borderTopWidth: `${PIXEL_SCALE * 2}px`,
+        borderRightWidth: `${PIXEL_SCALE * 2}px`,
+        borderBottomWidth: `${PIXEL_SCALE * 4}px`,
+        borderLeftWidth: `${PIXEL_SCALE * 5}px`,
+        borderImageSlice: "2 2 4 5 fill",
+        imageRendering: "pixelated",
+        borderImageRepeat: "stretch",
+      }}
+    >
+      <div
+        className="flex items-center justify-center"
+        style={{
+          marginLeft: `-${PIXEL_SCALE * 3}px`,
+          width: `${PIXEL_SCALE * 6}px`,
+        }}
+      >
+        <img src={ITEM_DETAILS[mutantName]?.image} className="h-4" />
+      </div>
+    </div>
+  );
+};

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -46,6 +46,7 @@ import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { OuterPanel } from "components/ui/Panel";
 import { SleepingAnimalModal } from "features/barn/components/SleepingAnimalModal";
+import { MutantBubble } from "features/game/expansion/components/animals/MutantBubble";
 
 export const CHICKEN_EMOTION_ICONS: Record<
   Exclude<TState["value"], "idle" | "needsLove" | "initial" | "sick">,
@@ -546,6 +547,13 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
         // Don't block level up UI with wakes in panel if accidentally clicked
         onLevelUp={() => setShowAnimalDetails(false)}
       />
+      {/* Mutant */}
+      {mutantName && (
+        <MutantBubble
+          mutantName={mutantName as MutantAnimal}
+          animalType="Chicken"
+        />
+      )}
       {/* Feed XP */}
       <Transition
         appear={true}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6250,6 +6250,7 @@
   "sleepingAnimal.dollCount": "1 x {{name}}",
   "sleepingAnimal.availableAtCraftingBox": "Available at the Crafting Box",
   "sleepingAnimal.wakeUp": "Wake up",
+  "sleepingAnimal.mutantDrop": "Next harvest produces a {{mutantName}}",
   "removeAll.description.one": "This action will remove all items from the {{location}}.",
   "removeAll.description.two": "Are you sure you want to continue?",
   "removeAll.title": "Remove All Items",


### PR DESCRIPTION
# Description
Displays the details for the mutant animal that will be produced on the next harvest. Helps players who might sell the animal before harvesting and lose the mutant.

https://github.com/user-attachments/assets/c682898d-da13-4fd0-8825-ec1a968dd4bc