### PR TITLE
[FIX] Don't set initial Id if player is playing on mobile

### DIFF
--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -56,9 +56,12 @@ export const ChoreBoard: React.FC<Props> = ({ state }) => {
   const { choreBoard, bumpkin } = state;
   const { chores } = choreBoard;
 
-  const [selectedId, setSelectedId] = useState<NPCName | undefined>(
-    getKeys(chores)[0],
-  );
+  const [selectedId, setSelectedId] = useState<NPCName | undefined>(() => {
+    if (isMobile) {
+      return undefined;
+    }
+    return getKeys(chores)[0];
+  });
 
   const end = useCountdown(weekResetsAt());
   const level = getBumpkinLevel(bumpkin.experience ?? 0);

--- a/src/features/island/hud/components/codex/pages/Deliveries.tsx
+++ b/src/features/island/hud/components/codex/pages/Deliveries.tsx
@@ -2,14 +2,18 @@ import { DeliveryOrders } from "features/island/delivery/components/Orders";
 import React, { useState } from "react";
 
 import { GameState } from "features/game/types/game";
+import { isMobile } from "mobile-device-detect";
 
 export const Deliveries: React.FC<{
   onClose: () => void;
   state: GameState;
 }> = ({ onClose, state }) => {
-  const [selected, setSelected] = useState<string | undefined>(
-    state.delivery.orders[0]?.id,
-  );
+  const [selected, setSelected] = useState<string | undefined>(() => {
+    if (isMobile) {
+      return undefined;
+    }
+    return state.delivery.orders[0]?.id;
+  });
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
# Description

This PR Fixes an issue where it selects an id on load on mobile

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE
- set view to mobile and reload
- When loading, it shouldn't select a delivery or chore on load

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
