### PR TITLE
[FIX] Collectables in Trophy Cases Dimensions

### DIFF
--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1185,15 +1185,9 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Lady Bug": { width: 1, height: 1 },
   "Squirrel Monkey": { width: 2, height: 2 },
   "Black Bearry": { width: 1, height: 1 },
-  "Iron Idol": { height: 2, width: 1 },
-  "Parasaur Skull": {
-    height: 1,
-    width: 2,
-  },
-  "Golden Bear Head": {
-    height: 1,
-    width: 2,
-  },
+  "Iron Idol": { height: 1, width: 2 },
+  "Parasaur Skull": { height: 1, width: 2 },
+  "Golden Bear Head": { height: 1, width: 2 },
 
   "Maneki Neko": { width: 1, height: 1 },
   "Collectible Bear": { width: 2, height: 2 },


### PR DESCRIPTION
# Description

I changed the height of Poseidon from 2x2 to be 2x1 just like the other Marvels

Edit: I also fixed the height of 4 more collectables that are in trophy cases to be consistant with 2x1 Dimensions:
- Golden Bear Head
- Parasaur Skull
- Immortal Pear
- Iron Idol
- Poseidon

Fixes #issue

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] I have read the contributing guidelines and agree to the T&Cs