### PR TITLE
[FEAT] Salt Awakening ticket reward bumps

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1925,7 +1925,9 @@ describe("deliver", () => {
       createdAt: now,
     });
 
-    expect(state.inventory[getChapterTicket(now)]).toEqual(new Decimal(10));
+    expect(state.inventory[getChapterTicket(now)]).toEqual(
+      new Decimal(TICKET_REWARDS.tywin * 2),
+    );
   });
 
   it("returns 0 tickets for coin NPC (no tickets from coin deliveries)", () => {

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -42,10 +42,10 @@ export const TICKET_REWARDS: Record<QuestNPCName, number> = {
   miranda: 2,
   finley: 2,
   raven: 3,
-  finn: 3,
+  finn: 4,
   timmy: 4,
   cornwell: 4,
-  tywin: 5,
+  tywin: 10,
   jester: 4,
   pharaoh: 5,
 };


### PR DESCRIPTION
## Summary
- Bump `TICKET_REWARDS` to mirror BE: **Finn** 3 → 4, **Tywin** 5 → 10.

Companion BE PR: https://github.com/sunflower-land/sunflower-land-api/pull/3375 (also contains the regenerated Salt Awakening `TICKET_DELIVERIES` and `DAILY_QUESTS`).

## Test plan
- [ ] `yarn test deliver` — existing delivery tests reading `TICKET_REWARDS[name]` should still pass.
- [ ] Open a Finn delivery in the deliveries panel — preview shows 4 chapter tickets.
- [ ] Open a Tywin delivery in the deliveries panel — preview shows 10 chapter tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Adjustments**
  * Increased quest completion ticket rewards in land expansion events: Finn now grants 4 tickets (was 3) and Tywin now grants 10 tickets (was 5), improving chapter ticket gains for those deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->