### PR TITLE
[FEAT] Show powerup icon on fruit patch with Turbofruit Mix

### DIFF
--- a/src/features/island/fruit/FruitPatch.tsx
+++ b/src/features/island/fruit/FruitPatch.tsx
@@ -263,15 +263,26 @@ export const FruitPatch: React.FC<Props> = ({ id }) => {
           />
         )}
         {fertiliser?.name === "Turbofruit Mix" && (
-          <img
-            className="absolute z-10 pointer-events-none"
-            src={SUNNYSIDE.icons.stopwatch}
-            style={{
-              width: `${PIXEL_SCALE * 6}px`,
-              bottom: `${PIXEL_SCALE * 16}px`,
-              right: `${PIXEL_SCALE * 2}px`,
-            }}
-          />
+          <>
+            <img
+              className="absolute z-10 pointer-events-none"
+              src={powerup}
+              style={{
+                width: `${PIXEL_SCALE * 5}px`,
+                bottom: `${PIXEL_SCALE * 16}px`,
+                left: `${PIXEL_SCALE * 2}px`,
+              }}
+            />
+            <img
+              className="absolute z-10 pointer-events-none"
+              src={SUNNYSIDE.icons.stopwatch}
+              style={{
+                width: `${PIXEL_SCALE * 6}px`,
+                bottom: `${PIXEL_SCALE * 16}px`,
+                right: `${PIXEL_SCALE * 2}px`,
+              }}
+            />
+          </>
         )}
 
         {/* Fruit drop animation */}


### PR DESCRIPTION
## Summary
- Adds the powerup icon to the left side of the fruit patch when Turbofruit Mix fertiliser is applied, alongside the existing stopwatch indicator on the right.

<img width="178" height="134" alt="image" src="https://github.com/user-attachments/assets/26519fbc-7153-403b-8d00-0f57d5f9d3ae" />


## Test plan
- [ ] Apply Turbofruit Mix to a fruit patch and verify both the powerup icon (left) and stopwatch icon (right) are visible.
- [ ] Apply Fruitful Blend and verify only the powerup icon appears on the right (unchanged behaviour).
- [ ] Verify no icons appear on an unfertilised patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)