### PR TITLE
[FIX] Pet Egg wrongly shown as bought even though player hasn't bought it yet

### DIFF
--- a/src/features/world/ui/megastore/chapter_store_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/chapter_store_components/ItemsList.tsx
@@ -203,7 +203,7 @@ export const ItemsList: React.FC<Props> = ({
     state.megastore?.boughtAt["Pet Egg" as ChapterTierItemName];
   const isPetEggBoughtInCurrentChapter = petEggBoughtAt
     ? (() => {
-        const chapterTime = CHAPTERS[getCurrentChapter(now)];
+        const chapterTime = CHAPTERS[currentChapter];
         const boughtDate = new Date(petEggBoughtAt);
         return (
           boughtDate >= chapterTime.startDate &&


### PR DESCRIPTION
# Description

This PR Fixes an issue where a pet egg is shown as bought in the megastore even though you haven't bought it yet.

Fixes #issue

# What needs to be tested by the reviewer?

## Reproduce bug
- Run FE + BE on main
- buy pet egg from love charm shop as well as from the pet shop
- unlock required items all the way until tier 3 in megastore
- you should see that as soon as you unlock tier 3 the pet egg is checked

## Test for fix
- Run FE + BE on PR branch
- go back to megastore and check that the check mark is no longer there
- for good measure now buy the pet egg and ensure that it is now checked

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
