### PR TITLE
[FIX] Unplaced water well doesn't cause plots to be infertile

### DIFF
--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -116,7 +116,7 @@ export const getSupportedPlots = ({
 }) => {
   let plots = INITIAL_SUPPORTED_PLOTS(island);
   const hasPlacedWell =
-    buildings["Water Well"]?.some((w) => w.coordinates != null) ?? false;
+    buildings["Water Well"]?.some((w) => !!w.coordinates) ?? false;
   let effectiveWellLevel = wellLevel;
 
   if (upgradeReadyAt && upgradeReadyAt > createdAt) {


### PR DESCRIPTION
# Description

- This PR fixes and issue where unplaced water well still keeps the plots fertile

Fixes #issue

# What needs to be tested by the reviewer?

- Run FE
- have more than 18 plots
- remove water well
- esure extra plots are unfertilised

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
