### PR TITLE
[CHORE] Remove SALT_CHAPTER time-based feature flag

### DIFF
--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -32,8 +32,6 @@ import { SkillReset } from "./SkillReset";
 import fruits from "assets/fruit/fruits.png";
 import Decimal from "decimal.js-light";
 import { capitalize } from "lib/utils/capitalize";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
-
 export const SKILL_TREE_ICONS: Record<BumpkinRevampSkillTree, string> = {
   Crops: SUNNYSIDE.skills.crops,
   Trees: SUNNYSIDE.skills.trees,
@@ -61,11 +59,6 @@ export const SkillCategoryList: React.FC<{
   const [showSkillsResetModal, setShowSkillsResetModal] = useState(false);
   const [showSkillsResetConfirmation, setShowSkillsResetConfirmation] =
     useState(false);
-
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
 
   const { bumpkin, inventory } = state;
   const availableSkillPoints = getAvailableBumpkinSkillPoints(bumpkin);
@@ -143,10 +136,7 @@ export const SkillCategoryList: React.FC<{
             state.island.type,
             islandType,
           );
-          const categories = getRevampSkillTreeCategoriesByIsland(
-            islandType,
-            hasSaltChapterAccess,
-          );
+          const categories = getRevampSkillTreeCategoriesByIsland(islandType);
           if (categories.length <= 0) return;
 
           return (

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -9,7 +9,6 @@ import {
 import { Bumpkin, GameState } from "features/game/types/game";
 import { populateSaltFarm } from "features/game/types/salt";
 import { produce } from "immer";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type ChoseSkillAction = {
   type: "skill.chosen";
@@ -172,17 +171,6 @@ export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
       throw new Error("This skill is disabled");
     }
 
-    if (
-      tree === "Aging" &&
-      !hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game: stateCopy,
-        now: createdAt,
-      })
-    ) {
-      throw new Error("This skill is not available yet");
-    }
-
     if (bumpkinHasSkill) {
       throw new Error("You already have this skill");
     }
@@ -192,19 +180,11 @@ export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
       [action.skill]: 1,
     };
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game: stateCopy,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({
-        gameBefore: state,
-        gameAfter: stateCopy,
-        now: createdAt,
-      });
-    }
+    populateSaltFarm({
+      gameBefore: state,
+      gameAfter: stateCopy,
+      now: createdAt,
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/collectAgedFish.ts
+++ b/src/features/game/events/landExpansion/collectAgedFish.ts
@@ -13,7 +13,6 @@ import type {
 } from "features/game/types/fishing";
 import { GameState } from "features/game/types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { hasPlacedAgingShed } from "./hasPlacedAgingShed";
 import { prngChance } from "lib/prng";
 
@@ -33,16 +32,6 @@ export function collectAgedFish({
   createdAt = Date.now(),
   farmId,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error("Aging Shed not enabled");
-  }
-
   return produce(state, (game) => {
     if (!hasPlacedAgingShed(game)) {
       throw new Error(translate("error.requiredBuildingNotExist"));

--- a/src/features/game/events/landExpansion/craftCollectible.ts
+++ b/src/features/game/events/landExpansion/craftCollectible.ts
@@ -21,7 +21,6 @@ import { ExoticCropName } from "features/game/types/beans";
 import { isExoticCrop } from "features/game/types/crops";
 import { PET_SHOP_ITEMS, PetShopItemName } from "features/game/types/petShop";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 type CraftableCollectibleItem =
   | HeliosBlacksmithItem
@@ -196,15 +195,6 @@ export function craftCollectible({
     };
 
     if (action.name === "Salt Sculpture") {
-      if (
-        !hasTimeBasedFeatureAccess({
-          featureName: "SALT_CHAPTER",
-          game: stateCopy,
-          now: createdAt,
-        })
-      ) {
-        throw new Error("Salt Sculpture not enabled");
-      }
       if (!stateCopy.sculptures) stateCopy.sculptures = {};
       stateCopy.sculptures["Salt Sculpture"] = {
         level: 1,

--- a/src/features/game/events/landExpansion/equip.ts
+++ b/src/features/game/events/landExpansion/equip.ts
@@ -4,7 +4,6 @@ import { Bumpkin, GameState, Wardrobe } from "features/game/types/game";
 import { produce } from "immer";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import { populateSaltFarm } from "features/game/types/salt";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type EquipBumpkinAction = {
   type: "bumpkin.equipped";
@@ -33,15 +32,7 @@ export function equip({
 
     bumpkin.equipped = action.equipment;
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
-    }
+    populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/equipFarmHand.ts
+++ b/src/features/game/events/landExpansion/equipFarmHand.ts
@@ -3,7 +3,6 @@ import { Equipped } from "features/game/types/bumpkin";
 import { GameState } from "features/game/types/game";
 import { populateSaltFarm } from "features/game/types/salt";
 import { produce } from "immer";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type EquipFarmHandAction = {
   type: "farmHand.equipped";
@@ -37,15 +36,7 @@ export function equipFarmhand({
 
     bumpkin.equipped = action.equipment;
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
-    }
+    populateSaltFarm({ gameBefore: state, gameAfter: game, now: createdAt });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/harvestSalt.ts
+++ b/src/features/game/events/landExpansion/harvestSalt.ts
@@ -12,7 +12,6 @@ import {
   SaltSyncOptions,
 } from "features/game/types/salt";
 import { produce } from "immer";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -23,7 +22,6 @@ export enum HARVEST_SALT_ERRORS {
   SALT_NODE_NOT_FOUND = "Salt node not found",
   NOT_ENOUGH_CHARGES = "Not enough salt charges",
   NOT_ENOUGH_SALT_RAKES = "Not enough Salt Rakes",
-  SALT_FARM_NOT_ENABLED = "Salt farm not enabled",
 }
 
 export type HarvestSaltAction = {
@@ -44,16 +42,6 @@ export function harvestSalt({
   createdAt = Date.now(),
   farmId,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error(HARVEST_SALT_ERRORS.SALT_FARM_NOT_ENABLED);
-  }
-
   return produce(state, (copy) => {
     const saltNode = copy.saltFarm.nodes[action.id];
     if (!saltNode) {

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -22,7 +22,6 @@ import {
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { COMPETITION_POINTS } from "features/game/types/competitions";
 import { populateSaltFarm } from "features/game/types/salt";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -291,19 +290,11 @@ export function placeCollectible({
       stateCopy.farmActivity,
     );
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game: stateCopy,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({
-        gameBefore: state,
-        gameAfter: stateCopy,
-        now: createdAt,
-      });
-    }
+    populateSaltFarm({
+      gameBefore: state,
+      gameAfter: stateCopy,
+      now: createdAt,
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/removeCollectible.ts
+++ b/src/features/game/events/landExpansion/removeCollectible.ts
@@ -12,7 +12,6 @@ import {
 import { PET_SHRINES } from "features/game/types/pets";
 import { populateSaltFarm } from "features/game/types/salt";
 import { isPetCollectible } from "./placeCollectible";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export enum REMOVE_COLLECTIBLE_ERRORS {
   INVALID_COLLECTIBLE = "This collectible does not exist",
@@ -121,19 +120,11 @@ export function removeCollectible({
       stateCopy.farmActivity,
     );
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game: stateCopy,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({
-        gameBefore: state,
-        gameAfter: stateCopy,
-        now: createdAt,
-      });
-    }
+    populateSaltFarm({
+      gameBefore: state,
+      gameAfter: stateCopy,
+      now: createdAt,
+    });
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/resetSkills.ts
+++ b/src/features/game/events/landExpansion/resetSkills.ts
@@ -3,7 +3,6 @@ import { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import Decimal from "decimal.js-light";
 import { populateSaltFarm } from "features/game/types/salt";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type PaymentType = "gems" | "free" | "ticket";
 
@@ -127,19 +126,11 @@ export function resetSkills({
 
     bumpkin.skills = {};
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({
-        gameBefore: state,
-        gameAfter: game,
-        now: createdAt,
-      });
-    }
+    populateSaltFarm({
+      gameBefore: state,
+      gameAfter: game,
+      now: createdAt,
+    });
 
     return game;
   });

--- a/src/features/game/events/landExpansion/startAging.ts
+++ b/src/features/game/events/landExpansion/startAging.ts
@@ -14,7 +14,6 @@ import {
 } from "features/game/types/agingFormulas";
 import type { FishName } from "features/game/types/fishing";
 import { GameState } from "features/game/types/game";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { hasPlacedAgingShed } from "./hasPlacedAgingShed";
 
 export type StartAgingAction = {
@@ -36,16 +35,6 @@ export function startAging({
   createdAt = Date.now(),
   farmId: _farmId,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error("Aging Shed not enabled");
-  }
-
   return produce(state, (game) => {
     if (!hasPlacedAgingShed(game)) {
       throw new Error(translate("error.requiredBuildingNotExist"));

--- a/src/features/game/events/landExpansion/startFermentation.ts
+++ b/src/features/game/events/landExpansion/startFermentation.ts
@@ -14,7 +14,6 @@ import { GameState } from "features/game/types/game";
 import { getAgingInputMultiplier } from "features/game/types/agingFormulas";
 import { hasPlacedAgingShed } from "./hasPlacedAgingShed";
 import { grantFermentationRecipeOutputs } from "./grantFermentationRecipeOutputs";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type StartFermentationAction = {
   type: "fermentation.started";
@@ -36,16 +35,6 @@ export function startFermentation({
   createdAt = Date.now(),
   farmId,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error("Aging Shed not enabled");
-  }
-
   return produce(state, (game) => {
     if (!hasPlacedAgingShed(game)) {
       throw new Error(translate("error.requiredBuildingNotExist"));

--- a/src/features/game/events/landExpansion/startSpiceRack.ts
+++ b/src/features/game/events/landExpansion/startSpiceRack.ts
@@ -12,7 +12,6 @@ import { getObjectEntries } from "lib/object";
 import { GameState } from "features/game/types/game";
 import { getAgingInputMultiplier } from "features/game/types/agingFormulas";
 import { hasPlacedAgingShed } from "./hasPlacedAgingShed";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type StartSpiceRackAction = {
   type: "spiceRack.started";
@@ -32,16 +31,6 @@ export function startSpiceRack({
   action,
   createdAt,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error("Aging Shed not enabled");
-  }
-
   return produce(state, (game) => {
     if (!hasPlacedAgingShed(game)) {
       throw new Error("Required building does not exist");

--- a/src/features/game/events/landExpansion/upgradeSaltFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltFarm.ts
@@ -9,7 +9,6 @@ import {
   MAX_STORED_SALT_CHARGES_PER_NODE,
   SALT_FARM_UPGRADES,
 } from "features/game/types/salt";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type UpgradeSaltFarmAction = {
@@ -27,15 +26,6 @@ export function upgradeSaltFarm({
   action: _action,
   createdAt,
 }: Options): GameState {
-  if (
-    !hasTimeBasedFeatureAccess({
-      featureName: "SALT_CHAPTER",
-      game: state,
-      now: createdAt,
-    })
-  ) {
-    throw new Error("Salt farm not enabled");
-  }
   return produce(state, (copy) => {
     const { saltFarm } = copy;
     const nextLevel = saltFarm.level + 1;

--- a/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
+++ b/src/features/game/events/landExpansion/upgradeSaltSculpture.ts
@@ -6,7 +6,6 @@ import {
 } from "features/game/types/saltSculpture";
 import { populateSaltFarm } from "features/game/types/salt";
 import { produce } from "immer";
-import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type UpgradeSaltSculptureAction = {
   type: "saltSculpture.upgraded";
@@ -23,16 +22,6 @@ export function upgradeSaltSculpture({
   createdAt = Date.now(),
 }: Options): GameState {
   return produce(state, (game) => {
-    if (
-      !hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game,
-        now: createdAt,
-      })
-    ) {
-      throw new Error("Salt Sculpture not enabled");
-    }
-
     const sculpture = game.sculptures?.["Salt Sculpture"];
     if (!sculpture) {
       throw new Error("Salt Sculpture not crafted");
@@ -80,18 +69,10 @@ export function upgradeSaltSculpture({
       upgradedAt: createdAt,
     };
 
-    if (
-      hasTimeBasedFeatureAccess({
-        featureName: "SALT_CHAPTER",
-        game,
-        now: createdAt,
-      })
-    ) {
-      populateSaltFarm({
-        gameBefore: state,
-        gameAfter: game,
-        now: createdAt,
-      });
-    }
+    populateSaltFarm({
+      gameBefore: state,
+      gameAfter: game,
+      now: createdAt,
+    });
   });
 }

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -56,7 +56,6 @@ import {
   getSaltNodesWithPositions,
 } from "features/game/types/salt";
 import { getPendingSaltNodeIdsForUpgrade } from "features/game/types/salt";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 
 export const LAND_WIDTH = 6;
 
@@ -376,11 +375,6 @@ export const LandComponent: React.FC = () => {
     _saltNodePositions,
     compareSaltFarmSlice,
   );
-  const gameState = useSelector(gameService, (s) => s.context.state);
-  const hasSaltFarmAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: gameState,
-  });
   const { mushrooms } = useSelector(
     gameService,
     _mushroomPositions,
@@ -1251,8 +1245,8 @@ export const LandComponent: React.FC = () => {
 
         {/* Water trap spots - rendered after Fisherman to ensure they appear on top */}
         {!landscaping && waterTrapElements}
-        {!landscaping && hasSaltFarmAccess && saltPlaceholderElements}
-        {!landscaping && hasSaltFarmAccess && saltNodeElements}
+        {!landscaping && saltPlaceholderElements}
+        {!landscaping && saltNodeElements}
 
         {/* Background darkens in landscaping */}
         <div

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -3454,17 +3454,13 @@ export const SKILL_TREE_CATEGORIES = Array.from(
 
 export const getRevampSkillTreeCategoriesByIsland = (
   islandType: IslandType,
-  hasSaltChapterAccess: boolean,
 ) => {
   return Array.from(
     new Set(
       getKeys(BUMPKIN_REVAMP_SKILL_TREE)
         .filter((skillName) => {
           const skill = BUMPKIN_REVAMP_SKILL_TREE[skillName];
-          return (
-            skill.requirements.island === islandType &&
-            (skill.tree !== "Aging" || hasSaltChapterAccess)
-          );
+          return skill.requirements.island === islandType;
         })
         .map((skill) => BUMPKIN_REVAMP_SKILL_TREE[skill].tree),
     ),

--- a/src/features/helios/components/blacksmith/component/IslandBlacksmithItems.tsx
+++ b/src/features/helios/components/blacksmith/component/IslandBlacksmithItems.tsx
@@ -4,7 +4,6 @@ import { useSelector } from "@xstate/react";
 import { Box } from "components/ui/Box";
 
 import { Context } from "features/game/GameProvider";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 import { getKeys } from "lib/object";
 import { ITEM_DETAILS } from "features/game/types/images";
 
@@ -127,10 +126,6 @@ export const IslandBlacksmithItems: React.FC = () => {
   >("Basic Scarecrow");
   const { gameService, shortcutItem } = useContext(Context);
   const state = useSelector(gameService, _state);
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
   const now = useNow();
   const ticket = getChapterTicket(now);
   const inventory = useSelector(gameService, _inventory);
@@ -224,7 +219,7 @@ export const IslandBlacksmithItems: React.FC = () => {
     "Macaw",
     "Squirrel",
     "Butterfly",
-    ...(hasSaltChapterAccess ? (["Salt Sculpture"] as const) : []),
+    "Salt Sculpture",
   ];
 
   return (

--- a/src/features/island/buildings/components/building/agingShed/AgingShedModal.tsx
+++ b/src/features/island/buildings/components/building/agingShed/AgingShedModal.tsx
@@ -14,7 +14,6 @@ import { FermentationRackPanel } from "./fermentationRack/FermentationRackPanel"
 import { AgingRackPanel } from "./agingRack/AgingRackPanel";
 import { SpiceRackPanel } from "./spiceRack/SpiceRackPanel";
 import { OuterPanel } from "components/ui/Panel";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useNow } from "lib/utils/hooks/useNow";
 
@@ -34,11 +33,6 @@ export const AgingShedModal: React.FC<Props> = ({ isOpen, onClose }) => {
     gameService,
     (state) => state.context.state.agingShed.level,
   );
-  const gameState = useSelector(gameService, (state) => state.context.state);
-  const hasAgingShedAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: gameState,
-  });
   const agingShedRacks = useSelector(
     gameService,
     (state) => state.context.state.agingShed.racks,
@@ -109,18 +103,13 @@ export const AgingShedModal: React.FC<Props> = ({ isOpen, onClose }) => {
       />
       <CloseButtonPanel<AgingShedTabs>
         onClose={closeUpgradeTab}
-        tabs={
-          !hasAgingShedAccess ? undefined : showUpgradeTab ? upgradeTab : tabs
-        }
-        currentTab={
-          showUpgradeTab && hasAgingShedAccess ? "upgrade" : currentTab
-        }
+        tabs={showUpgradeTab ? upgradeTab : tabs}
+        currentTab={showUpgradeTab ? "upgrade" : currentTab}
         setCurrentTab={showUpgradeTab ? undefined : setCurrentTab}
         container={showUpgradeTab ? undefined : OuterPanel}
       >
         <AgedShedPanel
           agingShedLevel={agingShedLevel}
-          hasAgingShedAccess={hasAgingShedAccess}
           setShowUpgradeTab={setShowUpgradeTab}
           closeUpgradeTab={closeUpgradeTab}
           showUpgradeTab={showUpgradeTab}
@@ -133,29 +122,18 @@ export const AgingShedModal: React.FC<Props> = ({ isOpen, onClose }) => {
 
 const AgedShedPanel: React.FC<{
   agingShedLevel: number;
-  hasAgingShedAccess: boolean;
   setShowUpgradeTab: React.Dispatch<React.SetStateAction<boolean>>;
   closeUpgradeTab: () => void;
   showUpgradeTab: boolean;
   currentTab: AgingShedTabs;
 }> = ({
   agingShedLevel,
-  hasAgingShedAccess,
   setShowUpgradeTab,
   closeUpgradeTab,
   showUpgradeTab,
   currentTab,
 }) => {
-  const { t } = useAppTranslation();
   const nextAgingShedLevel = agingShedLevel + 1;
-
-  if (!hasAgingShedAccess) {
-    return (
-      <div className="p-2">
-        <p className="text-sm">{t("coming.soon")}</p>
-      </div>
-    );
-  }
 
   if (showUpgradeTab) {
     return (

--- a/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/FullRestockModal.tsx
@@ -17,7 +17,6 @@ import { TREASURE_TOOLS, WORKBENCH_TOOLS } from "features/game/types/tools";
 import { SEEDS } from "features/game/types/seeds";
 import { CROP_LIFECYCLE } from "features/island/plots/lib/plant";
 import { getObjectEntries } from "lib/object";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 
 interface RestockModalProps {
   onClose: () => void;
@@ -37,10 +36,6 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
 
   const { gameService, showAnimations } = useContext(Context);
   const state = useSelector(gameService, (state) => state.context.state);
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
 
   const canRestock = state.inventory["Gem"]?.gte(20);
 
@@ -64,9 +59,9 @@ export const FullRestockModal: React.FC<RestockModalProps> = ({
   };
   const restockables = INITIAL_STOCK(state);
 
-  const restockTools = getObjectEntries(restockables)
-    .filter((item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS })
-    .filter(([item]) => item !== "Salt Rake" || hasSaltChapterAccess);
+  const restockTools = getObjectEntries(restockables).filter(
+    (item) => item[0] in { ...WORKBENCH_TOOLS, ...TREASURE_TOOLS },
+  );
 
   const restockSeeds = getObjectEntries(restockables).filter(
     (item) => item[0] in SEEDS,

--- a/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
+++ b/src/features/island/buildings/components/building/market/restock/NPCRestockModal.tsx
@@ -18,7 +18,6 @@ import {
 } from "features/game/events/landExpansion/npcRestock";
 import { capitalize } from "lodash";
 import { getObjectEntries } from "lib/object";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 import { useSelector } from "@xstate/react";
 
 interface RestockModalProps {
@@ -41,10 +40,6 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
 
   const { gameService, showAnimations } = useContext(Context);
   const state = useSelector(gameService, (state) => state.context.state);
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
 
   const { gemPrice, shopName, restockItem, categoryLabel } = RestockItems[npc];
   const canRestock = state.inventory["Gem"]?.gte(gemPrice);
@@ -71,9 +66,9 @@ export const NPCRestockModal: React.FC<RestockModalProps> = ({
   const { labelText, icon } = categoryLabel;
   const restockables = INITIAL_STOCK(state);
 
-  const restockItems = getObjectEntries(restockables)
-    .filter((item) => item[0] in restockItem)
-    .filter(([item]) => item !== "Salt Rake" || hasSaltChapterAccess);
+  const restockItems = getObjectEntries(restockables).filter(
+    (item) => item[0] in restockItem,
+  );
 
   return (
     <>

--- a/src/features/island/buildings/components/building/workBench/components/Tools.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/Tools.tsx
@@ -29,7 +29,6 @@ import { getToolPrice } from "features/game/events/landExpansion/craftTool";
 import { Restock } from "../../market/restock/Restock";
 import { getObjectEntries } from "lib/object";
 import { getBumpkinLevel } from "features/game/lib/level";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 
 const isLoveAnimalTool = (
   toolName: WorkbenchToolName | LoveAnimalItem,
@@ -44,10 +43,6 @@ export const Tools: React.FC = () => {
   const { gameService, shortcutItem } = useContext(Context);
 
   const state = useSelector(gameService, (state) => state.context.state);
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
 
   const selected = isLoveAnimalTool(selectedName)
     ? LOVE_ANIMAL_TOOLS[selectedName]
@@ -245,9 +240,7 @@ export const Tools: React.FC = () => {
             {t("waterTools")}
           </Label>
           <div className="flex flex-wrap mb-2">
-            {WATER_TOOLS.filter(
-              ([toolName]) => toolName !== "Salt Rake" || hasSaltChapterAccess,
-            ).map(([toolName, tool]) => {
+            {WATER_TOOLS.map(([toolName, tool]) => {
               const { requiredIsland } = tool;
               const isLocked =
                 !hasRequiredIslandExpansion(

--- a/src/features/island/fisherman/BaitSelection.tsx
+++ b/src/features/island/fisherman/BaitSelection.tsx
@@ -48,7 +48,6 @@ import { gameAnalytics } from "lib/gameAnalytics";
 import { ModalOverlay } from "components/ui/ModalOverlay";
 import { useNow } from "lib/utils/hooks/useNow";
 import { ModalContext } from "features/game/components/modal/ModalProvider";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 
 const BAIT: FishingBait[] = [
   "Earthworm",
@@ -123,10 +122,6 @@ export const BaitSelection: React.FC<Props> = ({ onCast, state }) => {
   };
 
   const isVip = useVipAccess({ game: state });
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
   const currentSeason = state.season.season;
   const now = useNow();
 
@@ -383,13 +378,7 @@ export const BaitSelection: React.FC<Props> = ({ onCast, state }) => {
           </div>
         </InnerPanel>
         <DropdownPanel
-          options={BAIT.filter(
-            (bait) =>
-              (bait !== "Capsule Bait" &&
-                bait !== "Umbrella Bait" &&
-                bait !== "Crimson Baitfish") ||
-              hasSaltChapterAccess,
-          ).map((bait) => ({
+          options={BAIT.map((bait) => ({
             value: bait,
             label: (
               <div className="flex flex-col gap-1">

--- a/src/features/island/hud/components/buildings/Buildings.tsx
+++ b/src/features/island/hud/components/buildings/Buildings.tsx
@@ -25,7 +25,6 @@ import { getCurrentBiome } from "features/island/biomes/biomes";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { MachineInterpreter } from "features/game/expansion/placeable/landscapingMachine";
 import { MachineState } from "features/game/lib/gameMachine";
-import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 import { GameState } from "features/game/types/game";
 import { getObjectEntries } from "lib/object";
 
@@ -33,10 +32,7 @@ interface Props {
   onClose: () => void;
 }
 
-const getValidBuildings = (
-  state: GameState,
-  hasSaltChapterAccess: boolean,
-): BuildingName[] => {
+const getValidBuildings = (state: GameState): BuildingName[] => {
   const UNSORTED_BUILDINGS: BuildingName[] = [
     "Kitchen",
     "Water Well",
@@ -55,7 +51,7 @@ const getValidBuildings = (
     "Barn",
     "Fish Market",
     "Pet House",
-    ...(hasSaltChapterAccess ? (["Aging Shed"] as BuildingName[]) : []),
+    "Aging Shed",
   ];
 
   const VALID_BUILDINGS = [...UNSORTED_BUILDINGS].sort(
@@ -86,10 +82,6 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
   const island = useSelector(gameService, _island);
   const collectibles = useSelector(gameService, _collectibles);
   const season = useSelector(gameService, _season);
-  const hasSaltChapterAccess = useTimeBasedFeatureAccess({
-    featureName: "SALT_CHAPTER",
-    game: state,
-  });
   const { t } = useAppTranslation();
   const buildingBlueprint = BUILDINGS[selectedName];
   const bumpkinLevel = getBumpkinLevel(bumpkin.experience ?? 0);
@@ -184,41 +176,39 @@ export const Buildings: React.FC<Props> = ({ onClose }) => {
       }
       content={
         <>
-          {[...getValidBuildings(state, hasSaltChapterAccess)].map(
-            (name: BuildingName) => {
-              const blueprint = BUILDINGS[name];
-              const inventoryCount = inventory[name] || new Decimal(0);
-              const isLocked = bumpkinLevel < blueprint.unlocksAtLevel;
+          {[...getValidBuildings(state)].map((name: BuildingName) => {
+            const blueprint = BUILDINGS[name];
+            const inventoryCount = inventory[name] || new Decimal(0);
+            const isLocked = bumpkinLevel < blueprint.unlocksAtLevel;
 
-              let secondaryIcon = undefined;
-              if (isLocked) {
-                secondaryIcon = SUNNYSIDE.icons.lock;
-              }
+            let secondaryIcon = undefined;
+            if (isLocked) {
+              secondaryIcon = SUNNYSIDE.icons.lock;
+            }
 
-              if (inventoryCount.greaterThanOrEqualTo(1)) {
-                secondaryIcon = SUNNYSIDE.icons.confirm;
-              }
+            if (inventoryCount.greaterThanOrEqualTo(1)) {
+              secondaryIcon = SUNNYSIDE.icons.confirm;
+            }
 
-              const hasLevel = isBuildingUpgradable(name)
-                ? state[makeUpgradableBuildingKey(name)].level
-                : undefined;
+            const hasLevel = isBuildingUpgradable(name)
+              ? state[makeUpgradableBuildingKey(name)].level
+              : undefined;
 
-              const image =
-                ITEM_ICONS(season, getCurrentBiome(island), hasLevel)[name] ??
-                ITEM_DETAILS[name].image;
+            const image =
+              ITEM_ICONS(season, getCurrentBiome(island), hasLevel)[name] ??
+              ITEM_DETAILS[name].image;
 
-              return (
-                <Box
-                  isSelected={selectedName === name}
-                  key={name}
-                  onClick={() => setSelectedName(name)}
-                  image={image}
-                  secondaryImage={secondaryIcon}
-                  showOverlay={isLocked}
-                />
-              );
-            },
-          )}
+            return (
+              <Box
+                isSelected={selectedName === name}
+                key={name}
+                onClick={() => setSelectedName(name)}
+                image={image}
+                secondaryImage={secondaryIcon}
+                showOverlay={isLocked}
+              />
+            );
+          })}
         </>
       }
     />

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -69,7 +69,6 @@ export const TIME_BASED_FEATURE_FLAG_WINDOWS = {
     start: new Date("2026-04-01T00:00:00Z"),
     end: new Date("2026-04-08T00:00:00Z"),
   },
-  SALT_CHAPTER: { start: new Date("2026-05-04T00:00:00Z"), end: null },
 } satisfies Record<string, TimeBasedFeatureWindow>;
 
 /** All time-based flags receive the full window; start-only helpers ignore `end`. */
@@ -85,7 +84,6 @@ export const TIME_BASED_FEATURE_FLAGS: Record<
 > = {
   TICKETS_FROM_COIN_NPC: timePeriodFeatureFlag,
   APRIL_FOOLS_EVENT_FLAG: betaTimePeriodFeatureFlag,
-  SALT_CHAPTER: betaTimePeriodFeatureFlag,
 };
 
 /**


### PR DESCRIPTION
## Summary

The Salt Chapter feature has shipped, so all gates around it can be retired.

- Drops the `SALT_CHAPTER` entry from `TIME_BASED_FEATURE_FLAG_WINDOWS` and `TIME_BASED_FEATURE_FLAGS`.
- Removes every `hasTimeBasedFeatureAccess` / `useTimeBasedFeatureAccess` call site that gated salt-farm, aging-shed, salt-sculpture, salt-rake stocking, capsule/umbrella/crimson bait, and the Aging skill tree.
- Simplifies helpers that took a `hasSaltChapterAccess` boolean (`getRevampSkillTreeCategoriesByIsland`, `getValidBuildings`, etc.).
- Drops the now-unused `HARVEST_SALT_ERRORS.SALT_FARM_NOT_ENABLED` enum value.

Pairs with the BE PR sunflower-land/sunflower-land-api#NEW.

## Test plan

- [ ] `yarn tsc --noEmit` clean (verified locally)
- [ ] Smoke-test salt farm, aging shed (aging / fermentation / spice racks), salt sculpture upgrade
- [ ] Buy a Salt Rake from workbench + market restock; verify capsule/umbrella/crimson baits show in fishing dropdown
- [ ] Open skill tree — Aging tree visible without flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Salt Farm features, Aging Shed, and aging/fermentation/spice rack systems are now permanently available
  * Salt Rake tool and Salt Sculpture collectible are now fully enabled
  * Aging skill tree category is now accessible to all players

<!-- end of auto-generated comment: release notes by coderabbit.ai -->