### PR TITLE
[FIX] Node Forging showing wrong requirements

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -27,13 +27,6 @@ import {
   EXPIRY_COOLDOWNS,
   TemporaryCollectibleName,
 } from "features/game/lib/collectibleBuilt";
-import {
-  RESOURCES_UPGRADES_TO,
-  ADVANCED_RESOURCES,
-  RESOURCES,
-  UpgradedResourceName,
-  RESOURCE_STATE_ACCESSORS,
-} from "features/game/types/resources";
 
 /**
  * The props for the details for items.
@@ -306,36 +299,8 @@ export const CraftingRequirements: React.FC<Props> = ({
             />
             {getKeys(requirements.resources).map((ingredientName, index) => {
               // If ingredient is a node, require it to be placed
-              let balance =
+              const balance =
                 gameState.inventory[ingredientName] ?? new Decimal(0);
-
-              if (ingredientName in RESOURCES) {
-                const stateAccessor =
-                  RESOURCE_STATE_ACCESSORS[
-                    ingredientName as UpgradedResourceName
-                  ];
-                const nodes = Object.values(
-                  stateAccessor(gameState) ?? {},
-                ).filter((resource) => {
-                  if (
-                    ingredientName in RESOURCES_UPGRADES_TO ||
-                    ingredientName in ADVANCED_RESOURCES
-                  ) {
-                    // If node is upgradeable, check if it has the same name as the current item
-                    if ("name" in resource) {
-                      return resource.name === ingredientName;
-                    }
-
-                    // If it has no name, it probably means it's a base resource
-                    return ingredientName in RESOURCES_UPGRADES_TO;
-                  }
-
-                  return true;
-                });
-                balance = new Decimal(
-                  nodes.filter((node) => node.removedAt === undefined).length,
-                );
-              }
 
               return (
                 <RequirementLabel


### PR DESCRIPTION
# Description

This PR Fixes an issue where the balance checks was incorrectly displayed for T3 nodes, it uses T2 nodes but it was displaying the balance of the T1 instead of the T2



Fixes #issue

# What needs to be tested by the reviewer?

- Go to Forge in Infernos
- Ensure that the balance for the T3 is using T2 nodes instead of T1

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
