### PR TITLE
[FIX] Upcoming expansion and composter timers

### DIFF
--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -163,7 +163,10 @@ export const ExpansionBuilding: React.FC<{
   state: GameState;
   onReveal: () => void;
 }> = ({ state, onReveal }) => {
-  const now = useNow();
+  const now = useNow({
+    live: true,
+    autoEndAt: state.expansionConstruction?.readyAt,
+  });
   // Land is still being built
   if (state.expansionConstruction) {
     const origin =

--- a/src/features/island/buildings/components/building/composters/Composter.tsx
+++ b/src/features/island/buildings/components/building/composters/Composter.tsx
@@ -45,8 +45,12 @@ export const Composter: React.FC<Props> = ({ name }) => {
 
   const startedAt = composter?.producing?.startedAt ?? 0;
   const readyAt = composter?.producing?.readyAt ?? 0;
-  const totalRunningSeconds = Math.max((readyAt - startedAt) / 1000, 0);
-  const percentage = Math.min((secondsLeft / totalRunningSeconds) * 100, 100);
+  const totalRunningSeconds = Math.max((readyAt - startedAt) / 1000, 1);
+  const elapsedSeconds = Math.max(totalRunningSeconds - secondsLeft, 0);
+  const percentage = Math.min(
+    (elapsedSeconds / totalRunningSeconds) * 100,
+    100,
+  );
   const ready = !!readyAt && secondsLeft <= 0;
   const composting = secondsLeft > 0;
 


### PR DESCRIPTION
# Description

Fixed two bugs:

- Upcoming expansion was getting stuck at 100% and not completing the expansion due to a static timer
- Composter progress bars were counting down instead of up

Fixes #issue

# What needs to be tested by the reviewer?

- Expand land and confirm it autocompletes once the ready at is reached
- Confirm compost progress bars are moving up from 0 -> 100

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
