### PR TITLE
[CHORE] Fix gems amount in buy reels modal

### DIFF
--- a/src/features/island/fisherman/BaitSelection.tsx
+++ b/src/features/island/fisherman/BaitSelection.tsx
@@ -550,7 +550,10 @@ export const BaitSelection: React.FC<Props> = ({ onCast, state }) => {
         <InnerPanel>
           <div className="flex flex-col p-2 pb-0 items-center">
             <span className="text-sm text-start w-full mb-1">
-              {t("fishing.buyReels.confirmation", { gemPrice })}
+              {t("fishing.buyReels.confirmation", {
+                reels: packsRequired * EXTRA_REELS_AMOUNT,
+                gemPrice,
+              })}
             </span>
           </div>
           <div className="flex justify-content-around mt-2 space-x-1">

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1770,7 +1770,7 @@
   "fishing.lookingMoreReels": "Ahhh you're looking for more reels? No worries! You can select a multiplier on the fish tab and purchase more reels with gems just before you cast. Or you can check out the boost options below!",
   "fishing.finishReels": "Finish your reels before buying more",
   "fishing.buyReels": "Buy 5 reels with {{gemPrice}}",
-  "fishing.buyReels.confirmation": "Are you sure you want to buy 5 reels for {{gemPrice}}?",
+  "fishing.buyReels.confirmation": "Are you sure you want to buy {{reels}} reels for {{gemPrice}}?",
   "fishing.extraReels": "Extra Reels",
   "fishing.cast": "Cast",
   "fishing.buyMoreReels": "Buy {{reels}} reels for {{price}}",


### PR DESCRIPTION
# Description

Update the UI to show the real amount of gems when buying reels.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
