### PR TITLE
[FEAT] Corn Maze portal wiring (slug + V2 subdomain routing)

### DIFF
--- a/src/features/game/types/minigames.ts
+++ b/src/features/game/types/minigames.ts
@@ -48,3 +48,9 @@ export const SUPPORTED_MINIGAMES: MinigameName[] = [
   "memory",
   "chaacs-temple",
 ];
+
+export const V2_MINIGAMES: MinigameName[] = [
+  "corn-maze",
+  "chaacs-temple",
+  "chicken-rescue-v2",
+];

--- a/src/features/game/types/minigames.ts
+++ b/src/features/game/types/minigames.ts
@@ -4,6 +4,7 @@ export type MinigameName =
   | "bumpkin-board-game"
   | "sfl-world"
   | "maze-run"
+  | "corn-maze"
   | "board-game"
   | "chicken-rescue"
   | "chicken-rescue-v2"
@@ -28,6 +29,7 @@ export const SUPPORTED_MINIGAMES: MinigameName[] = [
   "bumpkin-board-game",
   "sfl-world",
   "maze-run",
+  "corn-maze",
   "board-game",
   "chicken-rescue",
   "chicken-rescue-v2",

--- a/src/features/game/types/minigames.ts
+++ b/src/features/game/types/minigames.ts
@@ -23,16 +23,20 @@ export type MinigameName =
   | "memory"
   | "chaacs-temple";
 
+export const V2_MINIGAMES: MinigameName[] = [
+  "corn-maze",
+  "chaacs-temple",
+  "chicken-rescue-v2",
+];
+
 export const SUPPORTED_MINIGAMES: MinigameName[] = [
   "crop-boom",
   "bumpkin-fight-club",
   "bumpkin-board-game",
   "sfl-world",
   "maze-run",
-  "corn-maze",
   "board-game",
   "chicken-rescue",
-  "chicken-rescue-v2",
   "festival-of-colors",
   "crops-and-chickens",
   "farmer-football",
@@ -46,11 +50,5 @@ export const SUPPORTED_MINIGAMES: MinigameName[] = [
   "nightshade-arcade",
   "april-fools",
   "memory",
-  "chaacs-temple",
-];
-
-export const V2_MINIGAMES: MinigameName[] = [
-  "corn-maze",
-  "chaacs-temple",
-  "chicken-rescue-v2",
+  ...V2_MINIGAMES,
 ];

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -39,6 +39,8 @@ const DOMAIN_MAP: Partial<Record<MinigameName, string>> = {
   "chaacs-temple": "chaacs-temple.minigames",
   /** Host: `https://chicken-rescue-v2.minigames.sunflower-land.com` */
   "chicken-rescue-v2": "chicken-rescue-v2.minigames",
+  /** Host: `https://corn-maze.minigames.sunflower-land.com` */
+  "corn-maze": "corn-maze.minigames",
 };
 
 /**

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -5,6 +5,7 @@ import { useActor } from "@xstate/react";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { Context } from "features/game/GameProvider";
 import type { MinigameName } from "features/game/types/minigames";
+import { MinigameName, V2_MINIGAMES } from "features/game/types/minigames";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 
@@ -31,16 +32,13 @@ type PortalPurchase = {
 };
 
 /**
- * For minigames where the key is different to the hosted domain name
+ * For legacy minigames where the slug is different to the hosted subdomain.
+ * V2 minigames live at `{portalName}.minigames.sunflower-land.com` and are
+ * handled via the V2_MINIGAMES list instead.
  */
 const DOMAIN_MAP: Partial<Record<MinigameName, string>> = {
   "festival-of-colors-2025": "festival-of-colors",
   "april-fools": "halloween",
-  "chaacs-temple": "chaacs-temple.minigames",
-  /** Host: `https://chicken-rescue-v2.minigames.sunflower-land.com` */
-  "chicken-rescue-v2": "chicken-rescue-v2.minigames",
-  /** Host: `https://corn-maze.minigames.sunflower-land.com` */
-  "corn-maze": "corn-maze.minigames",
 };
 
 /**
@@ -48,7 +46,8 @@ const DOMAIN_MAP: Partial<Record<MinigameName, string>> = {
  * 1. `iframeBaseUrl` when set (e.g. player economy dashboard → `*.economies.sunflower-land.com`).
  * 2. `VITE_PORTAL_GAME_URL` when set (local / override).
  * 3. `apiPlayUrl` from the minigame session API when provided.
- * 4. `DOMAIN_MAP` / default `https://{portalName}.sunflower-land.com`.
+ * 4. V2 minigames → `https://{portalName}.minigames.sunflower-land.com`.
+ * 5. `DOMAIN_MAP` / default `https://{portalName}.sunflower-land.com`.
  */
 function resolveMinigameIframeBaseUrl(
   portalName: MinigameName,
@@ -68,6 +67,10 @@ function resolveMinigameIframeBaseUrl(
   const fromApi = apiPlayUrl?.trim();
   if (fromApi) {
     return fromApi.replace(/\/$/, "");
+  }
+
+  if (V2_MINIGAMES.includes(portalName)) {
+    return `https://${portalName}.minigames.sunflower-land.com`;
   }
 
   const slug = DOMAIN_MAP[portalName] ?? portalName;

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -5,7 +5,7 @@ import { useActor } from "@xstate/react";
 import * as AuthProvider from "features/auth/lib/Provider";
 import { Context } from "features/game/GameProvider";
 import type { MinigameName } from "features/game/types/minigames";
-import { MinigameName, V2_MINIGAMES } from "features/game/types/minigames";
+import { V2_MINIGAMES } from "features/game/types/minigames";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { ClaimReward } from "features/game/expansion/components/ClaimReward";
 


### PR DESCRIPTION
## Summary
- Adds `corn-maze` to `MinigameName` + `SUPPORTED_MINIGAMES` so the new portal can record attempts and scores.
- Introduces `V2_MINIGAMES` — portals hosted on the `*.minigames.sunflower-land.com` subdomain group (currently `corn-maze`, `chaacs-temple`, `chicken-rescue-v2`). `resolveMinigameIframeBaseUrl` now checks this list before falling back to the legacy `DOMAIN_MAP`, which lets us drop three ad-hoc entries.

## Context
The Corn Maze portal is a revival of the 2023 Witches' Eve maze, rebuilt against the current portal framework. Paired with:
- `sunflower-land/sunflower-land-api` → [#3351](https://github.com/sunflower-land/sunflower-land-api/pull/3351) (matching backend slug registration)
- `eliasSFL/sunflower-land` → [portal/corn-maze](https://github.com/eliasSFL/sunflower-land/tree/portal/corn-maze) (the portal bundle itself, deployed to `corn-maze.minigames.sunflower-land.com` via the `.github/workflows/portal.yml` workflow)

Kept alongside the historical `maze-run` slug (2023) to preserve existing leaderboard/history data.

## Test plan
- [ ] `yarn tsc --noEmit` passes
- [ ] Resolver returns `https://corn-maze.minigames.sunflower-land.com` for `portalName === "corn-maze"` when no overrides are set
- [ ] Existing V2 portals (`chaacs-temple`, `chicken-rescue-v2`) still resolve correctly after the DOMAIN_MAP cleanup
- [ ] Smoke test the full flow: open the Corn Maze portal → play a run → verify score lands under `minigames.games["corn-maze"].highscore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Corn Maze** minigame to the set of available V2 minigames.

* **Refactor**
  * Centralized V2 minigame configuration to keep supported minigames consistent.
  * Updated V2 minigame portal iframe URL resolution for more reliable hosting/launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->