### PR TITLE
[FIX] Instagrow shouldn't be free at >90% Progress

### DIFF
--- a/src/features/game/events/landExpansion/instaGrowProject.test.ts
+++ b/src/features/game/events/landExpansion/instaGrowProject.test.ts
@@ -152,6 +152,15 @@ describe("instaGrowProject", () => {
       ).toEqual(0.8);
     });
 
+    it("shouldn't be free for 90% complete", () => {
+      expect(
+        getPartialInstantGrowPrice({
+          progress: 181,
+          project: "Big Banana",
+        }),
+      ).toEqual(0.39);
+    });
+
     it("returns 0 for finished project", () => {
       expect(
         getPartialInstantGrowPrice({ progress: 50, project: "Big Apple" }),

--- a/src/features/game/events/landExpansion/instaGrowProject.ts
+++ b/src/features/game/events/landExpansion/instaGrowProject.ts
@@ -32,7 +32,7 @@ export function getPartialInstantGrowPrice({
   const requiredCheers = REQUIRED_CHEERS[project];
 
   // Round to the nearest tenth
-  const progressPercentage = Math.ceil((progress / requiredCheers) * 10) / 10;
+  const progressPercentage = Math.floor((progress / requiredCheers) * 10) / 10;
   const partialMultiplier = 1 - progressPercentage;
 
   return setPrecision(initialPrice * partialMultiplier, 2).toNumber();


### PR DESCRIPTION
# Description

This PR Fixes an issue where insta grow is free over 90% progress

Right now it would throw an error if price is 0 but good to fix it such that it shows the correct price

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
