### PR TITLE
[FEAT] Allow Petting of Friend's pet even if the social pet xp limit has been reached

### DIFF
--- a/src/features/game/events/visiting/helpPets.ts
+++ b/src/features/game/events/visiting/helpPets.ts
@@ -45,16 +45,16 @@ export function helpPets({
       throw new Error("Pet not found");
     }
 
-    const day = new Date(createdAt).toISOString().slice(0, 10);
-    const dailySocialXP = pet.dailySocialXP?.[day] ?? 0;
+    // If the pet has not hit the social limit, add the social XP
+    if (!hasHitSocialPetLimit(pet)) {
+      const day = new Date(createdAt).toISOString().slice(0, 10);
+      const dailySocialXP = pet.dailySocialXP?.[day] ?? 0;
 
-    if (hasHitSocialPetLimit(pet)) {
-      throw new Error("Pet social limit reached");
+      pet.dailySocialXP = pet.dailySocialXP ?? {};
+      pet.dailySocialXP[day] = dailySocialXP + SOCIAL_PET_XP_PER_HELP;
+      pet.experience = (pet.experience ?? 0) + SOCIAL_PET_XP_PER_HELP;
     }
 
-    pet.dailySocialXP = pet.dailySocialXP ?? {};
-    pet.dailySocialXP[day] = dailySocialXP + SOCIAL_PET_XP_PER_HELP;
-    pet.experience = (pet.experience ?? 0) + SOCIAL_PET_XP_PER_HELP;
     pet.visitedAt = createdAt;
   });
 }

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import { Decoration, getKeys } from "./decorations";
 import { GameState, InventoryItemName } from "./game";
 import { ClutterName } from "./clutter";
-import { hasHitSocialPetLimit, PetName, PetNFTName } from "./pets";
+import { PetName, PetNFTName } from "./pets";
 import { isCollectibleBuilt } from "../lib/collectibleBuilt";
 
 type HelpLimitMonumentName =
@@ -286,7 +286,6 @@ export function getHelpRequired({ game }: { game: GameState }) {
       if (!pet) return acc;
 
       if (pet.visitedAt) return acc;
-      if (hasHitSocialPetLimit(pet)) return acc;
 
       const isPetPlacedOnLand = !!collectibles[name]?.some(
         (item) => !!item.coordinates,
@@ -326,8 +325,6 @@ export function getHelpRequired({ game }: { game: GameState }) {
       if (!pet) return acc;
 
       if (pet.visitedAt) return acc;
-
-      if (hasHitSocialPetLimit(pet)) return acc;
 
       if (pet.location === "farm") {
         acc.pendingLandNftPets = [...acc.pendingLandNftPets, pet.name];

--- a/src/features/island/collectibles/components/petNFT/VisitingPetNFT.tsx
+++ b/src/features/island/collectibles/components/petNFT/VisitingPetNFT.tsx
@@ -4,7 +4,6 @@ import {
   isPetNeglected,
   isPetNapping,
   isPetOfTypeFed,
-  hasHitSocialPetLimit,
 } from "features/game/types/pets";
 import { PetSprite } from "features/island/pets/PetSprite";
 import { useContext } from "react";
@@ -107,7 +106,7 @@ export const VisitingPetNFT: React.FC<{
       onClick={handlePetClick}
       clickable={!hasHelpedPet}
     >
-      {!hasHelpedPet && petNFTData && !hasHitSocialPetLimit(petNFTData) && (
+      {!hasHelpedPet && petNFTData && (
         <div
           className="absolute -top-4 -right-4 pointer-events-auto cursor-pointer hover:img-highlight"
           onClick={(e) => {

--- a/src/features/island/pets/VisitingPet.tsx
+++ b/src/features/island/pets/VisitingPet.tsx
@@ -3,7 +3,6 @@ import {
   isPetNeglected,
   isPetNapping,
   PetName,
-  hasHitSocialPetLimit,
 } from "features/game/types/pets";
 import { _petData } from "./lib/petShared";
 import { useSelector } from "@xstate/react";
@@ -85,7 +84,7 @@ export const VisitingPet: React.FC<{ name: PetName }> = ({ name }) => {
       onClick={handlePetClick}
       clickable={!hasHelpedPet}
     >
-      {!hasHelpedPet && petData && !hasHitSocialPetLimit(petData) && (
+      {!hasHelpedPet && petData && (
         <div
           className="absolute -top-4 -right-4 pointer-events-auto cursor-pointer hover:img-highlight"
           onClick={(e) => {


### PR DESCRIPTION
# Description

This PR Reverts a change where it would stop allowing the visitor from petting a pet if the owner's pets has already reach daily limit.

Petting pets that has already reached the daily limit would not give the xp to them

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
