### PR TITLE
[FEAT] Rebalance Pet NFT Categories

### DIFF
--- a/src/features/game/types/pets.ts
+++ b/src/features/game/types/pets.ts
@@ -174,14 +174,14 @@ export const PET_CATEGORIES: Record<PetType, PetCategory> = {
   },
 
   // NFT Pet Types
-  Ram: {
-    primary: "Snowkin",
-    secondary: "Voyager",
-    tertiary: "Forager",
-  },
   Dragon: {
-    primary: "Hunter",
+    primary: "Snowkin",
     secondary: "Guardian",
+    tertiary: "Voyager",
+  },
+  Ram: {
+    primary: "Hunter",
+    secondary: "Voyager",
     tertiary: "Moonkin",
   },
   Phoenix: {
@@ -202,7 +202,7 @@ export const PET_CATEGORIES: Record<PetType, PetCategory> = {
   Wolf: {
     primary: "Guardian",
     secondary: "Hunter",
-    tertiary: "Voyager",
+    tertiary: "Forager",
   },
   Bear: {
     primary: "Forager",


### PR DESCRIPTION
# Description

Some players have pointed out that Dragon and Phoenix has the exact same category typing. 

As a result we have rebalanced the NFT Pet categories based on the following factors:

- Primary category remains the same
- Pets will not have any 2 same categories

New Typings:

|Pet Type|Primary|Secondary|Tertiary|
|---|---|---|---|
|Dragon|Snowkin|Guardian|Voyager
|Ram|Hunter|Voyager|Moonkin|
|Phoenix|Moonkin|Beast|Guardian|
|Griffin|Voyager|Forager|Beast|
|Warthog|Beast|Snowkin|Hunter|
|Wolf|Guardian|Hunter|Forager|
|Bear|Forager|Moonkin|Snowkin|

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
