### PR TITLE
[FEAT] Extend Festive Tree Date to 5th Jan

### DIFF
--- a/src/features/island/collectibles/components/FestiveTree.tsx
+++ b/src/features/island/collectibles/components/FestiveTree.tsx
@@ -19,7 +19,10 @@ import { useNow } from "lib/utils/hooks/useNow";
 import { useSelector } from "@xstate/react";
 import { MachineState } from "features/game/lib/gameMachine";
 
-const _state = (state: MachineState) => state.context.state;
+const _festiveTrees = (state: MachineState) =>
+  state.context.state.collectibles["Festive Tree"] ||
+  state.context.state.home.collectibles["Festive Tree"] ||
+  [];
 const _revealing = (state: MachineState) => state.matches("revealing");
 const _revealed = (state: MachineState) => state.matches("revealed");
 
@@ -36,15 +39,11 @@ const FestiveTreeImage: React.FC<{
   id: string;
 }> = ({ id, close, setShowGiftedModal }) => {
   const { gameService } = useContext(Context);
-  const state = useSelector(gameService, _state);
+  const festiveTrees = useSelector(gameService, _festiveTrees);
   const revealing = useSelector(gameService, _revealing);
   const revealed = useSelector(gameService, _revealed);
 
-  const trees = [
-    ...(state.collectibles["Festive Tree"] || []),
-    ...(state.home.collectibles["Festive Tree"] || []),
-  ];
-  const tree = trees.find((t) => t.id === id);
+  const tree = festiveTrees.find((tree) => tree.id === id);
 
   const [isRevealing, setIsRevealing] = useState(false);
 


### PR DESCRIPTION
# Description

Since Christmas Event lasts until 5th Jan, and the Festive Tree is part of it, extend the Festive Tree Claim date till 5th Jan

Fixes #issue
- remove impure `new Date()`

# What needs to be tested by the reviewer?

- Run FE + BE
- Set Festive Tree's `shakenAt` Timestamp to 1st Jan 2025 `1735698540000`
- Ensure you can still claim it (since it's different festive seasons)

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
