### PR TITLE
[CHORE] Open game options directly from settings gear

### DIFF
--- a/src/features/island/hud/components/Settings.tsx
+++ b/src/features/island/hud/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, type JSX } from "react";
+import React, { useRef, useState } from "react";
 
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { AudioControlsProvider } from "features/game/components/AudioControlsContext";
@@ -8,9 +8,7 @@ import {
   getGoblinSong,
   getGoblinSongCount,
 } from "assets/songs/playlist";
-import { SUNNYSIDE } from "assets/sunnyside";
 import settings from "assets/icons/settings.png";
-import { useLocation } from "react-router";
 import { GameOptionsModal } from "./settings-menu/GameOptions";
 import { useSound } from "lib/utils/hooks/useSound";
 import { RoundButton } from "components/ui/RoundButton";
@@ -23,34 +21,9 @@ interface Props {
 }
 
 export const Settings: React.FC<Props> = ({ isFarming }) => {
-  const [showMoreButtons, setShowMoreButtons] = useState(false);
   const [openSettingsMenu, setOpenSettingsMenu] = useState(false);
-  const { pathname } = useLocation();
 
   const button = useSound("button");
-
-  // The actions included in this more buttons should not be shown if the player is visiting another farm
-  const showLimitedButtons = pathname.includes("visit");
-
-  const cogRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: any) => {
-      if (cogRef.current && !cogRef.current.contains(event.target)) {
-        setShowMoreButtons(false);
-      }
-    };
-
-    document.addEventListener("click", handleClickOutside, true);
-    return () => {
-      document.removeEventListener("click", handleClickOutside, true);
-    };
-  }, []);
-
-  const handleCloseSettingsMenu = () => {
-    setOpenSettingsMenu(false);
-    setShowMoreButtons(false);
-  };
 
   // music controls
 
@@ -79,75 +52,7 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
     }
   };
 
-  const getSong = () => {
-    return isFarming ? getFarmingSong(songIndex) : getGoblinSong(songIndex);
-  };
-
-  const song = getSong();
-
-  // buttons
-
-  const createButton = (
-    index: number,
-    onClick: () => void,
-    children: JSX.Element,
-  ) => {
-    const rightMargin = 8;
-
-    return (
-      <div
-        key={`button-${index}`}
-        className="absolute"
-        style={{
-          transition: "transform 250ms ease",
-          transform: "translateX(0)",
-          ...(showMoreButtons && {
-            transform: `translateX(-${(buttonWidth + rightMargin) * index}px)`,
-          }),
-        }}
-      >
-        <RoundButton onClick={onClick}>{children}</RoundButton>
-      </div>
-    );
-  };
-
-  const gearButton = (index: number) =>
-    createButton(
-      index,
-      () => {
-        button.play();
-        setShowMoreButtons(!showMoreButtons);
-      },
-      <img
-        src={settings}
-        className="absolute group-active:translate-y-[2px]"
-        style={{
-          top: `${PIXEL_SCALE * 4}px`,
-          left: `${PIXEL_SCALE * 4}px`,
-          width: `${PIXEL_SCALE * 14}px`,
-        }}
-      />,
-    );
-
-  const moreButton = (index: number) =>
-    createButton(
-      index,
-      () => {
-        setOpenSettingsMenu(true);
-      },
-      <img
-        src={SUNNYSIDE.ui.more}
-        className="absolute group-active:translate-y-[2px]"
-        style={{
-          top: `${PIXEL_SCALE * 10}px`,
-          left: `${PIXEL_SCALE * 6}px`,
-          width: `${PIXEL_SCALE * 10}px`,
-        }}
-      />,
-    );
-
-  // list of buttons to show in the HUD from right to left in order
-  const buttons = [gearButton, ...(!showLimitedButtons ? [moreButton] : [])];
+  const song = isFarming ? getFarmingSong(songIndex) : getGoblinSong(songIndex);
 
   return (
     <AudioControlsProvider
@@ -167,14 +72,28 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
       />
       <GameOptionsModal
         show={openSettingsMenu}
-        onClose={handleCloseSettingsMenu}
+        onClose={() => setOpenSettingsMenu(false)}
       />
       <div
         className="relative"
         style={{ height: `${buttonHeight}px`, width: `${buttonWidth}px` }}
-        ref={cogRef}
       >
-        {buttons.map((item, index) => item(index)).reverse()}
+        <RoundButton
+          onClick={() => {
+            button.play();
+            setOpenSettingsMenu(true);
+          }}
+        >
+          <img
+            src={settings}
+            className="absolute group-active:translate-y-[2px]"
+            style={{
+              top: `${PIXEL_SCALE * 4}px`,
+              left: `${PIXEL_SCALE * 4}px`,
+              width: `${PIXEL_SCALE * 14}px`,
+            }}
+          />
+        </RoundButton>
       </div>
     </AudioControlsProvider>
   );

--- a/src/features/island/hud/components/Settings.tsx
+++ b/src/features/island/hud/components/Settings.tsx
@@ -9,6 +9,7 @@ import {
   getGoblinSongCount,
 } from "assets/songs/playlist";
 import settings from "assets/icons/settings.png";
+import { useLocation } from "react-router";
 import { GameOptionsModal } from "./settings-menu/GameOptions";
 import { useSound } from "lib/utils/hooks/useSound";
 import { RoundButton } from "components/ui/RoundButton";
@@ -22,6 +23,8 @@ interface Props {
 
 export const Settings: React.FC<Props> = ({ isFarming }) => {
   const [openSettingsMenu, setOpenSettingsMenu] = useState(false);
+  const { pathname } = useLocation();
+  const isVisiting = pathname.includes("visit");
 
   const button = useSound("button");
 
@@ -70,31 +73,35 @@ export const Settings: React.FC<Props> = ({ isFarming }) => {
         muted={true}
         controls
       />
-      <GameOptionsModal
-        show={openSettingsMenu}
-        onClose={() => setOpenSettingsMenu(false)}
-      />
-      <div
-        className="relative"
-        style={{ height: `${buttonHeight}px`, width: `${buttonWidth}px` }}
-      >
-        <RoundButton
-          onClick={() => {
-            button.play();
-            setOpenSettingsMenu(true);
-          }}
-        >
-          <img
-            src={settings}
-            className="absolute group-active:translate-y-[2px]"
-            style={{
-              top: `${PIXEL_SCALE * 4}px`,
-              left: `${PIXEL_SCALE * 4}px`,
-              width: `${PIXEL_SCALE * 14}px`,
-            }}
+      {!isVisiting && (
+        <>
+          <GameOptionsModal
+            show={openSettingsMenu}
+            onClose={() => setOpenSettingsMenu(false)}
           />
-        </RoundButton>
-      </div>
+          <div
+            className="relative"
+            style={{ height: `${buttonHeight}px`, width: `${buttonWidth}px` }}
+          >
+            <RoundButton
+              onClick={() => {
+                button.play();
+                setOpenSettingsMenu(true);
+              }}
+            >
+              <img
+                src={settings}
+                className="absolute group-active:translate-y-[2px]"
+                style={{
+                  top: `${PIXEL_SCALE * 4}px`,
+                  left: `${PIXEL_SCALE * 4}px`,
+                  width: `${PIXEL_SCALE * 14}px`,
+                }}
+              />
+            </RoundButton>
+          </div>
+        </>
+      )}
     </AudioControlsProvider>
   );
 };


### PR DESCRIPTION
## Summary
- Removed the intermediate "more" expand-button UI from the HUD settings control
- Gear icon now opens `GameOptionsModal` directly, since it contained the same actions the more-button used to surface
- Dropped now-unused state/effect (`showMoreButtons`, click-outside listener, sliding animation) and the visit-mode `showLimitedButtons` gate that only existed to hide the more-button

## Test plan
- [ ] Click the gear icon on the HUD — `GameOptionsModal` opens
- [ ] Close the modal — gear remains interactive
- [ ] Background music still plays and song advances on track end (audio element + `AudioControlsProvider` preserved)
- [ ] Visiting another farm: gear still opens the modal (note: previously the modal was unreachable during visits — flag if this should remain hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the expanded "more buttons" HUD and consolidated controls into a single gear/settings button.
  * Settings are only shown when not viewing another user's area.
  * Closing the settings modal now behaves more directly for a snappier experience.
  * Song selection flow simplified for more predictable playback choices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7192)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->