### PR TITLE
[CHORE] Type-safe split of map piece triggers (base vs chapter)

### DIFF
--- a/src/features/game/types/fishing.ts
+++ b/src/features/game/types/fishing.ts
@@ -907,9 +907,7 @@ export type MapPieceFishTrigger = {
   odds: number;
 };
 
-export const MAP_PIECE_FISH_TRIGGERS: Partial<
-  Record<FishName, MapPieceFishTrigger>
-> = {
+const BASE_MAP_PIECE_TRIGGERS = {
   Halibut: { marvel: "Starlight Tuna", odds: 0.025 },
   "Horse Mackerel": { marvel: "Starlight Tuna", odds: 0.36 },
   Clownfish: { marvel: "Twilight Anglerfish", odds: 0.025 },
@@ -920,16 +918,46 @@ export const MAP_PIECE_FISH_TRIGGERS: Partial<
   "Hammerhead shark": { marvel: "Radiant Ray", odds: 0.05 },
   "Mahi Mahi": { marvel: "Phantom Barracuda", odds: 0.0018 },
   Squid: { marvel: "Phantom Barracuda", odds: 0.05 },
-  "Red Snapper": { marvel: "Super Star", odds: 0.01 },
-  "Whale Shark": { marvel: "Super Star", odds: 0.1 },
-  Anchovy: { marvel: "Giant Isopod", odds: 0.008 },
-  Oarfish: { marvel: "Giant Isopod", odds: 0.03 },
-  "Sea Horse": { marvel: "Nautilus", odds: 0.01 },
-  Tuna: { marvel: "Nautilus", odds: 0.002 },
-  Sunfish: { marvel: "Dollocaris", odds: 0.005 },
-  "Football fish": { marvel: "Dollocaris", odds: 0.005 },
-  // TODO: Add Salt Awakening fish triggers
+} satisfies Record<string, MapPieceFishTrigger>;
+
+type BaseMapPieceFishName = keyof typeof BASE_MAP_PIECE_TRIGGERS;
+
+type MapPieceTriggers = Partial<
+  Record<Exclude<FishName, BaseMapPieceFishName>, MapPieceFishTrigger>
+>;
+
+const CHAPTER_MAP_PIECE_TRIGGERS: Partial<
+  Record<ChapterName, MapPieceTriggers>
+> = {
+  "Paw Prints": {
+    "Red Snapper": { marvel: "Super Star", odds: 0.01 },
+    "Whale Shark": { marvel: "Super Star", odds: 0.1 },
+  },
+  "Crabs and Traps": {
+    Anchovy: { marvel: "Giant Isopod", odds: 0.008 },
+    Oarfish: { marvel: "Giant Isopod", odds: 0.03 },
+    "Sea Horse": { marvel: "Nautilus", odds: 0.01 },
+    Tuna: { marvel: "Nautilus", odds: 0.002 },
+    Sunfish: { marvel: "Dollocaris", odds: 0.005 },
+    "Football fish": { marvel: "Dollocaris", odds: 0.005 },
+  },
+  "Salt Awakening": {
+    Tuna: { marvel: "Crystal Shrimp", odds: 0.008 },
+    "Sea Bass": { marvel: "Crystal Shrimp", odds: 0.03 },
+    Surgeonfish: { marvel: "Deep Sea Slug", odds: 0.001 },
+    "Barred Knifejaw": { marvel: "Deep Sea Slug", odds: 0.01 },
+    Sunfish: { marvel: "Deep Sea Pig", odds: 0.005 },
+    Coelacanth: { marvel: "Deep Sea Pig", odds: 0.005 },
+  },
 };
+
+export function getMapPieceFishTriggers(now: number) {
+  const currentChapter = getCurrentChapter(now);
+  return {
+    ...BASE_MAP_PIECE_TRIGGERS,
+    ...CHAPTER_MAP_PIECE_TRIGGERS[currentChapter],
+  };
+}
 
 export const MAP_PIECE_CHAPTERS: Partial<
   Record<MarineMarvelName, ChapterName>
@@ -944,5 +972,12 @@ export const MAP_PIECE_CHAPTERS: Partial<
 };
 
 export const MAP_PIECE_MARVELS: MarineMarvelName[] = [
-  ...new Set(Object.values(MAP_PIECE_FISH_TRIGGERS).map((t) => t.marvel)),
+  ...new Set(
+    [
+      ...Object.values(BASE_MAP_PIECE_TRIGGERS),
+      ...Object.values(CHAPTER_MAP_PIECE_TRIGGERS).flatMap((t) =>
+        Object.values(t ?? {}),
+      ),
+    ].map((t) => t.marvel),
+  ),
 ];

--- a/src/features/game/types/fishing.ts
+++ b/src/features/game/types/fishing.ts
@@ -918,7 +918,7 @@ const BASE_MAP_PIECE_TRIGGERS = {
   "Hammerhead shark": { marvel: "Radiant Ray", odds: 0.05 },
   "Mahi Mahi": { marvel: "Phantom Barracuda", odds: 0.0018 },
   Squid: { marvel: "Phantom Barracuda", odds: 0.05 },
-} satisfies Record<string, MapPieceFishTrigger>;
+} satisfies Partial<Record<FishName, MapPieceFishTrigger>>;
 
 type BaseMapPieceFishName = keyof typeof BASE_MAP_PIECE_TRIGGERS;
 
@@ -951,12 +951,16 @@ const CHAPTER_MAP_PIECE_TRIGGERS: Partial<
   },
 };
 
-export function getMapPieceFishTriggers(now: number) {
+export function getMapPieceFishTriggers(
+  now: number,
+): Partial<Record<FishName, MapPieceFishTrigger>> {
   const currentChapter = getCurrentChapter(now);
-  return {
+  const triggers: Partial<Record<FishName, MapPieceFishTrigger>> = {
     ...BASE_MAP_PIECE_TRIGGERS,
     ...CHAPTER_MAP_PIECE_TRIGGERS[currentChapter],
   };
+
+  return triggers;
 }
 
 export const MAP_PIECE_CHAPTERS: Partial<


### PR DESCRIPTION
## Summary
- Mirrors the BE refactor (sunflower-land-api#3365): replaces the flat `MAP_PIECE_FISH_TRIGGERS` const with a permanent `BASE_MAP_PIECE_TRIGGERS` plus a chapter-keyed `CHAPTER_MAP_PIECE_TRIGGERS`, exposed via `getMapPieceFishTriggers(now)`.
- Chapter triggers are typed as `Partial<Record<Exclude<FishName, BaseMapPieceFishName>, MapPieceFishTrigger>>`, so any chapter that tries to redefine a permanent base trigger (e.g. `Halibut`) becomes a TypeScript error rather than silently overriding it.
- Adds the Salt Awakening triggers that were previously marked TODO.
- Fixes `MAP_PIECE_MARVELS`, which referenced the renamed symbol — now computed across base + every chapter, matching the BE shape used by Joi validation.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [ ] Codex / fisherman map-piece UI still lists every marvel (Mutants section, Codex Fish page, FishermanNPC/Modal)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Fishing trigger data restructured into base and chapter-specific layers that are merged at runtime, so location-specific fishing behavior now reflects the active chapter.
  * Displayed “marvel” sets for map pieces are now computed from the combined base + chapter layers for more accurate in-game results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->