### PR TITLE
[FIX] Flag and season label

### DIFF
--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -131,6 +131,7 @@ interface Props {
   actionView?: JSX.Element;
   hideDescription?: boolean;
   label?: JSX.Element;
+  showSeason?: boolean;
 }
 
 function getDetails(
@@ -189,6 +190,7 @@ export const CraftingRequirements: React.FC<Props> = ({
   requirements,
   actionView,
   hideDescription,
+  showSeason = false,
   label,
 }: Props) => {
   const { t } = useAppTranslation();
@@ -312,13 +314,15 @@ export const CraftingRequirements: React.FC<Props> = ({
 
     return (
       <div className="border-t border-white w-full mb-2 pt-2 flex justify-between gap-x-3 gap-y-2 flex-wrap sm:flex-col sm:items-center sm:flex-nowrap my-1">
-        <Label
-          type="default"
-          icon={SEASON_ICONS[gameState.season.season]}
-          className="-mb-3.5"
-        >
-          {capitalize(gameState.season.season)}
-        </Label>
+        {showSeason && (
+          <Label
+            type="default"
+            icon={SEASON_ICONS[gameState.season.season]}
+            className="-mb-3.5"
+          >
+            {capitalize(gameState.season.season)}
+          </Label>
+        )}
         <div className=" w-full mb-2 pt-2 flex justify-between gap-x-3 gap-y-2 flex-wrap sm:flex-col sm:items-center sm:flex-nowrap my-1">
           {/* Item ingredients requirements */}
           {!!requirements.resources && (

--- a/src/features/island/buildings/components/building/fishMarket/FishMarketModal.tsx
+++ b/src/features/island/buildings/components/building/fishMarket/FishMarketModal.tsx
@@ -120,6 +120,7 @@ export const FishMarketModal: React.FC<Props> = ({
               details={{
                 item: selected,
               }}
+              showSeason={true}
               hideDescription
               requirements={{
                 resources: requirements,

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -122,7 +122,7 @@ const FEATURE_FLAGS = {
   DAILY_BOXES: defaultFeatureFlag,
   MICRO_INTERACTIONS: defaultFeatureFlag,
   MULTI_CAST: defaultFeatureFlag,
-  FISH_MARKET: testnetFeatureFlag,
+  FISH_MARKET: defaultFeatureFlag,
 } satisfies Record<string, FeatureFlag>;
 
 export type FeatureName = keyof typeof FEATURE_FLAGS;


### PR DESCRIPTION
# Description

Flip the flag to default. Remove the season label from Crafting Requirements by adding a prop for when to show.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
