### PR TITLE
[FIX] Bear Shrine Wrong Boost

### DIFF
--- a/src/features/game/events/landExpansion/harvestBeehive.ts
+++ b/src/features/game/events/landExpansion/harvestBeehive.ts
@@ -8,10 +8,7 @@ import { getKeys } from "features/game/types/craftables";
 import { trackActivity } from "features/game/types/bumpkinActivity";
 import { isWearableActive } from "features/game/lib/wearables";
 import { produce } from "immer";
-import {
-  isTemporaryCollectibleActive,
-  isCollectibleBuilt,
-} from "features/game/lib/collectibleBuilt";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export const HARVEST_BEEHIVE_ERRORS = {
@@ -88,11 +85,6 @@ export const getHoneyMultiplier = (game: GameState) => {
   if (isCollectibleBuilt({ name: "King of Bears", game })) {
     multiplier += 0.25;
     boostsUsed.push("King of Bears");
-  }
-
-  if (isTemporaryCollectibleActive({ name: "Bear Shrine", game })) {
-    multiplier += 0.5;
-    boostsUsed.push("Bear Shrine");
   }
 
   return { multiplier, boostsUsed };

--- a/src/features/game/lib/updateBeehives.ts
+++ b/src/features/game/lib/updateBeehives.ts
@@ -6,7 +6,10 @@ import {
   FlowerBeds,
   GameState,
 } from "../types/game";
-import { isCollectibleBuilt } from "./collectibleBuilt";
+import {
+  isCollectibleBuilt,
+  isTemporaryCollectibleActive,
+} from "./collectibleBuilt";
 import { getKeys } from "../types/craftables";
 import { FLOWERS, FLOWER_SEEDS } from "../types/flowers";
 import { isWearableActive } from "./wearables";
@@ -48,6 +51,11 @@ const getHoneyProductionRate = (
   if (bumpkin.skills["Flowery Abode"]) {
     rate += 0.5;
     boostsUsed.push("Flowery Abode");
+  }
+
+  if (isTemporaryCollectibleActive({ name: "Bear Shrine", game })) {
+    rate += 0.5;
+    boostsUsed.push("Bear Shrine");
   }
 
   return { rate, boostsUsed };


### PR DESCRIPTION
# Description

Bear Shrine was mistakenly coded to give +0.5 Honey instead of +0.5 Honey Production Rate

This PR Fixes that

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
