### PR TITLE
[FIX] New Faction Member XP Boost

### DIFF
--- a/src/features/game/lib/factionPetQualifiesForBoost.test.ts
+++ b/src/features/game/lib/factionPetQualifiesForBoost.test.ts
@@ -1,0 +1,25 @@
+import { qualifiesForFactionPetBoostFromPriorWeekRequests } from "./factionPetQualifiesForBoost";
+
+describe("qualifiesForFactionPetBoostFromPriorWeekRequests", () => {
+  it("returns false when there is no prior-week request data (new faction members)", () => {
+    expect(qualifiesForFactionPetBoostFromPriorWeekRequests([])).toBe(false);
+  });
+
+  it("returns false when at least one request was never fed", () => {
+    expect(
+      qualifiesForFactionPetBoostFromPriorWeekRequests([
+        { food: "Apple Pie", quantity: 1, dailyFulfilled: { 1: 1 } },
+        { food: "Honey Cake", quantity: 1, dailyFulfilled: {} },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns true when every request was fed at least once", () => {
+    expect(
+      qualifiesForFactionPetBoostFromPriorWeekRequests([
+        { food: "Apple Pie", quantity: 1, dailyFulfilled: { 1: 1 } },
+        { food: "Honey Cake", quantity: 1, dailyFulfilled: { 2: 1 } },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/features/game/lib/factionPetQualifiesForBoost.ts
+++ b/src/features/game/lib/factionPetQualifiesForBoost.ts
@@ -1,0 +1,21 @@
+import { FactionPetRequest } from "features/game/types/game";
+import { getKeys } from "lib/object";
+
+/**
+ * Whether the player fed each faction pet request at least once in the week
+ * that just ended (used when rolling into a new week).
+ *
+ * Must stay aligned with `qualifiesForFactionPetBoostFromPriorWeekRequests` in
+ * sunflower-land-api `domain/game/types/factionPet.ts`.
+ *
+ * Empty prior-week request data must not qualify — `Array.prototype.every` on
+ * `[]` is vacuously true in JavaScript, which incorrectly boosted new members.
+ */
+export function qualifiesForFactionPetBoostFromPriorWeekRequests(
+  priorWeekRequests: FactionPetRequest[],
+): boolean {
+  if (priorWeekRequests.length === 0) return false;
+  return priorWeekRequests.every(
+    (request) => getKeys(request.dailyFulfilled ?? {}).length > 0,
+  );
+}

--- a/src/features/game/lib/factions.ts
+++ b/src/features/game/lib/factions.ts
@@ -598,6 +598,7 @@ export function getFactionPetBoostMultiplier(game: GameState) {
 
   if (lastWeekStreak < 2) return 1;
 
+  // Set on week rollover in API populateFactionPet; see factionPetQualifiesForBoost.ts
   const qualifiesForBoost = game.faction?.pet?.qualifiesForBoost ?? false;
 
   if (!qualifiesForBoost) return 1;


### PR DESCRIPTION
This fixes an error where new members without any feeding history, were eligible for the faction pet XP boost.