### PR TITLE
[FEAT] Add chapter megastore items to chest rewards

### DIFF
--- a/src/components/ui/ChestRewardsList.tsx
+++ b/src/components/ui/ChestRewardsList.tsx
@@ -128,13 +128,14 @@ export const ChestRewardsList: React.FC<{
   const { t } = useAppTranslation();
   const state = useSelector(gameService, (state) => state.context.state);
   const now = useNow();
+  const chestLoot = CHEST_LOOT(state, now);
 
   const isChestRewardType = (
     type: ChestRewardType | RewardBoxName,
-  ): type is ChestRewardType => type in CHEST_LOOT(state, now);
+  ): type is ChestRewardType => type in chestLoot;
 
   const rewards: RewardBoxReward[] = isChestRewardType(type)
-    ? CHEST_LOOT(state, now)[type]
+    ? chestLoot[type]
     : REWARD_BOXES[type].rewards;
 
   // Based on total weighting for each list

--- a/src/components/ui/ChestRewardsList.tsx
+++ b/src/components/ui/ChestRewardsList.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useNow } from "lib/utils/hooks/useNow";
 import {
   CHEST_LOOT,
   ChestRewardType,
@@ -126,13 +127,14 @@ export const ChestRewardsList: React.FC<{
   const { gameService } = useContext(Context);
   const { t } = useAppTranslation();
   const state = useSelector(gameService, (state) => state.context.state);
+  const now = useNow();
 
   const isChestRewardType = (
     type: ChestRewardType | RewardBoxName,
-  ): type is ChestRewardType => type in CHEST_LOOT(state);
+  ): type is ChestRewardType => type in CHEST_LOOT(state, now);
 
   const rewards: RewardBoxReward[] = isChestRewardType(type)
-    ? CHEST_LOOT(state)[type]
+    ? CHEST_LOOT(state, now)[type]
     : REWARD_BOXES[type].rewards;
 
   // Based on total weighting for each list

--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -1,10 +1,53 @@
-import { BB_TO_GEM_RATIO } from "./game";
+import { BB_TO_GEM_RATIO, InventoryItemName } from "./game";
 import { RewardBoxReward } from "./rewardBoxes";
+import { BumpkinItem } from "./bumpkin";
+import { CHAPTERS, getCurrentChapter } from "./chapters";
+import { MEGASTORE } from "./megastore";
+import { CHAPTER_TICKET_BOOST_ITEMS } from "../events/landExpansion/completeNPCChore";
+import { HOURGLASSES } from "../events/landExpansion/burnCollectible";
+import {
+  isCollectible,
+  isWearable,
+} from "../events/landExpansion/buyChapterItem";
+import { INVENTORY_RELEASES, WEARABLE_RELEASES } from "./withdrawables";
 
 export const CHEST_MULTIPLIER = 900;
 
+function getChapterMegastoreChestRewards(
+  now: number,
+  weight: number,
+): RewardBoxReward[] {
+  const chapter = getCurrentChapter(now);
+  const { startDate, endDate } = CHAPTERS[chapter];
+  const nowDate = new Date(now);
+  if (nowDate < startDate || nowDate >= endDate) return [];
+
+  const restricted: (InventoryItemName | BumpkinItem)[] = [
+    ...Object.values(CHAPTER_TICKET_BOOST_ITEMS[chapter]),
+    ...HOURGLASSES,
+  ];
+
+  const rewards: RewardBoxReward[] = [];
+
+  for (const item of MEGASTORE[chapter].basic.items) {
+    if (isCollectible(item)) {
+      const name = item.collectible as InventoryItemName;
+      if (restricted.includes(name)) continue;
+      if (!INVENTORY_RELEASES[name]) continue;
+      rewards.push({ items: { [name]: 1 }, weighting: weight });
+    } else if (isWearable(item)) {
+      const name = item.wearable;
+      if (restricted.includes(name)) continue;
+      if (!WEARABLE_RELEASES[name]) continue;
+      rewards.push({ wearables: { [name]: 1 }, weighting: weight });
+    }
+  }
+
+  return rewards;
+}
+
 export const BASIC_CHAPTER_REWARDS_WEIGHT = 5 * CHEST_MULTIPLIER;
-export const BASIC_REWARDS: RewardBoxReward[] = [
+export const BASIC_REWARDS = (now: number): RewardBoxReward[] => [
   { coins: 1600, weighting: 100 * CHEST_MULTIPLIER },
   { coins: 3200, weighting: 50 * CHEST_MULTIPLIER },
   { coins: 8000, weighting: 20 * CHEST_MULTIPLIER },
@@ -31,9 +74,10 @@ export const BASIC_REWARDS: RewardBoxReward[] = [
   { items: { "Fancy Fries": 3 }, weighting: 100 * CHEST_MULTIPLIER },
   { items: { Rug: 1 }, weighting: 25 * CHEST_MULTIPLIER },
   { items: { "Prize Ticket": 1 }, weighting: 5 * CHEST_MULTIPLIER },
+  ...getChapterMegastoreChestRewards(now, 20 * CHEST_MULTIPLIER),
 ];
 
-export const RARE_REWARDS: RewardBoxReward[] = [
+export const RARE_REWARDS = (now: number): RewardBoxReward[] => [
   { coins: 1600, weighting: 100 * CHEST_MULTIPLIER },
   { coins: 3200, weighting: 50 * CHEST_MULTIPLIER },
   { coins: 8000, weighting: 50 * CHEST_MULTIPLIER },
@@ -61,9 +105,10 @@ export const RARE_REWARDS: RewardBoxReward[] = [
   { items: { "Grape Juice": 3 }, weighting: 40 * CHEST_MULTIPLIER },
   { items: { Sunstone: 1 }, weighting: 15 * CHEST_MULTIPLIER },
   { items: { "Prize Ticket": 1 }, weighting: 20 * CHEST_MULTIPLIER },
+  ...getChapterMegastoreChestRewards(now, 50 * CHEST_MULTIPLIER),
 ];
 
-export const LUXURY_REWARDS: RewardBoxReward[] = [
+export const LUXURY_REWARDS = (now: number): RewardBoxReward[] => [
   { coins: 3200, weighting: 100 * CHEST_MULTIPLIER },
   { coins: 8000, weighting: 50 * CHEST_MULTIPLIER },
   { coins: 16000, weighting: 50 * CHEST_MULTIPLIER },
@@ -83,6 +128,7 @@ export const LUXURY_REWARDS: RewardBoxReward[] = [
   { items: { "Grape Juice": 10 }, weighting: 25 * CHEST_MULTIPLIER },
   { items: { Sunstone: 3 }, weighting: 25 * CHEST_MULTIPLIER },
   { items: { "Prize Ticket": 1 }, weighting: 50 * CHEST_MULTIPLIER },
+  ...getChapterMegastoreChestRewards(now, 50 * CHEST_MULTIPLIER),
 ];
 
 export const BUD_BOX_REWARDS: RewardBoxReward[] = [

--- a/src/features/game/types/chests.ts
+++ b/src/features/game/types/chests.ts
@@ -74,7 +74,7 @@ export const BASIC_REWARDS = (now: number): RewardBoxReward[] => [
   { items: { "Fancy Fries": 3 }, weighting: 100 * CHEST_MULTIPLIER },
   { items: { Rug: 1 }, weighting: 25 * CHEST_MULTIPLIER },
   { items: { "Prize Ticket": 1 }, weighting: 5 * CHEST_MULTIPLIER },
-  ...getChapterMegastoreChestRewards(now, 20 * CHEST_MULTIPLIER),
+  ...getChapterMegastoreChestRewards(now, 5 * CHEST_MULTIPLIER),
 ];
 
 export const RARE_REWARDS = (now: number): RewardBoxReward[] => [
@@ -105,7 +105,7 @@ export const RARE_REWARDS = (now: number): RewardBoxReward[] => [
   { items: { "Grape Juice": 3 }, weighting: 40 * CHEST_MULTIPLIER },
   { items: { Sunstone: 1 }, weighting: 15 * CHEST_MULTIPLIER },
   { items: { "Prize Ticket": 1 }, weighting: 20 * CHEST_MULTIPLIER },
-  ...getChapterMegastoreChestRewards(now, 50 * CHEST_MULTIPLIER),
+  ...getChapterMegastoreChestRewards(now, 25 * CHEST_MULTIPLIER),
 ];
 
 export const LUXURY_REWARDS = (now: number): RewardBoxReward[] => [

--- a/src/features/world/ui/chests/ChestRevealing.tsx
+++ b/src/features/world/ui/chests/ChestRevealing.tsx
@@ -31,6 +31,7 @@ import {
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { RewardBoxReward } from "features/game/types/rewardBoxes";
+import { useNow } from "lib/utils/hooks/useNow";
 
 export type ChestRewardType =
   | Keys
@@ -53,10 +54,11 @@ interface Props {
 
 export const CHEST_LOOT: (
   game: GameState,
-) => Record<ChestRewardType, RewardBoxReward[]> = (state) => ({
-  "Treasure Key": BASIC_REWARDS,
-  "Rare Key": RARE_REWARDS,
-  "Luxury Key": LUXURY_REWARDS,
+  now: number,
+) => Record<ChestRewardType, RewardBoxReward[]> = (state, now) => ({
+  "Treasure Key": BASIC_REWARDS(now),
+  "Rare Key": RARE_REWARDS(now),
+  "Luxury Key": LUXURY_REWARDS(now),
   "Bud Box": BUD_BOX_REWARDS,
   "Gift Giver": GIFT_GIVER_REWARDS,
   "Basic Desert Rewards": BASIC_DESERT_STREAK,
@@ -79,8 +81,9 @@ export const ChestRevealing: React.FC<Props> = ({ type }) => {
 
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, (state) => state.context.state);
+  const now = useNow();
 
-  const chestLoot = useMemo(() => CHEST_LOOT(state), [state]);
+  const chestLoot = useMemo(() => CHEST_LOOT(state, now), [state, now]);
   const items = chestLoot[type];
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Re-adds deterministic chapter megastore drops to Treasure / Rare / Luxury chests, simplified for the now-flat megastore (only the basic tier is populated).
- New helper `getChapterMegastoreChestRewards(now, weight)` filters out `CHAPTER_TICKET_BOOST_ITEMS` for the active chapter, all `HOURGLASSES`, and any item without an `INVENTORY_RELEASES` / `WEARABLE_RELEASES` entry (i.e. never-tradable, e.g. Crystal Altar).
- Items are gated to the active chapter window — once the chapter ends, the megastore pool returns `[]`, so legacy items stop dropping.
- `BASIC_REWARDS` / `RARE_REWARDS` / `LUXURY_REWARDS` are now `(now: number) => RewardBoxReward[]` so chest contents reflect the active chapter at open time rather than module-load time.
- Per-chest weights match the prior values: basic 20×, rare 50×, luxury 50× per item.

For Salt Awakening the eligible pool resolves to `Bubble Aura`, `Deep Sea Salt Cave Background`, `Dino Egg Trophy`.

## Test plan
- [ ] Open a Treasure / Rare / Luxury chest during Salt Awakening and confirm the listed megastore items can drop.
- [ ] Verify Crystal Altar, Spa Hat/Robe/Slippers (boost items), and hourglasses do NOT appear in the chest reward list.
- [ ] Once chapter ends, confirm the chest pool no longer offers the chapter items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chest rewards now include chapter-specific megastore items, expanding available loot as chapters rotate.
  * Chest contents are time-aware and recomputed based on the current time and game state, ensuring rewards reflect active chapters and releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->