### PR TITLE
[FIX] Temporary Collectibles being deduced from inventory on upgrade

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -929,47 +929,6 @@ describe("upgradeFarm", () => {
     expect(state.island.previousExpansions).toEqual(16);
   });
 
-  it("removes all temporary collectibles", () => {
-    const now = Date.now();
-
-    const state = upgrade({
-      action: {
-        type: "farm.upgraded",
-      },
-      state: {
-        ...INITIAL_FARM,
-        inventory: {
-          "Basic Land": new Decimal(16),
-          Gold: new Decimal(15),
-          "Time Warp Totem": new Decimal(1),
-          "Super Totem": new Decimal(1),
-        },
-        collectibles: {
-          "Time Warp Totem": [
-            {
-              id: "1",
-              readyAt: now + 1 * 60 * 60 * 1000,
-              createdAt: now + 1 * 60 * 60 * 1000,
-              coordinates: { x: 0, y: 0 },
-            },
-          ],
-          "Super Totem": [
-            {
-              id: "1",
-              readyAt: now + 1 * 60 * 60 * 1000,
-              createdAt: now + 1 * 60 * 60 * 1000,
-              coordinates: { x: 1, y: 2 },
-            },
-          ],
-        },
-      },
-      createdAt: now,
-    });
-
-    expect(state.inventory["Time Warp Totem"]).toEqual(new Decimal(0));
-    expect(state.inventory["Super Totem"]).toEqual(new Decimal(0));
-  });
-
   it("does not give extra sunstones", () => {
     const createdAt = Date.now();
 
@@ -1212,5 +1171,51 @@ describe("upgradeFarm", () => {
     });
 
     expect(state.island.biome).toBeUndefined();
+  });
+
+  it("Does not remove temporary collectibles on upgrade", () => {
+    const now = Date.now();
+
+    const state = upgrade({
+      action: {
+        type: "farm.upgraded",
+      },
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(9),
+          Gold: new Decimal(15),
+          "Fire Pit": new Decimal(1),
+          "Crop Plot": new Decimal(31),
+          Tree: new Decimal(9),
+          "Stone Rock": new Decimal(7),
+          "Iron Rock": new Decimal(4),
+          "Gold Rock": new Decimal(2),
+          "Super Totem": new Decimal(2),
+        },
+        collectibles: {
+          "Super Totem": [
+            {
+              id: "1",
+              readyAt: now,
+              createdAt: now,
+              coordinates: { x: 0, y: 0 },
+            },
+          ],
+        },
+      },
+      createdAt: now,
+    });
+
+    expect(state.collectibles["Super Totem"]).toEqual([
+      {
+        id: "1",
+        readyAt: now,
+        createdAt: now,
+        coordinates: { x: 0, y: 0 },
+      },
+    ]);
+    expect(state.inventory["Super Totem"]).toEqual(new Decimal(2));
   });
 });


### PR DESCRIPTION
# Description

This PR Fixes a bug where if you have a tempoary collectible (hourglass,totem/shrine) it would deduct one from your inventory 

Video of bug:

https://github.com/user-attachments/assets/622a672d-db11-409e-90c9-7c06062cd71d

The fix is just to remove that function that was doing that previously.

## Some context as to why this bug is happening
The function that removes expireItems was there because previously there was a bug that returned an expired temporary collectible back into a player's inventory when a player upgraded their farm, since it would previously remove everything from their farm before placing new items from the new upgrade.

During the Landscaping update, there was a change with the upgradeFarm where we started using other functions in the upgradeFarm, one of them is the removeAll function. the removeAll function would remove all collectibles, buildings and buds, however it does not remove temporary collectibles anymore. Hence since temporary collectibles are not removed, there's no need to deduct from inventory anymore

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
