### PR TITLE
[FIX] Speed up buildings and timer alignments

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -248,13 +248,8 @@ export const LandComponent: React.FC = () => {
   const { collectibles, positions: collectiblePositions } = useSelector(
     gameService,
     _collectiblePositions,
-    comparePositions,
   );
-  const { buildings } = useSelector(
-    gameService,
-    _buildingPositions,
-    comparePositions,
-  );
+  const { buildings } = useSelector(gameService, _buildingPositions);
   const { stones } = useSelector(
     gameService,
     _stonePositions,
@@ -453,7 +448,7 @@ export const LandComponent: React.FC = () => {
 
     return getKeys(buildings)
       .filter((name) => buildings[name])
-      .flatMap((name, nameIndex) => {
+      .flatMap((name) => {
         const items = buildings[name]!;
         return items
           .filter((building) => building.coordinates !== undefined)

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -45,7 +45,6 @@ import {
   LandscapingPlaceableType,
   SaveEvent,
 } from "../expansion/placeable/landscapingMachine";
-import { Context } from "../GameProvider";
 import { isSwarming } from "../events/detectBot";
 import { generateTestLand } from "../expansion/actions/generateLand";
 

--- a/src/features/island/buildings/components/building/composters/Composter.tsx
+++ b/src/features/island/buildings/components/building/composters/Composter.tsx
@@ -91,7 +91,7 @@ export const Composter: React.FC<Props> = ({ name }) => {
     <>
       <BuildingImageWrapper name={name} onClick={handleClick} ready={ready}>
         <div
-          className="absolute pointer-events-none"
+          className="absolute pointer-events-none bg-black"
           style={{
             width: `${PIXEL_SCALE * width}px`,
             bottom: `${PIXEL_SCALE * 0}px`,
@@ -122,6 +122,9 @@ export const Composter: React.FC<Props> = ({ name }) => {
                 type="progress"
                 formatLength="short"
                 seconds={secondsLeft}
+                style={{
+                  width: `${PIXEL_SCALE * 14}px`,
+                }}
               />
             </div>
           )}

--- a/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
+++ b/src/features/island/buildings/components/building/waterWell/WaterWell.tsx
@@ -22,10 +22,12 @@ export const WaterWell: React.FC<BuildingProps> = ({ season }) => {
   const [showConstructingModal, setShowConstructingModal] =
     React.useState(false);
   const { gameService } = useGame();
-  const now = useNow();
+
   const waterWell = useSelector(gameService, _waterWell);
   const state = useSelector(gameService, _state);
   const { level, upgradeReadyAt, upgradedAt } = waterWell;
+  const now = useNow({ live: true, autoEndAt: upgradeReadyAt ?? 0 });
+
   const isUpgrading = (upgradeReadyAt ?? 0) > now;
   const currentLevel = isUpgrading ? level - 1 : level;
   const previousIsUpgrading = React.useRef(isUpgrading);

--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -83,7 +83,12 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
         }}
       >
         {showTimers && (
-          <div className="absolute bottom-0 left-0">
+          <div
+            className="absolute bottom-0 left-1/2 -translate-x-1/2"
+            style={{
+              width: `${PIXEL_SCALE * 14}px`,
+            }}
+          >
             <ProgressBar
               seconds={secondsToExpire}
               formatLength="medium"
@@ -155,7 +160,7 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
         {showTimers && (
           <div
             className="absolute bottom-0 left-1/2 -translate-x-1/2"
-            style={{ width: `${PIXEL_SCALE * 15}px` }}
+            style={{ width: `${PIXEL_SCALE * 14}px` }}
           >
             <ProgressBar
               seconds={secondsToExpire}


### PR DESCRIPTION
# Description

Fixes speeding up construction of buildings using gems. There was a bug where the speed up wasn't working for composters and water wells weren't updating to the next level after speeding up.

Fixes #issue

# What needs to be tested by the reviewer?

- Place a level 1 water well
- Speed up the upgrade with gems
- Confirm the building changes to next level

- Place a new composter
- Speed up with gems
- Confirm it works

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
