### PR TITLE
[FIX] Wrong Default Max Harvest Count

### DIFF
--- a/src/features/game/events/landExpansion/fruitPlanted.test.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.test.ts
@@ -673,6 +673,203 @@ describe("fruitPlanted", () => {
     ).toThrow("Invalid harvests left amount");
   });
 
+  it("accepts harvest count at the upper bound of default fruit harvest range (5)", () => {
+    const patchIndex = "1";
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Apple Seed": new Decimal(5),
+        },
+      },
+      createdAt: dateNow,
+      harvestsLeft: () => 5,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+        seed: "Apple Seed",
+      },
+    });
+    expect(state.fruitPatches[patchIndex].fruit?.harvestsLeft).toEqual(5);
+  });
+
+  it("does not accept harvest count above default random range without Immortal Pear", () => {
+    expect(() =>
+      plantFruit({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: {
+            "Apple Seed": new Decimal(3),
+          },
+        },
+        createdAt: dateNow,
+        harvestsLeft: () => 6,
+        action: {
+          type: "fruit.planted",
+          index: "1",
+          seed: "Apple Seed",
+        },
+      }),
+    ).toThrow("Invalid harvests left amount");
+  });
+
+  it("does not accept harvest count below default random range without Immortal Pear", () => {
+    expect(() =>
+      plantFruit({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: {
+            "Apple Seed": new Decimal(3),
+          },
+        },
+        createdAt: dateNow,
+        harvestsLeft: () => 2,
+        action: {
+          type: "fruit.planted",
+          index: "1",
+          seed: "Apple Seed",
+        },
+      }),
+    ).toThrow("Invalid harvests left amount");
+  });
+
+  it("accepts harvest count at the upper bound with Immortal Pear", () => {
+    const patchIndex = "1";
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Apple Seed": new Decimal(5),
+          "Immortal Pear": new Decimal(1),
+        },
+        collectibles: {
+          "Immortal Pear": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      harvestsLeft: () => 5,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+        seed: "Apple Seed",
+      },
+    });
+    expect(state.fruitPatches[patchIndex].fruit?.harvestsLeft).toEqual(6);
+  });
+
+  it("does not accept harvest count above Immortal Pear range without Pear Turbocharge", () => {
+    expect(() =>
+      plantFruit({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: {
+            "Apple Seed": new Decimal(3),
+            "Immortal Pear": new Decimal(1),
+          },
+          collectibles: {
+            "Immortal Pear": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: 0,
+                id: "123",
+                readyAt: 0,
+              },
+            ],
+          },
+        },
+        createdAt: dateNow,
+        harvestsLeft: () => 6,
+        action: {
+          type: "fruit.planted",
+          index: "1",
+          seed: "Apple Seed",
+        },
+      }),
+    ).toThrow("Invalid harvests left amount");
+  });
+
+  it("accepts harvest count at the upper bound with Immortal Pear and Pear Turbocharge", () => {
+    const patchIndex = "1";
+    const state = plantFruit({
+      state: {
+        ...GAME_STATE,
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          skills: { "Pear Turbocharge": 1 },
+        },
+        inventory: {
+          "Apple Seed": new Decimal(5),
+          "Immortal Pear": new Decimal(1),
+        },
+        collectibles: {
+          "Immortal Pear": [
+            {
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              id: "123",
+              readyAt: 0,
+            },
+          ],
+        },
+      },
+      createdAt: dateNow,
+      harvestsLeft: () => 5,
+      action: {
+        type: "fruit.planted",
+        index: patchIndex,
+        seed: "Apple Seed",
+      },
+    });
+    expect(state.fruitPatches[patchIndex].fruit?.harvestsLeft).toEqual(7);
+  });
+
+  it("does not accept harvest count above Immortal Pear range with Pear Turbocharge", () => {
+    expect(() =>
+      plantFruit({
+        state: {
+          ...GAME_STATE,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            skills: { "Pear Turbocharge": 1 },
+          },
+          inventory: {
+            "Apple Seed": new Decimal(3),
+            "Immortal Pear": new Decimal(1),
+          },
+          collectibles: {
+            "Immortal Pear": [
+              {
+                coordinates: { x: 0, y: 0 },
+                createdAt: 0,
+                id: "123",
+                readyAt: 0,
+              },
+            ],
+          },
+        },
+        createdAt: dateNow,
+        harvestsLeft: () => 6,
+        action: {
+          type: "fruit.planted",
+          index: "1",
+          seed: "Apple Seed",
+        },
+      }),
+    ).toThrow("Invalid harvests left amount");
+  });
+
   it("increments the fruit seed planted activity", () => {
     const amount = 1;
     const state = plantFruit({

--- a/src/features/game/events/landExpansion/fruitPlanted.ts
+++ b/src/features/game/events/landExpansion/fruitPlanted.ts
@@ -49,7 +49,7 @@ function getHarvestsLeft({
 
 function getHarvestRange({ state }: { state: GameState }) {
   let minHarvest = 3;
-  let maxHarvest = 6;
+  let maxHarvest = 5;
   if (isCollectibleBuilt({ name: "Immortal Pear", game: state })) {
     if (state.bumpkin.skills["Pear Turbocharge"]) {
       minHarvest += 2;


### PR DESCRIPTION
# Pull request description

## Summary

The Default Max Harvest was erronously set to 6 instead of 5

## Context / motivation

Why is this change needed? Link to design docs, Slack threads, or prior discussion if helpful.

## How to test

Numbered steps a reviewer can follow. Include seed data, feature flags, or environment notes if needed.

1.
2.

## Screenshots or screen recording

Required for any visual or UX change. For pure logic/backend PRs, write "N/A" or delete this section.

## Related issues

Use one line per issue. Remove if none.

Fixes #
Related #

---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated
