### PR TITLE
[FIX] Water Well Upgrade UI Bug

### DIFF
--- a/src/features/game/events/landExpansion/upgradeBuilding.ts
+++ b/src/features/game/events/landExpansion/upgradeBuilding.ts
@@ -102,19 +102,16 @@ export const BUILDING_UPGRADES: Record<
       coins: 200,
       items: { Wood: new Decimal(5), Stone: new Decimal(2) },
       requiredLevel: 4,
-      upgradeTime: 60 * 60 * 1000,
     },
     3: {
       coins: 400,
       items: { Wood: new Decimal(5), Stone: new Decimal(5) },
       requiredLevel: 11,
-      upgradeTime: 60 * 60 * 2 * 1000,
     },
     4: {
       coins: 800,
       items: { Wood: new Decimal(10), Stone: new Decimal(10) },
       requiredLevel: 15,
-      upgradeTime: 60 * 60 * 4 * 1000,
     },
   },
 };


### PR DESCRIPTION
Fixes the issue where there is no upgrade UI for water wells. For the past several weeks, this has caused problems for players, as they have been seeing the pre-upgrade UI until the upgrade is completed, after which the new level data is shown. This issue did not occur with animal buildings that use the same upgrade function, since they have no upgrade time. Therefore, by removing the upgrade time for water wells, this PR also ensures consistency in the upgrade process across all buildings.
### Backend changes probably is needed.