### PR TITLE
[CHORE] Add Max level badge to SleepingAnimalModal.tsx

### DIFF
--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -106,13 +106,7 @@ export const SleepingAnimalModal = ({
           <Label type="formula" className="text-xs">
             {`Lvl. ${level}`}
           </Label>
-          {isMaxLevel && (
-            <Label
-              type="warning"
-            >
-              {"MAX"}
-            </Label>
-          )}
+          {isMaxLevel && <Label type="warning">{"MAX"}</Label>}
         </div>
 
         <div className="flex text-sm p-1 items-center">

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -16,6 +16,7 @@ import { Animal } from "features/game/types/game";
 import {
   getAnimalFavoriteFood,
   getAnimalLevel,
+  isMaxLevel as isMaxAnimalLevel,
 } from "features/game/lib/animals";
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
@@ -90,6 +91,7 @@ export const SleepingAnimalModal = ({
   const hasTool = getCountAndType(state, animal.item).count.gt(0);
 
   const level = getAnimalLevel(animal.experience, animal.type);
+  const isMaxLevel = isMaxAnimalLevel(animal.type, level);
 
   const { name: mutantName } = animal.reward?.items?.[0] ?? {};
 
@@ -104,6 +106,18 @@ export const SleepingAnimalModal = ({
           <Label type="formula" className="text-xs">
             {`Lvl. ${level}`}
           </Label>
+          {isMaxLevel && (
+            <Label
+              type="formula"
+              className="text-xs ml-1"
+              style={{
+                background: "#E18C00",
+                color: "#3e2731",
+              }}
+            >
+              {"MAX"}
+            </Label>
+          )}
         </div>
 
         <div className="flex text-sm p-1 items-center">

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -108,12 +108,7 @@ export const SleepingAnimalModal = ({
           </Label>
           {isMaxLevel && (
             <Label
-              type="formula"
-              className="text-xs ml-1"
-              style={{
-                background: "#E18C00",
-                color: "#3e2731",
-              }}
+              type="warning"
             >
               {"MAX"}
             </Label>


### PR DESCRIPTION
Added a MAX badge next to the animal level badge in the sleeping animal modal. 
The badge appears only when the animal has reached the maximum configured level.



## Context / motivation

https://discord.com/channels/880987707214544966/1324494700719243416/1468478829482868738

## Screenshots or screen recording

<img width="884" height="388" alt="telegram-cloud-photo-size-2-5420454431175677767-y" src="https://github.com/user-attachments/assets/b51c8714-3069-4177-86bd-e9c18ad6a01a" />

(color badge background little lighter at code) 
