### PR TITLE
[FIX] Constrain Fisherman NPC click hitbox to sprite area

### DIFF
--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -39,6 +39,8 @@ import { FishermanPuzzle } from "features/island/fisherman/FishingPuzzle";
 import { Panel } from "components/ui/Panel";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 
+const HITBOX_SIZE_PX = 50;
+
 type SpriteFrames = { startAt: number; endAt: number };
 
 const FISHING_FRAMES: Record<FishingState, SpriteFrames> = {
@@ -307,8 +309,8 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
         style={{
           left: `${PIXEL_SCALE * x}px`,
           top: `${PIXEL_SCALE * y}px`,
-          width: `${PIXEL_SCALE * 50}px`,
-          height: `${PIXEL_SCALE * 50}px`,
+          width: `${PIXEL_SCALE * HITBOX_SIZE_PX}px`,
+          height: `${PIXEL_SCALE * HITBOX_SIZE_PX}px`,
         }}
       >
         {!canFish && (

--- a/src/features/island/fisherman/FishermanNPC.tsx
+++ b/src/features/island/fisherman/FishermanNPC.tsx
@@ -300,13 +300,15 @@ export const FishermanNPC: React.FC<Props> = ({ onClick }) => {
   return (
     <>
       <div
-        className={classNames("absolute z-50 w-full h-full", {
+        className={classNames("absolute z-50", {
           "cursor-pointer hover:img-highlight": !fishing.wharf.castedAt,
         })}
         onClick={handleClick}
         style={{
           left: `${PIXEL_SCALE * x}px`,
           top: `${PIXEL_SCALE * y}px`,
+          width: `${PIXEL_SCALE * 50}px`,
+          height: `${PIXEL_SCALE * 50}px`,
         }}
       >
         {!canFish && (


### PR DESCRIPTION
## Summary
- The Fisherman NPC clickable div used `w-full h-full`, inheriting the full width of the `MapPlacement` wharf container (~210×42px). This meant players could open the fishing modal by clicking anywhere along the wharf planks.
- Replaced `w-full h-full` with an explicit 50×50 pixel (scaled) hit area in `FishermanNPC.tsx` so the click region sits over the NPC and fishing spot only.

## Test plan
- [ ] Verify the fishing modal only opens when clicking on/near the fisherman on each island type (basic, spring, desert, volcano)
- [ ] Confirm overlay icons (lock/fish when locked, fish frenzy, full moon, ready marvel, reel button, sparkle) still render in the correct positions
- [ ] Confirm hover highlight still triggers as expected and is scoped to the hit area