### PR TITLE
[FEAT] Natural Size Image Component

### DIFF
--- a/src/components/ui/NaturalImage.tsx
+++ b/src/components/ui/NaturalImage.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useState } from "react";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+
+interface NaturalImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "width" | "height"> {
+  /**
+   * Max width in natural (unscaled) pixels before PIXEL_SCALE.
+   */
+  maxWidth?: number;
+  /**
+   * Max height in natural (unscaled) pixels before PIXEL_SCALE.
+   */
+  maxHeight?: number;
+}
+
+export const NaturalImage: React.FC<NaturalImageProps> = ({
+  maxWidth,
+  maxHeight,
+  onLoad,
+  src,
+  style,
+  ...props
+}) => {
+  const [naturalSize, setNaturalSize] = useState<{
+    width: number;
+    height: number;
+    src?: string;
+  } | null>(null);
+
+  const handleLoad = useCallback(
+    (event: React.SyntheticEvent<HTMLImageElement>) => {
+      const { naturalWidth, naturalHeight } = event.currentTarget;
+
+      if (naturalWidth > 0 && naturalHeight > 0) {
+        setNaturalSize({ width: naturalWidth, height: naturalHeight, src });
+      }
+
+      onLoad?.(event);
+    },
+    [onLoad, src],
+  );
+
+  const scaledSize = (() => {
+    if (!naturalSize || naturalSize.src !== src) return null;
+
+    const { width, height } = naturalSize;
+    const maxWidthScale = maxWidth ? Math.min(1, maxWidth / width) : 1;
+    const maxHeightScale = maxHeight ? Math.min(1, maxHeight / height) : 1;
+    const scale = Math.min(maxWidthScale, maxHeightScale);
+
+    return {
+      width: width * PIXEL_SCALE * scale,
+      height: height * PIXEL_SCALE * scale,
+    };
+  })();
+
+  const mergedStyle = scaledSize
+    ? { ...style, width: scaledSize.width, height: scaledSize.height }
+    : style;
+
+  return <img {...props} src={src} style={mergedStyle} onLoad={handleLoad} />;
+};

--- a/src/features/world/ui/tracks/ChapterTracks.tsx
+++ b/src/features/world/ui/tracks/ChapterTracks.tsx
@@ -40,6 +40,7 @@ import { GameState } from "features/game/types/game";
 import confetti from "canvas-confetti";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { NaturalImage } from "components/ui/NaturalImage";
 
 type TrackProgress = {
   points: number;
@@ -396,14 +397,19 @@ export const TrackItem: React.FC<{
       <ButtonPanel
         variant={isClaimed ? "secondary" : "primary"}
         key={milestone.points}
-        className="h-24 min-w-24 w-24 flex flex-col items-center justify-center relative"
+        className="h-24 min-w-24 w-24 flex flex-col relative"
       >
-        <div className="flex items-center justify-center mb-2">
+        <div className="flex justify-center h-[75%] items-center">
           {images.map((image) => (
-            <img key={image} src={image} className="h-12  rounded-md" />
+            <NaturalImage
+              key={image}
+              src={image}
+              className="rounded-md"
+              maxWidth={20}
+            />
           ))}
         </div>
-        <p className="text-center text-sm">{`x${amount}`}</p>
+        <p className="absolute bottom-0 left-1/2 -translate-x-1/2 text-center text-sm">{`x${amount}`}</p>
       </ButtonPanel>
     </div>
   );


### PR DESCRIPTION
# Description

- Add NaturalImage that sizes from natural image dimensions and applies PIXEL_SCALE.
- Support maxWidth/maxHeight as unscaled caps, preserving aspect ratio.

This new component helps us to keep the pixel scale of images consistent.

I have implemented this only in the new Chapter Tracks work. I will update other components that do this inline in a future PR.

https://github.com/user-attachments/assets/05564be0-c373-46fa-a224-f174c1c8aa04

Fixes #issue

# What needs to be tested by the reviewer?

- Check the Chapter Tracks images look good.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes