### PR TITLE
[CHORE] Improve Goblin Raffle Description

### DIFF
--- a/src/features/world/ui/chests/Raffle.tsx
+++ b/src/features/world/ui/chests/Raffle.tsx
@@ -53,7 +53,9 @@ export const Raffle: React.FC = () => {
                 {t("raffle.title")}
               </Label>
             </div>
-            <p className="text-xs mb-2">{t("raffle.description")}</p>
+            <Label type="warning" className="mb-2">
+              <span className="text-xs mb-2">{t("raffle.description")}</span>
+            </Label>
             <p className="text-xs mb-1 font-secondary">{`- 5 x 1000 FLOWER winners`}</p>
             <p className="text-xs mb-2 font-secondary">{`- 2 Bud NFTs`}</p>
             <div className="flex justify-between items-center">

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -140,7 +140,7 @@
   "budBox.description": "Each day, a bud type can unlock farming rewards.",
   "budBox.today": "Today - {{timeLeft}} left",
   "raffle.title": "Goblin Raffle",
-  "raffle.description": "Each month, you have a chance to win rewards. Winners will be announced on Discord.",
+  "raffle.description": "Each month, you have a chance to win rewards. The Goblin Raffle winners will be announced on the Friday Twitch Streams in the 1st or 2nd Fridays of the following month. Eg. May's winners will be announced on the first or second Friday of June. Results are also pinned in Discord on #farmers-chat",
   "raffle.entry": "entry",
   "raffle.entries": "entries",
   "raffle.noTicket": "Missing Prize Ticket",


### PR DESCRIPTION
# Description

Too many players ask about the Goblin Raffle winners as soon the month changes, so I changed the description to be the same text we have on Discord with Victoria the Cat and it make it as a label to call more the attention. 

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] I have read the contributing guidelines and agree to the T&Cs
