### PR TITLE
[FIX] Aging Shed slot selection by id, clear on collect

### DIFF
--- a/src/features/island/buildings/components/building/agingShed/AgingShed.tsx
+++ b/src/features/island/buildings/components/building/agingShed/AgingShed.tsx
@@ -44,8 +44,13 @@ export const AgingShed: React.FC<BuildingProps> = ({ isBuilt }) => {
 
   const hasReadyRecipe = allRackJobs.some((job) => job.readyAt <= now);
 
-  const agingShedVariant =
-    AGING_SHED_VARIANTS[agingShedLevel > 3 ? 3 : agingShedLevel];
+  const getAgingShedVariant = () => {
+    if (agingShedLevel >= 6) return AGING_SHED_VARIANTS[3];
+    if (agingShedLevel >= 4) return AGING_SHED_VARIANTS[2];
+    return AGING_SHED_VARIANTS[1];
+  };
+
+  const agingShedVariant = getAgingShedVariant();
 
   return (
     <>

--- a/src/features/island/buildings/components/building/agingShed/AgingShedModal.tsx
+++ b/src/features/island/buildings/components/building/agingShed/AgingShedModal.tsx
@@ -16,8 +16,6 @@ import { SpiceRackPanel } from "./spiceRack/SpiceRackPanel";
 import { OuterPanel } from "components/ui/Panel";
 import { hasFeatureAccess } from "lib/flags";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { BUILDING_UPGRADES } from "features/game/events/landExpansion/upgradeBuilding";
-import { getKeys } from "lib/object";
 import { useNow } from "lib/utils/hooks/useNow";
 
 interface Props {
@@ -94,12 +92,6 @@ export const AgingShedModal: React.FC<Props> = ({ isOpen, onClose }) => {
     onClose();
   };
 
-  const maxAgingShedLevel = Math.max(
-    1,
-    ...getKeys(BUILDING_UPGRADES["Aging Shed"]).map(Number),
-  );
-  const isAgingShedMaxLevel = agingShedLevel >= maxAgingShedLevel;
-
   return (
     <Modal show={isOpen} onHide={closeUpgradeTab}>
       <img
@@ -122,7 +114,7 @@ export const AgingShedModal: React.FC<Props> = ({ isOpen, onClose }) => {
           showUpgradeTab && hasAgingShedAccess ? "upgrade" : currentTab
         }
         setCurrentTab={showUpgradeTab ? undefined : setCurrentTab}
-        container={isAgingShedMaxLevel ? undefined : OuterPanel}
+        container={showUpgradeTab ? undefined : OuterPanel}
       >
         <AgedShedPanel
           agingShedLevel={agingShedLevel}

--- a/src/features/island/buildings/components/building/agingShed/agingRack/AgingRackPanel.tsx
+++ b/src/features/island/buildings/components/building/agingShed/agingRack/AgingRackPanel.tsx
@@ -52,9 +52,7 @@ export const AgingRackPanel: React.FC = () => {
 
   const now = useNow({ live: queue.length > 0, autoEndAt: agingClockEndAt });
 
-  const [selectedSlotIndex, setSelectedSlotIndex] = useState<number | null>(
-    null,
-  );
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
   const [selectedFish, setSelectedFish] = useState<FishName | undefined>();
   const [startError, setStartError] = useState<string | undefined>();
   const [collectError, setCollectError] = useState<string | undefined>();
@@ -64,20 +62,12 @@ export const AgingRackPanel: React.FC = () => {
   const shedPlaced = hasPlacedAgingShed(state);
   const merged = getMergedInventory(state);
 
-  const activeSelectedSlotIndex =
-    selectedSlotIndex !== null &&
-    selectedSlotIndex < queue.length &&
-    selectedSlotIndex < maxSlots
-      ? selectedSlotIndex
-      : null;
-
   const readySlots = queue.filter((slot) => slot.readyAt <= now);
   const canCollect = !isVisiting && shedPlaced && readySlots.length > 0;
 
-  const selectedSlot =
-    activeSelectedSlotIndex !== null
-      ? queue[activeSelectedSlotIndex]
-      : undefined;
+  const selectedSlot = selectedSlotId
+    ? queue.find((slot) => slot.id === selectedSlotId)
+    : undefined;
 
   const fishCost = getBoostedAgingFishCost(state);
   const saltNeeded = selectedFish
@@ -117,6 +107,7 @@ export const AgingRackPanel: React.FC = () => {
     try {
       gameService.send("agingRack.collected");
       gameService.send("SAVE");
+      setSelectedSlotId(null);
     } catch (e) {
       setCollectError(e instanceof Error ? e.message : String(e));
     }
@@ -168,7 +159,7 @@ export const AgingRackPanel: React.FC = () => {
               const slot = queue[index];
               const ready = slot.readyAt <= now;
               const remainingSec = Math.max(0, (slot.readyAt - now) / 1000);
-              const isSelected = activeSelectedSlotIndex === index;
+              const isSelected = selectedSlotId === slot.id;
 
               return (
                 <div
@@ -181,8 +172,8 @@ export const AgingRackPanel: React.FC = () => {
                     hideCount
                     isSelected={isSelected}
                     onClick={() =>
-                      setSelectedSlotIndex((current) =>
-                        current === index ? null : index,
+                      setSelectedSlotId((current) =>
+                        current === slot.id ? null : slot.id,
                       )
                     }
                   />
@@ -200,19 +191,10 @@ export const AgingRackPanel: React.FC = () => {
                 key={`empty-${index}`}
                 className={classNames(
                   "flex flex-col items-center max-w-[72px]",
-                  isInactiveEmpty && "opacity-40 pointer-events-none",
+                  isInactiveEmpty && "opacity-40",
                 )}
               >
-                <Box
-                  hideCount
-                  disabled={isInactiveEmpty}
-                  isSelected={activeSelectedSlotIndex === index}
-                  onClick={() =>
-                    setSelectedSlotIndex((current) =>
-                      current === index ? null : index,
-                    )
-                  }
-                >
+                <Box hideCount disabled>
                   <div className="w-full h-full border border-dashed border-[#181425]/35 opacity-60 rounded-sm" />
                 </Box>
               </div>

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
@@ -104,9 +104,7 @@ export const FermentationRackPanel: React.FC = () => {
 
   const groups = getFermentationOutputGroups();
 
-  const [selectedSlotIndex, setSelectedSlotIndex] = useState<number | null>(
-    null,
-  );
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
   const [selectedSignature, setSelectedSignature] = useState<
     string | undefined
   >(undefined);
@@ -120,12 +118,6 @@ export const FermentationRackPanel: React.FC = () => {
   const slotsFull = queue.length >= maxSlots;
 
   const shedPlaced = hasPlacedAgingShed(state);
-  const activeSelectedSlotIndex =
-    selectedSlotIndex !== null &&
-    selectedSlotIndex < queue.length &&
-    selectedSlotIndex < maxSlots
-      ? selectedSlotIndex
-      : null;
 
   const merged = getMergedInventory(state);
 
@@ -148,10 +140,9 @@ export const FermentationRackPanel: React.FC = () => {
   const readyJobs = queue.filter((job) => job.readyAt <= now);
   const canCollect = !isVisiting && shedPlaced && readyJobs.length > 0;
 
-  const selectedJob =
-    activeSelectedSlotIndex !== null
-      ? queue[activeSelectedSlotIndex]
-      : undefined;
+  const selectedJob = selectedSlotId
+    ? queue.find((job) => job.id === selectedSlotId)
+    : undefined;
 
   const applyOutputGroupSelection = useCallback(
     (group: FermentationOutputGroup) => {
@@ -237,6 +228,7 @@ export const FermentationRackPanel: React.FC = () => {
     try {
       gameService.send("fermentation.collected");
       gameService.send("SAVE");
+      setSelectedSlotId(null);
     } catch (e) {
       setCollectError(e instanceof Error ? e.message : String(e));
     }
@@ -285,6 +277,7 @@ export const FermentationRackPanel: React.FC = () => {
               const outputItem = getPrimaryOutputItem(job.recipe);
               const ready = job.readyAt <= now;
               const remainingSec = Math.max(0, (job.readyAt - now) / 1000);
+              const isSelected = selectedSlotId === job.id;
 
               return (
                 <div
@@ -295,10 +288,10 @@ export const FermentationRackPanel: React.FC = () => {
                     image={ITEM_DETAILS[outputItem]?.image}
                     disabled={false}
                     hideCount
-                    isSelected={activeSelectedSlotIndex === index}
+                    isSelected={isSelected}
                     onClick={() =>
-                      setSelectedSlotIndex((current) =>
-                        current === index ? null : index,
+                      setSelectedSlotId((current) =>
+                        current === job.id ? null : job.id,
                       )
                     }
                   />
@@ -316,19 +309,10 @@ export const FermentationRackPanel: React.FC = () => {
                 key={`empty-${index}`}
                 className={classNames(
                   "flex flex-col items-center max-w-[72px]",
-                  isInactiveEmpty && "opacity-40 pointer-events-none",
+                  isInactiveEmpty && "opacity-40",
                 )}
               >
-                <Box
-                  hideCount
-                  disabled={isInactiveEmpty}
-                  isSelected={activeSelectedSlotIndex === index}
-                  onClick={() =>
-                    setSelectedSlotIndex((current) =>
-                      current === index ? null : index,
-                    )
-                  }
-                >
+                <Box hideCount disabled>
                   <div className="w-full h-full border border-dashed border-[#181425]/35 opacity-60 rounded-sm" />
                 </Box>
               </div>

--- a/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackPanel.tsx
+++ b/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackPanel.tsx
@@ -75,9 +75,7 @@ export const SpiceRackPanel: React.FC = () => {
     autoEndAt: spiceClockEndAt,
   });
 
-  const [selectedSlotIndex, setSelectedSlotIndex] = useState<number | null>(
-    null,
-  );
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
   const [selectedRecipeId, setSelectedRecipeId] = useState<
     SpiceRackRecipeName | undefined
   >();
@@ -88,12 +86,6 @@ export const SpiceRackPanel: React.FC = () => {
   const slotsFull = queue.length >= maxSlots;
 
   const shedPlaced = hasPlacedAgingShed(state);
-  const activeSelectedSlotIndex =
-    selectedSlotIndex !== null &&
-    selectedSlotIndex < queue.length &&
-    selectedSlotIndex < maxSlots
-      ? selectedSlotIndex
-      : null;
 
   const merged = mergeBasketAndChestInventory(state);
 
@@ -112,10 +104,9 @@ export const SpiceRackPanel: React.FC = () => {
   const readyJobs = queue.filter((job) => job.readyAt <= now);
   const canCollect = !isVisiting && shedPlaced && readyJobs.length > 0;
 
-  const selectedJob =
-    activeSelectedSlotIndex !== null
-      ? queue[activeSelectedSlotIndex]
-      : undefined;
+  const selectedJob = selectedSlotId
+    ? queue.find((job) => job.id === selectedSlotId)
+    : undefined;
 
   const handleRecipeSelect = (recipeId: SpiceRackRecipeName) => {
     setStartError(undefined);
@@ -144,6 +135,7 @@ export const SpiceRackPanel: React.FC = () => {
     try {
       gameService.send("spiceRack.collected");
       gameService.send("SAVE");
+      setSelectedSlotId(null);
     } catch (e) {
       setCollectError(e instanceof Error ? e.message : String(e));
     }
@@ -190,6 +182,7 @@ export const SpiceRackPanel: React.FC = () => {
               const outputItem = getPrimaryOutputItem(job.recipe);
               const ready = job.readyAt <= now;
               const remainingSec = Math.max(0, (job.readyAt - now) / 1000);
+              const isSelected = selectedSlotId === job.id;
 
               return (
                 <div
@@ -200,10 +193,10 @@ export const SpiceRackPanel: React.FC = () => {
                     image={ITEM_DETAILS[outputItem]?.image}
                     disabled={false}
                     hideCount
-                    isSelected={activeSelectedSlotIndex === index}
+                    isSelected={isSelected}
                     onClick={() =>
-                      setSelectedSlotIndex((current) =>
-                        current === index ? null : index,
+                      setSelectedSlotId((current) =>
+                        current === job.id ? null : job.id,
                       )
                     }
                   />
@@ -221,19 +214,10 @@ export const SpiceRackPanel: React.FC = () => {
                 key={`empty-${index}`}
                 className={classNames(
                   "flex flex-col items-center max-w-[72px]",
-                  isInactiveEmpty && "opacity-40 pointer-events-none",
+                  isInactiveEmpty && "opacity-40",
                 )}
               >
-                <Box
-                  hideCount
-                  disabled={isInactiveEmpty}
-                  isSelected={activeSelectedSlotIndex === index}
-                  onClick={() =>
-                    setSelectedSlotIndex((current) =>
-                      current === index ? null : index,
-                    )
-                  }
-                >
+                <Box hideCount disabled>
                   <div className="w-full h-full border border-dashed border-[#181425]/35 opacity-60 rounded-sm" />
                 </Box>
               </div>


### PR DESCRIPTION
## Summary
- **Slot selection (aging / fermentation / spice racks):** Track selection by slot/job `id` rather than queue index, so collecting ready jobs can't silently shift the selection onto a different slot or leave it pointing out of bounds. Clear the selection after a successful collect so the player returns to the start form. Drop the dead-click behavior on empty grid tiles — they never rendered as `isSelected` and starting a job never needed a slot selection. Empty tiles are now purely visual placeholders.
- **Aging Shed sprite variant:** Pick the variant in discrete tiers (lvl 1–3 → v1, 4–5 → v2, 6+ → v3) instead of clamping level to 3.
- **Aging Shed modal container:** Keep the `OuterPanel` wrapper on all shed levels; only drop it while the upgrade tab is active.

## Desired slot-selection UX (now reflected in the code)
1. Player selects a filled slot and collects → selection is cleared.
2. Player selects a recipe/fish and starts a job; no slot selection required.
3. Player can keep starting jobs until all slots are full.
4. Selecting a slot is only for viewing that slot's details.

## Test plan
- [ ] Open Aging Shed → Aging Rack: start a job, confirm new tile appears and start form remains usable.
- [ ] Start jobs in Aging, Fermentation, and Spice racks until slots are full.
- [ ] Select a filled slot → details panel appears; click it again → deselects back to start form.
- [ ] With multiple ready jobs, select one then collect → selection clears and queue updates without silently pointing at a different slot.
- [ ] Click an empty/inactive tile → no visual or functional change.
- [ ] Upgrade the shed through levels 1 → 6+ and confirm the sprite changes at the level 4 and level 6 tier boundaries.
- [ ] Open the modal at low, mid, and max shed level; confirm the outer panel frame is present on the rack tabs and absent only on the upgrade tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)