### PR TITLE
[FIX] Rebalance Salt Sculpture craft cost and upgrade ingredients

### DIFF
--- a/src/features/game/events/landExpansion/upgradeSaltSculpture.test.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltSculpture.test.ts
@@ -33,7 +33,7 @@ describe("upgradeSaltSculpture", () => {
     const state = upgradeSaltSculpture({
       state: stateWith({
         inventory: {
-          "Refined Salt": new Decimal(55),
+          "Refined Salt": new Decimal(100),
           "Capsule Bait": new Decimal(20),
         },
       }),
@@ -42,7 +42,7 @@ describe("upgradeSaltSculpture", () => {
     });
 
     expect(state.sculptures?.["Salt Sculpture"]?.level).toBe(2);
-    expect(state.inventory["Refined Salt"]?.toNumber()).toBe(10);
+    expect(state.inventory["Refined Salt"]?.toNumber()).toBe(55);
     expect(state.inventory["Capsule Bait"]?.toNumber()).toBe(10);
   });
 
@@ -52,7 +52,7 @@ describe("upgradeSaltSculpture", () => {
         sculptures: { "Salt Sculpture": { level: 5 } },
         coins: 3000,
         inventory: {
-          "Refined Salt": new Decimal(200),
+          "Refined Salt": new Decimal(100),
           "Crimson Baitfish": new Decimal(20),
         },
       }),
@@ -62,7 +62,7 @@ describe("upgradeSaltSculpture", () => {
 
     expect(state.sculptures?.["Salt Sculpture"]?.level).toBe(6);
     expect(state.coins).toBe(1000);
-    expect(state.inventory["Refined Salt"]?.toNumber()).toBe(100);
+    expect(state.inventory["Refined Salt"]?.toNumber()).toBe(0);
     expect(state.inventory["Crimson Baitfish"]?.toNumber()).toBe(10);
   });
 
@@ -96,7 +96,7 @@ describe("upgradeSaltSculpture", () => {
     const state = upgradeSaltSculpture({
       state: stateWith({
         inventory: {
-          "Refined Salt": new Decimal(55),
+          "Refined Salt": new Decimal(100),
           "Capsule Bait": new Decimal(20),
         },
       }),

--- a/src/features/game/events/landExpansion/upgradeSaltSculpture.test.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltSculpture.test.ts
@@ -33,8 +33,8 @@ describe("upgradeSaltSculpture", () => {
     const state = upgradeSaltSculpture({
       state: stateWith({
         inventory: {
-          "Refined Salt": new Decimal(20),
-          Earthworm: new Decimal(20),
+          "Refined Salt": new Decimal(55),
+          "Capsule Bait": new Decimal(20),
         },
       }),
       action: { type: "saltSculpture.upgraded" },
@@ -43,7 +43,7 @@ describe("upgradeSaltSculpture", () => {
 
     expect(state.sculptures?.["Salt Sculpture"]?.level).toBe(2);
     expect(state.inventory["Refined Salt"]?.toNumber()).toBe(10);
-    expect(state.inventory.Earthworm?.toNumber()).toBe(10);
+    expect(state.inventory["Capsule Bait"]?.toNumber()).toBe(10);
   });
 
   it("upgrades from level 5 to 6, deducts coins and ingredients", () => {
@@ -52,8 +52,8 @@ describe("upgradeSaltSculpture", () => {
         sculptures: { "Salt Sculpture": { level: 5 } },
         coins: 3000,
         inventory: {
-          "Refined Salt": new Decimal(300),
-          "Red Wiggler": new Decimal(20),
+          "Refined Salt": new Decimal(200),
+          "Crimson Baitfish": new Decimal(20),
         },
       }),
       action: { type: "saltSculpture.upgraded" },
@@ -63,7 +63,7 @@ describe("upgradeSaltSculpture", () => {
     expect(state.sculptures?.["Salt Sculpture"]?.level).toBe(6);
     expect(state.coins).toBe(1000);
     expect(state.inventory["Refined Salt"]?.toNumber()).toBe(100);
-    expect(state.inventory["Red Wiggler"]?.toNumber()).toBe(10);
+    expect(state.inventory["Crimson Baitfish"]?.toNumber()).toBe(10);
   });
 
   it("throws when already at max level", () => {
@@ -96,8 +96,8 @@ describe("upgradeSaltSculpture", () => {
     const state = upgradeSaltSculpture({
       state: stateWith({
         inventory: {
-          "Refined Salt": new Decimal(20),
-          Earthworm: new Decimal(20),
+          "Refined Salt": new Decimal(55),
+          "Capsule Bait": new Decimal(20),
         },
       }),
       action: { type: "saltSculpture.upgraded" },

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -334,7 +334,7 @@ export const HELIOS_BLACKSMITH_ITEMS: Record<
     boost: translate("description.saltSculpture.boost"),
     coins: 2000,
     ingredients: {
-      "Refined Salt": new Decimal(10),
+      "Refined Salt": new Decimal(30),
     },
     inventoryLimit: 1,
   },

--- a/src/features/game/types/saltSculpture.ts
+++ b/src/features/game/types/saltSculpture.ts
@@ -15,30 +15,30 @@ export const SALT_SCULPTURE_UPGRADES: Record<
   2: {
     coins: 0,
     ingredients: {
-      "Refined Salt": new Decimal(10),
-      Earthworm: new Decimal(10),
+      "Refined Salt": new Decimal(45),
+      "Capsule Bait": new Decimal(10),
     },
   },
   3: {
     coins: 500,
     ingredients: {
-      "Refined Salt": new Decimal(40),
-      Earthworm: new Decimal(10),
-      Grub: new Decimal(10),
+      "Refined Salt": new Decimal(60),
+      "Capsule Bait": new Decimal(10),
+      "Umbrella Bait": new Decimal(10),
     },
   },
   4: {
     coins: 1000,
     ingredients: {
-      "Refined Salt": new Decimal(75),
-      "Greenhouse Glow": new Decimal(25),
-      "Greenhouse Goodie": new Decimal(25),
+      "Refined Salt": new Decimal(70),
+      "Greenhouse Glow": new Decimal(5),
+      "Greenhouse Goodie": new Decimal(5),
     },
   },
   5: {
     coins: 1500,
     ingredients: {
-      "Refined Salt": new Decimal(120),
+      "Refined Salt": new Decimal(85),
       "Sproutroot Surprise": new Decimal(10),
       "Turbofruit Mix": new Decimal(10),
     },
@@ -46,8 +46,8 @@ export const SALT_SCULPTURE_UPGRADES: Record<
   6: {
     coins: 2000,
     ingredients: {
-      "Refined Salt": new Decimal(200),
-      "Red Wiggler": new Decimal(10),
+      "Refined Salt": new Decimal(100),
+      "Crimson Baitfish": new Decimal(10),
     },
   },
 };


### PR DESCRIPTION
Update ingredient costs to use new fermentation bait items instead of worms, reduce Refined Salt quantities, and lower Greenhouse item requirements to match backend changes.