### PR TITLE
[FIX] Craft Tool Popover Issue

### DIFF
--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -49,7 +49,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Better Together Banner": new Decimal(1),
     Geniseed: new Decimal(400),
     Wheat: new Decimal(400),
-    Pickaxe: new Decimal(1),
     "Blue Tile": new Decimal(1000),
     "Beta Pass": new Decimal(1),
     "Colors Token 2025": new Decimal(10000),
@@ -112,7 +111,6 @@ export const STATIC_OFFLINE_FARM: GameState = {
     "Volcano Biome": new Decimal(1),
     "Lava Pit": new Decimal(1),
     Bush: new Decimal(3),
-    Axe: new Decimal(10),
     Gem: new Decimal(4000),
     Rug: new Decimal(1),
     Shovel: new Decimal(1),
@@ -231,8 +229,89 @@ export const STATIC_OFFLINE_FARM: GameState = {
         criticalHit: { Native: 1 },
       },
       createdAt: 0,
-      x: 8,
-      y: -4,
+      x: -12,
+      y: -5,
+    },
+    1: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -12,
+      y: -6,
+    },
+    2: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -12,
+      y: -7,
+    },
+    3: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -12,
+      y: -8,
+    },
+    4: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -13,
+      y: -5,
+    },
+    5: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -13,
+      y: -6,
+    },
+    6: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -13,
+      y: -7,
+    },
+    7: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -13,
+      y: -8,
+    },
+    8: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -14,
+      y: -5,
+    },
+    9: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -14,
+      y: -6,
     },
   },
   iron: {
@@ -242,8 +321,89 @@ export const STATIC_OFFLINE_FARM: GameState = {
         criticalHit: { Native: 1 },
       },
       createdAt: 0,
-      x: 8,
-      y: -3,
+      x: -8,
+      y: -5,
+    },
+    1: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -6,
+    },
+    2: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -7,
+    },
+    3: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -8,
+    },
+    4: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -5,
+    },
+    5: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -6,
+    },
+    6: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -7,
+    },
+    7: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -8,
+    },
+    8: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -6,
+      y: -5,
+    },
+    9: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -6,
+      y: -6,
     },
   },
   stones: {
@@ -253,8 +413,89 @@ export const STATIC_OFFLINE_FARM: GameState = {
         criticalHit: { Native: 1 },
       },
       createdAt: 0,
-      x: 8,
-      y: -2,
+      x: -8,
+      y: -10,
+    },
+    1: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -11,
+    },
+    2: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -12,
+    },
+    3: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -8,
+      y: -13,
+    },
+    4: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -10,
+    },
+    5: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -11,
+    },
+    6: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -12,
+    },
+    7: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -7,
+      y: -13,
+    },
+    8: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -6,
+      y: -10,
+    },
+    9: {
+      stone: {
+        minedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      createdAt: 0,
+      x: -6,
+      y: -11,
     },
   },
   trees: {
@@ -266,16 +507,64 @@ export const STATIC_OFFLINE_FARM: GameState = {
           coins: 200,
         },
       },
-      x: 4,
-      y: -2,
+      x: -12,
+      y: 10,
     },
     2: {
       wood: {
         choppedAt: 0,
         criticalHit: { Native: 1 },
       },
-      x: 6,
-      y: -2,
+      x: -12,
+      y: 12,
+    },
+    3: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -14,
+      y: 10,
+    },
+    4: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -14,
+      y: 12,
+    },
+    5: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -8,
+      y: 10,
+    },
+    6: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -8,
+      y: 12,
+    },
+    7: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -10,
+      y: 10,
+    },
+    8: {
+      wood: {
+        choppedAt: 0,
+        criticalHit: { Native: 1 },
+      },
+      x: -10,
+      y: 12,
     },
   },
   sunstones: {},

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -65,6 +65,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     ),
     "Gold Rock": () => (
       <div
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 14}px`,
           top: `${PIXEL_SCALE * 3}px`,
@@ -73,7 +74,6 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
       >
         <img
           src={ITEM_DETAILS["Gold Rock"].image}
-          className="relative pointer-events-none"
           style={{
             width: `${PIXEL_SCALE * 14}px`,
             top: `${PIXEL_SCALE * 3}px`,
@@ -85,7 +85,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Iron Rock": () => (
       <img
         src={ITEM_DETAILS["Iron Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 14}px`,
           top: `${PIXEL_SCALE * 3}px`,
@@ -96,7 +96,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Stone Rock": () => (
       <img
         src={ITEM_DETAILS["Stone Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 14}px`,
           top: `${PIXEL_SCALE * 4.52}px`,
@@ -107,7 +107,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Fused Stone Rock": () => (
       <img
         src={ITEM_DETAILS["Fused Stone Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           top: `${PIXEL_SCALE}px`,
@@ -118,7 +118,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Reinforced Stone Rock": () => (
       <img
         src={ITEM_DETAILS["Reinforced Stone Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           top: `${PIXEL_SCALE * -0.523}px`,
@@ -149,7 +149,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     Tree: () => (
       <img
         src={TREE_VARIANTS(currentBiome, season, "Tree")}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 26}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
@@ -216,7 +216,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Ancient Tree": () => (
       <img
         src={TREE_VARIANTS(currentBiome, season, "Ancient Tree")}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 26}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
@@ -227,7 +227,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Sacred Tree": () => (
       <img
         src={TREE_VARIANTS(currentBiome, season, "Sacred Tree")}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 26}px`,
           bottom: `${PIXEL_SCALE * 2}px`,
@@ -238,7 +238,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Refined Iron Rock": () => (
       <img
         src={ITEM_DETAILS["Refined Iron Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           top: `${PIXEL_SCALE * 3}px`,
@@ -249,7 +249,7 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
     "Tempered Iron Rock": () => (
       <img
         src={ITEM_DETAILS["Tempered Iron Rock"].image}
-        className="relative"
+        className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 15}px`,
           top: `${PIXEL_SCALE * 1}px`,


### PR DESCRIPTION
# Description

Fixes the following issue in the image, where the craft tool popover continues to show after moving the mouse away from certain nodes:
<img width="550" height="657" alt="image" src="https://github.com/user-attachments/assets/e23939de-60a2-49a2-b46f-907279544638" />



