### PR TITLE
[FIX] Store tree chopped count in tree

### DIFF
--- a/src/features/game/events/landExpansion/chop.ts
+++ b/src/features/game/events/landExpansion/chop.ts
@@ -334,10 +334,13 @@ export function chop({
       game: stateCopy,
       farmId,
       itemId: parseInt(`0x${action.index}`),
-      counter: stateCopy.farmActivity[`Tree Chopped`] ?? 0,
+      counter: tree.wood.choppedCount ?? 0,
     });
 
-    tree.wood = { choppedAt: time };
+    tree.wood = {
+      choppedAt: time,
+      choppedCount: (tree.wood.choppedCount ?? 0) + 1,
+    };
 
     inventory.Axe = axeAmount.sub(requiredAxes);
     inventory.Wood = woodAmount.add(woodHarvested);

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -650,6 +650,7 @@ export type Wood = {
   reward?: Omit<Reward, "sfl">;
   criticalHit?: CriticalHit;
   amount?: number;
+  choppedCount?: number;
 };
 
 export type CriticalHitName =


### PR DESCRIPTION
# Description

This PR Stores the chopped count in the tree itself. More details as to why is in the BE

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
