### PR TITLE
[FEAT] Extend VIP daily-chest banner perk to all chapters from Crabs and Traps onward

### DIFF
--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -9,7 +9,7 @@ const SALT_AWAKENING_NOW = new Date("2026-06-01T00:00:00.000Z").getTime();
 
 const vipFarm = (now: number): GameState => ({
   ...TEST_FARM,
-  vip: { expiresAt: now + 1000 * 60 * 60 * 24 * 30 },
+  vip: { expiresAt: now + 1000 * 60 * 60 * 24 * 30, bundles: [] },
 });
 
 describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {

--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -1,16 +1,31 @@
 import Decimal from "decimal.js-light";
 import { TEST_FARM } from "../lib/constants";
-import { GameState } from "./game";
+import { GameState, InventoryItemName } from "./game";
 import { getRewardsForStreak } from "./dailyRewards";
+import { CHAPTERS, CHAPTER_BANNERS, ChapterName } from "./chapters";
+import { getKeys } from "lib/object";
 
-const PAW_PRINTS_NOW = new Date("2026-01-15T00:00:00.000Z").getTime();
-const CRABS_AND_TRAPS_NOW = new Date("2026-03-01T00:00:00.000Z").getTime();
-const SALT_AWAKENING_NOW = new Date("2026-06-01T00:00:00.000Z").getTime();
+const midChapter = (chapter: ChapterName): number =>
+  CHAPTERS[chapter].startDate.getTime() + 1000 * 60 * 60 * 24;
+
+const PAW_PRINTS_NOW = midChapter("Paw Prints");
+const CRABS_AND_TRAPS_NOW = midChapter("Crabs and Traps");
+const SALT_AWAKENING_NOW = midChapter("Salt Awakening");
+
+const ALL_CHAPTER_BANNERS = getKeys(CHAPTER_BANNERS);
 
 const vipFarm = (now: number): GameState => ({
   ...TEST_FARM,
   vip: { expiresAt: now + 1000 * 60 * 60 * 24 * 30, bundles: [] },
 });
+
+const expectNoChapterBanner = (
+  items: Partial<Record<InventoryItemName, number>> | undefined,
+) => {
+  for (const banner of ALL_CHAPTER_BANNERS) {
+    expect(items?.[banner]).toBeUndefined();
+  }
+};
 
 describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
   it("does not grant a banner for VIPs before Crabs and Traps", () => {
@@ -24,7 +39,7 @@ describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
     });
 
     const defaultReward = rewards.find((r) => r.id === "default-reward")!;
-    expect(defaultReward.items?.["Paw Prints Banner"]).toBeUndefined();
+    expectNoChapterBanner(defaultReward.items);
   });
 
   it("grants the chapter banner for VIPs during Crabs and Traps", () => {
@@ -66,7 +81,7 @@ describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
     });
 
     const defaultReward = rewards.find((r) => r.id === "default-reward")!;
-    expect(defaultReward.items?.["Salt Awakening Banner"]).toBeUndefined();
+    expectNoChapterBanner(defaultReward.items);
   });
 
   it("does not grant the banner if the VIP already owns it", () => {

--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -1,0 +1,91 @@
+import Decimal from "decimal.js-light";
+import { TEST_FARM } from "../lib/constants";
+import { GameState } from "./game";
+import { getRewardsForStreak } from "./dailyRewards";
+
+const PAW_PRINTS_NOW = new Date("2026-01-15T00:00:00.000Z").getTime();
+const CRABS_AND_TRAPS_NOW = new Date("2026-03-01T00:00:00.000Z").getTime();
+const SALT_AWAKENING_NOW = new Date("2026-06-01T00:00:00.000Z").getTime();
+
+const vipFarm = (now: number): GameState => ({
+  ...TEST_FARM,
+  vip: { expiresAt: now + 1000 * 60 * 60 * 24 * 30 },
+});
+
+describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
+  it("does not grant a banner for VIPs before Crabs and Traps", () => {
+    const game = vipFarm(PAW_PRINTS_NOW);
+
+    const { rewards } = getRewardsForStreak({
+      game,
+      streak: 7,
+      currentDate: new Date(PAW_PRINTS_NOW).toISOString(),
+      now: PAW_PRINTS_NOW,
+    });
+
+    const defaultReward = rewards.find((r) => r.id === "default-reward")!;
+    expect(defaultReward.items?.["Paw Prints Banner"]).toBeUndefined();
+  });
+
+  it("grants the chapter banner for VIPs during Crabs and Traps", () => {
+    const game = vipFarm(CRABS_AND_TRAPS_NOW);
+
+    const { rewards } = getRewardsForStreak({
+      game,
+      streak: 7,
+      currentDate: new Date(CRABS_AND_TRAPS_NOW).toISOString(),
+      now: CRABS_AND_TRAPS_NOW,
+    });
+
+    const defaultReward = rewards.find((r) => r.id === "default-reward")!;
+    expect(defaultReward.items?.["Crabs and Traps Banner"]).toBe(1);
+  });
+
+  it("grants the chapter banner for VIPs in chapters after Crabs and Traps", () => {
+    const game = vipFarm(SALT_AWAKENING_NOW);
+
+    const { rewards } = getRewardsForStreak({
+      game,
+      streak: 7,
+      currentDate: new Date(SALT_AWAKENING_NOW).toISOString(),
+      now: SALT_AWAKENING_NOW,
+    });
+
+    const defaultReward = rewards.find((r) => r.id === "default-reward")!;
+    expect(defaultReward.items?.["Salt Awakening Banner"]).toBe(1);
+  });
+
+  it("does not grant the banner for non-VIPs in eligible chapters", () => {
+    const game: GameState = { ...TEST_FARM };
+
+    const { rewards } = getRewardsForStreak({
+      game,
+      streak: 7,
+      currentDate: new Date(SALT_AWAKENING_NOW).toISOString(),
+      now: SALT_AWAKENING_NOW,
+    });
+
+    const defaultReward = rewards.find((r) => r.id === "default-reward")!;
+    expect(defaultReward.items?.["Salt Awakening Banner"]).toBeUndefined();
+  });
+
+  it("does not grant the banner if the VIP already owns it", () => {
+    const game: GameState = {
+      ...vipFarm(SALT_AWAKENING_NOW),
+      inventory: {
+        ...TEST_FARM.inventory,
+        "Salt Awakening Banner": new Decimal(1),
+      },
+    };
+
+    const { rewards } = getRewardsForStreak({
+      game,
+      streak: 7,
+      currentDate: new Date(SALT_AWAKENING_NOW).toISOString(),
+      now: SALT_AWAKENING_NOW,
+    });
+
+    const defaultReward = rewards.find((r) => r.id === "default-reward")!;
+    expect(defaultReward.items?.["Salt Awakening Banner"]).toBeUndefined();
+  });
+});

--- a/src/features/game/types/dailyRewards.ts
+++ b/src/features/game/types/dailyRewards.ts
@@ -2,6 +2,7 @@ import { BuffName } from "./buffs";
 import { BoostName, GameState, InventoryItemName } from "./game";
 import { getBumpkinLevel, getExperienceToNextLevel } from "../lib/level";
 import {
+  CHAPTER_ORDER,
   getChapterBanner,
   getChapterTicket,
   getCurrentChapter,
@@ -309,7 +310,10 @@ export function getRewardsForStreak({
 
   const currentChapter = getCurrentChapter(now);
 
-  if (hasVipAccess({ game, now }) && currentChapter === "Crabs and Traps") {
+  if (
+    hasVipAccess({ game, now }) &&
+    CHAPTER_ORDER[currentChapter] >= CHAPTER_ORDER["Crabs and Traps"]
+  ) {
     const currentBanner = getChapterBanner(now);
     const bannerCount = game.inventory[currentBanner];
     if (!bannerCount || bannerCount.lt(1)) {


### PR DESCRIPTION
## Summary
The VIP daily-chest auto-grant of the current chapter's banner was hardcoded to `currentChapter === "Crabs and Traps"`, so VIP players in Salt Awakening (and every future chapter) silently lost the perk. Switch to a `CHAPTER_ORDER` comparison so the perk applies from Crabs and Traps onward, future-proofing it for every subsequent chapter.

```ts
// before
if (hasVipAccess({ game, now }) && currentChapter === "Crabs and Traps") { ... }

// after
if (
  hasVipAccess({ game, now }) &&
  CHAPTER_ORDER[currentChapter] >= CHAPTER_ORDER["Crabs and Traps"]
) { ... }
```

Mirrors the cutoff convention already used in `collections.ts`.

## Companion BE PR
sunflower-land/sunflower-land-api#TBD

## Test plan
- [ ] As a VIP without the Salt Awakening Banner, claim the daily reward → banner is granted
- [ ] As a VIP that already owns the Salt Awakening Banner → banner is NOT granted again
- [ ] As a non-VIP → no banner granted (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VIP daily reward eligibility now uses chapter progression cutoff, allowing chapter banner rewards once players reach or pass the specified chapter rather than requiring an exact chapter match.

* **Tests**
  * Added tests verifying VIP banner awarding across chapter progression, excluding non-VIPs, and preventing duplicate banner grants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->