### PR TITLE
Fix listings left count hardcoded to 1

### DIFF
--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -316,7 +316,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
                   className="mr-0.5"
                 >
                   {t("marketplace.listingsLeft", {
-                    amount: 1,
+                    amount: limitedTradesLeft,
                     limit: MAX_LIMITED_SALES,
                   })}
                 </Label>


### PR DESCRIPTION
## Summary
- Fix the "Listings left" label on limited marketplace items showing a hardcoded `1` instead of the actual `limitedTradesLeft` value
- After selling a limited item (e.g. Obsidian), the count now correctly shows `0/1 Listings left` instead of `1/1 Listings left` in red

## Test plan
- [ ] List a limited item (e.g. Obsidian) on the marketplace
- [ ] Verify it shows `1/1 Listings left` (yellow) before selling
- [ ] Sell the item and verify it updates to `0/1 Listings left` (red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)