### PR TITLE
[FIX] Ignore total seconds in TimerDisplay

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctionDetails.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionDetails.tsx
@@ -31,7 +31,7 @@ type TimeObject = {
     hours?: number;
     minutes: number;
     seconds: number;
-    totalSeconds: number;
+    totalSeconds?: number;
   };
   fontSize?: number;
   color?: string;


### PR DESCRIPTION
# Description

This PR fixes a bug in the `TimerDisplay` component. I have set it up so now it ignores `totalSeconds` which is a new field returned from the `useCountdown` hook.

Previously it was just blindly getting the time keys and joining them all together which put `totalSeconds` on the end. 

<img width="278" height="69" alt="Screenshot 2025-11-27 at 12 23 40 pm" src="https://github.com/user-attachments/assets/8a9ddfc0-84c2-4bc4-b75d-e3097fbe1da8" />

# What needs to be tested by the reviewer?

- Set an auction
- Check the label

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
