### PR TITLE
[FIX] Crop Machine Yield Calculation for Packs of the same crop

### DIFF
--- a/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
+++ b/src/features/island/buildings/components/building/cropMachine/CropMachineModal.tsx
@@ -88,6 +88,7 @@ const _growingCropPackIndex = (state: CropMachineState) =>
 const _inventory = (state: MachineState) => state.context.state.inventory;
 const _state = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
+const _farmActivity = (state: MachineState) => state.context.state.farmActivity;
 export const CropMachineModalContent: React.FC<Props> = ({
   show,
   queue,
@@ -100,13 +101,14 @@ export const CropMachineModalContent: React.FC<Props> = ({
 }) => {
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
-  const now = useNow({ live: true });
+  const now = useNow({ live: show });
   const farmId = useSelector(gameService, _farmId);
   const growingCropPackIndex = useSelector(service, _growingCropPackIndex);
   const idle = useSelector(service, _idle);
   const running = useSelector(service, _running);
   const paused = useSelector(service, _paused);
   const inventory = useSelector(gameService, _inventory);
+  const farmActivity = useSelector(gameService, _farmActivity);
 
   const [selectedPackIndex, setSelectedPackIndex] = useState<number>(
     growingCropPackIndex ?? 0,
@@ -242,33 +244,29 @@ export const CropMachineModalContent: React.FC<Props> = ({
 
   const allowedSeeds = ALLOWED_SEEDS(state.bumpkin, inventory);
 
-  const initialCounter = useSelector(gameService, (state) => {
+  const getInitialCounter = () => {
     const cropName = selectedPack?.crop;
     if (!cropName) return 0;
-    const cropHarvested =
-      state.context.state.farmActivity[`${cropName} Harvested`] ?? 0;
+    const cropHarvested = farmActivity[`${cropName} Harvested`] ?? 0;
     // Look for earlier harvest of the same crop in packed queue if it hasn't been harvested yet
-    const allHarvestsOfSameCrop = queue.filter(
+
+    const readySameCrop = queue.filter(
       (item) => item?.crop === cropName && item?.readyAt && item.readyAt < now,
     );
 
-    if (allHarvestsOfSameCrop.length > 0) {
-      const selectedPackIndex = allHarvestsOfSameCrop.findIndex(
-        (item) => item === selectedPack,
-      );
+    const selectedIndexInReady = readySameCrop.findIndex(
+      (item) => item === selectedPack,
+    );
+    if (selectedIndexInReady < 0) return cropHarvested;
 
-      // calculate sum of seeds of earlier harvest, up to the selected pack index
-      const sumOfSeeds = allHarvestsOfSameCrop
-        .slice(0, selectedPackIndex)
-        .reduce((acc, item) => acc + item.seeds, 0);
+    const sumOfSeeds = readySameCrop
+      .slice(0, selectedIndexInReady)
+      .reduce((acc, item) => acc + item.seeds, 0);
 
-      const counter = cropHarvested + sumOfSeeds;
+    return cropHarvested + sumOfSeeds;
+  };
 
-      return counter;
-    }
-
-    return cropHarvested;
-  });
+  const initialCounter = getInitialCounter();
 
   const cropYield = selectedPack
     ? (selectedPack.amount ??


### PR DESCRIPTION
# Description

This PR Fixes the calculation for crop machine yield if there's more than 1 pack of the same crop in the machine.

Before the calculation was taking the initial counter from what the harvested counter was at the point in time. However with multiple packs of the same crop, it needs to predict the amount based on what the counter would be after the earlier packs are harvested. 
The fix is to find out the what the counter would be at by the time the time that pack is due to be harvested


Fixes #issue

# What needs to be tested by the reviewer?

- Run FE
- Have Green Amulet equipped
- Plant multiple packs of sunflowers in crop machine 
- wait for them to finish
- ensure that each pack has different yield result

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
