### PR TITLE
[CHORE] Remove Gasless Banner

### DIFF
--- a/src/features/announcements/AnnouncementWidgets.tsx
+++ b/src/features/announcements/AnnouncementWidgets.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from "react";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import {
   pixelGreenBorderStyle,
-  pixelOrangeBorderStyle,
   pixelVibrantBorderStyle,
 } from "features/game/lib/style";
 import classNames from "classnames";
@@ -40,49 +39,6 @@ export const BuyGemsWidget: React.FC = () => {
           target="_blank"
           rel="noopener noreferrer"
           className="underline text-xxs pb-1 pt-0.5 hover:text-blue-500 mb-2 text-white"
-        >
-          {t("read.more")}
-        </a>
-      </div>
-      <img
-        src={SUNNYSIDE.icons.close}
-        className="absolute right-2 top-1 w-5 cursor-pointer"
-        onClick={() => setShowMessage(false)}
-      />
-    </div>
-  );
-};
-
-export const GaslessWidget: React.FC = () => {
-  const [showMessage, setShowMessage] = useState(true);
-
-  const { t } = useAppTranslation();
-
-  if (!showMessage) {
-    return null;
-  }
-
-  return (
-    <div
-      className={classNames(
-        `w-full items-center flex  text-xs p-1 pr-4 mt-1 relative`,
-      )}
-      style={{
-        background: "#f09100",
-        color: "#3e2731",
-        ...pixelOrangeBorderStyle,
-      }}
-    >
-      <img src={SUNNYSIDE.icons.heart} className="w-8 mr-2" />
-      <div>
-        <p className="text-xs flex-1">{t("announcement.gasless")}</p>
-        <a
-          href={
-            "https://docs.sunflower-land.com/getting-started/usdflower-erc20/schedule#usdflower-in-game"
-          }
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-xxs pb-1 pt-0.5 hover:text-blue-500 mb-2"
         >
           {t("read.more")}
         </a>

--- a/src/features/island/hud/Transaction.tsx
+++ b/src/features/island/hud/Transaction.tsx
@@ -27,7 +27,6 @@ import { Loading } from "features/auth/components";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
-import { GaslessWidget } from "features/announcements/AnnouncementWidgets";
 
 const _transaction = (state: MachineState) => state.context.state.transaction;
 const compareTransaction = (prev?: GameTransaction, next?: GameTransaction) => {
@@ -64,7 +63,6 @@ export const TransactionCountdown: React.FC = () => {
         <Panel>
           <Transaction onClose={() => setShowTransaction(false)} />
         </Panel>
-        <GaslessWidget />
       </Modal>
       <ButtonPanel onClick={() => setShowTransaction(true)} className="flex">
         <TransactionWidget


### PR DESCRIPTION
# Description

Removes the gasless banner from the transaction widget (when withdrawing for example)

Before:

<img width="586" height="304" alt="1" src="https://github.com/user-attachments/assets/b7825b87-1be1-4c77-acf8-773b5e2bde6e" />

After:

<img width="574" height="271" alt="2" src="https://github.com/user-attachments/assets/fe5221c9-afd0-41dc-82d6-77b5c8e5480a" />


# What needs to be tested by the reviewer?

1. Withdraw some flower
2. Check no banner is below the transaction modal

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]