### PR TITLE
[FIX] Initialize and persist extraReels in castRod function

### DIFF
--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -92,7 +92,12 @@ export function castRod({
     const now = new Date(createdAt);
     const today = new Date(now).toISOString().split("T")[0];
 
-    const { extraReels = { count: 0 } } = game.fishing;
+    // Initialize extraReels on game.fishing if it doesn't exist
+    if (!game.fishing.extraReels) {
+      game.fishing.extraReels = { count: 0 };
+    }
+    const extraReels = game.fishing.extraReels;
+
     const { limit: fishingLimit, boostsUsed: fishingBoostsUsed } =
       getDailyFishingLimit(game);
     const boostsUsed: BoostName[] = [];
@@ -125,8 +130,6 @@ export function castRod({
       }
 
       game.inventory.Gem = gemsInventory.sub(gemPrice);
-
-      const { extraReels = { count: 0 } } = game.fishing;
 
       const packsBought = action.reelPacksToBuy ?? 0;
 


### PR DESCRIPTION
# Description

Added tests to ensure extraReels are correctly initialized and updated when purchasing reels, even when initially undefined. Updated castRod function to initialize extraReels if it doesn't exist, ensuring proper reel count management during fishing actions.

Fixes #issue

Uncaught error when player who never bought extraReels before tries to buy more reels

# What needs to be tested by the reviewer?

- Checkout main
- delete gameState.fishing.extraReels
- fish until you run out of reels
- game will prompt you to buy more reels, cast again to try to buy more reels
- you'll get an uncaught error in the console.
- checkout this PR
- try to buy more reels again
- you should be able to buy and cast reels now

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
