### PR TITLE
[CHORE] Move Reset Requests to event endpoint

### DIFF
--- a/src/features/game/actions/effect.ts
+++ b/src/features/game/actions/effect.ts
@@ -52,6 +52,7 @@ type EffectName =
   | "auction.claimed"
   | "auction.bidPlaced"
   | "auction.bidCancelled"
+  | "reset.petRequests"
   | "auctionRaffle.entered"
   | "auctionRaffle.claimed"
   | "marketplace.buyBulkResources"
@@ -122,7 +123,8 @@ export type StateMachineStateName =
   | "marketplaceBuyingBulkResources"
   | "updatingLeagues"
   | "generatingAppInstall"
-  | "pickingUpWaterTrap";
+  | "pickingUpWaterTrap"
+  | "resettingPetRequests";
 
 export type StateMachineVisitStateName =
   | "helpingFarm"
@@ -177,6 +179,7 @@ export const STATE_MACHINE_EFFECTS: Record<
   "pet.wakeUp": "wakingPet",
   "auction.bidPlaced": "auctionBidding",
   "auction.bidCancelled": "auctionCancelling",
+  "reset.petRequests": "resettingPetRequests",
   "auctionRaffle.entered": "enteringAuctionRaffle",
   "auctionRaffle.claimed": "claimingAuctionRaffle",
   "marketplace.buyBulkResources": "marketplaceBuyingBulkResources",

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -168,6 +168,8 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   completingProjectSuccess: false,
   unlockingFarmhand: false,
   unlockingFarmhandSuccess: false,
+  resettingPetRequests: false,
+  resettingPetRequestsSuccess: false,
 
   // Every new state should be added below here
   gems: true,

--- a/src/features/island/buildings/components/building/petHouse/ManagePets.tsx
+++ b/src/features/island/buildings/components/building/petHouse/ManagePets.tsx
@@ -29,6 +29,11 @@ import { useNow } from "lib/utils/hooks/useNow";
 import { PetInfo } from "./PetInfo";
 import { PetCard } from "./PetCard";
 import { isWearableActive } from "features/game/lib/wearables";
+import * as Auth from "features/auth/lib/Provider";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+
+const _authToken = (state: AuthMachineState) =>
+  state.context.user.rawToken as string;
 
 type Props = {
   activePets: [PetName | number, Pet | PetNFT | undefined][];
@@ -39,6 +44,8 @@ export const ManagePets: React.FC<Props> = ({ activePets }) => {
   const now = useNow({ live: true });
   const [isBulkFeed, setIsBulkFeed] = useState(false);
   const { gameService } = useContext(Context);
+  const { authService } = useContext(Auth.Context);
+  const authToken = useSelector(authService, _authToken);
   const [selectedFeed, setSelectedFeed] = useState<
     {
       petId: PetName | number;
@@ -268,12 +275,9 @@ export const ManagePets: React.FC<Props> = ({ activePets }) => {
   };
 
   const handleResetRequests = (petId: PetName | number) => {
-    gameService.send("REVEAL", {
-      event: {
-        type: "reset.petRequests",
-        petId,
-        createdAt: new Date(now),
-      },
+    gameService.send("reset.petRequests", {
+      effect: { type: "reset.petRequests", petId },
+      authToken,
     });
   };
   return (

--- a/src/features/island/pets/PetModal.tsx
+++ b/src/features/island/pets/PetModal.tsx
@@ -42,6 +42,8 @@ import { capitalize } from "lib/utils/capitalize";
 import { useNow } from "lib/utils/hooks/useNow";
 import { isWearableActive } from "features/game/lib/wearables";
 import { getPetFoodRequests } from "features/game/events/pets/feedPet";
+import * as Auth from "features/auth/lib/Provider";
+import { AuthMachineState } from "features/auth/lib/authMachine";
 
 interface Props {
   show: boolean;
@@ -53,6 +55,8 @@ interface Props {
 }
 
 const _inventory = (state: MachineState) => state.context.state.inventory;
+const _authToken = (state: AuthMachineState) =>
+  state.context.user.rawToken as string;
 
 export const PetModal: React.FC<Props> = ({
   show,
@@ -61,6 +65,7 @@ export const PetModal: React.FC<Props> = ({
   isTypeFed,
 }) => {
   const { gameService } = useContext(Context);
+  const { authService } = useContext(Auth.Context);
   const { t } = useAppTranslation();
   const [display, setDisplay] = useState<
     "feeding" | "fetching" | "resetting" | "typeFed" | "guide"
@@ -90,6 +95,8 @@ export const PetModal: React.FC<Props> = ({
   }, [show, isTypeFed]);
 
   const inventory = useSelector(gameService, _inventory);
+  const authToken = useSelector(authService, _authToken);
+
   const isNFTPet = isPetNFT(data);
   const petId = isNFTPet ? data.id : data?.name;
 
@@ -126,12 +133,9 @@ export const PetModal: React.FC<Props> = ({
   };
 
   const handleResetRequests = () => {
-    gameService.send("REVEAL", {
-      event: {
-        type: "reset.petRequests",
-        petId,
-        createdAt: new Date(now),
-      },
+    gameService.send("reset.petRequests", {
+      effect: { type: "reset.petRequests", petId },
+      authToken,
     });
   };
 

--- a/src/features/island/pets/ResetFoodRequests.tsx
+++ b/src/features/island/pets/ResetFoodRequests.tsx
@@ -48,8 +48,10 @@ export function useTimeUntilUTCReset() {
   return getTimeUntil(tomorrowUTC);
 }
 
-const _revealing = (state: MachineState) => state.matches("revealing");
-const _revealed = (state: MachineState) => state.matches("revealed");
+const _resettingPetRequests = (state: MachineState) =>
+  state.matches("resettingPetRequests");
+const _resettingPetRequestsSuccess = (state: MachineState) =>
+  state.matches("resettingPetRequestsSuccess");
 
 export const ResetFoodRequests: React.FC<Props> = ({
   petData,
@@ -64,15 +66,21 @@ export const ResetFoodRequests: React.FC<Props> = ({
   const { t } = useAppTranslation();
   const [showConfirmation, setShowConfirmation] = useState(false);
 
-  const isRevealingState = useSelector(gameService, _revealing);
-  const isRevealedState = useSelector(gameService, _revealed);
+  const isResettingPetRequestsState = useSelector(
+    gameService,
+    _resettingPetRequests,
+  );
+  const isResettingPetRequestsSuccessState = useSelector(
+    gameService,
+    _resettingPetRequestsSuccess,
+  );
 
   const resetGemCost = getGemCost(petData.requests.resets?.[todayDate] ?? 0);
   const hasEnoughGem = inventory.Gem?.gte(resetGemCost);
 
   const timeUntilUTCReset = useTimeUntilUTCReset();
 
-  if (isRevealingState) {
+  if (isResettingPetRequestsState) {
     return (
       <PanelWrapper>
         <Loading text={t("pets.loadingFoodRequests")} />
@@ -80,7 +88,7 @@ export const ResetFoodRequests: React.FC<Props> = ({
     );
   }
 
-  if (isRevealedState) {
+  if (isResettingPetRequestsSuccessState) {
     return (
       <PanelWrapper>
         <Label type="success">{t("pets.requestsReset")}</Label>


### PR DESCRIPTION
# Description

This PR moves the reset pet requests function to the event endpoint

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE + BE
- Ensure you can reset pet requests like intended

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
