### PR TITLE
[FIX] Fruit Tree Timers

### DIFF
--- a/src/features/island/fruit/ReplenishingTree.tsx
+++ b/src/features/island/fruit/ReplenishingTree.tsx
@@ -78,7 +78,8 @@ export const ReplenishingTree: React.FC<Props> = ({
 
   const { plantSeconds } = PATCH_FRUIT_SEEDS[seed];
 
-  const replenishPercentage = 100 - (timeLeft / plantSeconds) * 100;
+  const replenishPercentage =
+    plantSeconds > 0 ? 100 - (timeLeft / plantSeconds) * 100 : 0;
 
   return (
     <div


### PR DESCRIPTION
# Description

Fruit tree timers were not updating. The React Compiler treated `getFruitTreeStatus(plantedFruit)` as a pure, memoizable computation (because its only argument plantedFruit doesn’t change while a tree is replenishing), even though it was secretly reading the clock via getTimeLeft → Date.now(). So:
useUiRefresher did cause FruitTree to re‑render every second.

But the compiler could safely reuse the previous result of
getFruitTreeStatus(plantedFruit) since the argument hadn’t changed.

Fixes #issue

# What needs to be tested by the reviewer?

- `yarn build && yarn preview`
-  harvest a fruit tree
-  confirm the timer goes down

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
