### PR TITLE
[FEAT] Auction Boosts

### DIFF
--- a/src/features/game/events/landExpansion/collectWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.test.ts
@@ -288,7 +288,7 @@ describe("collectWaterTrap", () => {
           },
         },
         farmActivity: {
-          "Barnacle Caught": 1,
+          "Barnacle Caught": counter,
         },
       },
       action: {

--- a/src/features/game/events/landExpansion/collectWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.test.ts
@@ -4,6 +4,8 @@ import { GameState } from "features/game/types/game";
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { InventoryItemName } from "features/game/types/game";
 import { CrustaceanName } from "features/game/types/crustaceans";
+import { KNOWN_IDS } from "features/game/types";
+import { prngChance } from "lib/prng";
 
 const trapId = "1";
 const GAME_STATE: GameState = {
@@ -24,6 +26,7 @@ describe("collectWaterTrap", () => {
   it("requires a water trap to be placed", () => {
     expect(() =>
       collectWaterTrap({
+        farmId: 1,
         state: GAME_STATE,
         action: {
           type: "waterTrap.collected",
@@ -37,6 +40,7 @@ describe("collectWaterTrap", () => {
   it("rejects collection when trap is not ready yet", () => {
     expect(() =>
       collectWaterTrap({
+        farmId: 1,
         state: {
           ...GAME_STATE,
           crabTraps: {
@@ -69,6 +73,7 @@ describe("collectWaterTrap", () => {
     };
 
     const state = collectWaterTrap({
+      farmId: 1,
       state: {
         ...GAME_STATE,
         inventory: {},
@@ -107,6 +112,7 @@ describe("collectWaterTrap", () => {
     };
 
     const state = collectWaterTrap({
+      farmId: 1,
       state: {
         ...GAME_STATE,
         inventory: {},
@@ -143,6 +149,7 @@ describe("collectWaterTrap", () => {
     };
 
     const state = collectWaterTrap({
+      farmId: 1,
       state: {
         ...GAME_STATE,
         inventory: {},
@@ -188,6 +195,7 @@ describe("collectWaterTrap", () => {
     };
 
     const state = collectWaterTrap({
+      farmId: 1,
       state: {
         ...GAME_STATE,
         inventory: {},
@@ -228,5 +236,69 @@ describe("collectWaterTrap", () => {
 
     // Without Crab House: 1, With Crab House: 1 + 2 = 3
     expect(state.inventory.Barnacle).toEqual(new Decimal(3));
+  });
+
+  it("grants +1 crustacean on 20% prng chance when 'Pistol Shrimp' wearable is active", () => {
+    // Arrange the trap/caught state
+    const caught: Partial<Record<CrustaceanName, number>> = {
+      Barnacle: 1,
+    };
+
+    let counter = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (
+        prngChance({
+          farmId: 1,
+          itemId: KNOWN_IDS.Barnacle,
+          counter,
+          chance: 20,
+          criticalHitName: "Pistol Shrimp",
+        })
+      ) {
+        break;
+      }
+      counter++;
+    }
+
+    const state = collectWaterTrap({
+      farmId: 1,
+      state: {
+        ...GAME_STATE,
+        inventory: {},
+        crabTraps: {
+          trapSpots: {
+            [trapId]: {
+              x: 0,
+              y: 0,
+              waterTrap: {
+                type: "Crab Pot",
+                placedAt: createdAt - 1000,
+                readyAt: createdAt - 1000,
+                caught,
+              },
+            },
+          },
+        },
+        bumpkin: {
+          ...GAME_STATE.bumpkin,
+          equipped: {
+            ...GAME_STATE.bumpkin?.equipped,
+            tool: "Pistol Shrimp",
+          },
+        },
+        farmActivity: {
+          "Barnacle Caught": 1,
+        },
+      },
+      action: {
+        type: "waterTrap.collected",
+        trapId,
+      },
+      createdAt,
+    });
+
+    // Expect original amount +1 thanks to Pistol Shrimp crit
+    expect(state.inventory.Barnacle).toEqual(new Decimal(2));
   });
 });

--- a/src/features/game/events/landExpansion/collectWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.test.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { collectWaterTrap } from "./collectWaterTrap";
 import { GameState } from "features/game/types/game";
 import { INITIAL_FARM } from "features/game/lib/constants";
-import { InventoryItemName } from "features/game/types/game";
 import { CrustaceanName } from "features/game/types/crustaceans";
 import { KNOWN_IDS } from "features/game/types";
 import { prngChance } from "lib/prng";
@@ -68,8 +67,8 @@ describe("collectWaterTrap", () => {
   });
 
   it("collects items from a picked up trap", () => {
-    const caught: Partial<Record<InventoryItemName, number>> = {
-      Crab: 8,
+    const caught: Partial<Record<CrustaceanName, number>> = {
+      Barnacle: 8,
     };
 
     const state = collectWaterTrap({
@@ -99,16 +98,16 @@ describe("collectWaterTrap", () => {
       createdAt,
     });
 
-    expect(state.inventory.Crab).toEqual(new Decimal(8));
+    expect(state.inventory.Barnacle).toEqual(new Decimal(8));
     expect(state.crabTraps.trapSpots?.[trapId]?.waterTrap).toBeUndefined();
-    expect(state.farmActivity["Crab Caught"]).toBe(8);
+    expect(state.farmActivity["Barnacle Caught"]).toBe(1);
   });
 
   it("tracks farm activity for each caught item", () => {
-    const caught: Partial<Record<InventoryItemName, number>> = {
-      Crab: 10,
-      "Sea Bass": 5,
-      Tuna: 1,
+    const caught: Partial<Record<CrustaceanName, number>> = {
+      Barnacle: 10,
+      "Sea Slug": 5,
+      "Sea Grapes": 1,
     };
 
     const state = collectWaterTrap({
@@ -138,14 +137,14 @@ describe("collectWaterTrap", () => {
       createdAt,
     });
 
-    expect(state.farmActivity["Crab Caught"]).toBe(10);
-    expect(state.farmActivity["Sea Bass Caught"]).toBe(5);
-    expect(state.farmActivity["Tuna Caught"]).toBe(1);
+    expect(state.farmActivity["Barnacle Caught"]).toBe(1);
+    expect(state.farmActivity["Sea Slug Caught"]).toBe(1);
+    expect(state.farmActivity["Sea Grapes Caught"]).toBe(1);
   });
 
   it("removes the water trap after collection", () => {
-    const caught: Partial<Record<InventoryItemName, number>> = {
-      Crab: 8,
+    const caught: Partial<Record<CrustaceanName, number>> = {
+      Barnacle: 8,
     };
 
     const state = collectWaterTrap({

--- a/src/features/game/events/landExpansion/collectWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.test.ts
@@ -3,6 +3,7 @@ import { collectWaterTrap } from "./collectWaterTrap";
 import { GameState } from "features/game/types/game";
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { InventoryItemName } from "features/game/types/game";
+import { CrustaceanName } from "features/game/types/crustaceans";
 
 const trapId = "1";
 const GAME_STATE: GameState = {
@@ -179,5 +180,53 @@ describe("collectWaterTrap", () => {
 
     expect(state.crabTraps.trapSpots?.[trapId]?.waterTrap).toBeUndefined();
     expect(state.crabTraps.trapSpots?.["other-trap"]?.waterTrap).toBeDefined();
+  });
+
+  it("gives extra crustaceans if the player has Crab House placed", () => {
+    const caught: Partial<Record<CrustaceanName, number>> = {
+      Barnacle: 1,
+    };
+
+    const state = collectWaterTrap({
+      state: {
+        ...GAME_STATE,
+        inventory: {},
+        crabTraps: {
+          trapSpots: {
+            [trapId]: {
+              x: 0,
+              y: 0,
+              waterTrap: {
+                type: "Crab Pot",
+                placedAt: createdAt - 1000,
+                readyAt: createdAt - 1000,
+                caught,
+              },
+            },
+          },
+        },
+        collectibles: {
+          "Crab House": [
+            {
+              id: "crab-house-1",
+              createdAt,
+              readyAt: createdAt,
+              coordinates: {
+                x: 0,
+                y: 0,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "waterTrap.collected",
+        trapId,
+      },
+      createdAt,
+    });
+
+    // Without Crab House: 1, With Crab House: 1 + 2 = 3
+    expect(state.inventory.Barnacle).toEqual(new Decimal(3));
   });
 });

--- a/src/features/game/events/landExpansion/collectWaterTrap.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.ts
@@ -1,9 +1,12 @@
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
-import { GameState, InventoryItemName } from "../../types/game";
+import { GameState } from "../../types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { getObjectEntries } from "lib/object";
 import { caughtCrustacean } from "features/game/types/crustaceans";
+import { BoostName } from "features/game/types/game";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+import { getKeys } from "lib/object";
 
 export type CollectWaterTrapAction = {
   type: "waterTrap.collected";
@@ -14,6 +17,23 @@ type Options = {
   state: Readonly<GameState>;
   action: CollectWaterTrapAction;
   createdAt?: number;
+};
+
+const getCrustaceanAmount = (
+  game: GameState,
+  amount: number,
+): {
+  boostedAmount: Decimal;
+  boostsUsed: { name: BoostName; value: string }[];
+} => {
+  let boostedAmount = new Decimal(amount);
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+  if (isCollectibleBuilt({ name: "Crab House", game })) {
+    boostedAmount = boostedAmount.add(2);
+    boostsUsed.push({ name: "Crab House", value: "+2" });
+  }
+
+  return { boostedAmount, boostsUsed };
 };
 
 export function collectWaterTrap({
@@ -35,33 +55,36 @@ export function collectWaterTrap({
 
     const caught =
       waterTrap.caught ?? caughtCrustacean(waterTrap.type, waterTrap.chum);
-    getObjectEntries(caught).forEach(([item, amount]) => {
-      if (amount) {
-        const currentAmount =
-          game.inventory[item as InventoryItemName] ?? new Decimal(0);
-        game.inventory[item as InventoryItemName] = currentAmount.add(amount);
+    const boostsUsed: { name: BoostName; value: string }[] = [];
+    getKeys(caught).forEach((name) => {
+      const { boostedAmount, boostsUsed: caughtBoostsUsed } =
+        getCrustaceanAmount(game, caught[name] ?? 1);
+      const previous = game.inventory[name] ?? new Decimal(0);
+      game.inventory[name] = previous.add(boostedAmount);
+      boostsUsed.push(...caughtBoostsUsed);
+    });
+
+    getKeys(caught).forEach((itemName) => {
+      game.farmActivity = trackFarmActivity(
+        `${itemName} Caught`,
+        game.farmActivity,
+        new Decimal(caught[itemName] ?? 0),
+      );
+      if (waterTrap.chum) {
+        game.farmActivity = trackFarmActivity(
+          `${itemName} Caught with ${waterTrap.chum}`,
+          game.farmActivity,
+          new Decimal(caught[itemName] ?? 0),
+        );
       }
     });
 
-    getObjectEntries(caught).forEach(([itemName, amount]) => {
-      if (amount) {
-        game.farmActivity = trackFarmActivity(
-          `${itemName} Caught`,
-          game.farmActivity,
-          new Decimal(amount),
-        );
-        if (waterTrap.chum) {
-          game.farmActivity = trackFarmActivity(
-            `${itemName} Caught with ${waterTrap.chum}`,
-            game.farmActivity,
-            new Decimal(amount),
-          );
-        }
-      }
+    game.boostsUsedAt = updateBoostUsed({
+      game,
+      boostNames: boostsUsed,
+      createdAt,
     });
 
     delete trapSpots[action.trapId].waterTrap;
-
-    return game;
   });
 }

--- a/src/features/game/events/landExpansion/collectWaterTrap.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.ts
@@ -96,13 +96,11 @@ export function collectWaterTrap({
       game.farmActivity = trackFarmActivity(
         `${itemName} Caught`,
         game.farmActivity,
-        new Decimal(caught[itemName] ?? 0),
       );
       if (waterTrap.chum) {
         game.farmActivity = trackFarmActivity(
           `${itemName} Caught with ${waterTrap.chum}`,
           game.farmActivity,
-          new Decimal(caught[itemName] ?? 0),
         );
       }
     });

--- a/src/features/game/events/landExpansion/collectWaterTrap.ts
+++ b/src/features/game/events/landExpansion/collectWaterTrap.ts
@@ -1,12 +1,17 @@
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
-import { GameState } from "../../types/game";
+import { BoostName, GameState } from "../../types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { caughtCrustacean } from "features/game/types/crustaceans";
-import { BoostName } from "features/game/types/game";
+import { getKeys } from "lib/object";
+import {
+  caughtCrustacean,
+  CrustaceanName,
+} from "features/game/types/crustaceans";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
-import { getKeys } from "lib/object";
+import { isWearableActive } from "features/game/lib/wearables";
+import { prngChance } from "lib/prng";
+import { KNOWN_IDS } from "features/game/types";
 
 export type CollectWaterTrapAction = {
   type: "waterTrap.collected";
@@ -14,6 +19,7 @@ export type CollectWaterTrapAction = {
 };
 
 type Options = {
+  farmId: number;
   state: Readonly<GameState>;
   action: CollectWaterTrapAction;
   createdAt?: number;
@@ -22,21 +28,39 @@ type Options = {
 const getCrustaceanAmount = (
   game: GameState,
   amount: number,
-): {
-  boostedAmount: Decimal;
-  boostsUsed: { name: BoostName; value: string }[];
-} => {
+  crustaceanName: CrustaceanName,
+  prngArgs?: { farmId: number; counter: number },
+): { boostedAmount: Decimal; boostsUsed: BoostName[] } => {
   let boostedAmount = new Decimal(amount);
-  const boostsUsed: { name: BoostName; value: string }[] = [];
+  const boostsUsed: BoostName[] = [];
+
+  if (prngArgs) {
+    const { farmId, counter } = prngArgs;
+    if (
+      isWearableActive({ game, name: "Pistol Shrimp" }) &&
+      prngChance({
+        farmId,
+        itemId: KNOWN_IDS[crustaceanName],
+        counter,
+        chance: 20,
+        criticalHitName: "Pistol Shrimp",
+      })
+    ) {
+      boostedAmount = boostedAmount.add(1);
+      boostsUsed.push("Pistol Shrimp");
+    }
+  }
+
   if (isCollectibleBuilt({ name: "Crab House", game })) {
     boostedAmount = boostedAmount.add(2);
-    boostsUsed.push({ name: "Crab House", value: "+2" });
+    boostsUsed.push("Crab House");
   }
 
   return { boostedAmount, boostsUsed };
 };
 
 export function collectWaterTrap({
+  farmId,
   state,
   action,
   createdAt = Date.now(),
@@ -55,10 +79,14 @@ export function collectWaterTrap({
 
     const caught =
       waterTrap.caught ?? caughtCrustacean(waterTrap.type, waterTrap.chum);
-    const boostsUsed: { name: BoostName; value: string }[] = [];
+    const boostsUsed: BoostName[] = [];
     getKeys(caught).forEach((name) => {
+      const prngArgs = {
+        farmId,
+        counter: game.farmActivity[`${name} Caught`] ?? 0,
+      };
       const { boostedAmount, boostsUsed: caughtBoostsUsed } =
-        getCrustaceanAmount(game, caught[name] ?? 1);
+        getCrustaceanAmount(game, caught[name] ?? 1, name, prngArgs);
       const previous = game.inventory[name] ?? new Decimal(0);
       game.inventory[name] = previous.add(boostedAmount);
       boostsUsed.push(...caughtBoostsUsed);
@@ -81,7 +109,11 @@ export function collectWaterTrap({
 
     game.boostsUsedAt = updateBoostUsed({
       game,
-      boostNames: boostsUsed,
+      boostNames: boostsUsed.map((name) => ({
+        name,
+        value:
+          name === "Crab House" ? "+2" : name === "Pistol Shrimp" ? "+1" : "",
+      })),
       createdAt,
     });
 

--- a/src/features/game/events/landExpansion/placeWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/placeWaterTrap.test.ts
@@ -121,4 +121,32 @@ describe("placeWaterTrap", () => {
 
     expect(state.inventory["Crab Pot"]).toEqual(new Decimal(2));
   });
+
+  it("does not deduct a trap from inventory if Royal Crab Pot is built", () => {
+    const state = placeWaterTrap({
+      state: {
+        ...GAME_STATE,
+        inventory: { "Crab Pot": new Decimal(1), Moonfur: new Decimal(5) },
+        collectibles: {
+          "Royal Crab Pot": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              createdAt: Date.now(),
+              readyAt: Date.now(),
+            },
+          ],
+        },
+      },
+      action: {
+        type: "waterTrap.placed",
+        trapId,
+        waterTrap: "Crab Pot",
+        chum: "Moonfur",
+      },
+      createdAt,
+    });
+
+    expect(state.inventory["Crab Pot"]).toEqual(new Decimal(1));
+  });
 });

--- a/src/features/game/events/landExpansion/placeWaterTrap.test.ts
+++ b/src/features/game/events/landExpansion/placeWaterTrap.test.ts
@@ -3,6 +3,7 @@ import { placeWaterTrap } from "./placeWaterTrap";
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
 import { GameState } from "features/game/types/game";
+import { WATER_TRAP } from "features/game/types/crustaceans";
 
 const trapId = "1";
 
@@ -148,5 +149,40 @@ describe("placeWaterTrap", () => {
     });
 
     expect(state.inventory["Crab Pot"]).toEqual(new Decimal(1));
+  });
+
+  it("reduces the ready time by 20% when Speed Trap is built", () => {
+    const createdAt = Date.now();
+    const state = placeWaterTrap({
+      state: {
+        ...GAME_STATE,
+        inventory: { "Crab Pot": new Decimal(2), Moonfur: new Decimal(3) },
+        collectibles: {
+          "Speed Trap": [
+            {
+              id: "1",
+              coordinates: { x: 1, y: 1 },
+              createdAt,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "waterTrap.placed",
+        trapId,
+        waterTrap: "Crab Pot",
+        chum: "Moonfur",
+      },
+      createdAt,
+    });
+
+    // Default ready time for Crab Pot is 8 hours (see WATER_TRAP config)
+    const defaultReadyTimeMs =
+      WATER_TRAP["Crab Pot"].readyTimeHours * 60 * 60 * 1000;
+    const expectedReadyTime = createdAt + defaultReadyTimeMs * 0.8;
+
+    expect(state.crabTraps.trapSpots?.[trapId]?.waterTrap?.readyAt).toBe(
+      expectedReadyTime,
+    );
   });
 });

--- a/src/features/game/events/landExpansion/placeWaterTrap.ts
+++ b/src/features/game/events/landExpansion/placeWaterTrap.ts
@@ -1,6 +1,6 @@
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
-import { GameState } from "../../types/game";
+import { BoostName, GameState } from "../../types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import {
   WaterTrapName,
@@ -10,6 +10,7 @@ import {
   caughtCrustacean,
 } from "features/game/types/crustaceans";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type PlaceWaterTrapAction = {
   trapId: string;
@@ -23,6 +24,31 @@ type Options = {
   action: PlaceWaterTrapAction;
   createdAt?: number;
 };
+
+export function getWaterTrapMilliseconds(
+  game: GameState,
+  waterTrap: WaterTrapName,
+) {
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+  let time = WATER_TRAP[waterTrap].readyTimeHours * 60 * 60 * 1000;
+  if (isCollectibleBuilt({ name: "Speed Trap", game })) {
+    time *= 0.8;
+    boostsUsed.push({ name: "Speed Trap", value: "x0.8" });
+  }
+  return { milliseconds: time, boostsUsed };
+}
+
+function getWaterTrapReadyAt(
+  game: GameState,
+  waterTrap: WaterTrapName,
+  createdAt: number,
+) {
+  const { milliseconds, boostsUsed } = getWaterTrapMilliseconds(
+    game,
+    waterTrap,
+  );
+  return { readyAt: createdAt + milliseconds, boostsUsed };
+}
 
 export function placeWaterTrap({
   state,
@@ -70,8 +96,17 @@ export function placeWaterTrap({
 
     const caught = caughtCrustacean(action.waterTrap, action.chum);
 
-    const hours = WATER_TRAP[action.waterTrap].readyTimeHours;
-    const readyAt = createdAt + hours * 60 * 60 * 1000;
+    const { readyAt, boostsUsed } = getWaterTrapReadyAt(
+      game,
+      action.waterTrap,
+      createdAt,
+    );
+
+    game.boostsUsedAt = updateBoostUsed({
+      game,
+      boostNames: boostsUsed,
+      createdAt,
+    });
 
     if (!game.crabTraps.trapSpots) {
       game.crabTraps.trapSpots = {};

--- a/src/features/game/events/landExpansion/placeWaterTrap.ts
+++ b/src/features/game/events/landExpansion/placeWaterTrap.ts
@@ -9,6 +9,7 @@ import {
   CRUSTACEAN_CHUM_AMOUNTS,
   caughtCrustacean,
 } from "features/game/types/crustaceans";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 
 export type PlaceWaterTrapAction = {
   trapId: string;
@@ -36,7 +37,11 @@ export function placeWaterTrap({
     }
 
     const potCount = game.inventory[action.waterTrap] ?? new Decimal(0);
-    if (potCount.lt(1)) {
+    const hasRoyalCrabPot = isCollectibleBuilt({
+      name: "Royal Crab Pot",
+      game,
+    });
+    if (!hasRoyalCrabPot && potCount.lt(1)) {
       throw new Error(`Missing ${action.waterTrap}`);
     }
 
@@ -80,7 +85,9 @@ export function placeWaterTrap({
       caught,
     };
 
-    game.inventory[action.waterTrap] = potCount.sub(1);
+    if (!hasRoyalCrabPot) {
+      game.inventory[action.waterTrap] = potCount.sub(1);
+    }
 
     game.farmActivity = trackFarmActivity(
       `${action.waterTrap} Placed`,

--- a/src/features/island/fisherman/WaterTrapModal.tsx
+++ b/src/features/island/fisherman/WaterTrapModal.tsx
@@ -26,6 +26,7 @@ import {
   caughtCrustacean,
 } from "features/game/types/crustaceans";
 import { getBumpkinLevel } from "features/game/lib/level";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { CrustaceanGuide } from "./CrustaceanGuide";
 import { getKeys } from "lib/object";
 import { useLocalStorage } from "lib/utils/hooks/useLocalStorage";
@@ -160,7 +161,12 @@ export const WaterTrapModal: React.FC<Props> = ({
 
   const isValidChumForTrap = selectedChum ? chums.includes(selectedChum) : true;
 
-  const hasTrap = state.inventory[selectedTrap]?.gte(1) ?? false;
+  const hasRoyalCrabPot = isCollectibleBuilt({
+    name: "Royal Crab Pot",
+    game: state,
+  });
+  const hasTrap =
+    hasRoyalCrabPot || (state.inventory[selectedTrap]?.gte(1) ?? false);
 
   const hasEnoughChum = selectedChum
     ? items[selectedChum]?.gte(CRUSTACEAN_CHUM_AMOUNTS[selectedChum])
@@ -282,10 +288,20 @@ export const WaterTrapModal: React.FC<Props> = ({
               onChange={(trap) => handleTrapChange(trap)}
             />
 
-            {!state.inventory[selectedTrap]?.gte(1) && (
-              <Label className="ml-1" type="danger">
-                {t("fishing.dont.have.enough.bait", { bait: selectedTrap })}
+            {hasRoyalCrabPot ? (
+              <Label
+                className="ml-1"
+                type="success"
+                icon={ITEM_DETAILS["Royal Crab Pot"].image}
+              >
+                {t("waterTrap.royalCrabPotActive")}
               </Label>
+            ) : (
+              !hasTrap && (
+                <Label className="ml-1" type="danger">
+                  {t("fishing.dont.have.enough.bait", { bait: selectedTrap })}
+                </Label>
+              )
             )}
 
             {chums.length === 0 ? (

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -8601,6 +8601,7 @@
   "waterTrap.loreMessage": "This spot looks like a trap... something a marine creature would only fall into. Perhaps with more experience, you'll learn how to use it.",
   "waterTrap.noChumsAvailable": "No chums available",
   "waterTrap.noChumSelected": "No chum selected",
+  "waterTrap.royalCrabPotActive": "Royal Crab Pot boost active",
   "fishing.yourCatch": "Your Catch",
   "fishing.missedFish": "Fish that got away!",
   "fishing.notEnoughBait": "You don't have enough {{bait}}!",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -8830,7 +8830,7 @@
   "description.crabHouse": "Home sweet home for the seaside shell dwellers. Increases crustacean yield by 2",
   "description.speedTrap": "Snaps shut before the crab even sees it coming. Reduces Crab trap time by 20%",
   "description.navigationTable.boost": "+100% Map Piece Odds",
-  "description.royalCrabPot.boost": "Trap without Crab Pots",
+  "description.royalCrabPot.boost": "Trap without Water Trap Pots",
   "description.crabHouse.boost": "+2 Crustacean yield",
   "description.speedTrap.boost": "-20% Crap trap time",
   "description.pistolShrimp.boost": "20% chance to get +1 crustacean yield",


### PR DESCRIPTION
## Summary

Client-side game logic for new and existing **water trap (crab trap) boosts**, kept in sync with the API.

## Changes

### `placeWaterTrap`
- **Speed Trap** collectible: reduces trap ready time by 20% (`×0.8`); records boost usage for UI.
- **Royal Crab Pot** collectible: allows placing a trap **without consuming** a pot from inventory when the collectible is built.

### `collectWaterTrap`
- **`farmId`** is required (same as server / `processEvent`) for deterministic PRNG.
- **Crab House**: +2 to each crustacean stack on collection.
- **Pistol Shrimp** (wearable): 20% chance per crustacean line to grant **+1**, using the same PRNG inputs as the server (`farmId`, `KNOWN_IDS`, activity counter, `"Pistol Shrimp"` critical name).

## Tests

- `yarn test src/features/game/events/landExpansion/placeWaterTrap.test.ts`
- `yarn test src/features/game/events/landExpansion/collectWaterTrap.test.ts`

## Related

- Backend PR: <!-- link sunflower-land-api PR -->