### PR TITLE
[FIX] Crash when crafting tool in Baily shop

### DIFF
--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -151,7 +151,11 @@ export function craftTool({ state, action }: Options) {
     ...subtractedInventory,
     [action.tool]: oldAmount.add(amount) as Decimal,
   };
-  stateCopy.stock[action.tool] = stateCopy.stock[action.tool]?.minus(amount);
+
+  const stock = stateCopy.stock[action.tool];
+  if (stock !== undefined) {
+    stateCopy.stock[action.tool] = stock.minus(amount);
+  }
 
   return stateCopy;
 }


### PR DESCRIPTION
# Description

Baily's shop was crashing due to the stock explicitly being set to undefined, after buying an item from Baily's shop and then performing an`autosave`.

This PR first checks if the stock value exists before attempting to decrement it.

# What needs to be tested by the reviewer?

1. Buy a tool from Baily's shop and ensure the frontend does not crash

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
