### PR TITLE
FEAT: Move pet outside dig site

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -50,7 +50,6 @@ export type DigAnalytics = { outputCoins: number; percentageFound: number };
 const SITE_COLS = DESERT_GRID_WIDTH;
 const SITE_ROWS = DESERT_GRID_HEIGHT;
 const PET_FOLLOW_OFFSET_X = 13;
-const PET_FOLLOW_OFFSET_Y = 11;
 
 export class BeachScene extends BaseScene {
   sceneId: SceneId = "beach";
@@ -1274,11 +1273,25 @@ export class BeachScene extends BaseScene {
       return;
     }
 
-    const targetX = perimeterPosition.x - PET_FOLLOW_OFFSET_X;
-    const targetY = perimeterPosition.y + PET_FOLLOW_OFFSET_Y;
+    const gridRight = this.gridX + this.cellSize * SITE_COLS;
+    const gridTop = this.gridY;
+    const gridBottom = this.gridY + this.cellSize * SITE_ROWS;
 
-    petContainer.setPosition(targetX, targetY);
-    petContainer.setDepth(targetY);
+    let offsetX = -PET_FOLLOW_OFFSET_X;
+
+    const isTopOrBottom =
+      perimeterPosition.y <= gridTop || perimeterPosition.y >= gridBottom;
+    const isRightEdge = perimeterPosition.x >= gridRight;
+
+    if (!isTopOrBottom && isRightEdge) {
+      offsetX = PET_FOLLOW_OFFSET_X;
+    }
+
+    petContainer.setPosition(
+      perimeterPosition.x + offsetX,
+      perimeterPosition.y,
+    );
+    petContainer.setDepth(perimeterPosition.y);
     petContainer.idle();
   }
 
@@ -1648,6 +1661,7 @@ export class BeachScene extends BaseScene {
       this.updateOtherPlayers();
       this.updateShaders();
       this.handleDigbyWarnings();
+      this.updatePets();
     } else {
       // this.noToolHoverBox?.setVisible(false);
       this.alreadyWarnedOfNoDigs = false;


### PR DESCRIPTION
# Description
Park the pets outside the dig site when digging

https://github.com/user-attachments/assets/5f88715d-722c-4032-a97e-cf245a421f34


# How to test?
1. Enter the Beach with 2 different accounts. At least 1 should have a Pet NFT
2. Go to the dig site - pets should be parked with their respective owners around the dig site
