### PR TITLE
[FIX] Yield amount not displaying correctly

### DIFF
--- a/src/features/game/expansion/components/resources/gold/Gold.tsx
+++ b/src/features/game/expansion/components/resources/gold/Gold.tsx
@@ -96,7 +96,7 @@ export const Gold: React.FC<Props> = ({ id }) => {
   );
   const skills = useSelector(gameService, selectSkills, compareSkills);
   const state = useSelector(gameService, selectGame);
-  const activityCount = useSelector(gameService, (state) => {
+  const currentCounter = useSelector(gameService, (state) => {
     const rockName = state.context.state.gold[id]?.name ?? "Gold Rock";
     return state.context.state.farmActivity[`${rockName} Mined`] ?? 0;
   });
@@ -162,7 +162,6 @@ export const Gold: React.FC<Props> = ({ id }) => {
 
   const mine = async () => {
     const goldRockName = resource.name ?? "Gold Rock";
-    const counter = activityCount;
     const itemId = KNOWN_IDS[goldRockName];
     const goldMined = new Decimal(
       resource.stone.amount ??
@@ -172,7 +171,7 @@ export const Gold: React.FC<Props> = ({ id }) => {
           createdAt: now,
           farmId,
           itemId,
-          counter,
+          counter: currentCounter,
         }).amount,
     );
     const newState = gameService.send("goldRock.mined", {

--- a/src/features/game/expansion/components/resources/iron/Iron.tsx
+++ b/src/features/game/expansion/components/resources/iron/Iron.tsx
@@ -131,7 +131,6 @@ export const Iron: React.FC<Props> = ({ id }) => {
 
   const mine = async () => {
     const ironName: RockName = resource.name ?? "Iron Rock";
-    const counter = activityCount;
     const itemId = KNOWN_IDS[ironName];
     const ironMined = new Decimal(
       resource.stone.amount ??
@@ -140,7 +139,7 @@ export const Iron: React.FC<Props> = ({ id }) => {
           rock: resource,
           createdAt: now,
           farmId,
-          counter,
+          counter: activityCount,
           itemId,
         }).amount,
     );

--- a/src/features/game/expansion/components/resources/stone/Stone.tsx
+++ b/src/features/game/expansion/components/resources/stone/Stone.tsx
@@ -148,7 +148,6 @@ export const Stone: React.FC<Props> = ({ id }) => {
 
   const mine = async () => {
     const stoneName: RockName = resource.name ?? "Stone Rock";
-    const counter = activityCount;
     const stoneMined = new Decimal(
       resource.stone.amount ??
         getStoneDropAmount({
@@ -157,7 +156,7 @@ export const Stone: React.FC<Props> = ({ id }) => {
           createdAt: now,
           id,
           farmId,
-          counter,
+          counter: activityCount,
           itemId: KNOWN_IDS[stoneName],
         }).amount,
     );

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -66,14 +66,11 @@ const selectFarmId = (state: MachineState) => state.context.farmId;
 const compareResource = (prev: TreeType, next: TreeType) => {
   return JSON.stringify(prev) === JSON.stringify(next);
 };
-const compareGame = (prev: GameState, next: GameState) => {
-  return (
-    isCollectibleBuilt({ name: "Foreman Beaver", game: prev }) ===
-      isCollectibleBuilt({ name: "Foreman Beaver", game: next }) &&
-    (prev.bumpkin?.skills["Insta-Chop"] ?? false) ===
-      (next.bumpkin?.skills["Insta-Chop"] ?? false)
-  );
-};
+const compareGame = (prev: GameState, next: GameState) =>
+  isCollectibleBuilt({ name: "Foreman Beaver", game: prev }) ===
+    isCollectibleBuilt({ name: "Foreman Beaver", game: next }) &&
+  (prev.bumpkin?.skills["Insta-Chop"] ?? false) ===
+    (next.bumpkin?.skills["Insta-Chop"] ?? false);
 
 // A player that has been vetted and is engaged in the season.
 const isSeasonedPlayer = (state: MachineState) =>
@@ -186,7 +183,6 @@ export const Tree: React.FC<Props> = ({ id }) => {
 
   // Calculate expected reward for UI preview (captcha gate for non-seasoned players)
   const treeName: TreeName = resource.name ?? "Tree";
-  const currentCounter = activityCount;
 
   const { reward: expectedReward } = resource.wood.reward
     ? { reward: resource.wood.reward }
@@ -194,7 +190,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
         skills: game.bumpkin?.skills ?? {},
         farmId,
         itemId: KNOWN_IDS[treeName],
-        counter: currentCounter,
+        counter: activityCount,
       });
 
   const shake = () => {
@@ -238,7 +234,7 @@ export const Tree: React.FC<Props> = ({ id }) => {
         tree: resource,
         farmId,
         itemId: KNOWN_IDS[treeName],
-        counter: currentCounter,
+        counter: activityCount,
       }).amount;
 
     const newState = gameService.send("timber.chopped", {


### PR DESCRIPTION
## Description

Fixes yield calculation counters not updating in real-time when mining/chopping resources. Resource components were reading farm activity counters directly from state instead of using reactive selectors, causing stale counter values in yield calculations.

**Changes:**
- Added `useSelector` hooks in `Gold.tsx`, `Iron.tsx`, `Stone.tsx`, and `Tree.tsx` to subscribe to specific farm activity counters
- Components now react to state changes, ensuring yield calculations use up-to-date counter values

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE
- set tree turnaround chance to 100
- pick up Tough Tree
- chop trees, ensure that the yield changes from time to time.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
