### PR TITLE
[FIX] Hide Pets from Visiting if they don't have access

### DIFF
--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { Decoration, getKeys } from "./decorations";
 import { GameState, InventoryItemName } from "./game";
 import { FARM_GARBAGE } from "./clutter";
+import { hasFeatureAccess } from "lib/flags";
 
 type LoveCharmMonumentName =
   | "Farmer's Monument"
@@ -185,12 +186,24 @@ export const REWARD_ITEMS: Partial<
   },
 };
 
-export function isHelpComplete({ game }: { game: GameState }) {
-  return getHelpRequired({ game }) <= 0;
+export function isHelpComplete({
+  game,
+  visitorState,
+}: {
+  game: GameState;
+  visitorState?: GameState;
+}) {
+  return getHelpRequired({ game, visitorState }) <= 0;
 }
 
 // Returns a count of help tasks needed on the farm
-export function getHelpRequired({ game }: { game: GameState }) {
+export function getHelpRequired({
+  game,
+  visitorState,
+}: {
+  game: GameState;
+  visitorState?: GameState;
+}) {
   const clutter = getKeys(game.socialFarming.clutter?.locations ?? {}).filter(
     (id) => {
       const type = game.socialFarming.clutter?.locations[id].type;
@@ -219,6 +232,11 @@ export function getHelpRequired({ game }: { game: GameState }) {
   );
 
   const pendingPets = getKeys(game.pets?.common ?? {}).filter((pet) => {
+    const hasAccess = !!visitorState && hasFeatureAccess(visitorState, "PETS");
+    if (!hasAccess) {
+      return false;
+    }
+
     const hasVisited = !!game.pets?.common?.[pet]?.visitedAt;
     return !hasVisited;
   });

--- a/src/features/island/clutter/Clutter.tsx
+++ b/src/features/island/clutter/Clutter.tsx
@@ -91,7 +91,12 @@ export const ClutterItem: React.FC<
       totalHelpedToday,
     });
 
-    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+    if (
+      isHelpComplete({
+        game: gameService.getSnapshot().context.state,
+        visitorState: gameService.getSnapshot().context.visitorState,
+      })
+    ) {
       onComplete();
     }
   };

--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -155,7 +155,12 @@ export const Monument: React.FC<MonumentProps> = (input) => {
       totalHelpedToday: totalHelpedToday ?? 0,
     });
 
-    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+    if (
+      isHelpComplete({
+        game: gameService.getSnapshot().context.state,
+        visitorState: gameService.getSnapshot().context.visitorState,
+      })
+    ) {
       setShowHelped(true);
     }
   };

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -520,7 +520,12 @@ export const Project: React.FC<ProjectProps> = (input) => {
       totalHelpedToday: totalHelpedToday ?? 0,
     });
 
-    if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+    if (
+      isHelpComplete({
+        game: gameService.getSnapshot().context.state,
+        visitorState: gameService.getSnapshot().context.visitorState,
+      })
+    ) {
       setShowHelped(true);
     }
   };

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -88,6 +88,7 @@ export const VisitingHud: React.FC = () => {
 
   const helpRequired = getHelpRequired({
     game: gameState.context.state,
+    visitorState: gameState.context.visitorState,
   });
 
   const handleCloseVisitorGuide = () => {

--- a/src/features/island/pets/VisitingPet.tsx
+++ b/src/features/island/pets/VisitingPet.tsx
@@ -19,6 +19,11 @@ import { SUNNYSIDE } from "assets/sunnyside";
 
 const _hasHelpedPet = (name: PetName) => (state: MachineState) => {
   if (state.context.visitorState) {
+    const hasAccess = hasFeatureAccess(state.context.visitorState, "PETS");
+    if (!hasAccess) {
+      return true;
+    }
+
     const hasHelpedToday = state.context.hasHelpedPlayerToday ?? false;
 
     const hasHelpedPet = !!state.context.state.pets?.common?.[name]?.visitedAt;
@@ -57,7 +62,12 @@ export const VisitingPet: React.FC<{ name: PetName }> = ({ name }) => {
     ) {
       gameService.send("pet.visitingPets", { pet: name, totalHelpedToday });
 
-      if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+      if (
+        isHelpComplete({
+          game: gameService.getSnapshot().context.state,
+          visitorState: gameService.getSnapshot().context.visitorState,
+        })
+      ) {
         setShowHelped(true);
       }
     }
@@ -96,6 +106,7 @@ export const VisitingPet: React.FC<{ name: PetName }> = ({ name }) => {
                 width: `${PIXEL_SCALE * 14}px`,
                 right: `${PIXEL_SCALE * 3}px`,
                 top: `${PIXEL_SCALE * 2}px`,
+                zIndex: 1000,
               }}
             />
           </div>


### PR DESCRIPTION
# Description

Somehow pets are still showing for non beta testers despite the condition set in gameMachine. This PR excludes the pets from the visiting from being one of the help tasks

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
