### PR TITLE
[FEAT] Instant Helped Them Today Icon 

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -198,6 +198,13 @@ export const Feed: React.FC<Props> = ({
     mutate,
   );
 
+  useOnMachineTransition(
+    gameService,
+    "helpingFarm",
+    "helpingFarmSuccess",
+    mutate,
+  );
+
   const handleInteractionClick = (interaction: Interaction) => {
     setShowFeed(false);
     playerModalManager.open({


### PR DESCRIPTION
# Description

This PR instantly updated the helped feed interaction with the `helpedThem` icon when you help a farm that has helped you already.

Prior it would only update after a refresh of the feed.

<img width="325" height="79" alt="Screenshot 2025-12-09 at 12 09 29 pm" src="https://github.com/user-attachments/assets/6f67db3f-3435-4e13-9453-8d60e18e827f" />

Fixes #issue

# What needs to be tested by the reviewer?

- Load up two farms
- Have farm A help farm B
- Go to farm B and look at your feed and see the help interaction
- Click on the interaction and go and help farm A
- Click on your feed and verify that the `helpedThem` icon shows on the help interaction

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
