### PR TITLE
[FIX] Marine Marvel Hoard Limit

### DIFF
--- a/src/features/game/lib/offChainItems.ts
+++ b/src/features/game/lib/offChainItems.ts
@@ -15,7 +15,6 @@ import { FRUIT_COMPOST, CROP_COMPOST, WORM } from "../types/composters";
 import { REWARD_BOXES } from "../types/rewardBoxes";
 import { PROCESSED_RESOURCES } from "../types/processedFood";
 import { SELLABLE_TREASURES } from "../types/treasure";
-import { FISH } from "../types/fishing";
 import { CRUSTACEANS } from "../types/crustaceans";
 import { CONSUMABLES } from "../types/consumables";
 import { TRADE_LIMITS } from "../actions/tradeLimits";
@@ -46,14 +45,13 @@ const BASE_OFFCHAIN_ITEMS = new Set<InventoryItemName>([
   "Bronze Friends Trophy",
   "Basic Land",
   ...getKeys(REWARD_BOXES),
-  // Fishing + water traps (no hoarding limits)
-  ...getKeys(FISH),
   ...CRUSTACEANS,
   "Holiday Token 2025",
   "Holiday Ticket 2025",
   ...Object.values(CHAPTER_RAFFLE_TICKET_NAME).filter(
     (ticket): ticket is ChapterRaffleTicket => ticket !== undefined,
   ),
+  // Consumables includes fish, cookables, and consumables
   ...getKeys(CONSUMABLES),
   ...getKeys({ ...CROP_COMPOST, ...FRUIT_COMPOST }),
   "Town Sign",


### PR DESCRIPTION
# Description

Marine Marvels and Chapter Fish were added to offchain items together with the rest of the fish by mistake, hence some players were not able to store their marine marvels on chain, causing a regression on trading.

This PR Removes them from offchain items

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
