### PR TITLE
[FIX] Crimstone Time Calculation

### DIFF
--- a/src/features/game/events/landExpansion/mineCrimstone.test.ts
+++ b/src/features/game/events/landExpansion/mineCrimstone.test.ts
@@ -254,5 +254,41 @@ describe("mineCrimstone", () => {
 
       expect(time).toEqual(now - CRIMSTONE_RECOVERY_TIME * 0.15 * 1000);
     });
+
+    it("crimstone replenishes faster with Fireside Alchemist, Crimstone Amulet and Mole Shrine", () => {
+      const now = Date.now();
+
+      const { time } = getMinedAt({
+        game: {
+          ...GAME_STATE,
+          bumpkin: {
+            ...GAME_STATE.bumpkin,
+            skills: {
+              "Fireside Alchemist": 1,
+            },
+            equipped: {
+              ...GAME_STATE.bumpkin.equipped,
+              necklace: "Crimstone Amulet",
+            },
+          },
+          collectibles: {
+            "Mole Shrine": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: now,
+                id: "12",
+                readyAt: now,
+              },
+            ],
+          },
+        },
+        createdAt: now,
+      });
+
+      const expectedCooldownTime =
+        CRIMSTONE_RECOVERY_TIME - CRIMSTONE_RECOVERY_TIME * 0.8 * 0.85 * 0.75;
+
+      expect(time).toEqual(now - expectedCooldownTime * 1000);
+    });
   });
 });

--- a/src/features/game/events/landExpansion/mineCrimstone.ts
+++ b/src/features/game/events/landExpansion/mineCrimstone.ts
@@ -27,27 +27,40 @@ type GetMinedAtArgs = {
   game: GameState;
 };
 
-export function getMinedAt({ createdAt, game }: GetMinedAtArgs): {
-  time: number;
+function getBoostedTime({ game }: GetMinedAtArgs): {
+  boostedTime: number;
   boostsUsed: BoostName[];
 } {
-  let time = createdAt;
+  let totalSeconds = CRIMSTONE_RECOVERY_TIME;
   const boostsUsed: BoostName[] = [];
 
   if (isWearableActive({ name: "Crimstone Amulet", game })) {
-    time -= CRIMSTONE_RECOVERY_TIME * 0.2 * 1000;
+    totalSeconds = totalSeconds * 0.8;
     boostsUsed.push("Crimstone Amulet");
   }
 
   if (game.bumpkin.skills["Fireside Alchemist"]) {
-    time -= CRIMSTONE_RECOVERY_TIME * 0.15 * 1000;
+    totalSeconds = totalSeconds * 0.85;
     boostsUsed.push("Fireside Alchemist");
   }
 
   if (isTemporaryCollectibleActive({ name: "Mole Shrine", game })) {
-    time -= CRIMSTONE_RECOVERY_TIME * 0.25 * 1000;
+    totalSeconds = totalSeconds * 0.75;
     boostsUsed.push("Mole Shrine");
   }
+
+  const buff = CRIMSTONE_RECOVERY_TIME - totalSeconds;
+
+  return { boostedTime: buff * 1000, boostsUsed };
+}
+
+export function getMinedAt({ createdAt, game }: GetMinedAtArgs): {
+  time: number;
+  boostsUsed: BoostName[];
+} {
+  const { boostedTime, boostsUsed } = getBoostedTime({ game, createdAt });
+
+  const time = createdAt - boostedTime;
 
   return { time, boostsUsed };
 }


### PR DESCRIPTION
# Description

Crimstone Recovery time was calculated wrongly if player has multiple boosts

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
