### PR TITLE
FIX: Prevent direct navigation when a building is destoryed

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -37,6 +37,7 @@ import { PlayerModal } from "features/social/PlayerModal";
 import { hasFeatureAccess } from "lib/flags";
 import { Context as AuthContext } from "features/auth/lib/Provider";
 import { AuthMachineState } from "features/auth/lib/authMachine";
+import { isBuildingDestroyed } from "features/island/buildings/components/building/Building";
 
 export const EXTERIOR_ISLAND_BG: Record<LandBiomeName, string> = {
   "Basic Biome": SUNNYSIDE.land.basic_building_bg,
@@ -142,6 +143,15 @@ export const BarnInside: React.FC = () => {
     return organizedAnimals.filter((animal) => isValidDeal({ animal, deal }))
       .length;
   }, [organizedAnimals, deal]);
+
+  const calendarEvent = isBuildingDestroyed({
+    name: "Barn",
+    calendar: context.state.calendar,
+  });
+
+  if (calendarEvent) {
+    navigate("/");
+  }
 
   return (
     <>

--- a/src/features/greenhouse/GreenhouseInside.tsx
+++ b/src/features/greenhouse/GreenhouseInside.tsx
@@ -18,6 +18,7 @@ import { hasFeatureAccess } from "lib/flags";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import { Context as AuthContext } from "features/auth/lib/Provider";
 import { useSelector } from "@xstate/react";
+import { isBuildingDestroyed } from "features/island/buildings/components/building/Building";
 
 const background = SUNNYSIDE.land.greenhouse_inside;
 
@@ -44,6 +45,15 @@ export const GreenhouseInside: React.FC = () => {
   useLayoutEffect(() => {
     scrollIntoView(Section.GenesisBlock, "auto");
   }, []);
+
+  const calendarEvent = isBuildingDestroyed({
+    name: "Greenhouse",
+    calendar: context.state.calendar,
+  });
+
+  if (calendarEvent) {
+    navigate("/");
+  }
 
   return (
     <>

--- a/src/features/island/buildings/components/building/Building.tsx
+++ b/src/features/island/buildings/components/building/Building.tsx
@@ -247,7 +247,7 @@ const DESTROYED_BUILDINGS: BuildingName[] = [
   "Deli",
 ];
 
-function isBuildingDestroyed({
+export function isBuildingDestroyed({
   name,
   calendar,
 }: {


### PR DESCRIPTION
# Description

Fixes the issue where players can directly access Barn and Greenhouse by link when it's affected by a calendar event

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
