### PR TITLE
[FIX] Remove Oaken from Megastore

### DIFF
--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -985,10 +985,6 @@ const CRABS_AND_TRAPS_ITEMS: ChapterStore = {
         cost: { sfl: 0, items: { Floater: 5000 } },
       },
       {
-        collectible: "Oaken",
-        cost: { sfl: 0, items: { Floater: 5000 } },
-      },
-      {
         wearable: "Corn Silk Hair",
         cost: { sfl: 0, items: { Floater: 5000 } },
       },


### PR DESCRIPTION
# Description

Oaken is already in the Chapter Tracks, and it's not supposed to be in the megastore

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
