### PR TITLE
[FIX] Gem Starter Bundle

### DIFF
--- a/src/features/game/components/modal/components/BuyGems.tsx
+++ b/src/features/game/components/modal/components/BuyGems.tsx
@@ -43,9 +43,11 @@ const PRICES: Price[] = [
 ];
 
 const _starterOfferSecondsLeft = (state: MachineState) => {
-  const hasPurchased = state.context.purchases.length > 0;
+  const hasPurchasedXsolla = state.context.purchases.length > 0;
 
-  if (hasPurchased) return 0;
+  if (hasPurchasedXsolla) return 0;
+
+  if (state.context.state.farmActivity["Gems Purchased"]) return 0;
 
   return (
     (new Date(state.context.state.createdAt).getTime() +

--- a/src/features/game/types/farmActivity.ts
+++ b/src/features/game/types/farmActivity.ts
@@ -147,6 +147,7 @@ export type FarmActivityName =
   | BiomeBought
   | "Obsidian Exchanged"
   | "FLOWER Exchanged"
+  | "Gems Purchased"
   | ResourceNodeUpgradeEvent
   | `${PetResourceName} Fetched`
   | PlantGreenHouseFruitEvent


### PR DESCRIPTION
# Description

Do not allow players to buy the starter bundle with Gems (via FLOWER) again if they already have.

**How to test?**

1. Create a new account
2. Buy the bundle with FLOWER
3. It will disappear