### PR TITLE
[FIX] Multi-cast Activity tracking

### DIFF
--- a/src/features/game/events/landExpansion/castRod.test.ts
+++ b/src/features/game/events/landExpansion/castRod.test.ts
@@ -212,6 +212,7 @@ describe("castRod", () => {
     // 50 sunflower per chum * 5 casts = 250
     expect(state.inventory.Sunflower).toEqual(new Decimal(750));
     expect(state.fishing.wharf.multiplier).toEqual(5);
+    expect(state.farmActivity["Rod Casted"]).toEqual(5);
   });
 
   it("requires VIP when multiplier is greater than 1", () => {

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -173,7 +173,11 @@ export function castRod({
       };
     }
 
-    game.farmActivity = trackFarmActivity("Rod Casted", game.farmActivity);
+    game.farmActivity = trackFarmActivity(
+      "Rod Casted",
+      game.farmActivity,
+      new Decimal(multiplier),
+    );
 
     game.boostsUsedAt = updateBoostUsed({
       game,


### PR DESCRIPTION
# Description

Multi cast was increment farm activity by 1 regardless of multiplier. it should increment based on the mutliplier

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
