### PR TITLE
[FIX] Oil reserve not replenishing in real-time

### DIFF
--- a/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
@@ -24,6 +24,7 @@ const _reserve = (id: string) => (state: MachineState) =>
   state.context.state.oilReserves[id];
 const _drills = (state: MachineState) =>
   state.context.state.inventory["Oil Drill"] ?? new Decimal(0);
+const selectGame = (state: MachineState) => state.context.state;
 
 const compareResource = (prev: IOilReserve, next: IOilReserve) => {
   return JSON.stringify(prev) === JSON.stringify(next);
@@ -34,8 +35,7 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
   const [drilling, setDrilling] = useState(false);
   const [oilHarvested, setOilHarvested] = useState(0);
 
-  const state = gameService.getSnapshot().context.state;
-
+  const state = useSelector(gameService, selectGame);
   const reserve = useSelector(gameService, _reserve(id), compareResource);
   const drills = useSelector(gameService, _drills);
   const timeLeft = getTimeLeft(


### PR DESCRIPTION
# Description

Fixes the issue where the game needs to be refreshed for oil reserves to be harvestable. Replaced `gameService.getSnapshot().context.state` with `useSelector(gameService, selectGame)`


# What needs to be tested by the reviewer?
- Adjust and oil reserve's `drilledAt` so that you can see it replenish without refreshing the game
