### PR TITLE
[FEAT] Pet Bowls Boost

### DIFF
--- a/src/features/game/events/pets/feedPet.test.ts
+++ b/src/features/game/events/pets/feedPet.test.ts
@@ -744,6 +744,60 @@ describe("feedPet", () => {
     expect(BarkleyData?.experience).toEqual(1700);
   });
 
+  it("feeds pet with Pet Bowls boost", () => {
+    const state = feedPet({
+      state: {
+        ...INITIAL_FARM,
+        pets: {
+          common: {
+            Barkley: {
+              name: "Barkley",
+              requests: {
+                food: ["Pumpkin Soup", "Bumpkin Salad", "Antipasto"],
+                foodFed: [],
+                fedAt: now,
+              },
+              energy: 0,
+              experience: 1500, // Level 5
+              pettedAt: now,
+            },
+          },
+        },
+        inventory: {
+          "Bumpkin Salad": new Decimal(10),
+        },
+        collectibles: {
+          "Pet Bowls": [
+            {
+              createdAt: now,
+              id: "1",
+              readyAt: now,
+              coordinates: { x: 2, y: 2 },
+            },
+          ],
+          Barkley: [
+            {
+              createdAt: now,
+              id: "1",
+              readyAt: now,
+              coordinates: { x: 1, y: 1 },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "pet.fed",
+        petId: "Barkley",
+        food: "Bumpkin Salad",
+      },
+      createdAt: now,
+    });
+    const BarkleyData = state.pets?.common?.Barkley;
+
+    expect(BarkleyData?.energy).toEqual(105);
+    expect(BarkleyData?.experience).toEqual(1610);
+  });
+
   it("gives experience boost for level 27", () => {
     const level27XP = 27 * 26 * 50;
     const state = feedPet({

--- a/src/features/game/events/pets/feedPet.ts
+++ b/src/features/game/events/pets/feedPet.ts
@@ -1,5 +1,8 @@
 import { getObjectEntries } from "features/game/expansion/lib/utils";
-import { isTemporaryCollectibleActive } from "features/game/lib/collectibleBuilt";
+import {
+  isCollectibleBuilt,
+  isTemporaryCollectibleActive,
+} from "features/game/lib/collectibleBuilt";
 import { CookableName } from "features/game/types/consumables";
 import { GameState } from "features/game/types/game";
 import {
@@ -108,6 +111,10 @@ export function getPetExperience({
 
   if (isTemporaryCollectibleActive({ name: "Hound Shrine", game })) {
     experience += 100;
+  }
+
+  if (isCollectibleBuilt({ name: "Pet Bowls", game })) {
+    experience += 10;
   }
 
   if (isPetNFT && petData.traits?.bib) {

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -1700,6 +1700,13 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
       boostTypeIcon: powerup,
     },
   ],
+  "Pet Bowls": () => [
+    {
+      shortDescription: translate("description.petBowls.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+    },
+  ],
   "Stag Shrine": () => [
     {
       shortDescription: translate("description.stagShrine.buff"),

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6781,6 +6781,7 @@
   "description.pawPrintsRug": "A cozy rug patterned with playful paw prints.",
   "description.petBed": "A snug resting spot for your loyal companions.",
   "description.petBowls": "Keep every pet happy with matching food and water bowls.",
+  "description.petBowls.boost": "+10 Pet XP per food request.",
   "description.moonFoxStatue": "A statue honoring the Moon Fox's gentle watch.",
   "rocketman.vip": "You need to be a VIP to exchange Love Charms for FLOWER.",
   "ronin.airdrop.claimed": "Reward claimed",


### PR DESCRIPTION
# Description

Adds +10 experience to Pets when Pet Bowls are placed.

<img width="491" height="62" alt="1" src="https://github.com/user-attachments/assets/fca5a42b-c4f8-49c6-abc1-6803384c64b0" />

# What needs to be tested by the reviewer?

1. Place Pet Bowls
2. Ensure UI shows +10 experience
3. Feed Pet
4. Ensure Pet gets the bonus XP.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes