### PR TITLE
[FEAT] Restrict Pet Withdrawals if it's not revealed yet

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3785,6 +3785,7 @@
   "withdraw.flower.limited": "During the initial launch of $FLOWER, the amount of $FLOWER you can withdraw is limited.",
   "withdraw.boostedItem.timeLeft": "Withdrawable in {{time}}",
   "withdraw.requires.storeOnChain": "Store on Chain Required",
+  "withdraw.pet.notRevealed": "Pet will be revealed on {{date}}",
   "world.lvl.requirement": "Lvl {{lvl}}",
   "world.factionMembersOnly": "Faction members only",
   "world.newArea": "New",


### PR DESCRIPTION
# Description

Pets that are not revealed should be restricted

<img width="523" height="604" alt="image" src="https://github.com/user-attachments/assets/abc204df-f55e-43f3-8564-f3218f7814ce" />


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
