### PR TITLE
[CHORE] Hornet Mask description update

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -499,7 +499,7 @@
   "bumpkinItemBuff.crimstone.hammer": "+2 Crimstones on 5th mine",
   "bumpkinItemBuff.crimstone.amulet": "-20% Crimstone Cooldown Time",
   "bumpkinItemBuff.crimstone.armor": "+0.1 Crimstones",
-  "bumpkinItemBuff.hornet.mask": "2x base Bee Swarm chance (+10% chance)",
+  "bumpkinItemBuff.hornet.mask": "2x base Bee Swarm chance",
   "bumpkinItemBuff.honeycomb.shield": "+1 Honey per Full Beehive",
   "bumpkinItemBuff.flower.crown": "-50% Flower Growth Time",
   "bumpkinItemBuff.goblin.armor": "+20% Marks",


### PR DESCRIPTION
Change Hornet Mask description. This comes after seeing yet another question about how the Hornet Mask works. The description is misleading when you look at other items such as scarecrow. Scarecrow is +20% crop yield. This is multiplied by green amulet which is chance of 10x crops. Whereas with bee swarms, the Bee Collective skill which is +20% Bee Swarm chance isn't multiplied by Hornet Mask which is 2x Bee Swarm Chance.

<img width="665" height="114" alt="image" src="https://github.com/user-attachments/assets/a01d445c-88ab-460c-86e6-15f33f2393a0" />

<img width="428" height="71" alt="image" src="https://github.com/user-attachments/assets/d4daea91-6de6-4610-9d58-39e4882bc2c9" />

<img width="547" height="49" alt="image" src="https://github.com/user-attachments/assets/cfc94ac2-5cad-4d3c-8ea2-177239d7a280" />

<img width="637" height="62" alt="image" src="https://github.com/user-attachments/assets/0612a228-ba3d-48ea-b059-1cbeafc1698b" />

<img width="653" height="116" alt="image" src="https://github.com/user-attachments/assets/75f73f63-410a-4341-85c1-762b08803497" />

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
