### PR TITLE
[FIX] Salt Surge respects Salt Sculpture storage cap

### DIFF
--- a/src/features/game/types/salt.test.ts
+++ b/src/features/game/types/salt.test.ts
@@ -5,6 +5,7 @@ import {
   getSaltChargeGenerationTime,
   materializeSaltRegen,
   populateSaltFarm,
+  rechargeAllSaltNodes,
   syncSaltNode,
   type Salt,
   type SaltNode,
@@ -284,5 +285,107 @@ describe("populateSaltFarm", () => {
     populateSaltFarm({ gameBefore, gameAfter, now });
 
     expect(gameAfter.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
+  });
+});
+
+describe("rechargeAllSaltNodes", () => {
+  const t0 = 1_000_000_000_000;
+
+  function makeGameWithNodes(
+    nodeIds: string[],
+    overrides: Partial<GameState> = {},
+  ): GameState {
+    const nodes: Record<string, SaltNode> = {};
+    for (const id of nodeIds) {
+      nodes[id] = {
+        createdAt: t0,
+        coordinates: { x: 0, y: 0 },
+        salt: {
+          storedCharges: 0,
+          nextChargeAt: t0 + SALT_CHARGE_GENERATION_TIME,
+        },
+      };
+    }
+    return {
+      ...INITIAL_FARM,
+      saltFarm: { level: 1, nodes },
+      ...overrides,
+    };
+  }
+
+  it("fills every node to the base cap when no sculpture is placed", () => {
+    const game = makeGameWithNodes(["0", "1", "2"]);
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    for (const id of ["0", "1", "2"]) {
+      expect(result.saltFarm.nodes[id].salt.storedCharges).toBe(
+        MAX_STORED_SALT_CHARGES_PER_NODE,
+      );
+      expect(result.saltFarm.nodes[id].salt.nextChargeAt).toBe(
+        now + SALT_CHARGE_GENERATION_TIME,
+      );
+    }
+  });
+
+  it("raises the cap to 4 when Salt Sculpture is level 3", () => {
+    const game = makeGameWithNodes(["0"], {
+      sculptures: { "Salt Sculpture": { level: 3 } },
+    });
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    expect(result.saltFarm.nodes["0"].salt.storedCharges).toBe(4);
+  });
+
+  it("raises the cap to 5 when Salt Sculpture is level 6", () => {
+    const game = makeGameWithNodes(["0"], {
+      sculptures: { "Salt Sculpture": { level: 6 } },
+    });
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    expect(result.saltFarm.nodes["0"].salt.storedCharges).toBe(5);
+  });
+
+  it("uses the boosted interval for nextChargeAt when Salty Seas is active", () => {
+    const game = makeGameWithNodes(["0"], {
+      bumpkin: { ...INITIAL_FARM.bumpkin, skills: { "Salty Seas": 1 } },
+    });
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    expect(result.saltFarm.nodes["0"].salt.nextChargeAt).toBe(
+      now + SALT_CHARGE_GENERATION_TIME * 0.9,
+    );
+    expect(result.saltFarm.nodes["0"].salt.storedCharges).toBe(
+      MAX_STORED_SALT_CHARGES_PER_NODE,
+    );
+  });
+
+  it("clamps existing storedCharges that exceed the sculpture-derived cap", () => {
+    const game = makeGameWithNodes(["0"]);
+    game.saltFarm.nodes["0"].salt.storedCharges =
+      MAX_STORED_SALT_CHARGES_PER_NODE + 10;
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    expect(result.saltFarm.nodes["0"].salt.storedCharges).toBe(
+      MAX_STORED_SALT_CHARGES_PER_NODE,
+    );
+  });
+
+  it("is a no-op on an empty salt farm", () => {
+    const game = makeGameWithNodes([]);
+    const now = t0 + 1234;
+
+    const result = rechargeAllSaltNodes(game, now);
+
+    expect(Object.keys(result.saltFarm.nodes)).toHaveLength(0);
   });
 });

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -136,23 +136,16 @@ export const MAX_STORED_SALT_CHARGES_PER_NODE = 3; // 3 salt charges per node
 export const SEA_BLESSED_CHANCE = 5;
 export const SEA_BLESSED_NODE_COUNT = 4;
 
-export function rechargeAllSaltNodes(
-  game: GameState,
-  createdAt: number,
-): GameState {
+export function rechargeAllSaltNodes(game: GameState, now: number): GameState {
   const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
     gameState: game,
   });
   const maxCharges = getMaxStoredSaltCharges(
     game.sculptures?.["Salt Sculpture"]?.level ?? 0,
   );
-  const syncOpts: SaltSyncOptions = { chargeIntervalMs: interval, maxCharges };
   for (const nodeId of Object.keys(game.saltFarm.nodes)) {
-    const node = game.saltFarm.nodes[nodeId];
-    const syncedNode = syncSaltNode(node, createdAt, syncOpts);
-    syncedNode.salt.storedCharges = maxCharges;
-    syncedNode.salt.nextChargeAt = createdAt + interval;
-    game.saltFarm.nodes[nodeId] = syncedNode;
+    game.saltFarm.nodes[nodeId].salt.storedCharges = maxCharges;
+    game.saltFarm.nodes[nodeId].salt.nextChargeAt = now + interval;
   }
   return game;
 }

--- a/src/features/game/types/salt.ts
+++ b/src/features/game/types/salt.ts
@@ -143,10 +143,16 @@ export function rechargeAllSaltNodes(
   const { chargeGenerationTimeMs: interval } = getSaltChargeGenerationTime({
     gameState: game,
   });
+  const maxCharges = getMaxStoredSaltCharges(
+    game.sculptures?.["Salt Sculpture"]?.level ?? 0,
+  );
+  const syncOpts: SaltSyncOptions = { chargeIntervalMs: interval, maxCharges };
   for (const nodeId of Object.keys(game.saltFarm.nodes)) {
-    game.saltFarm.nodes[nodeId].salt.storedCharges =
-      MAX_STORED_SALT_CHARGES_PER_NODE;
-    game.saltFarm.nodes[nodeId].salt.nextChargeAt = createdAt + interval;
+    const node = game.saltFarm.nodes[nodeId];
+    const syncedNode = syncSaltNode(node, createdAt, syncOpts);
+    syncedNode.salt.storedCharges = maxCharges;
+    syncedNode.salt.nextChargeAt = createdAt + interval;
+    game.saltFarm.nodes[nodeId] = syncedNode;
   }
   return game;
 }


### PR DESCRIPTION
## Summary
- `rechargeAllSaltNodes` (used by the Salt Surge skill) was filling every node to the hardcoded base of 3 charges, ignoring the +1/+2 storage bonuses from Salt Sculpture levels 3 and 6.
- Switched to `getMaxStoredSaltCharges` for the fill target and routed each node through `syncSaltNode` first so any over-cap residue is clamped rather than silently preserved.
- Adds `rechargeAllSaltNodes` integration tests covering base cap, sculpture-boosted caps, boosted `nextChargeAt`, over-cap clamping, and the empty-farm no-op.
- Mirrors the API-side fix in sunflower-land-api#3332.

## Test plan
- [x] `npx jest src/features/game/types/salt.test.ts` passes (17 tests)
- [ ] Sanity-check in-game Salt Surge with Salt Sculpture at level ≥ 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)