### PR TITLE
[FIX] Stream reward max

### DIFF
--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1748,7 +1748,10 @@ export interface GameState {
       tier: "bronze" | "silver" | "gold" | "platinum" | "diamond";
     };
     giftGiver?: { openedAt: number };
-    streamerHat?: { openedAt: number };
+    streamerHat?: {
+      openedAt: number;
+      dailyCount?: number;
+    };
     pirateChest?: { openedAt: number };
     keysBought?: KeysBought;
   };


### PR DESCRIPTION
# Description

We have situations where the team forget to dequip the Streamer Hat - allowing players with the modal open to keep claiming.

**Fix:** Max 10 claims per day

## How to test?

Equip streamer hat and try claim an 11th time in one day.