### PR TITLE
[CHORE] Flag Salt Rake in Restock

### DIFF
--- a/src/features/game/events/landExpansion/npcRestock.ts
+++ b/src/features/game/events/landExpansion/npcRestock.ts
@@ -23,8 +23,13 @@ type Options = {
   action: NPCRestockAction;
 };
 
+type RestockItem =
+  | typeof SEEDS
+  | typeof WORKBENCH_TOOLS
+  | typeof TREASURE_TOOLS;
+
 type Restock = {
-  restockItem: typeof SEEDS | typeof WORKBENCH_TOOLS | typeof TREASURE_TOOLS;
+  restockItem: RestockItem;
   gemPrice: number;
   shopName: string;
   categoryLabel: {

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -61,12 +61,12 @@ export const INITIAL_STOCK = (
 ): Record<StockableName, Decimal> => {
   const tools = getObjectEntries(WORKBENCH_TOOLS).reduce(
     (acc, [toolName, tool]) => {
-      if (tool.disabled) return acc;
-
-      return {
-        ...acc,
-        [toolName]: tool.stock,
-      };
+      if (tool.disabled) {
+        acc[toolName] = new Decimal(0);
+        return acc;
+      }
+      acc[toolName] = tool.stock;
+      return acc;
     },
     {} as Record<WorkbenchToolName, Decimal>,
   );

--- a/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
@@ -58,14 +58,15 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
     if (showAnimations) confetti();
     onClose();
   };
+  const restockables = INITIAL_STOCK(state);
 
-  const restockTools = getObjectEntries(INITIAL_STOCK(state))
+  const restockTools = getObjectEntries(restockables)
     .filter((item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS })
     .filter(
       ([item]) => item !== "Salt Rake" || hasFeatureAccess(state, "SALT_FARM"),
     );
 
-  const restockSeeds = getObjectEntries(INITIAL_STOCK(state)).filter(
+  const restockSeeds = getObjectEntries(restockables).filter(
     (item) => item[0] in SEEDS,
   );
 

--- a/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
@@ -65,8 +65,9 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
   };
 
   const { labelText, icon } = categoryLabel;
+  const restockables = INITIAL_STOCK(state);
 
-  const restockItems = getObjectEntries(INITIAL_STOCK(state))
+  const restockItems = getObjectEntries(restockables)
     .filter((item) => item[0] in restockItem)
     .filter(
       ([item]) => item !== "Salt Rake" || hasFeatureAccess(state, "SALT_FARM"),


### PR DESCRIPTION
# Pull request description

## Summary

- Updated restockItem type to include specific tool categories (SEEDS, WORKBENCH_TOOLS, TREASURE_TOOLS).
- Flag Salt Rake under "SALT_FARM" feature flag

## Context / motivation

- Salt Rake is not filtered out from the restock modal. Since it is using the sand shovel as placeholder it has caused confusion to some players

---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated
