### PR TITLE
[CHORE] Add  (excluding Crop Machine) to certain boost

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6388,7 +6388,7 @@
   "description.summerGuardian.boost2": "Blessed Summer Events",
   "description.obsidianNecklace.boost": "-50% Lava Pit Time",
   "description.medicApron.boost": "-50% Medicine to heal animals",
-  "description.broccoliHat.boost": "-50% Broccoli Growth Time (excluding Crop Machine)",
+  "description.broccoliHat.boost": "-50% Broccoli Plot Growth Time",
   "description.redPepperOnesie.boost": "-25% Red Pepper Growth Time",
   "interactableModals.petalClue.message1": "When the petals are in an orange bloom, a prize appears. Can you find it?",
   "current.timezone": "Current timezone: {{timeZone}}",


### PR DESCRIPTION
# Description

Recently, I did received some of the players asking about why these boost unable to function in Crop Machine, after some communication, I found that they confused and misunderstanding on this part, so to make the boost description more easy to understand, I add a  (excluding Crop Machine) words there, just like how we did on "Golden Sunflower" skill.

Fixes #issue

# What needs to be tested by the reviewer?

Please describe how this can be tested.

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
