### PR TITLE
[FIX] Hide Pest Net on restock screens

### DIFF
--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -64,13 +64,15 @@ export type StockableName = Extract<
 export const INITIAL_STOCK = (
   state?: GameState,
 ): Record<StockableName, Decimal> => {
-  const tools = Object.entries(WORKBENCH_TOOLS).reduce(
-    (acc, [toolName, tool]) => ({
-      ...acc,
-      [toolName]: tool.stock,
-    }),
-    {} as Record<WorkbenchToolName, Decimal>,
-  );
+  const tools = Object.entries(WORKBENCH_TOOLS)
+    .filter((tool) => !tool[1].disabled)
+    .reduce(
+      (acc, [toolName, tool]) => ({
+        ...acc,
+        [toolName]: tool.stock,
+      }),
+      {} as Record<WorkbenchToolName, Decimal>,
+    );
 
   // increase in 50% tool stock if you have a toolshed
   if (state?.buildings.Toolshed && isBuildingReady(state.buildings.Toolshed)) {


### PR DESCRIPTION
# Description

Pest Net is currently disabled, but it still appears on the restock screens (image below). This PR updates the code so that tools are only shown there if they are not disabled.

<img width="489" height="510" alt="image" src="https://github.com/user-attachments/assets/9b14b079-0244-4d7f-8aca-f021cf6cf076" />
 
