### PR TITLE
[FIX] Enable water traps crafting

### DIFF
--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1775,11 +1775,11 @@ export const ITEM_DETAILS: Items = {
     translatedName: translate("tool.oilDrill"),
   },
   "Crab Pot": {
-    image: SUNNYSIDE.tools.fishing_rod, // TODO: Replace with crab pot image
+    image: SUNNYSIDE.icons.expression_confused,
     description: TOOLS["Crab Pot"].description,
   },
   "Mariner Pot": {
-    image: SUNNYSIDE.tools.fishing_rod, // TODO: Replace with mariner pot image
+    image: SUNNYSIDE.icons.expression_confused,
     description: TOOLS["Mariner Pot"].description,
   },
   "Petting Hand": {

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -5,7 +5,6 @@
 import Decimal from "decimal.js-light";
 import { Inventory, IslandType, LoveAnimalItem, Skills } from "./game";
 import { translate } from "lib/i18n/translate";
-import { testnetFeatureFlag } from "lib/flags";
 import { WATER_TRAP } from "./crustaceans";
 
 export type WorkbenchToolName =
@@ -134,7 +133,6 @@ export const WORKBENCH_TOOLS: Record<
       Wool: new Decimal(3),
     }),
     stock: new Decimal(15),
-    disabled: !testnetFeatureFlag(),
     requiredLevel: WATER_TRAP["Crab Pot"].requiredBumpkinLevel,
   },
   "Mariner Pot": {
@@ -146,7 +144,6 @@ export const WORKBENCH_TOOLS: Record<
       "Merino Wool": new Decimal(10),
     }),
     stock: new Decimal(10),
-    disabled: !testnetFeatureFlag(),
     requiredLevel: WATER_TRAP["Mariner Pot"].requiredBumpkinLevel,
   },
 };

--- a/src/features/island/buildings/components/building/workBench/components/Tools.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/Tools.tsx
@@ -29,6 +29,8 @@ import { getToolPrice } from "features/game/events/landExpansion/craftTool";
 import { Restock } from "../../market/restock/Restock";
 import { getObjectEntries } from "features/game/expansion/lib/utils";
 import { getBumpkinLevel } from "features/game/lib/level";
+import { hasFeatureAccess } from "lib/flags";
+import { WATER_TRAP } from "features/game/types/crustaceans";
 
 const isLoveAnimalTool = (
   toolName: WorkbenchToolName | LoveAnimalItem,
@@ -210,6 +212,13 @@ export const Tools: React.FC = () => {
                   state.island.type,
                   requiredIsland,
                 ) || !hasRequiredLevel(tool);
+
+              if (
+                toolName in WATER_TRAP &&
+                !hasFeatureAccess(state, "CRUSTACEANS")
+              ) {
+                return null;
+              }
 
               return (
                 <Box


### PR DESCRIPTION
# Description

Enable `Crab Pot` and `Mariner Pot` for beta testing