### PR TITLE
[FIX] Non Beta Players can't buy extra reels

### DIFF
--- a/src/features/island/fisherman/BaitSelection.tsx
+++ b/src/features/island/fisherman/BaitSelection.tsx
@@ -105,7 +105,6 @@ type Props = {
     guaranteedCatch?: FishName,
     reelPacksToBuy?: number,
   ) => void;
-  onClickBuy?: () => void;
   state: GameState;
 };
 

--- a/src/features/island/fisherman/FishermanModal.tsx
+++ b/src/features/island/fisherman/FishermanModal.tsx
@@ -177,11 +177,7 @@ export const FishermanModal: React.FC<Props> = ({
       container={OuterPanel}
     >
       {tab === "fish" && (
-        <BaitSelectionComponent
-          onCast={onCast}
-          onClickBuy={() => setTab("extras")}
-          state={state}
-        />
+        <BaitSelectionComponent onCast={onCast} state={state} />
       )}
 
       {tab === "guide" && (

--- a/src/features/island/fisherman/OldBaitSelection.tsx
+++ b/src/features/island/fisherman/OldBaitSelection.tsx
@@ -27,6 +27,7 @@ import Decimal from "decimal.js-light";
 import {
   getReelsPackGemPrice,
   getRemainingReels,
+  EXTRA_REELS_AMOUNT,
 } from "features/game/events/landExpansion/castRod";
 import { isFishFrenzy, isFullMoon } from "features/game/types/calendar";
 import { SEASON_ICONS } from "../buildings/components/building/market/SeasonalSeeds";
@@ -36,6 +37,8 @@ import { hasFeatureAccess } from "lib/flags";
 import { SmallBox } from "components/ui/SmallBox";
 import { ChumSelection } from "./ChumSelection";
 import { useNow } from "lib/utils/hooks/useNow";
+import { ModalOverlay } from "components/ui/ModalOverlay";
+import { gameAnalytics } from "lib/gameAnalytics";
 
 const BAIT: FishingBait[] = [
   "Earthworm",
@@ -50,10 +53,10 @@ export const OldBaitSelection: React.FC<{
     chum?: InventoryItemName,
     multiplier?: number,
     guaranteedCatch?: FishName,
+    reelPacksToBuy?: number,
   ) => void;
-  onClickBuy: () => void;
   state: GameState;
-}> = ({ onCast, onClickBuy, state }) => {
+}> = ({ onCast, state }) => {
   const items = {
     ...getBasketItems(state.inventory),
     ...getChestItems(state),
@@ -84,6 +87,7 @@ export const OldBaitSelection: React.FC<{
   const [chum, setChum] = useState<Chum | undefined>();
   const [bait, setBait] = useState<FishingBait>("Earthworm");
   const [multiplier, setMultiplier] = useState<number>(1);
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
   const { t } = useAppTranslation();
 
@@ -108,13 +112,46 @@ export const OldBaitSelection: React.FC<{
   }
 
   const reelsLeft = getRemainingReels(state);
-
-  const fishingLimitReached = reelsLeft <= 0;
-  const hasAncientRod = isWearableActive({ name: "Ancient Rod", game: state });
-
   const effectiveMultiplier = isVip ? multiplier : 1;
 
+  const getExtraReelPacksRequired = () => {
+    // Find the diff between the effective multiplier and reels left
+    const diff = effectiveMultiplier - reelsLeft;
+
+    // then work out how many groups of 5 need to be purchased (never negative)
+    const reelPacksRequired = Math.max(0, Math.ceil(diff / EXTRA_REELS_AMOUNT));
+
+    // if the multiplier is just 1 then let them just buy the 5
+    return reelPacksRequired;
+  };
+
+  const fishingLimitReached = reelsLeft <= 0 || effectiveMultiplier > reelsLeft;
+  const hasAncientRod = isWearableActive({ name: "Ancient Rod", game: state });
   const rodsRequired = hasAncientRod ? 0 : effectiveMultiplier;
+  // Get reels required to make the cast
+  const packsRequired = fishingLimitReached ? getExtraReelPacksRequired() : 0;
+  // Get the gems cost for the reels
+  const gemPrice =
+    packsRequired > 0
+      ? getReelsPackGemPrice({
+          state,
+          packs: packsRequired,
+          createdAt: now,
+        })
+      : 0;
+
+  const handleBuyMoreReelsAndCast = () => {
+    onCast(bait, chum, effectiveMultiplier, undefined, packsRequired);
+
+    gameAnalytics.trackSink({
+      currency: "Gem",
+      amount: gemPrice,
+      item: "FishingReels",
+      type: "Fee",
+    });
+
+    setShowConfirmationModal(false);
+  };
 
   const missingRod =
     !hasAncientRod &&
@@ -124,214 +161,241 @@ export const OldBaitSelection: React.FC<{
 
   return (
     <>
-      <InnerPanel>
-        <div className="p-2">
-          <div className="flex items-center justify-between flex-wrap gap-1">
-            <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-1">
+        <InnerPanel>
+          <div className="p-2">
+            <div className="flex items-center justify-between flex-wrap gap-1">
+              <div className="flex items-center gap-2">
+                <Label
+                  icon={SEASON_ICONS[currentSeason]}
+                  type="default"
+                  className="capitalize"
+                >
+                  {t(`season.${currentSeason}`)}
+                </Label>
+                {isFishFrenzy(state) && (
+                  <Label icon={lightning} type="vibrant">
+                    {t("calendar.events.fishFrenzy.title")}
+                  </Label>
+                )}
+                {isFullMoon(state) && (
+                  <Label icon={fullMoon} type="vibrant">
+                    {t("calendar.events.fullMoon.title")}
+                  </Label>
+                )}
+              </div>
+
               <Label
-                icon={SEASON_ICONS[currentSeason]}
-                type="default"
-                className="capitalize"
+                icon={SUNNYSIDE.tools.fishing_rod}
+                type={reelsLeft <= 0 ? "danger" : "default"}
               >
-                {t(`season.${currentSeason}`)}
+                {reelsLeft === 1
+                  ? t("fishing.oneReelLeft")
+                  : t("fishing.reelsLeft", { reelsLeft })}
               </Label>
-              {isFishFrenzy(state) && (
-                <Label icon={lightning} type="vibrant">
-                  {t("calendar.events.fishFrenzy.title")}
-                </Label>
-              )}
-              {isFullMoon(state) && (
-                <Label icon={fullMoon} type="vibrant">
-                  {t("calendar.events.fullMoon.title")}
-                </Label>
-              )}
-            </div>
-
-            <Label
-              icon={SUNNYSIDE.tools.fishing_rod}
-              type={reelsLeft <= 0 ? "danger" : "default"}
-            >
-              {reelsLeft === 1
-                ? t("fishing.oneReelLeft")
-                : t("fishing.reelsLeft", { reelsLeft })}
-            </Label>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap">
-          {BAIT.map((name) => (
-            <Box
-              image={ITEM_DETAILS[name].image}
-              isSelected={bait === name}
-              count={items[name]}
-              onClick={() => {
-                setBait(name);
-                localStorage.setItem("lastSelectedBait", name);
-              }}
-              key={name}
-            />
-          ))}
-        </div>
-      </InnerPanel>
-      <div>
-        <InnerPanel className="my-1 relative">
-          <div className="flex p-1 items-center">
-            <div className="flex-shrink-0 h-10 w-10 mr-2 justify-items-center">
-              <img src={ITEM_DETAILS[bait].image} className="h-8" />
-            </div>
-            <div>
-              <p className="text-sm mb-1">
-                {t("fishing.baitMultiplier", {
-                  count: effectiveMultiplier,
-                  bait,
-                })}
-              </p>
-
-              <p className="text-xs">{ITEM_DETAILS[bait].description}</p>
-              {!items[bait] && bait !== "Fishing Lure" && (
-                <Label className="mt-2" type="default">
-                  {t("statements.craft.composter")}
-                </Label>
-              )}
-              {!items[bait] && bait === "Fishing Lure" && (
-                <Label className="mt-1" type="default">
-                  {t("fishermanModal.craft.beach")}
-                </Label>
-              )}
             </div>
           </div>
-          {!items[bait] && (
-            <Label className="absolute -top-3 right-0" type={"danger"}>
-              {t("fishermanModal.zero.available")}
-            </Label>
+
+          <div className="flex flex-wrap">
+            {BAIT.map((name) => (
+              <Box
+                image={ITEM_DETAILS[name].image}
+                isSelected={bait === name}
+                count={items[name]}
+                onClick={() => {
+                  setBait(name);
+                  localStorage.setItem("lastSelectedBait", name);
+                }}
+                key={name}
+              />
+            ))}
+          </div>
+        </InnerPanel>
+        <div>
+          <InnerPanel className="my-1 relative">
+            <div className="flex p-1 items-center">
+              <div className="flex-shrink-0 h-10 w-10 mr-2 justify-items-center">
+                <img src={ITEM_DETAILS[bait].image} className="h-8" />
+              </div>
+              <div>
+                <p className="text-sm mb-1">
+                  {t("fishing.baitMultiplier", {
+                    count: effectiveMultiplier,
+                    bait,
+                  })}
+                </p>
+
+                <p className="text-xs">{ITEM_DETAILS[bait].description}</p>
+                {!items[bait] && bait !== "Fishing Lure" && (
+                  <Label className="mt-2" type="default">
+                    {t("statements.craft.composter")}
+                  </Label>
+                )}
+                {!items[bait] && bait === "Fishing Lure" && (
+                  <Label className="mt-1" type="default">
+                    {t("fishermanModal.craft.beach")}
+                  </Label>
+                )}
+              </div>
+            </div>
+            {!items[bait] && (
+              <Label className="absolute -top-3 right-0" type={"danger"}>
+                {t("fishermanModal.zero.available")}
+              </Label>
+            )}
+          </InnerPanel>
+        </div>
+        {isVip && hasFeatureAccess(state, "MULTI_CAST") && (
+          <InnerPanel className="mb-1">
+            <div className="flex flex-col justify-between space-y-2">
+              <Label type="default" className="text-xs ml-1" icon={multiCast}>
+                {t("fishing.multiCast")}
+              </Label>
+              <div className="flex items-center space-x-2 p-1">
+                <SmallBox
+                  image={SUNNYSIDE.tools.fishing_rod}
+                  count={state.inventory["Rod"] ?? new Decimal(0)}
+                />
+                <div className="flex gap-2">
+                  {[1, 5, 10, 25].map((value) => {
+                    const isSelected = effectiveMultiplier === value;
+
+                    return (
+                      <div
+                        key={value}
+                        className="flex items-center gap-1 cursor-pointer"
+                        onClick={() => setMultiplier(value)}
+                      >
+                        <span className="text-xs ml-1 -mr-0.5">{`${value}x`}</span>
+                        <Checkbox checked={isSelected} onChange={() => {}} />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </InnerPanel>
+        )}
+        <InnerPanel className="mb-1">
+          {chum ? (
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center">
+                <Label
+                  type="default"
+                  icon={ITEM_DETAILS[chum].image}
+                  className="ml-1.5"
+                >
+                  {t("fishermanModal.chum", {
+                    count: CHUM_AMOUNTS[chum] * effectiveMultiplier,
+                    type: chum,
+                  })}
+                </Label>
+              </div>
+              <img
+                src={SUNNYSIDE.icons.cancel}
+                className="h-5 pr-0.5 cursor-pointer"
+                onClick={() => {
+                  setChum(undefined);
+                  localStorage.removeItem("lastSelectedChum");
+                }}
+              />
+            </div>
+          ) : (
+            <div className="p-1 flex justify-between items-center flex-1 w-full">
+              <div className="flex">
+                <img
+                  src={SUNNYSIDE.icons.expression_confused}
+                  className="h-4 mr-2"
+                />
+                <p className="text-xs mb-1">
+                  {t("fishermanModal.attractFish")}
+                </p>
+              </div>
+              <Button
+                disabled={!bait}
+                className={`h-[30px] w-[40px]`}
+                onClick={() => setShowChum(true)}
+              >
+                <div className="flex items-center">
+                  <img src={plus} className="w-8 mt-1" />
+                </div>
+              </Button>
+            </div>
           )}
         </InnerPanel>
-      </div>
-      {isVip && hasFeatureAccess(state, "MULTI_CAST") && (
-        <InnerPanel className="mb-1">
-          <div className="flex flex-col justify-between space-y-2">
-            <Label type="default" className="text-xs ml-1" icon={multiCast}>
-              {t("fishing.multiCast")}
-            </Label>
-            <div className="flex items-center space-x-2 p-1">
-              <SmallBox
-                image={SUNNYSIDE.tools.fishing_rod}
-                count={state.inventory["Rod"] ?? new Decimal(0)}
-              />
-              <div className="flex gap-2">
-                {[1, 5, 10, 25].map((value) => {
-                  const isSelected = effectiveMultiplier === value;
 
-                  return (
-                    <div
-                      key={value}
-                      className="flex items-center gap-1 cursor-pointer"
-                      onClick={() => setMultiplier(value)}
-                    >
-                      <span className="text-xs ml-1 -mr-0.5">{`${value}x`}</span>
-                      <Checkbox checked={isSelected} onChange={() => {}} />
-                    </div>
-                  );
-                })}
-              </div>
+        {fishingLimitReached && (
+          <Label className="mb-1 ml-1" type="danger">
+            {fishingLimitReached
+              ? t("fishermanModal.fishingLimitReached")
+              : t("fishermanModal.notEnoughReels")}
+          </Label>
+        )}
+
+        {missingRod && (
+          <Label className="mb-1 ml-1" type="danger">
+            {t("fishermanModal.needCraftRod")}
+          </Label>
+        )}
+
+        {fishingLimitReached ? (
+          <Button
+            disabled={
+              missingRod ||
+              !bait ||
+              !items[bait as InventoryItemName]?.gte(effectiveMultiplier)
+            }
+            onClick={() => setShowConfirmationModal(true)}
+          >
+            <div className="flex items-center">
+              {t("fishing.buyMoreReels", {
+                reels: packsRequired * EXTRA_REELS_AMOUNT, // total reels to buy
+                price: gemPrice,
+              })}
+              <img src={ITEM_DETAILS.Gem.image} className="ml-1 h-4" />
             </div>
+          </Button>
+        ) : (
+          <Button
+            onClick={() => onCast(bait, chum, effectiveMultiplier)}
+            disabled={
+              !bait ||
+              effectiveMultiplier > reelsLeft ||
+              fishingLimitReached ||
+              missingRod ||
+              !items[bait as InventoryItemName]?.gte(effectiveMultiplier) ||
+              (chum
+                ? !items[chum as InventoryItemName]?.gte(
+                    new Decimal(CHUM_AMOUNTS[chum] * effectiveMultiplier),
+                  )
+                : false)
+            }
+          >
+            <div className="flex items-center">
+              <span className="text-sm mr-1">{t("fishing.cast")}</span>
+              <img src={SUNNYSIDE.tools.fishing_rod} className="h-5" />
+            </div>
+          </Button>
+        )}
+      </div>
+      <ModalOverlay
+        show={showConfirmationModal}
+        onBackdropClick={() => setShowConfirmationModal(false)}
+      >
+        <InnerPanel>
+          <div className="flex flex-col p-2 pb-0 items-center">
+            <span className="text-sm text-start w-full mb-1">
+              {t("fishing.buyReels.confirmation", { gemPrice })}
+            </span>
+          </div>
+          <div className="flex justify-content-around mt-2 space-x-1">
+            <Button onClick={() => setShowConfirmationModal(false)}>
+              {t("cancel")}
+            </Button>
+            <Button onClick={handleBuyMoreReelsAndCast}>{t("confirm")}</Button>
           </div>
         </InnerPanel>
-      )}
-      <InnerPanel className="mb-1">
-        {chum ? (
-          <div className="flex items-center justify-between mb-1">
-            <div className="flex items-center">
-              <Label
-                type="default"
-                icon={ITEM_DETAILS[chum].image}
-                className="ml-1.5"
-              >
-                {t("fishermanModal.chum", {
-                  count: CHUM_AMOUNTS[chum] * effectiveMultiplier,
-                  type: chum,
-                })}
-              </Label>
-            </div>
-            <img
-              src={SUNNYSIDE.icons.cancel}
-              className="h-5 pr-0.5 cursor-pointer"
-              onClick={() => {
-                setChum(undefined);
-                localStorage.removeItem("lastSelectedChum");
-              }}
-            />
-          </div>
-        ) : (
-          <div className="p-1 flex justify-between items-center flex-1 w-full">
-            <div className="flex">
-              <img
-                src={SUNNYSIDE.icons.expression_confused}
-                className="h-4 mr-2"
-              />
-              <p className="text-xs mb-1">{t("fishermanModal.attractFish")}</p>
-            </div>
-            <Button
-              disabled={fishingLimitReached || multiplier > reelsLeft}
-              className={`h-[30px] w-[40px]`}
-              onClick={() => setShowChum(true)}
-            >
-              <div className="flex items-center">
-                <img src={plus} className="w-8 mt-1" />
-              </div>
-            </Button>
-          </div>
-        )}
-      </InnerPanel>
-
-      {(fishingLimitReached || multiplier > reelsLeft) && (
-        <Label className="mb-1" type="danger">
-          {fishingLimitReached
-            ? t("fishermanModal.fishingLimitReached")
-            : t("fishermanModal.notEnoughReels")}
-        </Label>
-      )}
-
-      {!fishingLimitReached && missingRod && (
-        <Label className="mb-1 ml-1" type="danger">
-          {t("fishermanModal.needCraftRod")}
-        </Label>
-      )}
-
-      {fishingLimitReached ? (
-        <Button onClick={onClickBuy}>
-          <div className="flex items-center">
-            {t("fishing.buyMoreReels.old", {
-              gemPrice: getReelsPackGemPrice({
-                state,
-                packs: 1,
-                createdAt: now,
-              }),
-            })}
-            <img src={ITEM_DETAILS.Gem.image} className="h-5" />
-          </div>
-        </Button>
-      ) : (
-        <Button
-          onClick={() => onCast(bait, chum, effectiveMultiplier)}
-          disabled={
-            multiplier > reelsLeft ||
-            fishingLimitReached ||
-            missingRod ||
-            !items[bait as InventoryItemName]?.gte(effectiveMultiplier) ||
-            (chum
-              ? !items[chum as InventoryItemName]?.gte(
-                  new Decimal(CHUM_AMOUNTS[chum] * effectiveMultiplier),
-                )
-              : false)
-          }
-        >
-          <div className="flex items-center">
-            <span className="text-sm mr-1">{t("fishing.cast")}</span>
-            <img src={SUNNYSIDE.tools.fishing_rod} className="h-5" />
-          </div>
-        </Button>
-      )}
+      </ModalOverlay>
     </>
   );
 };


### PR DESCRIPTION
# Description

Previously, non-beta players using OldBaitSelection were redirected to the "extras" tab when they ran out of reels. After moving reel purchases to the cast flow, this logic was only implemented in BaitSelection (beta players), leaving non-beta players unable to buy reels when casting.
This change applies the same reel purchase logic from BaitSelection to OldBaitSelection, allowing non-beta players to:
- See a "Buy More Reels" button when they run out of reels
- Purchase the required number of reel packs directly from the cast interface
- Confirm the purchase via a confirmation modal before casting

This ensures feature parity between beta and non-beta players for the fishing experience.

Fixes #issue

# What needs to be tested by the reviewer?

- Turn off beta flag

```   
MULTI_CAST: () => false, 
```

- finish all your reels
- attempt to buy reels

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
