### PR TITLE
[FIX] Boost Tracking

### DIFF
--- a/src/features/game/events/landExpansion/plantFlower.ts
+++ b/src/features/game/events/landExpansion/plantFlower.ts
@@ -72,6 +72,7 @@ export const getFlowerTime = (
 
   if (bumpkin.skills["Flower Power"]) {
     seconds *= 0.8;
+    boostsUsed.push("Flower Power");
   }
 
   if (bumpkin.skills["Flowery Abode"]) {

--- a/src/features/game/events/landExpansion/sellCrop.ts
+++ b/src/features/game/events/landExpansion/sellCrop.ts
@@ -20,6 +20,7 @@ import {
 import { produce } from "immer";
 import { ExoticCrop } from "features/game/types/beans";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type SellableName = CropName | PatchFruitName;
 export type SellableItem =
@@ -77,7 +78,7 @@ export function sellCrop({
       throw new Error("Insufficient quantity to sell");
     }
 
-    const price = getSellPrice({
+    const { price, boostsUsed } = getSellPrice({
       item: sellables,
       game,
       now: new Date(createdAt),
@@ -99,6 +100,12 @@ export function sellCrop({
     game.inventory[action.crop] = setPrecision(
       (game.inventory[action.crop] ?? new Decimal(0)).sub(amount),
     );
+
+    game.boostsUsedAt = updateBoostUsed({
+      game,
+      boostNames: boostsUsed,
+      createdAt,
+    });
 
     return game;
   });

--- a/src/features/game/expansion/lib/boosts.test.ts
+++ b/src/features/game/expansion/lib/boosts.test.ts
@@ -16,7 +16,7 @@ describe("boosts", () => {
         },
         now: new Date(),
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 2);
+    ).toEqual({ price: CROPS.Sunflower.sellPrice * 2, boostsUsed: [] });
   });
 
   it("removes crop shortage price after 2 hours", () => {
@@ -32,7 +32,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice);
+    ).toEqual({ price: CROPS.Sunflower.sellPrice, boostsUsed: [] });
   });
 
   it("applies special event pricing", () => {
@@ -59,7 +59,7 @@ describe("boosts", () => {
           },
         },
       }),
-    ).toEqual(PATCH_FRUIT.Tomato.sellPrice * 1.05);
+    ).toEqual({ price: PATCH_FRUIT.Tomato.sellPrice * 1.05, boostsUsed: [] });
   });
 
   it("does not apply special event pricing if ineligible", () => {
@@ -86,7 +86,7 @@ describe("boosts", () => {
           },
         },
       }),
-    ).toEqual(PATCH_FRUIT.Tomato.sellPrice);
+    ).toEqual({ price: PATCH_FRUIT.Tomato.sellPrice, boostsUsed: [] });
   });
 
   it("applies Green Thumb boost to crop", () => {
@@ -105,7 +105,10 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 1.05);
+    ).toEqual({
+      price: CROPS.Sunflower.sellPrice * 1.05,
+      boostsUsed: ["Green Thumb"],
+    });
   });
 
   it("does not apply Green Thumb boost to non crops", () => {
@@ -124,7 +127,7 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(PATCH_FRUIT.Tomato.sellPrice);
+    ).toEqual({ price: PATCH_FRUIT.Tomato.sellPrice, boostsUsed: [] });
   });
 
   it("applies Coin Swindler boost to crop", () => {
@@ -148,10 +151,13 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 1.1);
+    ).toEqual({
+      price: CROPS.Sunflower.sellPrice * 1.1,
+      boostsUsed: ["Coin Swindler"],
+    });
   });
 
-  it("applies Coin Swindler boost to crop", () => {
+  it("does not apply Coin Swindler boost to non crops", () => {
     const now = new Date();
     expect(
       getSellPrice({
@@ -172,7 +178,10 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(PATCH_FRUIT.Tomato.sellPrice);
+    ).toEqual({
+      price: PATCH_FRUIT.Tomato.sellPrice,
+      boostsUsed: [],
+    });
   });
 
   it("boosts are additive", () => {
@@ -197,6 +206,9 @@ describe("boosts", () => {
         },
         now,
       }),
-    ).toEqual(CROPS.Sunflower.sellPrice * 2.15);
+    ).toEqual({
+      price: CROPS.Sunflower.sellPrice * 2.15,
+      boostsUsed: ["Green Thumb", "Coin Swindler"],
+    });
   });
 });

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -70,22 +70,20 @@ export const getSellPrice = ({
   item: SellableItem;
   game: GameState;
   now?: Date;
-}) => {
+}): { price: number; boostsUsed: BoostName[] } => {
+  const boostUsed: BoostName[] = [];
   const price = item.sellPrice;
 
   const { inventory, bumpkin } = game;
 
-  if (!bumpkin) {
-    throw new Error("You do not have a Bumpkin");
-  }
-
-  if (!price) return 0;
+  if (!price) return { price: 0, boostsUsed: [] };
 
   let multiplier = 1;
 
   // apply Green Thumb boost to crop LEGACY SKILL!
   if (item.name in crops && inventory["Green Thumb"]?.greaterThanOrEqualTo(1)) {
     multiplier += 0.05;
+    boostUsed.push("Green Thumb");
   }
 
   // Crop Shortage during initial gameplay
@@ -111,9 +109,10 @@ export const getSellPrice = ({
 
   if (bumpkin.skills["Coin Swindler"] && item.name in CROPS) {
     multiplier += 0.1;
+    boostUsed.push("Coin Swindler");
   }
 
-  return price * multiplier;
+  return { price: price * multiplier, boostsUsed: boostUsed };
 };
 
 /**

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1613,8 +1613,9 @@ export type BoostName =
   | BumpkinItem
   | BumpkinRevampSkillName
   | BudNFTName
-  | "Power hour"
-  | "Sunshower";
+  | SpecialBoostName;
+
+export type SpecialBoostName = "Sunshower" | "Power hour";
 
 export type BoostUsedAt = Partial<Record<BoostName, number>>;
 

--- a/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
@@ -79,7 +79,7 @@ export const SeasonalCrops: React.FC = () => {
   ) =>
     isExoticCrop(crop.name)
       ? crop.sellPrice
-      : getSellPrice({ item: crop, game: state });
+      : getSellPrice({ item: crop, game: state }).price;
 
   const cropAmount = setPrecision(
     getCountAndType(state, selected.name).count,


### PR DESCRIPTION
# Description

- Add missing Flower Power boost tracking
- move non greenhouse boosts to getPlotCropTime function.
- Added tracking for Crop Sell Price

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
