### PR TITLE
[FIX] Pet Neglect doesn't trigger if pet has never been fed before

### DIFF
--- a/src/features/game/events/claimPurchase.test.ts
+++ b/src/features/game/events/claimPurchase.test.ts
@@ -474,6 +474,7 @@ describe("purchase.claimed", () => {
               id: 1,
               requests: {
                 food: [],
+                fedAt: 0,
               },
               energy: 0,
               experience: 0,

--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -265,6 +265,7 @@ describe("Place Collectible", () => {
         energy: 0,
         requests: {
           food: [],
+          fedAt: dateNow,
         },
         pettedAt: dateNow,
       },
@@ -289,6 +290,7 @@ describe("Place Collectible", () => {
               energy: 0,
               requests: {
                 food: ["Pumpkin Cake", "Pumpkin Soup", "Antipasto"],
+                fedAt: dateNow,
               },
               pettedAt: dateNow,
             },
@@ -315,6 +317,7 @@ describe("Place Collectible", () => {
         energy: 0,
         requests: {
           food: ["Pumpkin Cake", "Pumpkin Soup", "Antipasto"],
+          fedAt: dateNow,
         },
         pettedAt: dateNow,
       },
@@ -324,6 +327,7 @@ describe("Place Collectible", () => {
         energy: 0,
         requests: {
           food: [],
+          fedAt: dateNow,
         },
         pettedAt: dateNow,
       },

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -96,6 +96,7 @@ export function placeCollectible({
           energy: 0,
           requests: {
             food: [], // Pet Requests are populated on the server
+            fedAt: createdAt,
           },
           pettedAt: createdAt,
         };

--- a/src/features/game/events/pets/bulkFeedPets.test.ts
+++ b/src/features/game/events/pets/bulkFeedPets.test.ts
@@ -16,6 +16,7 @@ describe("bulkFeedPets", () => {
                 name: "Barkley",
                 requests: {
                   food: ["Bumpkin Salad"],
+                  fedAt: now,
                 },
                 energy: 0,
                 experience: 0,
@@ -25,6 +26,7 @@ describe("bulkFeedPets", () => {
                 name: "Meowchi",
                 requests: {
                   food: ["Bumpkin Salad"],
+                  fedAt: now,
                 },
                 energy: 0,
                 experience: 0,
@@ -57,6 +59,7 @@ describe("bulkFeedPets", () => {
             name: "Barkley",
             requests: {
               food: ["Bumpkin Salad"],
+              fedAt: now,
             },
             energy: 0,
             experience: 0,
@@ -66,6 +69,7 @@ describe("bulkFeedPets", () => {
             name: "Meowchi",
             requests: {
               food: ["Bumpkin Salad"],
+              fedAt: now,
             },
             energy: 0,
             experience: 0,

--- a/src/features/game/events/pets/feedPet.test.ts
+++ b/src/features/game/events/pets/feedPet.test.ts
@@ -106,6 +106,7 @@ describe("feedPet", () => {
                 name: "Barkley",
                 requests: {
                   food: [],
+                  fedAt: now,
                 },
                 energy: 100,
                 experience: 0,
@@ -143,6 +144,7 @@ describe("feedPet", () => {
                 name: "Barkley",
                 requests: {
                   food: ["Pumpkin Soup", "Roast Veggies", "Antipasto"],
+                  fedAt: now,
                 },
                 energy: 100,
                 experience: 0,
@@ -334,6 +336,7 @@ describe("feedPet", () => {
                 requests: {
                   food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                   foodFed: [],
+                  fedAt: now,
                 },
                 energy: 100,
                 experience: 0,
@@ -419,6 +422,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: 100,
@@ -491,6 +495,7 @@ describe("feedPet", () => {
               pettedAt: now,
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
+                fedAt: 0,
               },
               coordinates: { x: 1, y: 1 },
             },
@@ -521,6 +526,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: 1500, // Level 5
@@ -566,6 +572,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: 1500, // Level 5
@@ -613,6 +620,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: level27XP, // Level 27
@@ -665,6 +673,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: level40XP, // Level 40
@@ -709,6 +718,7 @@ describe("feedPet", () => {
               requests: {
                 food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
                 foodFed: [],
+                fedAt: now,
               },
               energy: 0,
               experience: level85XP, // Level 85
@@ -745,6 +755,7 @@ describe("feedPet", () => {
         name: "Barkley",
         requests: {
           food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
+          fedAt: now,
         },
         energy: 100,
         experience: 0,
@@ -766,6 +777,7 @@ describe("feedPet", () => {
         name: "Barkley",
         requests: {
           food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
+          fedAt: now,
         },
         energy: 100,
         experience: 5500, // Level 10

--- a/src/features/game/events/pets/fetchPet.test.ts
+++ b/src/features/game/events/pets/fetchPet.test.ts
@@ -22,7 +22,7 @@ describe("fetchPet", () => {
             common: {
               Barkley: {
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 100,
                 experience: 0,
                 pettedAt: now - 2 * 60 * 60 * 1000,
@@ -68,7 +68,7 @@ describe("fetchPet", () => {
             common: {
               Barkley: {
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 100,
                 experience: 0,
                 pettedAt: now,
@@ -90,7 +90,7 @@ describe("fetchPet", () => {
             common: {
               Barkley: {
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 100,
                 experience: 100,
                 pettedAt: now,
@@ -112,7 +112,7 @@ describe("fetchPet", () => {
             common: {
               Barkley: {
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 0,
                 experience: 0,
                 pettedAt: now,
@@ -133,7 +133,7 @@ describe("fetchPet", () => {
           common: {
             Barkley: {
               name: "Barkley",
-              requests: { food: [] },
+              requests: { food: [], fedAt: now },
               energy: 100,
               experience: 0,
               pettedAt: now,
@@ -156,7 +156,7 @@ describe("fetchPet", () => {
           common: {
             Barkley: {
               name: "Barkley",
-              requests: { food: [] },
+              requests: { food: [], fedAt: now },
               fetches: { Acorn: 2 },
               energy: 100,
               experience: 0,

--- a/src/features/game/events/pets/neglectPet.test.ts
+++ b/src/features/game/events/pets/neglectPet.test.ts
@@ -21,7 +21,7 @@ describe("neglectPet", () => {
             common: {
               Barkley: {
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 100,
                 experience: 0,
                 pettedAt: now,

--- a/src/features/game/events/pets/neglectPet.ts
+++ b/src/features/game/events/pets/neglectPet.ts
@@ -18,7 +18,7 @@ type Options = {
   createdAt?: number;
 };
 
-export function neglectPet({ state, action, createdAt }: Options) {
+export function neglectPet({ state, action, createdAt = Date.now() }: Options) {
   return produce(state, (stateCopy) => {
     const { petId } = action;
     const isPetNFT = typeof petId === "number";

--- a/src/features/game/events/pets/petPet.test.ts
+++ b/src/features/game/events/pets/petPet.test.ts
@@ -22,7 +22,7 @@ describe("petPet", () => {
               Barkley: {
                 pettedAt: now,
                 name: "Barkley",
-                requests: { food: [] },
+                requests: { food: [], fedAt: now },
                 energy: 0,
                 experience: 0,
               },
@@ -43,7 +43,7 @@ describe("petPet", () => {
             Barkley: {
               pettedAt: now - 2 * 60 * 60 * 1000,
               name: "Barkley",
-              requests: { food: [] },
+              requests: { food: [], fedAt: now },
               energy: 0,
               experience: 0,
             },

--- a/src/features/game/types/pets.ts
+++ b/src/features/game/types/pets.ts
@@ -91,7 +91,7 @@ export type Pet = {
   requests: {
     food: CookableName[];
     foodFed?: CookableName[];
-    fedAt?: number;
+    fedAt: number;
     resets?: {
       [date: string]: number;
     };
@@ -670,7 +670,7 @@ export function isPetNeglected(
 
   const PET_NEGLECT_DAYS = isPetNFT(pet) ? 7 : 3;
 
-  const lastFedAt = pet.requests.fedAt ?? createdAt; // Default to createdAt otherwise the pet will be neglected if it hasn't been fed before
+  const lastFedAt = pet.requests.fedAt;
   const lastFedAtDate = new Date(lastFedAt).toISOString().split("T")[0];
   const todayDate = new Date(createdAt).toISOString().split("T")[0];
   const daysSinceLastFedMs =
@@ -709,7 +709,6 @@ export function isPetOfTypeFed({
   const isPetOfTypeFed = petsOfType.some((pet) => {
     if (pet.id === id) return false;
     const lastFedAt = pet.requests.fedAt;
-    if (!lastFedAt) return false;
     const todayDate = new Date(now).toISOString().split("T")[0];
     const lastFedAtDate = new Date(lastFedAt).toISOString().split("T")[0];
     return lastFedAtDate === todayDate;


### PR DESCRIPTION
# Description

fedAt was not compulsory, hence in isPetNeglected, if it's not assigned, it defaulted to current time. This results in the pet being able to earn experience from petting and never have to be worried on whether a pet is neglected.

Fixes #issue

# What needs to be tested by the reviewer?

No manual testing could be done but just understand the code for isPetNeglected and how it worked before and after.


# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
