### PR TITLE
[FEAT] Display VIP loss condition warning in confirm-purchase screen

### DIFF
--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -182,6 +182,19 @@ export const VIPItems: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
               {t("vip.oneYear.warning")}
             </Label>
           )}
+          <div className="absolute -bottom-11 sm:-bottom-12 -mb-1 left-1/2 -translate-x-1/2 w-full">
+            <Label type="danger">
+              <div className="flex items-center m-1">
+                <img
+                  src={SUNNYSIDE.icons.expression_alerted}
+                  className="h-6 sm:h-7"
+                />
+                <p className="flex text-xxs sm:text-xs leading-4 ml-2">
+                  {t("vip.transfer.warning")}
+                </p>
+              </div>
+            </Label>
+          </div>
           <div className="flex ">
             <Button className="mr-1" onClick={() => setSelected(undefined)}>
               {t("no")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5359,6 +5359,7 @@
   "vip.purchase.confirm": "Are you sure you want to purchase {{name}} of VIP access?",
   "vip.benefits": "Benefits",
   "vip.oneYear.warning": "You already have 1 year VIP access.",
+  "vip.transfer.warning": "Transferring the farm outside the game will remove your purchased VIP",
   "vip.access": "VIP Access",
   "vip.benefit.airdrop": "Monthly airdrop",
   "vip.benefit.expBoost": "10% EXP Boost",


### PR DESCRIPTION
# Description

Adds a warning in the confirm-purchase VIP modal to inform players about the condition under which they would lose their purchased VIP.

| Mobile | Desktop |
|--------|--------|
| <img width="451" height="926" alt="image" src="https://github.com/user-attachments/assets/053980c5-fe07-424f-955c-48eb5c3c9f0a" /> | <img width="562" height="618" alt="image" src="https://github.com/user-attachments/assets/4835f87a-fea2-40bb-aa00-bbdb15673b7f" /> | 
