### PR TITLE
[FIX] useUiRefresher for NFT Pets

### DIFF
--- a/src/features/island/collectibles/components/petNFT/LandPetNFT.tsx
+++ b/src/features/island/collectibles/components/petNFT/LandPetNFT.tsx
@@ -68,7 +68,7 @@ export const LandPetNFT: React.FC<{ id: string }> = ({ id }) => {
   };
 
   // Used to move the pet through different states (neglected, napping)
-  useUiRefresher();
+  useUiRefresher({ active: !!petNFTData?.traits });
 
   if (!petNFTData || !petNFTData.traits) return null;
 

--- a/src/features/island/collectibles/components/petNFT/VisitingPetNFT.tsx
+++ b/src/features/island/collectibles/components/petNFT/VisitingPetNFT.tsx
@@ -92,7 +92,7 @@ export const VisitingPetNFT: React.FC<{
   };
 
   // Used to move the pet through different states (neglected, napping)
-  useUiRefresher();
+  useUiRefresher({ active: !!petNFTData?.traits });
 
   if (!petNFTData || !petNFTData.traits) return null;
 


### PR DESCRIPTION
# Description

Similar to a previous bug with common pets, nft pets weren't using useUIRefresher so it wasn't refreshing the isNeglected and isNapping states in real time

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
