### PR TITLE
[FIX] Power Hour Buff Label

### DIFF
--- a/src/components/ui/layouts/SeedRequirements.tsx
+++ b/src/components/ui/layouts/SeedRequirements.tsx
@@ -12,7 +12,7 @@ import React, { type JSX } from "react";
 import { Label } from "../Label";
 import { RequirementLabel } from "../RequirementsLabel";
 import { SquareIcon } from "../SquareIcon";
-import { formatDateRange } from "lib/utils/time";
+import { formatDateRange, secondsToString } from "lib/utils/time";
 import { SUNNYSIDE } from "assets/sunnyside";
 import emptyPot from "assets/greenhouse/greenhouse_pot.webp";
 import flowerBed from "assets/flowers/empty_flowerbed.webp";
@@ -32,6 +32,7 @@ import {
   calculateCropTime,
   CROP_MACHINE_PLOTS,
 } from "features/game/events/landExpansion/supplyCropMachine";
+import { useActiveBuff } from "features/game/types/buffs";
 
 /**
  * The props for the details for items.
@@ -164,6 +165,11 @@ export const SeedRequirements: React.FC<Props> = ({
   showBoosts,
 }) => {
   const { t } = useAppTranslation();
+  const { isActive: isPowerHourActive, remainingTime: powerHourRemainingTime } =
+    useActiveBuff({
+      buff: "Power hour",
+      game: gameState,
+    });
 
   const getStock = () => {
     if (!stock) return <></>;
@@ -390,6 +396,15 @@ export const SeedRequirements: React.FC<Props> = ({
           )} ${limit} ${t("statements.perplayer")}`}</p>
         )}
         {getRequirements()}
+        {isPowerHourActive && (
+          <div className="flex flex-col items-center mb-2">
+            <Label type="vibrant" icon={SUNNYSIDE.icons.lightning}>
+              {`Power hour - ${secondsToString(powerHourRemainingTime / 1000, {
+                length: "medium",
+              })}`}
+            </Label>
+          </div>
+        )}
       </div>
       {actionView}
     </div>

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -32,10 +32,6 @@ import { setImageWidth } from "lib/images";
 import { LegacyBadges } from "./LegacyBadges";
 import { getKeys } from "lib/object";
 import { PowerSkills } from "features/island/hud/components/PowerSkills";
-import { isBuffActive } from "features/game/types/buffs";
-import { Label } from "components/ui/Label";
-import { secondsToString } from "lib/utils/time";
-import { useNow } from "lib/utils/hooks/useNow";
 import { PanelTabs } from "features/game/components/CloseablePanel";
 import foodIcon from "assets/food/chicken_drumstick.png";
 import { Equipped } from "features/game/types/bumpkin";
@@ -278,8 +274,8 @@ export const BumpkinInfo: React.FC<{
   readonly,
 }) => {
   const { t } = useAppTranslation();
-  const now = useNow();
   const { bumpkin, inventory } = gameState;
+
   const BADGES = getKeys(LEGACY_BADGE_TREE);
 
   const badges = BADGES.map((badge) => {
@@ -301,11 +297,6 @@ export const BumpkinInfo: React.FC<{
 
     return null;
   }).filter(Boolean);
-
-  const isPowerHourActive = isBuffActive({
-    buff: "Power hour",
-    game: gameState,
-  });
 
   return (
     <div className="flex flex-wrap">
@@ -373,23 +364,6 @@ export const BumpkinInfo: React.FC<{
             </div>
             <div className="flex flex-wrap items-center mt-2">{badges}</div>
           </ButtonPanel>
-        )}
-
-        {isPowerHourActive && (
-          <div className="flex items-center">
-            <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
-              {`Power hour`}
-            </Label>
-            <span className="text-xs ml-2">
-              {secondsToString(
-                ((gameState.buffs?.["Power hour"]?.startedAt ?? 0) +
-                  (gameState.buffs?.["Power hour"]?.durationMS ?? 0) -
-                  now) /
-                  1000,
-                { length: "medium" },
-              )}
-            </span>
-          </div>
         )}
 
         <ButtonPanel

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -239,7 +239,7 @@ export function getCropYieldAmount({
   const criticalDrop = (criticalHitName: CriticalHitName, chance: number) =>
     prngChance({ ...prngArgs, itemId, chance, criticalHitName });
 
-  if (isBuffActive({ buff: "Power hour", game })) {
+  if (isBuffActive({ buff: "Power hour", game, now: createdAt })) {
     amount += 0.2;
   }
 

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -324,7 +324,7 @@ export const getCropPlotTime = ({
     boostsUsed.push({ name: "Sparrow Shrine", value: "x0.75" });
   }
 
-  if (isBuffActive({ buff: "Power hour", game })) {
+  if (isBuffActive({ buff: "Power hour", game, now: createdAt })) {
     seconds = seconds * 0.5;
     boostsUsed.push({ name: "Power hour", value: "x0.5" });
   }

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -6,4 +6,10 @@ import { INITIAL_FARM } from "./constants";
 
 export const STATIC_OFFLINE_FARM: GameState = {
   ...INITIAL_FARM,
+  buffs: {
+    "Power hour": {
+      startedAt: Date.now(),
+      durationMS: 1000 * 60 * 60,
+    },
+  },
 };

--- a/src/features/game/types/buffs.ts
+++ b/src/features/game/types/buffs.ts
@@ -2,6 +2,7 @@ import cloneDeep from "lodash.clonedeep";
 import { GameState } from "./game";
 import { getKeys } from "lib/object";
 import { CROPS } from "./crops";
+import { useNow } from "lib/utils/hooks/useNow";
 
 // 50% faster crops, +0.2 Crops
 export type BuffName = "Power hour";
@@ -14,17 +15,40 @@ export type Buff = {
 export function isBuffActive({
   buff,
   game,
-  now = Date.now(),
+  now,
 }: {
   buff: BuffName;
   game: GameState;
-  now?: number;
+  now: number;
 }) {
   return (
     game.buffs?.[buff]?.startedAt &&
     game.buffs?.[buff].startedAt + game.buffs?.[buff].durationMS > now
   );
 }
+
+export function useActiveBuff({
+  buff,
+  game,
+}: {
+  buff: BuffName;
+  game: GameState;
+}) {
+  const { buffs } = game;
+  const buffData = buffs?.[buff];
+  const buffStartedAt = buffData?.startedAt ?? 0;
+  const buffDurationMS = buffData?.durationMS ?? 0;
+  const buffEndsAt = buffStartedAt + buffDurationMS;
+
+  const now = useNow({ live: true, autoEndAt: buffEndsAt });
+  const isActive = isBuffActive({ buff, game, now });
+
+  return {
+    isActive,
+    remainingTime: buffEndsAt - now,
+  };
+}
+
 export function applyBuff({
   buff,
   game,


### PR DESCRIPTION
# Pull request description

## Summary

This PR Moves the Power Hour Time Left label to the Market Tab.

## Context / motivation

The Power Hour buff label is in the bumpkin profile previously, so it's not readily visible how long the buff lasts for. Moving it to the market will tell the player clearer how long they have left before the end of the power hour buff.

## How to test
1. Run FE
2. Go to Market
3. Ensure that the Power Hour Label is counting down

## Screenshots or screen recording
<img width="204" height="366" alt="image" src="https://github.com/user-attachments/assets/b0980ce1-a41a-4774-8f38-ee4e64a60fc0" />


---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated
