### PR TITLE
[FIX] Paw Prints Chapter Marvel crashing Codex

### DIFF
--- a/src/features/game/types/seasons.ts
+++ b/src/features/game/types/seasons.ts
@@ -161,7 +161,7 @@ export const CHAPTER_MARVEL_FISH: Record<SeasonName, ChapterFish> = {
   "Winds of Change": "Jellyfish",
   "Great Bloom": "Pink Dolphin",
   "Better Together": "Poseidon",
-  "Paw Prints": "???" as ChapterFish,
+  "Paw Prints": "Super Star",
 };
 
 export function getChapterMarvelFish(now = new Date()): ChapterFish {


### PR DESCRIPTION
# Description

Prevents the codex from crashing when selecting the fishing category.

# What needs to be tested by the reviewer?

1. checkout `main`
2. See the codex crash when the fishing tab is selected
3. checkout this PR.
4. Double check codex loads.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]