### PR TITLE
[FIX] Resources jumping when interacting with them

### DIFF
--- a/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
+++ b/src/features/game/expansion/components/resources/tree/components/RecoveredTree.tsx
@@ -111,7 +111,6 @@ const RecoveredTreeComponent: React.FC<Props> = ({
 
         {/* static tree image */}
         {!showSpritesheet && <Image />}
-
         {/* spritesheet */}
         {showSpritesheet && (
           <Spritesheet
@@ -124,7 +123,7 @@ const RecoveredTreeComponent: React.FC<Props> = ({
 
               // Adjust the base of tree to be perfectly aligned to
               // on a grid point.
-              bottom: `${PIXEL_SCALE * 2}px`,
+              bottom: `${PIXEL_SCALE * 0}px`,
               right: `${PIXEL_SCALE * -4}px`,
             }}
             getInstance={(spritesheet) => {

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -99,8 +99,10 @@ export const READONLY_RESOURCE_COMPONENTS = (): Record<
         className="relative pointer-events-none"
         style={{
           width: `${PIXEL_SCALE * 14}px`,
-          top: `${PIXEL_SCALE * 4.52}px`,
-          left: `${PIXEL_SCALE * 1.38}px`,
+          // Align the base stone rock with the gold/iron rocks so that the
+          // shared strike animation lines up without a visible jump.
+          top: `${PIXEL_SCALE * 3}px`,
+          left: `${PIXEL_SCALE * 1}px`,
         }}
       />
     ),


### PR DESCRIPTION
# Description

Small PR to fix the issue where trees and stone jump up a couple of pixels when your chopping/mining them.

__Before__

https://github.com/user-attachments/assets/a79a15dc-1581-4c62-b9ce-64f880e1b642

__After__

https://github.com/user-attachments/assets/da93cf9e-0061-4869-b39b-68eeda0285ca

# What needs to be tested by the reviewer?

- Chop a tree (confirm the tree doesn't jump up)
- Mine a stone (confirm it doesn't jump up)

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes