### PR TITLE
[FIX] Update description.deepSeaSlug.boost at dictionary.json

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -8852,7 +8852,7 @@
   "description.flamingoChicken.boost": "-2.5% Chicken Sleep Time",
   "description.spaSheep.boost": "+5 Animal XP from Animal Affection",
   "description.spaCow.boost": "+0.1 Milk",
-  "description.deepSeaSlug.boost": "+5 Fishing Attempts",
+  "description.deepSeaSlug.boost": "+5 daily fishing reels",
   "description.deepSeaSlug.boost.2": "+1 Worm from Composting",
   "description.saltCrystalFlower.boost": "5% chance for +1 Flower"
 }


### PR DESCRIPTION
Consistent description of boost as well as other fish reels boosters.

<img width="992" height="910" alt="image" src="https://github.com/user-attachments/assets/5d1ce41f-16ae-4f9a-adc5-41d198638ae2" />
