### PR TITLE
[FEAT] Apply PRNG to Tree cooldown Boosts

### DIFF
--- a/src/features/game/events/landExpansion/chop.test.ts
+++ b/src/features/game/events/landExpansion/chop.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 import Decimal from "decimal.js-light";
 import {
   INITIAL_BUMPKIN,
@@ -13,6 +14,7 @@ import {
   CHOP_ERRORS,
 } from "./chop";
 import { EXPIRY_COOLDOWNS } from "features/game/lib/collectibleBuilt";
+import { prng } from "lib/prng";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -424,6 +426,28 @@ describe("getChoppedAt", () => {
     const buff = TREE_RECOVERY_TIME - TREE_RECOVERY_TIME * 0.5;
 
     expect(time).toEqual(now - buff * 1000);
+  });
+
+  it("applies an instant growth with Tree Turnaround skill", () => {
+    const now = Date.now();
+    do {
+      var seed = Math.random() * (2 ** 31 - 1);
+      var { value: prngValue } = prng(seed);
+    } while (prngValue * 100 >= 15);
+
+    const { time } = getChoppedAt({
+      game: {
+        ...INITIAL_FARM,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          skills: { "Tree Turnaround": 1 },
+        },
+      },
+      createdAt: now,
+      seed,
+    });
+
+    expect(time).toEqual(now - TREE_RECOVERY_TIME * 1000);
   });
 
   it("does not go negative with all buffs", () => {

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -19,6 +19,7 @@ import {
 } from "features/game/types/game";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import { produce } from "immer";
+import { prng } from "lib/prng";
 
 export enum CHOP_ERRORS {
   MISSING_AXE = "No axe",
@@ -30,6 +31,7 @@ export enum CHOP_ERRORS {
 type GetChoppedAtArgs = {
   game: GameState;
   createdAt: number;
+  seed?: number;
 };
 
 export type LandExpansionChopAction = {
@@ -169,13 +171,31 @@ export function getWoodDropAmount({
 /**
  * Set a chopped in the past to make it replenish faster
  */
-export function getChoppedAt({ game, createdAt }: GetChoppedAtArgs): {
+export function getChoppedAt({ game, createdAt, seed }: GetChoppedAtArgs): {
   time: number;
   boostsUsed: BoostName[];
+  nextSeed: number;
 } {
   const { bumpkin } = game;
   let totalSeconds = TREE_RECOVERY_TIME;
   const boostsUsed: BoostName[] = [];
+  const { value: prngValue, nextSeed } = prng(seed ?? createdAt);
+
+  const instantGrowthGenerator = () => prngValue * 100 < 15;
+
+  // If Tree Turnaround skill and instant growth
+  if (
+    bumpkin.skills["Tree Turnaround"] &&
+    instantGrowthGenerator() &&
+    seed !== undefined
+  ) {
+    boostsUsed.push("Tree Turnaround");
+    return {
+      time: createdAt - TREE_RECOVERY_TIME * 1000,
+      boostsUsed,
+      nextSeed,
+    };
+  }
 
   const hasApprenticeBeaver = isCollectibleBuilt({
     name: "Apprentice Beaver",
@@ -228,7 +248,7 @@ export function getChoppedAt({ game, createdAt }: GetChoppedAtArgs): {
 
   const buff = TREE_RECOVERY_TIME - totalSeconds;
 
-  return { time: createdAt - buff * 1000, boostsUsed };
+  return { time: createdAt - buff * 1000, boostsUsed, nextSeed };
 }
 
 /**
@@ -300,12 +320,17 @@ export function chop({
           });
     const woodAmount = inventory.Wood || new Decimal(0);
 
-    const { time, boostsUsed: choppedAtBoostsUsed } = getChoppedAt({
+    const {
+      time,
+      boostsUsed: choppedAtBoostsUsed,
+      nextSeed,
+    } = getChoppedAt({
       createdAt,
       game: stateCopy,
+      seed: tree.wood.seed,
     });
 
-    tree.wood = { choppedAt: time };
+    tree.wood = { choppedAt: time, seed: nextSeed };
 
     inventory.Axe = axeAmount.sub(requiredAxes);
     inventory.Wood = woodAmount.add(woodHarvested);

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -624,6 +624,7 @@ export type WarCollectionOffer = {
 
 export type Wood = {
   choppedAt: number;
+  seed?: number;
   reward?: Omit<Reward, "sfl">;
   criticalHit?: CriticalHit;
   amount?: number;


### PR DESCRIPTION
# Description

This PR Applys the PRNG algorithm to determine whether a player gets the tree turnaround instant growth

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE + BE
- Pick up Tree Turnaround boosts
- Chop the first round of trees to set the seed 
- set your `tree.wood.choppedAt` to 1 to reset it
- Chop your trees again 
- repeat the last 2 steps until your trees proc

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
