### PR TITLE
[FEAT] Remove heartbeat from useSocial

### DIFF
--- a/src/features/social/components/FollowDetailPanel.tsx
+++ b/src/features/social/components/FollowDetailPanel.tsx
@@ -62,11 +62,7 @@ export const FollowDetailPanel: React.FC<Props> = ({
             <NPCIcon parts={clothing} />
           </div>
           <div className="absolute -top-1 -right-1">
-            <OnlineStatus
-              loggedInFarmId={loggedInFarmId}
-              playerId={playerId}
-              lastUpdatedAt={lastOnlineAt}
-            />
+            <OnlineStatus lastUpdatedAt={lastOnlineAt} />
           </div>
         </div>
         <div className="flex flex-col gap-0.5 w-full">

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSocial } from "../hooks/useSocial";
 import { Label } from "components/ui/Label";
 import { FollowDetailPanel } from "./FollowDetailPanel";
 import { Button } from "components/ui/Button";
@@ -28,7 +27,6 @@ export const FollowList: React.FC<Props> = ({
   loggedInFarmId,
   token,
   networkFarmId,
-  networkList,
   networkCount,
   playerLoading,
   showLabel = true,
@@ -37,10 +35,6 @@ export const FollowList: React.FC<Props> = ({
   searchResults = [],
   navigateToPlayer,
 }) => {
-  useSocial({
-    farmId: networkFarmId,
-    following: networkList,
-  });
   const { t } = useTranslation();
   const [isScrollable, setIsScrollable] = useState(false);
   // Intersection observer to load more details when the loader is in view

--- a/src/features/social/components/OnlineStatus.tsx
+++ b/src/features/social/components/OnlineStatus.tsx
@@ -1,24 +1,15 @@
 import React from "react";
-import { useSocial } from "../hooks/useSocial";
 
 type OnlineStatusProps = {
-  loggedInFarmId: number;
-  playerId: number;
   lastUpdatedAt: number;
   size?: number;
 };
 
 export const OnlineStatus: React.FC<OnlineStatusProps> = ({
-  loggedInFarmId,
-  playerId,
   lastUpdatedAt,
   size = 12,
 }) => {
-  const { online } = useSocial({
-    farmId: loggedInFarmId,
-  });
-
-  const lastOnlineAt = online[playerId] ?? lastUpdatedAt ?? 0;
+  const lastOnlineAt = lastUpdatedAt ?? 0;
   const isOnline = lastOnlineAt > Date.now() - 30 * 60 * 1000;
 
   const color = isOnline ? "#22c55e" : "#ef4444"; // Tailwind green-500/red-500

--- a/src/features/social/components/PlayerDetails.tsx
+++ b/src/features/social/components/PlayerDetails.tsx
@@ -132,7 +132,6 @@ export const PlayerDetails: React.FC<Props> = ({
 
   useSocial({
     farmId: loggedInFarmId,
-    following: player?.followedBy ?? [],
     callbacks: {
       onFollow: () => mutate(),
       onUnfollow: () => mutate(),
@@ -291,8 +290,6 @@ export const PlayerDetails: React.FC<Props> = ({
                     <div className="absolute -top-2 -right-2 z-10">
                       {player?.id && (
                         <OnlineStatus
-                          playerId={player?.id}
-                          loggedInFarmId={loggedInFarmId}
                           lastUpdatedAt={player?.lastUpdatedAt ?? 0}
                         />
                       )}

--- a/src/features/social/hooks/useSocial.ts
+++ b/src/features/social/hooks/useSocial.ts
@@ -1,42 +1,26 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useEffect } from "react";
 import { Room, Client } from "colyseus.js";
 import { CONFIG } from "lib/config";
 import { Interaction, Milestone, PlayerUpdate } from "../types/types";
 
-const HEARTBEAT_INTERVAL = 15 * 60 * 1000;
 const MAX_RETRY_INTERVAL = 15 * 60 * 1000;
 
 // Private data specific to the connection to the colyseus server
-const subscribers: Map<
-  () => void,
-  {
-    following: number[];
-    callbacks?: {
-      onFollow?: (update: PlayerUpdate) => void;
-      onUnfollow?: (update: PlayerUpdate) => void;
-      onInteraction?: (update: Interaction) => void;
-      onMilestone?: (update: Milestone) => void;
-    };
-  }
-> = new Map();
+const subscribers: Set<{
+  callbacks?: {
+    onFollow?: (update: PlayerUpdate) => void;
+    onUnfollow?: (update: PlayerUpdate) => void;
+    onInteraction?: (update: Interaction) => void;
+    onMilestone?: (update: Milestone) => void;
+  };
+}> = new Set();
 let room: Room<unknown> | undefined = undefined;
-let heartBeatTimeout: NodeJS.Timeout | undefined = undefined;
 let reconnectTimeout: NodeJS.Timeout | undefined = undefined;
 let retries = 0;
-
-// Global snapshot of the player's social data
-type Snapshot = {
-  status: "loading" | "connected" | "error";
-  online: Record<number, number>;
-};
-let snapshot: Snapshot = {
-  status: "loading",
-  online: {},
-};
+let status: "loading" | "connected" | "error" = "loading";
 
 type UseSocialParams = {
   farmId: number;
-  following?: number[];
   callbacks?: {
     onFollow?: (update: PlayerUpdate) => void;
     onUnfollow?: (update: PlayerUpdate) => void;
@@ -45,12 +29,11 @@ type UseSocialParams = {
   };
 };
 
-const updateStatus = (status: "loading" | "connected" | "error") => {
-  snapshot = { ...snapshot, status };
-  notifyAllSubscribers();
+const updateStatus = (updatedStatus: "loading" | "connected" | "error") => {
+  status = updatedStatus;
 };
 
-const reconnect = (notifySubscriber: () => void, farmId: number) => {
+const reconnect = (farmId: number) => {
   const backoffDelay = Math.min(
     1000 * (Math.pow(2, retries) - 1),
     MAX_RETRY_INTERVAL,
@@ -59,8 +42,8 @@ const reconnect = (notifySubscriber: () => void, farmId: number) => {
 
   reconnectTimeout && clearTimeout(reconnectTimeout);
   reconnectTimeout = setTimeout(() => {
-    if (snapshot.status === "connected") return;
-    joinRoom(notifySubscriber, farmId);
+    if (status === "connected") return;
+    joinRoom(farmId);
   }, backoffDelay);
 };
 
@@ -68,31 +51,15 @@ const onLoading = () => {
   updateStatus("loading");
 };
 
-const onError = (notifySubscriber: () => void, farmId: number) => {
+const onError = (farmId: number) => {
   updateStatus("error");
   leaveRoom();
-  reconnect(notifySubscriber, farmId);
+  reconnect(farmId);
 };
 
-const onConnected = (notifySubscriber: () => void) => {
+const onConnected = () => {
   retries = 0;
   updateStatus("connected");
-  notifySubscriber();
-};
-
-const updateOnline = (online: Record<number, number>) => {
-  snapshot = {
-    ...snapshot,
-    online: {
-      ...snapshot.online,
-      ...online,
-    },
-  };
-  notifyAllSubscribers();
-};
-
-const notifyAllSubscribers = () => {
-  [...subscribers.keys()].forEach((notifySubscriber) => notifySubscriber());
 };
 
 const onFollow = (update: PlayerUpdate) => {
@@ -129,32 +96,13 @@ const onMilestone = (update: Milestone) => {
 
 const clearListeners = () => {
   room?.removeAllListeners();
-  heartBeatTimeout && clearInterval(heartBeatTimeout);
 };
 
-const setupListeners = (
-  room: Room<unknown>,
-  cb: () => void,
-  farmId: number,
-) => {
-  heartBeatTimeout = setInterval(
-    () => room?.send("heartbeat"),
-    HEARTBEAT_INTERVAL,
-  );
-  room.onError(() => onError(cb, farmId));
-  room.onLeave(() => onError(cb, farmId));
-  room.onMessage("heartbeat", updateOnline);
+const setupListeners = (room: Room<unknown>) => {
   room.onMessage("follow", onFollow);
   room.onMessage("unfollow", onUnfollow);
   room.onMessage("interaction", onInteraction);
   room.onMessage("milestone", onMilestone);
-};
-
-const updateFollowing = () => {
-  room?.send(
-    "updateFollowing",
-    [...subscribers.values()].flatMap((s) => s.following),
-  );
 };
 
 const leaveRoom = async () => {
@@ -163,7 +111,7 @@ const leaveRoom = async () => {
   room = undefined;
 };
 
-const joinRoom = async (notifySubscriber: () => void, farmId: number) => {
+const joinRoom = async (farmId: number) => {
   const client = new Client(CONFIG.ROOM_URL);
 
   try {
@@ -172,56 +120,41 @@ const joinRoom = async (notifySubscriber: () => void, farmId: number) => {
 
     room = await client.joinOrCreate("sunflorea_social", {
       farmId,
-      following: [...subscribers.values()].flatMap((s) => s.following),
     });
-    setupListeners(room, notifySubscriber, farmId);
+    setupListeners(room);
 
-    onConnected(notifySubscriber);
+    onConnected();
   } catch (e) {
-    onError(notifySubscriber, farmId);
+    onError(farmId);
   }
 };
 
-const getSnapshot = () => snapshot;
-
 /**
- * Gets online status from the sunflorea_social room in the Colyseus WebSocket Server
- * Used to both retrieve the online status of farms and updating your own online status
- *
- * Pings the server every HEARTBEAT_INTERVAL to update your online status
- * Retrieves the online status of the farms you are following when a "heartbeat" message is received
+ * Maintains a persistent connection to the sunflorea_social room in the Colyseus WebSocket Server
+ * for receiving real-time events, such as follow/unfollow, interactions, and milestones.
+ * Check @callbacks for the events you can subscribe to.
  *
  * @param farmId Your farm id
- * @param following The IDs of the farms you want presence data about
  * @param callbacks An object of callbacks registering for different events
- * @returns The presence data of the farms
+ * @returns void
  */
-export const useSocial = ({
-  farmId,
-  following = [],
-  callbacks,
-}: UseSocialParams) => {
-  const subscribe = useCallback(
-    (notifySubscriber: () => void) => {
-      subscribers.set(notifySubscriber, { following, callbacks });
+export const useSocial = ({ farmId, callbacks }: UseSocialParams) => {
+  useEffect(() => {
+    const subscriber = { callbacks };
+    subscribers.add(subscriber);
 
-      // Only connect to server when the first component subscribes
-      if (subscribers.size === 1) joinRoom(notifySubscriber, farmId);
-      // Force a reconnection attempt if the connection is down when a component subscribes
-      else if (snapshot.status === "error") {
-        retries = 0;
-        reconnect(notifySubscriber, farmId);
-      } else updateFollowing();
+    // Only connect to server when the first component subscribes
+    if (subscribers.size === 1) joinRoom(farmId);
+    // Force a reconnection attempt if the connection is down when a component subscribes
+    else if (status === "error") {
+      retries = 0;
+      reconnect(farmId);
+    }
 
-      return () => {
-        subscribers.delete(notifySubscriber);
-        // Leave the room if no component is subscribed
-        if (subscribers.size === 0) leaveRoom();
-        else updateFollowing();
-      };
-    },
-    [following.length],
-  );
-
-  return useSyncExternalStore(subscribe, getSnapshot);
+    return () => {
+      subscribers.delete(subscriber);
+      // Leave the room if no component is subscribed
+      if (subscribers.size === 0) leaveRoom();
+    };
+  }, []);
 };


### PR DESCRIPTION
# Description

This PR removes the heartbeat from the `useSocial` hook. This is a performance optimisation, as the data in the heartbeat is already available directly from the API.

This hook is now only used for subscribing to real time events.

# What needs to be tested by the reviewer?

1. Message between two clients and ensure that messages show up in real time

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
