### PR TITLE
[FIX] Tutorial Change Plot 5 Potatoes to Rhubarb

### DIFF
--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -28,7 +28,7 @@ import { OIL_RESERVE_RECOVERY_TIME } from "./drillOilReserve";
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
   4: "Sunflower",
-  5: "Rhubarb", // We need Potatos at expansion 5 for cooking
+  5: "Rhubarb", // Spring-available crop for early cooking tutorial
   6: "Pumpkin",
   7: "Carrot",
   8: "Cabbage",

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -28,7 +28,7 @@ import { OIL_RESERVE_RECOVERY_TIME } from "./drillOilReserve";
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
   4: "Sunflower",
-  5: "Potato", // We need Potatos at expansion 5 for cooking
+  5: "Rhubarb", // We need Potatos at expansion 5 for cooking
   6: "Pumpkin",
   7: "Carrot",
   8: "Cabbage",

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -93,7 +93,8 @@ export const FirePit: React.FC<Props> = ({ buildingId, isBuilt, island }) => {
     }
   };
 
-  const showHelper = rhubarbCount.gte(3) && experience === 0 && !rhubarbTartCooked && !cooking;
+  const showHelper =
+    rhubarbCount.gte(3) && experience === 0 && !rhubarbTartCooked && !cooking;
 
   return (
     <>

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -29,12 +29,12 @@ type Props = {
   season: TemperateSeasonName;
 };
 
-const _mashedPotatoCooked = (state: MachineState) =>
-  state.context.state.farmActivity["Mashed Potato Cooked"] ?? 0;
+const _rhubarbTartCooked = (state: MachineState) =>
+  state.context.state.farmActivity["Rhubarb Tart Cooked"] ?? 0;
 const _experience = (state: MachineState) =>
   state.context.state.bumpkin?.experience;
-const _potatoCount = (state: MachineState) =>
-  state.context.state.inventory.Potato ?? new Decimal(0);
+const _rhubarbCount = (state: MachineState) =>
+  state.context.state.inventory.Rhubarb ?? new Decimal(0);
 const _season = (state: MachineState) => state.context.state.season.season;
 const _firePit = (id: string) => (state: MachineState) =>
   state.context.state.buildings["Fire Pit"]?.find((b) => b.id === id);
@@ -43,9 +43,9 @@ export const FirePit: React.FC<Props> = ({ buildingId, isBuilt, island }) => {
   const { gameService } = useContext(Context);
   const [showModal, setShowModal] = useState(false);
 
-  const mashedPotatoCooked = useSelector(gameService, _mashedPotatoCooked);
+  const rhubarbTartCooked = useSelector(gameService, _rhubarbTartCooked);
   const experience = useSelector(gameService, _experience);
-  const potatoCount = useSelector(gameService, _potatoCount);
+  const rhubarbCount = useSelector(gameService, _rhubarbCount);
   const season = useSelector(gameService, _season);
   const firePit = useSelector(gameService, _firePit(buildingId));
 
@@ -67,7 +67,7 @@ export const FirePit: React.FC<Props> = ({ buildingId, isBuilt, island }) => {
       buildingId,
     });
 
-    if (item === "Mashed Potato" && !mashedPotatoCooked) {
+    if (item === "Rhubarb Tart" && !rhubarbTartCooked) {
       gameAnalytics.trackMilestone({
         event: "Tutorial:Cooked:Completed",
       });
@@ -93,7 +93,7 @@ export const FirePit: React.FC<Props> = ({ buildingId, isBuilt, island }) => {
     }
   };
 
-  const showHelper = potatoCount.gte(8) && experience === 0 && !cooking;
+  const showHelper = rhubarbCount.gte(3) && experience === 0 && !cooking;
 
   return (
     <>

--- a/src/features/island/buildings/components/building/firePit/FirePit.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePit.tsx
@@ -93,7 +93,7 @@ export const FirePit: React.FC<Props> = ({ buildingId, isBuilt, island }) => {
     }
   };
 
-  const showHelper = rhubarbCount.gte(3) && experience === 0 && !cooking;
+  const showHelper = rhubarbCount.gte(3) && experience === 0 && !rhubarbTartCooked && !cooking;
 
   return (
     <>

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -121,6 +121,20 @@ export const FirePitModal: React.FC<Props> = ({
 
   const [selected, setSelected] = useState<Cookable | undefined>(undefined);
 
+  const setSelectedCookable = useCallback<
+    React.Dispatch<React.SetStateAction<Cookable>>
+  >(
+    (next) => {
+      setSelected((prev) => {
+        const fallback = getDefaultSelection() ?? firePitRecipes[0];
+        const current = prev ?? fallback;
+
+        return typeof next === "function" ? next(current) : next;
+      });
+    },
+    [firePitRecipes, getDefaultSelection],
+  );
+
   useEffect(() => {
     if (!isOpen) return;
     if (selected) return;
@@ -168,7 +182,7 @@ export const FirePitModal: React.FC<Props> = ({
           {!!selected && (
             <Recipes
               selected={selected}
-              setSelected={setSelected}
+              setSelected={setSelectedCookable}
               recipes={firePitRecipes}
               onCook={onCook}
               onClose={onClose}

--- a/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
+++ b/src/features/island/buildings/components/building/firePit/FirePitModal.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { useActor } from "@xstate/react";
 
 import { Modal } from "components/ui/Modal";
 
@@ -22,6 +23,8 @@ import { CHAPTERS, getCurrentChapter } from "features/game/types/chapters";
 import { useNow } from "lib/utils/hooks/useNow";
 import { hasFeatureAccess } from "lib/flags";
 import { Context } from "features/game/GameProvider";
+import { getCookingRequirements } from "features/game/events/landExpansion/cook";
+import { InventoryItemName } from "features/game/types/game";
 
 const host = window.location.host.replace(/^www\./, "");
 const LOCAL_STORAGE_KEY = `bruce-read.${host}-${window.location.pathname}`;
@@ -57,33 +60,77 @@ export const FirePitModal: React.FC<Props> = ({
   const [showIntro, setShowIntro] = React.useState(!hasRead());
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
+  const [
+    {
+      context: { state },
+    },
+  ] = useActor(gameService);
   const now = useNow({
     live: true,
     autoEndAt: CHAPTERS["Paw Prints"].endDate.getTime(),
   });
-  const firePitRecipes = Object.values(FIRE_PIT_COOKABLES)
-    .filter((recipe) => {
-      if (getCurrentChapter(now) === "Paw Prints") return true;
+  const firePitRecipes = useMemo(() => {
+    return Object.values(FIRE_PIT_COOKABLES)
+      .filter((recipe) => {
+        if (getCurrentChapter(now) === "Paw Prints") return true;
 
-      return !isFishCookable(recipe.name);
-    })
-    .filter((recipe) => {
-      if (isInstantFishRecipe(recipe.name)) {
-        return hasFeatureAccess(
-          gameService?.getSnapshot().context.state ?? {},
-          "INSTANT_RECIPES",
-        );
-      }
-      return true;
-    })
-    .sort(
-      (a, b) => a.experience - b.experience, // Sorts Foods based on their cooking time
+        return !isFishCookable(recipe.name);
+      })
+      .filter((recipe) => {
+        if (isInstantFishRecipe(recipe.name)) {
+          return hasFeatureAccess(state ?? {}, "INSTANT_RECIPES");
+        }
+        return true;
+      })
+      .sort(
+        (a, b) => a.experience - b.experience, // "Lowest entry" == first in this order
+      );
+  }, [now, state]);
+
+  /**
+   * Stored selection is intentionally session-only (component state).
+   * If no selection exists yet (first open this session), choose the first recipe
+   * the player can currently cook; otherwise default to the first entry.
+   */
+  const getDefaultSelection = () => {
+    const inProgress = firePitRecipes.find(
+      (recipe) => recipe.name === itemInProgress,
     );
+    if (inProgress) return inProgress;
 
-  const [selected, setSelected] = useState<Cookable>(
-    firePitRecipes.find((recipe) => recipe.name === itemInProgress) ||
-      firePitRecipes[0],
-  );
+    const canCook = (recipe: Cookable) => {
+      const requirements = getCookingRequirements({
+        state,
+        item: recipe.name,
+      });
+
+      return !Object.entries(requirements).some(([name, amount]) =>
+        amount.greaterThan(state.inventory[name as InventoryItemName] ?? 0),
+      );
+    };
+
+    return firePitRecipes.find(canCook) ?? firePitRecipes[0];
+  };
+
+  const [selected, setSelected] = useState<Cookable | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (selected) return;
+    if (!firePitRecipes.length) return;
+
+    setSelected(getDefaultSelection());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, firePitRecipes.length, itemInProgress]);
+
+  useEffect(() => {
+    // If recipes list changes (feature flags/chapter), ensure selection is still valid
+    if (!selected) return;
+    if (firePitRecipes.some((r) => r.name === selected.name)) return;
+
+    setSelected(getDefaultSelection());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [firePitRecipes]);
 
   return (
     <Modal show={isOpen} onHide={onClose}>
@@ -113,18 +160,20 @@ export const FirePitModal: React.FC<Props> = ({
           bumpkinParts={NPC_WEARABLES.bruce}
           container={OuterPanel}
         >
-          <Recipes
-            selected={selected}
-            setSelected={setSelected}
-            recipes={firePitRecipes}
-            onCook={onCook}
-            onClose={onClose}
-            cooking={cooking}
-            buildingName="Fire Pit"
-            buildingId={buildingId}
-            queue={queue}
-            readyRecipes={readyRecipes}
-          />
+          {!!selected && (
+            <Recipes
+              selected={selected}
+              setSelected={setSelected}
+              recipes={firePitRecipes}
+              onCook={onCook}
+              onClose={onClose}
+              cooking={cooking}
+              buildingName="Fire Pit"
+              buildingId={buildingId}
+              queue={queue}
+              readyRecipes={readyRecipes}
+            />
+          )}
         </CloseButtonPanel>
       )}
     </Modal>


### PR DESCRIPTION
Second land expansion (Plot 5) changed to contain Rhubarb rather than Potato to keep Seasonal planting consistency (Potatoes cant be planted on Spring Island, inconsistent to teach player to grow them as first Food lesson). 
Logic added to Fire Pit to default selection to a cookable item to prevent defaulting to uncookable mashed potato on first open and generically select lowest cookable item when opening the FirePit. 

# What needs to be tested by the reviewer?

New tutorial flow is completeable (can be tested in <2 mins from new account) 
Tutorial prompts are still showing 
FirePit now defaults to lowest cookable item when opened without a prior selection & there are valid items 