### PR TITLE
[FIX] Ager exploit: stamp skill at start so toggling before collect cannot double output

### DIFF
--- a/src/features/game/events/landExpansion/collectAgedFish.test.ts
+++ b/src/features/game/events/landExpansion/collectAgedFish.test.ts
@@ -22,7 +22,7 @@ const PRIME_AGED_PRNG_FIXTURE = {
 };
 
 function stateWithAgingSlots(
-  slots: { fish: string; readyAt: number }[],
+  slots: { fish: string; readyAt: number; agerApplied?: boolean }[],
   extra: Record<string, unknown> = {},
 ) {
   return createFermentationTestState({
@@ -36,6 +36,7 @@ function stateWithAgingSlots(
           fish: s.fish as "Anchovy",
           startedAt: createdAt - 10000,
           readyAt: s.readyAt,
+          skills: { Ager: s.agerApplied ?? false },
         })),
       },
     },
@@ -135,9 +136,56 @@ describe("collectAgedFish", () => {
   it("applies Ager skill to grant 2 items per slot", () => {
     const past = createdAt - 1;
     const state = collectAgedFish({
-      state: stateWithAgingSlots([{ fish: "Anchovy", readyAt: past }], {
-        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
-      }),
+      state: stateWithAgingSlots(
+        [{ fish: "Anchovy", readyAt: past, agerApplied: true }],
+        {
+          bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        },
+      ),
+      action: { type: "agingRack.collected" },
+      farmId: 1,
+      createdAt,
+    });
+
+    const aged = state.inventory["Aged Anchovy"]?.toNumber() ?? 0;
+    const prime = state.inventory["Prime Aged Anchovy"]?.toNumber() ?? 0;
+
+    expect(aged + prime).toBe(2);
+  });
+
+  it("ignores Ager skill activated after starting (exploit guard)", () => {
+    // Slot was queued without the Ager stamp; player then activated the skill.
+    // Output must still be 1x because the input was paid at 1x.
+    const past = createdAt - 1;
+    const state = collectAgedFish({
+      state: stateWithAgingSlots(
+        [{ fish: "Anchovy", readyAt: past, agerApplied: false }],
+        {
+          bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        },
+      ),
+      action: { type: "agingRack.collected" },
+      farmId: 1,
+      createdAt,
+    });
+
+    const aged = state.inventory["Aged Anchovy"]?.toNumber() ?? 0;
+    const prime = state.inventory["Prime Aged Anchovy"]?.toNumber() ?? 0;
+
+    expect(aged + prime).toBe(1);
+  });
+
+  it("honours Ager stamp even when skill is deactivated after starting", () => {
+    // Slot was queued with Ager active (2x input paid); skill then removed.
+    // Output must still be 2x because the slot was paid at 2x.
+    const past = createdAt - 1;
+    const state = collectAgedFish({
+      state: stateWithAgingSlots(
+        [{ fish: "Anchovy", readyAt: past, agerApplied: true }],
+        {
+          bumpkin: { ...INITIAL_BUMPKIN, skills: {} },
+        },
+      ),
       action: { type: "agingRack.collected" },
       farmId: 1,
       createdAt,

--- a/src/features/game/events/landExpansion/collectAgedFish.ts
+++ b/src/features/game/events/landExpansion/collectAgedFish.ts
@@ -68,11 +68,17 @@ export function collectAgedFish({
         (game.farmActivity[`${agedName} Collected`] ?? 0) +
         (game.farmActivity[`${primeAgedName} Collected`] ?? 0);
 
-      const outputAmount = getAgingOutput(game, new Decimal(1), slot.fish, {
-        farmId,
-        itemId: KNOWN_IDS[slot.fish],
-        counter,
-      });
+      const outputAmount = getAgingOutput(
+        game,
+        new Decimal(1),
+        slot.fish,
+        !!slot.skills?.Ager,
+        {
+          farmId,
+          itemId: KNOWN_IDS[slot.fish],
+          counter,
+        },
+      );
 
       const isPrime = prngChance({
         farmId,

--- a/src/features/game/events/landExpansion/collectFermentation.test.ts
+++ b/src/features/game/events/landExpansion/collectFermentation.test.ts
@@ -392,7 +392,7 @@ describe("collectFermentation", () => {
     },
   );
 
-  it("applies Ager skill to double fermentation output", () => {
+  it("applies Ager skill to double fermentation output when stamped", () => {
     const past = createdAt - 1;
 
     const state = collectFermentation({
@@ -408,6 +408,69 @@ describe("collectFermentation", () => {
                 recipe: "Pickled Radish",
                 startedAt: past,
                 readyAt: past,
+                skills: { Ager: true },
+              },
+            ],
+          },
+        },
+      }),
+      action: { type: "fermentation.collected" },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.inventory["Pickled Radish"]?.toNumber()).toEqual(2);
+  });
+
+  it("ignores Ager skill activated after starting (exploit guard)", () => {
+    // Job was queued without the Ager stamp (1x input); activating Ager after
+    // must not double the output.
+    const past = createdAt - 1;
+
+    const state = collectFermentation({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        agingShed: {
+          ...createInitialAgingShed(),
+          racks: {
+            ...createInitialAgingShed().racks,
+            fermentation: [
+              {
+                id: "ager-exploit",
+                recipe: "Pickled Radish",
+                startedAt: past,
+                readyAt: past,
+                skills: { Ager: false },
+              },
+            ],
+          },
+        },
+      }),
+      action: { type: "fermentation.collected" },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.inventory["Pickled Radish"]?.toNumber()).toEqual(1);
+  });
+
+  it("honours Ager stamp even when skill is deactivated after starting", () => {
+    const past = createdAt - 1;
+
+    const state = collectFermentation({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: {} },
+        agingShed: {
+          ...createInitialAgingShed(),
+          racks: {
+            ...createInitialAgingShed().racks,
+            fermentation: [
+              {
+                id: "ager-stamped",
+                recipe: "Pickled Radish",
+                startedAt: past,
+                readyAt: past,
+                skills: { Ager: true },
               },
             ],
           },

--- a/src/features/game/events/landExpansion/collectFermentation.ts
+++ b/src/features/game/events/landExpansion/collectFermentation.ts
@@ -42,7 +42,12 @@ export function collectFermentation({
     );
 
     ready.forEach((job) => {
-      grantFermentationRecipeOutputs(game, job.recipe, farmId);
+      grantFermentationRecipeOutputs(
+        game,
+        job.recipe,
+        farmId,
+        !!job.skills?.Ager,
+      );
     });
   });
 }

--- a/src/features/game/events/landExpansion/collectSpiceRack.test.ts
+++ b/src/features/game/events/landExpansion/collectSpiceRack.test.ts
@@ -175,7 +175,7 @@ describe("collectSpiceRack", () => {
     },
   );
 
-  it("applies Ager skill to double spice rack output", () => {
+  it("applies Ager skill to double spice rack output when stamped", () => {
     const past = createdAt - 1;
 
     const state = collectSpiceRack({
@@ -191,6 +191,7 @@ describe("collectSpiceRack", () => {
                 recipe: "Salt Lick",
                 startedAt: past,
                 readyAt: past,
+                skills: { Ager: true },
               },
             ],
           },
@@ -202,6 +203,38 @@ describe("collectSpiceRack", () => {
     });
 
     expect(state.inventory["Salt Lick"]?.toNumber()).toEqual(10);
+  });
+
+  it("ignores Ager skill activated after starting (exploit guard)", () => {
+    // Job was queued without Ager (1x input paid); activating Ager after
+    // must not double the output.
+    const past = createdAt - 1;
+
+    const state = collectSpiceRack({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        agingShed: {
+          ...createInitialAgingShed(),
+          racks: {
+            ...createInitialAgingShed().racks,
+            spice: [
+              {
+                id: "ager-exploit",
+                recipe: "Salt Lick",
+                startedAt: past,
+                readyAt: past,
+                skills: { Ager: false },
+              },
+            ],
+          },
+        },
+      }),
+      action: { type: "spiceRack.collected" },
+      createdAt,
+      farmId: 1,
+    });
+
+    expect(state.inventory["Salt Lick"]?.toNumber()).toEqual(5);
   });
 
   describe("Refiner skill (Refined Salt output)", () => {
@@ -308,6 +341,7 @@ describe("collectSpiceRack", () => {
                   recipe: "Refined Salt",
                   startedAt: past,
                   readyAt: past,
+                  skills: { Ager: true },
                 },
               ],
             },

--- a/src/features/game/events/landExpansion/collectSpiceRack.ts
+++ b/src/features/game/events/landExpansion/collectSpiceRack.ts
@@ -51,14 +51,21 @@ export function collectSpiceRack({
       const recipeDef = getSpiceRackRecipe(job.recipe);
       const counter =
         game.farmActivity[spiceRackCollectedActivity(job.recipe)] ?? 0;
+      const agerApplied = !!job.skills?.Ager;
 
       for (const [item, amount] of getObjectEntries(recipeDef.outputs)) {
         const prev = game.inventory[item] ?? new Decimal(0);
-        const add = getAgingOutput(game, amount ?? new Decimal(0), item, {
-          farmId,
-          itemId: KNOWN_IDS[item],
-          counter,
-        });
+        const add = getAgingOutput(
+          game,
+          amount ?? new Decimal(0),
+          item,
+          agerApplied,
+          {
+            farmId,
+            itemId: KNOWN_IDS[item],
+            counter,
+          },
+        );
 
         game.inventory[item] = prev.add(add);
       }

--- a/src/features/game/events/landExpansion/grantFermentationRecipeOutputs.ts
+++ b/src/features/game/events/landExpansion/grantFermentationRecipeOutputs.ts
@@ -18,16 +18,23 @@ export function grantFermentationRecipeOutputs(
   game: GameState,
   recipe: FermentationRecipeName,
   farmId: number,
+  agerApplied: boolean,
 ): void {
   const recipeDef = getFermentationRecipe(recipe);
 
   for (const [item, amount] of getObjectEntries(recipeDef.outputs)) {
     const prev = game.inventory[item] ?? new Decimal(0);
-    const add = getAgingOutput(game, amount ?? new Decimal(0), item, {
-      farmId,
-      itemId: KNOWN_IDS[item],
-      counter: game.farmActivity[`${item} Fermented`] ?? 0,
-    });
+    const add = getAgingOutput(
+      game,
+      amount ?? new Decimal(0),
+      item,
+      agerApplied,
+      {
+        farmId,
+        itemId: KNOWN_IDS[item],
+        counter: game.farmActivity[`${item} Fermented`] ?? 0,
+      },
+    );
     game.inventory[item] = prev.add(add);
 
     const activityName: FermentationCollectedActivity = `${item} Fermented`;

--- a/src/features/game/events/landExpansion/startAging.test.ts
+++ b/src/features/game/events/landExpansion/startAging.test.ts
@@ -340,6 +340,41 @@ describe("startAging", () => {
     expect(state.inventory.Anchovy?.toNumber()).toBe(3);
   });
 
+  it("stamps Ager=true on the slot when the skill is active", () => {
+    const state = startAging({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        inventory: { Anchovy: new Decimal(5), Salt: new Decimal(100) },
+      }),
+      action: {
+        type: "agingRack.started",
+        fish: "Anchovy",
+        slotId: TEST_SLOT_ID,
+      },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.aging[0].skills?.Ager).toBe(true);
+  });
+
+  it("stamps Ager=false on the slot when the skill is not active", () => {
+    const state = startAging({
+      state: createFermentationTestState({
+        inventory: { Anchovy: new Decimal(1), Salt: new Decimal(100) },
+      }),
+      action: {
+        type: "agingRack.started",
+        fish: "Anchovy",
+        slotId: TEST_SLOT_ID,
+      },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.aging[0].skills?.Ager).toBe(false);
+  });
+
   it("throws when Ager requires 2 fish but only 1 available", () => {
     expect(() =>
       startAging({

--- a/src/features/game/events/landExpansion/startAging.ts
+++ b/src/features/game/events/landExpansion/startAging.ts
@@ -82,6 +82,8 @@ export function startAging({
       fish: action.fish,
       startedAt: createdAt,
       readyAt: createdAt + getBoostedAgingTimeMs(baseXP, game),
+      // Marks whether the Ager skill was applied at the time of starting
+      skills: { Ager: !!game.bumpkin.skills["Ager"] },
     };
 
     game.agingShed.racks.aging = [...queue, slot];

--- a/src/features/game/events/landExpansion/startFermentation.test.ts
+++ b/src/features/game/events/landExpansion/startFermentation.test.ts
@@ -641,6 +641,41 @@ describe("startFermentation", () => {
     expect(state.inventory.Salt?.toNumber()).toBe(0);
   });
 
+  it("stamps Ager=true on the fermentation job when the skill is active", () => {
+    const state = startFermentation({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        inventory: { Radish: new Decimal(20), Salt: new Decimal(10) },
+      }),
+      action: {
+        type: "fermentation.started",
+        recipe: "Pickled Radish",
+        jobId: "ager-stamp",
+      },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.fermentation[0].skills?.Ager).toBe(true);
+  });
+
+  it("stamps Ager=false on the fermentation job when the skill is not active", () => {
+    const state = startFermentation({
+      state: createFermentationTestState({
+        inventory: { Radish: new Decimal(10), Salt: new Decimal(5) },
+      }),
+      action: {
+        type: "fermentation.started",
+        recipe: "Pickled Radish",
+        jobId: "no-ager-stamp",
+      },
+      farmId: 1,
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.fermentation[0].skills?.Ager).toBe(false);
+  });
+
   it("throws when Ager doubles cost beyond available ingredients", () => {
     expect(() =>
       startFermentation({

--- a/src/features/game/events/landExpansion/startFermentation.ts
+++ b/src/features/game/events/landExpansion/startFermentation.ts
@@ -78,8 +78,10 @@ export function startFermentation({
       game.inventory[ingredient] = count.sub(need);
     }
 
+    const agerApplied = !!game.bumpkin.skills["Ager"];
+
     if (durationSeconds === 0) {
-      grantFermentationRecipeOutputs(game, action.recipe, farmId);
+      grantFermentationRecipeOutputs(game, action.recipe, farmId, agerApplied);
       return;
     }
 
@@ -90,6 +92,8 @@ export function startFermentation({
       recipe: action.recipe,
       startedAt: createdAt,
       readyAt,
+      // Marks whether the Ager skill was applied at the time of starting
+      skills: { Ager: agerApplied },
     };
 
     game.agingShed.racks.fermentation = [...queue, job];

--- a/src/features/game/events/landExpansion/startSpiceRack.test.ts
+++ b/src/features/game/events/landExpansion/startSpiceRack.test.ts
@@ -206,6 +206,41 @@ describe("startSpiceRack", () => {
     expect(state.inventory.Salt?.toNumber()).toEqual(0);
   });
 
+  it("stamps Ager=true on the spice rack job when the skill is active", () => {
+    const state = startSpiceRack({
+      state: createFermentationTestState({
+        bumpkin: { ...INITIAL_BUMPKIN, skills: { Ager: 1 } },
+        agingShed: { ...createInitialAgingShed(), level: 2 },
+        inventory: { Salt: new Decimal(20) },
+      }),
+      action: {
+        type: "spiceRack.started",
+        recipe: "Refined Salt",
+        jobId: TEST_JOB_ID,
+      },
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.spice[0].skills?.Ager).toBe(true);
+  });
+
+  it("stamps Ager=false on the spice rack job when the skill is not active", () => {
+    const state = startSpiceRack({
+      state: createFermentationTestState({
+        agingShed: { ...createInitialAgingShed(), level: 2 },
+        inventory: { Salt: new Decimal(10) },
+      }),
+      action: {
+        type: "spiceRack.started",
+        recipe: "Refined Salt",
+        jobId: TEST_JOB_ID,
+      },
+      createdAt,
+    });
+
+    expect(state.agingShed.racks.spice[0].skills?.Ager).toBe(false);
+  });
+
   it("throws when Ager doubles cost beyond available ingredients", () => {
     expect(() =>
       startSpiceRack({

--- a/src/features/game/events/landExpansion/startSpiceRack.ts
+++ b/src/features/game/events/landExpansion/startSpiceRack.ts
@@ -84,6 +84,8 @@ export function startSpiceRack({
       recipe: action.recipe,
       startedAt: createdAt,
       readyAt,
+      // Marks whether the Ager skill was applied at the time of starting
+      skills: { Ager: !!game.bumpkin.skills["Ager"] },
     };
 
     game.agingShed.racks.spice = [...queue, job];

--- a/src/features/game/lib/agingShed.ts
+++ b/src/features/game/lib/agingShed.ts
@@ -7,11 +7,16 @@ import type {
 } from "../types/fishing";
 import type { SpiceRackRecipeName } from "../types/spiceRack";
 
+// Marks whether an Ager-stamped skill was applied at the time of starting the job.
+// Optional for backwards compatibility with jobs queued before the stamp existed.
+export type AgingSkillStamp = { Ager?: boolean };
+
 export type FermentationJob = {
   id: string;
   recipe: FermentationRecipeName;
   startedAt: number;
   readyAt: number;
+  skills?: AgingSkillStamp;
 };
 
 export type AgingRackSlot = {
@@ -19,6 +24,7 @@ export type AgingRackSlot = {
   fish: FishName;
   startedAt: number;
   readyAt: number;
+  skills?: AgingSkillStamp;
 };
 
 export type AgingCollectResult = {
@@ -31,6 +37,7 @@ export type SpiceRackJob = {
   recipe: SpiceRackRecipeName;
   startedAt: number;
   readyAt: number;
+  skills?: AgingSkillStamp;
 };
 
 export type AgingShed = UpgradableBuilding & {

--- a/src/features/game/types/agingFormulas.test.ts
+++ b/src/features/game/types/agingFormulas.test.ts
@@ -47,7 +47,7 @@ describe("getAgingOutput", () => {
   it("returns base amount when no relevant skills", () => {
     const state = stateWithSkills({} as Skills);
     expect(
-      getAgingOutput(state, new Decimal(3), "Salt", {
+      getAgingOutput(state, new Decimal(3), "Salt", false, {
         farmId,
         itemId: KNOWN_IDS.Salt,
         counter: 0,
@@ -55,10 +55,34 @@ describe("getAgingOutput", () => {
     ).toBe(3);
   });
 
-  it("doubles output for Ager on any item", () => {
+  it("doubles output when agerApplied is true", () => {
     const state = stateWithSkills({ Ager: 1 } as Skills);
     expect(
-      getAgingOutput(state, new Decimal(2), "Pickled Radish", {
+      getAgingOutput(state, new Decimal(2), "Pickled Radish", true, {
+        farmId,
+        itemId: KNOWN_IDS["Pickled Radish"],
+        counter: 0,
+      }).toNumber(),
+    ).toBe(4);
+  });
+
+  it("ignores current Ager skill when stamp says not applied", () => {
+    // Exploit guard: player activates Ager after starting; stamp was false → 1x output
+    const state = stateWithSkills({ Ager: 1 } as Skills);
+    expect(
+      getAgingOutput(state, new Decimal(2), "Pickled Radish", false, {
+        farmId,
+        itemId: KNOWN_IDS["Pickled Radish"],
+        counter: 0,
+      }).toNumber(),
+    ).toBe(2);
+  });
+
+  it("applies Ager stamp even when current skill is off", () => {
+    // Symmetric guard: player deactivates Ager after starting; stamp was true → 2x output
+    const state = stateWithSkills({} as Skills);
+    expect(
+      getAgingOutput(state, new Decimal(2), "Pickled Radish", true, {
         farmId,
         itemId: KNOWN_IDS["Pickled Radish"],
         counter: 0,
@@ -97,18 +121,24 @@ describe("getAgingOutput", () => {
     it("does not add Refiner bonus without the skill", () => {
       const base = new Decimal(2);
       expect(
-        getAgingOutput(stateWithSkills({} as Skills), base, "Refined Salt", {
-          farmId,
-          itemId: refinedSaltId,
-          counter: 4,
-        }).toNumber(),
+        getAgingOutput(
+          stateWithSkills({} as Skills),
+          base,
+          "Refined Salt",
+          false,
+          {
+            farmId,
+            itemId: refinedSaltId,
+            counter: 4,
+          },
+        ).toNumber(),
       ).toBe(2);
     });
 
     it("does not roll Refiner for non–Refined Salt items", () => {
       const stateWithRefiner = stateWithSkills({ Refiner: 1 } as Skills);
       expect(
-        getAgingOutput(stateWithRefiner, new Decimal(2), "Salt", {
+        getAgingOutput(stateWithRefiner, new Decimal(2), "Salt", false, {
           farmId,
           itemId: KNOWN_IDS.Salt,
           counter: 4,
@@ -118,7 +148,7 @@ describe("getAgingOutput", () => {
 
     it("adds +1 on PRNG hit (counter 4) from base 2", () => {
       expect(
-        getAgingOutput(state, new Decimal(2), "Refined Salt", {
+        getAgingOutput(state, new Decimal(2), "Refined Salt", false, {
           farmId,
           itemId: refinedSaltId,
           counter: 4,
@@ -128,7 +158,7 @@ describe("getAgingOutput", () => {
 
     it("does not add Refiner +1 on PRNG miss (counter 0) from base 2", () => {
       expect(
-        getAgingOutput(state, new Decimal(2), "Refined Salt", {
+        getAgingOutput(state, new Decimal(2), "Refined Salt", false, {
           farmId,
           itemId: refinedSaltId,
           counter: 0,
@@ -142,7 +172,7 @@ describe("getAgingOutput", () => {
         Refiner: 1,
       } as Skills);
       expect(
-        getAgingOutput(agerRefinerState, new Decimal(2), "Refined Salt", {
+        getAgingOutput(agerRefinerState, new Decimal(2), "Refined Salt", true, {
           farmId,
           itemId: refinedSaltId,
           counter: 4,

--- a/src/features/game/types/agingFormulas.ts
+++ b/src/features/game/types/agingFormulas.ts
@@ -82,11 +82,12 @@ export function getAgingOutput(
   state: GameState,
   baseAmount: Decimal,
   item: InventoryItemName,
+  agerApplied: boolean,
   prngArgs?: { farmId: number; itemId: number; counter: number },
 ): Decimal {
   const skills = state.bumpkin.skills;
   let output = baseAmount;
-  if (skills["Ager"]) {
+  if (agerApplied) {
     output = output.mul(2);
   }
 

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackEmpty.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackEmpty.tsx
@@ -124,6 +124,7 @@ export const FermentationRackEmpty: React.FC<Props> = ({
           getFermentationRecipe(recipeId).outputs[selectedItem] ??
             new Decimal(0),
           selectedItem,
+          !!gameState.bumpkin.skills["Ager"],
         )
       : undefined;
 

--- a/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackInProgress.tsx
+++ b/src/features/island/buildings/components/building/agingShed/fermentationRack/FermentationRackInProgress.tsx
@@ -51,6 +51,7 @@ export const FermentationRackInProgress: React.FC<Props> = ({
     state,
     outputEntry?.[1] ?? new Decimal(0),
     outputItem,
+    !!job.skills?.Ager,
   );
 
   const timeRemainingMs = Math.max(0, job.readyAt - now);

--- a/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackEmpty.tsx
+++ b/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackEmpty.tsx
@@ -84,6 +84,7 @@ export const SpiceRackEmpty: React.FC<Props> = ({
         gameState,
         recipeDef?.outputs[selectedRecipeId] ?? new Decimal(0),
         selectedRecipeId,
+        !!gameState.bumpkin.skills["Ager"],
       )
     : undefined;
 

--- a/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackInProgress.tsx
+++ b/src/features/island/buildings/components/building/agingShed/spiceRack/SpiceRackInProgress.tsx
@@ -55,6 +55,7 @@ export const SpiceRackInProgress: React.FC<Props> = ({
     state,
     outputEntry?.[1] ?? new Decimal(0),
     outputItem,
+    !!job.skills?.Ager,
   );
 
   const timeRemainingMs = Math.max(0, job.readyAt - now);


### PR DESCRIPTION
## Summary

The **Ager** skill doubles both the input cost (at start time) and the output amount (at collect time). Because both sides read the current bumpkin skill state, a player could:

1. Queue an aging / fermentation / spice rack job **without** Ager — pays 1× input.
2. Activate Ager via skill tree.
3. Collect — receives 2× output.

The reverse toggle was also broken: starting with Ager (2× input paid) then deactivating it before collecting would give only 1× output.

## Fix

Stamp the skill state onto each in-flight slot / job at the moment input is deducted:

- `AgingRackSlot`, `FermentationJob`, `SpiceRackJob` gain an optional `skills?: { Ager?: boolean }` field.
- `startAging`, `startFermentation`, `startSpiceRack` write the stamp from current bumpkin state.
- `getAgingOutput` now takes an explicit `agerApplied: boolean`; `collectAgedFish`, `collectFermentation` (via `grantFermentationRecipeOutputs`), and `collectSpiceRack` pass the slot's stamp.
- UI "in progress" panels read the stamp; "empty" panels (preview of a job you're about to start) keep using current bumpkin state — the preview matches what would be stamped if you started now.

Mirrors the same pattern used for **Double Nom** in the cooking path ([cook.ts:260, 299](https://github.com/sunflower-land/sunflower-land/blob/main/src/features/game/events/landExpansion/cook.ts#L260)), which solves the same class of bug.

Refiner and Bacalhau are deliberately untouched — they only affect output (no matching input cost), so there is no input/output asymmetry to exploit.

## Backend

Mirrored server-side at sunflower-land/sunflower-land-api#3336. Both sides must ship together.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Jest suite for aging / fermentation / spice rack / formulas — 400/400 tests pass locally
- [x] New test cases cover: queue-without-Ager-then-activate (1× output), queue-with-Ager-then-deactivate (2× output), Ager + Refiner stacking on hit, stamp assertion at start
- [ ] Smoke test in browser: start fermentation without Ager → activate Ager → collect should not grant bonus

🤖 Generated with [Claude Code](https://claude.com/claude-code)