### PR TITLE
[CHORE] useCountdown to call useNow() instead of Date.now()

### DIFF
--- a/src/lib/utils/hooks/useCountdown.ts
+++ b/src/lib/utils/hooks/useCountdown.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNow } from "./useNow";
 
 export const getReturnValues = (timeLeft: number) => {
   // calculate time left
@@ -12,20 +13,23 @@ export const getReturnValues = (timeLeft: number) => {
   return { days, hours, minutes, seconds };
 };
 
-const getTimeRemaining = (targetDate?: number | null) => {
+const getTimeRemaining = (now: number, targetDate?: number | null) => {
   if (!targetDate) return 0;
 
-  return Math.max(targetDate - Date.now(), 0);
+  return Math.max(targetDate - now, 0);
 };
 
 export const useCountdown = (targetDate?: number | null) => {
-  const [timeLeft, setTimeLeft] = useState(() => getTimeRemaining(targetDate));
+  const now = useNow();
+  const [timeLeft, setTimeLeft] = useState(() =>
+    getTimeRemaining(now, targetDate),
+  );
 
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | undefined;
 
     const tick = () => {
-      const remaining = getTimeRemaining(targetDate);
+      const remaining = getTimeRemaining(now, targetDate);
       setTimeLeft(remaining);
 
       if (remaining <= 0 && intervalId) {


### PR DESCRIPTION
# Description

Part of the React Compiler updates, to purify the function we call useNow instead of Date.now() in useCountdown

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
