### PR TITLE
[FIX] Apply Bubble Aura on gem-instant cook + show time boost in Fish Market UI

### DIFF
--- a/src/features/game/events/landExpansion/speedUpProcessing.test.ts
+++ b/src/features/game/events/landExpansion/speedUpProcessing.test.ts
@@ -16,6 +16,7 @@ import { speedUpProcessing } from "./speedUpProcessing";
 import Decimal from "decimal.js-light";
 import { FISH_PROCESSING_TIME_SECONDS } from "features/game/types/fishProcessing";
 import { ProcessedResource } from "features/game/types/processedFood";
+import { GameState } from "features/game/types/game";
 
 describe("instantProcessing", () => {
   beforeEach(() => {
@@ -334,6 +335,145 @@ describe("instantProcessing", () => {
       [new Date(now).toISOString().substring(0, 10)]: {
         spent: 40,
       },
+    });
+  });
+
+  describe("Bubble Aura on the gem path", () => {
+    const baseStateWithProcessing = (overrides: {
+      auraEquipped: boolean;
+      processedCounter?: number;
+    }): GameState => ({
+      ...INITIAL_FARM,
+      bumpkin: {
+        ...INITIAL_FARM.bumpkin!,
+        equipped: {
+          ...INITIAL_FARM.bumpkin!.equipped,
+          aura: overrides.auraEquipped
+            ? ("Bubble Aura" as const)
+            : INITIAL_FARM.bumpkin!.equipped.aura,
+        },
+      },
+      inventory: { Gem: new Decimal(100) },
+      farmActivity:
+        overrides.processedCounter !== undefined
+          ? {
+              ...INITIAL_FARM.farmActivity,
+              "Fish Flake Processed": overrides.processedCounter,
+            }
+          : INITIAL_FARM.farmActivity,
+      buildings: {
+        "Fish Market": [
+          {
+            id: "123",
+            coordinates: { x: 0, y: 0 },
+            createdAt: 0,
+            readyAt: 0,
+            processing: [{ name: "Fish Flake", readyAt: Date.now() + 30000 }],
+          },
+        ],
+      },
+    });
+
+    it("increments the `${name} Processed` counter even without the aura", () => {
+      const state = speedUpProcessing({
+        farmId,
+        action: {
+          buildingId: "123",
+          buildingName: "Fish Market",
+          type: "processing.spedUp",
+        },
+        state: baseStateWithProcessing({ auraEquipped: false }),
+        createdAt: Date.now(),
+      });
+
+      expect(state.farmActivity["Fish Flake Processed"]).toBe(1);
+      expect(state.inventory["Fish Flake"]).toEqual(new Decimal(1));
+    });
+
+    it("yields 2 and bumps the counter when the aura procs (deterministic hit)", () => {
+      const { prngChance } = jest.requireActual(
+        "lib/prng",
+      ) as typeof import("lib/prng");
+      const { KNOWN_IDS } = jest.requireActual(
+        "features/game/types",
+      ) as typeof import("features/game/types");
+
+      let hitCounter = -1;
+      for (let counter = 0; counter < 200; counter++) {
+        if (
+          prngChance({
+            farmId,
+            itemId: KNOWN_IDS["Fish Flake"],
+            counter,
+            chance: 20,
+            criticalHitName: "Bubble Aura",
+          })
+        ) {
+          hitCounter = counter;
+          break;
+        }
+      }
+      expect(hitCounter).toBeGreaterThanOrEqual(0);
+
+      const state = speedUpProcessing({
+        farmId,
+        action: {
+          buildingId: "123",
+          buildingName: "Fish Market",
+          type: "processing.spedUp",
+        },
+        state: baseStateWithProcessing({
+          auraEquipped: true,
+          processedCounter: hitCounter,
+        }),
+        createdAt: Date.now(),
+      });
+
+      expect(state.inventory["Fish Flake"]).toEqual(new Decimal(2));
+      expect(state.farmActivity["Fish Flake Processed"]).toBe(hitCounter + 1);
+    });
+
+    it("yields 1 when the aura misses (deterministic miss)", () => {
+      const { prngChance } = jest.requireActual(
+        "lib/prng",
+      ) as typeof import("lib/prng");
+      const { KNOWN_IDS } = jest.requireActual(
+        "features/game/types",
+      ) as typeof import("features/game/types");
+
+      let missCounter = -1;
+      for (let counter = 0; counter < 200; counter++) {
+        if (
+          !prngChance({
+            farmId,
+            itemId: KNOWN_IDS["Fish Flake"],
+            counter,
+            chance: 20,
+            criticalHitName: "Bubble Aura",
+          })
+        ) {
+          missCounter = counter;
+          break;
+        }
+      }
+      expect(missCounter).toBeGreaterThanOrEqual(0);
+
+      const state = speedUpProcessing({
+        farmId,
+        action: {
+          buildingId: "123",
+          buildingName: "Fish Market",
+          type: "processing.spedUp",
+        },
+        state: baseStateWithProcessing({
+          auraEquipped: true,
+          processedCounter: missCounter,
+        }),
+        createdAt: Date.now(),
+      });
+
+      expect(state.inventory["Fish Flake"]).toEqual(new Decimal(1));
+      expect(state.farmActivity["Fish Flake Processed"]).toBe(missCounter + 1);
     });
   });
 

--- a/src/features/game/events/landExpansion/speedUpProcessing.ts
+++ b/src/features/game/events/landExpansion/speedUpProcessing.ts
@@ -9,6 +9,10 @@ import {
   SpeedUpPaymentMethod,
 } from "features/game/lib/getInstantGems";
 import { recalculateProcessingQueue } from "./cancelProcessedResource";
+import { getProcessedResourceAmount } from "./collectProcessedResource";
+import { ProcessedResource } from "features/game/types/processedFood";
+import { trackFarmActivity } from "features/game/types/farmActivity";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type SpeedUpProcessingAction = {
   type: "processing.spedUp";
@@ -38,6 +42,7 @@ export const speedUpProcessing = ({
   state,
   action,
   createdAt = Date.now(),
+  farmId,
 }: Options): GameState => {
   return produce(state, (game) => {
     const building = game.buildings[action.buildingName]?.find(
@@ -76,9 +81,28 @@ export const speedUpProcessing = ({
       game = makeGemHistory({ game, amount: gems, createdAt });
     }
 
+    const { amount, boostsUsed } = getProcessedResourceAmount({
+      game,
+      resource: currentProcessingItem.name as ProcessedResource,
+      farmId,
+    });
+
     game.inventory[currentProcessingItem.name] = (
       game.inventory[currentProcessingItem.name] ?? new Decimal(0)
-    ).add(1);
+    ).add(amount);
+
+    game.farmActivity = trackFarmActivity(
+      `${currentProcessingItem.name} Processed` as `${ProcessedResource} Processed`,
+      game.farmActivity,
+    );
+
+    if (boostsUsed.length > 0) {
+      game.boostsUsedAt = updateBoostUsed({
+        game,
+        boostNames: boostsUsed,
+        createdAt,
+      });
+    }
 
     const queue = building.processing ?? [];
     const queueWithoutSpedUpItem = queue.filter(

--- a/src/features/island/buildings/components/building/fishMarket/FishMarketModal.tsx
+++ b/src/features/island/buildings/components/building/fishMarket/FishMarketModal.tsx
@@ -11,7 +11,11 @@ import { Button } from "components/ui/Button";
 import vipIcon from "assets/icons/vip.webp";
 
 import { Context } from "features/game/GameProvider";
-import { BuildingProduct, InventoryItemName } from "features/game/types/game";
+import {
+  BoostName,
+  BuildingProduct,
+  InventoryItemName,
+} from "features/game/types/game";
 import {
   FISH_PROCESSING_TIME_SECONDS,
   getFishProcessingRequirements,
@@ -19,7 +23,11 @@ import {
 } from "features/game/types/fishProcessing";
 import { ProcessedResource } from "features/game/types/processedFood";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { MAX_FISH_PROCESSING_SLOTS } from "features/game/events/landExpansion/processResource";
+import {
+  getFishProcessingTimeMs,
+  MAX_FISH_PROCESSING_SLOTS,
+} from "features/game/events/landExpansion/processResource";
+import { isWearableActive } from "features/game/lib/wearables";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { InProgressInfo } from "../InProgressInfo";
@@ -75,6 +83,7 @@ export const FishMarketModal: React.FC<Props> = ({
     PROCESSED_ITEMS[0],
   );
   const [showQueueInformation, setShowQueueInformation] = useState(false);
+  const [showTimeBoosts, setShowTimeBoosts] = useState(false);
 
   const requirements = getFishProcessingRequirements({
     item: selected,
@@ -103,9 +112,17 @@ export const FishMarketModal: React.FC<Props> = ({
   const totalQueued = ready.length + queue.length + (processing ? 1 : 0);
   const isQueueFull = totalQueued >= availableSlots;
 
-  const totalSeconds = isProcessedFood(selected)
+  const baseTimeSeconds = isProcessedFood(selected)
     ? FISH_PROCESSING_TIME_SECONDS[selected]
     : 0;
+  const totalSeconds = isProcessedFood(selected)
+    ? getFishProcessingTimeMs(selected, state) / 1000
+    : 0;
+  const timeBoostsUsed: { name: BoostName; value: string }[] = isWearableActive(
+    { game: state, name: "Bubble Aura" },
+  )
+    ? [{ name: "Bubble Aura", value: "x0.8" }]
+    : [];
 
   return (
     <Modal show={isOpen} onHide={onClose}>
@@ -129,7 +146,11 @@ export const FishMarketModal: React.FC<Props> = ({
               requirements={{
                 resources: requirements,
                 timeSeconds: totalSeconds,
+                baseTimeSeconds,
+                timeBoostsUsed,
               }}
+              showTimeBoosts={showTimeBoosts}
+              setShowTimeBoosts={setShowTimeBoosts}
               actionView={
                 <div className="flex flex-col gap-1">
                   {isProcessedFood(selected) && (


### PR DESCRIPTION
## Summary
- Wire `getFishProcessingTimeMs` into the Fish Market modal so Bubble Aura's −20% processing time renders with the boosted-time + strikethrough + click-to-expand boost panel that cooking buildings already use ([Recipes.tsx:175-193](https://github.com/sunflower-land/sunflower-land/blob/main/src/features/island/buildings/components/building/Recipes.tsx#L175-L193) precedent).
- Fix `speedUpProcessing` (gem-instant cook): it was hardcoding `+1` to inventory and never calling `trackFarmActivity`, so Bubble Aura's +1 yield never rolled and `${name} Processed` never advanced. Now mirrors `speedUpRecipe` by reusing `getProcessedResourceAmount`, bumping the counter, and recording boost usage via `updateBoostUsed`.
- Add tests pinning the new gem-path behaviour: counter increments without aura, deterministic hit yields 2 + bumps counter, deterministic miss yields 1 + bumps counter.

## Background
Reported by Elias: gemmed 20+ Fish Flakes with Bubble Aura equipped, never saw a proc, and `Fish Flake Processed` farmActivity stayed at 2. Diagnosed with a deterministic PRNG simulation against his exact `farmId`, which would have produced 6 procs over 25 collects — confirming the proc/counter logic was simply being skipped on the gem path.

The corresponding BE fix is in https://github.com/sunflower-land/sunflower-land-api/pull/new/fix/bubble-aura-gem-cook (must ship together for save validation).

## Test plan
- [ ] `yarn jest src/features/game/events/landExpansion/speedUpProcessing.test.ts` — 13/13 pass
- [ ] `yarn jest src/features/game/events/landExpansion/collectProcessedResource.test.ts` — 7/7 pass
- [ ] `yarn tsc --noEmit` — clean
- [ ] Manual: equip Bubble Aura, open Fish Market modal, confirm boosted processing time displays with strikethrough base time and clickable boost label
- [ ] Manual: gem-instant cook a Fish Flake, confirm `Fish Flake Processed` counter advances and proc occasionally yields 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bubble Aura wearable now provides processing time boosts in the Fish Market, enhancing fish processing efficiency
  * Speed-up processing now calculates yields dynamically based on active boosts and equipped items

* **Bug Fixes**
  * Fixed speed-up processing to award appropriate resource quantities instead of fixed amounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->