### PR TITLE
[FIX] Bulk Fertilise Bugs

### DIFF
--- a/src/features/game/events/landExpansion/bulkFertilisePlot.test.ts
+++ b/src/features/game/events/landExpansion/bulkFertilisePlot.test.ts
@@ -1,0 +1,121 @@
+import Decimal from "decimal.js-light";
+import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import { CROPS } from "features/game/types/crops";
+import { GameState } from "features/game/types/game";
+import { bulkFertilisePlot, getPlotsToFertilise } from "./bulkFertilisePlot";
+
+const BASE_STATE: GameState = {
+  ...INITIAL_FARM,
+  balance: new Decimal(0),
+  inventory: {
+    "Sprout Mix": new Decimal(10),
+  },
+  bumpkin: TEST_BUMPKIN,
+};
+
+describe("bulkFertilisePlot", () => {
+  const createdAt = Date.now();
+
+  it("getPlotsToFertilise includes empty & growing plots, excludes ready/unplaced/fertilised", () => {
+    const harvestMs = CROPS.Sunflower.harvestSeconds * 1000;
+
+    const state: GameState = {
+      ...BASE_STATE,
+      crops: {
+        // eligible: empty + placed
+        "1": { x: 0, y: 0, createdAt: 0 },
+        // eligible: growing + placed
+        "2": {
+          x: 1,
+          y: 0,
+          createdAt: 0,
+          crop: { name: "Sunflower", plantedAt: createdAt - 1000 },
+        },
+        // excluded: ready to harvest
+        "3": {
+          x: 2,
+          y: 0,
+          createdAt: 0,
+          crop: { name: "Sunflower", plantedAt: createdAt - harvestMs },
+        },
+        // excluded: unplaced
+        "4": { createdAt: 0 },
+        // excluded: already fertilised
+        "5": {
+          x: 3,
+          y: 0,
+          createdAt: 0,
+          fertiliser: { name: "Sprout Mix", fertilisedAt: createdAt - 5000 },
+        },
+      },
+    };
+
+    const eligible = getPlotsToFertilise(state, createdAt).map(([id]) => id);
+    expect(eligible.sort()).toEqual(["1", "2"]);
+  });
+
+  it("fertilises only eligible plots (skips ready to harvest) and decrements inventory", () => {
+    const harvestMs = CROPS.Sunflower.harvestSeconds * 1000;
+
+    const state: GameState = {
+      ...BASE_STATE,
+      inventory: { "Sprout Mix": new Decimal(2) },
+      crops: {
+        // eligible empty
+        "1": { x: 0, y: 0, createdAt: 0 },
+        // eligible growing
+        "2": {
+          x: 1,
+          y: 0,
+          createdAt: 0,
+          crop: { name: "Sunflower", plantedAt: createdAt - 1000 },
+        },
+        // excluded ready
+        "3": {
+          x: 2,
+          y: 0,
+          createdAt: 0,
+          crop: { name: "Sunflower", plantedAt: createdAt - harvestMs },
+        },
+      },
+    };
+
+    const newState = bulkFertilisePlot({
+      state,
+      createdAt,
+      action: { type: "plots.bulkFertilised", fertiliser: "Sprout Mix" },
+    });
+
+    expect(newState.inventory["Sprout Mix"]).toEqual(new Decimal(0));
+    expect(newState.crops["1"].fertiliser?.name).toEqual("Sprout Mix");
+    expect(newState.crops["2"].fertiliser?.name).toEqual("Sprout Mix");
+    expect(newState.crops["3"].fertiliser).toBeUndefined();
+  });
+
+  it("throws if there are no eligible plots to fertilise", () => {
+    const harvestMs = CROPS.Sunflower.harvestSeconds * 1000;
+
+    const state: GameState = {
+      ...BASE_STATE,
+      inventory: { "Sprout Mix": new Decimal(10) },
+      crops: {
+        // ready only -> not eligible
+        "1": {
+          x: 0,
+          y: 0,
+          createdAt: 0,
+          crop: { name: "Sunflower", plantedAt: createdAt - harvestMs },
+        },
+      },
+    };
+
+    expect(() =>
+      bulkFertilisePlot({
+        state,
+        createdAt,
+        action: { type: "plots.bulkFertilised", fertiliser: "Sprout Mix" },
+      }),
+    ).toThrow("Not enough fertiliser to apply");
+  });
+});

--- a/src/features/game/events/landExpansion/redeemTradeReward.test.ts
+++ b/src/features/game/events/landExpansion/redeemTradeReward.test.ts
@@ -84,7 +84,7 @@ describe("redeemTradeRewards", () => {
     expect(state.inventory["Trade Point"]).toEqual(new Decimal(0));
   });
 
-  it.only("buys a Trade Rewards Pack", () => {
+  it("buys a Trade Rewards Pack", () => {
     const state = redeemTradeReward({
       state: {
         ...INITIAL_FARM,

--- a/src/features/island/hud/components/PowerSkills.tsx
+++ b/src/features/island/hud/components/PowerSkills.tsx
@@ -28,6 +28,7 @@ import {
   getSkillCooldown,
   powerSkillDisabledConditions,
 } from "features/game/events/landExpansion/skillUsed";
+import { getPlotsToFertilise } from "features/game/events/landExpansion/bulkFertilisePlot";
 import { getRelativeTime, millisecondsToString } from "lib/utils/time";
 import { ConfirmButton } from "components/ui/ConfirmButton";
 import { useNow } from "lib/utils/hooks/useNow";
@@ -68,7 +69,7 @@ const PowerSkillsContent: React.FC<{
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
-  const { bumpkin, crops, fruitPatches, inventory } = state;
+  const { bumpkin, fruitPatches, inventory } = state;
   const { skills, previousPowerUseAt } = bumpkin;
   const now = useNow();
 
@@ -109,6 +110,10 @@ const PowerSkillsContent: React.FC<{
     skillName === "Sprout Surge" || skillName === "Root Rocket";
 
   const isFruitFertiliserSkill = skillName === "Blend-tastic";
+
+  const cropFertiliseEligible = isCropFertiliserSkill
+    ? getPlotsToFertilise(state, now)
+    : [];
 
   const useSkill = () => {
     if (isCropFertiliserSkill) {
@@ -213,13 +218,7 @@ const PowerSkillsContent: React.FC<{
               <div className="flex flex-col items-center mb-2">
                 <RequirementLabel
                   type="item"
-                  requirement={
-                    new Decimal(
-                      Object.values(crops).filter(
-                        (plot) => !plot.fertiliser,
-                      ).length,
-                    )
-                  }
+                  requirement={new Decimal(cropFertiliseEligible.length)}
                   item={
                     skillName === "Sprout Surge" ? "Sprout Mix" : "Rapid Root"
                   }


### PR DESCRIPTION
# Description

This PR Fixes some bugs regarding bulk fertilise

Fixes #issue
- Empty Plots can't be fertilised
- Fully Grown Crops shouldn't be able to be fertilised

# What needs to be tested by the reviewer?

- Run FE + BE
- Have no crops growing, ensure that you can fertilise them
- Have a mixture of crops growing, fully grown crops and empty crops - ensure that the amount that can be fertilised are those that are growing + empty plots, and excludes the fully grown ones

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
