### PR TITLE
[FIX] Populate salt farm on skill reset

### DIFF
--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -129,8 +129,8 @@ export function resetSkills({
 
     if (hasFeatureAccess(game, "SALT_FARM")) {
       populateSaltFarm({
-        gameBefore: { ...state },
-        gameAfter: { ...game },
+        gameBefore: state,
+        gameAfter: game,
         now: createdAt,
       });
     }

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -2,6 +2,8 @@ import { getKeys } from "lib/object";
 import { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
+import { populateSaltFarm } from "features/game/types/salt";
+import { hasFeatureAccess } from "lib/flags";
 
 export type PaymentType = "gems" | "free" | "ticket";
 
@@ -124,6 +126,14 @@ export function resetSkills({
     }
 
     bumpkin.skills = {};
+
+    if (hasFeatureAccess(game, "SALT_FARM")) {
+      populateSaltFarm({
+        gameBefore: { ...state },
+        gameAfter: { ...game },
+        now: createdAt,
+      });
+    }
 
     return game;
   });


### PR DESCRIPTION
## Summary
- Skill resets can remove skills that affect salt charge generation time, active boosts, or max stored charges. Without crystallising accrued salt charges at the pre-reset rate, players would either lose or unfairly accumulate charges across the reset boundary.
- Calls `populateSaltFarm` at the end of `resetSkills` (gated by `SALT_FARM` feature access), matching how other boost-changing mutations (`choseSkill`, `equip`, `equipFarmHand`, `removeCollectible`, `placeCollectible`, `upgradeSaltSculpture`) already handle this.

## Test plan
- [ ] With `SALT_FARM` enabled, have a bumpkin with a salt-affecting skill, let charges accrue, then reset skills — charges should be crystallised at the pre-reset rate and the new rate should apply going forward.
- [ ] Resetting skills with no salt-affecting skill should leave salt farm state unchanged (early-return path in `populateSaltFarm`).
- [ ] Without `SALT_FARM` feature access, skill reset behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)