### PR TITLE
[FIX] Saw Fish on extras tab on Fisherman modal

### DIFF
--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -572,6 +572,10 @@ const BoostReelItems: (
     buff: Object.values(BUMPKIN_REVAMP_SKILL_TREE["More With Less"].boosts),
     location: "Fishing Skill Tree",
   },
+  "Saw Fish": {
+    buff: BUMPKIN_ITEM_BUFF_LABELS["Saw Fish"] as BuffLabel[],
+    location: "Stella's Megastore",
+  },
 });
 
 const isWearable = (
@@ -685,7 +689,7 @@ const FishermanExtras: React.FC<{
               {t("fishing.lookingMoreReels")}
             </span>
           </InnerPanel>
-          <InnerPanel className="flex flex-col mb-1 overflow-y-scroll overflow-x-hidden scrollable max-h-[330px] sm:max-h-max sm:overflow-y-hidden">
+          <InnerPanel className="flex flex-col mb-1 overflow-y-scroll overflow-x-hidden scrollable max-h-[330px]">
             {Object.entries(BoostReelItems(state)).map(([name, item]) => (
               <div key={name} className="flex -ml-1">
                 {getItemIcon(


### PR DESCRIPTION
# Description

- Added Saw Fish on the extras tab
- Updated max height to be the same for all screen sizes

| Before | After |
|---|---|
| <img width="2096" height="1718" alt="image" src="https://github.com/user-attachments/assets/e4057ff6-9a04-44cd-8695-79d4be5d5cfc" /> | <img width="2096" height="1718" alt="image" src="https://github.com/user-attachments/assets/5b365fa9-cd1d-48fb-9dc0-a957188e3566" /> |


