### PR TITLE
[FEAT] Astronaut Sheep Wool Boost

### DIFF
--- a/src/features/game/events/landExpansion/claimProduce.test.ts
+++ b/src/features/game/events/landExpansion/claimProduce.test.ts
@@ -724,6 +724,49 @@ describe("claimProduce", () => {
     expect(newState.inventory["Merino Wool"]).toEqual(new Decimal(1.1));
   });
 
+  it("gives +0.1 Wool for sheep when Astronaut Sheep is placed", () => {
+    const sheepId = "123";
+
+    const newState = claimProduce({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Astronaut Sheep": new Decimal(1),
+        },
+        collectibles: {
+          "Astronaut Sheep": [
+            {
+              id: "astro-1",
+              createdAt: now,
+              coordinates: { x: 0, y: 0 },
+              readyAt: now,
+            },
+          ],
+        },
+        barn: {
+          ...GAME_STATE.barn,
+          animals: {
+            [sheepId]: {
+              id: sheepId,
+              type: "Sheep",
+              createdAt: 0,
+              state: "ready",
+              experience: 240,
+              asleepAt: 0,
+              lovedAt: 0,
+              item: "Petting Hand",
+              awakeAt: 0,
+            },
+          },
+        },
+      },
+      action: { type: "produce.claimed", animal: "Sheep", id: sheepId },
+      createdAt: now,
+    });
+
+    expect(newState.inventory.Wool).toEqual(new Decimal(1.1));
+  });
+
   it("gives +0.25 Leather for cows when player has Moo-ver placed", () => {
     const cowId = "123";
 

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -231,6 +231,11 @@ function getWoolYieldBoosts(game: GameState): {
     boostsUsed.push("White Sheep Onesie");
   }
 
+  if (isCollectibleBuilt({ name: "Astronaut Sheep", game })) {
+    boost += 0.1;
+    boostsUsed.push("Astronaut Sheep");
+  }
+
   if (game.bumpkin.skills["Abundant Harvest"]) {
     boost += 0.2;
     boostsUsed.push("Abundant Harvest");


### PR DESCRIPTION
# Description

Adds a wool boost for the Astronaut Sheep

# What needs to be tested by the reviewer?

Ensure the Astronaut Sheep gives 0.1+ Wool

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]