### PR TITLE
[FIX] Multiple UI bug fixes (#6284, #6548, #5888)

### DIFF
--- a/src/components/ui/SFTDetailPopover.tsx
+++ b/src/components/ui/SFTDetailPopover.tsx
@@ -8,6 +8,7 @@ import { Label } from "./Label";
 import useSWR from "swr";
 import { loadTradeable } from "features/marketplace/actions/loadTradeable";
 import { KNOWN_IDS } from "features/game/types";
+import { ITEM_IDS } from "features/game/types/bumpkin";
 import { useSelector } from "@xstate/react";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { AuthMachineState } from "features/auth/lib/authMachine";
@@ -94,11 +95,18 @@ export const SFTDetailPopoverTradeDetails = ({
   const { authService } = useContext(AuthProvider.Context);
   const rawToken = useSelector(authService, _rawToken);
 
+  // Determine collection type and ID based on item type
+  const isWearable = name in ITEM_IDS;
+  const collectionType = isWearable ? "wearables" : "collectibles";
+  const itemId = isWearable
+    ? ITEM_IDS[name as keyof typeof ITEM_IDS]
+    : KNOWN_IDS[name];
+
   const { data: tradeable, error } = useSWR(
-    ["collectibles", KNOWN_IDS[name], rawToken],
-    ([, id, token]) =>
+    [collectionType, itemId, rawToken],
+    ([type, id, token]) =>
       loadTradeable({
-        type: "collectibles",
+        type: type as "collectibles" | "wearables",
         id: Number(id),
         token: token as string,
       }),


### PR DESCRIPTION
## Summary
- Fix 2-year streak reward showing "365 days" instead of "730 days" (#6284)
- Fix supply not showing for wearable items like Pickaxe Shark (#6548)
- Fix marketplace % change showing wrong direction (#5888)

## Changes

### 1. Daily Rewards - 730 day streak label (#6284)
The 2-year streak milestone was incorrectly showing "365 day streak reward". Added new translation key `reward.streak.twoYear` and updated logic to distinguish between 1-year (365 days) and 2-year (730 days) milestones.

### 2. Supply display for wearables (#6548)
`SFTDetailPopover.tsx` was hardcoding `type: "collectibles"` when loading tradeable data. For wearable items (like Pickaxe Shark), this caused the API to return no data. Now checks if item is in `ITEM_IDS` to determine correct collection type.

### 3. Price history % change calculation (#5888)
The price fill loop in `getPriceHistory()` was iterating in the wrong direction after sorting. Since dates are sorted newest-first, dates with no price should inherit from older dates (higher index), not newer ones.

## Test plan
- [ ] Verify 730 day streak shows correct label (requires test account with streak)
- [ ] Verify Pickaxe Shark shows supply in item popover
- [ ] Verify marketplace % changes reflect actual price direction