### PR TITLE
Remove 'Withdraw Resources' from Cropkeeper benefits

### DIFF
--- a/src/features/island/hud/components/reputation/Reputation.tsx
+++ b/src/features/island/hud/components/reputation/Reputation.tsx
@@ -260,11 +260,6 @@ export const ReputationTiers: React.FC = () => {
               text: t("reputation.cropkeeper.description"),
               icon: sflIcon,
             },
-
-            {
-              text: t("reputation.cropkeeper.resources"),
-              icon: ITEM_DETAILS.Eggplant.image,
-            },
           ]}
         />
 


### PR DESCRIPTION
## Summary
- Removes the "Withdraw Resources" line from the Cropkeeper reputation tier benefits list, as this feature is no longer available

## Test plan
- [ ] Verify the Cropkeeper benefits section no longer shows "Withdraw Resources"
- [ ] Confirm remaining benefits (Make & Accept Offers, Unlimited Listings & Offers, Unlock all FLOWER Deliveries) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)