### PR TITLE
[FEAT] Deterministic Bumpkin holiday from Salt Awakening

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -10,7 +10,10 @@ import {
   getCurrentChapter,
 } from "features/game/types/chapters";
 import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
-import { getBumpkinHoliday, HOLIDAYS } from "lib/utils/getSeasonWeek";
+import {
+  getBumpkinHoliday,
+  getCurrentChapterHolidayPeriod,
+} from "lib/utils/getSeasonWeek";
 import { GameState } from "features/game/types/game";
 import { getChapterTaskPoints } from "features/game/types/tracks";
 import { CONFIG } from "lib/config";
@@ -55,18 +58,11 @@ describe("deliver", () => {
 
     if (getBumpkinHoliday({ now }).holiday === nowDate) {
       jest.useFakeTimers();
-      // Find the latest holiday
-      const latestHoliday = HOLIDAYS.reduce((latest, holiday) => {
-        const holidayDate = new Date(holiday);
-        return holidayDate > latest ? holidayDate : latest;
-      }, new Date(now));
-
-      // Set the system time to the day after the latest holiday
-      const calculatedSystemDate = latestHoliday.setDate(
-        latestHoliday.getDate() + 1,
-      );
-
-      jest.setSystemTime(new Date(calculatedSystemDate));
+      const period = getCurrentChapterHolidayPeriod(now);
+      if (period) {
+        // Set the system time to the first instant after the chapter's holiday window
+        jest.setSystemTime(period.end);
+      }
     }
   });
 

--- a/src/lib/utils/getSeasonWeek.test.ts
+++ b/src/lib/utils/getSeasonWeek.test.ts
@@ -1,4 +1,4 @@
-import { getChapterChangeover } from "./getSeasonWeek";
+import { getBumpkinHoliday, getChapterChangeover } from "./getSeasonWeek";
 
 describe("getChapterChangeover", () => {
   it("delays tasks for one week", () => {
@@ -20,5 +20,30 @@ describe("getChapterChangeover", () => {
     const result = getChapterChangeover({ id: 1, now: now.getTime() });
 
     expect(result.ticketTasksAreFrozen).toBeFalsy();
+  });
+});
+
+describe("getBumpkinHoliday", () => {
+  // Salt Awakening starts Mon 2026-05-04 UTC; 2nd Monday of May 2026 is 2026-05-11.
+  // Holiday window is [2026-05-04T00:00:00Z, 2026-05-11T00:00:00Z).
+
+  it("is active on the chapter start date", () => {
+    const now = new Date("2026-05-04T00:00:00.000Z").getTime();
+    expect(getBumpkinHoliday({ now }).holiday).toEqual("2026-05-04");
+  });
+
+  it("is active mid-window", () => {
+    const now = new Date("2026-05-08T12:00:00.000Z").getTime();
+    expect(getBumpkinHoliday({ now }).holiday).toEqual("2026-05-08");
+  });
+
+  it("is active on the last full day (Sun 2026-05-10)", () => {
+    const now = new Date("2026-05-10T23:59:59.000Z").getTime();
+    expect(getBumpkinHoliday({ now }).holiday).toEqual("2026-05-10");
+  });
+
+  it("is no longer active at midnight UTC of the 2nd Monday", () => {
+    const now = new Date("2026-05-11T00:00:00.000Z").getTime();
+    expect(getBumpkinHoliday({ now }).holiday).not.toEqual("2026-05-11");
   });
 });

--- a/src/lib/utils/getSeasonWeek.ts
+++ b/src/lib/utils/getSeasonWeek.ts
@@ -1,5 +1,10 @@
 import { SeasonWeek } from "features/game/types/game";
-import { CHAPTERS, getCurrentChapter } from "features/game/types/chapters";
+import {
+  CHAPTERS,
+  CHAPTER_ORDER,
+  ChapterName,
+  getCurrentChapter,
+} from "features/game/types/chapters";
 import { ADMIN_IDS } from "lib/access";
 
 /**
@@ -56,7 +61,71 @@ export function getChapterChangeover({
 }
 
 /**
- * The days that Bumpkins are on holiday (no deliveries)
+ * From this chapter onwards, holidays are computed deterministically:
+ * the holiday window runs from the chapter's startDate (inclusive) until
+ * midnight UTC of the 2nd Monday of the chapter's start month (exclusive).
+ *
+ * Chapters before this still use the hardcoded HOLIDAYS list below.
+ */
+const COMPUTED_HOLIDAY_FROM_CHAPTER: ChapterName = "Salt Awakening";
+
+function isComputedHolidayChapter(chapter: ChapterName): boolean {
+  return CHAPTER_ORDER[chapter] >= CHAPTER_ORDER[COMPUTED_HOLIDAY_FROM_CHAPTER];
+}
+
+/**
+ * Returns the holiday window for a chapter using the 2nd-Monday rule.
+ * `start` is inclusive, `end` is exclusive (midnight UTC of the 2nd Monday).
+ */
+export function getChapterHolidayPeriod(chapter: ChapterName): {
+  start: Date;
+  end: Date;
+} {
+  const start = CHAPTERS[chapter].startDate;
+  const year = start.getUTCFullYear();
+  const monthIdx = start.getUTCMonth();
+
+  const firstOfMonth = new Date(Date.UTC(year, monthIdx, 1));
+  const dayOfWeek = firstOfMonth.getUTCDay(); // 0 = Sun … 1 = Mon … 6 = Sat
+  const daysToFirstMonday = (1 - dayOfWeek + 7) % 7;
+  const secondMondayDay = 1 + daysToFirstMonday + 7;
+
+  const end = new Date(Date.UTC(year, monthIdx, secondMondayDay));
+
+  return { start, end };
+}
+
+/**
+ * The holiday window for the chapter that contains `now`, or undefined if
+ * the chapter has no holiday. Used by tests to step around the freeze.
+ */
+export function getCurrentChapterHolidayPeriod(
+  now: number,
+): { start: Date; end: Date } | undefined {
+  const chapter = getCurrentChapter(now);
+
+  if (isComputedHolidayChapter(chapter)) {
+    return getChapterHolidayPeriod(chapter);
+  }
+
+  const chapterStart = CHAPTERS[chapter].startDate.getTime();
+  const chapterEnd = CHAPTERS[chapter].endDate.getTime();
+  const inChapter = HOLIDAYS.filter((d) => {
+    const t = new Date(d).getTime();
+    return t >= chapterStart && t < chapterEnd;
+  });
+  if (inChapter.length === 0) return undefined;
+
+  const start = new Date(inChapter[0]);
+  const lastDay = new Date(inChapter[inChapter.length - 1]);
+  const end = new Date(lastDay.getTime() + 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
+/**
+ * The days that Bumpkins are on holiday (no deliveries) — legacy, hand-maintained.
+ * Only covers chapters before {@link COMPUTED_HOLIDAY_FROM_CHAPTER}; from that
+ * chapter onwards holidays are computed via {@link getChapterHolidayPeriod}.
  */
 export const HOLIDAYS: string[] = [
   "2024-11-01",
@@ -109,19 +178,40 @@ export const HOLIDAYS: string[] = [
   "2026-02-08",
 ];
 
-export function getBumpkinHoliday({ now }: { now: number }) {
-  // Get upcoming holiday, return today if there is one today.
+export function getBumpkinHoliday({ now }: { now: number }): {
+  holiday: string | undefined;
+} {
   const todayKey = new Date(now).toISOString().split("T")[0];
 
+  // Active legacy holiday today
   if (HOLIDAYS.includes(todayKey)) {
     return { holiday: todayKey };
   }
 
-  const nextHoliday = HOLIDAYS.find(
-    (holiday) => new Date(holiday) > new Date(now),
+  // Active computed holiday today, and earliest upcoming computed holiday.
+  // Iterate directly so we don't call getCurrentChapter() for timestamps
+  // that fall outside any chapter range (e.g. createdAt: 0).
+  let nextComputed: string | undefined;
+  for (const chapter of Object.keys(CHAPTERS) as ChapterName[]) {
+    if (!isComputedHolidayChapter(chapter)) continue;
+    const { start, end } = getChapterHolidayPeriod(chapter);
+    if (now >= start.getTime() && now < end.getTime()) {
+      return { holiday: todayKey };
+    }
+    if (!nextComputed && start.getTime() > now) {
+      nextComputed = start.toISOString().split("T")[0];
+    }
+  }
+
+  // Next upcoming legacy holiday.
+  const nextLegacy = HOLIDAYS.find(
+    (holiday) => new Date(holiday).getTime() > now,
   );
 
-  return { holiday: nextHoliday };
+  if (nextLegacy && nextComputed) {
+    return { holiday: nextLegacy < nextComputed ? nextLegacy : nextComputed };
+  }
+  return { holiday: nextLegacy ?? nextComputed };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaces the hand-maintained `HOLIDAYS` list with a computed rule for chapters from **Salt Awakening** onwards: holiday window runs from chapter start (inclusive) → `00:00 UTC` of the 2nd Monday of the chapter's start month (exclusive). Earlier chapters still read the legacy list, so historical behaviour is preserved.
- Adds `getChapterHolidayPeriod(chapter)` (pure 2nd-Monday calc) and `getCurrentChapterHolidayPeriod(now)` (used by tests to step around the freeze). `getBumpkinHoliday` now merges legacy + computed sources and is bound-safe for timestamps outside any chapter range (e.g. `createdAt: 0`).
- Salt Awakening (starts Mon 2026-05-04): holiday is 2026-05-04 → 2026-05-10 inclusive; ends at 2026-05-11T00:00:00Z.

Pairs with sunflower-land/sunflower-land-api#3364 (BE).

## Test plan
- [x] `yarn jest src/lib/utils/getSeasonWeek.test.ts` — new `getBumpkinHoliday` block (start, mid, last full day, midnight UTC of 2nd Monday)
- [x] `yarn jest src/features/game/events/landExpansion/deliver.test.ts` — pre-existing tests still pass with new test setup helper
- [x] `yarn tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for holiday period detection logic.

* **Chores**
  * Improved internal holiday period calculation system for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->