### PR TITLE
[FIX] Hoarder limit for Mutants of Crabs and Traps Chapter

### DIFF
--- a/src/features/game/lib/processEvent.ts
+++ b/src/features/game/lib/processEvent.ts
@@ -60,7 +60,7 @@ export const MAX_INVENTORY_ITEMS: Inventory = {
   "Anemone Flower": new Decimal(5),
   "Squid Chicken": new Decimal(5),
   "Mermaid Cow": new Decimal(5),
-  "Mermaid Sheep": new Decimal(5), 
+  "Mermaid Sheep": new Decimal(5),
 
   "War Bond": new Decimal(500),
   "Human War Banner": new Decimal(1),


### PR DESCRIPTION
# Pull request description

I added a hoarding limit for mutants in the Crabs and Traps chapter to prevent an AS-001 error when players exceed the limit, and to show that the cap has been reached instead.

---

## Checklist

### PR and scope

- [X] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [X] I have read the contributing guidelines and agree to the T&Cs