### PR TITLE
[FEAT] Less marketplace API calls

### DIFF
--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -9,7 +9,7 @@ import {
   TradeableDetails,
 } from "features/game/types/marketplace";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { TradeableListItem } from "./TradeableList";
 import { ListingTable } from "./TradeTable";
 import { Context } from "features/game/GameProvider";
@@ -125,12 +125,6 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
           : undefined,
       }),
   );
-
-  useEffect(() => {
-    if (isFirstRender) return;
-
-    reload();
-  }, [myListingsCount, isFirstRender, reload]);
 
   const handleSelectListing = (id: string) => {
     const selectedListing = tradeable?.listings.find(

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -32,7 +32,6 @@ import { KeyedMutator } from "swr";
 import { isTradeResource } from "features/game/actions/tradeLimits";
 import { MAX_LIMITED_SALES } from "./Tradeable";
 import { ResourceTaxes } from "./TradeableInfo";
-import { useFirstRender } from "lib/utils/hooks/useFirstRender";
 
 type TradeableListingsProps = {
   authToken: string;
@@ -71,12 +70,9 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
 
   const isListing = useSelector(gameService, _isListing);
   const balance = useSelector(gameService, _balance);
-  const myListingsCount = useSelector(gameService, _myListingsCount);
 
   const [selectedListing, setSelectedListing] = useState<Listing>();
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
-
-  const isFirstRender = useFirstRender();
 
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,
@@ -104,6 +100,13 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,
     "marketplaceListingCancellingSuccess",
+    "playing",
+    reload,
+  );
+
+  useOnMachineTransition<ContextType, BlockchainEvent>(
+    gameService,
+    "marketplaceBulkListingsCancellingSuccess",
     "playing",
     reload,
   );

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -38,7 +38,6 @@ import { KeyedMutator } from "swr";
 import { MAX_LIMITED_PURCHASES } from "./Tradeable";
 import { ResourceTaxes } from "./TradeableInfo";
 import { hasVipAccess } from "features/game/lib/vipAccess";
-import { useFirstRender } from "lib/utils/hooks/useFirstRender";
 
 const _hasPendingOfferEffect = (state: MachineState) =>
   state.matches("marketplaceOffering") || state.matches("marketplaceAccepting");
@@ -102,7 +101,12 @@ export const TradeableOffers: React.FC<{
     return offer.sfl > highest.sfl ? offer : highest;
   }, tradeable?.offers[0]);
 
-  const isFirstRender = useFirstRender();
+  useOnMachineTransition<ContextType, BlockchainEvent>(
+    gameService,
+    "marketplaceBulkOffersCancellingSuccess",
+    "playing",
+    reload,
+  );
 
   useOnMachineTransition<ContextType, BlockchainEvent>(
     gameService,

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 
 import { Button } from "components/ui/Button";
 import { Label } from "components/ui/Label";
@@ -138,12 +138,6 @@ export const TradeableOffers: React.FC<{
           : undefined,
       }),
   );
-
-  useEffect(() => {
-    if (isFirstRender) return;
-
-    reload();
-  }, [myOffersCount, isFirstRender, reload]);
 
   const handleHide = () => {
     if (hasPendingOfferEffect) return;


### PR DESCRIPTION
# Description

Every time the details for an item is opened, the API is hit 3 times with the same call.

The parent component was already calling the API so we don't need these child components calling them as well.

## How to test?

Run against dev API and visit an item. Everything should load correctly.