### PR TITLE
[FIX] Player search undefined Farm ID error

### DIFF
--- a/src/features/island/hud/components/settings-menu/developer-options/DEV_PlayerSearch.tsx
+++ b/src/features/island/hud/components/settings-menu/developer-options/DEV_PlayerSearch.tsx
@@ -53,7 +53,7 @@ export const DEV_PlayerSearch: React.FC<ContentComponentProps> = () => {
     return <Loading />;
   }
 
-  if (state === "loaded" && !farm) {
+  if (state === "loaded" && !farm?.id) {
     return <p>{`Farm not found`}</p>;
   }
 


### PR DESCRIPTION
When a Discord account has not been linked to any farms and its ID is used to search for a player...

```TS
<div className="flex items-center">
    <p className="mr-2">{`Farm ID:`}</p>
    <CopyAddress address={farm.id.toString()} />
</div>
```


the `farm.id` in the code above is undefined and causes an error:

<img width="559" height="272" alt="image" src="https://github.com/user-attachments/assets/994d1651-02ac-4cb6-85a4-9475d3385cc8" />

---
I updated the condition so that if there is no farm ID, the code stops before reaching this point and instead displays the "Farm not found" message.

<img width="618" height="116" alt="image" src="https://github.com/user-attachments/assets/8a95c080-965f-4693-87c2-19c87eb4eb5f" />
