### PR TITLE
[FEAT] Update chest item filtering logic to use ITEM_IDS and KNOWN_IDS

### DIFF
--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -1,3 +1,4 @@
+import { KNOWN_IDS } from ".";
 import {
   FLOWER_BOXES,
   isCollectible,
@@ -5,7 +6,7 @@ import {
 } from "../events/landExpansion/buySeasonalItem";
 import { CHAPTER_TICKET_BOOST_ITEMS } from "../events/landExpansion/completeNPCChore";
 import { getObjectEntries } from "../expansion/lib/utils";
-import { BumpkinItem } from "./bumpkin";
+import { BumpkinItem, ITEM_IDS } from "./bumpkin";
 import { ARTEFACT_SHOP_KEYS } from "./collectibles";
 import { getKeys } from "./decorations";
 import { BB_TO_GEM_RATIO, InventoryItemName } from "./game";
@@ -29,12 +30,8 @@ export const MEGASTORE_RESTRICTED_ITEMS: (InventoryItemName | BumpkinItem)[] = [
   ...Object.values(CHAPTER_TICKET_BOOST_ITEMS[currentSeason]),
   ...getKeys(FLOWER_BOXES),
   ...getKeys(ARTEFACT_SHOP_KEYS),
-  ...getObjectEntries(BUMPKIN_RELEASES)
-    .filter(([_, tradeDetail]) => !tradeDetail)
-    .map(([wearable]) => wearable),
-  ...getObjectEntries(INVENTORY_RELEASES)
-    .filter(([_, tradeDetail]) => !tradeDetail)
-    .map(([item]) => item),
+  ...getKeys(ITEM_IDS).filter((name) => !BUMPKIN_RELEASES[name]),
+  ...getKeys(KNOWN_IDS).filter((name) => !INVENTORY_RELEASES[name]),
   "Pet Egg",
 ];
 


### PR DESCRIPTION
# Description

This PR Uses ITEM_IDS and KNOWN_IDS to determine whether an item should be restricted from the chest keys instead of using BUMPKIN_RELEASES and INVENTORY_RELEASES as the former are full objects. this ensures that keys that are missing from BUMPKIN_RELEASES and INVENTORY_RELEASES are properly excluded

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
