### PR TITLE
[FIX] Node Forging showing wrong requirements

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -142,21 +142,24 @@ function getDetails(
   description: string;
 } {
   if (details.item) {
-    const inventoryCount = game.inventory[details.item] ?? new Decimal(0);
+    const count = game.inventory[details.item] ?? new Decimal(0);
     const limit = isSeed(details.item)
       ? INVENTORY_LIMIT(game)[details.item]
       : undefined;
 
-    return {
-      count: inventoryCount,
-      description: ITEM_DETAILS[details.item].description,
-      image:
-        ITEM_ICONS(game.season.season, getCurrentBiome(game.island))[
-          details.item
-        ] ?? ITEM_DETAILS[details.item].image,
-      name: ITEM_DETAILS[details.item].translatedName ?? details.item,
-      limit,
-    };
+    const {
+      description,
+      image: defaultImage,
+      translatedName,
+    } = ITEM_DETAILS[details.item];
+
+    const image =
+      ITEM_ICONS(game.season.season, getCurrentBiome(game.island))[
+        details.item
+      ] ?? defaultImage;
+    const name = translatedName ?? details.item;
+
+    return { count, description, image, name, limit };
   }
 
   const wardrobeCount = game.wardrobe[details.wearable] ?? 0;


### PR DESCRIPTION
# Description
Take 2 from #6518 

This PR Fixes an issue where the node inventory count is showing wrongly in the requirements screen to forge a node. It was previously showing the inventory count of normal nodes instead of the enhanced ones (if that's the requirement)

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE
- Ensure that your node requirements are showing the correct inventory amount

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
