### PR TITLE
[FIX] Strengthen postMessage origin validation

### DIFF
--- a/src/features/auth/components/Verifying.tsx
+++ b/src/features/auth/components/Verifying.tsx
@@ -34,10 +34,9 @@ export const Verifying: React.FC = () => {
           const frame = document.getElementById("iframe") as HTMLIFrameElement;
 
           // Only listen to events from the IFrame in focus
-          if (
-            e.origin.includes(CONFIG.API_URL as string) ||
-            (e.origin === "null" && e.source === frame?.contentWindow)
-          ) {
+          // Use strict origin comparison to prevent subdomain attacks
+          const apiOrigin = new URL(CONFIG.API_URL as string).origin;
+          if (e.origin === apiOrigin && e.source === frame?.contentWindow) {
             authService.send("VERIFIED", {
               data: {
                 account: wallet.getAccount(),


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability in the postMessage origin validation in the `Verifying` component.

### Problem

The previous implementation used a weak origin check:
```typescript
if (e.origin.includes(CONFIG.API_URL as string) || 
    (e.origin === "null" && e.source === frame?.contentWindow))
```

This has two security issues:
1. **Subdomain spoofing**: `.includes()` would match `https://evil-api.sunflower-land.com.attacker.com` if `CONFIG.API_URL` contains `sunflower-land.com`
2. **Overly permissive null origin**: Accepting `origin === "null"` could allow attacks from sandboxed iframes or data URLs

### Fix

- Use strict `URL.origin` comparison instead of `.includes()`
- Require both origin match AND source window match for validation
- Remove the standalone `origin === "null"` condition

```typescript
const apiOrigin = new URL(CONFIG.API_URL as string).origin;
if (e.origin === apiOrigin && e.source === frame?.contentWindow) {
```

## Test plan

- [x] Verify authentication flow still works correctly
- [x] Verify postMessage events from the iframe are processed
- [x] Confirm malicious origins are rejected

## Security

This change hardens the authentication flow against potential origin spoofing attacks via postMessage.