### PR TITLE
[FIX] April Fool Rugs Collision and Trading

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -387,6 +387,9 @@ export const NON_COLLIDING_OBJECTS: InventoryItemName[] = [
   "Long Rug",
   "Paw Prints Rug",
   "Crabs and Fish Rug",
+  "Bumpkin Rug",
+  "Goblin Rug",
+  "Pet Rug",
 ];
 
 function detectHomeCollision({

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1702,7 +1702,18 @@ export const INVENTORY_RELEASES: InventoryReleases = {
     tradeAt: new Date("2026-04-17T00:00:00Z"),
     withdrawAt: new Date("2026-04-17T00:00:00Z"),
   },
-
+  "Bumpkin Rug": {
+    tradeAt: new Date("2026-04-17T00:00:00Z"),
+    withdrawAt: new Date("2026-04-17T00:00:00Z"),
+  },
+  "Goblin Rug": {
+    tradeAt: new Date("2026-04-17T00:00:00Z"),
+    withdrawAt: new Date("2026-04-17T00:00:00Z"),
+  },
+  "Pet Rug": {
+    tradeAt: new Date("2026-04-17T00:00:00Z"),
+    withdrawAt: new Date("2026-04-17T00:00:00Z"),
+  },
   "Jester in a box": {
     tradeAt: new Date("2026-04-17T00:00:00Z"),
     withdrawAt: new Date("2026-04-17T00:00:00Z"),


### PR DESCRIPTION
# Pull request description

I added the rugs to the NON_COLLIDING_OBJECTS list so we can place things over them, I also added them to be tradable since they were missing.


## Checklist

- [X] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [X] I have read the contributing guidelines and agree to the T&Cs
