### PR TITLE
[FIX] Marketplace Search Performance

### DIFF
--- a/src/components/ui/SFTDetailPopover.tsx
+++ b/src/components/ui/SFTDetailPopover.tsx
@@ -44,10 +44,10 @@ const SFTDetailPopoverBuffsImplementation = ({
   const { gameService } = useContext(Context);
 
   const state = gameService.getSnapshot().context.state;
-  const buff = COLLECTIBLE_BUFF_LABELS({
+  const buff = COLLECTIBLE_BUFF_LABELS[name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[name];
+  });
 
   if (!buff) return null;
 

--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -116,10 +116,10 @@ export const InventoryItemDetails: React.FC<Props> = ({
       }
     }
 
-    const boost = COLLECTIBLE_BUFF_LABELS({
+    const boost = COLLECTIBLE_BUFF_LABELS[details.item]?.({
       skills: game.bumpkin.skills,
       collectibles: game.collectibles,
-    })[details.item];
+    });
 
     return (
       <>

--- a/src/features/farming/animals/components/MutantAnimalModal.tsx
+++ b/src/features/farming/animals/components/MutantAnimalModal.tsx
@@ -25,10 +25,10 @@ export const MutantAnimalModal = ({ mutant, show, onContinue }: Props) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
-  const boost = COLLECTIBLE_BUFF_LABELS({
+  const boost = COLLECTIBLE_BUFF_LABELS[mutant]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[mutant];
+  });
 
   return (
     <Modal show={show} dialogClassName="max-w-[480px]">

--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -150,16 +150,14 @@ export const WithdrawItems: React.FC<Props> = ({
       };
     } = {};
 
-    const buffLabels = COLLECTIBLE_BUFF_LABELS({
-      skills: state.bumpkin.skills,
-      collectibles: state.collectibles,
-    });
-
     getKeys(inventory).forEach((itemName) => {
       const { cooldownTimeLeft } = getRestrictionStatus(itemName);
       const isOnCooldown = cooldownTimeLeft > 0;
       const hasMoreOffChain = hasMoreOffChainItems(itemName);
-      const hasBuff = !!buffLabels[itemName]?.length;
+      const hasBuff = !!COLLECTIBLE_BUFF_LABELS[itemName]?.({
+        skills: state.bumpkin.skills,
+        collectibles: state.collectibles,
+      })?.length;
 
       cache[itemName] = {
         cooldownMs: cooldownTimeLeft,

--- a/src/features/game/expansion/components/ClaimReward.tsx
+++ b/src/features/game/expansion/components/ClaimReward.tsx
@@ -8,7 +8,7 @@ import powerup from "assets/icons/level_up.png";
 import factionPoint from "assets/icons/faction_point.webp";
 import vip from "assets/icons/vip.webp";
 import recipeIcon from "assets/decorations/page.png";
-import { CollectibleName, getKeys } from "features/game/types/craftables";
+import { getKeys } from "features/game/types/craftables";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
@@ -130,10 +130,10 @@ export const ClaimReward: React.FC<ClaimRewardProps> = ({
 
           {itemNames.length > 0 &&
             itemNames.map((name) => {
-              const buff = COLLECTIBLE_BUFF_LABELS({
+              const buff = COLLECTIBLE_BUFF_LABELS[name]?.({
                 skills: game.bumpkin.skills,
                 collectibles: game.collectibles,
-              })[name as CollectibleName];
+              });
               return (
                 <ButtonPanel
                   className="flex items-start cursor-context-menu hover:brightness-100"

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -9,7 +9,6 @@ import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ITEM_DETAILS } from "./images";
 import { translate } from "lib/i18n/translate";
-import memoize from "lodash.memoize";
 import {
   getCurrentSeason,
   getSeasonalTicket,
@@ -21,1889 +20,1881 @@ import { TranslationKeys } from "lib/i18n/dictionaries/types";
 import { isCollectible } from "../events/landExpansion/garbageSold";
 import { getObjectEntries } from "../expansion/lib/utils";
 
-export const COLLECTIBLE_BUFF_LABELS = memoize(getCollectibleBuffLabels);
+export const COLLECTIBLE_BUFF_LABELS: Partial<
+  Record<
+    InventoryItemName,
+    ({
+      skills,
+      collectibles,
+    }: {
+      skills: GameState["bumpkin"]["skills"];
+      collectibles: GameState["collectibles"];
+    }) => BuffLabel[]
+  >
+> = {
+  // Crop Boosts
+  "Basic Scarecrow": ({ skills }) => [
+    {
+      shortDescription: skills["Chonky Scarecrow"]
+        ? translate("description.basic.scarecrow.boost.skill")
+        : translate("description.basic.scarecrow.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: skills["Chonky Scarecrow"]
+        ? translate("description.basic.scarecrow.boost.aoe.skill")
+        : translate("description.basic.scarecrow.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Scary Mike": ({ skills }) => [
+    {
+      shortDescription: skills["Horror Mike"]
+        ? translate("description.scary.mike.boost.skill")
+        : translate("description.scary.mike.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: skills["Horror Mike"]
+        ? translate("description.scary.mike.boost.aoe.skill")
+        : translate("description.scary.mike.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Laurie the Chuckle Crow": ({ skills }) => [
+    {
+      shortDescription: skills["Laurie's Gains"]
+        ? translate("description.laurie.chuckle.crow.boost.skill")
+        : translate("description.laurie.chuckle.crow.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: skills["Laurie's Gains"]
+        ? translate("description.laurie.chuckle.crow.boost.aoe.skill")
+        : translate("description.laurie.chuckle.crow.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  Nancy: () => [
+    {
+      shortDescription: translate("description.nancy.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate("description.nancy.warning"),
+      labelType: "danger",
+    },
+  ],
+  Scarecrow: () => [
+    {
+      shortDescription: translate("description.nancy.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate("description.scarecrow.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.scarecrow.warning"),
+      labelType: "danger",
+    },
+  ],
+  Kuebiko: () => [
+    {
+      shortDescription: translate("description.nancy.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate("description.scarecrow.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.kuebiko.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  Gnome: () => [
+    {
+      shortDescription: translate("description.gnome.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.gnome.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+    {
+      shortDescription: translate("description.gnome.warning"),
+      labelType: "danger",
+    },
+  ],
+  "Sir Goldensnout": () => [
+    {
+      shortDescription: translate("description.sir.goldensnout.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.sir.goldensnout.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Lunar Calendar": () => [
+    {
+      shortDescription: translate("description.lunar.calendar.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Peeled Potato": () => [
+    {
+      shortDescription: translate("description.peeled.potato.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Potato.crop,
+    },
+  ],
+  "Victoria Sisters": () => [
+    {
+      shortDescription: translate("description.victoria.sisters.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
+    },
+  ],
+  "Freya Fox": () => [
+    {
+      shortDescription: translate("description.freya.fox.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
+    },
+  ],
+  "Easter Bunny": () => [
+    {
+      shortDescription: translate("description.easter.bunny.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
+    },
+  ],
+  "Pablo The Bunny": () => [
+    {
+      shortDescription: translate("description.pablo.bunny.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
+    },
+  ],
+  "Cabbage Boy": ({ collectibles }) => [
+    {
+      shortDescription: collectibles["Cabbage Girl"]
+        ? translate("description.cabbage.boy.boost.boosted")
+        : translate("description.cabbage.boy.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
+    },
+  ],
+  "Cabbage Girl": () => [
+    {
+      shortDescription: translate("description.cabbage.girl.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
+    },
+  ],
+  Karkinos: ({ collectibles }) => [
+    ...(collectibles["Cabbage Boy"]
+      ? []
+      : ([
+          {
+            shortDescription: translate("description.Karkinos.boost"),
+            labelType: "success",
+            boostTypeIcon: powerup,
+            boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
+          },
+          {
+            shortDescription: translate("description.Karkinos.warning"),
+            labelType: "danger",
+          },
+        ] as BuffLabel[])),
+  ],
+  "Golden Cauliflower": () => [
+    {
+      shortDescription: translate("description.golden.cauliflower.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cauliflower.crop,
+    },
+  ],
+  "Mysterious Parsnip": () => [
+    {
+      shortDescription: translate("description.mysterious.parsnip.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Parsnip.crop,
+    },
+  ],
+  "Purple Trail": () => [
+    {
+      shortDescription: translate("description.purple.trail.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
+    },
+  ],
+  Obie: () => [
+    {
+      shortDescription: translate("description.obie.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
+    },
+  ],
+  Maximus: () => [
+    {
+      shortDescription: translate("description.maximus.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
+    },
+  ],
+  Poppy: () => [
+    {
+      shortDescription: translate("description.poppy.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
+    },
+  ],
+  Kernaldo: () => [
+    {
+      shortDescription: translate("description.kernaldo.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
+    },
+  ],
+  "Queen Cornelia": () => [
+    {
+      shortDescription: translate("description.queen.cornelia.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
+    },
+    {
+      shortDescription: translate("description.queen.cornelia.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  Foliant: () => [
+    {
+      shortDescription: translate("description.foliant.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Kale.crop,
+    },
+  ],
+  Hoot: () => [
+    {
+      shortDescription: translate("description.hoot.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Hungry Caterpillar": () => [
+    {
+      shortDescription: translate("description.hungry.caterpillar.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
 
-function getCollectibleBuffLabels({
-  skills,
-  collectibles,
-}: {
-  skills: GameState["bumpkin"]["skills"];
-  collectibles: GameState["collectibles"];
-}): Partial<Record<InventoryItemName, BuffLabel[]>> {
-  // Delete the cache if this function is invoked.
-  COLLECTIBLE_BUFF_LABELS.cache.clear?.();
+  // Clash of Factions
+  "Turbo Sprout": () => [
+    {
+      shortDescription: translate("description.turbo.sprout.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
 
-  const buffLabels: Partial<Record<InventoryItemName, BuffLabel[]>> = {
-    // Crop Boosts
-    "Basic Scarecrow": [
-      {
-        shortDescription: skills["Chonky Scarecrow"]
-          ? translate("description.basic.scarecrow.boost.skill")
-          : translate("description.basic.scarecrow.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: skills["Chonky Scarecrow"]
-          ? translate("description.basic.scarecrow.boost.aoe.skill")
-          : translate("description.basic.scarecrow.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Scary Mike": [
-      {
-        shortDescription: skills["Horror Mike"]
-          ? translate("description.scary.mike.boost.skill")
-          : translate("description.scary.mike.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: skills["Horror Mike"]
-          ? translate("description.scary.mike.boost.aoe.skill")
-          : translate("description.scary.mike.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Laurie the Chuckle Crow": [
-      {
-        shortDescription: skills["Laurie's Gains"]
-          ? translate("description.laurie.chuckle.crow.boost.skill")
-          : translate("description.laurie.chuckle.crow.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: skills["Laurie's Gains"]
-          ? translate("description.laurie.chuckle.crow.boost.aoe.skill")
-          : translate("description.laurie.chuckle.crow.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    Nancy: [
-      {
-        shortDescription: translate("description.nancy.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate("description.nancy.warning"),
-        labelType: "danger",
-      },
-    ],
-    Scarecrow: [
-      {
-        shortDescription: translate("description.nancy.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate("description.scarecrow.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.scarecrow.warning"),
-        labelType: "danger",
-      },
-    ],
-    Kuebiko: [
-      {
-        shortDescription: translate("description.nancy.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate("description.scarecrow.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.kuebiko.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    Gnome: [
-      {
-        shortDescription: translate("description.gnome.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.gnome.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-      {
-        shortDescription: translate("description.gnome.warning"),
-        labelType: "danger",
-      },
-    ],
-    "Sir Goldensnout": [
-      {
-        shortDescription: translate("description.sir.goldensnout.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.sir.goldensnout.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Lunar Calendar": [
-      {
-        shortDescription: translate("description.lunar.calendar.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Peeled Potato": [
-      {
-        shortDescription: translate("description.peeled.potato.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Potato.crop,
-      },
-    ],
-    "Victoria Sisters": [
-      {
-        shortDescription: translate("description.victoria.sisters.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
-      },
-    ],
-    "Freya Fox": [
-      {
-        shortDescription: translate("description.freya.fox.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
-      },
-    ],
-    "Easter Bunny": [
-      {
-        shortDescription: translate("description.easter.bunny.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
-      },
-    ],
-    "Pablo The Bunny": [
-      {
-        shortDescription: translate("description.pablo.bunny.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
-      },
-    ],
-    "Cabbage Boy": [
-      {
-        shortDescription: collectibles["Cabbage Girl"]
-          ? translate("description.cabbage.boy.boost.boosted")
-          : translate("description.cabbage.boy.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
-      },
-    ],
-    "Cabbage Girl": [
-      {
-        shortDescription: translate("description.cabbage.girl.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
-      },
-    ],
-    Karkinos: [
-      ...(collectibles["Cabbage Boy"]
-        ? []
-        : ([
-            {
-              shortDescription: translate("description.Karkinos.boost"),
-              labelType: "success",
-              boostTypeIcon: powerup,
-              boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
-            },
-            {
-              shortDescription: translate("description.Karkinos.warning"),
-              labelType: "danger",
-            },
-          ] as BuffLabel[])),
-    ],
-    "Golden Cauliflower": [
-      {
-        shortDescription: translate("description.golden.cauliflower.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cauliflower.crop,
-      },
-    ],
-    "Mysterious Parsnip": [
-      {
-        shortDescription: translate("description.mysterious.parsnip.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Parsnip.crop,
-      },
-    ],
-    "Purple Trail": [
-      {
-        shortDescription: translate("description.purple.trail.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
-      },
-    ],
-    Obie: [
-      {
-        shortDescription: translate("description.obie.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
-      },
-    ],
-    Maximus: [
-      {
-        shortDescription: translate("description.maximus.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Eggplant.crop,
-      },
-    ],
-    Poppy: [
-      {
-        shortDescription: translate("description.poppy.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
-      },
-    ],
-    Kernaldo: [
-      {
-        shortDescription: translate("description.kernaldo.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
-      },
-    ],
-    "Queen Cornelia": [
-      {
-        shortDescription: translate("description.queen.cornelia.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Corn.crop,
-      },
-      {
-        shortDescription: translate("description.queen.cornelia.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    Foliant: [
-      {
-        shortDescription: translate("description.foliant.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Kale.crop,
-      },
-    ],
-    Hoot: [
-      {
-        shortDescription: translate("description.hoot.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Hungry Caterpillar": [
-      {
-        shortDescription: translate("description.hungry.caterpillar.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
+  Soybliss: () => [
+    {
+      shortDescription: translate("description.soybliss.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Soybean.crop,
+    },
+  ],
 
-    // Clash of Factions
-    "Turbo Sprout": [
-      {
-        shortDescription: translate("description.turbo.sprout.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
+  "Grape Granny": () => [
+    {
+      shortDescription: translate("description.grape.granny.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Grape.image,
+    },
+  ],
+  Vinny: () => [
+    {
+      shortDescription: translate("description.vinny.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Grape.image,
+    },
+  ],
+  "Rice Panda": () => [
+    {
+      shortDescription: translate("description.rice.panda.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Rice.image,
+    },
+  ],
 
-    Soybliss: [
-      {
-        shortDescription: translate("description.soybliss.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Soybean.crop,
-      },
-    ],
+  // Fruit Boosts
+  "Immortal Pear": ({ skills }) => [
+    {
+      shortDescription: skills["Pear Turbocharge"]
+        ? translate("description.immortal.pear.boosted.boost")
+        : translate("description.immortal.pear.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Black Bearry": () => [
+    {
+      shortDescription: translate("description.black.bearry.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Blueberry.image,
+    },
+  ],
+  "Squirrel Monkey": () => [
+    {
+      shortDescription: translate("description.squirrel.monkey.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Orange.image,
+    },
+  ],
+  "Lady Bug": () => [
+    {
+      shortDescription: translate("description.lady.bug.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Apple.image,
+    },
+  ],
+  "Banana Chicken": () => [
+    {
+      shortDescription: translate("description.banana.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Banana.image,
+    },
+  ],
+  Nana: () => [
+    {
+      shortDescription: translate("description.nana.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Banana.image,
+    },
+  ],
 
-    "Grape Granny": [
-      {
-        shortDescription: translate("description.grape.granny.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Grape.image,
-      },
-    ],
-    Vinny: [
-      {
-        shortDescription: translate("description.vinny.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Grape.image,
-      },
-    ],
-    "Rice Panda": [
-      {
-        shortDescription: translate("description.rice.panda.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Rice.image,
-      },
-    ],
+  // Mutant Crops
+  "Carrot Sword": () => [
+    {
+      shortDescription: translate("description.carrot.sword.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Stellar Sunflower": () => [
+    {
+      shortDescription: translate("description.stellar.sunflower.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Sunflower.crop,
+    },
+  ],
+  "Potent Potato": () => [
+    {
+      shortDescription: translate("description.potent.potato.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Potato.crop,
+    },
+  ],
+  "Radical Radish": () => [
+    {
+      shortDescription: translate("description.radical.radish.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Radish.crop,
+    },
+  ],
+  "Lab Grown Pumpkin": () => [
+    {
+      shortDescription: translate("description.lg.pumpkin.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
+    },
+  ],
+  "Lab Grown Carrot": () => [
+    {
+      shortDescription: translate("description.lg.carrot.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
+    },
+  ],
+  "Lab Grown Radish": () => [
+    {
+      shortDescription: translate("description.lg.radish.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Radish.crop,
+    },
+  ],
 
-    // Fruit Boosts
-    "Immortal Pear": [
-      {
-        shortDescription: skills["Pear Turbocharge"]
-          ? translate("description.immortal.pear.boosted.boost")
-          : translate("description.immortal.pear.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Black Bearry": [
-      {
-        shortDescription: translate("description.black.bearry.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Blueberry.image,
-      },
-    ],
-    "Squirrel Monkey": [
-      {
-        shortDescription: translate("description.squirrel.monkey.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Orange.image,
-      },
-    ],
-    "Lady Bug": [
-      {
-        shortDescription: translate("description.lady.bug.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Apple.image,
-      },
-    ],
-    "Banana Chicken": [
-      {
-        shortDescription: translate("description.banana.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Banana.image,
-      },
-    ],
-    Nana: [
-      {
-        shortDescription: translate("description.nana.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Banana.image,
-      },
-    ],
+  // Animals
+  "Fat Chicken": () => [
+    {
+      shortDescription: translate("description.fat.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
+    },
+  ],
+  "Rich Chicken": () => [
+    {
+      shortDescription: translate("description.rich.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+  ],
+  "Speed Chicken": () => [
+    {
+      shortDescription: translate("description.speed.chicken.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+  ],
+  "Ayam Cemani": () => [
+    {
+      shortDescription: translate("description.ayam.cemani.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+  ],
+  "El Pollo Veloz": () => [
+    {
+      shortDescription: translate("description.el.pollo.veloz.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+  ],
+  Rooster: () => [
+    {
+      shortDescription: translate("description.rooster.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Undead Rooster": () => [
+    {
+      shortDescription: translate("description.undead.rooster.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+  ],
+  "Chicken Coop": () => [
+    {
+      shortDescription: translate("description.chicken.coop.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+    {
+      shortDescription: translate("description.chicken.coop.boost.two"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.chicken.coop.boost.three"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Farm Dog": () => [
+    {
+      shortDescription: translate("description.farm.dog.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
+    },
+  ],
+  "Gold Egg": () => [
+    {
+      shortDescription: translate("description.gold.egg.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
+    },
+  ],
+  Bale: ({ skills }) => [
+    {
+      shortDescription: skills["Double Bale"]
+        ? translate("description.bale.eggBoost.boosted")
+        : translate("description.bale.eggBoost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.egg,
+    },
+    ...(skills["Bale Economy"]
+      ? ([
+          {
+            shortDescription: skills["Double Bale"]
+              ? translate("description.bale.milkBoost.boosted")
+              : translate("description.bale.milkBoost"),
+            labelType: "success",
+            boostTypeIcon: powerup,
+            boostedItemIcon: SUNNYSIDE.resource.milk,
+          },
+          {
+            shortDescription: skills["Double Bale"]
+              ? translate("description.bale.woolBoost.boosted")
+              : translate("description.bale.woolBoost"),
+            labelType: "success",
+            boostTypeIcon: powerup,
+            boostedItemIcon: SUNNYSIDE.resource.wool,
+          },
+        ] as BuffLabel[])
+      : []),
+  ],
 
-    // Mutant Crops
-    "Carrot Sword": [
-      {
-        shortDescription: translate("description.carrot.sword.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Stellar Sunflower": [
-      {
-        shortDescription: translate("description.stellar.sunflower.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Sunflower.crop,
-      },
-    ],
-    "Potent Potato": [
-      {
-        shortDescription: translate("description.potent.potato.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Potato.crop,
-      },
-    ],
-    "Radical Radish": [
-      {
-        shortDescription: translate("description.radical.radish.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Radish.crop,
-      },
-    ],
-    "Lab Grown Pumpkin": [
-      {
-        shortDescription: translate("description.lg.pumpkin.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Pumpkin.crop,
-      },
-    ],
-    "Lab Grown Carrot": [
-      {
-        shortDescription: translate("description.lg.carrot.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Carrot.crop,
-      },
-    ],
-    "Lab Grown Radish": [
-      {
-        shortDescription: translate("description.lg.radish.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Radish.crop,
-      },
-    ],
+  // Resources
+  "Woody the Beaver": () => [
+    {
+      shortDescription: translate("description.woody.beaver.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+    {
+      shortDescription: translate("description.woody.beaver.warning"),
+      labelType: "danger",
+    },
+  ],
+  "Apprentice Beaver": () => [
+    {
+      shortDescription: translate("description.woody.beaver.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+    {
+      shortDescription: translate("description.apprentice.beaver.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+    {
+      shortDescription: translate("description.apprentice.beaver.warning"),
+      labelType: "danger",
+    },
+  ],
+  "Foreman Beaver": () => [
+    {
+      shortDescription: translate("description.woody.beaver.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+    {
+      shortDescription: translate("description.apprentice.beaver.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+    {
+      shortDescription: translate("description.foreman.beaver.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+  ],
+  "Wood Nymph Wendy": () => [
+    {
+      shortDescription: translate("description.wood.nymph.wendy.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+  ],
+  "Tiki Totem": () => [
+    {
+      shortDescription: translate("description.tiki.totem.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+  ],
+  "Tunnel Mole": () => [
+    {
+      shortDescription: translate("description.tunnel.mole.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  "Rocky the Mole": () => [
+    {
+      shortDescription: translate("description.rocky.mole.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  Nugget: () => [
+    {
+      shortDescription: translate("description.nugget.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+  ],
+  "Rock Golem": () => [
+    {
+      shortDescription: translate("description.rock.golem.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  "Iron Idol": () => [
+    {
+      shortDescription: translate("description.iron.idol.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  "Tin Turtle": () => [
+    {
+      shortDescription: translate("description.tin.turtle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+    {
+      shortDescription: translate("description.turtle.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  "Emerald Turtle": () => [
+    {
+      shortDescription: translate("description.emerald.turtle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.turtle.boost.aoe"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  "Crimson Carp": () => [
+    {
+      labelType: "success",
+      shortDescription: translate("description.crimson.carp.boost"),
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Crimstone.image,
+    },
+  ],
+  "Battle Fish": () => [
+    {
+      labelType: "success",
+      shortDescription: translate("description.battle.fish.boost"),
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Lemon Shark": () => [
+    {
+      labelType: "success",
+      shortDescription: translate("description.lemon.shark.boost"),
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Lemon.image,
+    },
+  ],
+  "Longhorn Cowfish": () => [
+    {
+      labelType: "success",
+      shortDescription: translate("description.longhorn.cowfish.boost"),
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Milk.image,
+    },
+  ],
+  "Crim Peckster": () => [
+    {
+      shortDescription: translate("description.crim.peckster.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Crimstone.image,
+    },
+  ],
+  "Knight Chicken": () => [
+    {
+      shortDescription: translate("description.knight.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Mushroom House": () => [
+    {
+      shortDescription: translate("description.mushroom.house.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wild_mushroom,
+    },
+  ],
+  "Queen Bee": () => [
+    {
+      shortDescription: translate("description.queen.bee.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Honey.image,
+    },
+  ],
+  "Humming Bird": () => [
+    {
+      shortDescription: translate("description.humming.bird.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS["Red Pansy"].image,
+    },
+  ],
+  Beehive: () => [
+    {
+      shortDescription: translate("description.beehive.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Pharaoh Chicken": () => [
+    {
+      shortDescription: translate("description.pharaoh.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Sand Shovel"].image,
+    },
+  ],
 
-    // Animals
-    "Fat Chicken": [
-      {
-        shortDescription: translate("description.fat.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
-      },
-    ],
-    "Rich Chicken": [
-      {
-        shortDescription: translate("description.rich.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-    ],
-    "Speed Chicken": [
-      {
-        shortDescription: translate("description.speed.chicken.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-    ],
-    "Ayam Cemani": [
-      {
-        shortDescription: translate("description.ayam.cemani.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-    ],
-    "El Pollo Veloz": [
-      {
-        shortDescription: translate("description.el.pollo.veloz.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-    ],
-    Rooster: [
-      {
-        shortDescription: translate("description.rooster.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Undead Rooster": [
-      {
-        shortDescription: translate("description.undead.rooster.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-    ],
-    "Chicken Coop": [
-      {
-        shortDescription: translate("description.chicken.coop.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-      {
-        shortDescription: translate("description.chicken.coop.boost.two"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.chicken.coop.boost.three"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Farm Dog": [
-      {
-        shortDescription: translate("description.farm.dog.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
-      },
-    ],
-    "Gold Egg": [
-      {
-        shortDescription: translate("description.gold.egg.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
-      },
-    ],
-    Bale: [
-      {
-        shortDescription: skills["Double Bale"]
-          ? translate("description.bale.eggBoost.boosted")
-          : translate("description.bale.eggBoost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.egg,
-      },
-      ...(skills["Bale Economy"]
-        ? ([
-            {
-              shortDescription: skills["Double Bale"]
-                ? translate("description.bale.milkBoost.boosted")
-                : translate("description.bale.milkBoost"),
-              labelType: "success",
-              boostTypeIcon: powerup,
-              boostedItemIcon: SUNNYSIDE.resource.milk,
-            },
-            {
-              shortDescription: skills["Double Bale"]
-                ? translate("description.bale.woolBoost.boosted")
-                : translate("description.bale.woolBoost"),
-              labelType: "success",
-              boostTypeIcon: powerup,
-              boostedItemIcon: SUNNYSIDE.resource.wool,
-            },
-          ] as BuffLabel[])
-        : []),
-    ],
+  // Fish
+  "Skill Shrimpy": () => [
+    {
+      shortDescription: translate("description.skill.shrimpy.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
+  Walrus: () => [
+    {
+      shortDescription: translate("description.walrus.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
+  Alba: () => [
+    {
+      shortDescription: translate("description.alba.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
 
-    // Resources
-    "Woody the Beaver": [
-      {
-        shortDescription: translate("description.woody.beaver.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-      {
-        shortDescription: translate("description.woody.beaver.warning"),
-        labelType: "danger",
-      },
-    ],
-    "Apprentice Beaver": [
-      {
-        shortDescription: translate("description.woody.beaver.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-      {
-        shortDescription: translate("description.apprentice.beaver.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-      {
-        shortDescription: translate("description.apprentice.beaver.warning"),
-        labelType: "danger",
-      },
-    ],
-    "Foreman Beaver": [
-      {
-        shortDescription: translate("description.woody.beaver.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-      {
-        shortDescription: translate("description.apprentice.beaver.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-      {
-        shortDescription: translate("description.foreman.beaver.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-    ],
-    "Wood Nymph Wendy": [
-      {
-        shortDescription: translate("description.wood.nymph.wendy.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-    ],
-    "Tiki Totem": [
-      {
-        shortDescription: translate("description.tiki.totem.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-    ],
-    "Tunnel Mole": [
-      {
-        shortDescription: translate("description.tunnel.mole.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    "Rocky the Mole": [
-      {
-        shortDescription: translate("description.rocky.mole.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    Nugget: [
-      {
-        shortDescription: translate("description.nugget.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-    ],
-    "Rock Golem": [
-      {
-        shortDescription: translate("description.rock.golem.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    "Iron Idol": [
-      {
-        shortDescription: translate("description.iron.idol.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    "Tin Turtle": [
-      {
-        shortDescription: translate("description.tin.turtle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-      {
-        shortDescription: translate("description.turtle.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    "Emerald Turtle": [
-      {
-        shortDescription: translate("description.emerald.turtle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.turtle.boost.aoe"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    "Crimson Carp": [
-      {
-        labelType: "success",
-        shortDescription: translate("description.crimson.carp.boost"),
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Crimstone.image,
-      },
-    ],
-    "Battle Fish": [
-      {
-        labelType: "success",
-        shortDescription: translate("description.battle.fish.boost"),
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Lemon Shark": [
-      {
-        labelType: "success",
-        shortDescription: translate("description.lemon.shark.boost"),
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Lemon.image,
-      },
-    ],
-    "Longhorn Cowfish": [
-      {
-        labelType: "success",
-        shortDescription: translate("description.longhorn.cowfish.boost"),
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Milk.image,
-      },
-    ],
-    "Crim Peckster": [
-      {
-        shortDescription: translate("description.crim.peckster.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Crimstone.image,
-      },
-    ],
-    "Knight Chicken": [
-      {
-        shortDescription: translate("description.knight.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Mushroom House": [
-      {
-        shortDescription: translate("description.mushroom.house.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wild_mushroom,
-      },
-    ],
-    "Queen Bee": [
-      {
-        shortDescription: translate("description.queen.bee.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Honey.image,
-      },
-    ],
-    "Humming Bird": [
-      {
-        shortDescription: translate("description.humming.bird.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: ITEM_DETAILS["Red Pansy"].image,
-      },
-    ],
-    Beehive: [
-      {
-        shortDescription: translate("description.beehive.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Pharaoh Chicken": [
-      {
-        shortDescription: translate("description.pharaoh.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Sand Shovel"].image,
-      },
-    ],
+  // Other
+  "Soil Krabby": () => [
+    {
+      shortDescription: translate("description.soil.krabby.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Knowledge Crab": () => [
+    {
+      shortDescription: translate("description.knowledge.crab.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS["Sprout Mix"].image,
+    },
+  ],
+  "Maneki Neko": () => [
+    {
+      shortDescription: translate("description.maneki.neko.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS["Pumpkin Soup"].image,
+    },
+  ],
+  "Treasure Map": () => [
+    {
+      shortDescription: translate("description.treasure.map.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Pirate Bounty"].image,
+    },
+  ],
+  "Heart of Davy Jones": () => [
+    {
+      shortDescription: translate("description.heart.of.davy.jones.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.tools.sand_shovel,
+    },
+  ],
+  "Genie Lamp": () => [
+    {
+      shortDescription: translate("description.genie.lamp.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Grain Grinder": () => [
+    {
+      shortDescription: translate("description.grain.grinder.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  Observatory: () => [
+    {
+      shortDescription: translate("description.observatory.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  Blossombeard: () => [
+    {
+      labelType: "vibrant",
+      shortDescription: translate("description.blossombeard.boost"),
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Desert Gnome": () => [
+    {
+      labelType: "vibrant",
+      shortDescription: translate("description.desertgnome.boost"),
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Christmas Tree": () => [
+    {
+      shortDescription: translate("description.christmas.festive.tree.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Festive Tree": () => [
+    {
+      shortDescription: translate("description.christmas.festive.tree.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Grinx's Hammer": () => [
+    {
+      shortDescription: translate("description.grinxs.hammer.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.tools.hammer,
+    },
+  ],
+  "Time Warp Totem": () => [
+    {
+      shortDescription: translate("description.time.warp.totem.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.time.warp.totem.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
 
-    // Fish
-    "Skill Shrimpy": [
-      {
-        shortDescription: translate("description.skill.shrimpy.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
-    Walrus: [
-      {
-        shortDescription: translate("description.walrus.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
-    Alba: [
-      {
-        shortDescription: translate("description.alba.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
+  // Marine Marvels with Boosts
+  "Radiant Ray": () => [
+    {
+      shortDescription: translate("description.radiant.ray.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  "Gilded Swordfish": () => [
+    {
+      shortDescription: translate("description.boost.gilded.swordfish"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+  ],
 
-    // Other
-    "Soil Krabby": [
-      {
-        shortDescription: translate("description.soil.krabby.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Knowledge Crab": [
-      {
-        shortDescription: translate("description.knowledge.crab.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: ITEM_DETAILS["Sprout Mix"].image,
-      },
-    ],
-    "Maneki Neko": [
-      {
-        shortDescription: translate("description.maneki.neko.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: ITEM_DETAILS["Pumpkin Soup"].image,
-      },
-    ],
-    "Treasure Map": [
-      {
-        shortDescription: translate("description.treasure.map.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Pirate Bounty"].image,
-      },
-    ],
-    "Heart of Davy Jones": [
-      {
-        shortDescription: translate("description.heart.of.davy.jones.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.tools.sand_shovel,
-      },
-    ],
-    "Genie Lamp": [
-      {
-        shortDescription: translate("description.genie.lamp.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Grain Grinder": [
-      {
-        shortDescription: translate("description.grain.grinder.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    Observatory: [
-      {
-        shortDescription: translate("description.observatory.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    Blossombeard: [
-      {
-        labelType: "vibrant",
-        shortDescription: translate("description.blossombeard.boost"),
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Desert Gnome": [
-      {
-        labelType: "vibrant",
-        shortDescription: translate("description.desertgnome.boost"),
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Christmas Tree": [
-      {
-        shortDescription: translate("description.christmas.festive.tree.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Festive Tree": [
-      {
-        shortDescription: translate("description.christmas.festive.tree.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Grinx's Hammer": [
-      {
-        shortDescription: translate("description.grinxs.hammer.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.tools.hammer,
-      },
-    ],
-    "Time Warp Totem": [
-      {
-        shortDescription: translate("description.time.warp.totem.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.time.warp.totem.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
+  "Flower Fox": () => [
+    {
+      shortDescription: translate("description.flower.fox.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS.Honey.image,
+    },
+  ],
 
-    // Marine Marvels with Boosts
-    "Radiant Ray": [
-      {
-        shortDescription: translate("description.radiant.ray.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    "Gilded Swordfish": [
-      {
-        shortDescription: translate("description.boost.gilded.swordfish"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-    ],
+  "Hungry Hare": () => [
+    {
+      shortDescription: translate("description.hungryHare.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Fermented Carrots"].image,
+    },
+  ],
 
-    "Flower Fox": [
-      {
-        shortDescription: translate("description.flower.fox.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: ITEM_DETAILS.Honey.image,
-      },
-    ],
+  // Faction Shop
+  "Gourmet Hourglass": () => [
+    {
+      shortDescription: translate("description.gourmet.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.gourmet.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Harvest Hourglass": () => [
+    {
+      shortDescription: translate("description.harvest.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.harvest.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Timber Hourglass": () => [
+    {
+      shortDescription: translate("description.timber.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.timber.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Ore Hourglass": () => [
+    {
+      shortDescription: translate("description.ore.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate("description.ore.hourglass.boost.effectTime"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Orchard Hourglass": () => [
+    {
+      shortDescription: translate("description.orchard.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.orchard.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Fisher's Hourglass": () => [
+    {
+      shortDescription: translate("description.fishers.hourglass.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate(
+        "description.fishers.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Blossom Hourglass": () => [
+    {
+      shortDescription: translate("description.blossom.hourglass.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate(
+        "description.blossom.hourglass.boost.effectTime",
+      ),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Desert Rose": () => [
+    {
+      shortDescription: translate("description.desert.rose.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.icons.plant,
+    },
+  ],
+  Chicory: () => [
+    {
+      shortDescription: translate("description.chicory.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.icons.plant,
+    },
+  ],
+  "Pharaoh Gnome": () => [
+    {
+      shortDescription: translate("description.pharaoh.gnome.boost"),
+      labelType: "success",
+      boostedItemIcon: powerup,
+    },
+  ],
+  "Lemon Tea Bath": () => [
+    {
+      shortDescription: translate("description.lemon.tea.bath.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Lemon.image,
+    },
+  ],
+  "Tomato Clown": () => [
+    {
+      shortDescription: translate("description.tomato.clown.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Tomato.image,
+    },
+  ],
+  Cannonball: () => [
+    {
+      shortDescription: translate("description.cannonball.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Tomato.image,
+    },
+  ],
+  "Tomato Bombard": () => [
+    {
+      shortDescription: translate("description.tomato.bombard.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Tomato.image,
+    },
+  ],
+  Camel: () => [
+    {
+      shortDescription: translate("description.camel.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Sand.image,
+    },
+    {
+      shortDescription: translate("description.camel.boost.two"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.ui.coins,
+    },
+  ],
+  "Reveling Lemon": () => [
+    {
+      shortDescription: translate("description.reveling.lemon.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Lemon.image,
+    },
+  ],
+  "Lemon Frog": () => [
+    {
+      shortDescription: translate("description.lemon.frog.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Lemon.image,
+    },
+  ],
+  "Stone Beetle": () => [
+    {
+      shortDescription: translate("description.stone.beetle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  "Iron Beetle": () => [
+    {
+      shortDescription: translate("description.iron.beetle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  "Gold Beetle": () => [
+    {
+      shortDescription: translate("description.gold.beetle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+  ],
+  "Fairy Circle": () => [
+    {
+      shortDescription: translate("description.fairy.circle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wild_mushroom,
+    },
+  ],
+  Squirrel: () => [
+    {
+      shortDescription: translate("description.squirrel.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.wood,
+    },
+  ],
+  Butterfly: () => [
+    {
+      shortDescription: translate("description.butterfly.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  Macaw: ({ skills }) => [
+    {
+      shortDescription: skills["Loyal Macaw"]
+        ? translate("description.macaw.boosted.boost")
+        : translate("description.macaw.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  // Bull Run
+  "Sheaf of Plenty": () => [
+    {
+      shortDescription: translate("description.sheafOfPlenty.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Barley.crop,
+    },
+  ],
+  "Moo-ver": () => [
+    {
+      shortDescription: translate("description.mooVer.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.leather,
+    },
+  ],
+  "Swiss Whiskers": () => [
+    {
+      shortDescription: translate("description.swissWhiskers.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: chefHat,
+    },
+  ],
+  Cluckulator: () => [
+    {
+      shortDescription: translate("description.cluckulator.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
+    },
+  ],
+  "Alien Chicken": () => [
+    {
+      shortDescription: translate("description.alien.chicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.feather,
+    },
+  ],
+  "Toxic Tuft": () => [
+    {
+      shortDescription: translate("description.toxic.tuft.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.merino_wool,
+    },
+  ],
+  Mootant: () => [
+    {
+      shortDescription: translate("description.mootant.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.leather,
+    },
+  ],
+  "King of Bears": () => [
+    {
+      shortDescription: translate("description.kingOfBears.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Honey.image,
+    },
+  ],
+  "Super Totem": () => [
+    {
+      shortDescription: translate("description.superTotem.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+    {
+      shortDescription: translate("description.superTotem.boost.effectTime"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Golden Cow": () => [
+    {
+      shortDescription: translate("description.golden.cow.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
+    },
+  ],
+  "Volcano Gnome": () => [
+    {
+      shortDescription: translate("description.volcanoGnome.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.resource.stone,
+    },
+  ],
+  Igloo: () => [
+    ...(hasSeasonEnded("Winds of Change")
+      ? []
+      : ([
+          {
+            shortDescription: translate("description.bonusTimeshard.boost"),
+            labelType: "success",
+            boostTypeIcon: powerup,
+            boostedItemIcon: ITEM_DETAILS.Timeshard.image,
+          },
+        ] as BuffLabel[])),
+  ],
+  Hammock: () => [
+    ...(hasSeasonEnded("Winds of Change")
+      ? []
+      : ([
+          {
+            shortDescription: translate("description.bonusTimeshard.boost"),
+            labelType: "success",
+            boostTypeIcon: powerup,
+            boostedItemIcon: ITEM_DETAILS.Timeshard.image,
+          },
+        ] as BuffLabel[])),
+  ],
 
-    "Hungry Hare": [
-      {
-        shortDescription: translate("description.hungryHare.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Fermented Carrots"].image,
-      },
-    ],
+  Mammoth: () => [
+    {
+      shortDescription: translate("description.mammoth.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
+    },
+  ],
+  "Frozen Sheep": () => [
+    {
+      shortDescription: translate("description.frozen.sheep.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  Jellyfish: () => [
+    {
+      shortDescription: translate("description.jellyfish.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
+  "Frozen Cow": () => [
+    {
+      shortDescription: translate("description.frozen.cow.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Summer Chicken": () => [
+    {
+      shortDescription: translate("description.summer.chicken.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Golden Sheep": () => [
+    {
+      shortDescription: translate("description.goldenSheep.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
+    },
+  ],
+  "Barn Blueprint": () => [
+    {
+      shortDescription: translate("description.barnBlueprint.boost1"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.barnBlueprint.boost2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Giant Yam": () => [
+    {
+      shortDescription: translate("description.giantYam.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Yam.image,
+    },
+  ],
+  "Giant Zucchini": () => [
+    {
+      shortDescription: translate("description.giantZucchini.boost"),
+      labelType: "success",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Zucchini.image,
+    },
+  ],
+  "Giant Kale": () => [
+    {
+      shortDescription: translate("description.giantKale.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Kale.image,
+    },
+  ],
+  "Obsidian Turtle": () => [
+    {
+      shortDescription: translate("description.obsidianTurtle.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Obsidian Turtle"].image,
+    },
+  ],
+  Quarry: () => [
+    {
+      shortDescription: translate("description.quarry.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+      boostedItemIcon: ITEM_DETAILS["Stone"].image,
+    },
+  ],
+  "Winter Guardian": () => [
+    {
+      shortDescription: translate("description.winterGuardian.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+    {
+      shortDescription: translate("description.winterGuardian.boost2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Autumn Guardian": () => [
+    {
+      shortDescription: translate("description.autumnGuardian.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+    {
+      shortDescription: translate("description.autumnGuardian.boost2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Spring Guardian": () => [
+    {
+      shortDescription: translate("description.springGuardian.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+    {
+      shortDescription: translate("description.springGuardian.boost2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Summer Guardian": () => [
+    {
+      shortDescription: translate("description.summerGuardian.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+    {
+      shortDescription: translate("description.summerGuardian.boost2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
 
-    // Faction Shop
-    "Gourmet Hourglass": [
-      {
-        shortDescription: translate("description.gourmet.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.gourmet.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Harvest Hourglass": [
-      {
-        shortDescription: translate("description.harvest.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.harvest.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Timber Hourglass": [
-      {
-        shortDescription: translate("description.timber.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.timber.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Ore Hourglass": [
-      {
-        shortDescription: translate("description.ore.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.ore.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Orchard Hourglass": [
-      {
-        shortDescription: translate("description.orchard.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.orchard.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Fisher's Hourglass": [
-      {
-        shortDescription: translate("description.fishers.hourglass.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate(
-          "description.fishers.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Blossom Hourglass": [
-      {
-        shortDescription: translate("description.blossom.hourglass.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate(
-          "description.blossom.hourglass.boost.effectTime",
-        ),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Desert Rose": [
-      {
-        shortDescription: translate("description.desert.rose.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.icons.plant,
-      },
-    ],
-    Chicory: [
-      {
-        shortDescription: translate("description.chicory.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.icons.plant,
-      },
-    ],
-    "Pharaoh Gnome": [
-      {
-        shortDescription: translate("description.pharaoh.gnome.boost"),
-        labelType: "success",
-        boostedItemIcon: powerup,
-      },
-    ],
-    "Lemon Tea Bath": [
-      {
-        shortDescription: translate("description.lemon.tea.bath.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Lemon.image,
-      },
-    ],
-    "Tomato Clown": [
-      {
-        shortDescription: translate("description.tomato.clown.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Tomato.image,
-      },
-    ],
-    Cannonball: [
-      {
-        shortDescription: translate("description.cannonball.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Tomato.image,
-      },
-    ],
-    "Tomato Bombard": [
-      {
-        shortDescription: translate("description.tomato.bombard.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Tomato.image,
-      },
-    ],
-    Camel: [
-      {
-        shortDescription: translate("description.camel.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Sand.image,
-      },
-      {
-        shortDescription: translate("description.camel.boost.two"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.ui.coins,
-      },
-    ],
-    "Reveling Lemon": [
-      {
-        shortDescription: translate("description.reveling.lemon.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Lemon.image,
-      },
-    ],
-    "Lemon Frog": [
-      {
-        shortDescription: translate("description.lemon.frog.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Lemon.image,
-      },
-    ],
-    "Stone Beetle": [
-      {
-        shortDescription: translate("description.stone.beetle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    "Iron Beetle": [
-      {
-        shortDescription: translate("description.iron.beetle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    "Gold Beetle": [
-      {
-        shortDescription: translate("description.gold.beetle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-    ],
-    "Fairy Circle": [
-      {
-        shortDescription: translate("description.fairy.circle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wild_mushroom,
-      },
-    ],
-    Squirrel: [
-      {
-        shortDescription: translate("description.squirrel.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.wood,
-      },
-    ],
-    Butterfly: [
-      {
-        shortDescription: translate("description.butterfly.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    Macaw: [
-      {
-        shortDescription: skills["Loyal Macaw"]
-          ? translate("description.macaw.boosted.boost")
-          : translate("description.macaw.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    // Bull Run
-    "Sheaf of Plenty": [
-      {
-        shortDescription: translate("description.sheafOfPlenty.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Barley.crop,
-      },
-    ],
-    "Moo-ver": [
-      {
-        shortDescription: translate("description.mooVer.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.leather,
-      },
-    ],
-    "Swiss Whiskers": [
-      {
-        shortDescription: translate("description.swissWhiskers.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: chefHat,
-      },
-    ],
-    Cluckulator: [
-      {
-        shortDescription: translate("description.cluckulator.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
-      },
-    ],
-    "Alien Chicken": [
-      {
-        shortDescription: translate("description.alien.chicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.feather,
-      },
-    ],
-    "Toxic Tuft": [
-      {
-        shortDescription: translate("description.toxic.tuft.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.merino_wool,
-      },
-    ],
-    Mootant: [
-      {
-        shortDescription: translate("description.mootant.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.leather,
-      },
-    ],
-    "King of Bears": [
-      {
-        shortDescription: translate("description.kingOfBears.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Honey.image,
-      },
-    ],
-    "Super Totem": [
-      {
-        shortDescription: translate("description.superTotem.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-      {
-        shortDescription: translate("description.superTotem.boost.effectTime"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Golden Cow": [
-      {
-        shortDescription: translate("description.golden.cow.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
-      },
-    ],
-    "Volcano Gnome": [
-      {
-        shortDescription: translate("description.volcanoGnome.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.resource.stone,
-      },
-    ],
-    Igloo: [
-      ...(hasSeasonEnded("Winds of Change")
-        ? []
-        : ([
-            {
-              shortDescription: translate("description.bonusTimeshard.boost"),
-              labelType: "success",
-              boostTypeIcon: powerup,
-              boostedItemIcon: ITEM_DETAILS.Timeshard.image,
-            },
-          ] as BuffLabel[])),
-    ],
-    Hammock: [
-      ...(hasSeasonEnded("Winds of Change")
-        ? []
-        : ([
-            {
-              shortDescription: translate("description.bonusTimeshard.boost"),
-              labelType: "success",
-              boostTypeIcon: powerup,
-              boostedItemIcon: ITEM_DETAILS.Timeshard.image,
-            },
-          ] as BuffLabel[])),
-    ],
+  ...Object.fromEntries(
+    getObjectEntries(CHAPTER_TICKET_BOOST_ITEMS)
+      .filter(([chapter]) => getCurrentSeason() === chapter)
+      .flatMap(([chapter, items]) => {
+        const ticket = getSeasonalTicket(new Date(SEASONS[chapter].startDate));
+        const translationKey =
+          `description.bonus${ticket.replace(/\s+/g, "")}.boost` as TranslationKeys;
 
-    Mammoth: [
-      {
-        shortDescription: translate("description.mammoth.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
-      },
-    ],
-    "Frozen Sheep": [
-      {
-        shortDescription: translate("description.frozen.sheep.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    Jellyfish: [
-      {
-        shortDescription: translate("description.jellyfish.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
-    "Frozen Cow": [
-      {
-        shortDescription: translate("description.frozen.cow.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Summer Chicken": [
-      {
-        shortDescription: translate("description.summer.chicken.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Golden Sheep": [
-      {
-        shortDescription: translate("description.goldenSheep.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: SUNNYSIDE.animalFoods.kernel_blend,
-      },
-    ],
-    "Barn Blueprint": [
-      {
-        shortDescription: translate("description.barnBlueprint.boost1"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.barnBlueprint.boost2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Giant Yam": [
-      {
-        shortDescription: translate("description.giantYam.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Yam.image,
-      },
-    ],
-    "Giant Zucchini": [
-      {
-        shortDescription: translate("description.giantZucchini.boost"),
-        labelType: "success",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Zucchini.image,
-      },
-    ],
-    "Giant Kale": [
-      {
-        shortDescription: translate("description.giantKale.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Kale.image,
-      },
-    ],
-    "Obsidian Turtle": [
-      {
-        shortDescription: translate("description.obsidianTurtle.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Obsidian Turtle"].image,
-      },
-    ],
-    Quarry: [
-      {
-        shortDescription: translate("description.quarry.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-        boostedItemIcon: ITEM_DETAILS["Stone"].image,
-      },
-    ],
-    "Winter Guardian": [
-      {
-        shortDescription: translate("description.winterGuardian.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-      {
-        shortDescription: translate("description.winterGuardian.boost2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Autumn Guardian": [
-      {
-        shortDescription: translate("description.autumnGuardian.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-      {
-        shortDescription: translate("description.autumnGuardian.boost2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Spring Guardian": [
-      {
-        shortDescription: translate("description.springGuardian.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-      {
-        shortDescription: translate("description.springGuardian.boost2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Summer Guardian": [
-      {
-        shortDescription: translate("description.summerGuardian.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-      {
-        shortDescription: translate("description.summerGuardian.boost2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-
-    ...Object.fromEntries(
-      getObjectEntries(CHAPTER_TICKET_BOOST_ITEMS)
-        .filter(([chapter]) => getCurrentSeason() === chapter)
-        .flatMap(([chapter, items]) => {
-          const ticket = getSeasonalTicket(
-            new Date(SEASONS[chapter].startDate),
-          );
-          const translationKey =
-            `description.bonus${ticket.replace(/\s+/g, "")}.boost` as TranslationKeys;
-
-          return Object.values(items)
-            .filter(isCollectible)
-            .map((item) => [
-              item,
-              [
-                {
-                  shortDescription: translate(translationKey),
-                  labelType: "success",
-                  boostTypeIcon: powerup,
-                  boostedItemIcon: ITEM_DETAILS[ticket].image,
-                },
-              ],
-            ]);
-        }),
-    ),
-    "Nurse Sheep": [
-      {
-        shortDescription: translate("description.nurseSheep.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
-      },
-    ],
-    "Dr Cow": [
-      {
-        shortDescription: translate("description.drCow.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
-      },
-    ],
-    "Pink Dolphin": [
-      {
-        shortDescription: translate("description.pinkDolphin.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
-    Poseidon: [
-      {
-        shortDescription: translate("description.poseidon.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.icons.fish,
-      },
-    ],
-    Toolshed: [
-      {
-        shortDescription: translate("description.toolshed.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    Warehouse: [
-      {
-        shortDescription: translate("description.warehouse.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Groovy Gramophone": [
-      {
-        shortDescription: translate("description.groovy.gramophone.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,
-      },
-    ],
-    "Giant Onion": [
-      {
-        shortDescription: translate("description.giantOnion.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Onion"].image,
-      },
-    ],
-    "Giant Turnip": [
-      {
-        shortDescription: translate("description.giantTurnip.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Turnip"].image,
-      },
-    ],
-    "Baby Cow": [
-      {
-        shortDescription: translate("description.babyCow.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
-      },
-    ],
-    "Janitor Chicken": [
-      {
-        shortDescription: translate("description.janitorChicken.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: SUNNYSIDE.animals.chickenAsleep,
-      },
-    ],
-    "Reelmaster's Chair": [
-      {
-        shortDescription: translate("description.reelmastersChair.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Rod"].image,
-      },
-    ],
-    "Fruit Tune Box": [
-      {
-        shortDescription: translate("description.fruitTuneBox.boost"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Fruit Patch"].image,
-      },
-    ],
-    "Double Bed": [
-      {
-        shortDescription: translate("description.doubleBed.boost"),
-        labelType: "vibrant",
-        boostTypeIcon: lightning,
-      },
-    ],
-    "Giant Artichoke": [
-      {
-        shortDescription: translate("description.giantArtichoke.boost"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Artichoke"].image,
-      },
-    ],
-    "Farmer's Monument": [
-      {
-        shortDescription: translate("description.monument.buff"),
-        labelType: "success",
-        boostTypeIcon: helpIcon,
-      },
-    ],
-    "Woodcutter's Monument": [
-      {
-        shortDescription: translate("description.monument.buff"),
-        labelType: "success",
-        boostTypeIcon: helpIcon,
-      },
-    ],
-    "Miner's Monument": [
-      {
-        shortDescription: translate("description.monument.buff"),
-        labelType: "success",
-        boostTypeIcon: helpIcon,
-      },
-    ],
-    "Teamwork Monument": [
-      {
-        shortDescription: translate("description.monument.buff"),
-        labelType: "success",
-        boostTypeIcon: helpIcon,
-      },
-    ],
-    "Fox Shrine": [
-      {
-        shortDescription: translate("description.foxShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Crafting Box"].image,
-      },
-    ],
-    "Boar Shrine": [
-      {
-        shortDescription: translate("description.boarShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: chefHat,
-      },
-    ],
-    "Hound Shrine": [
-      {
-        shortDescription: translate("description.houndShrine.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-    ],
-    "Stag Shrine": [
-      {
-        shortDescription: translate("description.stagShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Oil.image,
-      },
-    ],
-    "Sparrow Shrine": [
-      {
-        shortDescription: translate("description.sparrowShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Toucan Shrine": [
-      {
-        shortDescription: translate("description.toucanShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-      },
-    ],
-    "Collie Shrine": [
-      {
-        shortDescription: translate("description.collieShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
-      },
-      {
-        shortDescription: translate("description.collieShrine.buff.2"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
-      },
-    ],
-    "Badger Shrine": [
-      {
-        shortDescription: translate("description.badgerShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Tree.image,
-      },
-      {
-        shortDescription: translate("description.badgerShrine.buff.2"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Stone.image,
-      },
-    ],
-    "Legendary Shrine": [
-      {
-        shortDescription: translate("description.legendaryShrine.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-      },
-      {
-        shortDescription: translate("description.legendaryShrine.buff.2"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS["Fruit Patch"].image,
-      },
-      {
-        shortDescription: translate("description.legendaryShrine.buff.3"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Wood.image,
-      },
-      {
-        shortDescription: translate("description.legendaryShrine.buff.4"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Stone.image,
-      },
-    ],
-    "Obsidian Shrine": [
-      {
-        shortDescription: translate("description.obsidianShrine.buff"),
-        labelType: "vibrant",
-        boostTypeIcon: SUNNYSIDE.icons.lightning,
-      },
-    ],
-    "Mole Shrine": [
-      {
-        shortDescription: translate("description.moleShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-      {
-        shortDescription: translate("description.moleShrine.buff.2"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-      {
-        shortDescription: translate("description.moleShrine.buff.3"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Crimstone.image,
-      },
-    ],
-    "Bear Shrine": [
-      {
-        shortDescription: translate("description.bearShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS.Honey.image,
-      },
-    ],
-    "Tortoise Shrine": [
-      {
-        shortDescription: translate("description.tortoiseShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Greenhouse"].image,
-      },
-      {
-        shortDescription: translate("description.tortoiseShrine.buff.2"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,
-      },
-    ],
-    "Moth Shrine": [
-      {
-        shortDescription: translate("description.mothShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: ITEM_DETAILS["Red Pansy"].image,
-      },
-    ],
-    "Bantam Shrine": [
-      {
-        shortDescription: translate("description.bantamShrine.buff"),
-        labelType: "info",
-        boostTypeIcon: SUNNYSIDE.icons.stopwatch,
-        boostedItemIcon: SUNNYSIDE.animals.chickenAsleep,
-      },
-    ],
-    "Trading Shrine": [
-      {
-        shortDescription: translate("description.tradingShrine.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: tradeIcon,
-      },
-    ],
-    "Ancient Tree": [
-      {
-        shortDescription: translate("description.ancientTree.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Wood.image,
-      },
-    ],
-    "Sacred Tree": [
-      {
-        shortDescription: translate("description.sacredTree.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Wood.image,
-      },
-    ],
-    "Fused Stone Rock": [
-      {
-        shortDescription: translate("description.fusedStoneRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Stone.image,
-      },
-    ],
-    "Reinforced Stone Rock": [
-      {
-        shortDescription: translate("description.reinforcedStoneRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Stone.image,
-      },
-    ],
-    "Refined Iron Rock": [
-      {
-        shortDescription: translate("description.refinedIronRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    "Tempered Iron Rock": [
-      {
-        shortDescription: translate("description.temperedIronRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Iron.image,
-      },
-    ],
-    "Pure Gold Rock": [
-      {
-        shortDescription: translate("description.pureGoldRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-    ],
-    "Prime Gold Rock": [
-      {
-        shortDescription: translate("description.primeGoldRock.buff"),
-        labelType: "success",
-        boostTypeIcon: powerup,
-        boostedItemIcon: ITEM_DETAILS.Gold.image,
-      },
-    ],
-  };
-
-  return buffLabels;
-}
+        return Object.values(items)
+          .filter(isCollectible)
+          .map((item) => [
+            item,
+            [
+              {
+                shortDescription: translate(translationKey),
+                labelType: "success",
+                boostTypeIcon: powerup,
+                boostedItemIcon: ITEM_DETAILS[ticket].image,
+              },
+            ],
+          ]);
+      }),
+  ),
+  "Nurse Sheep": () => [
+    {
+      shortDescription: translate("description.nurseSheep.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
+    },
+  ],
+  "Dr Cow": () => [
+    {
+      shortDescription: translate("description.drCow.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
+    },
+  ],
+  "Pink Dolphin": () => [
+    {
+      shortDescription: translate("description.pinkDolphin.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
+  Poseidon: () => [
+    {
+      shortDescription: translate("description.poseidon.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.icons.fish,
+    },
+  ],
+  Toolshed: () => [
+    {
+      shortDescription: translate("description.toolshed.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  Warehouse: () => [
+    {
+      shortDescription: translate("description.warehouse.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Groovy Gramophone": () => [
+    {
+      shortDescription: translate("description.groovy.gramophone.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,
+    },
+  ],
+  "Giant Onion": () => [
+    {
+      shortDescription: translate("description.giantOnion.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Onion"].image,
+    },
+  ],
+  "Giant Turnip": () => [
+    {
+      shortDescription: translate("description.giantTurnip.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Turnip"].image,
+    },
+  ],
+  "Baby Cow": () => [
+    {
+      shortDescription: translate("description.babyCow.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
+    },
+  ],
+  "Janitor Chicken": () => [
+    {
+      shortDescription: translate("description.janitorChicken.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: SUNNYSIDE.animals.chickenAsleep,
+    },
+  ],
+  "Reelmaster's Chair": () => [
+    {
+      shortDescription: translate("description.reelmastersChair.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Rod"].image,
+    },
+  ],
+  "Fruit Tune Box": () => [
+    {
+      shortDescription: translate("description.fruitTuneBox.boost"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Fruit Patch"].image,
+    },
+  ],
+  "Double Bed": () => [
+    {
+      shortDescription: translate("description.doubleBed.boost"),
+      labelType: "vibrant",
+      boostTypeIcon: lightning,
+    },
+  ],
+  "Giant Artichoke": () => [
+    {
+      shortDescription: translate("description.giantArtichoke.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Artichoke"].image,
+    },
+  ],
+  "Farmer's Monument": () => [
+    {
+      shortDescription: translate("description.monument.buff"),
+      labelType: "success",
+      boostTypeIcon: helpIcon,
+    },
+  ],
+  "Woodcutter's Monument": () => [
+    {
+      shortDescription: translate("description.monument.buff"),
+      labelType: "success",
+      boostTypeIcon: helpIcon,
+    },
+  ],
+  "Miner's Monument": () => [
+    {
+      shortDescription: translate("description.monument.buff"),
+      labelType: "success",
+      boostTypeIcon: helpIcon,
+    },
+  ],
+  "Teamwork Monument": () => [
+    {
+      shortDescription: translate("description.monument.buff"),
+      labelType: "success",
+      boostTypeIcon: helpIcon,
+    },
+  ],
+  "Fox Shrine": () => [
+    {
+      shortDescription: translate("description.foxShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Crafting Box"].image,
+    },
+  ],
+  "Boar Shrine": () => [
+    {
+      shortDescription: translate("description.boarShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: chefHat,
+    },
+  ],
+  "Hound Shrine": () => [
+    {
+      shortDescription: translate("description.houndShrine.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
+  "Stag Shrine": () => [
+    {
+      shortDescription: translate("description.stagShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Oil.image,
+    },
+  ],
+  "Sparrow Shrine": () => [
+    {
+      shortDescription: translate("description.sparrowShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Toucan Shrine": () => [
+    {
+      shortDescription: translate("description.toucanShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+    },
+  ],
+  "Collie Shrine": () => [
+    {
+      shortDescription: translate("description.collieShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.cowSleeping,
+    },
+    {
+      shortDescription: translate("description.collieShrine.buff.2"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.sheepSleeping,
+    },
+  ],
+  "Badger Shrine": () => [
+    {
+      shortDescription: translate("description.badgerShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Tree.image,
+    },
+    {
+      shortDescription: translate("description.badgerShrine.buff.2"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Stone.image,
+    },
+  ],
+  "Legendary Shrine": () => [
+    {
+      shortDescription: translate("description.legendaryShrine.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+    {
+      shortDescription: translate("description.legendaryShrine.buff.2"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS["Fruit Patch"].image,
+    },
+    {
+      shortDescription: translate("description.legendaryShrine.buff.3"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Wood.image,
+    },
+    {
+      shortDescription: translate("description.legendaryShrine.buff.4"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Stone.image,
+    },
+  ],
+  "Obsidian Shrine": () => [
+    {
+      shortDescription: translate("description.obsidianShrine.buff"),
+      labelType: "vibrant",
+      boostTypeIcon: SUNNYSIDE.icons.lightning,
+    },
+  ],
+  "Mole Shrine": () => [
+    {
+      shortDescription: translate("description.moleShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+    {
+      shortDescription: translate("description.moleShrine.buff.2"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+    {
+      shortDescription: translate("description.moleShrine.buff.3"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Crimstone.image,
+    },
+  ],
+  "Bear Shrine": () => [
+    {
+      shortDescription: translate("description.bearShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS.Honey.image,
+    },
+  ],
+  "Tortoise Shrine": () => [
+    {
+      shortDescription: translate("description.tortoiseShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Greenhouse"].image,
+    },
+    {
+      shortDescription: translate("description.tortoiseShrine.buff.2"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Crop Machine"].image,
+    },
+  ],
+  "Moth Shrine": () => [
+    {
+      shortDescription: translate("description.mothShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: ITEM_DETAILS["Red Pansy"].image,
+    },
+  ],
+  "Bantam Shrine": () => [
+    {
+      shortDescription: translate("description.bantamShrine.buff"),
+      labelType: "info",
+      boostTypeIcon: SUNNYSIDE.icons.stopwatch,
+      boostedItemIcon: SUNNYSIDE.animals.chickenAsleep,
+    },
+  ],
+  "Trading Shrine": () => [
+    {
+      shortDescription: translate("description.tradingShrine.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: tradeIcon,
+    },
+  ],
+  "Ancient Tree": () => [
+    {
+      shortDescription: translate("description.ancientTree.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Wood.image,
+    },
+  ],
+  "Sacred Tree": () => [
+    {
+      shortDescription: translate("description.sacredTree.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Wood.image,
+    },
+  ],
+  "Fused Stone Rock": () => [
+    {
+      shortDescription: translate("description.fusedStoneRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Stone.image,
+    },
+  ],
+  "Reinforced Stone Rock": () => [
+    {
+      shortDescription: translate("description.reinforcedStoneRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Stone.image,
+    },
+  ],
+  "Refined Iron Rock": () => [
+    {
+      shortDescription: translate("description.refinedIronRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  "Tempered Iron Rock": () => [
+    {
+      shortDescription: translate("description.temperedIronRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Iron.image,
+    },
+  ],
+  "Pure Gold Rock": () => [
+    {
+      shortDescription: translate("description.pureGoldRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+  ],
+  "Prime Gold Rock": () => [
+    {
+      shortDescription: translate("description.primeGoldRock.buff"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: ITEM_DETAILS.Gold.image,
+    },
+  ],
+};

--- a/src/features/game/types/getItemBuffs.ts
+++ b/src/features/game/types/getItemBuffs.ts
@@ -29,10 +29,10 @@ export function getItemBuffs({
   }
 
   if (collection === "collectibles") {
-    const buff = COLLECTIBLE_BUFF_LABELS({
+    const buff = COLLECTIBLE_BUFF_LABELS[item as InventoryItemName]?.({
       skills: state.bumpkin.skills,
       collectibles: state.collectibles,
-    })[item as InventoryItemName];
+    });
 
     return buff ? buff : [];
   }

--- a/src/features/helios/components/blacksmith/component/IslandBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/IslandBlacksmithItems.tsx
@@ -215,12 +215,10 @@ export const IslandBlacksmithItems: React.FC = () => {
             from: selectedItem?.from,
             to: selectedItem?.to,
           }}
-          boost={
-            COLLECTIBLE_BUFF_LABELS({
-              skills: state.bumpkin.skills,
-              collectibles: state.collectibles,
-            })[selectedName]
-          }
+          boost={COLLECTIBLE_BUFF_LABELS[selectedName]?.({
+            skills: state.bumpkin.skills,
+            collectibles: state.collectibles,
+          })}
           requirements={{
             resources: selectedItem?.ingredients ?? {},
             coins: selectedItem?.coins ?? 0,

--- a/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/RecipesTab.tsx
@@ -321,10 +321,12 @@ export const RecipesTab: React.FC<Props> = ({
                       <div className="flex mt-1">
                         <SquareIcon
                           icon={
-                            COLLECTIBLE_BUFF_LABELS({
+                            COLLECTIBLE_BUFF_LABELS[
+                              recipe.name as InventoryItemName
+                            ]?.({
                               skills: state.bumpkin.skills,
                               collectibles: state.collectibles,
-                            })[recipe.name as InventoryItemName]?.length
+                            })?.length
                               ? lightningIcon
                               : SUNNYSIDE.icons.expression_confused
                           }

--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -42,10 +42,10 @@ const ProjectModal: React.FC<{
   const { t } = useAppTranslation();
 
   const isProjectComplete = cheers >= REQUIRED_CHEERS[project];
-  const boostLabel = COLLECTIBLE_BUFF_LABELS({
+  const boostLabel = COLLECTIBLE_BUFF_LABELS[project]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[project];
+  });
 
   return (
     <Panel>

--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -543,10 +543,10 @@ const BoostReelItems: (
   Record<BumpkinItem | CollectibleName | BumpkinRevampSkillName, BoostReelItem>
 > = (state) => ({
   "Reelmaster's Chair": {
-    buff: COLLECTIBLE_BUFF_LABELS({
+    buff: COLLECTIBLE_BUFF_LABELS["Reelmaster's Chair"]?.({
       skills: state.bumpkin.skills,
       collectibles: state.collectibles,
-    })["Reelmaster's Chair"] as BuffLabel[],
+    }) as BuffLabel[],
     location: hasSeasonEnded("Better Together")
       ? "Marketplace"
       : "Stella's Megastore",

--- a/src/features/island/flowers/FlowerBed.tsx
+++ b/src/features/island/flowers/FlowerBed.tsx
@@ -290,10 +290,10 @@ export const FlowerBed: React.FC<Props> = ({ id }) => {
                     {t("reward")}
                   </Label>
                   {(reward.items ?? []).map((item) => {
-                    const boost = COLLECTIBLE_BUFF_LABELS({
+                    const boost = COLLECTIBLE_BUFF_LABELS[item.name]?.({
                       skills: state.bumpkin.skills,
                       collectibles: state.collectibles,
-                    })[item.name];
+                    });
 
                     return (
                       <>

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -179,12 +179,10 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
           details={{
             item: selectedName,
           }}
-          boost={
-            COLLECTIBLE_BUFF_LABELS({
-              skills: state.bumpkin.skills,
-              collectibles: state.collectibles,
-            })[selectedName]
-          }
+          boost={COLLECTIBLE_BUFF_LABELS[selectedName]?.({
+            skills: state.bumpkin.skills,
+            collectibles: state.collectibles,
+          })}
           requirements={{
             coins,
             resources: buildingBlueprints[

--- a/src/features/island/hud/components/codex/components/Detail.tsx
+++ b/src/features/island/hud/components/codex/components/Detail.tsx
@@ -58,10 +58,10 @@ export const Detail: React.FC<Props> = ({
     image.src = ITEM_DETAILS[name].image;
   }, []);
 
-  const buff = COLLECTIBLE_BUFF_LABELS({
+  const buff = COLLECTIBLE_BUFF_LABELS[name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[name];
+  });
 
   const isChapterFish = name in CHAPTER_FISH;
 

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -370,16 +370,12 @@ export const Chest: React.FC<Props> = ({
   const boosts = getKeys(collectibles)
     .filter(
       (name) =>
-        name in
-          COLLECTIBLE_BUFF_LABELS({
-            skills: state.bumpkin.skills,
-            collectibles: state.collectibles,
-          }) &&
+        name in COLLECTIBLE_BUFF_LABELS &&
         (
-          COLLECTIBLE_BUFF_LABELS({
+          COLLECTIBLE_BUFF_LABELS[name]?.({
             skills: state.bumpkin.skills,
             collectibles: state.collectibles,
-          })[name] ?? []
+          }) ?? []
         ).length > 0,
     )
     .filter(

--- a/src/features/pets/PetShopModal.tsx
+++ b/src/features/pets/PetShopModal.tsx
@@ -171,10 +171,10 @@ const PetShopActionView: React.FC<{
 }) => {
   const { t } = useAppTranslation();
   const boostDescription = [
-    ...(COLLECTIBLE_BUFF_LABELS({
+    ...(COLLECTIBLE_BUFF_LABELS[petItem]?.({
       skills: gameState.bumpkin.skills,
       collectibles: gameState.collectibles,
-    })[petItem] ?? []), // Spread to prevent mutations
+    }) ?? []), // Spread to prevent mutations
   ];
   const isPetEgg = (petItem: PetShopItemName): petItem is "Pet Egg" =>
     petItem === "Pet Egg";

--- a/src/features/retreat/components/auctioneer/lib/getAuctionItemDisplay.ts
+++ b/src/features/retreat/components/auctioneer/lib/getAuctionItemDisplay.ts
@@ -44,10 +44,10 @@ export function getAuctionItemDisplay({
 }): Display {
   if (auction.type === "collectible") {
     const image = ITEM_DETAILS[auction.collectible].image;
-    const buffLabels = COLLECTIBLE_BUFF_LABELS({
+    const buffLabels = COLLECTIBLE_BUFF_LABELS[auction.collectible]?.({
       skills,
       collectibles,
-    })[auction.collectible];
+    });
 
     return {
       image,

--- a/src/features/world/ui/beach/Digby.tsx
+++ b/src/features/world/ui/beach/Digby.tsx
@@ -346,17 +346,17 @@ const BoostDigItems: (
   state,
 ) => ({
   "Pharaoh Chicken": {
-    buff: COLLECTIBLE_BUFF_LABELS({
+    buff: COLLECTIBLE_BUFF_LABELS["Pharaoh Chicken"]?.({
       skills: state.bumpkin.skills,
       collectibles: state.collectibles,
-    })["Pharaoh Chicken"] as BuffLabel[],
+    }) as BuffLabel[],
     location: "Marketplace",
   },
   "Heart of Davy Jones": {
-    buff: COLLECTIBLE_BUFF_LABELS({
+    buff: COLLECTIBLE_BUFF_LABELS["Heart of Davy Jones"]?.({
       skills: state.bumpkin.skills,
       collectibles: state.collectibles,
-    })["Heart of Davy Jones"] as BuffLabel[],
+    }) as BuffLabel[],
     location: "Marketplace",
   },
   "Bionic Drill": {

--- a/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
@@ -397,10 +397,10 @@ export const TreasureShopBuy: React.FC = () => {
                 isSelected={selectedName === name}
                 secondaryImage={SUNNYSIDE.icons.stopwatch}
                 alternateIcon={
-                  COLLECTIBLE_BUFF_LABELS({
+                  COLLECTIBLE_BUFF_LABELS[name]?.({
                     skills: state.bumpkin.skills,
                     collectibles: state.collectibles,
-                  })[name]
+                  })
                     ? lightning
                     : undefined
                 }
@@ -416,10 +416,10 @@ export const TreasureShopBuy: React.FC = () => {
                   isSelected={selectedName === name}
                   key={name}
                   alternateIcon={
-                    COLLECTIBLE_BUFF_LABELS({
+                    COLLECTIBLE_BUFF_LABELS[name]?.({
                       skills: state.bumpkin.skills,
                       collectibles: state.collectibles,
-                    })[name]
+                    })
                       ? lightning
                       : undefined
                   }
@@ -469,10 +469,10 @@ export const TreasureShopBuy: React.FC = () => {
                   isSelected={selectedName === name}
                   key={name}
                   alternateIcon={
-                    COLLECTIBLE_BUFF_LABELS({
+                    COLLECTIBLE_BUFF_LABELS[name]?.({
                       skills: state.bumpkin.skills,
                       collectibles: state.collectibles,
-                    })[name]
+                    })
                       ? lightning
                       : undefined
                   }

--- a/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
@@ -148,10 +148,10 @@ const CollectibleContent: React.FC<CollectibleContentProps> = ({
       selected.ingredients[name]?.greaterThan(inventory[name] || 0),
     );
   const isAlreadyCrafted = inventory[selectedName]?.greaterThanOrEqualTo(1);
-  const isBoost = COLLECTIBLE_BUFF_LABELS({
+  const isBoost = COLLECTIBLE_BUFF_LABELS[selectedName]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[selectedName];
+  });
 
   const craft = () => {
     gameService.send("collectible.crafted", {

--- a/src/features/world/ui/eventmegastore/EventMegaStore.tsx
+++ b/src/features/world/ui/eventmegastore/EventMegaStore.tsx
@@ -52,10 +52,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.name];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.name];
+  });
 };
 
 const _state = (state: MachineState) => state.context.state;

--- a/src/features/world/ui/eventmegastore/EventStore.tsx
+++ b/src/features/world/ui/eventmegastore/EventStore.tsx
@@ -60,10 +60,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.wearable];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.collectible]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.collectible];
+  });
 };
 export const getItemDescription = (item: EventStoreItem | null): string => {
   if (!item) return "";

--- a/src/features/world/ui/factionShop/FactionShop.tsx
+++ b/src/features/world/ui/factionShop/FactionShop.tsx
@@ -87,10 +87,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.name];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.name];
+  });
 };
 
 export const FactionShop: React.FC<Props> = ({ onClose }) => {

--- a/src/features/world/ui/infernos/tabs/Forge.tsx
+++ b/src/features/world/ui/infernos/tabs/Forge.tsx
@@ -84,12 +84,10 @@ export const Forge: React.FC = () => {
             details={{
               item: selectedResource,
             }}
-            boost={
-              COLLECTIBLE_BUFF_LABELS({
-                skills: state.bumpkin.skills,
-                collectibles: state.collectibles,
-              })[selectedResource]
-            }
+            boost={COLLECTIBLE_BUFF_LABELS[selectedResource]?.({
+              skills: state.bumpkin.skills,
+              collectibles: state.collectibles,
+            })}
             requirements={
               forgingSoon
                 ? undefined

--- a/src/features/world/ui/loveRewardShop/FloatingIslandShop.tsx
+++ b/src/features/world/ui/loveRewardShop/FloatingIslandShop.tsx
@@ -50,10 +50,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.name];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.name];
+  });
 };
 export const getItemDescription = (item: FloatingShopItem | null): string => {
   if (!item) return "";

--- a/src/features/world/ui/megastore/MegaStore.tsx
+++ b/src/features/world/ui/megastore/MegaStore.tsx
@@ -58,10 +58,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.name];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.name]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.name];
+  });
 };
 
 const _state = (state: MachineState) => state.context.state;

--- a/src/features/world/ui/megastore/SeasonalStore.tsx
+++ b/src/features/world/ui/megastore/SeasonalStore.tsx
@@ -59,10 +59,10 @@ export const getItemBuffLabel = (
     return BUMPKIN_ITEM_BUFF_LABELS[item.wearable];
   }
 
-  return COLLECTIBLE_BUFF_LABELS({
+  return COLLECTIBLE_BUFF_LABELS[item.collectible]?.({
     skills: state.bumpkin.skills,
     collectibles: state.collectibles,
-  })[item.collectible];
+  });
 };
 export const getItemDescription = (item: SeasonalStoreItem | null): string => {
   if (!item) return "";


### PR DESCRIPTION
# Description

Marketplace Search Performance is very laggy as it is calling `translate` too many times when fetching buff labels.

This PR narrows `COLLECTIBLE_BUFF_LABELS` functions, so that we only call `translate` on the items we are interested in, rather than all items.

Fixes #issue

# What needs to be tested by the reviewer?

1. Test marketplace search on `main` and then on this PR.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
