### PR TITLE
[FEAT] Data endpoint hashing

### DIFF
--- a/src/features/game/actions/effect.ts
+++ b/src/features/game/actions/effect.ts
@@ -2,6 +2,7 @@ import { CONFIG } from "lib/config";
 import { ERRORS } from "lib/errors";
 import { GameState } from "../types/game";
 import { makeGame } from "../lib/transforms";
+import { getRecordHash } from "lib/stateHash";
 
 const API_URL = CONFIG.API_URL;
 
@@ -192,11 +193,16 @@ type Request = {
   token: string;
   transactionId: string;
   effect: Effect;
+  state?: GameState;
 };
 
 export async function postEffect(
   request: Request,
 ): Promise<{ gameState: GameState; data: any }> {
+  const stateHash = request.state
+    ? await getRecordHash(request.state as unknown as Record<string, unknown>)
+    : undefined;
+
   const response = await window.fetch(`${API_URL}/event/${request.farmId}`, {
     method: "POST",
     headers: {
@@ -211,6 +217,7 @@ export async function postEffect(
     body: JSON.stringify({
       event: request.effect,
       createdAt: new Date().toISOString(),
+      ...(stateHash ? { stateHash } : {}),
     }),
   });
 
@@ -230,8 +237,16 @@ export async function postEffect(
 
   const { gameState, data } = await response.json();
 
+  const mergedGameState = request.state
+    ? // Response may be pruned (diff); merge over the current client state
+      ({
+        ...request.state,
+        ...gameState,
+      } as GameState)
+    : (gameState as GameState);
+
   return {
-    gameState: makeGame(gameState),
+    gameState: makeGame(mergedGameState),
     data,
   };
 }

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -538,6 +538,7 @@ const EFFECT_STATES = Object.values(STATE_MACHINE_EFFECTS).reduce(
             effect,
             token: authToken ?? context.rawToken,
             transactionId: context.transactionId as string,
+            state: context.state,
           });
 
           if (context.visitorId) {
@@ -640,6 +641,7 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
             effect,
             token: authToken ?? context.rawToken,
             transactionId: context.transactionId as string,
+            state: context.state,
           });
 
           if (event.effect.type === "farm.followed") {

--- a/src/lib/deepMerge.ts
+++ b/src/lib/deepMerge.ts
@@ -1,0 +1,33 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+/**
+ * Deep merge for JSON-ish objects.
+ * - Arrays are replaced, not concatenated.
+ * - Non-plain objects are replaced.
+ */
+export function deepMerge<T>(base: T | undefined, patch: unknown): T {
+  if (base === undefined) return patch as T;
+
+  if (Array.isArray(base) || Array.isArray(patch)) {
+    return patch as T;
+  }
+
+  if (isPlainObject(base) && isPlainObject(patch)) {
+    const merged: Record<string, unknown> = { ...base };
+
+    for (const [key, value] of Object.entries(patch)) {
+      merged[key] = deepMerge((base as any)[key], value);
+    }
+
+    return merged as T;
+  }
+
+  return patch as T;
+}

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,17 @@
+export function readLocalStorageJSON<T>(key: string): T | undefined {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return;
+    return JSON.parse(raw) as T;
+  } catch {
+    return;
+  }
+}
+
+export function writeLocalStorageJSON(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore quota / serialization / privacy mode errors
+  }
+}

--- a/src/lib/stateHash.ts
+++ b/src/lib/stateHash.ts
@@ -1,0 +1,28 @@
+// Browser-friendly SHA-256 → hex
+export async function hashString(str: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str); // UTF-8
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return "sha256:" + hashHex;
+}
+
+/**
+ * Hashes each top-level field of a JSON-ish record.
+ * { a: "sha256:..", b: "sha256:.." }
+ */
+export async function getRecordHash<T extends Record<string, unknown>>(
+  record: T,
+): Promise<Record<keyof T, string>> {
+  const hashes = {} as Record<keyof T, string>;
+
+  for (const key of Object.keys(record) as Array<keyof T>) {
+    const stable = JSON.stringify(record[key]);
+    hashes[key] = await hashString(stable);
+  }
+
+  return hashes;
+}


### PR DESCRIPTION
# Description

Include a hashed version of the current game state when making `/event` calls.

This ensures the backend will only return the **changed data** = saves us significant transfer cost and faster responses.

## How to test?

Load the game and perform an action that requires an effect:

- E.g. List an item on the marketplace

Inspect the payload and you should see only the fields that have changed are included on the response, instead of everything.

_Note: There are some other dynamic fields that may appear. This often occurs when FE and BE don't have the exact same fields._