### PR TITLE
[FEAT] Withdraw Ronin

### DIFF
--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -18,6 +18,8 @@ import { translate } from "lib/i18n/translate";
 import { Transaction } from "features/island/hud/Transaction";
 import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
 import { GameWallet } from "features/wallet/Wallet";
+import { hasFeatureAccess } from "lib/flags";
+import { base } from "viem/chains";
 
 const getPageIcon = (page: Page) => {
   switch (page) {
@@ -202,12 +204,20 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
     return <Transaction isBlocked onClose={onClose} />;
   }
 
+  const enforceBaseWithdrawal = !hasFeatureAccess(
+    gameService.getSnapshot().context.state,
+    "RONIN_FLOWER",
+  );
+
   return (
     <>
       {page === "main" && <MainMenu setPage={setPage} />}
       {page !== "main" && <NavigationMenu page={page} setPage={setPage} />}
       {page === "tokens" && (
-        <GameWallet action="withdrawFlower">
+        <GameWallet
+          action="withdrawFlower"
+          enforceChainId={enforceBaseWithdrawal ? base.id : undefined}
+        >
           <WithdrawFlower onWithdraw={onWithdrawTokens} />
         </GameWallet>
       )}

--- a/src/features/game/components/bank/components/Withdraw.tsx
+++ b/src/features/game/components/bank/components/Withdraw.tsx
@@ -153,10 +153,13 @@ export const Withdraw: React.FC<Props> = ({ onClose }) => {
 
   const [page, setPage] = useState<Page>("main");
 
-  const onWithdrawTokens = async (sfl: string) => {
+  const onWithdrawTokens = async (sfl: string, chainId: number) => {
     gameService.send("TRANSACT", {
       transaction: "transaction.flowerWithdrawn",
-      request: { farmId, effect: { type: "withdraw.flower", amount: sfl } },
+      request: {
+        farmId,
+        effect: { type: "withdraw.flower", amount: sfl, chainId },
+      },
     });
     onClose();
   };

--- a/src/features/game/components/bank/components/WithdrawFlower.tsx
+++ b/src/features/game/components/bank/components/WithdrawFlower.tsx
@@ -86,7 +86,7 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
         onBackdropClick={() => setShowConfirmation(false)}
       >
         <InnerPanel>
-          <div className="p-1">
+          <div className="p-1 mb-1">
             <div className="flex flex-col gap-1 mb-3">
               <Label type="default" icon={withdrawIcon}>
                 {t("withdraw.flower.confirm")}

--- a/src/features/game/components/bank/components/WithdrawFlower.tsx
+++ b/src/features/game/components/bank/components/WithdrawFlower.tsx
@@ -20,9 +20,14 @@ import { RequiredReputation } from "features/island/hud/components/reputation/Re
 import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
 import { FaceRecognition } from "features/retreat/components/personhood/FaceRecognition";
 import { hasFeatureAccess } from "lib/flags";
+import { useAccount } from "wagmi";
+import { ModalOverlay } from "components/ui/ModalOverlay";
+import { InnerPanel } from "components/ui/Panel";
+import { shortAddress } from "lib/utils/shortAddress";
+import withdrawIcon from "assets/icons/withdraw.png";
 
 interface Props {
-  onWithdraw: (sfl: string) => void;
+  onWithdraw: (sfl: string, chainId: number) => void;
 }
 
 const _state = (state: MachineState) => state.context.state;
@@ -33,9 +38,11 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
   const autosaving = useSelector(gameService, _autosaving);
+  const { chain } = useAccount();
 
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
   const [tax, setTax] = useState(0);
+  const [showConfirmation, setShowConfirmation] = useState(false);
 
   const { balance } = state;
 
@@ -48,9 +55,9 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
     setTax(_tax);
   }, [amount]);
 
-  const withdraw = () => {
+  const withdraw = (chainId: number) => {
     if (amount > new Decimal(0)) {
-      onWithdraw(toWei(amount.toString()));
+      onWithdraw(toWei(amount.toString()), chainId);
     } else {
       setAmount(new Decimal(0));
     }
@@ -69,10 +76,58 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
     return <FaceRecognition />;
   }
 
-  const disableWithdraw = amount.greaterThan(balance) || amount.lessThan(0);
+  const disableWithdraw =
+    amount.greaterThan(balance) || amount.lessThanOrEqualTo(0);
 
   return (
     <>
+      <ModalOverlay
+        show={showConfirmation}
+        onBackdropClick={() => setShowConfirmation(false)}
+      >
+        <InnerPanel>
+          <div className="p-1">
+            <div className="flex flex-col gap-1 mb-3">
+              <Label type="default" icon={withdrawIcon}>
+                {t("withdraw.flower.confirm")}
+              </Label>
+              <Label type="transparent">
+                {t("withdraw.flower.chain", {
+                  chain: chain?.name || "",
+                })}
+              </Label>
+              <Label type="transparent">
+                {t("withdraw.flower.amount", {
+                  amount: formatNumber(amount, { decimalPlaces: 4 }),
+                })}
+              </Label>
+              <Label type="transparent" className="text-nowrap">
+                {t("withdraw.flower.recipient", {
+                  address: shortAddress(wallet.getAccount() || "XXXX"),
+                })}
+              </Label>
+            </div>
+
+            <Label type="danger">{t("withdraw.flower.cannotCancel")}</Label>
+            <Label type="transparent">
+              <span className="text-xxs">
+                {t("withdraw.flower.transaction", {
+                  chain: chain?.name || "",
+                })}
+              </span>
+            </Label>
+          </div>
+
+          <div className="flex  gap-1">
+            <Button onClick={() => setShowConfirmation(false)}>
+              {t("back")}
+            </Button>
+            <Button onClick={() => chain && withdraw(chain.id)}>
+              {t("confirm")}
+            </Button>
+          </div>
+        </InnerPanel>
+      </ModalOverlay>
       <div className="p-2 mb-2">
         <div className="flex flex-col items-start gap-2">
           {hasFeatureAccess(state, "WITHDRAWAL_THRESHOLD") && (
@@ -153,7 +208,10 @@ export const WithdrawFlower: React.FC<Props> = ({ onWithdraw }) => {
         </div>
       </div>
 
-      <Button onClick={withdraw} disabled={disableWithdraw || autosaving}>
+      <Button
+        onClick={() => setShowConfirmation(true)}
+        disabled={disableWithdraw || autosaving}
+      >
         {t("withdraw")}
       </Button>
     </>

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -248,7 +248,14 @@ export const Transaction: React.FC<Props> = ({ onClose, isBlocked }) => {
 
   return (
     <>
-      <GameWallet action={walletAction}>
+      <GameWallet
+        action={walletAction}
+        enforceChainId={
+          "chainId" in transaction.data.params
+            ? transaction.data.params.chainId
+            : undefined
+        }
+      >
         <TransactionProgress isBlocked={isBlocked} onClose={onClose} />
       </GameWallet>
     </>
@@ -342,6 +349,7 @@ export const TransactionProgress: React.FC<Props> = ({
         effect: {
           type: "withdraw.flower",
           amount: flowerTransaction.data.amount,
+          chainId: flowerTransaction.data.params.chainId,
         },
       },
     });

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -61,6 +61,7 @@ interface Props {
   farmAddress?: string;
   wallet?: string;
   reputation?: Reputation;
+  enforceChainId?: number;
 }
 
 type WalletActionSettings = {
@@ -140,6 +141,7 @@ const WALLET_ACTIONS: Record<WalletAction, WalletActionSettings> = {
     requiresNFT: false,
     chains: {
       [CONFIG.NETWORK === "mainnet" ? base.id : baseSepolia.id]: true,
+      [CONFIG.NETWORK === "mainnet" ? ronin.id : saigon.id]: true,
     },
   },
   dequip: {
@@ -373,6 +375,7 @@ export const Wallet: React.FC<PropsWithChildren<Props>> = ({
   action,
   linkedAddress,
   farmAddress,
+  enforceChainId,
 }) => {
   const { address, isConnected, chainId } = useAccount();
 
@@ -391,9 +394,9 @@ export const Wallet: React.FC<PropsWithChildren<Props>> = ({
     !!linkedAddress &&
     isAddressEqual(address, linkedAddress as `0x${string}`);
 
-  const availableChains = Object.keys(WALLET_ACTIONS[action].chains).map(
-    Number,
-  );
+  const availableChains = enforceChainId
+    ? [enforceChainId]
+    : Object.keys(WALLET_ACTIONS[action].chains).map(Number);
 
   if (requiresConnection && !hasConnection) {
     return (
@@ -439,6 +442,7 @@ const _linkedWallet = (state: MachineState): string | undefined =>
 export const GameWallet: React.FC<PropsWithChildren<Props>> = ({
   children,
   action,
+  enforceChainId,
 }) => {
   const { gameService } = useContext(Context);
 
@@ -455,6 +459,7 @@ export const GameWallet: React.FC<PropsWithChildren<Props>> = ({
         linkedAddress={linkedWallet}
         wallet={wallet}
         farmAddress={farmAddress}
+        enforceChainId={enforceChainId}
       >
         {children}
       </Wallet>

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -388,7 +388,6 @@ export const Wallet: React.FC<PropsWithChildren<Props>> = ({
   const hasLinkedWallet = !!linkedAddress;
   const hasNFT = !!farmAddress;
   const hasConnection = isConnected;
-  const hasChain = !!chainId && chainId in chains;
   const hasLinkedWalletSelected =
     !!address &&
     !!linkedAddress &&
@@ -397,6 +396,7 @@ export const Wallet: React.FC<PropsWithChildren<Props>> = ({
   const availableChains = enforceChainId
     ? [enforceChainId]
     : Object.keys(WALLET_ACTIONS[action].chains).map(Number);
+  const hasChain = !!chainId && chainId in availableChains;
 
   if (requiresConnection && !hasConnection) {
     return (

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -8,10 +8,10 @@ import { saveTxHash } from "features/game/types/transactions";
 import { base, baseSepolia, polygon, polygonAmoy, saigon } from "viem/chains";
 
 const address = CONFIG.WITHDRAWAL_CONTRACT;
-const WITHDRAW_FLOWER_ADDRESS = {
+const WITHDRAW_FLOWER_ADDRESS: Record<number, `0x${string}`> = {
   [saigon.id]: "0x6E625972Ca5206Ae213650CDc10fba1878540352",
-  [base.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT,
-  [baseSepolia.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT,
+  [base.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT as `0x${string}`,
+  [baseSepolia.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT as `0x${string}`,
 };
 
 export type WithdrawItemsParams = {
@@ -175,7 +175,7 @@ export async function withdrawFlowerTransaction({
   deadline,
 }: WithdrawFlowerParams): Promise<string> {
   const hash = await writeContract(config, {
-    chainId: chainId,
+    chainId: chainId as any,
     abi: SunflowerLandWithdrawFlowerABI,
     address: WITHDRAW_FLOWER_ADDRESS[chainId],
     functionName: "withdrawFlower",

--- a/src/lib/blockchain/Withdrawals.ts
+++ b/src/lib/blockchain/Withdrawals.ts
@@ -5,10 +5,14 @@ import { getNextSessionId, getSessionId } from "./Session";
 import { waitForTransactionReceipt, writeContract } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
 import { saveTxHash } from "features/game/types/transactions";
-import { base, baseSepolia, polygon, polygonAmoy } from "viem/chains";
+import { base, baseSepolia, polygon, polygonAmoy, saigon } from "viem/chains";
 
 const address = CONFIG.WITHDRAWAL_CONTRACT;
-const withdrawFlowerAddress = CONFIG.WITHDRAW_FLOWER_CONTRACT;
+const WITHDRAW_FLOWER_ADDRESS = {
+  [saigon.id]: "0x6E625972Ca5206Ae213650CDc10fba1878540352",
+  [base.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT,
+  [baseSepolia.id]: CONFIG.WITHDRAW_FLOWER_CONTRACT,
+};
 
 export type WithdrawItemsParams = {
   signature: string;
@@ -167,12 +171,13 @@ export async function withdrawFlowerTransaction({
   signature,
   withdrawId,
   amount,
+  chainId,
   deadline,
 }: WithdrawFlowerParams): Promise<string> {
   const hash = await writeContract(config, {
-    chainId: CONFIG.NETWORK === "mainnet" ? base.id : baseSepolia.id,
+    chainId: chainId,
     abi: SunflowerLandWithdrawFlowerABI,
-    address: withdrawFlowerAddress as `0x${string}`,
+    address: WITHDRAW_FLOWER_ADDRESS[chainId],
     functionName: "withdrawFlower",
     args: [
       signature as `0x${string}`,

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -120,6 +120,7 @@ const FEATURE_FLAGS = {
   GASLESS_AUCTIONS: () => true,
   NODE_FORGING: defaultFeatureFlag,
   DEPOSIT_SFL: adminTimeBasedFeatureFlag(new Date("2025-08-28T00:00:00.000Z")),
+  RONIN_FLOWER: testnetFeatureFlag,
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6641,5 +6641,11 @@
   "description.refinedIronRock.buff": "+0.5 Iron",
   "description.temperedIronRock.buff": "+2.5 Iron",
   "description.pureGoldRock.buff": "+0.5 Gold",
-  "description.primeGoldRock.buff": "+2.5 Gold"
+  "description.primeGoldRock.buff": "+2.5 Gold",
+  "withdraw.flower.confirm": "Confirm Withdrawal",
+  "withdraw.flower.chain": "Chain: {{chain}}",
+  "withdraw.flower.amount": "Amount: {{amount}} FLOWER",
+  "withdraw.flower.recipient": "Recipient Address: {{address}}",
+  "withdraw.flower.cannotCancel": "This withdrawal cannot be cancelled.",
+  "withdraw.flower.transaction": "A transaction must be completed on {{chain}} to complete the withdrawal."
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6646,6 +6646,6 @@
   "withdraw.flower.chain": "Chain: {{chain}}",
   "withdraw.flower.amount": "Amount: {{amount}} FLOWER",
   "withdraw.flower.recipient": "Recipient Address: {{address}}",
-  "withdraw.flower.cannotCancel": "This withdrawal cannot be cancelled.",
+  "withdraw.flower.cannotCancel": "This withdrawal cannot be cancelled",
   "withdraw.flower.transaction": "A transaction must be completed on {{chain}} to complete the withdrawal."
 }


### PR DESCRIPTION
# Description

Adds the ability to withdraw to Ronin.  This feature is flagged for testnet only.

<img width="503" height="428" alt="roninwithdraw" src="https://github.com/user-attachments/assets/ac20bb56-83f9-497b-b379-583495fa3af2" />

# What needs to be tested by the reviewer?

1. Complete a withdraw on ronin
2. Check the flag enforces base only when `FLOWER_RONIN` feature flag is toggled (
Note: Test 2 will break on testnet  as`src/features/game/components/bank/components/Withdraw.tsx` enforces base chain. This can be updated to enforce `baseSepolia` for the test

```jsx
        <GameWallet
          action="withdrawFlower"
          enforceChainId={enforceBaseWithdrawal ? baseSepolia.id : undefined}
        >
```

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
