### PR TITLE
[FIX] Looping marketplace navigation

### DIFF
--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -85,6 +85,11 @@ export const Collection: React.FC<{
   const gridRef = useRef<any>(null);
   const location = useLocation();
 
+  const backRoute =
+    typeof location.state?.route === "string"
+      ? location.state.route
+      : `${location.pathname}${location.search}`;
+
   if (search && !filters.includes("buds") && !filters.includes("pets")) {
     filters = "collectibles,wearables,resources";
   }
@@ -530,7 +535,7 @@ export const Collection: React.FC<{
                         {
                           state: {
                             scrollPosition,
-                            route: `${location.pathname}${location.search}`,
+                            route: backRoute,
                           },
                         },
                       );


### PR DESCRIPTION
# Description

This PR fixes a bug where you could get stuck in a navigation loop in the marketplace if you used the search bar from a detail page. 

If you were on the milk page and then you used the search bar to search for potato... when you hit the back arrow you were taken back to milk and then if you hit the back arrow again you were taken back to potato over and over again.

This has now been fixed.

Fixes #issue

# What needs to be tested by the reviewer?

- The steps described above. You should always be taken back to the collection page.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
