### PR TITLE
[CHORE ]Adding offers and listing at main page markertplace

### DIFF
--- a/src/features/marketplace/components/MarketplaceHotNow.tsx
+++ b/src/features/marketplace/components/MarketplaceHotNow.tsx
@@ -165,9 +165,9 @@ export const MarketplaceHotNow: React.FC = () => {
 
           <TopTrades trends={data} />
         </div>
-      <InnerPanel className="mb-1">
+      </InnerPanel>
 
-      <InnerPanel>
+      <InnerPanel className="mb-1">
         <div className="p-2">
           <Label type="success" className="-ml-1 mb-2">
             {t("reward.whatsNew")}

--- a/src/features/marketplace/components/MarketplaceHotNow.tsx
+++ b/src/features/marketplace/components/MarketplaceHotNow.tsx
@@ -19,6 +19,8 @@ import { TopTrades } from "./TopTrades";
 import useSWR, { preload } from "swr";
 import { CONFIG } from "lib/config";
 import { useGame } from "features/game/GameProvider";
+import { MyOffers } from "./profile/MyOffers";
+import { MyListings } from "./profile/MyListings";
 
 const hotNowFetcher = ([, token]: [string, string]) => {
   if (CONFIG.API_URL) return loadTrends({ token });
@@ -163,7 +165,7 @@ export const MarketplaceHotNow: React.FC = () => {
 
           <TopTrades trends={data} />
         </div>
-      </InnerPanel>
+      <InnerPanel className="mb-1">
 
       <InnerPanel>
         <div className="p-2">
@@ -174,6 +176,9 @@ export const MarketplaceHotNow: React.FC = () => {
           <WhatsNew />
         </div>
       </InnerPanel>
+
+      <MyOffers />
+      <MyListings />
     </div>
   );
 };


### PR DESCRIPTION
UI changes at Market place with out change logic

Summary
Adding offers and listing at main page market place

Context / motivation
just improving user experience

How to test
At the bottom main page market place, aftet What New will appear 2 new sections from Profile/Trades

Screenshots or screen recording
should look something like that

<img width="1440" height="704" alt="image" src="https://github.com/user-attachments/assets/2207ad87-4909-4d35-8aba-5aa708873760" />
