### PR TITLE
[CHORE] Only show boost icon on boosted traits

### DIFF
--- a/src/features/island/pets/RevealPet.tsx
+++ b/src/features/island/pets/RevealPet.tsx
@@ -168,7 +168,10 @@ export const RevealPet: React.FC = () => {
                         <span>{`${capitalize(trait)}: `}</span>
                         <div className="inline-flex items-center gap-1">
                           <span className="whitespace-nowrap">{`${petTraits[trait]}`}</span>
-                          {(trait === "aura" || trait === "bib") && (
+                          {((trait === "aura" &&
+                            petTraits[trait] !== "No Aura") ||
+                            (trait === "bib" &&
+                              petTraits[trait] !== "Baby Bib")) && (
                             <img src={powerup} alt="Powerup" className="w-4" />
                           )}
                         </div>


### PR DESCRIPTION
# Description

In the reveal modal, only show the boost icon next to the aura and bib text in the reveal modal if they actually have a boost.

So it won't show if the:

Aura === "No Aura"
Bib === "Baby Bib"

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]