### PR TITLE
[FIX] obsidian shrine default tab

### DIFF
--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -236,7 +236,13 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
     );
     setShow(true);
     setActiveTab(
-      hasReadyCrops ? "harvest" : hasAvailablePlots ? "plant" : "fertilise",
+      hasReadyCrops
+        ? "harvest"
+        : hasAvailablePlots
+          ? "plant"
+          : hasFertiliseAccess
+            ? "fertilise"
+            : "harvest",
     );
   };
 

--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -48,7 +48,6 @@ import { selectGameState, selectVerified } from "features/game/lib/gameMachine";
 import { isSeasonedPlayer } from "features/game/lib/seasonedPlayer";
 import { ChestReward } from "features/island/common/chest-reward/ChestReward";
 import { FarmActivityName } from "features/game/types/farmActivity";
-import { hasFeatureAccess } from "lib/flags";
 
 export const ObsidianShrine: React.FC<CollectibleProps> = ({
   createdAt,
@@ -80,11 +79,6 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
   const verified = useSelector(gameService, selectVerified);
   const farmId = useSelector(gameService, (state) => state.context.farmId);
   const isSeasoned = isSeasonedPlayer({ game: state, verified, now });
-
-  const hasFertiliseAccess = hasFeatureAccess(
-    state,
-    "OBSIDIAN_SHRINE_BULK_FERTILISE",
-  );
 
   const availablePlots = getAvailablePlots(state);
   const { readyCrops, readyPlots } = getCropsToHarvest(state, now);
@@ -236,13 +230,7 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
     );
     setShow(true);
     setActiveTab(
-      hasReadyCrops
-        ? "harvest"
-        : hasAvailablePlots
-          ? "plant"
-          : hasFertiliseAccess
-            ? "fertilise"
-            : "harvest",
+      hasReadyCrops ? "harvest" : hasAvailablePlots ? "plant" : "fertilise",
     );
   };
 
@@ -293,15 +281,11 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
               icon: SUNNYSIDE.icons.plant,
               name: "Plant",
             },
-            ...(hasFertiliseAccess
-              ? ([
-                  {
-                    id: "fertilise",
-                    icon: ITEM_DETAILS["Sprout Mix"].image,
-                    name: "Fertilise",
-                  },
-                ] as const)
-              : []),
+            {
+              id: "fertilise",
+              icon: ITEM_DETAILS["Sprout Mix"].image,
+              name: "Fertilise",
+            },
           ]}
           currentTab={activeTab}
           setCurrentTab={setActiveTab}
@@ -332,7 +316,7 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
               close={close}
             />
           )}
-          {activeTab === "fertilise" && hasFertiliseAccess && (
+          {activeTab === "fertilise" && (
             <FertiliseAll
               state={state}
               close={close}

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -138,8 +138,6 @@ const FEATURE_FLAGS = {
   CHAACS_TEMPLE_BETA: betaFeatureFlag,
   SALT_FARM: betaFeatureFlag,
 
-  OBSIDIAN_SHRINE_BULK_FERTILISE: betaFeatureFlag,
-
   AGING_SHED: betaFeatureFlag,
 
   SALT_SKILLS: betaFeatureFlag,


### PR DESCRIPTION
# Pull request description

@eliasSFL 

Hi, I need your opinion. Today, working with Obsidian Shrine, I have stumbled over a default state that seems to not exist.

<img width="1280" height="659" alt="telegram-cloud-photo-size-2-5444970598422484092-y" src="https://github.com/user-attachments/assets/f6c64ac3-24bd-488f-874f-4997bd67c4a6" />


 As I understood, this is due to the fact that the Fertilize tab will only run with a new chapter. As Fix this state I made the simplest fallback , but I'm not very sure if it's worth fixing it if, in my opinion, this case will no longer be there next week. 
 
 What do you say? 


## Summary
- Fix Obsidian Shrine opening with no active tab when crops are planted but not ready to harvest.
- Only default to the `Fertilise` tab when the bulk fertilise feature is actually available.
- Fall back to `Harvest` so players see the existing “No crops ready to harvest” state instead of an empty panel.

## Problem
When all crop plots are occupied by growing crops, there are no ready crops and no available plots. The shrine previously selected `fertilise` as the default tab in that state. If the fertilise feature flag was disabled, that tab was not rendered, leaving no visible active tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Obsidian Shrine bulk fertilisation feature is now universally accessible to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->