### PR TITLE
[FEAT] Roll composter bait on collect with seeded PRNG (#7077)

### DIFF
--- a/src/features/game/events/landExpansion/collectCompost.test.ts
+++ b/src/features/game/events/landExpansion/collectCompost.test.ts
@@ -21,6 +21,7 @@ describe("collectCompost", () => {
           buildingId: "123",
         },
         createdAt: Date.now(),
+        farmId: 1,
       }),
     ).toThrow("Composter does not exist");
   });
@@ -47,6 +48,7 @@ describe("collectCompost", () => {
           buildingId: "123",
         },
         createdAt: Date.now(),
+        farmId: 1,
       }),
     ).toThrow("Composter is not producing anything");
   });
@@ -78,6 +80,7 @@ describe("collectCompost", () => {
           buildingId: "123",
         },
         createdAt: Date.now(),
+        farmId: 1,
       }),
     ).toThrow("Compost is not ready");
   });
@@ -115,6 +118,7 @@ describe("collectCompost", () => {
         buildingId: "123",
       },
       createdAt: Date.now(),
+      farmId: 1,
     });
 
     expect(state.buildings).toEqual({

--- a/src/features/game/events/landExpansion/collectCompost.test.ts
+++ b/src/features/game/events/landExpansion/collectCompost.test.ts
@@ -135,7 +135,7 @@ describe("collectCompost", () => {
     });
   });
 
-  it("adds the consumable to the inventory", () => {
+  it("adds the produce to the inventory and rolls worm amount at collect time", () => {
     const state = collectCompost({
       state: {
         ...GAME_STATE,
@@ -151,7 +151,7 @@ describe("collectCompost", () => {
               createdAt: 0,
               readyAt: 0,
               producing: {
-                items: { "Sprout Mix": 10, Earthworm: 1 },
+                items: { "Sprout Mix": 10 },
 
                 startedAt: dateNow - 10000,
                 readyAt: dateNow - 1000,
@@ -166,13 +166,86 @@ describe("collectCompost", () => {
         buildingId: "123",
       },
       createdAt: Date.now(),
+      farmId: 1,
     });
 
     expect(state.balance).toEqual(new Decimal(10));
-    expect(state.inventory).toEqual({
-      "Sprout Mix": new Decimal(10),
-      Earthworm: new Decimal(1),
-      Sunflower: new Decimal(22),
+    expect(state.inventory["Sprout Mix"]).toEqual(new Decimal(10));
+    expect(state.inventory.Sunflower).toEqual(new Decimal(22));
+    // Compost Bin worm is Earthworm; without boosts the roll lands in [2, 4].
+    const earthworms = state.inventory.Earthworm?.toNumber() ?? 0;
+    expect(earthworms).toBeGreaterThanOrEqual(2);
+    expect(earthworms).toBeLessThanOrEqual(4);
+  });
+
+  it("ignores legacy pre-rolled worm amount and re-rolls on collect", () => {
+    const state = collectCompost({
+      state: {
+        ...GAME_STATE,
+        inventory: {},
+        buildings: {
+          "Compost Bin": [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              createdAt: 0,
+              readyAt: 0,
+              producing: {
+                // Legacy shape: worm stored alongside produce.
+                items: { "Sprout Mix": 10, Earthworm: 99 },
+                startedAt: dateNow - 10000,
+                readyAt: dateNow - 1000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.collected",
+        building: "Compost Bin",
+        buildingId: "123",
+      },
+      createdAt: Date.now(),
+      farmId: 1,
     });
+
+    expect(state.inventory["Sprout Mix"]).toEqual(new Decimal(10));
+    const earthworms = state.inventory.Earthworm?.toNumber() ?? 0;
+    // The legacy 99 must be ignored; roll lands in [2, 4] without boosts.
+    expect(earthworms).toBeGreaterThanOrEqual(2);
+    expect(earthworms).toBeLessThanOrEqual(4);
+  });
+
+  it("tracks `${worm} Collected` in farmActivity", () => {
+    const state = collectCompost({
+      state: {
+        ...GAME_STATE,
+        buildings: {
+          "Compost Bin": [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              createdAt: 0,
+              readyAt: 0,
+              producing: {
+                items: { "Sprout Mix": 10 },
+                startedAt: dateNow - 10000,
+                readyAt: dateNow - 1000,
+              },
+            },
+          ],
+        },
+      },
+      action: {
+        type: "compost.collected",
+        building: "Compost Bin",
+        buildingId: "123",
+      },
+      createdAt: Date.now(),
+      farmId: 1,
+    });
+
+    expect(state.farmActivity["Earthworm Collected"]).toEqual(1);
+    expect(state.farmActivity["Compost Bin Collected"]).toEqual(1);
   });
 });

--- a/src/features/game/events/landExpansion/collectCompost.ts
+++ b/src/features/game/events/landExpansion/collectCompost.ts
@@ -21,14 +21,14 @@ type Options = {
   state: Readonly<GameState>;
   action: collectCompostAction;
   createdAt?: number;
-  farmId?: number;
+  farmId: number;
 };
 
 export function collectCompost({
   state,
   action,
   createdAt = Date.now(),
-  farmId = 0,
+  farmId,
 }: Options): GameState {
   return produce(state, (stateCopy) => {
     const { bumpkin } = stateCopy;

--- a/src/features/game/events/landExpansion/collectCompost.ts
+++ b/src/features/game/events/landExpansion/collectCompost.ts
@@ -1,10 +1,15 @@
 import Decimal from "decimal.js-light";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { ComposterName } from "features/game/types/composters";
+import {
+  ComposterName,
+  composterDetails,
+} from "features/game/types/composters";
 import { getKeys } from "lib/object";
 import { CompostBuilding, GameState } from "features/game/types/game";
 import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
+import { rollWormAmount } from "./composterBait";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type collectCompostAction = {
   type: "compost.collected";
@@ -16,12 +21,14 @@ type Options = {
   state: Readonly<GameState>;
   action: collectCompostAction;
   createdAt?: number;
+  farmId?: number;
 };
 
 export function collectCompost({
   state,
   action,
   createdAt = Date.now(),
+  farmId = 0,
 }: Options): GameState {
   return produce(state, (stateCopy) => {
     const { bumpkin } = stateCopy;
@@ -47,15 +54,45 @@ export function collectCompost({
       throw new Error("Compost is not ready");
     }
 
+    const { worm } = composterDetails[action.building];
+    const counter = stateCopy.farmActivity[`${worm} Collected`] ?? 0;
+    const { worms, boostsUsed: wormBoostsUsed } = rollWormAmount({
+      state: stateCopy,
+      building: action.building,
+      farmId,
+      counter,
+    });
+
     getKeys(compost.items ?? {}).forEach((name) => {
+      // Legacy composters started before roll-on-collect was introduced
+      // still store a pre-rolled worm amount here; ignore it so the new
+      // seeded roll below is the single source of truth.
+      if (name === worm) return;
       const previousCount = stateCopy.inventory[name] || new Decimal(0);
       stateCopy.inventory[name] = previousCount.add(compost.items[name] ?? 0);
     });
+
+    if (worms > 0) {
+      const previousWorms = stateCopy.inventory[worm] || new Decimal(0);
+      stateCopy.inventory[worm] = previousWorms.add(worms);
+    }
 
     stateCopy.farmActivity = trackFarmActivity(
       `${action.building} Collected`,
       stateCopy.farmActivity,
     );
+    stateCopy.farmActivity = trackFarmActivity(
+      `${worm} Collected`,
+      stateCopy.farmActivity,
+    );
+
+    if (wormBoostsUsed.length > 0) {
+      stateCopy.boostsUsedAt = updateBoostUsed({
+        game: stateCopy,
+        boostNames: wormBoostsUsed,
+        createdAt,
+      });
+    }
 
     if (building.requires) {
       delete building.requires;

--- a/src/features/game/events/landExpansion/composterBait.ts
+++ b/src/features/game/events/landExpansion/composterBait.ts
@@ -1,0 +1,115 @@
+import { KNOWN_IDS } from "features/game/types";
+import {
+  ComposterName,
+  Worm,
+  composterDetails,
+} from "features/game/types/composters";
+import { BoostName, GameState } from "features/game/types/game";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isWearableActive } from "features/game/lib/wearables";
+import { prng } from "lib/prng";
+
+export const WORM_AMOUNTS: Record<Worm, number[]> = {
+  Earthworm: [2, 3, 3, 3, 4],
+  Grub: [2, 2, 2, 3, 3],
+  "Red Wiggler": [1, 1, 2, 2, 2, 3],
+};
+
+type WormBoost = {
+  delta: number;
+  boostsUsed: { name: BoostName; value: string }[];
+};
+
+function getWormAdjustment(state: GameState): WormBoost {
+  const { skills } = state.bumpkin;
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+  let delta = 0;
+
+  if (isWearableActive({ name: "Bucket O' Worms", game: state })) {
+    delta += 1;
+    boostsUsed.push({ name: "Bucket O' Worms", value: "+1" });
+  }
+
+  if (skills["Wormy Treat"]) {
+    delta += 1;
+    boostsUsed.push({ name: "Wormy Treat", value: "+1" });
+  }
+
+  if (skills["Composting Overhaul"]) {
+    delta += 2;
+    boostsUsed.push({ name: "Composting Overhaul", value: "+2" });
+  }
+
+  if (skills["More With Less"]) {
+    delta -= 1;
+    boostsUsed.push({ name: "More With Less", value: "-1" });
+  }
+
+  if (skills["Composting Revamp"]) {
+    delta -= 3;
+    boostsUsed.push({ name: "Composting Revamp", value: "-3" });
+  }
+
+  if (isWearableActive({ name: "Saw Fish", game: state })) {
+    delta += 1;
+    boostsUsed.push({ name: "Saw Fish", value: "+1" });
+  }
+
+  if (isCollectibleBuilt({ name: "Deep Sea Slug", game: state })) {
+    delta += 1;
+    boostsUsed.push({ name: "Deep Sea Slug", value: "+1" });
+  }
+
+  return { delta, boostsUsed };
+}
+
+export function getWormRange({
+  state,
+  building,
+}: {
+  state: GameState;
+  building: ComposterName;
+}): {
+  min: number;
+  max: number;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
+  const { worm } = composterDetails[building];
+  const amounts = WORM_AMOUNTS[worm];
+  const { delta, boostsUsed } = getWormAdjustment(state);
+  return {
+    min: Math.max(0, Math.min(...amounts) + delta),
+    max: Math.max(0, Math.max(...amounts) + delta),
+    boostsUsed,
+  };
+}
+
+export function rollWormAmount({
+  state,
+  building,
+  farmId,
+  counter,
+}: {
+  state: GameState;
+  building: ComposterName;
+  farmId: number;
+  counter: number;
+}): {
+  worms: number;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
+  const { worm } = composterDetails[building];
+  const amounts = WORM_AMOUNTS[worm];
+  const roll = prng({
+    farmId,
+    itemId: KNOWN_IDS[worm],
+    counter,
+    criticalHitName: "Native",
+  });
+  const base = amounts[Math.floor(roll * amounts.length)];
+  const { delta, boostsUsed } = getWormAdjustment(state);
+  return {
+    worms: Math.max(0, base + delta),
+    boostsUsed,
+  };
+}

--- a/src/features/game/events/landExpansion/startComposter.ts
+++ b/src/features/game/events/landExpansion/startComposter.ts
@@ -148,7 +148,7 @@ export function startComposter({
       );
     });
 
-    const { produce, worm } = composterDetails[building];
+    const { produce } = composterDetails[building];
 
     const { produceAmount, boostsUsed: composterBoostsUsed } = getCompostAmount(
       {
@@ -162,11 +162,11 @@ export function startComposter({
     });
 
     // start the production
+    // Worm amount is rolled at collect time via a seeded PRNG, so boosts
+    // equipped any time before collect apply to the final bait output.
     buildings[0].producing = {
       items: {
         [produce]: produceAmount,
-        // Set on backend
-        [worm]: 1,
       },
       startedAt: createdAt,
       readyAt: createdAt + timeToFinishMilliseconds,

--- a/src/features/game/types/farmActivity.ts
+++ b/src/features/game/types/farmActivity.ts
@@ -38,7 +38,7 @@ import { GarbageName } from "./garbage";
 import { SeedName } from "./seeds";
 import { TreasureToolName, WorkbenchToolName } from "./tools";
 import { BeachBountyTreasure, TreasureName } from "./treasure";
-import { CompostName, ComposterName } from "./composters";
+import { CompostName, ComposterName, Worm } from "./composters";
 import { PurchaseableBait } from "./fishing";
 import { FlowerName, FlowerSeedName } from "./flowers";
 import { FactionShopItemName } from "./factionShop";
@@ -143,6 +143,7 @@ export type SellEvent = `${SellableName} Sold`;
 export type TreasureEvent = `${TreasureName} Dug`;
 export type ComposterCollectEvent = `${CompostName} Collected`;
 export type CompostedEvent = `${ComposterName} Collected`;
+export type WormCollectedEvent = `${Worm} Collected`;
 export type PlantGreenHouseFruitEvent = `${GreenHouseFruitName} Planted`;
 export type PlantGreenHouseCropEvent = `${GreenHouseCropName} Planted`;
 export type AnimalFeedMixedEvent =
@@ -230,6 +231,7 @@ export type FarmActivityName =
   | "Chore Skipped"
   | "Bud Placed"
   | ComposterCollectEvent
+  | WormCollectedEvent
   | "Crop Fertilised"
   | "Rod Casted"
   | "Farm Cheered"

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -277,6 +277,7 @@ const ComposterModalContent: React.FC<{
       farmId,
       counter: state.farmActivity[`${worm} Collected`] ?? 0,
     });
+    const wormLabel = readyWorms === 1 ? worm : `${worm}s`;
     return (
       <>
         <Label
@@ -306,7 +307,7 @@ const ComposterModalContent: React.FC<{
                 ))}
               <div className="flex space-x-2 justify-start mr-2 mb-1">
                 <img src={ITEM_DETAILS[worm].image} className="h-5" />
-                <Label type="default">{`${readyWorms} ${worm}s`}</Label>
+                <Label type="default">{`${readyWorms} ${wormLabel}`}</Label>
               </div>
             </div>
             <div className="flex items-center">

--- a/src/features/island/buildings/components/building/composters/ComposterModal.tsx
+++ b/src/features/island/buildings/components/building/composters/ComposterModal.tsx
@@ -34,7 +34,10 @@ import {
   getCompostAmount,
   getReadyAt,
 } from "features/game/events/landExpansion/startComposter";
-import { isWearableActive } from "features/game/lib/wearables";
+import {
+  getWormRange,
+  rollWormAmount,
+} from "features/game/events/landExpansion/composterBait";
 import {
   getSpeedUpCost,
   getSpeedUpTime,
@@ -47,72 +50,6 @@ import { getFruitfulBlendBuff } from "features/game/events/landExpansion/fertili
 import { useNow } from "lib/utils/hooks/useNow";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
-
-const WORM_OUTPUT: Record<ComposterName, { min: number; max: number }> = {
-  "Compost Bin": { min: 2, max: 4 },
-  "Turbo Composter": { min: 2, max: 3 },
-  "Premium Composter": { min: 1, max: 3 },
-};
-
-function getWormOutput({
-  state,
-  building,
-}: {
-  state: GameState;
-  building: ComposterName;
-}) {
-  const { skills } = state.bumpkin;
-  let { min, max } = WORM_OUTPUT[building];
-  if (isWearableActive({ name: "Bucket O' Worms", game: state })) {
-    min += 1;
-    max += 1;
-  }
-
-  // +1 Worm if the player has Wormy Treat skill
-  if (skills["Wormy Treat"]) {
-    min += 1;
-    max += 1;
-  }
-
-  // +2 Bait if the player has Composting Overhaul skill
-  if (skills["Composting Overhaul"]) {
-    min += 2;
-    max += 2;
-  }
-
-  // -1 bait if player has More with less skill (in exchange for +10 fishing limit)
-  if (skills["More With Less"]) {
-    min -= 1;
-    max -= 1;
-  }
-
-  // -3 worms with Composting Revamp
-  if (skills["Composting Revamp"]) {
-    min -= 3;
-    max -= 3;
-  }
-
-  if (isWearableActive({ name: "Saw Fish", game: state })) {
-    min += 1;
-    max += 1;
-  }
-
-  if (isCollectibleBuilt({ name: "Deep Sea Slug", game: state })) {
-    min += 1;
-    max += 1;
-  }
-
-  // If min/max somehow goes negative, show as 0
-  if (min < 0) {
-    min = 0;
-  }
-
-  if (max < 0) {
-    max = 0;
-  }
-
-  return { min, max };
-}
 
 export const COMPOSTER_IMAGES: Record<
   ComposterName,
@@ -273,6 +210,7 @@ const ComposterModalContent: React.FC<{
   const { t } = useAppTranslation();
 
   const state = useSelector(gameService, (state) => state.context.state);
+  const farmId = useSelector(gameService, (state) => state.context.farmId);
 
   const now = useNow({ live: !!readyAt, autoEndAt: readyAt ?? 0 });
   const composting = !!readyAt && readyAt >= now;
@@ -293,7 +231,7 @@ const ComposterModalContent: React.FC<{
     building: composterName,
   });
 
-  const { min, max } = getWormOutput({ state, building: composterName });
+  const { min, max } = getWormRange({ state, building: composterName });
   const { timeToFinishMilliseconds, boostsUsed } = getReadyAt({
     gameState: state,
     composter: composterName,
@@ -333,6 +271,12 @@ const ComposterModalContent: React.FC<{
   }; // We could do without this const but I added it for better security
 
   if (isReady) {
+    const { worms: readyWorms } = rollWormAmount({
+      state,
+      building: composterName,
+      farmId,
+      counter: state.farmActivity[`${worm} Collected`] ?? 0,
+    });
     return (
       <>
         <Label
@@ -349,15 +293,21 @@ const ComposterModalContent: React.FC<{
           />
           <div className="mt-2 flex-1">
             <div className="flex flex-wrap">
-              {getKeys(produces).map((name) => (
-                <div
-                  key={name}
-                  className="flex space-x-2 justify-start mr-2 mb-1"
-                >
-                  <img src={ITEM_DETAILS[name].image} className="h-5" />
-                  <Label type="default">{`${produces[name]} ${name}`}</Label>
-                </div>
-              ))}
+              {getKeys(produces)
+                .filter((name) => !(name in WORM))
+                .map((name) => (
+                  <div
+                    key={name}
+                    className="flex space-x-2 justify-start mr-2 mb-1"
+                  >
+                    <img src={ITEM_DETAILS[name].image} className="h-5" />
+                    <Label type="default">{`${produces[name]} ${name}`}</Label>
+                  </div>
+                ))}
+              <div className="flex space-x-2 justify-start mr-2 mb-1">
+                <img src={ITEM_DETAILS[worm].image} className="h-5" />
+                <Label type="default">{`${readyWorms} ${worm}s`}</Label>
+              </div>
             </div>
             <div className="flex items-center">
               <img src={SUNNYSIDE.icons.confirm} className="h-4 mr-1" />
@@ -395,21 +345,23 @@ const ComposterModalContent: React.FC<{
           <div className="mt-2 flex-1">
             <Timer readyAt={readyAt} />
             <div className="flex flex-wrap my-1">
-              {getKeys(produces).map((name) => (
-                <div
-                  key={name}
-                  className="flex space-x-2 justify-start mr-2 mb-1"
-                >
-                  <img src={ITEM_DETAILS[name].image} className="h-5" />
-                  <Label type="default">
-                    {name in WORM
-                      ? max === 0
-                        ? `0 ${name}s`
-                        : `${min}-${max} ${name}s`
-                      : `${produces[name]} ${name}`}
-                  </Label>
-                </div>
-              ))}
+              {getKeys(produces)
+                .filter((name) => !(name in WORM))
+                .map((name) => (
+                  <div
+                    key={name}
+                    className="flex space-x-2 justify-start mr-2 mb-1"
+                  >
+                    <img src={ITEM_DETAILS[name].image} className="h-5" />
+                    <Label type="default">{`${produces[name]} ${name}`}</Label>
+                  </div>
+                ))}
+              <div className="flex space-x-2 justify-start mr-2 mb-1">
+                <img src={ITEM_DETAILS[worm].image} className="h-5" />
+                <Label type="default">
+                  {max === 0 ? `0 ${worm}s` : `${min}-${max} ${worm}s`}
+                </Label>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Closes #7077. Paired with https://github.com/sunflower-land/sunflower-land-api/pull/3350.

Before: the worm amount was rolled on the backend at composter start (via `Math.random()`) and frozen into `producing.items`. Boosts equipped after starting didn't apply — the UX problem raised in #7077 — and the range displayed while running could overstate the actual output.

After: the worm amount is rolled at **collect time** using the shared seeded PRNG (`lib/prng`) with:
- `farmId`
- `itemId: KNOWN_IDS[worm]`
- `counter: farmActivity[\`\${worm} Collected\`] ?? 0`
- `criticalHitName: "Native"`

The seed is fully determined by pre-collect state, so the outcome can't be rerolled by replaying events, but boosts from the player's **live loadout at collect** all apply. Client and server compute the same number for the same seed + loadout (identical `composterBait.ts` in both repos), so the optimistic UI result equals the authoritative backend result — no jitter on autosave.

### Changes
- **[composterBait.ts](src/features/game/events/landExpansion/composterBait.ts)** (new) — shared `getWormRange` (for the display) and `rollWormAmount` (for the collect-time roll). Both use the same `getWormAdjustment` helper for boosts, replacing near-duplicate copies that lived in `ComposterModal.tsx` and the backend's old `getWormOutput`.
- **[startComposter.ts](src/features/game/events/landExpansion/startComposter.ts)** — drop the `[worm]: 1` placeholder from `producing.items`. Only the fertiliser is written at start now.
- **[collectCompost.ts](src/features/game/events/landExpansion/collectCompost.ts)** — roll via `rollWormAmount`, add the result to inventory alongside the fertiliser, track `${worm} Collected` in `farmActivity`. Legacy pre-rolled worm entries in `producing.items` are skipped.
- **[ComposterModal.tsx](src/features/island/buildings/components/building/composters/ComposterModal.tsx)** — uses `getWormRange` for the composting-state display (range reflects live loadout) and `rollWormAmount` for the ready-state display (shows the exact number the player will receive on collect). Removes the local duplicate of the boost math.
- **[farmActivity.ts](src/features/game/types/farmActivity.ts)** — adds `WormCollectedEvent` (`${Worm} Collected`) to the union.

### Migration
Per the chosen strategy (uniform re-roll on collect): composters started before this deploy will have a pre-rolled worm count in `producing.items`. On collect, that value is ignored and a fresh seeded roll is applied — no special branch needed. Since the seed counter is `farmActivity[\`\${worm} Collected\`] ?? 0`, pre-deploy farms begin from counter 0 cleanly.

## Test plan
- [x] `yarn test` passes (3406 tests).
- [x] `yarn tsc --noEmit` passes.
- [ ] Manual QA: start composting bare → equip Bucket O' Worms before collect → confirm received bait reflects the boost.
- [ ] Manual QA: start with full boosts → remove them before collect → confirm received bait drops accordingly.
- [ ] Manual QA: collect an in-flight composter started before this deploy; confirm a new roll is applied and the legacy stored amount is not double-counted.
- [ ] Manual QA: confirm fertiliser amount (Sprout Mix / Fruitful Blend / etc.) is unchanged.
- [ ] Manual QA: all three composter types (Compost Bin / Turbo / Premium) behave consistently.
- [ ] Watch for autosave jitter: the UI number after collecting should match the number after the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)