### PR TITLE
Fix petal puzzle chest visibility window (10s -> 60s)

### DIFF
--- a/src/features/world/scenes/LoveIslandScene.ts
+++ b/src/features/world/scenes/LoveIslandScene.ts
@@ -201,7 +201,7 @@ export class LoveIslandScene extends BaseScene {
     const flower = server.state.giantFlower;
 
     const isSolved =
-      !!flower.puzzleSolvedAt && flower.puzzleSolvedAt > Date.now() - 10 * 1000;
+      !!flower.puzzleSolvedAt && flower.puzzleSolvedAt > Date.now() - 60 * 1000;
 
     this.loveBox?.setVisible(isSolved);
   }


### PR DESCRIPTION
## Summary
- The puzzle chest (Bronze Love Box) on Love Island was only visible for **10 seconds** after the puzzle was solved, despite the comment stating it should be **1 minute**
- This explains reports of players being unable to see the chest to claim after solving the puzzle — the window was too short to notice and reach it
- Changed `10 * 1000` to `60 * 1000` to match the intended 1-minute visibility window

## Investigation notes
- There are **no per-player eligibility requirements** for seeing or claiming the chest — all players on the same server see it equally
- The `claimPetalPrize` logic only checks if the player has already claimed today (no lovecharm/reputation gates)
- The chest visibility is purely based on shared server state (`giantFlower.puzzleSolvedAt`), so the short window was the most likely cause of the reported issue

## Test plan
- [ ] Solve the petal puzzle on Love Island
- [ ] Verify the chest (love box) remains visible for ~60 seconds after solving
- [ ] Verify all players in the server can see and interact with the chest during that window

🤖 Generated with [Claude Code](https://claude.com/claude-code)