### PR TITLE
[FIX] Egg Trade Date

### DIFF
--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -51,25 +51,31 @@ const getNFTTraits = (
   display?: TradeableDisplay,
 ): {
   revealDate: Date | undefined;
+  tradeDate: Date | undefined;
   traits: PetTraits | Bud | undefined;
 } => {
   if (!display || (display.type !== "pets" && display.type !== "buds")) {
-    return { revealDate: undefined, traits: undefined };
+    return { revealDate: undefined, traits: undefined, tradeDate: undefined };
   }
 
   const id = Number(display.name.split("#")[1]);
 
   if (Number.isNaN(id)) {
-    return { revealDate: undefined, traits: undefined };
+    return { revealDate: undefined, traits: undefined, tradeDate: undefined };
   }
 
   if (display.type === "buds") {
-    return { revealDate: undefined, traits: getBudTraits(id) };
+    return {
+      revealDate: undefined,
+      traits: getBudTraits(id),
+      tradeDate: undefined,
+    };
   }
 
   return {
     revealDate: getPetNFTReleaseDate(id, Date.now()),
     traits: getPetTraits(id),
+    tradeDate: new Date("2025-11-10T00:00:00Z"),
   };
 };
 
@@ -172,7 +178,7 @@ export const TradeableDescription: React.FC<{
   const isCollectible = display.type === "collectibles";
   const isResource = isTradeResource(display.name as InventoryItemName);
 
-  const { revealDate, traits } = getNFTTraits(display);
+  const { revealDate, traits, tradeDate } = getNFTTraits(display);
 
   return (
     <InnerPanel className="mb-1">
@@ -235,6 +241,14 @@ export const TradeableDescription: React.FC<{
               ) : (
                 <Label type="danger">{t("marketplace.pet.comingSoon")}</Label>
               ))}
+
+            {tradeDate && (
+              <Label type="formula">
+                {t("marketplace.pet.trade.date", {
+                  date: formatDate(tradeDate),
+                })}
+              </Label>
+            )}
           </div>
         </div>
         {tradeable?.expiresAt && (

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2565,6 +2565,7 @@
   "lostSunflorian.line2": "Unfortunately, these Bumpkins don't like me watching them.",
   "lostSunflorian.line3": "I can't wait to return to Sunfloria.",
   "marketplace.pet.reveal.date": "Reveal date: {{date}}",
+  "marketplace.pet.trade.date": "Trade date: {{date}}",
   "marketplace.pet.comingSoon": "Coming soon",
   "marketplace.unlockSelling": "Unlock selling",
   "marketplace.unlockOffering": "Unlock offering",


### PR DESCRIPTION
# Description

Fixes eggs being traded. There is a dedicated 2 day window once Auctions end when eggs can be traded.

<img width="288" height="232" alt="Screenshot 2025-11-04 at 10 14 06 am" src="https://github.com/user-attachments/assets/12ed71f5-cc0c-46ca-bcb6-4fc0811f8261" />
