### PR TITLE
[FIX] Allow claiming final track milestone from mobile dashboard

### DIFF
--- a/src/features/world/ui/tracks/ChapterTracks.tsx
+++ b/src/features/world/ui/tracks/ChapterTracks.tsx
@@ -593,12 +593,40 @@ export const ChapterTracksPreview: React.FC = () => {
 
   const isComplete = progress.points >= finalMilestonePoints;
 
-  if (isComplete) {
+  const totalMilestones = track?.milestones.length ?? 0;
+  const hasUnclaimedFinalReward =
+    progress.free < totalMilestones ||
+    (hasVip && progress.premium < totalMilestones);
+
+  if (isComplete && !hasUnclaimedFinalReward) {
     return (
       <InnerPanel className="flex flex-wrap justify-between ">
         <Label type="success">{t("completed")}</Label>
         <img src={medalMilestoneComplete} className="h-8" />
       </InnerPanel>
+    );
+  }
+
+  if (isComplete) {
+    return (
+      <>
+        <InnerPanel className="flex flex-wrap justify-between items-center">
+          <div className="flex items-center">
+            <img src={giftIcon} className="h-8 mr-1" />
+            <Label type="warning">{t("rewards")}</Label>
+          </div>
+          <img src={medalMilestoneComplete} className="h-8" />
+        </InnerPanel>
+        <Button
+          className="w-full relative mt-1"
+          onClick={() => openModal("CHAPTER_TRACKS")}
+        >
+          <span className="flex items-center justify-center gap-2 w-full">
+            <span>{t("claim")}</span>
+            <img src={giftIcon} className="h-5" />
+          </span>
+        </Button>
+      </>
     );
   }
   if (!track) {


### PR DESCRIPTION
## Summary
- The mobile chapter dashboard renders `ChapterTracksPreview`, which short-circuited to a "Completed" label as soon as the player crossed the final milestone's points threshold — even when the final free or premium reward was still unclaimed. This forced players to travel to Stella's Megastore at Plaza (which uses the full `ChapterTracks`) just to claim the final reward.
- Reported in Discord during the prior chapter for the level 40 reward; this PR makes sure the new Salt Awakening level 60 reward (and any future final-milestone rewards) doesn't hit the same UX dead-end.
- Fix: `ChapterTracksPreview` now only renders the bare "Completed" state once nothing is unclaimed. If a final milestone is still owed (free, or premium for VIP players), it renders a Claim button that opens the full `CHAPTER_TRACKS` modal directly from the dashboard.

## Test plan
- [ ] On a small viewport (mobile / `< lg`), reach the final milestone's points without claiming the last free reward — verify the preview shows the Claim button and opens the full modal where the reward can be claimed.
- [ ] Same as above with a VIP account and an unclaimed premium final milestone — verify the Claim button shows.
- [ ] After claiming all milestones, verify the preview falls back to the original bare "Completed" label.
- [ ] Desktop (`lg+`) dashboard remains unchanged — the full `ChapterTracks` already supports claiming the final milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected milestone completion tracking to distinguish between points completion and final reward claims. Users now see a rewards-focused panel with a claim button when points are complete but rewards remain unclaimed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->