### PR TITLE
[CHORE] Improve marketplace profile navigation

### DIFF
--- a/src/features/marketplace/components/MarketplaceUser.tsx
+++ b/src/features/marketplace/components/MarketplaceUser.tsx
@@ -20,7 +20,11 @@ import { getAscensionDisplayText } from "features/game/lib/level";
 const _token = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
 
-export const MarketplaceUser: React.FC = () => {
+type MarketplaceUserView = "stats" | "history";
+
+export const MarketplaceUser: React.FC<{ view?: MarketplaceUserView }> = ({
+  view = "stats",
+}) => {
   const { authService } = useContext(Auth.Context);
   const token = useSelector(authService, _token);
 
@@ -48,23 +52,33 @@ export const MarketplaceUser: React.FC = () => {
 
   return (
     <div className="overflow-y-scroll scrollable pr-1">
-      <div className="flex flex-wrap">
-        <div className="w-full sm:w-1/3 pr-1 mb-1">
-          <InnerPanel
-            className="flex items-center h-full cursor-pointer"
-            onClick={() =>
-              playerModalManager.open({
-                farmId: profile.id,
-                username: profile.username,
-                clothing: interpretTokenUri(profile.tokenUri).equipped,
-              })
-            }
-          >
-            <div className="h-16 w-16 flex items-center justify-center mr-2 relative">
-              <NPCIcon
-                parts={interpretTokenUri(profile.tokenUri).equipped}
-                width={60}
-              />
+      {view === "stats" && (
+        <>
+          <div className="flex flex-wrap">
+            <div className="w-full sm:w-1/3 pr-1 mb-1">
+              <InnerPanel
+                className="flex items-center h-full cursor-pointer"
+                onClick={() =>
+                  playerModalManager.open({
+                    farmId: profile.id,
+                    username: profile.username,
+                    clothing: interpretTokenUri(profile.tokenUri).equipped,
+                  })
+                }
+              >
+                <div className="h-16 w-16 flex items-center justify-center mr-2 relative">
+                  <NPCIcon
+                    parts={interpretTokenUri(profile.tokenUri).equipped}
+                    width={60}
+                  />
+                </div>
+                <div className="flex-1 overflow-hidden">
+                  <Label type="default" className="mb-0.5">
+                    {`Lvl. ${profile.level}`}
+                  </Label>
+                  <p className="text-sm truncate">{profile.username}</p>
+                </div>
+              </InnerPanel>
             </div>
             <div className="flex-1 overflow-hidden">
               <Label type="default" className="mb-0.5">
@@ -77,85 +91,97 @@ export const MarketplaceUser: React.FC = () => {
               </Label>
               <p className="text-sm truncate">{profile.username}</p>
             </div>
-          </InnerPanel>
         </div>
 
-        <div className="w-full sm:w-1/3 pr-1 mb-1">
-          <InnerPanel className="flex items-center h-full">
-            <div className="h-16 w-16 flex items-center justify-center mr-2">
-              <img src={tradeIcon} className="h-12" />
-            </div>
-            <div>
-              <Label type="default" className="mb-0.5">
-                {`Total Trades`}
-              </Label>
-              <p className="text-sm">{profile.totalTrades}</p>
-            </div>
-          </InnerPanel>
-        </div>
-
-        <div className="w-full sm:w-1/3 mb-1">
-          <InnerPanel className="flex items-center h-full">
-            <div className="h-16 w-16 flex items-center justify-center mr-2">
-              <img src={sflIcon} className="h-12" />
-            </div>
-            <div>
-              <Label type="default" className="mb-0.5">
-                {`FLOWER Traded (last 7 days)`}
-              </Label>
-              <div className="flex items-center space-x-4">
+            <div className="w-full sm:w-1/3 pr-1 mb-1">
+              <InnerPanel className="flex items-center h-full">
+                <div className="h-16 w-16 flex items-center justify-center mr-2">
+                  <img src={tradeIcon} className="h-12" />
+                </div>
                 <div>
-                  <div className="flex items-center space-x-2">
-                    <span className="">{`Spent:`}</span>
-                    <span className="font-bold text-red-600">
-                      {profile.weeklyFlowerSpent.toFixed(2)}
-                    </span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <span className="">{`Earned:`}</span>
-                    <span className="font-bold text-green-700">
-                      {profile.weeklyFlowerEarned.toFixed(2)}
-                    </span>
+                  <Label type="default" className="mb-0.5">
+                    {`Total Trades`}
+                  </Label>
+                  <p className="text-sm">{profile.totalTrades}</p>
+                </div>
+              </InnerPanel>
+            </div>
+
+            <div className="w-full sm:w-1/3 mb-1">
+              <InnerPanel className="flex items-center h-full">
+                <div className="h-16 w-16 flex items-center justify-center mr-2">
+                  <img src={sflIcon} className="h-12" />
+                </div>
+                <div>
+                  <Label type="default" className="mb-0.5">
+                    {`FLOWER Traded (last 7 days)`}
+                  </Label>
+                  <div className="flex items-center space-x-4">
+                    <div>
+                      <div className="flex items-center space-x-2">
+                        <span className="">{`Spent:`}</span>
+                        <span className="font-bold text-red-600">
+                          {profile.weeklyFlowerSpent.toFixed(2)}
+                        </span>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <span className="">{`Earned:`}</span>
+                        <span className="font-bold text-green-700">
+                          {profile.weeklyFlowerEarned.toFixed(2)}
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </InnerPanel>
+            </div>
+          </div>
+
+          <InnerPanel className="mb-1">
+            <Label type="default" icon={tradeIcon} className="ml-2">
+              {t("marketplace.topFriends")}
+            </Label>
+            <div className="flex flex-wrap">
+              {profile.friends.map((friend) => (
+                <div
+                  key={friend.id}
+                  className="flex items-center w-full sm:w-1/3 pr-4 cursor-pointer"
+                  onClick={() =>
+                    playerModalManager.open({
+                      farmId: friend.id,
+                      username: friend.username,
+                      clothing: interpretTokenUri(friend.tokenUri).equipped,
+                    })
+                  }
+                >
+                  <div className="h-16 w-16 flex items-center justify-center relative">
+                    <NPCIcon
+                      parts={interpretTokenUri(friend.tokenUri).equipped}
+                    />
+                  </div>
+                  <div className="flex-1 overflow-hidden">
+                    <p className="text-sm truncate">{friend.username}</p>
+                    <p className="text-xs">{`${friend.trades} trades`}</p>
+                  </div>
+                </div>
+              ))}
             </div>
           </InnerPanel>
-        </div>
-      </div>
+        </>
+      )}
 
-      <InnerPanel className="mb-1">
-        <Label type="default" icon={tradeIcon} className="ml-2">
-          {t("marketplace.topFriends")}
-        </Label>
-        <div className="flex flex-wrap">
-          {profile.friends.map((friend) => (
-            <div
-              key={friend.id}
-              className="flex items-center w-full sm:w-1/3 pr-4 cursor-pointer"
-              onClick={() =>
-                playerModalManager.open({
-                  farmId: friend.id,
-                  username: friend.username,
-                  clothing: interpretTokenUri(friend.tokenUri).equipped,
-                })
-              }
-            >
-              <div className="h-16 w-16 flex items-center justify-center relative">
-                <NPCIcon parts={interpretTokenUri(friend.tokenUri).equipped} />
-              </div>
-              <div className="flex-1 overflow-hidden">
-                <p className="text-sm truncate">{friend.username}</p>
-                <p className="text-xs">{`${friend.trades} trades`}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </InnerPanel>
-
-      <InnerPanel>
-        <Sales sales={profile.trades ?? []} />
-      </InnerPanel>
+      {view === "history" && (
+        <InnerPanel>
+          <Label type="default" icon={tradeIcon} className="ml-2">
+            {t("marketplace.saleHistory")}
+          </Label>
+          {(profile.trades ?? []).length > 0 ? (
+            <Sales sales={profile.trades ?? []} />
+          ) : (
+            <p className="text-sm p-2">{t("marketplace.noSales")}</p>
+          )}
+        </InnerPanel>
+      )}
     </div>
   );
 };

--- a/src/features/marketplace/components/MarketplaceUser.tsx
+++ b/src/features/marketplace/components/MarketplaceUser.tsx
@@ -91,7 +91,6 @@ export const MarketplaceUser: React.FC<{ view?: MarketplaceUserView }> = ({
               </Label>
               <p className="text-sm truncate">{profile.username}</p>
             </div>
-        </div>
 
             <div className="w-full sm:w-1/3 pr-1 mb-1">
               <InnerPanel className="flex items-center h-full">

--- a/src/features/marketplace/components/home/Filters.tsx
+++ b/src/features/marketplace/components/home/Filters.tsx
@@ -33,8 +33,8 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
 import { Context } from "features/game/GameProvider";
 import * as Auth from "features/auth/lib/Provider";
-import { MachineState } from "features/game/lib/gameMachine";
-import { AuthMachineState } from "features/auth/lib/authMachine";
+import type { MachineState } from "features/game/lib/gameMachine";
+import type { AuthMachineState } from "features/auth/lib/authMachine";
 import { loadProfile } from "features/marketplace/actions/loadProfile";
 
 const _trades = (state: MachineState) => state.context.state.trades;
@@ -80,7 +80,7 @@ export const Filters: React.FC<{
     getKeys(trades.listings ?? {}).length > 0;
 
   useEffect(() => {
-    if (!pathname.includes("/profile")) return;
+    if (!pathname.includes("/profile") && !userProfileExpanded) return;
 
     let cancelled = false;
 
@@ -100,7 +100,7 @@ export const Filters: React.FC<{
     return () => {
       cancelled = true;
     };
-  }, [farmId, pathname, token]);
+  }, [farmId, pathname, token, userProfileExpanded]);
 
   const isChapterExpanded = !!chapterParam || userChapterExpanded;
   const isProfileExpanded =
@@ -351,7 +351,7 @@ export const Filters: React.FC<{
       ? [
           {
             icon: tradeIcon,
-            label: `${t("active")} ${t("marketplace.trades")}`,
+            label: t("marketplace.activeTrades"),
             onClick: () =>
               navigateTo({
                 path: profilePath("/trades"),

--- a/src/features/marketplace/components/home/Filters.tsx
+++ b/src/features/marketplace/components/home/Filters.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useNavigate, useLocation, useSearchParams } from "react-router";
+import { useSelector } from "@xstate/react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { FilterOption, type FilterOptionProps } from "./FilterOption";
@@ -30,12 +31,23 @@ import {
 import { CHAPTER_COLLECTIONS } from "features/game/types/collections";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
+import { Context } from "features/game/GameProvider";
+import * as Auth from "features/auth/lib/Provider";
+import { MachineState } from "features/game/lib/gameMachine";
+import { AuthMachineState } from "features/auth/lib/authMachine";
+import { loadProfile } from "features/marketplace/actions/loadProfile";
+
+const _trades = (state: MachineState) => state.context.state.trades;
+const _authToken = (state: AuthMachineState) =>
+  state.context.user.rawToken as string;
 
 export const Filters: React.FC<{
   onClose?: () => void;
   farmId: number;
   hideLimited?: boolean;
 }> = ({ onClose, farmId, hideLimited }) => {
+  const { gameService } = useContext(Context);
+  const { authService } = useContext(Auth.Context);
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [queryParams] = useSearchParams();
@@ -58,6 +70,37 @@ export const Filters: React.FC<{
     Record<string, boolean>
   >({});
   const [userChapterExpanded, setUserChapterExpanded] = useState(false);
+  const [hasTradeHistory, setHasTradeHistory] = useState(false);
+  const trades = useSelector(gameService, _trades);
+  const token = useSelector(authService, _authToken);
+
+  const hasActiveTrades =
+    getKeys(trades.offers ?? {}).length > 0 ||
+    getKeys(trades.listings ?? {}).length > 0;
+
+  useEffect(() => {
+    if (!pathname.includes("/profile")) return;
+
+    let cancelled = false;
+
+    loadProfile({
+      token,
+      id: farmId,
+    })
+      .then((profile) => {
+        if (cancelled) return;
+        setHasTradeHistory((profile.trades ?? []).length > 0);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setHasTradeHistory(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [farmId, pathname, token]);
+
   const isChapterExpanded = !!chapterParam || userChapterExpanded;
 
   const baseUrl = `${isWorldRoute ? "/world" : ""}/marketplace`;
@@ -295,6 +338,66 @@ export const Filters: React.FC<{
     });
   };
 
+  const profilePath = (path: string) => `profile/${farmId}${path}`;
+  const profileLandingPath = hasActiveTrades
+    ? profilePath("/trades")
+    : profilePath("");
+  const profileOptions: FilterOptionProps[] = [
+    ...(hasActiveTrades
+      ? [
+          {
+            icon: tradeIcon,
+            label: `${t("active")} ${t("marketplace.trades")}`,
+            onClick: () =>
+              navigateTo({
+                path: profilePath("/trades"),
+              }),
+            isActive: pathname === `${baseUrl}/${profilePath("/trades")}`,
+          },
+        ]
+      : []),
+    {
+      icon: SUNNYSIDE.icons.lightning,
+      label: t("marketplace.stats"),
+      onClick: () =>
+        navigateTo({
+          path: profilePath(""),
+        }),
+      isActive: pathname === `${baseUrl}/${profilePath("")}`,
+    },
+    ...(hasTradeHistory
+      ? [
+          {
+            icon: SUNNYSIDE.icons.stopwatch,
+            label: t("marketplace.saleHistory"),
+            onClick: () =>
+              navigateTo({
+                path: profilePath("/history"),
+              }),
+            isActive: pathname === `${baseUrl}/${profilePath("/history")}`,
+          },
+        ]
+      : []),
+    {
+      icon: SUNNYSIDE.icons.treasure,
+      label: t("marketplace.collection"),
+      onClick: () =>
+        navigateTo({
+          path: profilePath("/collection"),
+        }),
+      isActive: pathname === `${baseUrl}/${profilePath("/collection")}`,
+    },
+    {
+      icon: trade_point,
+      label: t("marketplace.rewards"),
+      onClick: () =>
+        navigateTo({
+          path: "profile/rewards",
+        }),
+      isActive: pathname === `${baseUrl}/profile/rewards`,
+    },
+  ];
+
   const filterOptions: FilterOptionProps[] = [
     // Trending
     {
@@ -469,40 +572,10 @@ export const Filters: React.FC<{
       onClick: () => {
         setExpandedTraitGroups({});
         navigateTo({
-          path: `profile/${farmId}`,
+          path: profileLandingPath,
         });
       },
-      options: pathname.includes("profile")
-        ? [
-            {
-              icon: SUNNYSIDE.icons.lightning,
-              label: t("marketplace.stats"),
-              onClick: () =>
-                navigateTo({
-                  path: `profile/${farmId}`,
-                }),
-              isActive: pathname === `${baseUrl}/profile/${farmId}`,
-            },
-            {
-              icon: tradeIcon,
-              label: t("marketplace.trades"),
-              onClick: () =>
-                navigateTo({
-                  path: `profile/${farmId}/trades`,
-                }),
-              isActive: pathname === `${baseUrl}/profile/${farmId}/trades`,
-            },
-            {
-              icon: trade_point,
-              label: t("marketplace.rewards"),
-              onClick: () =>
-                navigateTo({
-                  path: "profile/rewards",
-                }),
-              isActive: pathname === `${baseUrl}/profile/rewards`,
-            },
-          ]
-        : undefined,
+      options: pathname.includes("profile") ? profileOptions : undefined,
     },
     // Favorites
     {

--- a/src/features/marketplace/components/home/Filters.tsx
+++ b/src/features/marketplace/components/home/Filters.tsx
@@ -70,6 +70,7 @@ export const Filters: React.FC<{
     Record<string, boolean>
   >({});
   const [userChapterExpanded, setUserChapterExpanded] = useState(false);
+  const [userProfileExpanded, setUserProfileExpanded] = useState(false);
   const [hasTradeHistory, setHasTradeHistory] = useState(false);
   const trades = useSelector(gameService, _trades);
   const token = useSelector(authService, _authToken);
@@ -102,6 +103,9 @@ export const Filters: React.FC<{
   }, [farmId, pathname, token]);
 
   const isChapterExpanded = !!chapterParam || userChapterExpanded;
+  const isProfileExpanded =
+    pathname.includes("/profile") || userProfileExpanded;
+  const isMobileFilters = !!onClose;
 
   const baseUrl = `${isWorldRoute ? "/world" : ""}/marketplace`;
   const filterTokens = (filters ?? "")
@@ -571,11 +575,16 @@ export const Filters: React.FC<{
       label: t("marketplace.myProfile"),
       onClick: () => {
         setExpandedTraitGroups({});
+        if (isMobileFilters) {
+          setUserProfileExpanded((prev) => !prev);
+          return;
+        }
+
         navigateTo({
           path: profileLandingPath,
         });
       },
-      options: pathname.includes("profile") ? profileOptions : undefined,
+      options: isProfileExpanded ? profileOptions : undefined,
     },
     // Favorites
     {

--- a/src/features/marketplace/components/home/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/home/MarketplaceHome.tsx
@@ -10,6 +10,7 @@ import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { MarketplaceProfile } from "../MarketplaceProfile";
 import { MyTrades } from "../profile/MyTrades";
+import { MyCollection } from "../profile/MyCollection";
 import { MarketplaceRewards } from "../MarketplaceRewards";
 import { Tradeable } from "../Tradeable";
 import { MarketplaceHotNow } from "../MarketplaceHotNow";
@@ -236,8 +237,16 @@ export const MarketplaceNavigation: React.FC = () => {
                 path="/:collection/:id"
                 element={<Tradeable hideLimited={hideLimited} />}
               />
-              <Route path="/profile/:id" element={<MarketplaceUser />} />
               <Route path="/profile/:id/trades" element={<MyTrades />} />
+              <Route path="/profile/:id" element={<MarketplaceUser />} />
+              <Route
+                path="/profile/:id/history"
+                element={<MarketplaceUser view="history" />}
+              />
+              <Route
+                path="/profile/:id/collection"
+                element={<MyCollection />}
+              />
               <Route path="/profile/rewards" element={<MarketplaceRewards />} />
               {/* default to hot */}
               <Route path="/" element={<MarketplaceHotNow />} />

--- a/src/features/marketplace/components/profile/MyTrades.tsx
+++ b/src/features/marketplace/components/profile/MyTrades.tsx
@@ -1,14 +1,43 @@
-import React from "react";
+import { Label } from "components/ui/Label";
+import { InnerPanel } from "components/ui/Panel";
+import React, { useContext } from "react";
+import { useSelector } from "@xstate/react";
+import { Context } from "features/game/GameProvider";
+import { MachineState } from "features/game/lib/gameMachine";
+import { getKeys } from "lib/object";
 import { MyListings } from "./MyListings";
-import { MyCollection } from "./MyCollection";
 import { MyOffers } from "./MyOffers";
+import tradeIcon from "assets/icons/trade.png";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+const _trades = (state: MachineState) => state.context.state.trades;
 
 export const MyTrades: React.FC = () => {
+  const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+  const trades = useSelector(gameService, _trades);
+  const hasActiveTrades =
+    getKeys(trades.offers ?? {}).length > 0 ||
+    getKeys(trades.listings ?? {}).length > 0;
+
+  if (!hasActiveTrades) {
+    return (
+      <InnerPanel className="m-1">
+        <Label type="default" icon={tradeIcon}>
+          {`${t("active")} ${t("marketplace.trades")}`}
+        </Label>
+        <div className="text-sm p-2">
+          <p>{t("marketplace.noMyOffers")}</p>
+          <p>{t("marketplace.noMyListings")}</p>
+        </div>
+      </InnerPanel>
+    );
+  }
+
   return (
     <div className="overflow-y-scroll scrollable pr-1 h-full">
       <MyOffers />
       <MyListings />
-      <MyCollection />
     </div>
   );
 };

--- a/src/features/marketplace/components/profile/MyTrades.tsx
+++ b/src/features/marketplace/components/profile/MyTrades.tsx
@@ -3,7 +3,7 @@ import { InnerPanel } from "components/ui/Panel";
 import React, { useContext } from "react";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { MachineState } from "features/game/lib/gameMachine";
+import type { MachineState } from "features/game/lib/gameMachine";
 import { getKeys } from "lib/object";
 import { MyListings } from "./MyListings";
 import { MyOffers } from "./MyOffers";
@@ -24,7 +24,7 @@ export const MyTrades: React.FC = () => {
     return (
       <InnerPanel className="m-1">
         <Label type="default" icon={tradeIcon}>
-          {`${t("active")} ${t("marketplace.trades")}`}
+          {t("marketplace.activeTrades")}
         </Label>
         <div className="text-sm p-2">
           <p>{t("marketplace.noMyOffers")}</p>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6093,6 +6093,7 @@
   "marketplace.tradeInitiated": "Great news! It looks like someone is fulfilling your trade. Please wait for the trade to complete.",
   "marketplace.rewards": "Rewards",
   "marketplace.trades": "Trades",
+  "marketplace.activeTrades": "Active Trades",
   "marketplace.stats": "Stats",
   "marketplace.wearables": "Wearables",
   "marketplace.limited": "Limited",


### PR DESCRIPTION
# Pull request description

@adamhannigan Dear sir, its new iteration that idea https://github.com/sunflower-land/sunflower-land/pull/7105
I am really looking forward to your feedback and am open to any ideas

## Summary
This PR restructures the Marketplace profile navigation to create the shortest path to active deals for active traders.

The main problem this solves is that users who actively trade need a shortest route to their current offers and listings, without first landing in a mixed profile page or scanning through unrelated information.

## Changes
— Makes click to My Profile open Active Trades first when the player has active offers or listings.
— Renames the profile trade entry to Active Trades and routes it to the active offers/listings screen.
— Falls back to Stats when there are no active trades, so the first profile click does not open an empty screen.
— Splits trade history into a dedicated Sales History profile route.
— Splits collection into a dedicated profile route.
— Hides Active Trades from the profile submenu when there are no active offers/listings.
— Hides Sales History from the profile submenu when the profile has no trade history.
— Adds empty-state fallbacks for direct URLs, so old links or manual navigation remain safe.


Gives active traders the fastest possible path to their current marketplace work.
Makes the profile section easier to scan by separating active trades, stats, sales history, collection, and rewards.
Avoids showing empty navigation targets when there is nothing useful behind 

## Screensots

Active

Empty state
<img width="274" height="214" alt="image" src="https://github.com/user-attachments/assets/31ef308a-5a29-4bf5-823c-08b7594998de" />

Active state with history 
<img width="499" height="643" alt="image" src="https://github.com/user-attachments/assets/d5aab2d2-e66f-4473-a605-ed401a284787" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added switchable profile views (stats and history) in marketplace profile
  * New dedicated collections and sale history sections accessible in user profiles

* **Improvements**
  * Enhanced filter options with dynamic detection of active trades and history
  * Improved mobile navigation behavior for profile section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->