### PR TITLE
[FIX] Show bait range while composter is running (#7077)

### DIFF
--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -402,7 +402,11 @@ const ComposterModalContent: React.FC<{
                 >
                   <img src={ITEM_DETAILS[name].image} className="h-5" />
                   <Label type="default">
-                    {name in WORM ? `? ${name}s` : `${produces[name]} ${name}`}
+                    {name in WORM
+                      ? max === 0
+                        ? `0 ${name}s`
+                        : `${min}-${max} ${name}s`
+                      : `${produces[name]} ${name}`}
                   </Label>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- Closes #7077
- While a composter is running, the worm row now shows the same `min-max` bait range that's already displayed in the inactive state (e.g. `2-4 Earthworms`) instead of the `? Earthworms` placeholder.
- Reuses the existing `{ min, max }` from `getWormOutput` already computed in the render, and mirrors the `max === 0 ? "0 ${worm}s" : "${min}-${max} ${worm}s"` formatting from the inactive-state label for consistency.

## Test plan
- [x] `yarn dev` and open each composter (Compost Bin, Turbo Composter, Premium Composter) while composting; confirm the worm row shows the expected range (e.g. `2-4 Earthworms`, `2-3 Grubs`, `1-3 Red Wigglers`) instead of `?`.
- [x] Equip items/skills that shift output ("Bucket O' Worms", "Wormy Treat", "Composting Overhaul", "More With Less", "Composting Revamp", "Saw Fish", "Deep Sea Slug") and confirm the range while composting matches the range shown in the inactive state for the same loadout.
- [x] Confirm ready-state (collect) and inactive-state displays are unchanged.
- [ ] `yarn test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)