### PR TITLE
[FIX] Show correct label for 730 day streak reward

### DIFF
--- a/src/features/game/components/Revealed.tsx
+++ b/src/features/game/components/Revealed.tsx
@@ -32,7 +32,15 @@ export const Revealed: React.FC<{
   const currentStreaks = gameState.context.state.dailyRewards?.streaks ?? 1;
   const streakBonus = currentStreaks % 5 == 0;
 
-  const isOneYearStreakCycle = currentStreaks % 365 === 0;
+  const isOneYearStreak = currentStreaks === 365;
+  const isTwoYearStreak = currentStreaks === 730;
+  const isYearlyStreakMilestone = isOneYearStreak || isTwoYearStreak;
+
+  const getStreakLabel = () => {
+    if (isTwoYearStreak) return t("reward.streak.twoYear");
+    if (isOneYearStreak) return t("reward.streak.oneYear");
+    return t("reward.streakBonus");
+  };
 
   return (
     <>
@@ -55,12 +63,10 @@ export const Revealed: React.FC<{
         <div className="flex flex-col items-center p-2">
           <Label
             type="vibrant"
-            icon={isOneYearStreakCycle ? Gift : Lightning}
+            icon={isYearlyStreakMilestone ? Gift : Lightning}
             className="px-0.5 text-sm"
           >
-            {isOneYearStreakCycle
-              ? t("reward.streak.oneYear")
-              : t("reward.streakBonus")}
+            {getStreakLabel()}
           </Label>
         </div>
       )}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -3403,6 +3403,7 @@
   "reward.whatCouldItBe": "What could it be?",
   "reward.streakBonus": "3x streak bonus",
   "reward.streak.oneYear": "365 day streak reward",
+  "reward.streak.twoYear": "730 day streak reward",
   "reward.found": "You found",
   "reward.spendWisely": "Spend it wisely.",
   "reward.wearable": "A wearable for your Bumpkin",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -3403,6 +3403,7 @@
   "reward.whatCouldItBe": "What could it be?",
   "reward.streakBonus": "3x streak bonus",
   "reward.streak.oneYear": "365 day streak reward",
+  "reward.streak.twoYear": "730 day streak reward",
   "reward.found": "You found",
   "reward.spendWisely": "Spend it wisely.",
   "reward.wearable": "A wearable for your Bumpkin",


### PR DESCRIPTION
## Summary
- Fixed 2-year streak milestone showing '365 day streak reward' instead of '730 day streak reward'
- Added new translation key `reward.streak.twoYear`
- Updated logic to distinguish between 1-year (365 days) and 2-year (730 days) milestones

## Test plan
- [ ] Verify 365 day streak shows "365 day streak reward"
- [ ] Verify 730 day streak shows "730 day streak reward"
- [ ] Verify regular streak bonus shows "3x streak bonus"

Fixes #6284