### PR TITLE
[CHORE] Planting flower UI improving

### DIFF
--- a/src/features/island/flowers/FlowerBedContent.tsx
+++ b/src/features/island/flowers/FlowerBedContent.tsx
@@ -297,9 +297,15 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
 
         {selecting === "crossbreed" && seed && (
           <>
-            <Label type="default" className="mb-1">
-              {t("flowerBedContent.select.crossbreed")}
-            </Label>
+            <div className="flex flex-wrap items-center gap-x-1 gap-y-1 mb-1">
+              <Label type="default" icon={ITEM_DETAILS[seed].image}>
+                {seed}
+              </Label>
+              <span className="text-xs">{"+"}</span>
+              <Label type="default">
+                {t("flowerBedContent.select.crossbreed")}
+              </Label>
+            </div>
             <div className="flex flex-wrap mb-2">
               {getKeys(FLOWER_CROSS_BREED_AMOUNTS[seed])
                 .filter(


### PR DESCRIPTION
# Pull request description

## Problem

When selecting a flower seed, players only see the seed icon in the combination area. This makes it harder to confirm which seed is currently selected before choosing a crossbreed ingredient.

## Solution

Display the selected seed badge, including its icon and seed name, before the “Select a crossbreed” label during the crossbreed selection step.

## Impact

- Makes the selected seed clear before choosing the second planting component.
- Reduces mistakes when combining flower seeds.
- Reuses the existing label style and item icon display.
- Keeps the change isolated to the flower planting modal UI.

## Context / motivation

Original request – https://discord.com/channels/880987707214544966/1324494700719243416/1468480929910751283

## Screenshots or screen recording

Current state
<img width="349" height="221" alt="image" src="https://github.com/user-attachments/assets/417abf82-b2c5-416a-8f92-f31140acb3cc" />


After pr
<img width="648" height="393" alt="image" src="https://github.com/user-attachments/assets/72b8acdb-8df2-46d9-b0ba-dbadfb253213" />


