### PR TITLE
[FIX] Add min height to Stella Megastore

### DIFF
--- a/src/features/world/ui/megastore/MegaStore.tsx
+++ b/src/features/world/ui/megastore/MegaStore.tsx
@@ -103,7 +103,7 @@ export const MegaStore: React.FC<Props> = ({ onClose }) => {
       container={OuterPanel}
     >
       {tab === "chapter" && (
-        <InnerPanel>
+        <InnerPanel className="min-h-[240px]">
           <ChapterStore state={state} />
         </InnerPanel>
       )}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4972,7 +4972,7 @@
   "chore.prepare.bumpkinDetox.15": "Prepare 15 Bumpkin Detox",
   "chore.grow.whitePansy.3": "Grow 3 White Pansy",
   "chore.cook.fermentedFish.5": "Cook 5 Fermented Fish",
-  "megaStore.msg1": "Welcome to my seasonal store. Gather resources & exchange them for rare items before time runs out!",
+  "megaStore.msg1": "Welcome to my chapter store. Gather resources & exchange them for rare items before time runs out!",
   "megaBountyBoard.msg1": "Welcome to the Mega Bounty Board! Gather the resources & exchange them for rewards before time runs out!",
   "megaStore.tier.rare.requirements": "Buy 4 different basic items to unlock rare items.",
   "megaStore.tier.epic.requirements": "Buy 4 different rare items to unlock epic items.",


### PR DESCRIPTION
# Description

Stella's megastore only has basic items this chapter. The modal overlay is being cut off. Open to ideas how to use the dead space.

Before:
<img width="524" height="272" alt="1" src="https://github.com/user-attachments/assets/3595c7bd-c2a4-4a0a-9f22-80a87424c151" />



After:
<img width="589" height="334" alt="2" src="https://github.com/user-attachments/assets/57310379-c980-4efe-bced-1a796a939fca" />
<img width="555" height="324" alt="3" src="https://github.com/user-attachments/assets/4766f8e5-a2ac-4caf-acfd-0573cd285aca" />


# What needs to be tested by the reviewer?

Manual Review

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes