### PR TITLE
[FIX] Obsidian Shrine Ready State

### DIFF
--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -43,13 +43,14 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
   const [activeTab, setActiveTab] = useState(0);
   const [showPopover, setShowPopover] = useState(false);
 
-  const now = useNow({ live: true });
-
   const expiresAt = createdAt + (EXPIRY_COOLDOWNS[name as PetShrineName] ?? 0);
+
   const { totalSeconds: secondsToExpire } = useCountdown(expiresAt);
   const durationSeconds = EXPIRY_COOLDOWNS[name as PetShrineName] ?? 0;
   const percentage = 100 - (secondsToExpire / durationSeconds) * 100;
   const hasExpired = secondsToExpire <= 0;
+
+  const now = useNow({ live: !hasExpired, autoEndAt: expiresAt });
 
   const state = useSelector(gameService, (state) => state.context.state);
 


### PR DESCRIPTION
# Description

This fixes the issue where the Obsidian Shrine wasn't showing that crops were ready without needing a refresh.

Fixes #issue

# What needs to be tested by the reviewer?

- Build the app `yarn build && yarn preview`
- Place an obsidian shrine
- Plant sunflowers
- Ensure that the obsidian shrine shows as ready when the crops are done

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
