### PR TITLE
[FIX] Bumpkin Eating

### DIFF
--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { useSelector } from "@xstate/react";
 
 import { Box } from "components/ui/Box";
@@ -36,17 +36,22 @@ export const Feed: React.FC<Props> = ({ food }) => {
   const bumpkin = useSelector(gameService, _bumpkin);
   const game = useSelector(gameService, _game);
   const { t } = useAppTranslation();
+  // Derive the "active" selected food from the current props so that
+  // we never point at a food item that is no longer available.
+  const activeSelected =
+    food.find((item) => item.name === selected?.name) ?? food[0];
 
-  useEffect(() => {
-    if (food.length) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setSelected(food[0]);
-    } else {
-      setSelected(undefined);
-    }
-  }, [food]);
+  const inventoryFoodCount = activeSelected
+    ? (inventory[activeSelected.name] ?? new Decimal(0))
+    : new Decimal(0);
 
-  if (!selected) {
+  const feedVerb = activeSelected
+    ? isJuice(activeSelected.name)
+      ? t("drink")
+      : t("eat")
+    : "";
+
+  if (!activeSelected) {
     return (
       <InnerPanel>
         <div className="flex flex-col p-2">
@@ -70,13 +75,13 @@ export const Feed: React.FC<Props> = ({ food }) => {
   }
 
   const feed = (amount: number) => {
-    if (!selected) return;
+    if (!activeSelected) return;
 
     const previousExperience = bumpkin?.experience ?? 0;
     let previousLevel: number = getBumpkinLevel(bumpkin?.experience ?? 0);
 
     const newState = gameService.send("bumpkin.feed", {
-      food: selected.name,
+      food: activeSelected.name,
       amount,
     });
 
@@ -98,19 +103,16 @@ export const Feed: React.FC<Props> = ({ food }) => {
     }
   };
 
-  const inventoryFoodCount = inventory[selected.name] ?? new Decimal(0);
-  const feedVerb = isJuice(selected.name) ? "Drink" : "Eat";
-
   return (
     <SplitScreenView
       panel={
         <FeedBumpkinDetails
           details={{
-            item: selected.name,
+            item: activeSelected.name,
           }}
           properties={{
             xp: getFoodExpBoost({
-              food: selected,
+              food: activeSelected,
               game,
             }).boostedExp,
           }}
@@ -138,7 +140,7 @@ export const Feed: React.FC<Props> = ({ food }) => {
         <>
           {food.map((item) => (
             <Box
-              isSelected={selected.name === item.name}
+              isSelected={activeSelected?.name === item.name}
               key={item.name}
               onClick={() => setSelected(item)}
               image={ITEM_DETAILS[item.name].image}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1,4 +1,6 @@
 {
+  "drink": "Drink",
+  "eat": "Eat",
   "villageProjects": "Village Projects",
   "pet.resources": "Pet Resources",
   "reload": "Reload",


### PR DESCRIPTION
# Description

Fix bumpkin feeding issue where it was switching the selected item back even when you had more of the originally selected item to eat.

Fixes #issue

# What needs to be tested by the reviewer?

- Like the vid, confirm if you eat an item that you have more than one of, it lets you eat them all before moving you back to the first in your inventory.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
