### PR TITLE
[FEAT] Crustacean modal improvements

### DIFF
--- a/src/assets/sunnyside.ts
+++ b/src/assets/sunnyside.ts
@@ -1448,6 +1448,8 @@ export const SUNNYSIDE = {
     shovel: `${CONFIG.PROTECTED_IMAGE_URL}/tools/shovel.png`,
     stone_pickaxe: `${CONFIG.PROTECTED_IMAGE_URL}/tools/stone_pickaxe.png`,
     wood_pickaxe: `${CONFIG.PROTECTED_IMAGE_URL}/tools/wood_pickaxe.png`,
+    crab_pot: `${CONFIG.PROTECTED_IMAGE_URL}/tools/crab_pot.webp`,
+    mariner_pot: `${CONFIG.PROTECTED_IMAGE_URL}/tools/mariner_pot.webp`,
   },
   //UIs
   ui: {

--- a/src/features/game/expansion/components/effects/EffectSuccess.tsx
+++ b/src/features/game/expansion/components/effects/EffectSuccess.tsx
@@ -48,6 +48,7 @@ export const EFFECT_SUCCESS_COMPONENTS: Partial<
   marketplaceBuyingBulkResourcesSuccess: <BulkPurchaseSuccess />,
   seekingBlessingSuccess: <SuccessSkip />,
   claimingAuctionRaffleSuccess: <SuccessSkip />,
+  pickingUpWaterTrapSuccess: <SuccessSkip />,
 };
 
 function camelToDotCase(str: string): string {

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1806,11 +1806,11 @@ export const ITEM_DETAILS: Items = {
     translatedName: translate("tool.oilDrill"),
   },
   "Crab Pot": {
-    image: SUNNYSIDE.icons.expression_confused,
+    image: SUNNYSIDE.tools.crab_pot,
     description: TOOLS["Crab Pot"].description,
   },
   "Mariner Pot": {
-    image: SUNNYSIDE.icons.expression_confused,
+    image: SUNNYSIDE.tools.mariner_pot,
     description: TOOLS["Mariner Pot"].description,
   },
   "Petting Hand": {

--- a/src/features/island/common/TimerPopover.tsx
+++ b/src/features/island/common/TimerPopover.tsx
@@ -9,6 +9,8 @@ interface Props {
   image: string;
   description: string;
   timeLeft: number;
+  secondaryImage?: string | undefined;
+  secondaryDescription?: string;
 }
 
 export const TimerPopover: React.FC<Props> = ({
@@ -16,7 +18,11 @@ export const TimerPopover: React.FC<Props> = ({
   image,
   description,
   timeLeft,
+  secondaryImage,
+  secondaryDescription,
 }) => {
+  const hasSecondRow = secondaryImage != null || secondaryDescription != null;
+
   return (
     <InnerPanel
       className={classNames(
@@ -27,11 +33,19 @@ export const TimerPopover: React.FC<Props> = ({
         },
       )}
     >
-      <div className="flex flex-col text-xs mx-2">
+      <div className="flex flex-col text-xs mx-2 gap-0.5">
         <div className="flex flex-1 items-center justify-center">
           <img src={image} className="w-4 mr-1" />
           <span>{description}</span>
         </div>
+        {hasSecondRow && (
+          <div className="flex flex-1 items-center justify-center">
+            {secondaryImage && (
+              <img src={secondaryImage} className="w-4 mr-1" />
+            )}
+            {secondaryDescription && <span>{secondaryDescription}</span>}
+          </div>
+        )}
         <span className="flex-1 text-center font-secondary">
           {secondsToString(timeLeft, { length: "medium" })}
         </span>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2216,6 +2216,7 @@
   "list": "List",
   "list.trade": "List trade",
   "loading": "Loading",
+  "picking.up.water.trap": "Picking up your trap...",
   "locked": "Locked",
   "loser.refund": "Refund resources",
   "lvl": "Level",
@@ -7946,5 +7947,6 @@
   "description.crimstoneSpikesHair.boost": "Mine crimstone for free",
   "description.pawAura.boost": "Feed pets for free",
   "description.victoriasApron.boost": "33% chance to refresh pet requests",
-  "description.beastShoes.boost": "Pet XP +100/+250 (Med/Hard)"
+  "description.beastShoes.boost": "Pet XP +100/+250 (Med/Hard)",
+  "waterTrap.newCrustacean": "You discovered a new crustacean!"
 }


### PR DESCRIPTION
# Description
- In progress hover popover instead of Modal
- Newly discovered crustacean modal
- Water trap icons

<img width="608" height="292" alt="Crab Pot" src="https://github.com/user-attachments/assets/702e6399-fd9b-4d1b-8984-cee9e728aa22" />

<img width="579" height="341" alt="6 Blue Crab" src="https://github.com/user-attachments/assets/e14450cc-37dc-4194-9fec-f616f2d0d4d9" />

## Known catch
<img width="300" height="182" alt="F Isopod" src="https://github.com/user-attachments/assets/380074bb-be26-46ce-a81b-3935dee4d046" />


## Undiscovered crustacean
<img width="334" height="163" alt="› 3 Heart leaf" src="https://github.com/user-attachments/assets/533d5b74-8b9e-444a-9266-ddb4f62601c4" />

# Testing
- Place and collect from water traps
