### PR TITLE
[FIX] Update description.deepSeaSlug.boost at en.json

### DIFF
--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -8850,7 +8850,7 @@
   "description.flamingoChicken.boost": "-2.5% Chicken Sleep Time",
   "description.spaSheep.boost": "+5 Animal XP from Animal Affection",
   "description.spaCow.boost": "+0.1 Milk",
-  "description.deepSeaSlug.boost": "+5 Fishing Attempts",
+  "description.deepSeaSlug.boost": "+5 daily fishing reels",
   "description.deepSeaSlug.boost.2": "+1 Worm from Composting",
   "description.saltCrystalFlower.boost": "5% chance for +1 Flower"
 }


### PR DESCRIPTION
Consistent description of boost as well as other fish reels boosters.

<img width="496" height="455" alt="image" src="https://github.com/user-attachments/assets/c2b7b0d6-cc4a-4395-80c9-e058200d64ac" />
