### PR TITLE
[FEAT] Crafting Queue VIP Prompt

### DIFF
--- a/src/features/island/buildings/components/building/craftingBox/components/CraftButton.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftButton.tsx
@@ -15,6 +15,7 @@ export const CraftButton: React.FC<{
   isViewingReadyItem: boolean;
   handleCollect: () => void;
   handleCraft: () => void;
+  onAddToQueue?: () => void;
   handleCancelQueuedItem?: () => void;
   isCraftingBoxEmpty: boolean;
   selectedItems: (RecipeIngredient | null)[];
@@ -32,6 +33,7 @@ export const CraftButton: React.FC<{
   isViewingReadyItem,
   handleCollect,
   handleCraft,
+  onAddToQueue,
   handleCancelQueuedItem,
   isCraftingBoxEmpty,
   selectedItems,
@@ -63,6 +65,7 @@ export const CraftButton: React.FC<{
 
   const addToQueueDisabled =
     isQueueFull || isCraftingBoxEmpty || !hasRequiredIngredients;
+  const addToQueueHandler = onAddToQueue ?? handleCraft;
 
   if (isViewingQueuedRecipe && handleCancelQueuedItem) {
     return (
@@ -70,7 +73,7 @@ export const CraftButton: React.FC<{
         {hasCraftingBoxQueuesAccess && (
           <Button
             className="whitespace-nowrap relative"
-            onClick={handleCraft}
+            onClick={addToQueueHandler}
             disabled={addToQueueDisabled}
           >
             <img
@@ -92,7 +95,7 @@ export const CraftButton: React.FC<{
         {hasCraftingBoxQueuesAccess && (
           <Button
             className="whitespace-nowrap relative"
-            onClick={handleCraft}
+            onClick={addToQueueHandler}
             disabled={addToQueueDisabled}
           >
             <img

--- a/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftTab.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useContext, useState, useEffect, useMemo, useRef } from "react";
 import { useSelector } from "@xstate/react";
 import {
   MachineInterpreter,
@@ -35,6 +35,12 @@ import { hasVipAccess } from "features/game/lib/vipAccess";
 import { gameAnalytics } from "lib/gameAnalytics";
 import { hasFeatureAccess } from "lib/flags";
 import { useCraftingQueue } from "./useCraftingQueue";
+import { ModalContext } from "features/game/components/modal/ModalProvider";
+import { Panel } from "components/ui/Panel";
+import { ModalOverlay } from "components/ui/ModalOverlay";
+import { Button } from "components/ui/Button";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import vipIcon from "assets/icons/vip.webp";
 
 const _state = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -58,6 +64,8 @@ export const CraftTab: React.FC<Props> = ({
   initialQueueSlot,
   onQueueSelectionChange,
 }) => {
+  const { openModal } = useContext(ModalContext);
+  const { t } = useAppTranslation();
   const state = useSelector(gameService, _state);
   const farmId = useSelector(gameService, _farmId);
   const { inventory, wardrobe, craftingBox } = state;
@@ -84,6 +92,8 @@ export const CraftTab: React.FC<Props> = ({
   const isQueueFull = craftingQueue.length >= availableSlots;
 
   const [failedAttempt, setFailedAttempt] = useState(false);
+  const [showCraftingQueueVipModal, setShowCraftingQueueVipModal] =
+    useState(false);
   const prevSelectedItemsRef = useRef(selectedItems);
   const [selectedIngredient, setSelectedIngredient] =
     useState<RecipeIngredient | null>(null);
@@ -380,6 +390,14 @@ export const CraftTab: React.FC<Props> = ({
     }
   };
 
+  const handleAddToQueue = () => {
+    if (!isVIP) {
+      setShowCraftingQueueVipModal(true);
+      return;
+    }
+    handleCraft();
+  };
+
   const handleCollect = () => {
     const nextCooking = queue[0] ?? cooking;
     gameService.send("crafting.collected");
@@ -432,7 +450,10 @@ export const CraftTab: React.FC<Props> = ({
     if (isSameSlotSelected) return;
 
     if (isEmpty) {
-      if (!canAddToQueue) return;
+      if (!canAddToQueue) {
+        if (!isVIP) setShowCraftingQueueVipModal(true);
+        return;
+      }
       setQueueSelection({
         slot: slotIndex,
         item: cooking ?? defaultQueueItem,
@@ -601,6 +622,7 @@ export const CraftTab: React.FC<Props> = ({
             isViewingReadyItem={isViewingReadyItem}
             handleCollect={handleCollect}
             handleCraft={handleCraft}
+            onAddToQueue={handleAddToQueue}
             handleCancelQueuedItem={
               isViewingReadyItem ? undefined : handleCancelQueuedItem
             }
@@ -623,7 +645,7 @@ export const CraftTab: React.FC<Props> = ({
         </div>
       </div>
 
-      {isVIP && (
+      {hasCraftingBoxQueuesAccess && (
         <CraftingQueue
           readyProducts={readyProducts}
           displayItems={liveDisplayItems}
@@ -646,6 +668,36 @@ export const CraftTab: React.FC<Props> = ({
         disabled={isViewingMode || isPending || (isCrafting && !canAddToQueue)}
         discoveredRecipes={state.craftingBox.recipes}
       />
+
+      <ModalOverlay
+        show={showCraftingQueueVipModal}
+        onBackdropClick={() => setShowCraftingQueueVipModal(false)}
+      >
+        <Panel>
+          <div className="p-2 text-sm">
+            <p className="mb-1.5">{t("crafting.vipCraftingQueue")}</p>
+          </div>
+          <div className="flex space-x-1 justify-end">
+            <Button onClick={() => setShowCraftingQueueVipModal(false)}>
+              {t("close")}
+            </Button>
+            <Button
+              className="relative"
+              onClick={() => {
+                onClose();
+                openModal("BUY_BANNER");
+              }}
+            >
+              <img
+                src={vipIcon}
+                alt="VIP"
+                className="absolute w-6 sm:w-4 -top-[1px] -right-[2px]"
+              />
+              <span>{t("upgrade")}</span>
+            </Button>
+          </div>
+        </Panel>
+      </ModalOverlay>
     </>
   );
 };

--- a/src/lib/i18n/dictionaries/de.json
+++ b/src/lib/i18n/dictionaries/de.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Öl",
   "resource.sunstoneRecoveryTime": "Sonnenstein",
   "crafting.queue": "Warteschlange",
+  "crafting.vipCraftingQueue": "Werde VIP-Mitglied und schalte die Möglichkeit frei, bis zu 4 Rezepte gleichzeitig herzustellen! Mache jetzt ein Upgrade, um dein Crafting zu verbessern.",
   "crafting.inQueue": "In der Warteschlange",
   "crafting.addToQueue": "Zur Warteschlange hinzufügen",
   "vip.benefit.craftingQueue": "Stellen Sie Rezepte in der Bastelkiste in die Warteschlange"

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4562,6 +4562,7 @@
   "crafting.inProgress": "In progress",
   "crafting.noRecipe": "No recipe",
   "crafting.queue": "Queue",
+  "crafting.vipCraftingQueue": "Become a VIP member and unlock the ability to craft up to 4 recipes at once! Upgrade now to supercharge your crafting.",
   "crafting.inQueue": "In queue",
   "crafting.addToQueue": "Add to queue",
   "ready": "Ready",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -4561,6 +4561,7 @@
   "crafting.inProgress": "In progress",
   "crafting.noRecipe": "No recipe",
   "crafting.queue": "Queue",
+  "crafting.vipCraftingQueue": "Become a VIP member and unlock the ability to craft up to 4 recipes at once! Upgrade now to supercharge your crafting.",
   "crafting.inQueue": "In queue",
   "crafting.addToQueue": "Add to queue",
   "ready": "Ready",

--- a/src/lib/i18n/dictionaries/es.json
+++ b/src/lib/i18n/dictionaries/es.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Petróleo",
   "resource.sunstoneRecoveryTime": "Piedra solar",
   "crafting.queue": "Fila",
+  "crafting.vipCraftingQueue": "¡Conviértete en miembro VIP y desbloquea la posibilidad de elaborar hasta 4 recetas a la vez! Actualízate ahora para potenciar tu elaboración.",
   "crafting.inQueue": "En cola",
   "crafting.addToQueue": "Añadir a la cola",
   "vip.benefit.craftingQueue": "Haz cola para preparar recetas en la caja de manualidades"

--- a/src/lib/i18n/dictionaries/fr.json
+++ b/src/lib/i18n/dictionaries/fr.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Pétrole",
   "resource.sunstoneRecoveryTime": "Pierre solaire",
   "crafting.queue": "File d'attente",
+  "crafting.vipCraftingQueue": "Devenez membre VIP et débloquez la possibilité de fabriquer jusqu'à 4 recettes à la fois ! Passez à la version supérieure dès maintenant pour améliorer votre fabrication.",
   "crafting.inQueue": "En file d'attente",
   "crafting.addToQueue": "Ajouter à la file",
   "vip.benefit.craftingQueue": "Mettez les recettes en file d'attente dans une boîte à bricolage"

--- a/src/lib/i18n/dictionaries/id.json
+++ b/src/lib/i18n/dictionaries/id.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Minyak",
   "resource.sunstoneRecoveryTime": "Batu Matahari",
   "crafting.queue": "Antrian",
+  "crafting.vipCraftingQueue": "Menjadi anggota VIP dan buka kemampuan untuk membuat hingga 4 resep sekaligus! Tingkatkan sekarang untuk meningkatkan pembuatan Anda.",
   "crafting.inQueue": "Dalam antrian",
   "crafting.addToQueue": "Tambahkan ke antrian",
   "vip.benefit.craftingQueue": "Antrekan resep di kotak kerajinan"

--- a/src/lib/i18n/dictionaries/it.json
+++ b/src/lib/i18n/dictionaries/it.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Olio",
   "resource.sunstoneRecoveryTime": "Pietra solare",
   "crafting.queue": "Coda",
+  "crafting.vipCraftingQueue": "Diventa un membro VIP e sblocca la possibilità di creare fino a 4 ricette contemporaneamente! Effettua subito l'upgrade per potenziare la tua creazione.",
   "crafting.inQueue": "In coda",
   "crafting.addToQueue": "Aggiungi alla coda",
   "vip.benefit.craftingQueue": "Mette in coda le ricette nella scatola da lavoro"

--- a/src/lib/i18n/dictionaries/ja.json
+++ b/src/lib/i18n/dictionaries/ja.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "石油",
   "resource.sunstoneRecoveryTime": "サンストーン",
   "crafting.queue": "キュー",
+  "crafting.vipCraftingQueue": "VIPメンバーになると、一度に最大4つのレシピを制作できるようになります！今すぐアップグレードして制作を強化しましょう。",
   "crafting.inQueue": "待機中",
   "crafting.addToQueue": "キューに追加",
   "vip.benefit.craftingQueue": "クラフトボックスでレシピをキューに入れる"

--- a/src/lib/i18n/dictionaries/pt-BR.json
+++ b/src/lib/i18n/dictionaries/pt-BR.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Óleo",
   "resource.sunstoneRecoveryTime": "Pedra do sol",
   "crafting.queue": "Fila",
+  "crafting.vipCraftingQueue": "Torne-se um membro VIP e desbloqueie a capacidade de criar até 4 receitas ao mesmo tempo! Atualize agora para turbinar sua criação.",
   "crafting.inQueue": "Na fila",
   "crafting.addToQueue": "Adicionar à fila",
   "vip.benefit.craftingQueue": "Coloque receitas na fila na caixa de artesanato"

--- a/src/lib/i18n/dictionaries/ru.json
+++ b/src/lib/i18n/dictionaries/ru.json
@@ -8110,6 +8110,7 @@
   "resource.oilRecoveryTime": "Нефть",
   "resource.sunstoneRecoveryTime": "Санстоун",
   "crafting.queue": "Queue",
+  "crafting.vipCraftingQueue": "Станьте VIP-членом и получите возможность создавать до 4 рецептов одновременно! Обновитесь прямо сейчас, чтобы ускорить создание.",
   "crafting.inQueue": "In queue",
   "crafting.addToQueue": "Add to queue",
   "vip.benefit.craftingQueue": "Queue up recipes in crafting box",

--- a/src/lib/i18n/dictionaries/tr.json
+++ b/src/lib/i18n/dictionaries/tr.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "Yağ",
   "resource.sunstoneRecoveryTime": "Güneş taşı",
   "crafting.queue": "Kuyruk",
+  "crafting.vipCraftingQueue": "VIP üye olun ve aynı anda 4 tarife kadar üretim yeteneğinin kilidini açın! Üretiminizi güçlendirmek için şimdi yükseltin.",
   "crafting.inQueue": "Kuyrukta",
   "crafting.addToQueue": "Kuyruğa ekle",
   "vip.benefit.craftingQueue": "Tarifleri işçilik kutusunda sıraya koyun"

--- a/src/lib/i18n/dictionaries/zh-CN.json
+++ b/src/lib/i18n/dictionaries/zh-CN.json
@@ -8112,6 +8112,7 @@
   "resource.oilRecoveryTime": "石油",
   "resource.sunstoneRecoveryTime": "日光石",
   "crafting.queue": "队列",
+  "crafting.vipCraftingQueue": "成为 VIP 会员，解锁一次制作多达 4 个配方的能力！立即升级，为您的制作锦上添花。",
   "crafting.inQueue": "在队列中",
   "crafting.addToQueue": "添加到队列",
   "vip.benefit.craftingQueue": "在制作箱中排队配方"


### PR DESCRIPTION
# Description

Right now there's no prompt for players if they don't have VIP.

This PR Adds a prompt for it


https://github.com/user-attachments/assets/d2f66cbf-d0da-4ad4-bf48-e686a8ae7187



Fixes #issue

# What needs to be tested by the reviewer?

- in vipAccess.ts set VIP to false
- Go to crafting box ensure you see the vip prompt

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
