### PR TITLE
[FEAT] Improve extra reels boost checklist

### DIFF
--- a/src/features/island/fisherman/FishermanExtras.tsx
+++ b/src/features/island/fisherman/FishermanExtras.tsx
@@ -6,7 +6,7 @@ import { Label } from "components/ui/Label";
 import { InnerPanel } from "components/ui/Panel";
 import { CollectibleName } from "features/game/types/craftables";
 import { getKeys } from "lib/object";
-import { GameState } from "features/game/types/game";
+import { BoostName, GameState } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SquareIcon } from "components/ui/SquareIcon";
@@ -20,7 +20,6 @@ import {
   BumpkinRevampSkillName,
   BumpkinSkillRevamp,
 } from "features/game/types/bumpkinSkills";
-import { getImageUrl } from "lib/utils/getImageURLS";
 import {
   INNER_CANVAS_WIDTH,
   SkillBox,
@@ -29,17 +28,22 @@ import { getSkillImage } from "features/bumpkins/components/revamp/SkillPathDeta
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { isCollectible } from "features/game/events/landExpansion/garbageSold";
+import { getDailyFishingLimit } from "features/game/types/fishing";
+import { getWearableImage } from "features/game/lib/getWearableImage";
 
 interface BoostReelItem {
   location: string;
   buff: BuffLabel[];
 }
 
+type FishingReelBoostName =
+  | BumpkinItem
+  | CollectibleName
+  | BumpkinRevampSkillName;
+
 const BoostReelItems: (
   state: GameState,
-) => Partial<
-  Record<BumpkinItem | CollectibleName | BumpkinRevampSkillName, BoostReelItem>
-> = (state) => ({
+) => Partial<Record<FishingReelBoostName, BoostReelItem>> = (state) => ({
   "Reelmaster's Chair": {
     buff: COLLECTIBLE_BUFF_LABELS["Reelmaster's Chair"]?.({
       skills: state.bumpkin.skills,
@@ -59,6 +63,20 @@ const BoostReelItems: (
     buff: [BUMPKIN_REVAMP_SKILL_TREE["Fisherman's 10 Fold"].boosts.buff],
     location: "Fishing Skill Tree",
   },
+  Nautilus: {
+    buff: COLLECTIBLE_BUFF_LABELS["Nautilus"]?.({
+      skills: state.bumpkin.skills,
+      collectibles: state.collectibles,
+    }) as BuffLabel[],
+    location: "Marine Marvel",
+  },
+  "Deep Sea Slug": {
+    buff: COLLECTIBLE_BUFF_LABELS["Deep Sea Slug"]?.({
+      skills: state.bumpkin.skills,
+      collectibles: state.collectibles,
+    }) as BuffLabel[],
+    location: "Marine Marvel",
+  },
   "More With Less": {
     buff: Object.values(BUMPKIN_REVAMP_SKILL_TREE["More With Less"].boosts),
     location: "Fishing Skill Tree",
@@ -69,35 +87,56 @@ const BoostReelItems: (
   },
 });
 
-const isWearable = (
-  item: BumpkinItem | CollectibleName | BumpkinRevampSkillName,
-): item is BumpkinItem => {
+const isWearable = (item: FishingReelBoostName): item is BumpkinItem => {
   return getKeys(ITEM_IDS).includes(item as BumpkinItem);
 };
 
-const isSkill = (
-  item: BumpkinItem | CollectibleName | BumpkinRevampSkillName,
-): item is BumpkinRevampSkillName =>
+const isSkill = (item: FishingReelBoostName): item is BumpkinRevampSkillName =>
   getKeys(BUMPKIN_REVAMP_SKILL_TREE).includes(item as BumpkinRevampSkillName);
 
 const getItemImage = (item: BumpkinItem | CollectibleName): string => {
   if (!item) return "";
 
   if (isWearable(item)) {
-    return getImageUrl(ITEM_IDS[item]);
+    return getWearableImage(item);
   }
 
   return ITEM_DETAILS[item].image;
 };
 
+const InactiveIconFrame: React.FC<{ icon: string }> = ({ icon }) => (
+  <div
+    className="bg-brown-600 relative"
+    style={{
+      width: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
+      height: `${PIXEL_SCALE * (INNER_CANVAS_WIDTH + 4)}px`,
+      marginTop: `${PIXEL_SCALE * 3}px`,
+      marginBottom: `${PIXEL_SCALE * 2}px`,
+      marginLeft: `${PIXEL_SCALE * 2}px`,
+      marginRight: `${PIXEL_SCALE * 3}px`,
+      ...pixelDarkBorderStyle,
+    }}
+  >
+    <SquareIcon icon={icon} width={INNER_CANVAS_WIDTH} className="silhouette" />
+  </div>
+);
+
 const getItemIcon = (
-  item: BumpkinItem | CollectibleName | BumpkinRevampSkillName,
+  item: FishingReelBoostName,
+  isActive: boolean,
 ): JSX.Element => {
   if (isSkill(item)) {
     const { tree, image, boosts, requirements, npc, power } =
       BUMPKIN_REVAMP_SKILL_TREE[item] as BumpkinSkillRevamp;
     const { tier } = requirements;
     const { boostedItemIcon, boostTypeIcon } = boosts.buff;
+
+    if (!isActive) {
+      return (
+        <InactiveIconFrame icon={getSkillImage(image, boostedItemIcon, tree)} />
+      );
+    }
+
     return (
       <SkillBox
         className="mb-1"
@@ -124,6 +163,10 @@ const getItemIcon = (
       />
     );
   } else {
+    if (!isActive) {
+      return <InactiveIconFrame icon={getItemImage(item)} />;
+    }
+
     return (
       <div
         className={"bg-brown-600 relative"}
@@ -155,6 +198,11 @@ export const FishermanExtras: React.FC<{
   const { t } = useAppTranslation();
 
   const reelsLeft = getRemainingReels(state);
+  const { boostsUsed } = getDailyFishingLimit(state, Date.now());
+  const activeBoosts = new Set<BoostName>(
+    boostsUsed.map((boost) => boost.name),
+  );
+
   return (
     <>
       <InnerPanel className="mb-1">
@@ -174,31 +222,33 @@ export const FishermanExtras: React.FC<{
         </span>
       </InnerPanel>
       <InnerPanel className="flex flex-col mb-1 overflow-y-scroll overflow-x-hidden scrollable max-h-[330px]">
-        {Object.entries(BoostReelItems(state)).map(([name, item]) => (
-          <div key={name} className="flex -ml-1">
-            {getItemIcon(
-              name as BumpkinItem | CollectibleName | BumpkinRevampSkillName,
-            )}
-            <div className="flex flex-col justify-center space-y-1">
-              <div className="flex flex-col space-y-0.5">
-                <span className="text-xs">{name}</span>
-                <span className="text-xxs italic">{item.location}</span>
-              </div>
-              <div className="flex flex-col gap-1 mr-2">
-                {item.buff.map((buff, index) => (
-                  <Label
-                    key={index}
-                    type={buff.labelType}
-                    icon={buff.boostTypeIcon}
-                    secondaryIcon={buff.boostedItemIcon}
-                  >
-                    {buff.shortDescription}
-                  </Label>
-                ))}
+        {Object.entries(BoostReelItems(state)).map(([name, item]) => {
+          const isActive = activeBoosts.has(name as BoostName);
+
+          return (
+            <div key={name} className="flex -ml-1">
+              {getItemIcon(name as FishingReelBoostName, isActive)}
+              <div className="flex flex-col justify-center space-y-1">
+                <div className="flex flex-col space-y-0.5">
+                  <span className="text-xs">{name}</span>
+                  <span className="text-xxs italic">{item.location}</span>
+                </div>
+                <div className="flex flex-col gap-1 mr-2">
+                  {item.buff.map((buff, index) => (
+                    <Label
+                      key={index}
+                      type={buff.labelType}
+                      icon={buff.boostTypeIcon}
+                      secondaryIcon={buff.boostedItemIcon}
+                    >
+                      {buff.shortDescription}
+                    </Label>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </InnerPanel>
     </>
   );


### PR DESCRIPTION
# Pull request description

## Problem
The Extras tab explains ways to increase daily fishing reels, but it did not fully reflect every permanent boost used by the game logic. It also did not clearly tell players which boost sources they already have active and which ones are still missing.

@Dionis404's request

## Summary
- Add Extra Reels boost sources to the Fisherman Extras tab.
- Show active boosts with their normal item/skill artwork.
- Show inactive boosts using the same silhouette-style visual language used in the Codex.
- Use `getDailyFishingLimit(...).boostsUsed` as the source of truth for active state.


## Solution
The tab now includes:
- Reelmaster's Chair
- Angler Waders
- Fisherman's 5 Fold
- Fisherman's 10 Fold
- Nautilus
- Deep Sea Slug
- More With Less
- Saw Fish

Inactive entries are rendered as silhouettes, matching the Codex collection style. Active entries keep their normal full artwork. VIP Access is intentionally excluded because it is no longer obtainable by players.

## Screenshots
<img width="1020" height="1058" alt="telegram-cloud-photo-size-2-5440613491539645583-y" src="https://github.com/user-attachments/assets/977dff3e-0343-452a-acd6-386f8e6d8014" />


<img width="1068" height="1122" alt="telegram-cloud-photo-size-2-5440613491539645588-y" src="https://github.com/user-attachments/assets/36fb8a64-6137-4e6e-bf77-53b15baff78e" />

<img width="1048" height="1056" alt="telegram-cloud-photo-size-2-5440613491539645585-y" src="https://github.com/user-attachments/assets/c08c5fc3-c113-44a6-8c4c-1f4249271114" />
