### PR TITLE
[CHORE] Bump Salt Rake stock and increase bait fermentation output

### DIFF
--- a/src/features/game/events/landExpansion/collectFermentation.test.ts
+++ b/src/features/game/events/landExpansion/collectFermentation.test.ts
@@ -296,104 +296,101 @@ describe("collectFermentation", () => {
     expect(state.agingShed.racks.fermentation).toHaveLength(0);
   });
 
-  it("collecting Capsule Bait from Aged fish recipe grants 5 Capsule Bait", () => {
-    const past = createdAt - 1;
-    const fishName = getFishNamesByTier("basic")[0];
-    const recipe =
-      `Capsule Bait (Aged ${fishName}, Pickled Zucchini)` as FermentationRecipeName;
+  describe.each([
+    {
+      family: "Capsule Bait" as const,
+      tier: "basic" as const,
+      activePickle: "Pickled Zucchini",
+      retiredPickle: "Pickled Pepper",
+    },
+    {
+      family: "Umbrella Bait" as const,
+      tier: "advanced" as const,
+      activePickle: "Pickled Cabbage",
+      retiredPickle: "Pickled Onion",
+    },
+    {
+      family: "Crimson Baitfish" as const,
+      tier: "expert" as const,
+      activePickle: "Pickled Radish",
+      retiredPickle: "Pickled Tomato",
+    },
+  ])(
+    "$family fermentation output",
+    ({ family, tier, activePickle, retiredPickle }) => {
+      it.each([
+        { prefix: "Aged" as const, expected: 5 },
+        { prefix: "Prime Aged" as const, expected: 10 },
+      ])(
+        `grants $expected ${family} from $prefix fish`,
+        ({ prefix, expected }) => {
+          const past = createdAt - 1;
+          const fishName = getFishNamesByTier(tier)[0];
+          const recipe =
+            `${family} (${prefix} ${fishName}, ${activePickle})` as FermentationRecipeName;
 
-    const state = collectFermentation({
-      state: createFermentationTestState({
-        agingShed: {
-          ...createInitialAgingShed(),
-          racks: {
-            ...createInitialAgingShed().racks,
-            fermentation: [
-              {
-                id: "aged-bait",
-                recipe,
-                startedAt: past,
-                readyAt: past,
+          const state = collectFermentation({
+            state: createFermentationTestState({
+              agingShed: {
+                ...createInitialAgingShed(),
+                racks: {
+                  ...createInitialAgingShed().racks,
+                  fermentation: [
+                    {
+                      id: `${family}-${prefix}`,
+                      recipe,
+                      startedAt: past,
+                      readyAt: past,
+                    },
+                  ],
+                },
               },
-            ],
-          },
+            }),
+            action: { type: "fermentation.collected" },
+            farmId: 1,
+            createdAt,
+          });
+
+          expect(state.inventory[family]?.toNumber()).toEqual(expected);
+          expect(state.agingShed.racks.fermentation).toHaveLength(0);
+          expect(state.farmActivity[`${family} Fermented`]).toEqual(expected);
         },
-      }),
-      action: { type: "fermentation.collected" },
-      farmId: 1,
-      createdAt,
-    });
+      );
 
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(5);
-    expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(5);
-  });
+      it(`retired ${retiredPickle} recipe still grants 5 bait from Aged fish`, () => {
+        const past = createdAt - 1;
+        const fishName = getFishNamesByTier(tier)[0];
+        const recipe =
+          `${family} (Aged ${fishName}, ${retiredPickle})` as FermentationRecipeName;
 
-  it("collecting Capsule Bait from Prime Aged fish recipe grants 10 Capsule Bait", () => {
-    const past = createdAt - 1;
-    const fishName = getFishNamesByTier("basic")[0];
-    const recipe =
-      `Capsule Bait (Prime Aged ${fishName}, Pickled Zucchini)` as FermentationRecipeName;
-
-    const state = collectFermentation({
-      state: createFermentationTestState({
-        agingShed: {
-          ...createInitialAgingShed(),
-          racks: {
-            ...createInitialAgingShed().racks,
-            fermentation: [
-              {
-                id: "prime-bait",
-                recipe,
-                startedAt: past,
-                readyAt: past,
+        const state = collectFermentation({
+          state: createFermentationTestState({
+            agingShed: {
+              ...createInitialAgingShed(),
+              racks: {
+                ...createInitialAgingShed().racks,
+                fermentation: [
+                  {
+                    id: `${family}-retired`,
+                    recipe,
+                    startedAt: past,
+                    readyAt: past,
+                  },
+                ],
               },
-            ],
-          },
-        },
-      }),
-      action: { type: "fermentation.collected" },
-      farmId: 1,
-      createdAt,
-    });
+            },
+          }),
+          action: { type: "fermentation.collected" },
+          farmId: 1,
+          createdAt,
+        });
 
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(10);
-    expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(10);
-  });
-
-  it("collecting Capsule Bait from retired Pickled Pepper recipe still grants 5 bait", () => {
-    const past = createdAt - 1;
-    const fishName = getFishNamesByTier("basic")[0];
-    const recipe =
-      `Capsule Bait (Aged ${fishName}, Pickled Pepper)` as FermentationRecipeName;
-
-    const state = collectFermentation({
-      state: createFermentationTestState({
-        agingShed: {
-          ...createInitialAgingShed(),
-          racks: {
-            ...createInitialAgingShed().racks,
-            fermentation: [
-              {
-                id: "retired-pepper-bait",
-                recipe,
-                startedAt: past,
-                readyAt: past,
-              },
-            ],
-          },
-        },
-      }),
-      action: { type: "fermentation.collected" },
-      farmId: 1,
-      createdAt,
-    });
-
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(5);
-    expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(5);
-  });
+        expect(state.inventory[family]?.toNumber()).toEqual(5);
+        expect(state.agingShed.racks.fermentation).toHaveLength(0);
+        expect(state.farmActivity[`${family} Fermented`]).toEqual(5);
+      });
+    },
+  );
 
   it("applies Ager skill to double fermentation output", () => {
     const past = createdAt - 1;

--- a/src/features/game/events/landExpansion/collectFermentation.test.ts
+++ b/src/features/game/events/landExpansion/collectFermentation.test.ts
@@ -296,7 +296,7 @@ describe("collectFermentation", () => {
     expect(state.agingShed.racks.fermentation).toHaveLength(0);
   });
 
-  it("collecting Capsule Bait from Aged fish recipe grants 3 Capsule Bait", () => {
+  it("collecting Capsule Bait from Aged fish recipe grants 5 Capsule Bait", () => {
     const past = createdAt - 1;
     const fishName = getFishNamesByTier("basic")[0];
     const recipe =
@@ -324,12 +324,12 @@ describe("collectFermentation", () => {
       createdAt,
     });
 
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(3);
+    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(5);
     expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(3);
+    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(5);
   });
 
-  it("collecting Capsule Bait from Prime Aged fish recipe grants 6 Capsule Bait", () => {
+  it("collecting Capsule Bait from Prime Aged fish recipe grants 10 Capsule Bait", () => {
     const past = createdAt - 1;
     const fishName = getFishNamesByTier("basic")[0];
     const recipe =
@@ -357,12 +357,12 @@ describe("collectFermentation", () => {
       createdAt,
     });
 
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(6);
+    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(10);
     expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(6);
+    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(10);
   });
 
-  it("collecting Capsule Bait from retired Pickled Pepper recipe still grants 3 bait", () => {
+  it("collecting Capsule Bait from retired Pickled Pepper recipe still grants 5 bait", () => {
     const past = createdAt - 1;
     const fishName = getFishNamesByTier("basic")[0];
     const recipe =
@@ -390,9 +390,9 @@ describe("collectFermentation", () => {
       createdAt,
     });
 
-    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(3);
+    expect(state.inventory["Capsule Bait"]?.toNumber()).toEqual(5);
     expect(state.agingShed.racks.fermentation).toHaveLength(0);
-    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(3);
+    expect(state.farmActivity["Capsule Bait Fermented"]).toEqual(5);
   });
 
   it("applies Ager skill to double fermentation output", () => {

--- a/src/features/game/events/landExpansion/startFermentation.test.ts
+++ b/src/features/game/events/landExpansion/startFermentation.test.ts
@@ -575,7 +575,7 @@ describe("startFermentation", () => {
       `Capsule Bait (Prime Aged ${fishName}, Pickled Zucchini)` as FermentationRecipeName;
 
     expect(getFermentationRecipe(recipe).outputs["Capsule Bait"]).toEqual(
-      new Decimal(6),
+      new Decimal(10),
     );
   });
 

--- a/src/features/game/events/landExpansion/startFermentation.test.ts
+++ b/src/features/game/events/landExpansion/startFermentation.test.ts
@@ -3,6 +3,8 @@ import { INITIAL_BUMPKIN } from "features/game/lib/constants";
 import { createInitialAgingShed } from "features/game/lib/agingShed";
 import {
   BAIT_FERMENTATION_RECIPE_IDS,
+  BAIT_OUTPUT_AGED,
+  BAIT_OUTPUT_PRIME,
   getFermentationRecipe,
   GREENHOUSE_FERMENTATION_STARTABLE_IDS,
   LEGACY_FERMENTATION_RECIPE_IDS,
@@ -542,150 +544,83 @@ describe("startFermentation", () => {
     );
   });
 
-  it("starts Capsule Bait recipe for first basic-tier fish (Aged)", () => {
-    const fishName = getFishNamesByTier("basic")[0];
-    const agedFish = `Aged ${fishName}` as const;
-    const recipe =
-      `Capsule Bait (Aged ${fishName}, Pickled Zucchini)` as StartableFermentationRecipeName;
+  describe.each([
+    {
+      family: "Capsule Bait" as const,
+      tier: "basic" as const,
+      activePickles: ["Pickled Zucchini", "Pickled Tomato"] as const,
+      retiredPickle: "Pickled Pepper" as const,
+    },
+    {
+      family: "Umbrella Bait" as const,
+      tier: "advanced" as const,
+      activePickles: ["Pickled Cabbage", "Pickled Pepper"] as const,
+      retiredPickle: "Pickled Onion" as const,
+    },
+    {
+      family: "Crimson Baitfish" as const,
+      tier: "expert" as const,
+      activePickles: ["Pickled Radish", "Pickled Onion"] as const,
+      retiredPickle: "Pickled Tomato" as const,
+    },
+  ])(
+    "$family fermentation start (tier $tier)",
+    ({ family, tier, activePickles, retiredPickle }) => {
+      describe.each([
+        { prefix: "Aged" as const, expected: BAIT_OUTPUT_AGED },
+        { prefix: "Prime Aged" as const, expected: BAIT_OUTPUT_PRIME },
+      ])("$prefix fish", ({ prefix, expected }) => {
+        it.each(activePickles)(
+          `starts with %s, deducts ingredients, and recipe outputs ${family} matching centralised constant`,
+          (pickle) => {
+            const fishName = getFishNamesByTier(tier)[0];
+            const fishKey = `${prefix} ${fishName}` as const;
+            const recipe =
+              `${family} (${prefix} ${fishName}, ${pickle})` as StartableFermentationRecipeName;
 
-    const state = startFermentation({
-      state: createFermentationTestState({
-        inventory: {
-          [agedFish]: new Decimal(1),
-          "Pickled Zucchini": new Decimal(1),
-        },
-      }),
-      action: {
-        type: "fermentation.started",
-        recipe,
-        jobId: TEST_JOB_ID,
-      },
-      farmId: 1,
-      createdAt,
-    });
+            const state = startFermentation({
+              state: createFermentationTestState({
+                inventory: {
+                  [fishKey]: new Decimal(1),
+                  [pickle]: new Decimal(1),
+                },
+              }),
+              action: {
+                type: "fermentation.started",
+                recipe,
+                jobId: TEST_JOB_ID,
+              },
+              farmId: 1,
+              createdAt,
+            });
 
-    expect(state.inventory[agedFish]?.toNumber()).toEqual(0);
-    expect(state.inventory["Pickled Zucchini"]?.toNumber()).toEqual(0);
-    expect(state.agingShed.racks.fermentation[0].recipe).toEqual(recipe);
-  });
+            expect(state.inventory[fishKey]?.toNumber()).toEqual(0);
+            expect(state.inventory[pickle]?.toNumber()).toEqual(0);
+            expect(state.agingShed.racks.fermentation[0].recipe).toEqual(
+              recipe,
+            );
+            expect(
+              getFermentationRecipe(recipe).outputs[family]?.toNumber(),
+            ).toEqual(expected.toNumber());
+          },
+        );
+      });
 
-  it("Prime Aged basic bait recipe outputs 6 Capsule Bait", () => {
-    const fishName = getFishNamesByTier("basic")[0];
-    const recipe =
-      `Capsule Bait (Prime Aged ${fishName}, Pickled Zucchini)` as FermentationRecipeName;
-
-    expect(getFermentationRecipe(recipe).outputs["Capsule Bait"]).toEqual(
-      new Decimal(10),
-    );
-  });
-
-  it("starts Capsule Bait recipe with Prime Aged fish", () => {
-    const fishName = getFishNamesByTier("basic")[0];
-    const primeAgedFish = `Prime Aged ${fishName}` as const;
-    const recipe =
-      `Capsule Bait (Prime Aged ${fishName}, Pickled Zucchini)` as StartableFermentationRecipeName;
-
-    const state = startFermentation({
-      state: createFermentationTestState({
-        inventory: {
-          [primeAgedFish]: new Decimal(1),
-          "Pickled Zucchini": new Decimal(1),
-        },
-      }),
-      action: {
-        type: "fermentation.started",
-        recipe,
-        jobId: TEST_JOB_ID,
-      },
-      farmId: 1,
-      createdAt,
-    });
-
-    expect(state.inventory[primeAgedFish]?.toNumber()).toEqual(0);
-    expect(state.inventory["Pickled Zucchini"]?.toNumber()).toEqual(0);
-    expect(state.agingShed.racks.fermentation[0].recipe).toEqual(recipe);
-  });
-
-  it("starts Capsule Bait with Pickled Tomato for first basic-tier fish (Aged)", () => {
-    const fishName = getFishNamesByTier("basic")[0];
-    const agedFish = `Aged ${fishName}` as const;
-    const recipe =
-      `Capsule Bait (Aged ${fishName}, Pickled Tomato)` as StartableFermentationRecipeName;
-
-    const state = startFermentation({
-      state: createFermentationTestState({
-        inventory: {
-          [agedFish]: new Decimal(1),
-          "Pickled Tomato": new Decimal(1),
-        },
-      }),
-      action: {
-        type: "fermentation.started",
-        recipe,
-        jobId: TEST_JOB_ID,
-      },
-      farmId: 1,
-      createdAt,
-    });
-
-    expect(state.inventory[agedFish]?.toNumber()).toEqual(0);
-    expect(state.inventory["Pickled Tomato"]?.toNumber()).toEqual(0);
-    expect(state.agingShed.racks.fermentation[0].recipe).toEqual(recipe);
-  });
-
-  it("starts Umbrella Bait with Pickled Pepper for first advanced-tier fish (Aged)", () => {
-    const fishName = getFishNamesByTier("advanced")[0];
-    const agedFish = `Aged ${fishName}` as const;
-    const recipe =
-      `Umbrella Bait (Aged ${fishName}, Pickled Pepper)` as StartableFermentationRecipeName;
-
-    const state = startFermentation({
-      state: createFermentationTestState({
-        inventory: {
-          [agedFish]: new Decimal(1),
-          "Pickled Pepper": new Decimal(1),
-        },
-      }),
-      action: {
-        type: "fermentation.started",
-        recipe,
-        jobId: TEST_JOB_ID,
-      },
-      farmId: 1,
-      createdAt,
-    });
-
-    expect(state.inventory[agedFish]?.toNumber()).toEqual(0);
-    expect(state.inventory["Pickled Pepper"]?.toNumber()).toEqual(0);
-    expect(state.agingShed.racks.fermentation[0].recipe).toEqual(recipe);
-  });
-
-  it("starts Crimson Baitfish with Pickled Radish for first expert-tier fish (Aged)", () => {
-    const fishName = getFishNamesByTier("expert")[0];
-    const agedFish = `Aged ${fishName}` as const;
-    const recipe =
-      `Crimson Baitfish (Aged ${fishName}, Pickled Radish)` as StartableFermentationRecipeName;
-
-    const state = startFermentation({
-      state: createFermentationTestState({
-        inventory: {
-          [agedFish]: new Decimal(1),
-          "Pickled Radish": new Decimal(1),
-        },
-      }),
-      action: {
-        type: "fermentation.started",
-        recipe,
-        jobId: TEST_JOB_ID,
-      },
-      farmId: 1,
-      createdAt,
-    });
-
-    expect(state.inventory[agedFish]?.toNumber()).toEqual(0);
-    expect(state.inventory["Pickled Radish"]?.toNumber()).toEqual(0);
-    expect(state.agingShed.racks.fermentation[0].recipe).toEqual(recipe);
-  });
+      it(`retired ${retiredPickle} recipe output still matches centralised constants`, () => {
+        const fishName = getFishNamesByTier(tier)[0];
+        for (const { prefix, expected } of [
+          { prefix: "Aged" as const, expected: BAIT_OUTPUT_AGED },
+          { prefix: "Prime Aged" as const, expected: BAIT_OUTPUT_PRIME },
+        ]) {
+          const recipe =
+            `${family} (${prefix} ${fishName}, ${retiredPickle})` as FermentationRecipeName;
+          expect(
+            getFermentationRecipe(recipe).outputs[family]?.toNumber(),
+          ).toEqual(expected.toNumber());
+        }
+      });
+    },
+  );
 
   it("applies Ager skill to double ingredient costs", () => {
     const state = startFermentation({

--- a/src/features/game/types/fermentation.ts
+++ b/src/features/game/types/fermentation.ts
@@ -284,7 +284,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Zucchini": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(3),
+        "Capsule Bait": new Decimal(5),
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Zucchini)`] = {
@@ -294,7 +294,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Zucchini": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(6),
+        "Capsule Bait": new Decimal(10),
       },
     };
     recipes[`Capsule Bait (Aged ${fish}, Pickled Tomato)`] = {
@@ -304,7 +304,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(3),
+        "Capsule Bait": new Decimal(5),
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Tomato)`] = {
@@ -314,7 +314,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(6),
+        "Capsule Bait": new Decimal(10),
       },
     };
   }
@@ -330,7 +330,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Cabbage": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(3),
+        "Umbrella Bait": new Decimal(5),
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Cabbage)`] = {
@@ -340,7 +340,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Cabbage": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(6),
+        "Umbrella Bait": new Decimal(10),
       },
     };
     recipes[`Umbrella Bait (Aged ${fish}, Pickled Pepper)`] = {
@@ -350,7 +350,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(3),
+        "Umbrella Bait": new Decimal(5),
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Pepper)`] = {
@@ -360,7 +360,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(6),
+        "Umbrella Bait": new Decimal(10),
       },
     };
   }
@@ -376,7 +376,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Radish": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(3),
+        "Crimson Baitfish": new Decimal(5),
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Radish)`] = {
@@ -386,7 +386,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Radish": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(6),
+        "Crimson Baitfish": new Decimal(10),
       },
     };
     recipes[`Crimson Baitfish (Aged ${fish}, Pickled Onion)`] = {
@@ -396,7 +396,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(3),
+        "Crimson Baitfish": new Decimal(5),
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Onion)`] = {
@@ -406,7 +406,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(6),
+        "Crimson Baitfish": new Decimal(10),
       },
     };
   }
@@ -435,7 +435,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(3),
+        "Capsule Bait": new Decimal(5),
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Pepper)`] = {
@@ -445,7 +445,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(6),
+        "Capsule Bait": new Decimal(10),
       },
     };
   }
@@ -461,7 +461,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(3),
+        "Umbrella Bait": new Decimal(5),
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Onion)`] = {
@@ -471,7 +471,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(6),
+        "Umbrella Bait": new Decimal(10),
       },
     };
   }
@@ -487,7 +487,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(3),
+        "Crimson Baitfish": new Decimal(5),
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Tomato)`] = {
@@ -497,7 +497,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(6),
+        "Crimson Baitfish": new Decimal(10),
       },
     };
   }

--- a/src/features/game/types/fermentation.ts
+++ b/src/features/game/types/fermentation.ts
@@ -13,6 +13,14 @@ export type FermentationRecipeDefinition = {
 
 const GREENHOUSE_FERMENT_DURATION_SEC = 60 * 60 * 2;
 
+/**
+ * Bait fermentation output per (Aged | Prime Aged) fish. Shared across
+ * Capsule Bait, Umbrella Bait and Crimson Baitfish recipe families so
+ * balance changes stay one-touch.
+ */
+export const BAIT_OUTPUT_AGED = new Decimal(5);
+export const BAIT_OUTPUT_PRIME = new Decimal(10);
+
 const STATIC_FERMENTATION_RECIPES = {
   "Pickled Radish": {
     durationSeconds: 60 * 60,
@@ -284,7 +292,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Zucchini": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(5),
+        "Capsule Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Zucchini)`] = {
@@ -294,7 +302,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Zucchini": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(10),
+        "Capsule Bait": BAIT_OUTPUT_PRIME,
       },
     };
     recipes[`Capsule Bait (Aged ${fish}, Pickled Tomato)`] = {
@@ -304,7 +312,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(5),
+        "Capsule Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Tomato)`] = {
@@ -314,7 +322,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(10),
+        "Capsule Bait": BAIT_OUTPUT_PRIME,
       },
     };
   }
@@ -330,7 +338,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Cabbage": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(5),
+        "Umbrella Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Cabbage)`] = {
@@ -340,7 +348,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Cabbage": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(10),
+        "Umbrella Bait": BAIT_OUTPUT_PRIME,
       },
     };
     recipes[`Umbrella Bait (Aged ${fish}, Pickled Pepper)`] = {
@@ -350,7 +358,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(5),
+        "Umbrella Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Pepper)`] = {
@@ -360,7 +368,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(10),
+        "Umbrella Bait": BAIT_OUTPUT_PRIME,
       },
     };
   }
@@ -376,7 +384,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Radish": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(5),
+        "Crimson Baitfish": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Radish)`] = {
@@ -386,7 +394,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Radish": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(10),
+        "Crimson Baitfish": BAIT_OUTPUT_PRIME,
       },
     };
     recipes[`Crimson Baitfish (Aged ${fish}, Pickled Onion)`] = {
@@ -396,7 +404,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(5),
+        "Crimson Baitfish": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Onion)`] = {
@@ -406,7 +414,7 @@ function buildBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(10),
+        "Crimson Baitfish": BAIT_OUTPUT_PRIME,
       },
     };
   }
@@ -435,7 +443,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(5),
+        "Capsule Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Capsule Bait (Prime Aged ${fish}, Pickled Pepper)`] = {
@@ -445,7 +453,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Pepper": new Decimal(1),
       },
       outputs: {
-        "Capsule Bait": new Decimal(10),
+        "Capsule Bait": BAIT_OUTPUT_PRIME,
       },
     };
   }
@@ -461,7 +469,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(5),
+        "Umbrella Bait": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Umbrella Bait (Prime Aged ${fish}, Pickled Onion)`] = {
@@ -471,7 +479,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Onion": new Decimal(1),
       },
       outputs: {
-        "Umbrella Bait": new Decimal(10),
+        "Umbrella Bait": BAIT_OUTPUT_PRIME,
       },
     };
   }
@@ -487,7 +495,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(5),
+        "Crimson Baitfish": BAIT_OUTPUT_AGED,
       },
     };
     recipes[`Crimson Baitfish (Prime Aged ${fish}, Pickled Tomato)`] = {
@@ -497,7 +505,7 @@ function buildRetiredBaitFermentationRecipes(): Record<
         "Pickled Tomato": new Decimal(1),
       },
       outputs: {
-        "Crimson Baitfish": new Decimal(10),
+        "Crimson Baitfish": BAIT_OUTPUT_PRIME,
       },
     };
   }

--- a/src/features/game/types/tools.ts
+++ b/src/features/game/types/tools.ts
@@ -163,7 +163,7 @@ export const WORKBENCH_TOOLS: Record<
     description: "Used to harvest salt from salt nodes",
     price: 20,
     ingredients: () => ({ Wood: new Decimal(3) }),
-    stock: new Decimal(24),
+    stock: new Decimal(50),
     type: "water",
   },
 };


### PR DESCRIPTION
## Summary
- Salt Rake daily stock: 24 → 50
- Capsule Bait / Umbrella Bait / Crimson Baitfish fermentation output: 3 → 5 (Aged fish), 6 → 10 (Prime Aged fish) — applied to both startable and retired bait recipes
- Test expectations updated accordingly

Paired with API PR on `sunflower-land-api` same branch name.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn jest` for collectFermentation / startFermentation / harvestSalt / craftTool suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)