### PR TITLE
[FEAT] Auto show raffle widget

### DIFF
--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1826,7 +1826,7 @@ export interface GameState {
     }[];
   };
   raffle?: {
-    active: Record<string, { entries: number }>;
+    active: Record<string, { entries: number; endAt: number }>;
   };
   dailyRewards?: DailyRewards;
   auctioneer: Auctioneer;

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -27,6 +27,7 @@ import { WorldFeedButton } from "features/social/components/WorldFeedButton";
 import classNames from "classnames";
 import { isMobile } from "mobile-device-detect";
 import { Feed } from "features/social/Feed";
+import { RaffleWidget } from "features/retreat/components/auctioneer/RaffleWidget";
 
 const _farmAddress = (state: MachineState) => state.context.farmAddress;
 const _linkedWallet = (state: MachineState) => state.context.linkedWallet;
@@ -100,6 +101,7 @@ const HudComponent: React.FC<{
         <TravelButton />
       </div>
       <div className="absolute bottom-0 pb-2 pl-3 left-16 flex flex-col space-y-2.5">
+        <RaffleWidget />
         <TransactionCountdown />
         <StreamCountdown />
         <AuctionCountdown />

--- a/src/features/island/hud/WorldHud.tsx
+++ b/src/features/island/hud/WorldHud.tsx
@@ -36,6 +36,7 @@ import {
   Player,
 } from "features/world/ui/moderationTools/ModerationTools";
 import { DesertDiggingDisplay } from "./components/DesertDiggingDisplay";
+import { RaffleWidget } from "features/retreat/components/auctioneer/RaffleWidget";
 /**
  * Heads up display - a concept used in games for the small overlaid display of information.
  * Balances, Inventory, actions etc.
@@ -151,6 +152,7 @@ const HudComponent: React.FC<Props> = ({
         >
           <TransactionCountdown />
           <StreamCountdown />
+          <RaffleWidget />
           <FloatingIslandCountdown />
           <AuctionCountdown />
           <VersionUpdateWidget />

--- a/src/features/retreat/components/auctioneer/RaffleWidget.tsx
+++ b/src/features/retreat/components/auctioneer/RaffleWidget.tsx
@@ -1,0 +1,102 @@
+import React, { useContext, useEffect, useState } from "react";
+import * as AuthProvider from "features/auth/lib/Provider";
+import { useSelector } from "@xstate/react";
+
+import { ButtonPanel, Panel } from "components/ui/Panel";
+
+import { Context } from "features/game/GameProvider";
+
+import { AuthMachineState } from "features/auth/lib/authMachine";
+import {
+  loadRaffleResults,
+  RaffleResults,
+} from "features/world/ui/chapterRaffles/actions/loadRaffleResults";
+import { randomID } from "lib/utils/random";
+import { MachineState } from "features/game/lib/gameMachine";
+import trophyIcon from "assets/icons/trophy.png";
+import { ChapterRaffleResult } from "features/world/ui/chapterRaffles/ChapterRaffleResult";
+import { Modal } from "components/ui/Modal";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+const _token = (state: AuthMachineState) =>
+  state.context.user.rawToken as string;
+
+const _raffleId = (state: MachineState) => {
+  // Check for a completed raffle (endAt < now)
+  const now = new Date().getTime();
+  const activeRaffles = state.context.state.raffle?.active;
+  if (!activeRaffles) {
+    return null;
+  }
+  const finsihedRaffleID = Object.keys(activeRaffles).find(
+    (raffle) =>
+      activeRaffles[raffle].endAt && activeRaffles[raffle].endAt < now,
+  );
+  if (!finsihedRaffleID) {
+    return null;
+  }
+  return finsihedRaffleID;
+};
+
+export const RaffleWidget: React.FC = () => {
+  const { authService } = useContext(AuthProvider.Context);
+  const { gameService } = useContext(Context);
+
+  const { t } = useAppTranslation();
+
+  const [showResults, setShowResults] = useState(false);
+
+  const token = useSelector(authService, _token);
+
+  const [raffleResults, setRaffleResults] = useState<
+    RaffleResults | undefined
+  >();
+  const raffleId = useSelector(gameService, _raffleId);
+
+  useEffect(() => {
+    const load = async () => {
+      const upcoming = await loadRaffleResults({
+        token,
+        transactionId: randomID(),
+        id: raffleId!,
+      });
+      setRaffleResults(upcoming);
+    };
+
+    if (raffleId) {
+      load();
+    }
+  }, [token, raffleId]);
+
+  if (!raffleId || !raffleResults || raffleResults.status !== "complete") {
+    return null;
+  }
+
+  return (
+    <>
+      <ButtonPanel
+        className="flex "
+        id="test-auction"
+        onClick={() => setShowResults(true)}
+      >
+        <div className="flex items-center">
+          <img src={trophyIcon} className="h-6 mr-1" />
+          <div>
+            <p className="text-xs">{t("auction.raffle.finished")}</p>
+            <p className="text-xxs underline">
+              {t("auction.raffle.viewResults")}
+            </p>
+          </div>
+        </div>
+      </ButtonPanel>
+      <Modal
+        show={showResults && !!raffleId}
+        onHide={() => setShowResults(false)}
+      >
+        <Panel>
+          <ChapterRaffleResult id={raffleId!} />
+        </Panel>
+      </Modal>
+    </>
+  );
+};

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -157,6 +157,8 @@
   "auction.raffle": "Raffle",
   "auction.raffle.description": "Earn tickets by completing tasks & compete for prizes.",
   "auction.raffle.noWinners": "No winners.",
+  "auction.raffle.finished": "Raffle finished",
+  "auction.raffle.viewResults": "View the results",
   "auction.raffle.title": "Raffles",
   "auction.raffle.moreComing": "More raffles coming next Chapter.",
   "auction.raffle.prizeFallback": "Raffle Prize",


### PR DESCRIPTION
# Description

Once a raffle has finished, show the result widget.

<img width="257" height="212" alt="Screenshot 2026-01-20 at 2 38 01 pm" src="https://github.com/user-attachments/assets/15cc63b2-f8eb-4538-b4da-f48fec58bd32" />
