### PR TITLE
[FIX] Update LovedAt when Barn placed

### DIFF
--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -10,7 +10,6 @@ import {
 import { produce } from "immer";
 import { ComposterName } from "features/game/types/composters";
 import { getReadyAt } from "./startComposter";
-import { getBoostedAwakeAt } from "features/game/lib/animals";
 import { RECIPES } from "features/game/lib/crafting";
 import { getBoostedCraftingTime } from "./startCrafting";
 
@@ -142,13 +141,9 @@ export function placeBuilding({
         Object.values(animals).forEach((animal) => {
           if (existingBuilding.removedAt) {
             const timeOffset = existingBuilding.removedAt - animal.asleepAt;
-            animal.asleepAt = createdAt - timeOffset;
-            const { awakeAt } = getBoostedAwakeAt({
-              animalType: animal.type,
-              createdAt: animal.asleepAt, // use asleepAt to calculate the new awakeAt
-              game: stateCopy,
-            });
-            animal.awakeAt = awakeAt;
+            animal.asleepAt = animal.asleepAt + timeOffset;
+            animal.awakeAt = animal.awakeAt + timeOffset;
+            animal.lovedAt = animal.lovedAt + timeOffset;
           }
         });
       }


### PR DESCRIPTION
# Description

Players were able to get infinite animal love actions, by showing affection and then picking up the building. When they place the building down 8 hours later, they are able to love the animal again as the lovedAt timestamp was not being updated when the building is placed.

- This PR updates the `lovedAt` timestamp on the animals.
- This PR also removes the call to `getBoostedAwakeAt` when placing a building, as I believe time based boosts should only be applied when collecting produce.

# What needs to be tested by the reviewer?

1. Ensure feeding chickens continues to function before and after placing hen house

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]