### PR TITLE
[FEAT] MarketplaceSalesPopup: set max height for items and make it y scrollable

### DIFF
--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -59,61 +59,63 @@ export const MarketplaceSalesPopup: React.FC = () => {
         <div className="mb-2 ml-1">
           <InlineDialogue message={t("marketplace.youHaveHadSales")} />
         </div>
-        {soldListingIds.map((listingId) => {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const listing = trades.listings![listingId];
-          const itemName = getKeys(listing.items)[0];
-          const itemId = tradeToId({ details: listing });
-          const details = getTradeableDisplay({
-            id: itemId,
-            type: listing.collection,
-            state: state.context.state,
-          });
-          const amount = listing.items[itemName as InventoryItemName];
+        <div className="max-h-[450px] overflow-y-auto scrollable">
+          {soldListingIds.map((listingId) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const listing = trades.listings![listingId];
+            const itemName = getKeys(listing.items)[0];
+            const itemId = tradeToId({ details: listing });
+            const details = getTradeableDisplay({
+              id: itemId,
+              type: listing.collection,
+              state: state.context.state,
+            });
+            const amount = listing.items[itemName as InventoryItemName];
 
-          const tax = listing.tax ?? listing.sfl * MARKETPLACE_TAX;
-          const sfl = new Decimal(listing.sfl).sub(tax);
-          const estTradePoints = calculateTradePoints({
-            sfl: listing.sfl,
-            points: !listing.signature ? 1 : 3,
-          }).multipliedPoints;
+            const tax = listing.tax ?? listing.sfl * MARKETPLACE_TAX;
+            const sfl = new Decimal(listing.sfl).sub(tax);
+            const estTradePoints = calculateTradePoints({
+              sfl: listing.sfl,
+              points: !listing.signature ? 1 : 3,
+            }).multipliedPoints;
 
-          const isResource = isTradeResource(KNOWN_ITEMS[Number(itemId)]);
+            const isResource = isTradeResource(KNOWN_ITEMS[Number(itemId)]);
 
-          return (
-            <div className="flex flex-col space-y-1" key={listingId}>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center w-3/4 space-x-2">
-                  <Box image={details.image} />
-                  <div className="flex flex-col">
-                    <div>
-                      <p className="text-xs mt-0.5">{`${amount} x ${itemName}`}</p>
-                    </div>
-                    <div className="flex items-center space-x-1">
-                      <p className="text-xs mt-0.5">{`${formatNumber(sfl, {
-                        decimalPlaces: 4,
-                      })} FLOWER`}</p>
-                      <img src={token} className="w-4" />
-                    </div>
-                    {!isResource && (
-                      <div className="flex items-center">
-                        <span className="text-xs">
-                          {`${formatNumber(estTradePoints, {
-                            decimalPlaces: 2,
-                          })} Trade Points`}
-                        </span>
-                        <img
-                          src={ITEM_DETAILS["Trade Point"].image}
-                          className="h-6 ml-1"
-                        />
+            return (
+              <div className="flex flex-col space-y-1" key={listingId}>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center w-3/4 space-x-2">
+                    <Box image={details.image} />
+                    <div className="flex flex-col">
+                      <div>
+                        <p className="text-xs mt-0.5">{`${amount} x ${itemName}`}</p>
                       </div>
-                    )}
+                      <div className="flex items-center space-x-1">
+                        <p className="text-xs mt-0.5">{`${formatNumber(sfl, {
+                          decimalPlaces: 4,
+                        })} FLOWER`}</p>
+                        <img src={token} className="w-4" />
+                      </div>
+                      {!isResource && (
+                        <div className="flex items-center">
+                          <span className="text-xs">
+                            {`${formatNumber(estTradePoints, {
+                              decimalPlaces: 2,
+                            })} Trade Points`}
+                          </span>
+                          <img
+                            src={ITEM_DETAILS["Trade Point"].image}
+                            className="h-6 ml-1"
+                          />
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
       <div className="flex space-x-1">
         <Button className="w-full" onClick={() => gameService.send("CLOSE")}>


### PR DESCRIPTION
# Description

Copying from News.tsx, wrap the soldListings map in a div with set max height and make it vertical scroll. This is to avoid overflow when there are several listings. I'm not planning to contribute much again, just wanna have a look after years of inactivity :P Means I'm not gonna take the local setup seriously. 

Fixes #issue

# What needs to be tested by the reviewer?

Honestly, I haven't tested it but seems like a harmless change (i know, taboo). But if you could simulate some listings locally (more than 10?) the popup should appear and the change should be evident.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
