### PR TITLE
[FEAT] Standardise NPC & Bumpkin Modal

### DIFF
--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -1,10 +1,8 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 
 import levelIcon from "assets/icons/level_up.png";
 
-import { Equipped as BumpkinParts } from "features/game/types/bumpkin";
-import { DynamicNFT } from "./DynamicNFT";
-import { ButtonPanel, OuterPanel } from "components/ui/Panel";
+import { ButtonPanel, InnerPanel, OuterPanel } from "components/ui/Panel";
 import {
   getBumpkinLevel,
   getExperienceToNextLevel,
@@ -39,6 +37,14 @@ import { Feed } from "features/island/bumpkin/components/Feed";
 import { LevelUp } from "features/island/bumpkin/components/LevelUp";
 import { getAvailableFood } from "features/game/lib/availableFood";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
+import {
+  getPowerSkills,
+  BumpkinSkillRevamp,
+  BumpkinRevampSkillName,
+} from "features/game/types/bumpkinSkills";
+import { getSkillCooldown } from "features/game/events/landExpansion/skillUsed";
+import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/choseSkill";
+import { useNow } from "lib/utils/hooks/useNow";
 
 export type ViewState =
   | "home"
@@ -97,8 +103,6 @@ interface Props {
   inventory: Inventory;
   readonly: boolean;
   gameState: GameState;
-  powerSkillsReady: boolean;
-  hasPowerSkills: boolean;
 }
 
 export const BumpkinModal: React.FC<Props> = ({
@@ -108,8 +112,6 @@ export const BumpkinModal: React.FC<Props> = ({
   inventory,
   readonly,
   gameState,
-  powerSkillsReady,
-  hasPowerSkills,
 }) => {
   const { gameService } = useContext(Context);
   const { openModal } = useContext(ModalContext);
@@ -118,8 +120,49 @@ export const BumpkinModal: React.FC<Props> = ({
   const currentBumpkinLevel = level;
   const maxLevel = isMaxLevel(experience);
   const [view, setView] = useState<ViewState>("home");
-  const [tab, setTab] = useState(initialTab);
+  const [tab, setTab] = useState<Tab>(() => {
+    if (initialTab !== "feed" || readonly) return initialTab;
+    const stored = localStorage.getItem("bumpkinModalTab") as Tab | null;
+    const valid: Tab[] = ["feed", "equip", "skills", "info"];
+    return stored && valid.includes(stored) ? stored : initialTab;
+  });
   const { t } = useAppTranslation();
+  const now = useNow();
+
+  useEffect(() => {
+    if (!readonly) {
+      localStorage.setItem("bumpkinModalTab", tab);
+    }
+  }, [tab, readonly]);
+
+  const powerSkills = getPowerSkills();
+  const powerSkillsUnlocked = powerSkills.filter(
+    (skill) =>
+      !!gameState.bumpkin?.skills[skill.name as BumpkinRevampSkillName],
+  );
+  const hasPowerSkills = powerSkillsUnlocked.length > 0;
+  const powerSkillsReady =
+    hasPowerSkills &&
+    powerSkillsUnlocked
+      .filter((skill: BumpkinSkillRevamp) => {
+        const fertiliserSkill: BumpkinRevampSkillName[] = [
+          "Sprout Surge",
+          "Root Rocket",
+          "Blend-tastic",
+        ];
+        return !fertiliserSkill.includes(skill.name as BumpkinRevampSkillName);
+      })
+      .some((skill: BumpkinSkillRevamp) => {
+        const boostedCooldown = getSkillCooldown({
+          cooldown: skill.requirements.cooldown ?? 0,
+          state: gameState,
+        });
+        const nextSkillUse =
+          (gameState.bumpkin?.previousPowerUseAt?.[
+            skill.name as BumpkinRevampSkillName
+          ] ?? 0) + boostedCooldown;
+        return nextSkillUse < now;
+      });
 
   const [acknowledgedLevel, setAcknowledgedLevel] =
     useState(currentBumpkinLevel);
@@ -127,6 +170,7 @@ export const BumpkinModal: React.FC<Props> = ({
   const acknowledgeLevelUp = () => setAcknowledgedLevel(currentBumpkinLevel);
 
   const availableFood = getAvailableFood(inventory);
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
 
   if (view === "achievements") {
     return (
@@ -171,9 +215,9 @@ export const BumpkinModal: React.FC<Props> = ({
 
     return [
       {
-        id: "info",
-        icon: SUNNYSIDE.icons.player,
-        name: t("info"),
+        id: "feed",
+        icon: foodIcon,
+        name: t("feed"),
       },
       {
         id: "equip",
@@ -186,9 +230,9 @@ export const BumpkinModal: React.FC<Props> = ({
         name: t("skills"),
       },
       {
-        id: "feed",
-        icon: foodIcon,
-        name: t("feed.bumpkin"),
+        id: "info",
+        icon: SUNNYSIDE.icons.player,
+        name: t("info"),
       },
     ];
   };
@@ -201,6 +245,31 @@ export const BumpkinModal: React.FC<Props> = ({
       tabs={renderTabs()}
       container={tab === "skills" || tab === "feed" ? OuterPanel : undefined}
     >
+      {tab === "feed" && !hasLeveledUp && (
+        <InnerPanel className="flex items-center p-2 mb-1">
+          <img
+            src={levelIcon}
+            style={{
+              width: `${PIXEL_SCALE * 10}px`,
+              marginRight: `${PIXEL_SCALE * 4}px`,
+            }}
+          />
+          <div className="flex-1">
+            <p className="text-sm">
+              {t("lvl")} {level}
+              {maxLevel ? " (Max)" : ""}
+            </p>
+            <BumpkinLevel experience={bumpkin.experience} />
+          </div>
+          {availableSkillPoints > 0 && (
+            <p className="hidden sm:block text-xs text-right ml-2">
+              {t("skillTier.skillPoints.available", {
+                points: availableSkillPoints,
+              })}
+            </p>
+          )}
+        </InnerPanel>
+      )}
       <div
         style={{
           maxHeight: "calc(100vh - 200px)",
@@ -210,8 +279,6 @@ export const BumpkinModal: React.FC<Props> = ({
       >
         {tab === "info" && (
           <BumpkinInfo
-            level={level}
-            maxLevel={maxLevel}
             gameState={gameState}
             setView={setView}
             powerSkillsReady={powerSkillsReady}
@@ -235,17 +302,19 @@ export const BumpkinModal: React.FC<Props> = ({
         {tab === "feed" && (
           <>
             {hasLeveledUp ? (
-              <LevelUp
-                level={currentBumpkinLevel}
-                onClose={() => {
-                  onClose();
-                  if (currentBumpkinLevel === 2) {
-                    openModal("SECOND_LEVEL");
-                  }
-                  setTimeout(() => acknowledgeLevelUp(), 500);
-                }}
-                wearables={bumpkin.equipped as Equipped}
-              />
+              <InnerPanel>
+                <LevelUp
+                  level={currentBumpkinLevel}
+                  onClose={() => {
+                    onClose();
+                    if (currentBumpkinLevel === 2) {
+                      openModal("SECOND_LEVEL");
+                    }
+                    setTimeout(() => acknowledgeLevelUp(), 500);
+                  }}
+                  wearables={bumpkin.equipped as Equipped}
+                />
+              </InnerPanel>
             ) : (
               <Feed food={availableFood} />
             )}
@@ -257,22 +326,12 @@ export const BumpkinModal: React.FC<Props> = ({
 };
 
 export const BumpkinInfo: React.FC<{
-  level: number;
-  maxLevel: boolean;
   gameState: GameState;
   setView: (view: ViewState) => void;
   powerSkillsReady: boolean;
   hasPowerSkills: boolean;
   readonly: boolean;
-}> = ({
-  level,
-  maxLevel,
-  gameState,
-  setView,
-  powerSkillsReady,
-  hasPowerSkills,
-  readonly,
-}) => {
+}> = ({ gameState, setView, powerSkillsReady, hasPowerSkills, readonly }) => {
   const { t } = useAppTranslation();
   const { bumpkin, inventory } = gameState;
 
@@ -299,86 +358,54 @@ export const BumpkinInfo: React.FC<{
   }).filter(Boolean);
 
   return (
-    <div className="flex flex-wrap">
-      <div className="w-full sm:w-1/3 z-10 mr-0 sm:mr-2">
-        <div className="w-full rounded-md overflow-hidden mb-1">
-          <DynamicNFT
-            showBackground
-            bumpkinParts={bumpkin?.equipped as BumpkinParts}
-          />
-        </div>
-      </div>
-
-      <div className="flex-1">
-        <div className="mb-3">
-          <div className="flex items-center ml-1 my-2">
-            <img
-              src={levelIcon}
-              style={{
-                width: `${PIXEL_SCALE * 10}px`,
-                marginRight: `${PIXEL_SCALE * 4}px`,
-              }}
-            />
-            <div>
-              <p>
-                {t("lvl")} {level}
-                {maxLevel ? " (Max)" : ""}
-              </p>
-              {/* Progress bar */}
-              <BumpkinLevel experience={bumpkin.experience} />
-            </div>
-          </div>
-        </div>
-
-        <MyReputation />
-        {hasPowerSkills && !readonly && (
-          <ButtonPanel
-            onClick={() => setView("powerSkills")}
-            className="mb-2 relative mt-1 !px-2 !py-1"
-          >
-            <div className="flex items-center mb-1 justify-between">
-              <div className="flex items-center">
-                <span className="text-sm">{t("powerSkills.title")}</span>
-                {powerSkillsReady && (
-                  <img
-                    src={SUNNYSIDE.icons.expression_alerted}
-                    className="ml-2 w-2"
-                    alt="Exclamation"
-                  />
-                )}
-              </div>
-              <span className="underline text-sm">{t("viewAll")}</span>
-            </div>
-          </ButtonPanel>
-        )}
-        {badges.length > 0 && (
-          <ButtonPanel
-            className="mb-2 relative mt-1 !px-2 !py-1"
-            onClick={() => setView("legacyBadges")}
-          >
-            <div className="flex items-center mb-1 justify-between">
-              <div className="flex items-center">
-                <span className="text-sm">{`Legacy Badges`}</span>
-              </div>
-              <span className="underline text-sm">{t("viewAll")}</span>
-            </div>
-            <div className="flex flex-wrap items-center mt-2">{badges}</div>
-          </ButtonPanel>
-        )}
-
+    <div>
+      <MyReputation />
+      {hasPowerSkills && !readonly && (
         <ButtonPanel
-          onClick={() => setView("achievements")}
+          onClick={() => setView("powerSkills")}
           className="mb-2 relative mt-1 !px-2 !py-1"
         >
           <div className="flex items-center mb-1 justify-between">
             <div className="flex items-center">
-              <span className="text-sm">{t("achievements")}</span>
+              <span className="text-sm">{t("powerSkills.title")}</span>
+              {powerSkillsReady && (
+                <img
+                  src={SUNNYSIDE.icons.expression_alerted}
+                  className="ml-2 w-2"
+                  alt="Exclamation"
+                />
+              )}
             </div>
             <span className="underline text-sm">{t("viewAll")}</span>
           </div>
-          <AchievementBadges achievements={bumpkin?.achievements} />
         </ButtonPanel>
-      </div>
+      )}
+      {badges.length > 0 && (
+        <ButtonPanel
+          className="mb-2 relative mt-1 !px-2 !py-1"
+          onClick={() => setView("legacyBadges")}
+        >
+          <div className="flex items-center mb-1 justify-between">
+            <div className="flex items-center">
+              <span className="text-sm">{`Legacy Badges`}</span>
+            </div>
+            <span className="underline text-sm">{t("viewAll")}</span>
+          </div>
+          <div className="flex flex-wrap items-center mt-2">{badges}</div>
+        </ButtonPanel>
+      )}
+      <ButtonPanel
+        onClick={() => setView("achievements")}
+        className="mb-2 relative mt-1 !px-2 !py-1"
+      >
+        <div className="flex items-center mb-1 justify-between">
+          <div className="flex items-center">
+            <span className="text-sm">{t("achievements")}</span>
+          </div>
+          <span className="underline text-sm">{t("viewAll")}</span>
+        </div>
+        <AchievementBadges achievements={bumpkin?.achievements} />
+      </ButtonPanel>
     </div>
   );
 };

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -387,6 +387,7 @@ export const INITIAL_FARM: GameState = {
     Rug: new Decimal(1),
     Wardrobe: new Decimal(1),
     Shovel: new Decimal(1),
+    "Honey Cake": new Decimal(1),
   },
   previousInventory: {},
   wardrobe: {},

--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -61,16 +61,14 @@ export const Feed: React.FC<Props> = ({ food }) => {
           <span className="w-full my-2">
             {t("statements.feed.bumpkin.two")}
           </span>
-          <div className="flex flex-col items-center">
-            <img
-              src={SUNNYSIDE.building.firePit}
-              className="my-2"
-              alt={"Fire Pit"}
-              style={{
-                width: `${PIXEL_SCALE * 47}px`,
-              }}
-            />
-          </div>
+          <img
+            src={SUNNYSIDE.building.firePit}
+            className="my-2"
+            alt={"Fire Pit"}
+            style={{
+              width: `${PIXEL_SCALE * 47}px`,
+            }}
+          />
         </div>
       </InnerPanel>
     );

--- a/src/features/island/bumpkin/components/PlayerNPC.tsx
+++ b/src/features/island/bumpkin/components/PlayerNPC.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from "react";
 import { useState } from "react";
 import { NPCPlaceable, NPCProps } from "./NPC";
-import { NPCModal } from "./NPCModal";
 import { Context } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
 import { useSelector } from "@xstate/react";
@@ -18,6 +17,9 @@ import { hasFeatureAccess } from "lib/flags";
 import { PlayerModal } from "features/social/PlayerModal";
 import { AuthMachineState } from "features/auth/lib/authMachine";
 import { Discovery } from "features/social/Discovery";
+import { Modal } from "components/ui/Modal";
+import { BumpkinModal } from "features/bumpkins/components/BumpkinModal";
+import { Bumpkin } from "features/game/types/game";
 
 const _showHelper = (state: MachineState) =>
   // First Rhubarb Tart
@@ -28,6 +30,7 @@ const _showHelper = (state: MachineState) =>
     state.context.state.inventory["Pumpkin Soup"]?.gte(1));
 const _token = (state: AuthMachineState) => state.context.user.rawToken ?? "";
 const _isLandscaping = (state: MachineState) => state.matches("landscaping");
+const _gameState = (state: MachineState) => state.context.state;
 
 export const PlayerNPC: React.FC<NPCProps> = ({ parts: bumpkinParts }) => {
   const [open, setOpen] = useState(false);
@@ -37,6 +40,7 @@ export const PlayerNPC: React.FC<NPCProps> = ({ parts: bumpkinParts }) => {
   const showHelper = useSelector(gameService, _showHelper);
   const token = useSelector(authService, _token);
   const isLandscaping = useSelector(gameService, _isLandscaping);
+  const gameState = useSelector(gameService, _gameState);
   const { isVisiting } = useVisiting();
   const context = gameService.getSnapshot().context;
   const loggedInFarmId = context.visitorId ?? context.farmId;
@@ -84,7 +88,16 @@ export const PlayerNPC: React.FC<NPCProps> = ({ parts: bumpkinParts }) => {
         />
       )}
 
-      <NPCModal isOpen={open} onClose={() => setOpen(false)} />
+      <Modal show={open} onHide={() => setOpen(false)} size="lg">
+        <BumpkinModal
+          initialTab="feed"
+          onClose={() => setOpen(false)}
+          bumpkin={gameState.bumpkin as Bumpkin}
+          inventory={gameState.inventory}
+          readonly={false}
+          gameState={gameState}
+        />
+      </Modal>
       <PlayerModal
         loggedInFarmId={loggedInFarmId}
         token={token}

--- a/src/features/island/hud/components/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/BumpkinProfile.tsx
@@ -264,8 +264,6 @@ export const BumpkinProfile: React.FC = () => {
     (skill) => !!skills[skill.name as BumpkinRevampSkillName],
   );
 
-  const hasPowerSkills = powerSkillsUnlocked.length > 0;
-
   const powerSkillsReady = powerSkillsUnlocked
     .filter((skill: BumpkinSkillRevamp) => {
       const fertiliserSkill: BumpkinRevampSkillName[] = [
@@ -291,14 +289,12 @@ export const BumpkinProfile: React.FC = () => {
       {/* Bumpkin modal */}
       <Modal show={showModal} onHide={handleHideModal} size="lg">
         <BumpkinModal
-          initialTab={viewSkillsTab ? "skills" : "info"}
+          initialTab={viewSkillsTab ? "skills" : "feed"}
           onClose={handleHideModal}
           readonly={gameState.matches("visiting")}
           bumpkin={gameState.context.state.bumpkin as Bumpkin}
           inventory={gameState.context.state.inventory}
           gameState={gameState.context.state}
-          powerSkillsReady={powerSkillsReady}
-          hasPowerSkills={hasPowerSkills}
         />
       </Modal>
 

--- a/src/features/island/hud/components/bumpkinProfile/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/bumpkinProfile/BumpkinProfile.tsx
@@ -264,8 +264,6 @@ export const BumpkinProfile: React.FC = () => {
     (skill) => !!skills[skill.name as BumpkinRevampSkillName],
   );
 
-  const hasPowerSkills = powerSkillsUnlocked.length > 0;
-
   const powerSkillsReady = powerSkillsUnlocked
     .filter((skill: BumpkinSkillRevamp) => {
       const fertiliserSkill: BumpkinRevampSkillName[] = [
@@ -291,14 +289,12 @@ export const BumpkinProfile: React.FC = () => {
       {/* Bumpkin modal */}
       <Modal show={showModal} onHide={handleHideModal} size="lg">
         <BumpkinModal
-          initialTab={viewSkillsTab ? "skills" : "info"}
+          initialTab={viewSkillsTab ? "skills" : "feed"}
           onClose={handleHideModal}
           readonly={gameState.matches("visiting")}
           bumpkin={gameState.context.state.bumpkin as Bumpkin}
           inventory={gameState.context.state.inventory}
           gameState={gameState.context.state}
-          powerSkillsReady={powerSkillsReady}
-          hasPowerSkills={hasPowerSkills}
         />
       </Modal>
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5893,6 +5893,7 @@
   "skillPath.skills": "{{skillPath}} Skills",
   "skillTier.skillPoints.singular": "{{points}} Skill Point",
   "skillTier.skillPoints.plural": "{{points}} Skill Points",
+  "skillTier.skillPoints.available": "{{points}} skill points available",
   "skillTier.number": "Tier {{number}}",
   "powerSkills.title": "Power Skills",
   "powerSkills.ready": "Power Skill Ready",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -5893,6 +5893,7 @@
   "skillPath.skills": "{{skillPath}} Skills",
   "skillTier.skillPoints.singular": "{{points}} Skill Point",
   "skillTier.skillPoints.plural": "{{points}} Skill Points",
+  "skillTier.skillPoints.available": "{{points}} skill points available",
   "skillTier.number": "Tier {{number}}",
   "powerSkills.title": "Power Skills",
   "powerSkills.ready": "Power Skill Ready",


### PR DESCRIPTION
# Pull request description

Clicking both the NPC and Avatar opens the same modal - this allows players to feed, equip or do other actions from both.

Also freshened up the feed tab to include the XP so it is visible what is changing.

<img width="825" height="398" alt="Screenshot 2026-04-28 at 4 28 39 pm" src="https://github.com/user-attachments/assets/52a7531c-e647-415b-a710-072c1827026b" />
