### PR TITLE
[FIX] Add raffle tickets to coupons

### DIFF
--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -279,6 +279,7 @@ export type Coupons =
   | "Cheer"
   | Keys
   | ChapterTicket
+  | ChapterRaffleTicket
   | FactionEmblem;
 
 export type Keys = "Treasure Key" | "Rare Key" | "Luxury Key";
@@ -417,6 +418,12 @@ export const COUPONS: Record<Coupons, { description: string }> = {
   Cheer: { description: translate("description.cheer") },
   "Pet Cookie": { description: translate("description.petCookie") },
   Floater: { description: "Collected during the Crabs and Traps." },
+  "Paw Prints Raffle Ticket": {
+    description: translate("description.pawPrintsRaffleTicket"),
+  },
+  "Crabs and Traps Raffle Ticket": {
+    description: translate("description.crabsAndTrapsRaffleTicket"),
+  },
   "Halloween Token 2025": {
     description: translate("description.halloweenToken2025"),
   },

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -7943,6 +7943,8 @@
   "guide.crustacean.useChum": "Use chum to attract specific types of crustaceans",
   "guide.crustacean.catchCrustaceans": "Each trap cycle yields various crustaceans that can be collected",
   "guide.crustacean.differentTraps": "Different traps catch different types of crustaceans",
+  "description.pawPrintsRaffleTicket": "A ticket for the Paw Prints raffle.",
+  "description.crabsAndTrapsRaffleTicket": "A ticket for the Crabs and Traps raffle.",
   "raffle.newLocation": "New location",
   "raffle.newLocationDescription": "The monthly raffles can now be found in the Auction area. You can continue to use Prize tickets to enter the monthly bud raffle.",
   "description.crimstoneSpikesHair.boost": "Mine crimstone for free",


### PR DESCRIPTION
# Description

Raffle tickets were not showing in the inventory coupon section.