### PR TITLE
[FEAT] Add pet resource marketplace filter

### DIFF
--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -15,7 +15,11 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { InventoryItemName } from "features/game/types/game";
-import { PetCategory, getPetLevel } from "features/game/types/pets";
+import {
+  PET_FETCHES,
+  PetCategory,
+  getPetLevel,
+} from "features/game/types/pets";
 import { getNFTTraits } from "./TradeableInfo";
 import { PetTraits } from "features/pets/data/types";
 import { Bud } from "lib/buds/types";
@@ -452,6 +456,12 @@ export const Collection: React.FC<{
                   selectedValues.includes(category),
                 );
               }
+              case "resource":
+                return PET_FETCHES[petTraits.type].fetches.some(
+                  ({ name, level }) =>
+                    petLevel >= level &&
+                    selectedValues.includes(toTraitValueId(name)),
+                );
               case "aura":
                 return selectedValues.includes(
                   toTraitValueId(petTraits.aura ?? ""),

--- a/src/features/marketplace/components/home/Filters.tsx
+++ b/src/features/marketplace/components/home/Filters.tsx
@@ -185,6 +185,7 @@ export const Filters: React.FC<{
               };
 
               return {
+                icon: option.icon,
                 label: option.label,
                 onToggle: (checked: boolean) => {
                   ensureCollectionActive(collection);

--- a/src/features/marketplace/lib/marketplaceFilters.ts
+++ b/src/features/marketplace/lib/marketplaceFilters.ts
@@ -7,6 +7,7 @@ export type BudTrait = "type" | "aura" | "stem" | "colour";
 export type PetTrait =
   | "type"
   | "category"
+  | "resource"
   | "aura"
   | "bib"
   | "fur"
@@ -24,7 +25,16 @@ export interface TraitFilter {
 // Defines which trait keys are valid for each collection.
 const COLLECTION_TRAIT_KEYS: Record<TraitCollection, TraitKey[]> = {
   buds: ["type", "aura", "stem", "colour"],
-  pets: ["type", "category", "aura", "bib", "fur", "accessory", "level"],
+  pets: [
+    "type",
+    "category",
+    "resource",
+    "aura",
+    "bib",
+    "fur",
+    "accessory",
+    "level",
+  ],
 };
 
 const TRAIT_QUERY_KEYS = new Set<TraitKey>(

--- a/src/features/marketplace/lib/traitOptions.ts
+++ b/src/features/marketplace/lib/traitOptions.ts
@@ -1,4 +1,9 @@
-import { PET_CATEGORY_NAMES, PET_NFT_TYPES } from "features/game/types/pets";
+import {
+  FETCHES_BY_CATEGORY,
+  PET_CATEGORY_NAMES,
+  PET_NFT_TYPES,
+} from "features/game/types/pets";
+import { ITEM_DETAILS } from "features/game/types/images";
 import {
   ACCESSORY_TRAITS,
   AURA_TRAITS,
@@ -21,6 +26,7 @@ import {
 export interface TraitOptionDefinition {
   label: string;
   value: string;
+  icon?: string;
 }
 
 export interface TraitGroupDefinition<T extends string> {
@@ -81,6 +87,15 @@ export const PET_TRAIT_GROUPS: TraitGroupDefinition<PetTrait>[] = [
     trait: "category",
     label: "Category",
     options: mapOptions(PET_CATEGORY_NAMES),
+  },
+  {
+    trait: "resource",
+    label: "Resource",
+    options: Object.values(FETCHES_BY_CATEGORY).map((resource) => ({
+      label: resource,
+      value: toTraitValueId(resource),
+      icon: ITEM_DETAILS[resource].image,
+    })),
   },
   {
     trait: "aura",


### PR DESCRIPTION
Add a Resource filter to Pet NFTs in the Marketplace.

Players can now filter Pet NFTs by the pet resource they can **already** fetch, such as Ruffroot, Ribbon, Chewed Bone, Wild Grass, Heart leaf, Frost Pebble, and Dewberry.

The filter uses the existing pet fetch configuration. A pet is shown only when the selected resource is present in its `PET_FETCHES` list and the pet's current level meets the required unlock level.


Key code for finding right types of pets and checking the availability of resources at the level

> case "resource":
>   return PET_FETCHES[petTraits.type].fetches.some(
>     ({ name, level }) =>
>       petLevel >= level &&
>       selectedValues.includes(toTraitValueId(name)),
>   );

