### PR TITLE
[FIX] Visiting Effect States

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -532,7 +532,7 @@ const EFFECT_STATES = Object.values(STATE_MACHINE_EFFECTS).reduce(
           }
 
           const { gameState, data } = await postEffect({
-            farmId: Number(context.visitorId ?? context.farmId),
+            farmId: Number(context.farmId),
             effect,
             token: authToken ?? context.rawToken,
             transactionId: context.transactionId as string,
@@ -621,6 +621,10 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
         src: async (context: Context, event: PostEffectEvent) => {
           const { effect, authToken } = event;
 
+          if (!context.visitorState || !context.visitorId) {
+            throw new Error("Visitor state and/or visitor id are required");
+          }
+
           if (context.actions.length > 0) {
             await autosave({
               farmId: Number(context.visitorId),
@@ -630,7 +634,7 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
               fingerprint: context.fingerprint as string,
               deviceTrackerId: context.deviceTrackerId as string,
               transactionId: context.transactionId as string,
-              state: context.state,
+              state: context.visitorState,
             });
           }
 
@@ -639,7 +643,7 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
             effect,
             token: authToken ?? context.rawToken,
             transactionId: context.transactionId as string,
-            state: context.state,
+            state: context.visitorState,
           });
 
           if (event.effect.type === "farm.followed") {


### PR DESCRIPTION
# Description

As a result of the change made in #6733 state is now passed into the postEffect function. However when you're visiting a friend, `context.state` would be your friend's farm, however the returning gameState would be your own. 

```ts
  const mergedGameState = request.state
    ? // Response may be pruned (diff); merge over the current client state
      ({
        ...request.state,
        ...gameState,
      } as GameState)
    : (gameState as GameState);
```

As a result, `request.state` (friend's farm) is merging together with your farm, and any keys that your friend have but you don't, would be shown on your farm after you come back from visiting. (e.g. your friend is expanding but you're not)

Fix would be to pass down visitorState (your state) when you're visiting

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
