### PR TITLE
[FIX] Pet Fetch Sorting Order

### DIFF
--- a/src/features/island/pets/PetFeed.tsx
+++ b/src/features/island/pets/PetFeed.tsx
@@ -120,7 +120,7 @@ export const PetFeed: React.FC<Props> = ({ data, onFeed, onResetClick }) => {
           {t("pets.resetRequests")}
         </p>
       </div>
-      <div className="flex flex-col gap-1 max-h-[250px] overflow-y-auto scrollable">
+      <div className="flex flex-col gap-1 max-h-[300px] overflow-y-auto scrollable">
         {sortedFoodRequests.map((food) => {
           const foodAvailable = (
             game.inventory[food] ?? new Decimal(0)

--- a/src/features/island/pets/PetFetch.tsx
+++ b/src/features/island/pets/PetFetch.tsx
@@ -96,7 +96,7 @@ export const PetFetch: React.FC<Props> = ({ data, onShowRewards, onFetch }) => {
           {t("pets.fossilShellRewards")}
         </p>
       </div>
-      <div className="flex flex-col gap-1 max-h-[250px] overflow-y-auto scrollable">
+      <div className="flex flex-col gap-1 max-h-[300px] overflow-y-auto scrollable">
         {fetches.map(({ name, level: requiredLevel }) => {
           const hasRequiredLevel = level >= requiredLevel;
           const energyRequired = PET_RESOURCES[name].energy;


### PR DESCRIPTION
# Description

This PR Updates the sorting order for pet fetches based on the following:

- If Fetch hasn't been unlocked, it's sorted by level it unlocks
- If fetch is unlocked, sorted by energy cost, then level, then name in alphabetical order

|Pet with locked fetches|Pet with fetches unlocked|
|---|---|
|<img width="526" height="610" alt="image" src="https://github.com/user-attachments/assets/6d2f04a1-87af-40a2-ae76-acc72ef0d9d0" />|<img width="515" height="601" alt="image" src="https://github.com/user-attachments/assets/32d3de80-0efb-4171-9eb7-fa288f94b070" />|


Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
