### PR TITLE
Update referral rewards message

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5878,7 +5878,7 @@
   "claimReferralRewards.description": "Congratulations! {{totalUnclaimedReferrals}} new players have joined and bought VIP using your referral link. Here are your rewards!",
   "referral.vip": "25 Love Charms when your friend buys VIP",
   "referral.friend": "25 Love Charms - Only applies to the first referral",
-  "referral.flower": "(Coming soon) 10% of $FLOWER spent by your friend",
+  "referral.flower": "10% of $FLOWER spent on gems by your friend",
   "referral.description": "You will receive the following rewards when your friend signs up using your referral link:",
   "taskBoard.tasks": "Tasks",
   "taskBoard.loveCharmCount": "Inventory: {{loveCharmCount}} Love Charm",


### PR DESCRIPTION
The $FLOWER rewards have been live for a while. Also specifies that the $FLOWER spent has to be on gems (not the marketplace).

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
