### PR TITLE
[FEAT] Speed scaping

### DIFF
--- a/src/features/farming/hud/components/PlaceableController.tsx
+++ b/src/features/farming/hud/components/PlaceableController.tsx
@@ -53,6 +53,10 @@ import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { COMPETITION_POINTS } from "features/game/types/competitions";
 import { useNow } from "lib/utils/hooks/useNow";
 import {
+  needsPlacementConfirmation,
+  PlacementConfirmationModal,
+} from "features/game/expansion/placeable/PlacementConfirmationModal";
+import {
   getPetType,
   getPlacedCommonPetTypesInPetHouse,
   getPlacedNFTPetTypesInPetHouse,
@@ -129,6 +133,7 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
   const [previousPosition, setPreviousPosition] = useState<
     Coordinates | undefined
   >();
+  const [pendingConfirmation, setPendingConfirmation] = useState(false);
 
   const now = useNow();
 
@@ -249,12 +254,7 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
     return { width: 0, height: 0 };
   }, [placeable]);
 
-  const handleConfirmPlacement = useCallback(() => {
-    // prevents multiple toasts while spam clicking place button
-    if (!placingState) {
-      return;
-    }
-
+  const executePlacement = useCallback(() => {
     const state = gameService.getSnapshot().context.state;
 
     if (!placeable) return;
@@ -343,11 +343,23 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
     location,
     maximum,
     placeable,
-    placingState,
     previousPosition,
     requirements,
     send,
   ]);
+
+  const handleConfirmPlacement = useCallback(() => {
+    // prevents multiple toasts while spam clicking place button
+    if (!placingState) return;
+    if (!placeable) return;
+
+    if (needsPlacementConfirmation(placeable.name)) {
+      setPendingConfirmation(true);
+      return;
+    }
+
+    executePlacement();
+  }, [placingState, placeable, executePlacement]);
 
   const handleCancelPlacement = useCallback(() => {
     send("BACK");
@@ -540,6 +552,17 @@ export const PlaceableController: React.FC<Props> = ({ location }) => {
           </Button>
         </div>
       </OuterPanel>
+
+      {pendingConfirmation && placeable && (
+        <PlacementConfirmationModal
+          itemName={placeable.name}
+          onCancel={() => setPendingConfirmation(false)}
+          onConfirm={() => {
+            setPendingConfirmation(false);
+            executePlacement();
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/game/expansion/placeable/Placeable.tsx
+++ b/src/features/game/expansion/placeable/Placeable.tsx
@@ -8,7 +8,11 @@ import React, {
 } from "react";
 import { useActor, useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { GRID_WIDTH_PX, PIXEL_SCALE } from "features/game/lib/constants";
+import {
+  GRID_WIDTH_PX,
+  PIXEL_SCALE,
+  SQUARE_WIDTH,
+} from "features/game/lib/constants";
 import { MachineInterpreter } from "./landscapingMachine";
 
 import Draggable from "react-draggable";
@@ -149,6 +153,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
   const { placeable, collisionDetected, origin, coordinates } = machine.context;
 
   const nodeRef = useRef<HTMLDivElement>(null);
+  const [pixelPerfect, setPixelPerfect] = useState(false);
 
   const hintResetToken = useMemo(
     () => Symbol(`origin-${origin?.x ?? "none"}-${origin?.y ?? "none"}`),
@@ -233,25 +238,31 @@ export const Placeable: React.FC<Props> = ({ location }) => {
     [coordinates.x, coordinates.y],
   );
 
-  // Arrow/WASD keyboard movement to move the ghost placeable on the grid
+  // Arrow/WASD keyboard movement + p for pixel-perfect toggle
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!placeable) return;
-
-      // Only while placing; ignore if typing in inputs
       if (document.activeElement?.tagName === "INPUT") return;
+
+      if (e.key === "p") {
+        setPixelPerfect((prev) => !prev);
+        return;
+      }
+
+      // One grid unit normally; one in-game pixel (1/SQUARE_WIDTH) in pixel-perfect mode
+      const step = pixelPerfect ? 1 / SQUARE_WIDTH : 1;
 
       let deltaX = 0;
       let deltaY = 0;
 
       if (e.key === "ArrowUp" || e.key === "w") {
-        deltaY = 1;
+        deltaY = step;
       } else if (e.key === "ArrowDown" || e.key === "s") {
-        deltaY = -1;
+        deltaY = -step;
       } else if (e.key === "ArrowLeft" || e.key === "a") {
-        deltaX = -1;
+        deltaX = -step;
       } else if (e.key === "ArrowRight" || e.key === "d") {
-        deltaX = 1;
+        deltaX = step;
       } else {
         return;
       }
@@ -264,7 +275,7 @@ export const Placeable: React.FC<Props> = ({ location }) => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [placeable, coordinates.x, coordinates.y, detect, hideHint]);
+  }, [placeable, pixelPerfect, coordinates.x, coordinates.y, detect, hideHint]);
 
   if (!placeable) return null;
 
@@ -295,25 +306,34 @@ export const Placeable: React.FC<Props> = ({ location }) => {
         <Draggable
           key={`${origin?.x}-${origin?.y}`}
           nodeRef={nodeRef as React.RefObject<HTMLElement>}
-          grid={[GRID_WIDTH_PX * scale.get(), GRID_WIDTH_PX * scale.get()]}
+          grid={[
+            (pixelPerfect ? PIXEL_SCALE : GRID_WIDTH_PX) * scale.get(),
+            (pixelPerfect ? PIXEL_SCALE : GRID_WIDTH_PX) * scale.get(),
+          ]}
           scale={scale.get()}
           onStart={() => {
-            // reset
             send("DRAG");
           }}
           onDrag={(_, data) => {
-            const x = Math.round(data.x / GRID_WIDTH_PX);
-            const y = Math.round(-data.y / GRID_WIDTH_PX);
+            const x = pixelPerfect
+              ? Math.round(data.x / PIXEL_SCALE) / SQUARE_WIDTH
+              : Math.round(data.x / GRID_WIDTH_PX);
+            const y = pixelPerfect
+              ? -Math.round(data.y / PIXEL_SCALE) / SQUARE_WIDTH
+              : Math.round(-data.y / GRID_WIDTH_PX);
 
             detect({ x, y });
             hideHint();
           }}
           onStop={(_, data) => {
-            const x = Math.round(data.x / GRID_WIDTH_PX);
-            const y = Math.round(-data.y / GRID_WIDTH_PX);
+            const x = pixelPerfect
+              ? Math.round(data.x / PIXEL_SCALE) / SQUARE_WIDTH
+              : Math.round(data.x / GRID_WIDTH_PX);
+            const y = pixelPerfect
+              ? -Math.round(data.y / PIXEL_SCALE) / SQUARE_WIDTH
+              : Math.round(-data.y / GRID_WIDTH_PX);
 
             detect({ x, y });
-
             send("DROP");
           }}
           position={position}
@@ -336,6 +356,14 @@ export const Placeable: React.FC<Props> = ({ location }) => {
                 <span className="text-white text-sm">
                   {t("landscape.dragMe")}
                 </span>
+              </div>
+            )}
+            {pixelPerfect && (
+              <div
+                className="flex absolute pointer-events-none z-50 bg-[#000000af] px-1.5 py-0.5 rounded w-max"
+                style={{ bottom: "-24px" }}
+              >
+                <span className="text-white text-xs">{"Pixel perfect"}</span>
               </div>
             )}
             <div

--- a/src/features/game/expansion/placeable/PlacementConfirmationModal.tsx
+++ b/src/features/game/expansion/placeable/PlacementConfirmationModal.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { ConfirmationModal } from "components/ui/ConfirmationModal";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { Label } from "components/ui/Label";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { HOURGLASSES } from "features/game/events/landExpansion/burnCollectible";
+import { HourglassType } from "features/island/collectibles/components/Hourglass";
+import { TranslationKeys } from "lib/i18n/dictionaries/types";
+
+type TimeBasedConsumables = HourglassType | "Time Warp Totem" | "Super Totem";
+
+export const needsPlacementConfirmation = (name: string) =>
+  name === "Gnome" ||
+  HOURGLASSES.includes(name as HourglassType) ||
+  name === "Time Warp Totem" ||
+  name === "Super Totem";
+
+interface Props {
+  itemName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const PlacementConfirmationModal: React.FC<Props> = ({
+  itemName,
+  onConfirm,
+  onCancel,
+}) => {
+  const { t } = useAppTranslation();
+
+  const getResourceNodeCondition = (hourglass: TimeBasedConsumables) => {
+    const hourglassCondition: Record<TimeBasedConsumables, TranslationKeys> = {
+      "Blossom Hourglass": "landscape.hourglass.resourceNodeCondition.blossom",
+      "Gourmet Hourglass": "landscape.hourglass.resourceNodeCondition.gourmet",
+      "Harvest Hourglass": "landscape.hourglass.resourceNodeCondition.harvest",
+      "Orchard Hourglass": "landscape.hourglass.resourceNodeCondition.orchard",
+      "Ore Hourglass": "landscape.hourglass.resourceNodeCondition.ore",
+      "Timber Hourglass": "landscape.hourglass.resourceNodeCondition.timber",
+      "Time Warp Totem": "landscape.timeWarpTotem.resourceNodeCondition",
+      "Super Totem": "landscape.superTotem.resourceNodeCondition",
+      "Fisher's Hourglass": "landscape.hourglass.resourceNodeCondition.fishers",
+    };
+    return t(hourglassCondition[hourglass], { selectedChestItem: itemName });
+  };
+
+  const redGnomeBoostInstruction = () => (
+    <div className="flex flex-col gap-y-2 text-xs">
+      <p>{t("landscape.confirmation.gnomes.one")}</p>
+      <p>{t("landscape.confirmation.gnomes.two")}</p>
+      <div className="flex justify-center mt-2 space-x-2">
+        <img src={ITEM_DETAILS["Cobalt"].image} className="w-12" />
+        <img src={ITEM_DETAILS["Gnome"].image} className="w-12" />
+        <img src={ITEM_DETAILS["Clementine"].image} className="w-12" />
+      </div>
+      <div className="flex justify-center">
+        <img src={ITEM_DETAILS["Crop Plot"].image} className="w-12" />
+      </div>
+    </div>
+  );
+
+  const messages =
+    itemName === "Gnome"
+      ? [redGnomeBoostInstruction()]
+      : [
+          getResourceNodeCondition(itemName as TimeBasedConsumables),
+          t("landscape.confirmation.hourglass.one", {
+            selectedChestItem: itemName,
+          }),
+          t("landscape.confirmation.hourglass.two", {
+            selectedChestItem: itemName,
+          }),
+          itemName === "Time Warp Totem" || itemName === "Super Totem" ? (
+            <Label type="danger" icon={SUNNYSIDE.icons.cancel}>
+              {t("landscape.timeWarpTotem.nonStack")}
+            </Label>
+          ) : (
+            ""
+          ),
+        ];
+
+  return (
+    <ConfirmationModal
+      show
+      onHide={onCancel}
+      messages={messages}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      confirmButtonLabel={t("place")}
+    />
+  );
+};

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -406,7 +406,6 @@ export const landscapingMachine = createMachine<
                 cond: (context) =>
                   // When buying/crafting items, return them to playing mode once bought
                   context.action === "collectible.crafted" ||
-                  context.action === "collectible.placed" ||
                   context.action === "building.constructed",
                 actions: [
                   sendParent(

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -1,7 +1,35 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable unused-imports/no-unused-vars */
+import Decimal from "decimal.js-light";
 import { GameState } from "../types/game";
 
 import { INITIAL_FARM } from "./constants";
 
-export const STATIC_OFFLINE_FARM: GameState = { ...INITIAL_FARM };
+export const STATIC_OFFLINE_FARM: GameState = {
+  ...INITIAL_FARM,
+  inventory: {
+    ...INITIAL_FARM.inventory,
+    Shovel: new Decimal("1"),
+    "Sand Shovel": new Decimal("36"),
+    "Sand Drill": new Decimal("2"),
+    "Petting Hand": new Decimal("1"),
+    Brush: new Decimal("1"),
+    "Potato Statue": new Decimal("1"),
+    "Christmas Tree": new Decimal("1"),
+    Scarecrow: new Decimal("1"),
+    "Farm Cat": new Decimal("2"),
+    Gnome: new Decimal("1"),
+    "Chicken Coop": new Decimal("1"),
+    "Gold Egg": new Decimal("1"),
+    "Golden Cauliflower": new Decimal("1"),
+    "Sunflower Rock": new Decimal("2"),
+    "Goblin Crown": new Decimal("1"),
+    Fountain: new Decimal("2"),
+    Crate: new Decimal("1"),
+    "Long Table": new Decimal("5"),
+    "Large Podium": new Decimal("1"),
+  },
+  farmActivity: {
+    "welcome Bonus Claimed": 1, // Skip welcome screen
+  },
+};

--- a/src/features/game/lib/landDataStatic.ts
+++ b/src/features/game/lib/landDataStatic.ts
@@ -28,6 +28,7 @@ export const STATIC_OFFLINE_FARM: GameState = {
     Crate: new Decimal("1"),
     "Long Table": new Decimal("5"),
     "Large Podium": new Decimal("1"),
+    "Super Totem": new Decimal(1),
   },
   farmActivity: {
     "welcome Bonus Claimed": 1, // Skip welcome screen

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useLayoutEffect, useMemo, type JSX } from "react";
+import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 import { useNavigate, useSearchParams } from "react-router";
 import ScrollContainer from "react-indiana-drag-scroll";
@@ -321,6 +322,22 @@ export const Interior: React.FC = () => {
               />
 
               {debug && <InteriorGridOverlay island={island.type} />}
+
+              <div
+                className={classNames(
+                  "absolute inset-0 pointer-events-none transition-opacity z-10",
+                  {
+                    "opacity-0": !landscaping,
+                    "opacity-100": landscaping,
+                  },
+                )}
+                style={{
+                  backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
+                  backgroundImage: `
+                    linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
+                    linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
+                }}
+              />
 
               {landscaping && <Placeable location="interior" />}
 

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useLayoutEffect, useMemo, type JSX } from "react";
+import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 import { useNavigate, useSearchParams } from "react-router";
 import ScrollContainer from "react-indiana-drag-scroll";
@@ -341,6 +342,22 @@ export const LevelOne: React.FC = () => {
               />
 
               {debug && <LevelOneGridOverlay tier={expansion} />}
+
+              <div
+                className={classNames(
+                  "absolute inset-0 pointer-events-none transition-opacity z-10",
+                  {
+                    "opacity-0": !landscaping,
+                    "opacity-100": landscaping,
+                  },
+                )}
+                style={{
+                  backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
+                  backgroundImage: `
+                    linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
+                    linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
+                }}
+              />
 
               {landscaping && <Placeable location="level_one" />}
 

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -48,7 +48,9 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { getChestItems } from "./components/inventory/utils/inventory";
 import { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { LandscapingChest } from "./components/LandscapingChest";
+import { LandscapingQuickPanel } from "./components/LandscapingQuickPanel";
 import classNames from "classnames";
+import { hasFeatureAccess } from "lib/flags";
 
 const compareBalance = (prev: Decimal, next: Decimal) => {
   return prev.eq(next);
@@ -86,6 +88,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
     useState(false);
   const [showDecorations, setShowDecorations] = useState(false);
   const [showCraftBuild, setShowCraftBuild] = useState(false);
+  const [quickDragging, setQuickDragging] = useState(false);
   const button = useSound("button");
 
   const child = gameService.getSnapshot().children
@@ -114,6 +117,9 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
   const selectedItem = useSelector(child, selectMovingItem);
   const idle = useSelector(child, isIdle);
   const gameState = useSelector(gameService, (state) => state.context.state);
+  const hasQuickPanel = useSelector(gameService, (state) =>
+    hasFeatureAccess(state.context.state, "QUICK_LANDSCAPING_PANEL"),
+  );
   const farmHandIds = getKeys(gameState.farmHands.bumpkins);
   const hasNoBuildings = !gameState.buildings["Water Well"];
 
@@ -510,7 +516,16 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
         </div>
       )}
 
-      <PlaceableController location={location} />
+      {hasQuickPanel && (
+        <LandscapingQuickPanel
+          location={location}
+          onQuickDragChange={setQuickDragging}
+        />
+      )}
+
+      {(!hasQuickPanel || !quickDragging) && (
+        <PlaceableController location={location} />
+      )}
     </HudContainer>
   );
 };

--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -1,0 +1,777 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useActor, useSelector } from "@xstate/react";
+import classNames from "classnames";
+
+import { Context } from "features/game/GameProvider";
+import {
+  LandscapingPlaceable,
+  LandscapingPlaceableType,
+  MachineInterpreter,
+  placeEvent,
+} from "features/game/expansion/placeable/landscapingMachine";
+import { PlaceableLocation } from "features/game/types/collectibles";
+import { getKeys } from "lib/object";
+import {
+  getChestBuds,
+  getChestFarmHands,
+  getChestItems,
+  getChestPets,
+} from "./inventory/utils/inventory";
+import { RESOURCES, ResourceName } from "features/game/types/resources";
+import {
+  BUILDINGS,
+  BUILDINGS_DIMENSIONS,
+  BuildingName,
+} from "features/game/types/buildings";
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
+import { BANNERS } from "features/game/types/banners";
+import { BED_FARMHAND_COUNT } from "features/game/types/beds";
+import { MONUMENTS, REWARD_ITEMS } from "features/game/types/monuments";
+import { DOLLS } from "features/game/lib/crafting";
+import { PET_TYPES, isPetNFTRevealed } from "features/game/types/pets";
+import { WEATHER_SHOP_ITEM_COSTS } from "features/game/types/calendar";
+import { Box } from "components/ui/Box";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { SUNNYSIDE } from "assets/sunnyside";
+import lightning from "assets/icons/lightning.png";
+import { isMobile } from "mobile-device-detect";
+import { ITEM_ICONS } from "./inventory/Chest";
+import { getCurrentBiome } from "features/island/biomes/biomes";
+import {
+  isBuildingUpgradable,
+  makeUpgradableBuildingKey,
+  UpgradableBuildingType,
+} from "features/game/events/landExpansion/upgradeBuilding";
+import {
+  CollectibleName,
+  COLLECTIBLES_DIMENSIONS,
+} from "features/game/types/craftables";
+import { getBudImage } from "lib/buds/types";
+import { getPetImage } from "features/island/pets/lib/petShared";
+import { HOURGLASSES } from "features/game/events/landExpansion/burnCollectible";
+import { HourglassType } from "features/island/collectibles/components/Hourglass";
+import { ConfirmationModal } from "components/ui/ConfirmationModal";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { NFTName } from "features/game/events/landExpansion/placeNFT";
+import { NPCPlaceable } from "features/island/bumpkin/components/NPC";
+import { PIXEL_SCALE, GRID_WIDTH_PX } from "features/game/lib/constants";
+import { useNow } from "lib/utils/hooks/useNow";
+import { OuterPanel, InnerPanel } from "components/ui/Panel";
+import { Tab } from "components/ui/Tab";
+import { SquareIcon } from "components/ui/SquareIcon";
+import { useSound } from "lib/utils/hooks/useSound";
+import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
+import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
+
+type TabId =
+  | "nfts"
+  | "resources"
+  | "buildings"
+  | "boosts"
+  | "projects"
+  | "decorations";
+
+const TWO_ROW_HEIGHT_PX = PIXEL_SCALE * (13.7 + 4 + 3 + 2) * 2;
+
+const DRAG_THRESHOLD_PX = 8;
+
+const ALL_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  ...BUILDINGS_DIMENSIONS,
+  ...COLLECTIBLES_DIMENSIONS,
+  ...RESOURCE_DIMENSIONS,
+  Bud: { width: 1, height: 1 },
+  Pet: { width: 2, height: 2 },
+  FarmHand: { width: 1, height: 1 },
+};
+
+const getItemDims = (name: string) =>
+  ALL_DIMENSIONS[name] ?? { width: 1, height: 1 };
+
+const needsConfirmation = (name: string) =>
+  name === "Gnome" ||
+  HOURGLASSES.includes(name as HourglassType) ||
+  name === "Time Warp Totem" ||
+  name === "Super Totem";
+
+interface DragOrigin {
+  startX: number;
+  startY: number;
+  item: LandscapingPlaceableType;
+  activated: boolean;
+}
+
+interface Props {
+  location: PlaceableLocation;
+  onQuickDragChange: (active: boolean) => void;
+}
+
+export const LandscapingQuickPanel: React.FC<Props> = ({
+  location,
+  onQuickDragChange,
+}) => {
+  const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+  const [gameState] = useActor(gameService);
+  const state = gameState.context.state;
+  const now = useNow();
+  const tabSound = useSound("tab");
+
+  const child = gameService.getSnapshot().children
+    .landscaping as MachineInterpreter;
+
+  const isIdle = useSelector(child, (s) => s.matches({ editing: "idle" }));
+
+  const [activeTab, setActiveTab] = useState<TabId>("decorations");
+  const [confirmItem, setConfirmItem] =
+    useState<LandscapingPlaceableType | null>(null);
+
+  // ── Quick drag-and-drop state ──────────────────────────────────────────
+  const dragRef = useRef<DragOrigin | null>(null);
+  const wasDragRef = useRef(false);
+
+  const computeGridPos = useCallback((clientX: number, clientY: number) => {
+    // Placeable renders at `fixed left-1/2 top-1/2` + position offset,
+    // so coordinates must be measured from viewport centre — the same
+    // reference react-draggable's onDrag uses in normal landscaping.
+    return {
+      gridX: Math.round((clientX - window.innerWidth / 2) / GRID_WIDTH_PX),
+      gridY: Math.round(-(clientY - window.innerHeight / 2) / GRID_WIDTH_PX),
+    };
+  }, []);
+
+  useEffect(() => {
+    const sendSelect = (
+      item: LandscapingPlaceableType,
+      loc: PlaceableLocation,
+      freshChild: MachineInterpreter,
+    ) => {
+      if (item.name === "Bud" || item.name === "Pet") {
+        freshChild.send("SELECT", {
+          action: "nft.placed",
+          placeable: {
+            id: (item as { id: string; name: NFTName }).id,
+            name: item.name as NFTName,
+          },
+          requirements: { coins: 0, ingredients: {} },
+          collisionDetected: false,
+          location: loc,
+        } as any);
+      } else if (item.name === "FarmHand") {
+        freshChild.send("SELECT", {
+          placeable: {
+            name: "FarmHand",
+            id: (item as { id: string }).id,
+          },
+          action: "farmHand.placed",
+          requirements: { coins: 0, ingredients: {} },
+          collisionDetected: false,
+        } as any);
+      } else {
+        freshChild.send("SELECT", {
+          action: placeEvent(item.name as LandscapingPlaceable, loc),
+          placeable: { name: item.name as LandscapingPlaceable },
+          requirements: { coins: 0, ingredients: {} },
+          collisionDetected: false,
+          multiple: false,
+        } as any);
+      }
+    };
+
+    const handleMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      if (!drag.activated) {
+        const dx = e.clientX - drag.startX;
+        const dy = e.clientY - drag.startY;
+        if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+
+        // Only activate from idle state
+        const freshChild = gameService.getSnapshot().children
+          .landscaping as MachineInterpreter;
+        const machineState = freshChild.getSnapshot();
+        if (!machineState.matches({ editing: "idle" })) {
+          dragRef.current = null;
+          return;
+        }
+
+        drag.activated = true;
+        wasDragRef.current = true;
+        sendSelect(drag.item, location, freshChild);
+        freshChild.send("DRAG");
+        onQuickDragChange(true);
+      }
+
+      const { gridX, gridY } = computeGridPos(e.clientX, e.clientY);
+      const snap = gameService.getSnapshot().context.state;
+      const dims = getItemDims(drag.item.name);
+      const collision = detectCollision({
+        state: snap,
+        position: { x: gridX, y: gridY, ...dims },
+        location,
+        name: drag.item.name as CollectibleName,
+      });
+
+      const freshChild = gameService.getSnapshot().children
+        .landscaping as MachineInterpreter;
+      freshChild.send({
+        type: "UPDATE",
+        coordinates: { x: gridX, y: gridY },
+        collisionDetected: collision,
+      });
+    };
+
+    const handleUp = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+
+      if (!drag?.activated) return;
+
+      onQuickDragChange(false);
+
+      const { gridX, gridY } = computeGridPos(e.clientX, e.clientY);
+      const snap = gameService.getSnapshot().context.state;
+      const dims = getItemDims(drag.item.name);
+      const collision = detectCollision({
+        state: snap,
+        position: { x: gridX, y: gridY, ...dims },
+        location,
+        name: drag.item.name as CollectibleName,
+      });
+
+      const freshChild = gameService.getSnapshot().children
+        .landscaping as MachineInterpreter;
+
+      // DROP transitions from dragging → placing
+      freshChild.send("DROP");
+
+      if (collision) {
+        freshChild.send("BACK");
+      } else {
+        freshChild.send({
+          type: "UPDATE",
+          coordinates: { x: gridX, y: gridY },
+          collisionDetected: false,
+        });
+        freshChild.send({ type: "PLACE", location } as any);
+      }
+    };
+
+    const handleCancel = () => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      if (!drag?.activated) return;
+      onQuickDragChange(false);
+      const freshChild = gameService.getSnapshot().children
+        .landscaping as MachineInterpreter;
+      freshChild.send("DROP");
+      freshChild.send("BACK");
+    };
+
+    window.addEventListener("pointermove", handleMove, { capture: true });
+    window.addEventListener("pointerup", handleUp, { capture: true });
+    window.addEventListener("pointercancel", handleCancel, { capture: true });
+    return () => {
+      window.removeEventListener("pointermove", handleMove, { capture: true });
+      window.removeEventListener("pointerup", handleUp, { capture: true });
+      window.removeEventListener("pointercancel", handleCancel, {
+        capture: true,
+      });
+    };
+  }, [location, gameService, onQuickDragChange, computeGridPos]);
+
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent, item: LandscapingPlaceableType) => {
+      e.stopPropagation();
+      wasDragRef.current = false;
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        item,
+        activated: false,
+      };
+    },
+    [],
+  );
+
+  // ── Chest inventory ────────────────────────────────────────────────────
+  const buds = getChestBuds(state);
+  const petsNFTs = getChestPets(state.pets?.nfts ?? {});
+  const farmHands = getChestFarmHands(state.farmHands);
+  const chestMap = getChestItems(state);
+  const biome = useMemo(() => getCurrentBiome(state.island), [state.island]);
+
+  const collectibleNames = useMemo(
+    () => getKeys(chestMap).filter((item) => chestMap[item]?.gt(0)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chestMap],
+  );
+
+  // ── Group items ────────────────────────────────────────────────────────
+  const resources = collectibleNames.filter((name) => name in RESOURCES);
+  const buildings = collectibleNames.filter((name) => name in BUILDINGS);
+  const monuments = collectibleNames.filter((name) => name in MONUMENTS);
+  const villageProjects = collectibleNames.filter(
+    (name) => name in REWARD_ITEMS,
+  );
+  const banners = collectibleNames.filter((name) => name in BANNERS);
+  const beds = collectibleNames.filter((name) => name in BED_FARMHAND_COUNT);
+  const weatherItems = collectibleNames.filter(
+    (name) => name in WEATHER_SHOP_ITEM_COSTS,
+  );
+  const dolls = collectibleNames.filter((name) => name in DOLLS);
+  const pets = collectibleNames.filter((name) => name in PET_TYPES);
+
+  const resourcesSet = new Set(resources);
+  const buildingsSet = new Set(buildings);
+  const monumentsSet = new Set(monuments);
+  const villageProjectsSet = new Set(villageProjects);
+  const bedsSet = new Set(beds);
+  const bannersSet = new Set(banners);
+  const weatherItemsSet = new Set(weatherItems);
+  const dollsSet = new Set(dolls);
+  const petsSet = new Set(pets);
+
+  const boosts = collectibleNames
+    .filter(
+      (name) =>
+        name in COLLECTIBLE_BUFF_LABELS &&
+        (
+          COLLECTIBLE_BUFF_LABELS[name]?.({
+            skills: state.bumpkin.skills,
+            collectibles: state.collectibles,
+          }) ?? []
+        ).length > 0,
+    )
+    .filter(
+      (name) =>
+        !resourcesSet.has(name) &&
+        !buildingsSet.has(name) &&
+        !monumentsSet.has(name) &&
+        !villageProjectsSet.has(name) &&
+        !bedsSet.has(name),
+    );
+
+  const boostsSet = new Set(boosts);
+
+  const decorations = collectibleNames.filter(
+    (name) =>
+      !resourcesSet.has(name) &&
+      !buildingsSet.has(name) &&
+      !boostsSet.has(name) &&
+      !bannersSet.has(name) &&
+      !bedsSet.has(name) &&
+      !weatherItemsSet.has(name) &&
+      !monumentsSet.has(name) &&
+      !dollsSet.has(name) &&
+      !petsSet.has(name) &&
+      !villageProjectsSet.has(name),
+  );
+
+  // ── Tab definitions ────────────────────────────────────────────────────
+  const tabs: {
+    id: TabId;
+    label: string;
+    emptyLabel: string;
+    icon: string;
+    farmOnly?: boolean;
+    hasItems: boolean;
+  }[] = [
+    {
+      id: "resources",
+      label: t("resources"),
+      emptyLabel: "No resources available.",
+      icon: SUNNYSIDE.resource.tree,
+      farmOnly: true,
+      hasItems: resources.length > 0,
+    },
+    {
+      id: "buildings",
+      label: t("buildings"),
+      emptyLabel: "No buildings available.",
+      icon: SUNNYSIDE.icons.hammer,
+      farmOnly: true,
+      hasItems: buildings.length > 0,
+    },
+    {
+      id: "boosts",
+      label: t("boosts"),
+      emptyLabel: "No boosts available.",
+      icon: lightning,
+      hasItems: boosts.length > 0 || weatherItems.length > 0 || beds.length > 0,
+    },
+    {
+      id: "decorations",
+      label: t("decorations"),
+      emptyLabel: "No decorations available.",
+      icon: ITEM_DETAILS["Basic Bear"].image,
+      hasItems:
+        banners.length > 0 ||
+        dolls.length > 0 ||
+        pets.length > 0 ||
+        decorations.length > 0,
+    },
+    {
+      id: "projects",
+      label: "Projects",
+      emptyLabel: "No projects available.",
+      icon: ITEM_DETAILS["Farmer's Monument"].image,
+      farmOnly: true,
+      hasItems: monuments.length > 0 || villageProjects.length > 0,
+    },
+    {
+      id: "nfts",
+      label: "NFTs",
+      emptyLabel: "No NFTs available.",
+      icon: SUNNYSIDE.icons.heart,
+      hasItems:
+        Object.keys(buds).length > 0 ||
+        Object.keys(petsNFTs).length > 0 ||
+        Object.keys(farmHands).length > 0,
+    },
+  ];
+
+  const visibleTabs = tabs.filter(
+    (tab) => !tab.farmOnly || location === "farm",
+  );
+
+  // ── Placement helpers ──────────────────────────────────────────────────
+  const doPlace = (item: LandscapingPlaceableType) => {
+    if (item.name === "Bud" || item.name === "Pet") {
+      child.send("SELECT", {
+        action: "nft.placed",
+        placeable: { id: item.id, name: item.name as NFTName },
+        location,
+      });
+    } else if (item.name === "FarmHand") {
+      child.send("SELECT", {
+        placeable: { name: "FarmHand", id: item.id },
+        action: "farmHand.placed",
+        requirements: { coins: 0, ingredients: {} },
+      });
+    } else {
+      child.send("SELECT", {
+        action: placeEvent(item.name as LandscapingPlaceable, location),
+        placeable: { name: item.name as LandscapingPlaceable },
+        multiple: true,
+      });
+    }
+  };
+
+  const handleClick = (item: LandscapingPlaceableType) => {
+    if (wasDragRef.current) {
+      wasDragRef.current = false;
+      return;
+    }
+    const name = item.name;
+    if (
+      name !== "Bud" &&
+      name !== "Pet" &&
+      name !== "FarmHand" &&
+      needsConfirmation(name)
+    ) {
+      setConfirmItem(item);
+      return;
+    }
+    doPlace(item);
+  };
+
+  // ── Image resolver ─────────────────────────────────────────────────────
+  const getItemImage = (name: CollectibleName) => {
+    const level = isBuildingUpgradable(name as BuildingName)
+      ? state[makeUpgradableBuildingKey(name as UpgradableBuildingType)].level
+      : undefined;
+    return (
+      ITEM_ICONS(state.season.season, biome, level)[name] ??
+      ITEM_DETAILS[name]?.image
+    );
+  };
+
+  // ── Items for the active tab ───────────────────────────────────────────
+  const items = useMemo(() => {
+    const wrapBox = (
+      key: string,
+      item: LandscapingPlaceableType,
+      image: string,
+      boxNode: React.ReactNode,
+    ) => (
+      <div
+        key={key}
+        style={{ touchAction: "none" }}
+        onPointerDown={(e) => handleDragStart(e, item)}
+      >
+        {boxNode}
+      </div>
+    );
+
+    switch (activeTab) {
+      case "nfts":
+        return [
+          ...getKeys(buds).map((budId) => {
+            const image = getBudImage(Number(budId));
+            const item: LandscapingPlaceableType = {
+              name: "Bud",
+              id: String(budId),
+            };
+            return wrapBox(
+              `bud-${budId}`,
+              item,
+              image,
+              <Box
+                image={image}
+                iconClassName={classNames(
+                  "scale-[1.8] origin-bottom absolute",
+                  {
+                    "top-1": buds[budId].type === "Retreat",
+                    "left-1": buds[budId].type === "Plaza",
+                  },
+                )}
+                onClick={() => handleClick(item)}
+              />,
+            );
+          }),
+          ...getKeys(petsNFTs).map((petId) => {
+            const revealed = isPetNFTRevealed(Number(petId), now);
+            const image = getPetImage("happy", Number(petId));
+            const item: LandscapingPlaceableType = {
+              name: "Pet",
+              id: String(petId),
+            };
+            return wrapBox(
+              `pet-${petId}`,
+              item,
+              image,
+              <Box
+                image={image}
+                className={!revealed ? "opacity-50" : ""}
+                onClick={() => {
+                  if (!revealed) return;
+                  handleClick(item);
+                }}
+              />,
+            );
+          }),
+          ...Object.keys(farmHands).map((id) => {
+            const image = SUNNYSIDE.achievement.farmHand;
+            const item: LandscapingPlaceableType = { name: "FarmHand", id };
+            return wrapBox(
+              `farmhand-${id}`,
+              item,
+              image,
+              <Box image={image} onClick={() => handleClick(item)}>
+                <NPCPlaceable
+                  parts={farmHands[id].equipped}
+                  width={PIXEL_SCALE * 12}
+                />
+              </Box>,
+            );
+          }),
+        ];
+
+      case "resources":
+        return resources.map((name) => {
+          const image = getItemImage(name as CollectibleName);
+          const item: LandscapingPlaceableType = {
+            name: name as CollectibleName | BuildingName | ResourceName,
+          };
+          return wrapBox(
+            name,
+            item,
+            image,
+            <Box
+              count={chestMap[name]}
+              image={image}
+              onClick={() => handleClick(item)}
+            />,
+          );
+        });
+
+      case "buildings":
+        return buildings.map((name) => {
+          const image = getItemImage(name as CollectibleName);
+          const item: LandscapingPlaceableType = {
+            name: name as CollectibleName | BuildingName | ResourceName,
+          };
+          return wrapBox(
+            name,
+            item,
+            image,
+            <Box
+              count={chestMap[name]}
+              image={image}
+              onClick={() => handleClick(item)}
+            />,
+          );
+        });
+
+      case "boosts":
+        return [...boosts, ...weatherItems, ...beds].map((name) => {
+          const image = getItemImage(name as CollectibleName);
+          const item: LandscapingPlaceableType = {
+            name: name as CollectibleName | BuildingName | ResourceName,
+          };
+          return wrapBox(
+            name,
+            item,
+            image,
+            <Box
+              count={chestMap[name]}
+              image={image}
+              onClick={() => handleClick(item)}
+            />,
+          );
+        });
+
+      case "projects":
+        return [...monuments, ...villageProjects].map((name) => {
+          const image = getItemImage(name as CollectibleName);
+          const item: LandscapingPlaceableType = {
+            name: name as CollectibleName | BuildingName | ResourceName,
+          };
+          return wrapBox(
+            name,
+            item,
+            image,
+            <Box
+              count={chestMap[name]}
+              image={image}
+              onClick={() => handleClick(item)}
+            />,
+          );
+        });
+
+      case "decorations":
+        return [...banners, ...dolls, ...pets, ...decorations].map((name) => {
+          const image = getItemImage(name as CollectibleName);
+          const item: LandscapingPlaceableType = {
+            name: name as CollectibleName | BuildingName | ResourceName,
+          };
+          return wrapBox(
+            name,
+            item,
+            image,
+            <Box
+              count={chestMap[name]}
+              image={image}
+              onClick={() => handleClick(item)}
+            />,
+          );
+        });
+
+      default:
+        return [];
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, chestMap, buds, petsNFTs, farmHands, now]);
+
+  return (
+    <>
+      {isIdle && (
+        <div
+          className="absolute bottom-0 left-0 right-0"
+          data-prevent-drag-scroll
+          style={{ zIndex: 49 }}
+        >
+          <div className="flex items-center px-2 pb-1">
+            <img src={SUNNYSIDE.icons.drag} className="h-4 mr-1" />
+            <span className="text-white text-xs">{"Quick drag and drop"}</span>
+          </div>
+          <OuterPanel hasTabs className="relative !rounded-none">
+            {/* Tab bar */}
+            <div
+              className="absolute flex"
+              style={{
+                top: `${PIXEL_SCALE * 1}px`,
+                left: 0,
+                right: `${PIXEL_SCALE * 1}px`,
+              }}
+            >
+              <div className="flex overflow-x-auto scrollbar-hide">
+                {visibleTabs.map((tab, index) => (
+                  <Tab
+                    key={tab.id}
+                    isFirstTab={index === 0}
+                    className="relative mr-1"
+                    isActive={activeTab === tab.id}
+                    onClick={() => {
+                      tabSound.play();
+                      setActiveTab(tab.id);
+                    }}
+                  >
+                    <SquareIcon icon={tab.icon} width={7} />
+                    {!isMobile && (
+                      <span className="text-xs sm:text-sm ml-1 whitespace-nowrap">
+                        {tab.label}
+                      </span>
+                    )}
+                    {tab.hasItems && activeTab !== tab.id && (
+                      <img
+                        src={SUNNYSIDE.icons.expression_alerted}
+                        className="ml-1"
+                        style={{ width: `${PIXEL_SCALE * 3}px` }}
+                      />
+                    )}
+                  </Tab>
+                ))}
+              </div>
+            </div>
+
+            {/* Two-row horizontal scroll of item boxes */}
+            <InnerPanel>
+              <div
+                className="overflow-x-auto overflow-y-hidden"
+                style={{ height: `${TWO_ROW_HEIGHT_PX}px` }}
+              >
+                {items.length > 0 ? (
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateRows: "1fr 1fr",
+                      gridAutoFlow: "column",
+                      gridAutoColumns: "max-content",
+                      alignItems: "start",
+                      height: "100%",
+                      width: "max-content",
+                    }}
+                  >
+                    {items}
+                  </div>
+                ) : (
+                  <div className="h-full flex items-center justify-center px-4">
+                    <span className="text-xs">
+                      {
+                        visibleTabs.find((tab) => tab.id === activeTab)
+                          ?.emptyLabel
+                      }
+                    </span>
+                  </div>
+                )}
+              </div>
+            </InnerPanel>
+          </OuterPanel>
+        </div>
+      )}
+
+      {confirmItem && (
+        <ConfirmationModal
+          show
+          onHide={() => setConfirmItem(null)}
+          messages={[`Place ${confirmItem.name} on the map?`]}
+          onCancel={() => setConfirmItem(null)}
+          onConfirm={() => {
+            doPlace(confirmItem);
+            setConfirmItem(null);
+          }}
+          confirmButtonLabel={t("place")}
+        />
+      )}
+    </>
+  );
+};

--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -55,9 +55,10 @@ import {
 } from "features/game/types/craftables";
 import { getBudImage } from "lib/buds/types";
 import { getPetImage } from "features/island/pets/lib/petShared";
-import { HOURGLASSES } from "features/game/events/landExpansion/burnCollectible";
-import { HourglassType } from "features/island/collectibles/components/Hourglass";
-import { ConfirmationModal } from "components/ui/ConfirmationModal";
+import {
+  needsPlacementConfirmation,
+  PlacementConfirmationModal,
+} from "features/game/expansion/placeable/PlacementConfirmationModal";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { NPCPlaceable } from "features/island/bumpkin/components/NPC";
@@ -94,12 +95,6 @@ const ALL_DIMENSIONS: Record<string, { width: number; height: number }> = {
 const getItemDims = (name: string) =>
   ALL_DIMENSIONS[name] ?? { width: 1, height: 1 };
 
-const needsConfirmation = (name: string) =>
-  name === "Gnome" ||
-  HOURGLASSES.includes(name as HourglassType) ||
-  name === "Time Warp Totem" ||
-  name === "Super Totem";
-
 interface DragOrigin {
   startX: number;
   startY: number;
@@ -129,8 +124,11 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const isIdle = useSelector(child, (s) => s.matches({ editing: "idle" }));
 
   const [activeTab, setActiveTab] = useState<TabId>("decorations");
-  const [confirmItem, setConfirmItem] =
-    useState<LandscapingPlaceableType | null>(null);
+  const [pendingDragPlacement, setPendingDragPlacement] = useState<{
+    gridX: number;
+    gridY: number;
+    item: LandscapingPlaceableType;
+  } | null>(null);
 
   // ── Quick drag-and-drop state ──────────────────────────────────────────
   const dragRef = useRef<DragOrigin | null>(null);
@@ -234,8 +232,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
 
       if (!drag?.activated) return;
 
-      onQuickDragChange(false);
-
       const { gridX, gridY } = computeGridPos(e.clientX, e.clientY);
       const snap = gameService.getSnapshot().context.state;
       const dims = getItemDims(drag.item.name);
@@ -245,6 +241,20 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
         location,
         name: drag.item.name as CollectibleName,
       });
+
+      // Confirmation-required items: stay in dragging state and show modal.
+      // The ghost remains visible at the drop position while the user decides.
+      if (!collision && needsPlacementConfirmation(drag.item.name)) {
+        const freshChild = gameService.getSnapshot().children
+          .landscaping as MachineInterpreter;
+        freshChild.send({
+          type: "UPDATE",
+          coordinates: { x: gridX, y: gridY },
+          collisionDetected: false,
+        });
+        setPendingDragPlacement({ gridX, gridY, item: drag.item });
+        return;
+      }
 
       const freshChild = gameService.getSnapshot().children
         .landscaping as MachineInterpreter;
@@ -262,6 +272,8 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
         });
         freshChild.send({ type: "PLACE", location } as any);
       }
+
+      onQuickDragChange(false);
     };
 
     const handleCancel = () => {
@@ -470,16 +482,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
       wasDragRef.current = false;
       return;
     }
-    const name = item.name;
-    if (
-      name !== "Bud" &&
-      name !== "Pet" &&
-      name !== "FarmHand" &&
-      needsConfirmation(name)
-    ) {
-      setConfirmItem(item);
-      return;
-    }
     doPlace(item);
   };
 
@@ -499,7 +501,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
     const wrapBox = (
       key: string,
       item: LandscapingPlaceableType,
-      image: string,
       boxNode: React.ReactNode,
     ) => (
       <div
@@ -523,7 +524,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
             return wrapBox(
               `bud-${budId}`,
               item,
-              image,
               <Box
                 image={image}
                 iconClassName={classNames(
@@ -547,7 +547,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
             return wrapBox(
               `pet-${petId}`,
               item,
-              image,
               <Box
                 image={image}
                 className={!revealed ? "opacity-50" : ""}
@@ -564,7 +563,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
             return wrapBox(
               `farmhand-${id}`,
               item,
-              image,
               <Box image={image} onClick={() => handleClick(item)}>
                 <NPCPlaceable
                   parts={farmHands[id].equipped}
@@ -584,7 +582,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           return wrapBox(
             name,
             item,
-            image,
             <Box
               count={chestMap[name]}
               image={image}
@@ -602,7 +599,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           return wrapBox(
             name,
             item,
-            image,
             <Box
               count={chestMap[name]}
               image={image}
@@ -620,7 +616,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           return wrapBox(
             name,
             item,
-            image,
             <Box
               count={chestMap[name]}
               image={image}
@@ -638,7 +633,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           return wrapBox(
             name,
             item,
-            image,
             <Box
               count={chestMap[name]}
               image={image}
@@ -656,7 +650,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
           return wrapBox(
             name,
             item,
-            image,
             <Box
               count={chestMap[name]}
               image={image}
@@ -759,17 +752,31 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
         </div>
       )}
 
-      {confirmItem && (
-        <ConfirmationModal
-          show
-          onHide={() => setConfirmItem(null)}
-          messages={[`Place ${confirmItem.name} on the map?`]}
-          onCancel={() => setConfirmItem(null)}
-          onConfirm={() => {
-            doPlace(confirmItem);
-            setConfirmItem(null);
+      {pendingDragPlacement && (
+        <PlacementConfirmationModal
+          itemName={pendingDragPlacement.item.name}
+          onCancel={() => {
+            const freshChild = gameService.getSnapshot().children
+              .landscaping as MachineInterpreter;
+            freshChild.send("DROP");
+            freshChild.send("BACK");
+            onQuickDragChange(false);
+            setPendingDragPlacement(null);
           }}
-          confirmButtonLabel={t("place")}
+          onConfirm={() => {
+            const { gridX, gridY } = pendingDragPlacement;
+            const freshChild = gameService.getSnapshot().children
+              .landscaping as MachineInterpreter;
+            freshChild.send("DROP");
+            freshChild.send({
+              type: "UPDATE",
+              coordinates: { x: gridX, y: gridY },
+              collisionDetected: false,
+            });
+            freshChild.send({ type: "PLACE", location } as any);
+            onQuickDragChange(false);
+            setPendingDragPlacement(null);
+          }}
         />
       )}
     </>

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
@@ -42,8 +42,6 @@ import {
 } from "features/island/lib/alternateArt";
 import { BANNERS } from "features/game/types/banners";
 import { InnerPanel } from "components/ui/Panel";
-import { ConfirmationModal } from "components/ui/ConfirmationModal";
-import { HourglassType } from "features/island/collectibles/components/Hourglass";
 import { TranslationKeys } from "lib/i18n/dictionaries/types";
 import { BED_FARMHAND_COUNT } from "features/game/types/beds";
 import { WEATHER_SHOP_ITEM_COSTS } from "features/game/types/calendar";
@@ -65,7 +63,6 @@ import { getPetImage } from "features/island/pets/lib/petShared";
 import { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { MONUMENTS, REWARD_ITEMS } from "features/game/types/monuments";
 import { useNow } from "lib/utils/hooks/useNow";
-import { HOURGLASSES } from "features/game/events/landExpansion/burnCollectible";
 import { PlaceableLocation } from "features/game/types/collectibles";
 import { NPCPlaceable } from "features/island/bumpkin/components/NPC";
 import { FarmHandDetails } from "components/ui/layouts/FarmHandDetails";
@@ -108,11 +105,6 @@ interface PanelContentProps {
   isSaving?: boolean;
 }
 
-export type TimeBasedConsumables =
-  | HourglassType
-  | "Time Warp Totem"
-  | "Super Totem";
-
 const PanelContent: React.FC<PanelContentProps> = ({
   isSaving,
   onPlace,
@@ -127,46 +119,21 @@ const PanelContent: React.FC<PanelContentProps> = ({
   const { t } = useAppTranslation();
   const now = useNow();
 
-  const [confirmationModal, showConfirmationModal] = useState(false);
-
   // Bumpkin is not placeable from the chest
   if (!selectedChestItem || selectedChestItem.name === "Bumpkin") return null;
 
   const handlePlace = () => {
-    if (
-      selectedChestItem.name === "Gnome" ||
-      HOURGLASSES.includes(selectedChestItem.name as HourglassType) ||
-      selectedChestItem.name === "Time Warp Totem" ||
-      selectedChestItem.name === "Super Totem"
-    ) {
-      showConfirmationModal(true);
-    } else if (selectedChestItem.name === "FarmHand") {
+    if (selectedChestItem.name === "FarmHand") {
       onPlaceFarmHand?.(selectedChestItem.id);
-      closeModal();
+    } else if (
+      selectedChestItem.name === "Bud" ||
+      selectedChestItem.name === "Pet"
+    ) {
+      onPlaceNFT?.(selectedChestItem.id, selectedChestItem.name);
     } else {
-      selectedChestItem.name === "Bud" || selectedChestItem.name === "Pet"
-        ? onPlaceNFT && onPlaceNFT(selectedChestItem.id, selectedChestItem.name)
-        : onPlace && onPlace(selectedChestItem.name);
-      closeModal();
+      onPlace?.(selectedChestItem.name);
     }
-  };
-
-  const getResourceNodeCondition = (hourglass: TimeBasedConsumables) => {
-    const hourglassCondition: Record<TimeBasedConsumables, TranslationKeys> = {
-      "Blossom Hourglass": "landscape.hourglass.resourceNodeCondition.blossom",
-      "Gourmet Hourglass": "landscape.hourglass.resourceNodeCondition.gourmet",
-      "Harvest Hourglass": "landscape.hourglass.resourceNodeCondition.harvest",
-      "Orchard Hourglass": "landscape.hourglass.resourceNodeCondition.orchard",
-      "Ore Hourglass": "landscape.hourglass.resourceNodeCondition.ore",
-      "Timber Hourglass": "landscape.hourglass.resourceNodeCondition.timber",
-      "Time Warp Totem": "landscape.timeWarpTotem.resourceNodeCondition",
-      "Super Totem": "landscape.superTotem.resourceNodeCondition",
-      "Fisher's Hourglass": "landscape.hourglass.resourceNodeCondition.fishers",
-    };
-
-    return t(hourglassCondition[hourglass], {
-      selectedChestItem: selectedChestItem.name,
-    });
+    closeModal();
   };
 
   if (selectedChestItem.name === "FarmHand") {
@@ -231,78 +198,23 @@ const PanelContent: React.FC<PanelContentProps> = ({
     );
   }
 
-  const redGnomeBoostInstruction = () => {
-    return (
-      <div className="flex flex-col gap-y-2 text-xs">
-        <p>{t("landscape.confirmation.gnomes.one")}</p>
-        <p>{t("landscape.confirmation.gnomes.two")}</p>
-
-        <div className="flex justify-center mt-2 space-x-2">
-          <img src={ITEM_DETAILS["Cobalt"].image} className="w-12" />
-          <img src={ITEM_DETAILS["Gnome"].image} className="w-12" />
-          <img src={ITEM_DETAILS["Clementine"].image} className="w-12" />
-        </div>
-
-        <div className="flex justify-center">
-          <img src={ITEM_DETAILS["Crop Plot"].image} className="w-12" />
-        </div>
-      </div>
-    );
-  };
-
   return (
-    <>
-      <InventoryItemDetails
-        game={state}
-        details={{
-          item: selectedChestItem.name,
-        }}
-        properties={{
-          showOpenSeaLink: true,
-        }}
-        actionView={
-          onPlace && (
-            <Button onClick={handlePlace} disabled={isSaving}>
-              {isSaving ? t("saving") : t("place.map")}
-            </Button>
-          )
-        }
-      />
-      <ConfirmationModal
-        show={confirmationModal}
-        onHide={() => showConfirmationModal(false)}
-        messages={
-          selectedChestItem.name === "Gnome"
-            ? [redGnomeBoostInstruction()]
-            : [
-                getResourceNodeCondition(
-                  selectedChestItem.name as TimeBasedConsumables,
-                ),
-                t("landscape.confirmation.hourglass.one", {
-                  selectedChestItem: selectedChestItem.name,
-                }),
-                t("landscape.confirmation.hourglass.two", {
-                  selectedChestItem: selectedChestItem.name,
-                }),
-                selectedChestItem.name === "Time Warp Totem" ||
-                selectedChestItem.name === "Super Totem" ? (
-                  <Label type="danger" icon={SUNNYSIDE.icons.cancel}>
-                    {t("landscape.timeWarpTotem.nonStack")}
-                  </Label>
-                ) : (
-                  ""
-                ),
-              ]
-        }
-        onCancel={() => showConfirmationModal(false)}
-        onConfirm={() => {
-          onPlace && onPlace(selectedChestItem.name);
-          closeModal();
-          showConfirmationModal(false);
-        }}
-        confirmButtonLabel={t("place")}
-      />
-    </>
+    <InventoryItemDetails
+      game={state}
+      details={{
+        item: selectedChestItem.name,
+      }}
+      properties={{
+        showOpenSeaLink: true,
+      }}
+      actionView={
+        onPlace && (
+          <Button onClick={handlePlace} disabled={isSaving}>
+            {isSaving ? t("saving") : t("place.map")}
+          </Button>
+        )
+      }
+    />
   );
 };
 

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -154,6 +154,9 @@ const FEATURE_FLAGS = {
    */
   HOME_EXPANSIONS: adminFeatureFlag,
 
+  /** Quick drag-and-drop landscaping panel shown at the bottom of the screen. */
+  QUICK_LANDSCAPING_PANEL: adminFeatureFlag,
+
   /** Player economies: token dashboard, portal player-economy API, marketplace minigames row. */
   PLAYER_ECONOMIES: (game) => !!game.settings.economiesEnabled,
   /** @deprecated Use PLAYER_ECONOMIES */


### PR DESCRIPTION
# Pull request description

Placing items into the new interior is taking a lot of time. Introducing the Landscaping Quick Menu - here you can drag and drop much quicker than before and keep designing!

<img width="726" height="765" alt="Screenshot 2026-04-30 at 2 16 28 pm" src="https://github.com/user-attachments/assets/faaa14bf-f71e-4aeb-8fea-0cc3d92449f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pixel-Perfect Mode: press `p` to toggle one-pixel placement with a visible badge and finer keyboard/drag movement
  * Quick Landscaping Panel: fast-access inventory panel for drag-placement from storage; temporarily suspends other placement controls while dragging
  * Placement Confirmation Modal: prompts for certain high-impact items before finalizing placement

* **UX Changes**
  * Grid overlay visuals added to interior/level canvases (visibility toggled by landscaping)
  * Offline demo land now preseeded with starter items and skips the welcome bonus screen
<!-- end of auto-generated comment: release notes by coderabbit.ai -->