### PR TITLE
[BAL] Bump chore/bounty track-point ratios

### DIFF
--- a/src/features/game/types/tracks.ts
+++ b/src/features/game/types/tracks.ts
@@ -12,8 +12,8 @@ export type ChapterTask = "delivery" | "chore" | "bounty" | "coinDelivery";
 
 const CHAPTER_TASK_POINTS: Record<ChapterTask, number> = {
   delivery: 5,
-  bounty: 3,
-  chore: 1,
+  bounty: 5,
+  chore: 3,
   coinDelivery: 1,
 };
 


### PR DESCRIPTION
## Summary
- Chore Track Point : Ticket ratio bumped from **1:1 → 3:1**
- Bounty Track Point : Ticket ratio bumped from **3:1 → 5:1**
- Single-line edit to `CHAPTER_TASK_POINTS` in `src/features/game/types/tracks.ts`; all `getChapterTaskPoints` call sites (chore completion, bounty sale, animal bounty) pick up the new ratios automatically.

Backend companion PR: sunflower-land/sunflower-land-api#3367

## Test plan
- [x] `yarn jest` on completeNPCChore, sellBounty, sellAnimal, claimTrackMilestone, deliver — 114/114 pass
- [ ] Smoke test in-game: complete a chore and a bounty in a chapter with an active track and confirm Points Earned updates with the new ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted point values for task types to rebalance gameplay progression. Bounty tasks now award more points, while chore tasks have been recalibrated to better reflect their difficulty and value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->