### PR TITLE
[CHORE] Temp disable the sparkle effect on Gam3 hat

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -190,7 +190,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     // });
 
     this.scene.add.existing(this);
-    this.updateGam3sCelebrationEffect();
+    // this.updateGam3sCelebrationEffect();
 
     if (onClick) {
       this.setInteractive({ cursor: "pointer" }).on(
@@ -487,7 +487,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
     }
 
     this.showSmoke();
-    this.updateGam3sCelebrationEffect();
+    // this.updateGam3sCelebrationEffect();
   }
 
   public showCharm() {


### PR DESCRIPTION
# Description

Temporarily disabling the Gam3 sparkle to see if it helps this issue we are facing on android after upgrading `phaser3-rex-plugins`

<img width="300"  alt="Screenshot_20251209-192742" src="https://github.com/user-attachments/assets/6a365fbe-2228-4f00-8b12-90c2cc21ce76" />


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
