### PR TITLE
[FIX] Clear fermentation recipe when switching output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,8 @@ cache
 !/.cursor/rules/
 !/.cursor/rules/**
 
+# Claude Code: keep personal project rules local
+/CLAUDE.md
+/.claude/
+
 /*.json

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackEmpty.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackEmpty.tsx
@@ -132,7 +132,7 @@ export const FermentationRackEmpty: React.FC<Props> = ({
       <InnerPanel className="mb-1">
         <div className="flex flex-col gap-1 mb-1">
           <Label
-            type={selectedGroup ? "info" : "default"}
+            type={"default"}
             className="text-xs ml-1"
             icon={selectedItem ? ITEM_DETAILS[selectedItem]?.image : undefined}
           >

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
@@ -222,6 +222,10 @@ export const FermentationRackPanel: React.FC = () => {
       return t("error.noAvailableSlots");
     }
 
+    if (selectedSignature && selectedRecipeId === undefined) {
+      return t("agingShed.fermentation.selectRecipeRequired");
+    }
+
     if (selectedRecipeId && insufficientIngredient) {
       const name =
         ITEM_DETAILS[insufficientIngredient]?.translatedName ??

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackPanel.tsx
@@ -38,9 +38,6 @@ import { secondsToString } from "lib/utils/time";
 import { FermentationRackEmpty } from "./FermentationRackEmpty";
 import { FermentationRackInProgress } from "./FermentationRackInProgress";
 
-const OUTPUT_STORAGE_KEY = "lastFermentationOutputSignature";
-const RECIPE_STORAGE_KEY = "lastFermentationRecipeId";
-
 function getMergedInventory(state: GameState): Inventory {
   return {
     ...getBasketItems(state.inventory),
@@ -147,27 +144,13 @@ export const FermentationRackPanel: React.FC = () => {
   const applyOutputGroupSelection = useCallback(
     (group: FermentationOutputGroup) => {
       setSelectedSignature(group.signature);
-      if (typeof window !== "undefined") {
-        localStorage.setItem(OUTPUT_STORAGE_KEY, group.signature);
-      }
 
       if (group.recipeIds.length === 1) {
         setSelectedRecipeId(group.recipeIds[0]);
         return;
       }
 
-      const stored =
-        typeof window !== "undefined"
-          ? (localStorage.getItem(
-              RECIPE_STORAGE_KEY,
-            ) as FermentationRecipeName | null)
-          : null;
-
-      if (stored && group.recipeIds.includes(stored)) {
-        setSelectedRecipeId(stored);
-      } else {
-        setSelectedRecipeId(undefined);
-      }
+      setSelectedRecipeId(undefined);
     },
     [],
   );
@@ -178,10 +161,6 @@ export const FermentationRackPanel: React.FC = () => {
 
       const group = findFermentationGroupByStoredSignature(groups, sig);
       if (!group) {
-        if (typeof window !== "undefined") {
-          localStorage.removeItem(OUTPUT_STORAGE_KEY);
-        }
-
         const fallback = groups[0];
         if (fallback) {
           applyOutputGroupSelection(fallback);
@@ -200,10 +179,6 @@ export const FermentationRackPanel: React.FC = () => {
   const selectVariant = (recipeId: FermentationRecipeName) => {
     setStartError(undefined);
     setSelectedRecipeId(recipeId);
-
-    if (typeof window !== "undefined") {
-      localStorage.setItem(RECIPE_STORAGE_KEY, recipeId);
-    }
   };
 
   const handleStart = (recipeId: FermentationRecipeName) => {

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -8730,6 +8730,7 @@
   "agingShed.fermentation.timeRemaining": "{{time}} left",
   "agingShed.fermentation.slotsUsed": "Slots: {{used}}/{{max}}",
   "agingShed.fermentation.insufficientIngredient": "Not enough {{item}}",
+  "agingShed.fermentation.selectRecipeRequired": "Please select a recipe",
   "agingShed.spice.spiceSlots": "Spice Slots",
   "agingShed.spice.selectRecipe": "Select recipe",
   "agingShed.spice.requirementsTitle": "Ingredients",


### PR DESCRIPTION
## Summary
- Switching output groups in the Fermentation Rack no longer auto-restores the last recipe from `localStorage`. The recipe resets for multi-recipe groups so the user explicitly picks one before starting.
- Removed the unread `lastFermentationOutputSignature` storage key and the now-unused `lastFermentationRecipeId` key along with their read/write sites.
- Minor: output label in `FermentationRackEmpty` uses the `default` type consistently instead of flipping to `info` when a group is selected.

## Test plan
- [ ] Open Fermentation Rack, pick output A (multi-recipe), pick recipe X, then switch to output B (multi-recipe) → recipe field is empty, Start is disabled until a recipe is chosen.
- [ ] Switch to an output group with a single recipe → recipe auto-selects (unchanged).
- [ ] Reload the page → no stale recipe/output auto-selection from `localStorage`.
- [ ] Start a fermentation job end-to-end to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)