### PR TITLE
[FIX] Crash when selecting overlapping Pet or Bud

### DIFF
--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -46,7 +46,7 @@ import flipped from "assets/icons/flipped.webp";
 import flipIcon from "assets/icons/flip.webp";
 import debounce from "lodash.debounce";
 import { LIMITED_ITEMS } from "features/game/events/landExpansion/burnCollectible";
-import { isPetNFTRevealed, PET_SHRINES } from "features/game/types/pets";
+import { PET_SHRINES } from "features/game/types/pets";
 import {
   EXPIRY_COOLDOWNS,
   TemporaryCollectibleName,
@@ -417,22 +417,7 @@ export const MoveableComponent: React.FC<
 
   const isShrine = name in PET_SHRINES || name === "Obsidian Shrine";
 
-  // Compute overlaps early for determining if we need live time updates
-  const overlaps = getOverlappingCollectibles({
-    state: gameService.getSnapshot().context.state,
-    x: coordinatesX,
-    y: coordinatesY,
-    location,
-    current: { id, name },
-  });
-
-  const initialNow = useNow();
-  const hasUnrevealedPets = overlaps.some(
-    (item) =>
-      item.name === "Pet" && !isPetNFTRevealed(Number(item.id), initialNow),
-  );
-
-  const now = useNow({ live: isShrine || hasUnrevealedPets });
+  const now = useNow({ live: isShrine });
 
   const removeAction =
     !isMobile &&
@@ -743,6 +728,15 @@ export const MoveableComponent: React.FC<
     onStop,
     position,
   ]);
+
+  // Compute overlaps early for determining if we need live time updates
+  const overlaps = getOverlappingCollectibles({
+    state: gameService.getSnapshot().context.state,
+    x: coordinatesX,
+    y: coordinatesY,
+    location,
+    current: { id, name },
+  });
 
   // Disable dragging if there are overlaps and this item is not selected
   const shouldDisableDrag = overlaps.length > 1 && !isSelected;


### PR DESCRIPTION
# Description
This PR Fixes a crash when you try to select a tile that has a Pet or Bud overlapping a tile or rug

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
