### PR TITLE
[FIX] Feed when Main Bumpkin is placed

### DIFF
--- a/src/features/island/bumpkin/components/PlacedBumpkin.tsx
+++ b/src/features/island/bumpkin/components/PlacedBumpkin.tsx
@@ -1,11 +1,10 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { NPCPlaceable } from "./NPC";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import { MoveableComponent } from "features/island/collectibles/MovableComponent";
 import { PlaceableLocation } from "features/game/types/collectibles";
-import { NPCModal } from "./NPCModal";
 import { PlayerNPC } from "./PlayerNPC";
 
 const _bumpkin = (state: MachineState) => state.context.state.bumpkin;
@@ -14,7 +13,6 @@ const _isLandscaping = (state: MachineState) => state.matches("landscaping");
 export const PlacedBumpkin: React.FC<{
   location?: PlaceableLocation;
 }> = ({ location = "farm" }) => {
-  const [showModal, setShowModal] = useState(false);
   const { gameService } = useContext(Context);
   const bumpkin = useSelector(gameService, _bumpkin);
   const isLandscaping = useSelector(gameService, _isLandscaping);
@@ -22,7 +20,7 @@ export const PlacedBumpkin: React.FC<{
   if (!bumpkin) return null;
 
   if (!bumpkin.coordinates) {
-    return <PlayerNPC parts={bumpkin.equipped} isManuallyPlaced={true} />;
+    return <NPCPlaceable parts={bumpkin.equipped} isManuallyPlaced={true} />;
   }
 
   if (!isLandscaping) {
@@ -31,7 +29,6 @@ export const PlacedBumpkin: React.FC<{
         <div style={{ position: "relative", top: "-24px" }}>
           <PlayerNPC parts={bumpkin.equipped} isManuallyPlaced={true} />
         </div>
-        <NPCModal isOpen={showModal} onClose={() => setShowModal(false)} />
       </>
     );
   }


### PR DESCRIPTION
# Description

The feed currently does not allow notifications to open the player modal if the `bumpkin` has coordinates set, i.e. the bumpkin is placed. This is due to a bug, where a listener on the playerNPCModal bus is not registered.

This PR updates the `PlacedBumpkin` component to use `PlayerNPC` instead of `NPCPlaceable`, which results in the PlayerNPC setting the correct listeners up.

## How to Test

On **main**
1. Have a bumpkin and at least one farm hand
2. Place the farm hand
3. Select the farm hand, and click `Set as Main Bumpkin`
4. Refresh the page
5. Open the feed and try open any notification. The feed should close without showing the Player Modal.
6. Test again on this PR and ensure the Player modal can open.

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [X] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]