### PR TITLE
[CHORE] populateSaltFarm changes

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -180,15 +180,18 @@ export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
       throw new Error("You already have this skill");
     }
 
-    // Populate the salt farm with the new salt charges
-    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
-      populateSaltFarm({ game: stateCopy, now: createdAt });
-    }
-
     bumpkin.skills = {
       ...bumpkin.skills,
       [action.skill]: 1,
     };
+
+    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
+      populateSaltFarm({
+        gameBefore: state,
+        gameAfter: stateCopy,
+        now: createdAt,
+      });
+    }
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/equip.ts
+++ b/src/features/game/events/landExpansion/equip.ts
@@ -31,12 +31,11 @@ export function equip({
 
     assertEquipment({ game, equipment: action.equipment, bumpkin });
 
-    // Populate the salt farm with the new salt charges
-    if (hasFeatureAccess(game, "SALT_FARM")) {
-      populateSaltFarm({ game, now: createdAt });
-    }
-
     bumpkin.equipped = action.equipment;
+
+    if (hasFeatureAccess(game, "SALT_FARM")) {
+      populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
+    }
 
     return game;
   });

--- a/src/features/game/events/landExpansion/equipFarmHand.ts
+++ b/src/features/game/events/landExpansion/equipFarmHand.ts
@@ -35,11 +35,11 @@ export function equipFarmhand({
       game,
     });
 
-    // Populate the salt farm with the new salt charges
-    if (hasFeatureAccess(game, "SALT_FARM")) {
-      populateSaltFarm({ game, now: createdAt });
-    }
     bumpkin.equipped = action.equipment;
+
+    if (hasFeatureAccess(game, "SALT_FARM")) {
+      populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
+    }
 
     return game;
   });

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -53,7 +53,9 @@ export function harvestSalt({
       throw new Error(HARVEST_SALT_ERRORS.SALT_NODE_NOT_FOUND);
     }
 
-    const interval = getSaltChargeGenerationTime({ gameState: copy });
+    const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
+      gameState: copy,
+    });
     const maxCharges = getMaxStoredSaltCharges(
       copy.sculptures?.["Salt Sculpture"]?.level ?? 0,
     );
@@ -113,7 +115,10 @@ export function harvestSalt({
       });
 
       if (seaBlessedHit) {
-        const interval = getSaltChargeGenerationTime({ gameState: copy });
+        const { chargeGenerationTimeMs: interval } =
+          getSaltChargeGenerationTime({
+            gameState: copy,
+          });
         const nodeIds = getKeys(copy.saltFarm.nodes);
         const eligible = nodeIds.filter(
           (id) =>

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -74,7 +74,8 @@ export function harvestSalt({
     if (availableRakes.lt(1)) {
       throw new Error(HARVEST_SALT_ERRORS.NOT_ENOUGH_SALT_RAKES);
     }
-    const saltPerRake = getSaltYieldPerRake(copy);
+    const { saltYield: saltPerRake, boostsUsed: saltYieldBoostsUsed } =
+      getSaltYieldPerRake(copy);
     const legacySalt = legacyReadySlots * saltPerRake;
 
     const saltInInventory = copy.inventory["Salt"] ?? new Decimal(0);
@@ -143,7 +144,7 @@ export function harvestSalt({
 
     copy.boostsUsedAt = updateBoostUsed({
       game: copy,
-      boostNames: boostsUsed,
+      boostNames: [...boostsUsed, ...saltYieldBoostsUsed],
       createdAt,
     });
   });

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -17,6 +17,7 @@ import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { getKeys } from "lib/object";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export enum HARVEST_SALT_ERRORS {
   SALT_NODE_NOT_FOUND = "Salt node not found",
@@ -53,9 +54,10 @@ export function harvestSalt({
       throw new Error(HARVEST_SALT_ERRORS.SALT_NODE_NOT_FOUND);
     }
 
-    const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
-      gameState: copy,
-    });
+    const { chargeGenerationTimeMs: interval, boostsUsed } =
+      getSaltChargeGenerationTime({
+        gameState: copy,
+      });
     const maxCharges = getMaxStoredSaltCharges(
       copy.sculptures?.["Salt Sculpture"]?.level ?? 0,
     );
@@ -138,5 +140,11 @@ export function harvestSalt({
         }
       }
     }
+
+    copy.boostsUsedAt = updateBoostUsed({
+      game: copy,
+      boostNames: boostsUsed,
+      createdAt,
+    });
   });
 }

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -9,8 +9,8 @@ import {
   getStoredSaltCharges,
   materializeSaltRegen,
   syncSaltNode,
+  getMaxStoredSaltCharges,
 } from "features/game/types/salt";
-import { getMaxStoredSaltCharges } from "features/game/types/saltSculpture";
 import { produce } from "immer";
 import { hasFeatureAccess } from "lib/flags";
 import { prngChance } from "lib/prng";

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js-light";
 import { GameState } from "features/game/types/game";
 import {
-  MAX_STORED_SALT_CHARGES_PER_NODE,
   SEA_BLESSED_CHANCE,
   SEA_BLESSED_NODE_COUNT,
   getSaltChargeGenerationTime,
@@ -10,14 +9,15 @@ import {
   materializeSaltRegen,
   syncSaltNode,
   getMaxStoredSaltCharges,
+  SaltSyncOptions,
 } from "features/game/types/salt";
 import { produce } from "immer";
 import { hasFeatureAccess } from "lib/flags";
 import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { getKeys } from "lib/object";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+import { getObjectEntries } from "lib/object";
 
 export enum HARVEST_SALT_ERRORS {
   SALT_NODE_NOT_FOUND = "Salt node not found",
@@ -54,14 +54,12 @@ export function harvestSalt({
       throw new Error(HARVEST_SALT_ERRORS.SALT_NODE_NOT_FOUND);
     }
 
-    const { chargeGenerationTimeMs: interval, boostsUsed } =
-      getSaltChargeGenerationTime({
-        gameState: copy,
-      });
+    const { chargeGenerationTimeMs: chargeIntervalMs, boostsUsed } =
+      getSaltChargeGenerationTime({ gameState: copy });
     const maxCharges = getMaxStoredSaltCharges(
       copy.sculptures?.["Salt Sculpture"]?.level ?? 0,
     );
-    const syncOpts = { chargeIntervalMs: interval, maxCharges };
+    const syncOpts: SaltSyncOptions = { chargeIntervalMs, maxCharges };
     const syncedNode = syncSaltNode(saltNode, createdAt, syncOpts);
     const storedCharges = getStoredSaltCharges(syncedNode, createdAt, syncOpts);
 
@@ -86,9 +84,9 @@ export function harvestSalt({
     const syncedNextChargeAt = syncedNode.salt.nextChargeAt;
     const baselineNextChargeAt = Number.isFinite(syncedNextChargeAt)
       ? syncedNextChargeAt
-      : createdAt + interval;
+      : createdAt + chargeIntervalMs;
     const nextChargeAt = wasFullBeforeHarvest
-      ? createdAt + interval
+      ? createdAt + chargeIntervalMs
       : baselineNextChargeAt;
 
     const draftSalt = {
@@ -118,26 +116,34 @@ export function harvestSalt({
       });
 
       if (seaBlessedHit) {
-        const { chargeGenerationTimeMs: interval } =
-          getSaltChargeGenerationTime({
-            gameState: copy,
-          });
-        const nodeIds = getKeys(copy.saltFarm.nodes);
-        const eligible = nodeIds.filter(
-          (id) =>
-            copy.saltFarm.nodes[id].salt.storedCharges <
-            MAX_STORED_SALT_CHARGES_PER_NODE,
-        );
+        const eligible = getObjectEntries(copy.saltFarm.nodes)
+          .filter(([, node]) => {
+            const syncedNode = syncSaltNode(node, createdAt, syncOpts);
+            const storedCharges = getStoredSaltCharges(
+              syncedNode,
+              createdAt,
+              syncOpts,
+            );
+            return storedCharges < maxCharges;
+          })
+          .map(([nodeId]) => nodeId);
         const toRestore = eligible.slice(0, SEA_BLESSED_NODE_COUNT);
         for (const nodeId of toRestore) {
           const node = copy.saltFarm.nodes[nodeId];
-          node.salt.storedCharges = Math.min(
-            node.salt.storedCharges + 1,
-            MAX_STORED_SALT_CHARGES_PER_NODE,
+          const syncedNode = syncSaltNode(node, createdAt, syncOpts);
+          const storedCharges = getStoredSaltCharges(
+            syncedNode,
+            createdAt,
+            syncOpts,
           );
-          if (node.salt.storedCharges === MAX_STORED_SALT_CHARGES_PER_NODE) {
-            node.salt.nextChargeAt = createdAt + interval;
+          syncedNode.salt.storedCharges = Math.min(
+            storedCharges + 1,
+            maxCharges,
+          );
+          if (syncedNode.salt.storedCharges === maxCharges) {
+            syncedNode.salt.nextChargeAt = createdAt + chargeIntervalMs;
           }
+          copy.saltFarm.nodes[nodeId] = syncedNode;
         }
       }
     }

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -81,11 +81,6 @@ export function placeCollectible({
       throw new Error("You cannot place this item");
     }
 
-    // Populate the salt farm with the new salt charges
-    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
-      populateSaltFarm({ game: stateCopy, now: createdAt });
-    }
-
     // Only pet collectibles can be placed in the pet house
     if (action.location === "petHouse" && !isPetCollectible(action.name)) {
       throw new Error("Only pet collectibles can be placed in the pet house");
@@ -262,6 +257,14 @@ export function placeCollectible({
       "Collectible Placed",
       stateCopy.farmActivity,
     );
+
+    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
+      populateSaltFarm({
+        gameBefore: state,
+        gameAfter: stateCopy,
+        now: createdAt,
+      });
+    }
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -105,11 +105,6 @@ export function removeCollectible({
       }
     }
 
-    // Populate the salt farm with the new salt charges
-    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
-      populateSaltFarm({ game: stateCopy, now: createdAt });
-    }
-
     delete collectibleToRemove.coordinates;
     collectibleToRemove.removedAt = createdAt;
 
@@ -117,6 +112,14 @@ export function removeCollectible({
       "Collectible Removed",
       stateCopy.farmActivity,
     );
+
+    if (hasFeatureAccess(stateCopy, "SALT_FARM")) {
+      populateSaltFarm({
+        gameBefore: state,
+        gameAfter: stateCopy,
+        now: createdAt,
+      });
+    }
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -30,8 +30,9 @@ import { updateBeehives } from "features/game/lib/updateBeehives";
 import { isWearableActive } from "features/game/lib/wearables";
 import { getPlotsToFertilise } from "./bulkFertilisePlot";
 import {
+  getMaxStoredSaltCharges,
+  getSaltChargeGenerationTime,
   getStoredSaltCharges,
-  MAX_STORED_SALT_CHARGES_PER_NODE,
   rechargeAllSaltNodes,
 } from "features/game/types/salt";
 
@@ -438,11 +439,19 @@ export function powerSkillDisabledConditions({
 
     case "Salt Surge": {
       const { nodes } = state.saltFarm;
+      const maxCharges = getMaxStoredSaltCharges(
+        state.sculptures?.["Salt Sculpture"]?.level ?? 0,
+      );
+      const { chargeGenerationTimeMs } = getSaltChargeGenerationTime({
+        gameState: state,
+      });
       if (
         Object.values(nodes).every(
           (node) =>
-            getStoredSaltCharges(node, createdAt) ===
-            MAX_STORED_SALT_CHARGES_PER_NODE,
+            getStoredSaltCharges(node, createdAt, {
+              chargeIntervalMs: chargeGenerationTimeMs,
+              maxCharges,
+            }) === maxCharges,
         )
       ) {
         return {

--- a/src/features/game/events/landExpansion/upgradeSaltFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltFarm.test.ts
@@ -115,7 +115,10 @@ describe("upgradeSaltFarm", () => {
       coordinates: { x: 8, y: -6 },
       salt: {
         storedCharges: MAX_STORED_SALT_CHARGES_PER_NODE,
-        nextChargeAt: now + getSaltChargeGenerationTime({ gameState: state }),
+        nextChargeAt:
+          now +
+          getSaltChargeGenerationTime({ gameState: state })
+            .chargeGenerationTimeMs,
       },
     });
   });

--- a/src/features/game/events/landExpansion/upgradeSaltFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltFarm.ts
@@ -63,7 +63,9 @@ export function upgradeSaltFarm({
 
     const currentNodes = Object.keys(saltFarm.nodes).length;
     const nodesToAdd: number = totalExpectedNodes - currentNodes;
-    const interval = getSaltChargeGenerationTime({ gameState: copy });
+    const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
+      gameState: copy,
+    });
 
     for (let i = 0; i < nodesToAdd; i++) {
       copy.saltFarm.nodes[`${currentNodes + i}`] = {

--- a/src/features/game/events/landExpansion/upgradeSaltFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltFarm.ts
@@ -10,6 +10,7 @@ import {
   SALT_FARM_UPGRADES,
 } from "features/game/types/salt";
 import { hasFeatureAccess } from "lib/flags";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type UpgradeSaltFarmAction = {
   type: "saltFarm.upgraded";
@@ -63,9 +64,10 @@ export function upgradeSaltFarm({
 
     const currentNodes = Object.keys(saltFarm.nodes).length;
     const nodesToAdd: number = totalExpectedNodes - currentNodes;
-    const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
-      gameState: copy,
-    });
+    const { chargeGenerationTimeMs: interval, boostsUsed } =
+      getSaltChargeGenerationTime({
+        gameState: copy,
+      });
 
     for (let i = 0; i < nodesToAdd; i++) {
       copy.saltFarm.nodes[`${currentNodes + i}`] = {
@@ -83,6 +85,12 @@ export function upgradeSaltFarm({
       };
     }
     copy.saltFarm.level = nextLevel;
+
+    copy.boostsUsedAt = updateBoostUsed({
+      game: copy,
+      boostNames: boostsUsed,
+      createdAt,
+    });
 
     return copy;
   });

--- a/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
@@ -79,7 +79,6 @@ export function upgradeSaltSculpture({
         gameBefore: state,
         gameAfter: game,
         now: createdAt,
-        saltSculptureLevelForMaxCharges: nextLevel,
       });
     }
   });

--- a/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
@@ -68,18 +68,19 @@ export function upgradeSaltSculpture({
       );
     }
 
-    if (hasFeatureAccess(game, "SALT_FARM")) {
-      populateSaltFarm({
-        game,
-        now: createdAt,
-        saltSculptureLevelForMaxCharges: nextLevel,
-      });
-    }
-
     if (!game.sculptures) game.sculptures = {};
     game.sculptures["Salt Sculpture"] = {
       level: nextLevel,
       upgradedAt: createdAt,
     };
+
+    if (hasFeatureAccess(game, "SALT_FARM")) {
+      populateSaltFarm({
+        gameBefore: state,
+        gameAfter: game,
+        now: createdAt,
+        saltSculptureLevelForMaxCharges: nextLevel,
+      });
+    }
   });
 }

--- a/src/features/game/expansion/components/salt/SaltNode.tsx
+++ b/src/features/game/expansion/components/salt/SaltNode.tsx
@@ -38,7 +38,8 @@ export const SaltNode: React.FC<Props> = ({ id, visiting, position }) => {
   const [showInfoPanel, setShowInfoPanel] = useState(false);
   const now = useNow({ live: true });
 
-  const chargeIntervalMs = getSaltChargeGenerationTime({ gameState });
+  const { chargeGenerationTimeMs: chargeIntervalMs } =
+    getSaltChargeGenerationTime({ gameState });
   const availableRakes = Math.floor(inventory["Salt Rake"]?.toNumber() ?? 0);
 
   const storedCharges = node

--- a/src/features/game/expansion/components/salt/SaltNode.tsx
+++ b/src/features/game/expansion/components/salt/SaltNode.tsx
@@ -13,6 +13,7 @@ import {
   getSaltChargeGenerationTime,
   getStoredSaltCharges,
   materializeSaltRegen,
+  getMaxStoredSaltCharges,
 } from "features/game/types/salt";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { canInstantHarvestSaltNode, getSaltNodeSprite } from "./saltNodeStage";
@@ -42,12 +43,16 @@ export const SaltNode: React.FC<Props> = ({ id, visiting, position }) => {
     getSaltChargeGenerationTime({ gameState });
   const availableRakes = Math.floor(inventory["Salt Rake"]?.toNumber() ?? 0);
 
+  const maxCharges = getMaxStoredSaltCharges(
+    gameState.sculptures?.["Salt Sculpture"]?.level ?? 0,
+  );
+
   const storedCharges = node
-    ? getStoredSaltCharges(node, now, { chargeIntervalMs })
+    ? getStoredSaltCharges(node, now, { chargeIntervalMs, maxCharges })
     : 0;
 
   const materialized = node
-    ? materializeSaltRegen(node.salt, now, { chargeIntervalMs })
+    ? materializeSaltRegen(node.salt, now, { chargeIntervalMs, maxCharges })
     : null;
   const nextChargeInSeconds = materialized
     ? getNextSaltChargeInSeconds({

--- a/src/features/game/types/salt.test.ts
+++ b/src/features/game/types/salt.test.ts
@@ -96,7 +96,9 @@ describe("populateSaltFarm", () => {
       sculptures: { "Salt Sculpture": { level: 2 } },
     } as unknown as GameState;
 
-    const intervalMs = getSaltChargeGenerationTime({ gameState: game });
+    const { chargeGenerationTimeMs: intervalMs } = getSaltChargeGenerationTime({
+      gameState: game,
+    });
     const now = t0 + intervalMs * 5;
 
     const base = JSON.parse(JSON.stringify(game)) as unknown as GameState;

--- a/src/features/game/types/salt.test.ts
+++ b/src/features/game/types/salt.test.ts
@@ -28,7 +28,7 @@ describe("salt nextChargeAt regen", () => {
       nextChargeAt: t0 + SALT_CHARGE_GENERATION_TIME,
     };
     const later = t0 + SALT_CHARGE_GENERATION_TIME * 3 + 1;
-    const out = materializeSaltRegen(salt, later);
+    const out = materializeSaltRegen(salt, later, undefined);
     expect(out.storedCharges).toBe(3);
     expect(out.nextChargeAt).toBe(t0 + SALT_CHARGE_GENERATION_TIME * 4);
   });
@@ -38,7 +38,7 @@ describe("salt nextChargeAt regen", () => {
       storedCharges: MAX_STORED_SALT_CHARGES_PER_NODE - 1,
       nextChargeAt: t0,
     };
-    const out = materializeSaltRegen(salt, t0 + 1);
+    const out = materializeSaltRegen(salt, t0 + 1, undefined);
     expect(out.storedCharges).toBe(MAX_STORED_SALT_CHARGES_PER_NODE);
     expect(out.nextChargeAt).toBe(t0 + SALT_CHARGE_GENERATION_TIME);
   });
@@ -48,7 +48,7 @@ describe("salt nextChargeAt regen", () => {
       storedCharges: MAX_STORED_SALT_CHARGES_PER_NODE + 10,
       nextChargeAt: t0 + SALT_CHARGE_GENERATION_TIME,
     };
-    const out = materializeSaltRegen(salt, t0);
+    const out = materializeSaltRegen(salt, t0, undefined);
     expect(out.storedCharges).toBe(MAX_STORED_SALT_CHARGES_PER_NODE);
   });
 
@@ -164,7 +164,55 @@ describe("populateSaltFarm", () => {
     );
   });
 
-  it("uses saltSculptureLevelForMaxCharges for cap while charge interval follows current sculpture level", () => {
+  it("crystallizes boosted progress when boost is removed, then follows slower cadence", () => {
+    const boostedInterval = SALT_CHARGE_GENERATION_TIME * 0.9;
+    const gameBefore = makeGame({
+      bumpkin: { ...INITIAL_FARM.bumpkin, skills: { "Salty Seas": 1 } },
+      saltFarm: {
+        level: 1,
+        nodes: {
+          "0": {
+            createdAt: t0,
+            coordinates: { x: 0, y: 0 },
+            salt: {
+              storedCharges: 0,
+              nextChargeAt: t0 + boostedInterval,
+            },
+          },
+        },
+      },
+    });
+    const game: GameState = {
+      ...gameBefore,
+      bumpkin: { ...gameBefore.bumpkin, skills: {} },
+    };
+
+    const now = t0 + boostedInterval + boostedInterval / 2;
+
+    populateSaltFarm({ gameBefore, gameAfter: game, now });
+
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(1);
+    expect(game.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      t0 + boostedInterval * 2,
+    );
+
+    const { chargeGenerationTimeMs: slowerInterval } =
+      getSaltChargeGenerationTime({
+        gameState: game,
+      });
+    const afterCadence = syncSaltNode(
+      game.saltFarm.nodes["0"],
+      game.saltFarm.nodes["0"].salt.nextChargeAt + slowerInterval - 1,
+      { chargeIntervalMs: slowerInterval },
+    );
+
+    expect(afterCadence.salt.storedCharges).toBe(2);
+    expect(afterCadence.salt.nextChargeAt).toBe(
+      t0 + boostedInterval * 2 + slowerInterval,
+    );
+  });
+
+  it("uses gameAfter sculpture level for max charge cap while charge interval follows current sculpture level", () => {
     const gameBefore = makeGame({
       saltFarm: {
         level: 4,
@@ -193,9 +241,48 @@ describe("populateSaltFarm", () => {
       gameBefore,
       gameAfter: game,
       now,
-      saltSculptureLevelForMaxCharges: 3,
     });
 
     expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
+  });
+
+  it("runs sync when sculpture upgrade increases max charges without changing charge interval", () => {
+    const gameBefore = makeGame({
+      sculptures: { "Salt Sculpture": { level: 2 } },
+      saltFarm: {
+        level: 1,
+        nodes: {
+          "0": {
+            createdAt: t0,
+            coordinates: { x: 0, y: 0 },
+            salt: {
+              storedCharges: 3,
+              nextChargeAt: t0,
+            },
+          },
+        },
+      },
+    });
+    const gameAfter: GameState = {
+      ...gameBefore,
+      sculptures: { "Salt Sculpture": { level: 3 } },
+    };
+
+    expect(
+      getSaltChargeGenerationTime({ gameState: gameBefore })
+        .chargeGenerationTimeMs,
+    ).toBe(
+      getSaltChargeGenerationTime({ gameState: gameAfter })
+        .chargeGenerationTimeMs,
+    );
+
+    const { chargeGenerationTimeMs: intervalMs } = getSaltChargeGenerationTime({
+      gameState: gameBefore,
+    });
+    const now = t0 + intervalMs * 5;
+
+    populateSaltFarm({ gameBefore, gameAfter, now });
+
+    expect(gameAfter.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
   });
 });

--- a/src/features/game/types/salt.test.ts
+++ b/src/features/game/types/salt.test.ts
@@ -9,6 +9,7 @@ import {
   type Salt,
   type SaltNode,
 } from "./salt";
+import { INITIAL_FARM } from "../lib/constants";
 
 describe("salt nextChargeAt regen", () => {
   const t0 = 1_000_000_000_000;
@@ -78,8 +79,93 @@ describe("salt nextChargeAt regen", () => {
 describe("populateSaltFarm", () => {
   const t0 = 1_000_000_000_000;
 
+  function makeGame(overrides: Partial<GameState> = {}): GameState {
+    return {
+      ...INITIAL_FARM,
+      saltFarm: {
+        level: 1,
+        nodes: {
+          "0": {
+            createdAt: t0,
+            coordinates: { x: 0, y: 0 },
+            salt: {
+              storedCharges: 0,
+              nextChargeAt: t0 + SALT_CHARGE_GENERATION_TIME,
+            },
+          },
+        },
+      },
+      ...overrides,
+    };
+  }
+
+  it("returns early when charge generation time has not changed", () => {
+    const gameBefore = makeGame();
+    const game: GameState = { ...gameBefore };
+    const now = t0 + SALT_CHARGE_GENERATION_TIME * 2;
+
+    populateSaltFarm({ gameBefore, gameAfter: game, now });
+
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(0);
+    expect(game.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      t0 + SALT_CHARGE_GENERATION_TIME,
+    );
+  });
+
+  it("returns early when charge generation time has not changed with active boost", () => {
+    const gameBefore = makeGame({
+      bumpkin: { ...INITIAL_FARM.bumpkin, skills: { "Salty Seas": 1 } },
+    });
+    const game: GameState = { ...gameBefore };
+    const now = t0 + SALT_CHARGE_GENERATION_TIME * 2;
+
+    populateSaltFarm({ gameBefore, gameAfter: game, now });
+
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(0);
+    expect(game.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      t0 + SALT_CHARGE_GENERATION_TIME,
+    );
+  });
+
+  it("crystallizes at old rate when boost is added", () => {
+    const gameBefore = makeGame();
+    const game: GameState = { ...gameBefore };
+    game.bumpkin = { ...game.bumpkin, skills: { "Salty Seas": 1 } };
+
+    const boostedInterval = SALT_CHARGE_GENERATION_TIME * 0.9;
+    const now = t0 + SALT_CHARGE_GENERATION_TIME + boostedInterval + 1;
+
+    populateSaltFarm({ gameBefore, gameAfter: game, now });
+
+    // Should crystallize 1 charge at the OLD (unboosted) rate, not the new boosted rate.
+    // nextChargeAt starts at t0 + SALT_CHARGE_GENERATION_TIME (one old interval).
+    // At now, one old interval has elapsed -> storedCharges = 1.
+    // If the new boosted rate were applied retroactively, a second charge
+    // would have been granted since boostedInterval < SALT_CHARGE_GENERATION_TIME.
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(1);
+    expect(game.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      t0 + SALT_CHARGE_GENERATION_TIME * 2,
+    );
+  });
+
+  it("crystallizes at old rate when sculpture upgrades", () => {
+    const gameBefore = makeGame();
+    const game: GameState = { ...gameBefore };
+    game.sculptures = { ...game.sculptures, "Salt Sculpture": { level: 1 } };
+
+    const boostedInterval = SALT_CHARGE_GENERATION_TIME * 0.95;
+    const now = t0 + SALT_CHARGE_GENERATION_TIME + boostedInterval + 1;
+
+    populateSaltFarm({ gameBefore, gameAfter: game, now });
+
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(1);
+    expect(game.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      t0 + SALT_CHARGE_GENERATION_TIME * 2,
+    );
+  });
+
   it("uses saltSculptureLevelForMaxCharges for cap while charge interval follows current sculpture level", () => {
-    const game = {
+    const gameBefore = makeGame({
       saltFarm: {
         level: 4,
         nodes: {
@@ -93,27 +179,23 @@ describe("populateSaltFarm", () => {
           },
         },
       },
-      sculptures: { "Salt Sculpture": { level: 2 } },
-    } as unknown as GameState;
+    });
+
+    const game: GameState = { ...gameBefore };
+    game.sculptures = { ...game.sculptures, "Salt Sculpture": { level: 3 } };
 
     const { chargeGenerationTimeMs: intervalMs } = getSaltChargeGenerationTime({
-      gameState: game,
+      gameState: gameBefore,
     });
     const now = t0 + intervalMs * 5;
 
-    const base = JSON.parse(JSON.stringify(game)) as unknown as GameState;
-    populateSaltFarm({ game: base, now });
-
-    const withOverride = JSON.parse(
-      JSON.stringify(game),
-    ) as unknown as GameState;
     populateSaltFarm({
-      game: withOverride,
+      gameBefore,
+      gameAfter: game,
       now,
       saltSculptureLevelForMaxCharges: 3,
     });
 
-    expect(base.saltFarm.nodes["0"].salt.storedCharges).toBe(3);
-    expect(withOverride.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
+    expect(game.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
   });
 });

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -258,40 +258,54 @@ export function getNextSaltChargeInSeconds({
 export const SALT_FARM_UPDATE_INTERVAL = 1000 * 60 * 10; // 10 minutes
 
 /**
- * Populates the salt farm with the new salt charges BEFORE any boost is applied
- * @param game - The game state
- * @param now - The current time
- * @param saltSculptureLevelForMaxCharges - The level of the Salt Sculpture upgrade
- * @returns void
+ * Crystallises accrued salt charges at the pre-mutation rate.
+ * Call AFTER the boost-changing mutation so that `gameBefore` still
+ * reflects the old rate and `game` reflects the new rate.
+ * Skips work when the charge generation time hasn't changed.
  */
 export function populateSaltFarm({
-  game,
+  gameBefore,
+  gameAfter,
   now,
   /** When set (e.g. Salt Sculpture upgrade), use this level only for max stored charges; charge interval still follows current `game` state. */
   saltSculptureLevelForMaxCharges,
 }: {
-  game: GameState;
+  gameBefore: Readonly<GameState>;
+  gameAfter: GameState;
   now: number;
   saltSculptureLevelForMaxCharges?: number;
 }) {
-  const { chargeGenerationTimeMs: chargeIntervalMs, boostsUsed } =
-    getSaltChargeGenerationTime({ gameState: game });
+  const { chargeGenerationTimeMs: chargeGenerationTimeBefore } =
+    getSaltChargeGenerationTime({ gameState: gameBefore });
+  const { chargeGenerationTimeMs: chargeGenerationTimeAfter, boostsUsed } =
+    getSaltChargeGenerationTime({ gameState: gameAfter });
+
+  if (
+    !saltSculptureLevelForMaxCharges &&
+    chargeGenerationTimeAfter === chargeGenerationTimeBefore
+  ) {
+    return;
+  }
+
   const maxCharges = getMaxStoredSaltChargesFromLevel(
     saltSculptureLevelForMaxCharges ??
-      game.sculptures?.["Salt Sculpture"]?.level ??
+      gameAfter.sculptures?.["Salt Sculpture"]?.level ??
       0,
   );
-  const syncOpts: SaltSyncOptions = { chargeIntervalMs, maxCharges };
+  const syncOpts: SaltSyncOptions = {
+    chargeIntervalMs: chargeGenerationTimeBefore,
+    maxCharges,
+  };
 
-  for (const nodeId of Object.keys(game.saltFarm.nodes)) {
-    game.saltFarm.nodes[nodeId] = syncSaltNode(
-      game.saltFarm.nodes[nodeId],
+  for (const nodeId of Object.keys(gameAfter.saltFarm.nodes)) {
+    gameAfter.saltFarm.nodes[nodeId] = syncSaltNode(
+      gameAfter.saltFarm.nodes[nodeId],
       now,
       syncOpts,
     );
   }
-  game.boostsUsedAt = updateBoostUsed({
-    game,
+  gameAfter.boostsUsedAt = updateBoostUsed({
+    game: gameAfter,
     boostNames: boostsUsed,
     createdAt: now,
   });

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -285,7 +285,9 @@ export function populateSaltFarm({
 
   const sameBoostSet =
     boostsUsedBefore.length === boostsUsedAfter.length &&
-    boostsUsedBefore.every((b) => boostsUsedAfter.includes(b));
+    boostsUsedBefore.every((b) =>
+      boostsUsedAfter.some((a) => a.name === b.name && a.value === b.value),
+    );
 
   if (
     chargeGenerationTimeAfter === chargeGenerationTimeBefore &&

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -152,14 +152,19 @@ export function rechargeAllSaltNodes(
   return game;
 }
 
-export function getSaltYieldPerRake(gameState: GameState): number {
+export function getSaltYieldPerRake(gameState: GameState): {
+  saltYield: number;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
   let saltYield = BASE_SALT_YIELD;
+  const boostsUsed: { name: BoostName; value: string }[] = [];
 
   if (gameState.bumpkin?.skills["Wide Rakes"]) {
     saltYield += 2;
+    boostsUsed.push({ name: "Wide Rakes", value: "+2" });
   }
 
-  return saltYield;
+  return { saltYield, boostsUsed };
 }
 
 function clampStoredCharges(

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -1,8 +1,9 @@
 import Decimal from "decimal.js-light";
 import { Coordinates } from "../expansion/components/MapPlacement";
-import type { GameState, InventoryItemName } from "./game";
+import type { BoostName, GameState, InventoryItemName } from "./game";
 import { getObjectEntries } from "lib/object";
 import { getMaxStoredSaltCharges as getMaxStoredSaltChargesFromLevel } from "./saltSculpture";
+import { updateBoostUsed } from "./updateBoostUsed";
 
 export type SaltNode = {
   createdAt: number;
@@ -111,18 +112,24 @@ export function getSaltChargeGenerationTime({
   gameState,
 }: {
   gameState: GameState;
-}): number {
+}): {
+  chargeGenerationTimeMs: number;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
   let chargeGenerationTimeMs = SALT_CHARGE_GENERATION_TIME;
+  const boostsUsed: { name: BoostName; value: string }[] = [];
 
   if (gameState.bumpkin?.skills["Salty Seas"]) {
     chargeGenerationTimeMs *= 0.9;
+    boostsUsed.push({ name: "Salty Seas", value: "x0.9" });
   }
 
   if ((gameState.sculptures?.["Salt Sculpture"]?.level ?? 0) >= 1) {
     chargeGenerationTimeMs *= 0.95;
+    boostsUsed.push({ name: "Salt Sculpture", value: "x0.95" });
   }
 
-  return chargeGenerationTimeMs;
+  return { chargeGenerationTimeMs, boostsUsed };
 }
 
 export const BASE_SALT_YIELD = 10; // 10 salt per rake
@@ -135,7 +142,9 @@ export function rechargeAllSaltNodes(
   game: GameState,
   createdAt: number,
 ): GameState {
-  const interval = getSaltChargeGenerationTime({ gameState: game });
+  const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
+    gameState: game,
+  });
   for (const nodeId of Object.keys(game.saltFarm.nodes)) {
     game.saltFarm.nodes[nodeId].salt.storedCharges =
       MAX_STORED_SALT_CHARGES_PER_NODE;
@@ -248,6 +257,13 @@ export function getNextSaltChargeInSeconds({
 
 export const SALT_FARM_UPDATE_INTERVAL = 1000 * 60 * 10; // 10 minutes
 
+/**
+ * Populates the salt farm with the new salt charges BEFORE any boost is applied
+ * @param game - The game state
+ * @param now - The current time
+ * @param saltSculptureLevelForMaxCharges - The level of the Salt Sculpture upgrade
+ * @returns void
+ */
 export function populateSaltFarm({
   game,
   now,
@@ -258,7 +274,8 @@ export function populateSaltFarm({
   now: number;
   saltSculptureLevelForMaxCharges?: number;
 }) {
-  const chargeIntervalMs = getSaltChargeGenerationTime({ gameState: game });
+  const { chargeGenerationTimeMs: chargeIntervalMs, boostsUsed } =
+    getSaltChargeGenerationTime({ gameState: game });
   const maxCharges = getMaxStoredSaltChargesFromLevel(
     saltSculptureLevelForMaxCharges ??
       game.sculptures?.["Salt Sculpture"]?.level ??
@@ -273,6 +290,11 @@ export function populateSaltFarm({
       syncOpts,
     );
   }
+  game.boostsUsedAt = updateBoostUsed({
+    game,
+    boostNames: boostsUsed,
+    createdAt: now,
+  });
 }
 
 export const SALT_NODE_COORDINATES: Record<string, Coordinates> = {

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { Coordinates } from "../expansion/components/MapPlacement";
 import type { BoostName, GameState, InventoryItemName } from "./game";
 import { getObjectEntries } from "lib/object";
-import { getMaxStoredSaltCharges as getMaxStoredSaltChargesFromLevel } from "./saltSculpture";
 import { updateBoostUsed } from "./updateBoostUsed";
 
 export type SaltNode = {
@@ -192,7 +191,7 @@ function rollNextChargeBoundary(
 export function materializeSaltRegen(
   salt: Salt,
   now: number,
-  options?: SaltSyncOptions,
+  options: SaltSyncOptions | undefined,
 ): Salt {
   const intervalMs = options?.chargeIntervalMs ?? SALT_CHARGE_GENERATION_TIME;
   const maxCharges = options?.maxCharges ?? MAX_STORED_SALT_CHARGES_PER_NODE;
@@ -221,15 +220,7 @@ export function materializeSaltRegen(
 export function getStoredSaltCharges(
   saltNode: SaltNode,
   now: number,
-  options?: SaltSyncOptions,
-): number {
-  return materializeSaltRegen(saltNode.salt, now, options).storedCharges;
-}
-
-export function getDisplaySaltCharges(
-  saltNode: SaltNode,
-  now: number,
-  options?: SaltSyncOptions,
+  options: SaltSyncOptions | undefined,
 ): number {
   return materializeSaltRegen(saltNode.salt, now, options).storedCharges;
 }
@@ -237,7 +228,7 @@ export function getDisplaySaltCharges(
 export function syncSaltNode(
   saltNode: SaltNode,
   now: number,
-  options?: SaltSyncOptions,
+  options: SaltSyncOptions | undefined,
 ): SaltNode {
   return {
     ...saltNode,
@@ -261,37 +252,48 @@ export const SALT_FARM_UPDATE_INTERVAL = 1000 * 60 * 10; // 10 minutes
  * Crystallises accrued salt charges at the pre-mutation rate.
  * Call AFTER the boost-changing mutation so that `gameBefore` still
  * reflects the old rate and `game` reflects the new rate.
- * Skips work when the charge generation time hasn't changed.
+ * Skips work when charge generation time, active boosts, and max stored charges are unchanged.
  */
 export function populateSaltFarm({
   gameBefore,
   gameAfter,
   now,
-  /** When set (e.g. Salt Sculpture upgrade), use this level only for max stored charges; charge interval still follows current `game` state. */
-  saltSculptureLevelForMaxCharges,
 }: {
   gameBefore: Readonly<GameState>;
   gameAfter: GameState;
   now: number;
-  saltSculptureLevelForMaxCharges?: number;
 }) {
-  const { chargeGenerationTimeMs: chargeGenerationTimeBefore } =
-    getSaltChargeGenerationTime({ gameState: gameBefore });
-  const { chargeGenerationTimeMs: chargeGenerationTimeAfter, boostsUsed } =
-    getSaltChargeGenerationTime({ gameState: gameAfter });
+  const {
+    chargeGenerationTimeMs: chargeGenerationTimeBefore,
+    boostsUsed: boostsUsedBefore,
+  } = getSaltChargeGenerationTime({ gameState: gameBefore });
+  const {
+    chargeGenerationTimeMs: chargeGenerationTimeAfter,
+    boostsUsed: boostsUsedAfter,
+  } = getSaltChargeGenerationTime({ gameState: gameAfter });
+
+  const prevMax = getMaxStoredSaltCharges(
+    gameBefore.sculptures?.["Salt Sculpture"]?.level ?? 0,
+  );
+  const nextMax = getMaxStoredSaltCharges(
+    gameAfter.sculptures?.["Salt Sculpture"]?.level ?? 0,
+  );
+
+  const boostsUnchanged =
+    boostsUsedBefore.length === boostsUsedAfter.length &&
+    boostsUsedBefore.every((boost) =>
+      boostsUsedAfter.some((b) => b.name === boost.name),
+    );
 
   if (
-    !saltSculptureLevelForMaxCharges &&
-    chargeGenerationTimeAfter === chargeGenerationTimeBefore
+    chargeGenerationTimeAfter === chargeGenerationTimeBefore &&
+    boostsUnchanged &&
+    prevMax === nextMax
   ) {
     return;
   }
 
-  const maxCharges = getMaxStoredSaltChargesFromLevel(
-    saltSculptureLevelForMaxCharges ??
-      gameAfter.sculptures?.["Salt Sculpture"]?.level ??
-      0,
-  );
+  const maxCharges = nextMax;
   const syncOpts: SaltSyncOptions = {
     chargeIntervalMs: chargeGenerationTimeBefore,
     maxCharges,
@@ -306,7 +308,7 @@ export function populateSaltFarm({
   }
   gameAfter.boostsUsedAt = updateBoostUsed({
     game: gameAfter,
-    boostNames: boostsUsed,
+    boostNames: boostsUsedBefore,
     createdAt: now,
   });
 }
@@ -408,4 +410,11 @@ export function getSaltNodesWithPositions(
 
     return acc;
   }, {});
+}
+
+export function getMaxStoredSaltCharges(sculptureLevel: number): number {
+  let max = MAX_STORED_SALT_CHARGES_PER_NODE;
+  if (sculptureLevel >= 3) max += 1;
+  if (sculptureLevel >= 6) max += 1;
+  return max;
 }

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { Coordinates } from "../expansion/components/MapPlacement";
 import type { BoostName, GameState, InventoryItemName } from "./game";
 import { getObjectEntries } from "lib/object";
-import { updateBoostUsed } from "./updateBoostUsed";
 
 export type SaltNode = {
   createdAt: number;
@@ -284,15 +283,13 @@ export function populateSaltFarm({
     gameAfter.sculptures?.["Salt Sculpture"]?.level ?? 0,
   );
 
-  const boostsUnchanged =
+  const sameBoostSet =
     boostsUsedBefore.length === boostsUsedAfter.length &&
-    boostsUsedBefore.every((boost) =>
-      boostsUsedAfter.some((b) => b.name === boost.name),
-    );
+    boostsUsedBefore.every((b) => boostsUsedAfter.includes(b));
 
   if (
     chargeGenerationTimeAfter === chargeGenerationTimeBefore &&
-    boostsUnchanged &&
+    sameBoostSet &&
     prevMax === nextMax
   ) {
     return;
@@ -311,11 +308,6 @@ export function populateSaltFarm({
       syncOpts,
     );
   }
-  gameAfter.boostsUsedAt = updateBoostUsed({
-    game: gameAfter,
-    boostNames: boostsUsedBefore,
-    createdAt: now,
-  });
 }
 
 export const SALT_NODE_COORDINATES: Record<string, Coordinates> = {

--- a/src/features/game/types/saltSculpture.ts
+++ b/src/features/game/types/saltSculpture.ts
@@ -64,10 +64,3 @@ export const SALT_SCULPTURE_BUFFS: Record<number, string> = {
 export function getSaltSculptureLevel(state: GameState): number {
   return state.sculptures?.["Salt Sculpture"]?.level ?? 0;
 }
-
-export function getMaxStoredSaltCharges(sculptureLevel: number): number {
-  let max = 3;
-  if (sculptureLevel >= 3) max += 1;
-  if (sculptureLevel >= 6) max += 1;
-  return max;
-}


### PR DESCRIPTION
# Pull request description

This PR updates the populateSaltFarm function to only call the function when player equips a boost that would  change the salt generation time

## Summary

- populateSaltFarm now calls a before and after gameState to compare the charge generation time before and after equipping the boost, if the times are the same, it would return early, skipping the updates of salt node
- populateSaltFarm is now called after the boost is applied, instead of before as it did previously. The underlying function would use the chargeTime before to update the node so that the current cooldown time doesn't get affected when equipping the boost

Secondary change:
- Updates boostUsed for salt generation time boosts

## Context / motivation

Why is this change needed? Link to design docs, Slack threads, or prior discussion if helpful.

## How to test

Numbered steps a reviewer can follow. Include seed data, feature flags, or environment notes if needed.

1.
2.

## Screenshots or screen recording

Required for any visual or UX change. For pure logic/backend PRs, write "N/A" or delete this section.

## Related issues

Use one line per issue. Remove if none.

Fixes #
Related #

---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated
