### PR TITLE
[FIX] Next Reward Preview

### DIFF
--- a/src/features/world/ui/tracks/ChapterTracks.tsx
+++ b/src/features/world/ui/tracks/ChapterTracks.tsx
@@ -609,7 +609,7 @@ export const ChapterTracksPreview: React.FC = () => {
     return null;
   }
 
-  let { items, wearables, coins, flower } = rewards.free;
+  const { items, wearables, coins, flower } = rewards.free;
   const freeImages: string[] = [];
   const freeText: string[] = [];
 
@@ -647,39 +647,49 @@ export const ChapterTracksPreview: React.FC = () => {
 
   const premiumImages: string[] = [];
   const premiumText: string[] = [];
-  ({ items, wearables, coins, flower } = rewards.premium);
+  const {
+    items: premiumItems,
+    wearables: premiumWearables,
+    coins: premiumCoins,
+    flower: premiumFlower,
+  } = rewards.premium;
 
-  if (items) {
+  if (premiumItems) {
     premiumImages.push(
-      ...getKeys(items).map((item) => ITEM_DETAILS[item].image),
+      ...getKeys(premiumItems).map((item) => ITEM_DETAILS[item].image),
     );
-    amount += Object.values(items).reduce((acc, curr) => acc + curr, 0);
+    amount += Object.values(premiumItems).reduce((acc, curr) => acc + curr, 0);
     premiumText.push(
-      ...getKeys(items).map((item) => `${items[item]} x ${item}`),
+      ...getKeys(premiumItems).map((item) => `${premiumItems[item]} x ${item}`),
     );
   }
 
-  if (wearables) {
+  if (premiumWearables) {
     premiumImages.push(
-      ...getKeys(wearables).map((wearable) => getImageUrl(ITEM_IDS[wearable])),
+      ...getKeys(premiumWearables).map((wearable) =>
+        getImageUrl(ITEM_IDS[wearable]),
+      ),
     );
-    amount += Object.values(wearables).reduce((acc, curr) => acc + curr, 0);
+    amount += Object.values(premiumWearables).reduce(
+      (acc, curr) => acc + curr,
+      0,
+    );
     premiumText.push(
-      ...getKeys(wearables).map(
-        (wearable) => `${wearables[wearable]} x ${wearable}`,
+      ...getKeys(premiumWearables).map(
+        (wearable) => `${premiumWearables[wearable]} x ${wearable}`,
       ),
     );
   }
 
-  if (coins) {
+  if (premiumCoins) {
     premiumImages.push(coinsIcon);
-    amount += coins;
+    amount += premiumCoins;
     premiumText.push(`${coins} coins`);
   }
 
-  if (flower) {
+  if (premiumFlower) {
     premiumImages.push(flowerIcon);
-    amount += flower;
+    amount += premiumFlower;
     premiumText.push(`${flower} FLOWER`);
   }
 


### PR DESCRIPTION
# Description

The chapter preview is showing the incorrect information. There are two errors:

1. The free track image text is displayed twice
2. The items do not match the actual next reward

This PR updates this component to display more accurate information.

_Note this is a mobile only component_

**Before:**

<img width="426" height="230" alt="a" src="https://github.com/user-attachments/assets/d80bd1b9-5231-4913-bfd7-28611ace81ca" />

**After:**

<img width="445" height="206" alt="b" src="https://github.com/user-attachments/assets/2cc8dd5c-7a6d-4c6c-88f2-5b15497e3c45" />

# What needs to be tested by the reviewer?

Manual Review

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [X] Screenshot if it includes any UI changes
