### PR TITLE
[FIX] Trading Shrine Taxes

### DIFF
--- a/src/features/game/types/marketplace.ts
+++ b/src/features/game/types/marketplace.ts
@@ -302,12 +302,12 @@ const ISLAND_RESOURCE_TAXES: Record<IslandType, number> = {
 export function getResourceTax({ game }: { game: GameState }): number {
   let tax = ISLAND_RESOURCE_TAXES[game.island.type];
 
-  if (hasVipAccess({ game })) {
-    tax *= 0.5;
+  if (isTemporaryCollectibleActive({ name: "Trading Shrine", game })) {
+    tax -= 0.025;
   }
 
-  if (isTemporaryCollectibleActive({ name: "Trading Shrine", game })) {
-    tax -= 2.5;
+  if (hasVipAccess({ game })) {
+    tax *= 0.5;
   }
 
   return tax;


### PR DESCRIPTION
# Description

Trading shrine was incorrectly calculated. it was deducting 2.5 tax, essentially giving the player free FLOWER, instead of deducting them

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
