### PR TITLE
[FEAT] Re-add Power Skills button to HUD

### DIFF
--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -21,6 +21,11 @@ import { MachineState } from "features/game/lib/gameMachine";
 import { useSound } from "lib/utils/hooks/useSound";
 import { TransactionCountdown } from "./Transaction";
 import { MarketplaceButton } from "./components/MarketplaceButton";
+import { PowerSkillsButton } from "./components/PowerSkillsButton";
+import {
+  BumpkinRevampSkillName,
+  getPowerSkills,
+} from "features/game/types/bumpkinSkills";
 import { LandscapeButton } from "./components/LandscapeButton";
 import { StreamCountdown } from "./components/streamCountdown/StreamCountdown";
 import { HudBumpkin } from "./components/bumpkinProfile/HudBumpkin";
@@ -70,6 +75,11 @@ const HudComponent: React.FC<{
   const isFullUser = farmAddress !== undefined;
   const isTutorial = gameState.context.state.island.type === "basic";
 
+  const { skills } = gameState.context.state.bumpkin;
+  const hasPowerSkills = getPowerSkills().some(
+    (skill) => !!skills[skill.name as BumpkinRevampSkillName],
+  );
+
   const showDesktopFeed = showFeed && !isMobile;
   const hideDesktopFeed = !showFeed && !isMobile;
 
@@ -98,6 +108,7 @@ const HudComponent: React.FC<{
         )}
       >
         <WorldFeedButton showFeed={showFeed} setShowFeed={setShowFeed} />
+        {hasPowerSkills && <PowerSkillsButton />}
         <MarketplaceButton />
         <TravelButton location={location} />
       </div>

--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useContext } from "react";
+import lightning from "assets/icons/lightning.png";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PowerSkills } from "./PowerSkills";
+import { Context } from "features/game/GameProvider";
+import {
+  BumpkinSkillRevamp,
+  BumpkinRevampSkillName,
+  getPowerSkills,
+} from "features/game/types/bumpkinSkills";
+import { useSelector } from "@xstate/react";
+import { RoundButton } from "components/ui/RoundButton";
+import { useNow } from "lib/utils/hooks/useNow";
+import { Modal } from "components/ui/Modal";
+
+const FERTILISER_SKILLS: BumpkinRevampSkillName[] = [
+  "Sprout Surge",
+  "Root Rocket",
+  "Blend-tastic",
+];
+
+export const PowerSkillsButton: React.FC = () => {
+  const [show, setShow] = useState(false);
+  const { gameService } = useContext(Context);
+  const bumpkin = useSelector(
+    gameService,
+    (state) => state.context.state.bumpkin,
+  );
+  const { skills, previousPowerUseAt } = bumpkin;
+
+  const now = useNow({ live: true, intervalMs: 30000 });
+
+  const powerSkillsUnlocked = getPowerSkills().filter(
+    (skill) => !!skills[skill.name as BumpkinRevampSkillName],
+  );
+
+  const powerSkillsReady = powerSkillsUnlocked
+    .filter(
+      (skill: BumpkinSkillRevamp) =>
+        !FERTILISER_SKILLS.includes(skill.name as BumpkinRevampSkillName),
+    )
+    .some((skill: BumpkinSkillRevamp) => {
+      const nextSkillUse =
+        (previousPowerUseAt?.[skill.name as BumpkinRevampSkillName] ?? 0) +
+        (skill.requirements.cooldown ?? 0);
+      return nextSkillUse < now;
+    });
+
+  return (
+    <>
+      <RoundButton onClick={() => setShow(true)}>
+        <img
+          src={lightning}
+          className="absolute group-active:translate-y-[2px]"
+          style={{
+            top: `${PIXEL_SCALE * 4}px`,
+            left: `${PIXEL_SCALE * 7}px`,
+            width: `${PIXEL_SCALE * 8}px`,
+          }}
+        />
+        {powerSkillsReady && (
+          <img
+            src={SUNNYSIDE.icons.expression_alerted}
+            className="absolute animate-pulsate"
+            style={{
+              width: `${PIXEL_SCALE * 4}px`,
+              top: `-${PIXEL_SCALE * 2}px`,
+              right: `-${PIXEL_SCALE * 2}px`,
+            }}
+          />
+        )}
+      </RoundButton>
+      <Modal show={show} onHide={() => setShow(false)} size="lg">
+        <PowerSkills
+          onHide={() => setShow(false)}
+          onBack={() => setShow(false)}
+          readonly={false}
+        />
+      </Modal>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- Restores the lightning-bolt Power Skills shortcut on the left HUD stack (between World Feed and Marketplace), originally removed in #5448 when power skills moved to the Bumpkin profile.
- Button is gated on the player having unlocked at least one power skill, and shows a pulsing alert icon whenever a non-fertiliser power skill is off cooldown.
- Cooldown readiness is driven by `useNow({ live: true })` so the alert turns on as cooldowns expire without needing an unrelated re-render.

## Test plan
- [ ] Load a save with no power skills unlocked — button is hidden.
- [ ] Unlock a non-fertiliser power skill that is off cooldown — alert pulse appears on the lightning button.
- [ ] Use that skill — alert pulse disappears and reappears when cooldown elapses.
- [ ] Click the button — Power Skills modal opens; closing it via the X or back behaves as expected.
- [ ] Power Skills tab in the Bumpkin profile still works (both entry points coexist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Power Skills button to the HUD that displays when power skills are available
  * Power Skills button shows a visual alert indicator when a skill is ready to use based on cooldown timers
  * Clicking the button opens a modal to view and manage power skills

<!-- end of auto-generated comment: release notes by coderabbit.ai -->