### PR TITLE
[FEAT] Add Animation for Tree Turnaround

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -780,6 +780,7 @@ type Handlers<T> = {
     announcements?: Announcements;
     farmId?: number;
     visitorState?: GameState;
+    createdAt: number;
   }) => GameState | [GameState, GameState];
 };
 

--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -351,6 +351,7 @@ export function chop({
       ],
       createdAt,
     });
+
     return stateCopy;
   });
 }

--- a/src/features/game/events/pets/fetchPet.ts
+++ b/src/features/game/events/pets/fetchPet.ts
@@ -27,6 +27,7 @@ export function getFetchYield({
 }) {
   let yieldAmount = 1;
   let fetchPercentage = 0;
+
   const { value: prngValue, nextSeed } = prng(seed ?? createdAt);
 
   if (petLevel < 15) return { yieldAmount, nextSeed }; // skips the rest of the logic if pet is less than level 15

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -30,6 +30,8 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { hasReputation, Reputation } from "features/game/lib/reputation";
 import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
 import { setPrecision } from "lib/utils/formatNumber";
+import { Transition } from "@headlessui/react";
+import lightning from "assets/icons/lightning.png";
 
 const HITS = 3;
 const tool = "Axe";
@@ -130,6 +132,32 @@ export const Tree: React.FC<Props> = ({ id }) => {
   const timeLeft = getTimeLeft(resource.wood.choppedAt, TREE_RECOVERY_TIME);
   const chopped = !canChop(resource);
 
+  const [isAnimationRunning, setIsAnimationRunning] = useState(false);
+  const [isRecentlyChopped, setIsRecentlyChopped] = useState(false);
+  const choppedAtRef = useRef(resource.wood.choppedAt);
+
+  useEffect(() => {
+    if (choppedAtRef.current !== resource.wood.choppedAt) {
+      setIsRecentlyChopped(true);
+
+      const timeout = setTimeout(() => {
+        setIsRecentlyChopped(false);
+        setIsAnimationRunning(true);
+      }, 1900);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [resource.wood.choppedAt]);
+
+  useEffect(() => {
+    if (isAnimationRunning) {
+      const timeout = setTimeout(() => {
+        setIsAnimationRunning(false);
+      }, 500);
+      return () => clearTimeout(timeout);
+    }
+  }, [isAnimationRunning]);
+
   useUiRefresher({ active: chopped });
 
   const claimAnyReward = () => {
@@ -217,8 +245,21 @@ export const Tree: React.FC<Props> = ({ id }) => {
 
   return (
     <div className="relative w-full h-full">
+      <Transition
+        show={isAnimationRunning}
+        enter="transition-opacity transition-transform duration-200"
+        enterFrom="opacity-0 translate-y-4"
+        enterTo="opacity-100 -translate-y-0"
+        leave="transition-opacity duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+        className="flex -top-2 right-0 absolute z-40 pointer-events-none"
+        as="div"
+      >
+        <img src={lightning} className="h-6 img-highlight-heavy" />
+      </Transition>
       {/* Resource ready to collect */}
-      {!chopped && (
+      {!chopped && !isRecentlyChopped && (
         <div ref={divRef} className="absolute w-full h-full" onClick={shake}>
           <RecoveredTree
             hasTool={hasTool}
@@ -237,7 +278,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
       )}
 
       {/* Depleted resource */}
-      {chopped && (
+      {(chopped || isRecentlyChopped) && (
         <DepletedTree timeLeft={timeLeft} island={island} season={season} />
       )}
 

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -334,6 +334,7 @@ const playingEventHandler = (eventName: string) => {
             state: context.state as GameState,
             action: event,
             farmId: context.farmId,
+            createdAt: Date.now(),
           });
 
           return !valid;
@@ -344,6 +345,7 @@ const playingEventHandler = (eventName: string) => {
               state: context.state as GameState,
               action: event,
               farmId: context.farmId,
+              createdAt: Date.now(),
             });
 
             return { maxedItem };
@@ -353,19 +355,22 @@ const playingEventHandler = (eventName: string) => {
       {
         actions: assign(
           (context: Context, event: PlayingEvent | VisitingEvent) => {
+            const createdAt = new Date();
+
             const result = processEvent({
               state: context.state,
               action: event,
               announcements: context.announcements,
               farmId: context.farmId,
               visitorState: context.visitorState,
+              createdAt: createdAt.getTime(),
             });
 
             let actions = [
               ...context.actions,
               {
                 ...event,
-                createdAt: new Date(),
+                createdAt,
               },
             ];
 
@@ -423,17 +428,20 @@ const PLACEMENT_EVENT_HANDLERS: TransitionsConfig<Context, BlockchainEvent> = [
     ...events,
     [eventName]: {
       actions: assign((context: Context, event: PlacementEvent) => {
+        const createdAt = new Date();
+
         return {
           state: processEvent({
             state: context.state as GameState,
             action: event,
             farmId: context.farmId,
+            createdAt: createdAt.getTime(),
           }) as GameState,
           actions: [
             ...context.actions,
             {
               ...event,
-              createdAt: new Date(),
+              createdAt,
             },
           ],
         };
@@ -829,6 +837,7 @@ const handleSuccessfulSave = (context: Context, event: any) => {
       announcements: context.announcements,
       farmId: context.farmId,
       visitorState: context.visitorState,
+      createdAt: action.createdAt.getTime(),
     });
   }, event.data.farm);
 

--- a/src/features/game/lib/processEvent.test.ts
+++ b/src/features/game/lib/processEvent.test.ts
@@ -37,6 +37,7 @@ describe("processEvent", () => {
           buildingId: "1",
         },
         farmId: 1,
+        createdAt: Date.now(),
       });
 
       expect(result.valid).toBe(false);
@@ -72,6 +73,7 @@ describe("processEvent", () => {
           item: "Axe",
         },
         farmId: 1,
+        createdAt: Date.now(),
       });
 
       expect(result.valid).toBe(false);
@@ -106,6 +108,7 @@ describe("processEvent", () => {
           item: "Axe",
         },
         farmId: 1,
+        createdAt: Date.now(),
       });
 
       expect(result.valid).toBe(false);
@@ -140,6 +143,7 @@ describe("processEvent", () => {
           item: "Axe",
         },
         farmId: 1,
+        createdAt: Date.now(),
       });
 
       expect(result.valid).toBe(false);
@@ -161,6 +165,7 @@ describe("processEvent", () => {
           item: "Axe",
         },
         farmId: 1,
+        createdAt: Date.now(),
       });
 
       expect(result.valid).toBe(true);

--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -611,14 +611,19 @@ export const MAX_WEARABLES: Wardrobe = {
   "Basic Hair": 1000,
 };
 
-export function checkProgress({ state, action, farmId }: ProcessEventArgs): {
+export function checkProgress({
+  state,
+  action,
+  farmId,
+  createdAt,
+}: ProcessEventArgs): {
   valid: boolean;
   maxedItem?: MaxedItem;
 } {
   let newState: GameState;
 
   try {
-    newState = processEvent({ state, action, farmId }) as GameState;
+    newState = processEvent({ state, action, farmId, createdAt }) as GameState;
   } catch {
     // Not our responsibility to catch events, pass on to the next handler
     return { valid: true };
@@ -724,6 +729,7 @@ export function hasMaxItems({
 type ProcessEventArgs = {
   state: GameState;
   action: GameEvent;
+  createdAt: number;
   announcements?: Announcements;
   farmId: number;
   visitorState?: GameState;
@@ -735,6 +741,7 @@ export function processEvent({
   announcements,
   farmId,
   visitorState,
+  createdAt,
 }: ProcessEventArgs): GameState | [GameState, GameState] {
   const handler = EVENTS[action.type];
 
@@ -749,6 +756,7 @@ export function processEvent({
     announcements,
     farmId,
     visitorState,
+    createdAt,
   });
 
   return newState;


### PR DESCRIPTION
# Description

Adds an Animation for the `Tree Turnaround` skill. When `Tree Turnaround` procs, a small lightning bolt will appear to show you that the skill was activated.

In order for this to work a small fix was applied to. bug in the `gameMachine`.

**The bug:**

The time an action run was being set as `Date.now()` in the event handler, but inside the game machine a different `new Date()` was being used as the timestamp to the backend. This can result in 1-2ms difference in the event logic running between the backend and the frontend.

The new update supplies the same timestamp to both the backend and frontend event, to allow for fully deterministic processing.

# What needs to be tested by the reviewer?

1. Harvest trees with `Tree Turnaround` skill.
2. 15% of the time, a tree should respawn with a lightnin bolt

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]