### PR TITLE
[FIX] Money Tree coin rewards for upgraded trees

### DIFF
--- a/src/features/game/events/landExpansion/collectTreeReward.test.ts
+++ b/src/features/game/events/landExpansion/collectTreeReward.test.ts
@@ -97,4 +97,35 @@ describe("collectTreeReward", () => {
     expect(trees?.[0]?.wood?.reward).toBeUndefined();
     expect(state.coins).toEqual(100);
   });
+
+  it("provides coin rewards for upgraded trees", () => {
+    const state = collectTreeReward({
+      state: {
+        ...TEST_FARM,
+        trees: {
+          0: {
+            x: -2,
+            y: -1,
+            multiplier: 4,
+            wood: {
+              choppedAt: 0,
+              reward: {
+                coins: 100,
+              },
+            },
+          },
+        },
+      },
+      action: {
+        type: "treeReward.collected",
+        treeIndex: "0",
+      },
+      createdAt: dateNow,
+    });
+
+    const { trees } = state;
+
+    expect(trees?.[0]?.wood?.reward).toBeUndefined();
+    expect(state.coins).toEqual(400);
+  });
 });

--- a/src/features/game/events/landExpansion/collectTreeReward.ts
+++ b/src/features/game/events/landExpansion/collectTreeReward.ts
@@ -54,7 +54,7 @@ export function collectTreeReward({
     }
 
     if (coins) {
-      stateCopy.coins = stateCopy.coins + coins;
+      stateCopy.coins = stateCopy.coins + coins * (tree.multiplier ?? 1);
     }
 
     delete wood.reward;


### PR DESCRIPTION
# Description

Added the tree multipler when collecting tree rewards

# What needs to be tested by the reviewer?

- Add `{ reward: { coins: 200 } }` to a Sacred Tree and Ancient Tree
- Chop the trees
- It should give out 800 and 3200 coins, respectively

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
