### PR TITLE
[FEAT] Salt Awakening chapter collection

### DIFF
--- a/src/features/game/types/collections.ts
+++ b/src/features/game/types/collections.ts
@@ -42,6 +42,7 @@ export function getChapterMegastoreCollectibles(
     "Bronze Flower Box",
     "Silver Flower Box",
     "Gold Flower Box",
+    ...HOURGLASSES,
   ];
   // Runtime type guard to ensure result is ChapterCollectibleName
   function isChapterCollectible(

--- a/src/features/game/types/collections.ts
+++ b/src/features/game/types/collections.ts
@@ -401,6 +401,23 @@ export const CHAPTER_COLLECTIONS: Partial<
       other: { collectibles: ["Crabs and Traps Banner"] },
     },
   }),
+  "Salt Awakening": buildChapterCollection({
+    chapter: "Salt Awakening",
+    overrides: {
+      auctioneer: {
+        collectibles: [
+          "Pufferfish",
+          "Fat Crab",
+          "Navigation Table",
+          "Royal Crab Pot",
+          "Crab House",
+          "Speed Trap",
+        ],
+        wearables: ["Pistol Shrimp"],
+      },
+      other: { collectibles: ["Salt Awakening Banner"] },
+    },
+  }),
 };
 
 /** Flattens source-keyed collection into collectibles and wearables arrays for the grid. */

--- a/src/features/island/hud/components/codex/components/ChapterCollectionItemDetail.tsx
+++ b/src/features/island/hud/components/codex/components/ChapterCollectionItemDetail.tsx
@@ -103,7 +103,7 @@ const ChapterCollectionItemDetailContent: React.FC<ContentProps> = ({
         <div className="flex items-center gap-1">
           <SquareIcon icon={image} width={9} />
           <Label type="transparent" className="ml-2">
-            <span className="text-xs whitespace-nowrap">{itemName}</span>
+            <span className="text-xs">{itemName}</span>
           </Label>
         </div>
 

--- a/src/features/island/hud/components/codex/pages/ChapterCollections.tsx
+++ b/src/features/island/hud/components/codex/pages/ChapterCollections.tsx
@@ -8,7 +8,9 @@ import {
   ChapterBanner,
   ChapterName,
   CHAPTERS,
+  hasChapterStarted,
 } from "features/game/types/chapters";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import { CHAPTER_BANNER_IMAGES } from "features/game/types/chapters";
@@ -36,11 +38,13 @@ export const ChapterCollections: React.FC<Props> = ({
   onClose,
 }) => {
   const { inventory, wardrobe } = state;
+  const now = useNow({ live: true });
 
   return (
     <div className="flex flex-col h-full overflow-y-auto scrollable">
       <div className="space-y-2 mt-1 px-1">
         {getKeys(CHAPTER_COLLECTIONS)
+          .filter((chapter) => hasChapterStarted(chapter, now))
           .filter((chapter) => !selected || chapter === selected)
           .sort((chapterA, chapterB) => {
             const chapterBStartDate = CHAPTERS[chapterB].startDate;


### PR DESCRIPTION
## Summary
Adds the Salt Awakening entry to `CHAPTER_COLLECTIONS` so the in-game collection grid surfaces all chapter items.

Auto-derived from existing helpers:
- **Megastore** — pulled from `MEGASTORE["Salt Awakening"]`
- **Mutants** — Flamingo Chicken, Salt Crystal Flower, Deep Sea Pig/Slug, Crystal Shrimp, Spa Cow, Spa Sheep
- **Track** — collectibles + wearables from `CHAPTER_TRACKS["Salt Awakening"]` milestones

Explicitly listed:
- **Auctioneer collectibles** — Pufferfish, Fat Crab, Navigation Table, Royal Crab Pot, Crab House, Speed Trap
- **Auctioneer wearables** — Pistol Shrimp
- **Other** — Salt Awakening Banner

(Auctioneer items derived from the Salt Awakening section of `AuctioneerItemName` in `sunflower-land-api/src/domain/game/types/auctioneer.ts`.)

## Companion BE PR
sunflower-land/sunflower-land-api#TBD

## Test plan
- [ ] Open the in-game collection screen during Salt Awakening and confirm all sections are populated
- [ ] Spot-check that auctioneer items show up correctly
- [ ] Banner appears under "other"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Salt Awakening" chapter with new collectibles and wearables.

* **Bug Fixes**
  * Megastore now correctly excludes hourglass items from collections.
  * Chapters display only those that have started.
  * Item names wrap properly in chapter collection details for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->