### PR TITLE
[FIX] Remove Poseidon's Throne Withdrawal Date

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1526,10 +1526,6 @@ export const INVENTORY_RELEASES: Partial<Record<InventoryItemName, Releases>> =
       tradeAt: CHAPTERS["Crabs and Traps"].endDate,
       withdrawAt: new Date("2026-06-04T00:00:00Z"),
     },
-    "Poseidon's Throne": {
-      tradeAt: CHAPTERS["Crabs and Traps"].endDate,
-      withdrawAt: new Date("2026-06-04T00:00:00Z"),
-    },
     "Fish Kite": {
       tradeAt: CHAPTERS["Crabs and Traps"].endDate,
       withdrawAt: new Date("2026-06-04T00:00:00Z"),


### PR DESCRIPTION
# Description

Poseidon's Throne is a non-withdrawable monument, however it was mistakenly given a withdrawal date on the FE (BE doesn't have a withdrawal date)

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
