### PR TITLE
[FIX] Apply Luna's Crescent boost to Power Skills HUD alert

### DIFF
--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -13,6 +13,8 @@ import { useSelector } from "@xstate/react";
 import { RoundButton } from "components/ui/RoundButton";
 import { useNow } from "lib/utils/hooks/useNow";
 import { Modal } from "components/ui/Modal";
+import { MachineState } from "features/game/lib/gameMachine";
+import { getSkillCooldown } from "features/game/events/landExpansion/skillUsed";
 
 const FERTILISER_SKILLS: BumpkinRevampSkillName[] = [
   "Sprout Surge",
@@ -20,32 +22,43 @@ const FERTILISER_SKILLS: BumpkinRevampSkillName[] = [
   "Blend-tastic",
 ];
 
+const _state = (state: MachineState) => state.context.state;
+
 export const PowerSkillsButton: React.FC = () => {
   const [show, setShow] = useState(false);
   const { gameService } = useContext(Context);
-  const bumpkin = useSelector(
-    gameService,
-    (state) => state.context.state.bumpkin,
-  );
-  const { skills, previousPowerUseAt } = bumpkin;
+  const state = useSelector(gameService, _state);
+  const { skills, previousPowerUseAt } = state.bumpkin;
 
-  const now = useNow({ live: true, intervalMs: 30000 });
-
-  const powerSkillsUnlocked = getPowerSkills().filter(
-    (skill) => !!skills[skill.name as BumpkinRevampSkillName],
+  const alertablePowerSkills = getPowerSkills().filter(
+    (skill: BumpkinSkillRevamp) =>
+      !!skills[skill.name as BumpkinRevampSkillName] &&
+      !FERTILISER_SKILLS.includes(skill.name as BumpkinRevampSkillName),
   );
 
-  const powerSkillsReady = powerSkillsUnlocked
-    .filter(
-      (skill: BumpkinSkillRevamp) =>
-        !FERTILISER_SKILLS.includes(skill.name as BumpkinRevampSkillName),
-    )
-    .some((skill: BumpkinSkillRevamp) => {
-      const nextSkillUse =
+  const nextSkillUseTimes = alertablePowerSkills.map(
+    (skill: BumpkinSkillRevamp) => {
+      const cooldown = getSkillCooldown({
+        cooldown: skill.requirements.cooldown ?? 0,
+        state,
+      });
+      return (
         (previousPowerUseAt?.[skill.name as BumpkinRevampSkillName] ?? 0) +
-        (skill.requirements.cooldown ?? 0);
-      return nextSkillUse < now;
-    });
+        cooldown
+      );
+    },
+  );
+
+  const earliestSkillReadyAt =
+    nextSkillUseTimes.length > 0 ? Math.min(...nextSkillUseTimes) : undefined;
+
+  const now = useNow({
+    live: earliestSkillReadyAt !== undefined,
+    autoEndAt: earliestSkillReadyAt,
+    intervalMs: 30000,
+  });
+
+  const powerSkillsReady = nextSkillUseTimes.some((t) => t < now);
 
   return (
     <>

--- a/src/features/island/hud/components/PowerSkillsButton.tsx
+++ b/src/features/island/hud/components/PowerSkillsButton.tsx
@@ -58,7 +58,7 @@ export const PowerSkillsButton: React.FC = () => {
     intervalMs: 30000,
   });
 
-  const powerSkillsReady = nextSkillUseTimes.some((t) => t < now);
+  const powerSkillsReady = nextSkillUseTimes.some((t) => t <= now);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- The Power Skills HUD button's ready-pulse was using the raw skill cooldown, ignoring the Luna's Crescent wearable's 50% reduction. Now uses `getSkillCooldown` so the alert matches the actual cooldown the player is subject to.
- `useNow` now stops ticking via `autoEndAt` once the earliest unlocked alertable skill flips ready, instead of running a 30s timer indefinitely.
- Switched to selecting the full game state (matching the `PowerSkills` modal pattern) so `isWearableActive` inside `getSkillCooldown` can see the equipped Crescent.

## Test plan
- [ ] Equip Luna's Crescent and use a power skill — the lightning HUD pulse should reappear after the halved cooldown, not the full one.
- [ ] Without Luna's Crescent equipped, cooldown behaviour is unchanged.
- [ ] After the alert pulse appears, no further re-renders occur from the HUD button (timer has stopped).
- [ ] Player with only fertiliser power skills unlocked never sees a pulse and the timer never runs (\`live: false\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how power-skill availability and readiness times are determined, yielding more accurate live availability indicators and slightly adjusted "ready now" behavior.
  * Reduced redundant state calculations for these controls to improve responsiveness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->