### PR TITLE
[FIX] Assign NFTId on visit

### DIFF
--- a/src/features/game/actions/loadGameStateForVisit.ts
+++ b/src/features/game/actions/loadGameStateForVisit.ts
@@ -31,6 +31,7 @@ export async function loadGameStateForVisit(
   isBanned: boolean;
   visitorId: number;
   visitedFarmState: GameState;
+  visitedFarmNftId?: number;
   hasHelpedPlayerToday: boolean;
   totalHelpedToday: number;
 }> {
@@ -46,11 +47,12 @@ export async function loadGameStateForVisit(
 
   const data = await response.json();
 
-  const { visitorFarmState, visitedFarmState } = data;
+  const { visitorFarmState, visitedFarmState, visitedFarmNftId } = data;
 
   return {
     ...data,
     visitorFarmState: makeGame(visitorFarmState),
     visitedFarmState: makeGame(visitedFarmState),
+    visitedFarmNftId,
   };
 }

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -187,6 +187,7 @@ export interface Context {
   rawToken?: string;
   visitorId?: number;
   visitorState?: GameState;
+  visitorNftId?: number;
   hasHelpedPlayerToday?: boolean;
   totalHelpedToday?: number;
   apiKey?: string;
@@ -1102,6 +1103,7 @@ export function startGame(authContext: AuthContext) {
                 hasHelpedPlayerToday,
                 totalHelpedToday,
                 visitorId,
+                visitedFarmNftId,
               } = await loadGameStateForVisit(
                 Number(farmId),
                 authContext.user.rawToken as string,
@@ -1114,6 +1116,7 @@ export function startGame(authContext: AuthContext) {
                 totalHelpedToday,
                 visitorId,
                 visitorState: visitorFarmState,
+                visitedFarmNftId,
               };
             },
             onDone: {
@@ -1123,10 +1126,12 @@ export function startGame(authContext: AuthContext) {
                 farmId: (_, event) => event.data.farmId,
                 visitorId: (_, event) => event.data.visitorId,
                 visitorState: (_, event) => event.data.visitorState,
+                nftId: (_, event) => event.data.visitedFarmNftId,
+                visitorNftId: (context) => context.nftId,
                 hasHelpedPlayerToday: (_, event) =>
                   event.data.hasHelpedPlayerToday,
                 totalHelpedToday: (_, event) => event.data.totalHelpedToday,
-                actions: (_, event) => [],
+                actions: () => [],
               }),
             },
             onError: {
@@ -1159,10 +1164,12 @@ export function startGame(authContext: AuthContext) {
               actions: assign((context) => ({
                 visitorId: undefined,
                 visitorState: undefined,
+                visitorNftId: undefined,
                 hasHelpedPlayerToday: undefined,
                 totalHelpedToday: undefined,
                 state: context.visitorState,
                 farmId: context.visitorId,
+                nftId: context.visitorNftId,
                 actions: [],
               })),
             },

--- a/src/features/game/lib/offChainItems.ts
+++ b/src/features/game/lib/offChainItems.ts
@@ -53,6 +53,7 @@ export const OFFCHAIN_ITEMS_SET = new Set<InventoryItemName>([
   ),
   ...getKeys(CONSUMABLES),
   ...getKeys({ ...CROP_COMPOST, ...FRUIT_COMPOST }),
+  "Town Sign",
 ]);
 
 export const OFFCHAIN_ITEMS: InventoryItemName[] =

--- a/src/features/island/collectibles/components/Sign.tsx
+++ b/src/features/island/collectibles/components/Sign.tsx
@@ -7,6 +7,7 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { SFTDetailPopover } from "components/ui/SFTDetailPopover";
 import { CollectibleProps } from "../Collectible";
+import { shortAddress } from "lib/utils/shortAddress";
 
 const _username = (state: MachineState) => state.context.state.username;
 const _nftId = (state: MachineState) => state.context.nftId;
@@ -46,6 +47,7 @@ export const Sign: React.FC<CollectibleProps> = ({ index }) => {
           return `#${farmId}`;
       }
     }
+    return `#${farmId}`;
   };
   const displayName = getDisplayName(index);
 
@@ -70,7 +72,11 @@ export const Sign: React.FC<CollectibleProps> = ({ index }) => {
             textShadow: "1px 1px #723e39",
           }}
         >
-          <p className="text-xxs mt-2 font-pixel">{displayName}</p>
+          <p className="text-xxs mt-2 font-pixel">
+            {displayName === `#${farmId}` && farmId.toString().length > 6
+              ? shortAddress(displayName, 4, 3)
+              : displayName}
+          </p>
         </div>
       </div>
     </SFTDetailPopover>

--- a/src/lib/utils/shortAddress.ts
+++ b/src/lib/utils/shortAddress.ts
@@ -1,5 +1,9 @@
-export const shortAddress = (address: string): string => {
+export const shortAddress = (
+  address: string,
+  startLength: number = 5,
+  endLength: number = 4,
+): string => {
   if (!address) return "";
 
-  return `${address.slice(0, 5)}...${address.slice(-4)}`;
+  return `${address.slice(0, startLength)}...${address.slice(-endLength)}`;
 };


### PR DESCRIPTION
# Description

This PR Fixes an issue where NFTId isn't assigned to your friend's nftID when visiting. This primarily affects viewing your friend's town sign when that sign is showing nftId, it would show your nftId instead of your friend's nftId

Other fixes:
- Shorten long farmId
- Add Town Sign to offchain


Fixes #issue

# What needs to be tested by the reviewer?

- Run FE + BE
- On one account, place 3 town signs
- on the other account, visit the other account
- ensure that the NFTID and FarmID is not yours

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
