### PR TITLE
[FIX] Emblem Bulk Buy

### DIFF
--- a/src/features/marketplace/components/BulkPurchaseModalContent.tsx
+++ b/src/features/marketplace/components/BulkPurchaseModalContent.tsx
@@ -71,6 +71,7 @@ export const BulkPurchaseModalContent: React.FC<
     gameService.send("marketplace.buyBulkResources", {
       effect: {
         type: "marketplace.buyBulkResources",
+        itemId: tradeable.id,
         listingIds,
       },
       authToken,

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -38,7 +38,7 @@ import { InventoryItemName } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { MAX_INVENTORY_ITEMS } from "features/game/lib/processEvent";
 import debounce from "lodash.debounce";
-import { BulkPurchaseModalContent } from "./BulkPurcahseModalContent";
+import { BulkPurchaseModalContent } from "./BulkPurchaseModalContent";
 import { useDeepEffect } from "lib/utils/hooks/useDeepEffect";
 
 type TradeableListingsProps = {
@@ -362,6 +362,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
               {!!availableListings.length &&
                 isResource &&
                 !showBulkBuy &&
+                tradeable?.isActive &&
                 limitedTradesLeft === Infinity && (
                   <Button
                     className="w-fit h-8 rounded-none"


### PR DESCRIPTION
# Description

Fixes a bug where bulk buy was active on Emblems of a faction you were not a part of.

Fixes #issue

# What needs to be tested by the reviewer?

- List emblems for a faction on one account
- On another account that isn't part of that faction, attempt to buy those emblems
- Confirm you are not able to

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
