### PR TITLE
[FIX] Crash when invalid chum combination is stored in localstorage

### DIFF
--- a/src/features/island/fisherman/WaterTrapModal.tsx
+++ b/src/features/island/fisherman/WaterTrapModal.tsx
@@ -67,7 +67,6 @@ const getStoredTrap = (canUseMarinerPot: boolean): WaterTrapName => {
 
   return stored;
 };
-
 const getStoredChum = (
   trap: WaterTrapName | undefined,
   state: GameState,
@@ -132,11 +131,17 @@ export const WaterTrapModal: React.FC<Props> = ({
         const trap = getStoredTrap(canUseMarinerPot);
         const chum = getStoredChum(trap, state);
         setPersisted({ trap, chum });
+        setUserSelection({ trap, chum });
       } catch {
-        setPersisted({
+        const fallback: {
+          trap: WaterTrapName;
+          chum: CrustaceanChum | undefined;
+        } = {
           trap: "Crab Pot",
           chum: undefined,
-        });
+        };
+        setPersisted(fallback);
+        setUserSelection(fallback);
       }
     });
   }, [canUseMarinerPot, state]);
@@ -147,7 +152,11 @@ export const WaterTrapModal: React.FC<Props> = ({
       : undefined;
 
   const selectedTrap = userSelection.trap ?? persisted.trap;
-  const selectedChum = userSelection.chum ?? persisted.chum ?? initialChum;
+  const resolvedChum = userSelection.chum ?? persisted.chum ?? initialChum;
+  const selectedChum =
+    resolvedChum && WATER_TRAP[selectedTrap].chums.includes(resolvedChum)
+      ? resolvedChum
+      : undefined;
 
   const items = {
     ...getBasketItems(state.inventory),


### PR DESCRIPTION
# Description

This PR fixes a crash that happens when user somehow doesn't have the right combination 

Fixes #issue

# What needs to be tested by the reviewer?

## Test the bug
- Checkout main
- Run FE
- Open water trap modal
- Select Mariner Pot and Dewberry
- close modal
- Open modal again
- Crash

## Test fix
- Checkout this branch
- do the same steps as above
- ensure that no crash

## Additional checks
- Select trap and chum
- switch to other trap
- ensure chum selection is cleared

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
