### PR TITLE
[FEAT] Add greenhouse exterior activity indicator

### DIFF
--- a/src/features/island/buildings/components/building/greenhouse/Greenhouse.tsx
+++ b/src/features/island/buildings/components/building/greenhouse/Greenhouse.tsx
@@ -13,6 +13,7 @@ import { GreenHouseCropName } from "features/game/types/crops";
 import { GreenHouseFruitName } from "features/game/types/fruits";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { GREENHOUSE_VARIANTS } from "features/island/lib/alternateArt";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 const selectReadyPlants = (state: MachineState) => {
   const pots = state.context.state.greenhouse.pots;
@@ -39,10 +40,14 @@ const selectReadyPlants = (state: MachineState) => {
   );
 };
 
+const selectHasActivePlants = (state: MachineState) =>
+  Object.values(state.context.state.greenhouse.pots).some((pot) => !!pot.plant);
+
 export const Greenhouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
   const { gameService, showAnimations } = useContext(Context);
 
   const readyPlants = useSelector(gameService, selectReadyPlants);
+  const hasActivePlants = useSelector(gameService, selectHasActivePlants);
 
   const navigate = useNavigate();
 
@@ -58,6 +63,17 @@ export const Greenhouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
   return (
     <div className="absolute h-full w-full">
       <BuildingImageWrapper name="Greenhouse" onClick={handleClick}>
+        {hasActivePlants && (
+          <img
+            src={SUNNYSIDE.building.smoke}
+            className="absolute pointer-events-none"
+            style={{
+              width: `${PIXEL_SCALE * 20}px`,
+              left: `calc(${PIXEL_SCALE * 26}px - 50px)`,
+              bottom: `calc(${PIXEL_SCALE * 46}px + 30px)`,
+            }}
+          />
+        )}
         <img
           src={GREENHOUSE_VARIANTS[season]}
           className="absolute pointer-events-none"


### PR DESCRIPTION
# Pull request description

Add an exterior activity indicator to the Greenhouse went something grow inside.

# Context / motivation

Players could not tell from the outside whether the Greenhouse was in use, which made it easy to forget planted grapes, olives, or rice and leave the building idle for long periods. This change reuses the existing smoke animation from the Greenhouse oil machine and shows it on the exterior while greenhouse crops are actively growing.

As a result:
- players had no quick visual reminder that the Greenhouse was currently occupied
- the building looked inactive even when production was underway

# Solution

Reuse the existing `SUNNYSIDE.building.smoke` animation on the exterior Greenhouse sprite whenever at least one greenhouse pot contains a planted crop.

The smoke was positioned and layered behind the Greenhouse art so it reads as part of the building rather than a UI overlay.

# Implementation

- adds a selector to detect whether any Greenhouse pot currently has an active plant
- renders the existing smoke animation on the Greenhouse exterior when active
- keeps the existing ready-to-harvest produce icons unchanged
- reuses an existing animation asset already used in the Greenhouse interior
- no smoke when there are no crops 
- no changes inside greenhouse
- no smoke when crops are ripe 

# Files

- `src/features/island/buildings/components/building/greenhouse/Greenhouse.tsx`

# Screenshots or screen recording

<img width="214" height="219" alt="image" src="https://github.com/user-attachments/assets/15480f24-3b3d-4b17-900e-5cce34431ca0" />
<img width="192" height="174" alt="image" src="https://github.com/user-attachments/assets/3b7cbda5-a539-4c26-b604-fd088d8e7461" />
<img width="188" height="194" alt="image" src="https://github.com/user-attachments/assets/321ee383-aaaf-4ee8-abda-d562a7838e56" />
