### PR TITLE
[FIX] Competition Modal showing after competition end

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -1291,7 +1291,10 @@ export function startGame(authContext: AuthContext) {
 
                 const hasStarted =
                   Date.now() > COMPETITION_POINTS.BUILDING_FRIENDSHIPS.startAt;
-                if (!hasStarted) return false;
+
+                const hasEnded =
+                  Date.now() > COMPETITION_POINTS.BUILDING_FRIENDSHIPS.endAt;
+                if (!hasStarted || hasEnded) return false;
 
                 const level = getBumpkinLevel(
                   context.state.bumpkin?.experience ?? 0,


### PR DESCRIPTION
# Description

This PR fixes the issue where the competition modal shows even after the competition ended

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
