### PR TITLE
[FIX] Lava Pit Requirements Mutating if they have lava swimwear

### DIFF
--- a/src/features/game/events/landExpansion/startLavaPit.test.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.test.ts
@@ -1,5 +1,9 @@
 import Decimal from "decimal.js-light";
-import { LAVA_PIT_TIME, startLavaPit } from "./startLavaPit";
+import {
+  LAVA_PIT_TIME,
+  getLavaPitRequirements,
+  startLavaPit,
+} from "./startLavaPit";
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { GameState } from "features/game/types/game";
 
@@ -18,6 +22,97 @@ const TEST_FARM: GameState = {
     startedAt: 0,
   },
 };
+
+describe("getLavaPitRequirements", () => {
+  const NOVEMBER_10_2025 = new Date("2025-11-10T00:00:00.000Z").getTime();
+
+  it("uses the old requirements before the migration date", () => {
+    const { requirements, boostUsed } = getLavaPitRequirements(
+      {
+        ...TEST_FARM,
+        season: {
+          ...TEST_FARM.season,
+          season: "summer",
+        },
+      },
+      NOVEMBER_10_2025 - 1,
+    );
+
+    expect(requirements).toEqual({
+      Oil: new Decimal(100),
+      Pepper: new Decimal(750),
+      Zucchini: new Decimal(1000),
+    });
+    expect(boostUsed).toEqual([]);
+  });
+
+  it("uses the new requirements from the migration date", () => {
+    const { requirements, boostUsed } = getLavaPitRequirements(
+      TEST_FARM,
+      NOVEMBER_10_2025,
+    );
+
+    expect(requirements).toEqual({
+      Oil: new Decimal(70),
+      Pepper: new Decimal(750),
+      Zucchini: new Decimal(1000),
+      Crimstone: new Decimal(4),
+    });
+    expect(boostUsed).toEqual([]);
+  });
+
+  it("applies lava swimwear without mutating the base requirements", () => {
+    const createdAt = NOVEMBER_10_2025;
+
+    const swimwearGame: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...TEST_FARM.bumpkin,
+        equipped: {
+          ...TEST_FARM.bumpkin.equipped,
+          dress: "Lava Swimwear",
+        },
+      },
+    };
+
+    const withoutSwimwear: GameState = {
+      ...TEST_FARM,
+      bumpkin: {
+        ...TEST_FARM.bumpkin,
+        equipped: {
+          ...TEST_FARM.bumpkin.equipped,
+          dress: undefined,
+        },
+      },
+    };
+
+    const swimwearRequirements = getLavaPitRequirements(
+      swimwearGame,
+      createdAt,
+    );
+
+    expect(swimwearRequirements.requirements).toEqual({
+      Oil: new Decimal(35),
+      Pepper: new Decimal(375),
+      Zucchini: new Decimal(500),
+      Crimstone: new Decimal(2),
+    });
+    expect(swimwearRequirements.boostUsed).toEqual(["Lava Swimwear"]);
+
+    const defaultRequirements = getLavaPitRequirements(
+      withoutSwimwear,
+      createdAt,
+    );
+
+    expect(defaultRequirements.requirements).toEqual({
+      Oil: new Decimal(70),
+      Pepper: new Decimal(750),
+      Zucchini: new Decimal(1000),
+      Crimstone: new Decimal(4),
+    });
+    expect(defaultRequirements.boostUsed).toEqual([]);
+  });
+});
 
 describe("startLavaPit", () => {
   const spy = jest.spyOn((config as any).default, "CONFIG", "get");

--- a/src/features/game/events/landExpansion/startLavaPit.ts
+++ b/src/features/game/events/landExpansion/startLavaPit.ts
@@ -86,7 +86,7 @@ export const getLavaPitRequirements = (
       ? { ...LAVA_PIT_REQUIREMENTS_NEW }
       : { ...LAVA_PIT_REQUIREMENTS_OLD };
 
-  let requirements: Inventory = requirementsMap[season];
+  const baseRequirements: Inventory = requirementsMap[season];
 
   let requirementsMultiplier = 1;
   const boostUsed: BoostName[] = [];
@@ -96,15 +96,18 @@ export const getLavaPitRequirements = (
     boostUsed.push("Lava Swimwear");
   }
 
-  requirements = getObjectEntries(requirements).reduce((acc, [item, req]) => {
-    if (!req) {
+  const requirements = getObjectEntries(baseRequirements).reduce(
+    (acc, [item, req]) => {
+      if (!req) {
+        return acc;
+      }
+
+      acc[item] = req.mul(requirementsMultiplier);
+
       return acc;
-    }
-
-    acc[item] = req.mul(requirementsMultiplier);
-
-    return acc;
-  }, requirements);
+    },
+    { ...baseRequirements },
+  );
 
   return { requirements, boostUsed };
 };


### PR DESCRIPTION
# Description

Lava Pit requirements were mutating hence this bug showed up if you have lava swimwear
![lavapitbug](https://github.com/user-attachments/assets/4fc78d84-2a12-4fe0-be77-fabdfcb6fdb4)

Fixes #issue

# What needs to be tested by the reviewer?
- Equip lava swimwear

Checkout Main
- Whenever the component is clicked the requirements keeps halving

Checkout this PR
- Requirements shouldn't mutate and half 

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
