### PR TITLE
[FEAT] Award track points for flower deliveries

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -2184,6 +2184,123 @@ describe("deliver", () => {
     expect(state.farmActivity[`${chapter} Points Earned`]).toBeUndefined();
   });
 
+  it("does not award chapter points for flower deliveries when TICKETS_FROM_FLOWER_NPC flag is inactive", () => {
+    // Use a date before TICKETS_FROM_FLOWER_NPC flag (2026-05-11)
+    const now = new Date("2026-05-09T00:00:01Z").getTime();
+    const chapter = getCurrentChapter(now);
+
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        balance: new Decimal(0),
+        inventory: {
+          "Mashed Potato": new Decimal(20),
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 0,
+          orders: [
+            {
+              id: "123",
+              createdAt: now,
+              readyAt: now,
+              from: "grimbly",
+              items: { "Mashed Potato": 12 },
+              reward: { sfl: 1 },
+            },
+          ],
+        },
+        bumpkin: TEST_BUMPKIN,
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: now + 5000,
+    });
+
+    expect(state.farmActivity[`${chapter} Points Earned`]).toBeUndefined();
+  });
+
+  it("awards flat 10 chapter points for flower deliveries when TICKETS_FROM_FLOWER_NPC flag is active", () => {
+    // Use a date after TICKETS_FROM_FLOWER_NPC flag (2026-05-11) so points are tracked
+    const now = new Date("2026-05-12T00:00:01Z").getTime();
+    const chapter = getCurrentChapter(now);
+
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        balance: new Decimal(0),
+        inventory: {
+          "Mashed Potato": new Decimal(20),
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 0,
+          orders: [
+            {
+              id: "123",
+              createdAt: now,
+              readyAt: now,
+              from: "grimbly",
+              items: { "Mashed Potato": 12 },
+              reward: { sfl: 1 },
+            },
+          ],
+        },
+        bumpkin: TEST_BUMPKIN,
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: now + 5000,
+    });
+
+    expect(state.farmActivity[`${chapter} Points Earned`]).toEqual(10);
+  });
+
+  it("does not award flowerDelivery chapter points when order was created on holiday", () => {
+    // Order createdAt 2026-05-04 falls in Salt Awakening's computed bumpkin
+    // holiday window (2026-05-04 → 2026-05-11 exclusive); deliver after the
+    // freeze ends so the flag is also active.
+    const orderCreatedAt = new Date("2026-05-04T12:00:00.000Z").getTime();
+    const deliveryCreatedAt = new Date("2026-05-12T12:00:00.000Z").getTime();
+    const chapter = getCurrentChapter(deliveryCreatedAt);
+
+    const state = deliverOrder({
+      state: {
+        ...INITIAL_FARM,
+        balance: new Decimal(0),
+        inventory: {
+          "Mashed Potato": new Decimal(20),
+        },
+        delivery: {
+          ...INITIAL_FARM.delivery,
+          fulfilledCount: 0,
+          orders: [
+            {
+              id: "123",
+              createdAt: orderCreatedAt,
+              readyAt: orderCreatedAt,
+              from: "grimbly",
+              items: { "Mashed Potato": 12 },
+              reward: { sfl: 1 },
+            },
+          ],
+        },
+        bumpkin: TEST_BUMPKIN,
+      },
+      action: {
+        id: "123",
+        type: "order.delivered",
+      },
+      createdAt: deliveryCreatedAt,
+    });
+
+    expect(state.farmActivity[`${chapter} Points Earned`]).toBeUndefined();
+  });
+
   it("can deliver items from the wardrobe", () => {
     const mockDate = new Date("2024-05-10").getTime();
     const state = deliverOrder({

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -28,7 +28,11 @@ import { getActiveCalendarEvent } from "features/game/types/calendar";
 import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { hasReputation, Reputation } from "features/game/lib/reputation";
 
-import { isCoinNPC, isTicketNPC } from "features/island/delivery/lib/delivery";
+import {
+  isCoinNPC,
+  isSFLNPC,
+  isTicketNPC,
+} from "features/island/delivery/lib/delivery";
 import { CHAPTER_TICKET_BOOST_ITEMS } from "./completeNPCChore";
 import { isCollectible } from "./garbageSold";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
@@ -476,6 +480,37 @@ export function deliverOrder({
         "FLOWER Order Delivered",
         game.farmActivity,
       );
+
+      // Take the timestamp of the order
+      const flowerCreatedAt = order.createdAt;
+      const isFlowerTasksFrozen = areBumpkinsOnHoliday(flowerCreatedAt);
+
+      if (
+        isSFLNPC(order.from) &&
+        hasTimeBasedFeatureAccess({
+          featureName: "TICKETS_FROM_FLOWER_NPC",
+          now: flowerCreatedAt,
+          game,
+        }) &&
+        !isFlowerTasksFrozen
+      ) {
+        const flowerChapter = getCurrentChapter(flowerCreatedAt);
+
+        handleChapterAnalytics({
+          task: "flowerDelivery",
+          points: 10,
+          farmActivity: game.farmActivity,
+          createdAt: flowerCreatedAt,
+        });
+
+        game.farmActivity = trackFarmActivity(
+          `${flowerChapter} Points Earned`,
+          game.farmActivity,
+          new Decimal(
+            getChapterTaskPoints({ task: "flowerDelivery", points: 10 }),
+          ),
+        );
+      }
     }
     const chapter = getCurrentChapter(createdAt);
 

--- a/src/features/game/types/tracks.ts
+++ b/src/features/game/types/tracks.ts
@@ -8,13 +8,19 @@ export type MilestoneRewards = {
   flower?: number;
 };
 
-export type ChapterTask = "delivery" | "chore" | "bounty" | "coinDelivery";
+export type ChapterTask =
+  | "delivery"
+  | "chore"
+  | "bounty"
+  | "coinDelivery"
+  | "flowerDelivery";
 
 const CHAPTER_TASK_POINTS: Record<ChapterTask, number> = {
   delivery: 5,
   bounty: 5,
   chore: 3,
   coinDelivery: 1,
+  flowerDelivery: 1,
 };
 
 export function getChapterTaskPoints({

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -285,6 +285,27 @@ export const DeliveryOrders: React.FC<Props> = ({
         points: 10,
       });
     }
+    if (
+      isSFLNPC(previewOrder.from) &&
+      hasTimeBasedFeatureAccess({
+        featureName: "TICKETS_FROM_FLOWER_NPC",
+        now: previewOrder.createdAt,
+        game: state,
+      })
+    ) {
+      if (areBumpkinsOnHoliday(previewOrder.createdAt)) {
+        return 0;
+      }
+      if (
+        getCurrentChapter(previewOrder.createdAt) !== getCurrentChapter(now)
+      ) {
+        return 0;
+      }
+      return getChapterTaskPoints({
+        task: "flowerDelivery",
+        points: 10,
+      });
+    }
     return getChapterTaskPoints({
       task: "delivery",
       points: ticketDisplay,

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -34,6 +34,7 @@ import {
   NPC_DELIVERY_LEVELS,
   DeliveryNpcName,
   isCoinNPC,
+  isSFLNPC,
   isTicketNPC,
 } from "features/island/delivery/lib/delivery";
 import {
@@ -126,6 +127,25 @@ const OrderCard: React.FC<{
       }
       return getChapterTaskPoints({
         task: "coinDelivery",
+        points: 10,
+      });
+    }
+    if (
+      isSFLNPC(order.from) &&
+      hasTimeBasedFeatureAccess({
+        featureName: "TICKETS_FROM_FLOWER_NPC",
+        now: order.createdAt,
+        game,
+      })
+    ) {
+      if (areBumpkinsOnHoliday(order.createdAt)) {
+        return 0;
+      }
+      if (getCurrentChapter(order.createdAt) !== getCurrentChapter(now)) {
+        return 0;
+      }
+      return getChapterTaskPoints({
+        task: "flowerDelivery",
         points: 10,
       });
     }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -65,6 +65,10 @@ export type TimeBasedFeatureWindow = { start: Date; end: Date | null };
 
 export const TIME_BASED_FEATURE_FLAG_WINDOWS = {
   TICKETS_FROM_COIN_NPC: { start: new Date("2026-02-24T00:00:00Z"), end: null },
+  TICKETS_FROM_FLOWER_NPC: {
+    start: new Date("2026-05-11T00:00:00Z"),
+    end: null,
+  },
   APRIL_FOOLS_EVENT_FLAG: {
     start: new Date("2026-04-01T00:00:00Z"),
     end: new Date("2026-04-08T00:00:00Z"),
@@ -83,6 +87,7 @@ export const TIME_BASED_FEATURE_FLAGS: Record<
   TimeBasedFeatureFlag
 > = {
   TICKETS_FROM_COIN_NPC: timePeriodFeatureFlag,
+  TICKETS_FROM_FLOWER_NPC: timePeriodFeatureFlag,
   APRIL_FOOLS_EVENT_FLAG: betaTimePeriodFeatureFlag,
 };
 

--- a/src/lib/gameAnalytics.ts
+++ b/src/lib/gameAnalytics.ts
@@ -249,7 +249,7 @@ class GameAnalyticTracker {
     source,
   }: {
     chapter: string;
-    source: "delivery" | "chore" | "bounty" | "coinDelivery";
+    source: "delivery" | "chore" | "bounty" | "coinDelivery" | "flowerDelivery";
   }) {
     try {
       GameAnalytics.addDesignEvent(`Tracks:Activated:${chapter}:${source}`);
@@ -265,7 +265,7 @@ class GameAnalyticTracker {
     points,
   }: {
     chapter: string;
-    source: "delivery" | "chore" | "bounty" | "coinDelivery";
+    source: "delivery" | "chore" | "bounty" | "coinDelivery" | "flowerDelivery";
     points: number;
   }) {
     try {

--- a/src/lib/gameAnalytics.ts
+++ b/src/lib/gameAnalytics.ts
@@ -4,6 +4,7 @@ import { Currency, InventoryItemName } from "features/game/types/game";
 import { BumpkinItem } from "features/game/types/bumpkin";
 import { DigAnalytics } from "features/world/scenes/BeachScene";
 import { VipBundle } from "features/game/lib/vipAccess";
+import { ChapterTask } from "features/game/types/tracks";
 
 // Their type definition has some issues, extract to here
 enum EGAResourceFlowType {
@@ -249,7 +250,7 @@ class GameAnalyticTracker {
     source,
   }: {
     chapter: string;
-    source: "delivery" | "chore" | "bounty" | "coinDelivery" | "flowerDelivery";
+    source: ChapterTask;
   }) {
     try {
       GameAnalytics.addDesignEvent(`Tracks:Activated:${chapter}:${source}`);
@@ -265,7 +266,7 @@ class GameAnalyticTracker {
     points,
   }: {
     chapter: string;
-    source: "delivery" | "chore" | "bounty" | "coinDelivery" | "flowerDelivery";
+    source: ChapterTask;
     points: number;
   }) {
     try {


### PR DESCRIPTION
## Summary
Mirror the BE flower-delivery track-points work and surface the points pill in the deliveries UI. Each completed flower (goblin NPC) delivery now awards a flat **10 chapter points**, gated by a new `TICKETS_FROM_FLOWER_NPC` time-based feature flag (live from **2026-05-11**) and the bumpkin holiday window evaluated at `order.createdAt`.

### Changes
- [tracks.ts](src/features/game/types/tracks.ts) — add `flowerDelivery` to `ChapterTask` with multiplier `1`.
- [flags.ts](src/lib/flags.ts) — register `TICKETS_FROM_FLOWER_NPC` starting `2026-05-11T00:00:00Z`.
- [deliver.ts](src/features/game/events/landExpansion/deliver.ts) — in the SFL reward branch, when `isSFLNPC(order.from)` AND the flag is active at `order.createdAt` AND the order was not rolled during a bumpkin holiday, write `getChapterTaskPoints({ task: "flowerDelivery", points: 10 })` to `${chapter at order.createdAt} Points Earned`. Calls `handleChapterAnalytics` symmetrically with the coin path.
- [Orders.tsx](src/features/island/delivery/components/Orders.tsx), [BumpkinDelivery.tsx](src/features/world/ui/deliveries/BumpkinDelivery.tsx) — extend `getChapterPoints()` to also return `10` for flower deliveries, behind the same flag / holiday / cross-chapter gates that the coin branch uses, so the +10 pill renders for in-chapter, non-frozen flower orders only.

## Companion BE PR
sunflower-land/sunflower-land-api#3377

## Test plan
- [ ] `yarn test deliver` — 54 → 57 passing.
- [ ] In the deliveries panel after 2026-05-11, open a Grimbly/Grubnuk/etc. order rolled in the current chapter — the +10 chapter points label should render.
- [ ] Open a flower order rolled in a previous chapter — no points label (cross-chapter gate).
- [ ] Open a flower order rolled before 2026-05-11 — no points label (flag inactive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flower NPC deliveries now award 10 chapter points when the flower-ticket feature is active; no points awarded during holiday periods.
  * Flower-ticket feature is scheduled to be available starting 2026-05-11.

* **Tests**
  * Added tests covering flower delivery chapter point awards and holiday handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->