### PR TITLE
[FIX] use tier-based filtering for node forging requirements (crafting)

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -28,7 +28,6 @@ import {
   TemporaryCollectibleName,
 } from "features/game/lib/collectibleBuilt";
 import {
-  RESOURCES_UPGRADES_TO,
   ADVANCED_RESOURCES,
   RESOURCES,
   UpgradedResourceName,
@@ -312,23 +311,27 @@ export const CraftingRequirements: React.FC<Props> = ({
                   RESOURCE_STATE_ACCESSORS[
                     ingredientName as UpgradedResourceName
                   ];
+
+                // Determine the expected tier for this ingredient
+                let expectedTier: number;
+                if (ingredientName in ADVANCED_RESOURCES) {
+                  expectedTier =
+                    ADVANCED_RESOURCES[ingredientName as UpgradedResourceName]
+                      .tier;
+                } else {
+                  // Base resources (Stone Rock, Iron Rock, etc.) are tier 1
+                  expectedTier = 1;
+                }
+
                 const nodes = Object.values(
                   stateAccessor(gameState) ?? {},
                 ).filter((resource) => {
-                  if (
-                    ingredientName in RESOURCES_UPGRADES_TO ||
-                    ingredientName in ADVANCED_RESOURCES
-                  ) {
-                    // If node is upgradeable, check if it has the same name as the current item
-                    if ("name" in resource) {
-                      return resource.name === ingredientName;
-                    }
-
-                    // If it has no name, it probably means it's a base resource
-                    return ingredientName in RESOURCES_UPGRADES_TO;
-                  }
-
-                  return true;
+                  // Check the node's tier matches the expected tier for this ingredient
+                  const nodeTier = "tier" in resource ? resource.tier : 1;
+                  // Ensure node is placed and matches the expected tier
+                  const isPlaced =
+                    resource.x !== undefined && resource.y !== undefined;
+                  return isPlaced && nodeTier === expectedTier;
                 });
                 balance = new Decimal(
                   nodes.filter((node) => node.removedAt === undefined).length,


### PR DESCRIPTION
## Summary
- Fixes #6518 - Node Forging showing wrong requirements

The previous logic in `CraftingRequirements.tsx` incorrectly counted base tier nodes when checking requirements for upgraded resources. For example, when checking requirements for "Reinforced Stone Rock" (tier 3) which needs 4 "Fused Stone Rock" (tier 2) nodes, the code was counting all stone nodes regardless of tier.

### Changes
- Determines the expected tier from `ADVANCED_RESOURCES` for upgraded resources (tier 2 or 3)
- Base resources default to tier 1
- Filters nodes by their actual `tier` property (defaults to 1 if not present)
- Ensures only placed nodes are counted (x/y coordinates defined)

This approach is consistent with `getUpgradeableNodes()` in `resourceNodes.ts`.

## Test plan
- [ ] Check that forging "Fused Stone Rock" correctly shows count of tier 1 Stone Rock nodes
- [ ] Check that forging "Reinforced Stone Rock" correctly shows count of tier 2 Fused Stone Rock nodes
- [ ] Verify the same behavior for Trees, Iron, and Gold upgrade paths