### PR TITLE
[FEAT] Add a Boost filter to Bud NFTs at the Marketplace

### DIFF
--- a/src/features/marketplace/components/Collection.tsx
+++ b/src/features/marketplace/components/Collection.tsx
@@ -45,6 +45,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Label } from "components/ui/Label";
 import { marketplaceMinigameItemPath } from "../lib/minigameTradePath";
+import { getBudBoostFilterLabels } from "../lib/budBoostFilters";
 
 const budTraitLabels = createTraitLabelLookup(BUD_TRAIT_GROUPS);
 const petTraitLabels = createTraitLabelLookup(PET_TRAIT_GROUPS);
@@ -520,6 +521,10 @@ export const Collection: React.FC<{
               case "colour":
                 return selectedValues.includes(
                   toTraitValueId(budTraits.colour ?? ""),
+                );
+              case "boost":
+                return getBudBoostFilterLabels(budTraits).some((boost) =>
+                  selectedValues.includes(toTraitValueId(boost)),
                 );
               default:
                 return true;

--- a/src/features/marketplace/lib/budBoostFilters.ts
+++ b/src/features/marketplace/lib/budBoostFilters.ts
@@ -1,0 +1,74 @@
+import { Bud } from "lib/buds/types";
+
+export const BUD_BOOST_FILTER_OPTIONS = [
+  "Basic Crops",
+  "Medium Crops",
+  "Advanced Crops",
+  "All Crops",
+  "Crop Growth Time",
+  "Carrot",
+  "Sunflower",
+  "Fruit",
+  "Mushroom",
+  "Magic Mushroom",
+  "Wood",
+  "Stone",
+  "Iron",
+  "Gold",
+  "Minerals",
+  "Egg",
+  "Animal Produce",
+  "Fish",
+  "Bumpkin XP from Fish",
+];
+
+const BUD_TYPE_BOOST_FILTERS: Partial<Record<Bud["type"], string>> = {
+  Plaza: "Basic Crops",
+  Woodlands: "Wood",
+  Cave: "Minerals",
+  Sea: "Fish",
+  Castle: "Medium Crops",
+  Port: "Bumpkin XP from Fish",
+  Retreat: "Animal Produce",
+  Saphiro: "Crop Growth Time",
+  Snow: "Advanced Crops",
+  Beach: "Fruit",
+};
+
+const BUD_STEM_BOOST_FILTERS: Partial<Record<Bud["stem"], string>> = {
+  "3 Leaf Clover": "All Crops",
+  "Fish Hat": "Fish",
+  "Diamond Gem": "Minerals",
+  "Gold Gem": "Gold",
+  "Miner Hat": "Iron",
+  "Carrot Head": "Carrot",
+  "Sunflower Hat": "Sunflower",
+  "Basic Leaf": "Basic Crops",
+  "Ruby Gem": "Stone",
+  Mushroom: "Mushroom",
+  "Magic Mushroom": "Magic Mushroom",
+  "Acorn Hat": "Wood",
+  Banana: "Fruit",
+  "Tree Hat": "Wood",
+  "Egg Head": "Egg",
+  "Apple Head": "Fruit",
+};
+
+export const getBudBoostFilterLabels = (
+  bud?: Pick<Bud, "type" | "stem"> | undefined,
+) => {
+  const labels = new Set<string>();
+
+  const typeBoost = bud?.type ? BUD_TYPE_BOOST_FILTERS[bud.type] : undefined;
+  const stemBoost = bud?.stem ? BUD_STEM_BOOST_FILTERS[bud.stem] : undefined;
+
+  if (typeBoost) {
+    labels.add(typeBoost);
+  }
+
+  if (stemBoost) {
+    labels.add(stemBoost);
+  }
+
+  return [...labels];
+};

--- a/src/features/marketplace/lib/marketplaceFilters.ts
+++ b/src/features/marketplace/lib/marketplaceFilters.ts
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router";
 
 export type TraitCollection = "buds" | "pets";
 
-export type BudTrait = "type" | "aura" | "stem" | "colour";
+export type BudTrait = "type" | "aura" | "stem" | "colour" | "boost";
 export type PetTrait =
   | "type"
   | "category"
@@ -23,7 +23,7 @@ export interface TraitFilter {
 
 // Defines which trait keys are valid for each collection.
 const COLLECTION_TRAIT_KEYS: Record<TraitCollection, TraitKey[]> = {
-  buds: ["type", "aura", "stem", "colour"],
+  buds: ["type", "aura", "stem", "colour", "boost"],
   pets: ["type", "category", "aura", "bib", "fur", "accessory", "level"],
 };
 

--- a/src/features/marketplace/lib/traitOptions.ts
+++ b/src/features/marketplace/lib/traitOptions.ts
@@ -17,6 +17,7 @@ import {
   PET_LEVEL_FILTERS,
   toTraitValueId,
 } from "./marketplaceFilters";
+import { BUD_BOOST_FILTER_OPTIONS } from "./budBoostFilters";
 
 export interface TraitOptionDefinition {
   label: string;
@@ -67,6 +68,14 @@ export const BUD_TRAIT_GROUPS: TraitGroupDefinition<BudTrait>[] = [
     options: BUD_COLOURS.map((colour) => ({
       label: colour.name,
       value: toTraitValueId(colour.name),
+    })),
+  },
+  {
+    trait: "boost",
+    label: "Boost",
+    options: BUD_BOOST_FILTER_OPTIONS.map((boost) => ({
+      label: boost,
+      value: toTraitValueId(boost),
     })),
   },
 ];


### PR DESCRIPTION
# Pull request description

Players can now filter Buds by the gameplay boost, making it easier to find Buds for crop, resource, animal, and fishing strategies without knowing the underlying trait combinations.

# Details

- Adds a new `Boost` filter group for Bud NFTs.
- Excludes Aura boosts from the filter.
- Merges Bud `type` and `stem` boost sources into a single normalized filter list.
- Uses player-facing boost categories instead of raw trait names or numeric values.
- Keeps the existing card UI unchanged; the filter only improves discovery.

# Boost filter options

- Basic Crops
- Medium Crops
- Advanced Crops
- All Crops
- Crop Growth Time
- Carrot
- Sunflower
- Fruit
- Mushroom
- Magic Mushroom
- Wood
- Stone
- Iron
- Gold
- Minerals
- Egg
- Animal Produce
- Fish
- Bumpkin XP from Fish
