### PR TITLE
[FEAT] Add animal buff shortcut tab to Feeder Machine

### DIFF
--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -12,7 +12,7 @@ import type {
   InventoryItemName,
 } from "features/game/types/game";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { getKeys } from "lib/object";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -86,7 +86,8 @@ export const FeederMachineModal: React.FC<Props> = ({
   const hasSpices = spices.length > 0;
   const selectedSpiceItem = spices.includes(selectedSpice)
     ? selectedSpice
-    : spices[0];
+    : undefined;
+  const nextAvailableSpice = selectedSpiceItem ?? spices[0];
   const { requests, feeds, animalsWaiting, freeFeedBoosts } =
     getBulkMixRequirements(state, building);
 
@@ -116,13 +117,51 @@ export const FeederMachineModal: React.FC<Props> = ({
   // selection has to fall back to the food tab rather than render an empty
   // panel.
   const activeTab = hasSpices ? tab : "food";
-  const setActiveTab: React.Dispatch<React.SetStateAction<Tab>> = (nextTab) => {
-    setTab((currentTab) => {
-      const resolvedTab =
-        typeof nextTab === "function" ? nextTab(currentTab) : nextTab;
 
-      return resolvedTab === "spices" && !hasSpices ? "food" : resolvedTab;
+  useEffect(() => {
+    if (tab !== "spices") {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      if (!hasSpices) {
+        setTab("food");
+        shortcutItem(selectedName);
+        return;
+      }
+
+      if (nextAvailableSpice && nextAvailableSpice !== selectedSpice) {
+        setSelectedSpice(nextAvailableSpice);
+        shortcutItem(nextAvailableSpice);
+      }
     });
+
+    return () => window.clearTimeout(timeout);
+  }, [
+    hasSpices,
+    nextAvailableSpice,
+    selectedName,
+    selectedSpice,
+    shortcutItem,
+    tab,
+  ]);
+
+  const setActiveTab: React.Dispatch<React.SetStateAction<Tab>> = (nextTab) => {
+    const resolvedTab =
+      typeof nextTab === "function" ? nextTab(activeTab) : nextTab;
+
+    if (resolvedTab === "spices" && !hasSpices) {
+      shortcutItem(selectedName);
+      setTab("food");
+      return;
+    }
+
+    if (resolvedTab === "spices" && nextAvailableSpice) {
+      setSelectedSpice(nextAvailableSpice);
+      shortcutItem(nextAvailableSpice);
+    }
+
+    setTab(resolvedTab);
   };
 
   const groupedItems = getKeys(ANIMAL_FOODS).reduce(
@@ -558,10 +597,14 @@ export const FeederMachineModal: React.FC<Props> = ({
           {activeTab === "spices" && (
             <SplitScreenView
               panel={
-                <InventoryItemDetails
-                  game={state}
-                  details={{ item: selectedSpiceItem as InventoryItemName }}
-                />
+                selectedSpiceItem ? (
+                  <InventoryItemDetails
+                    game={state}
+                    details={{ item: selectedSpiceItem as InventoryItemName }}
+                  />
+                ) : (
+                  <></>
+                )
               }
               content={
                 <div className="flex flex-col">

--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -5,6 +5,7 @@ import { SplitScreenView } from "components/ui/SplitScreenView";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Context } from "features/game/GameProvider";
 import type {
+  AnimalFeedBuffName,
   AnimalFoodName,
   AnimalMedicineName,
   GameState,
@@ -33,6 +34,7 @@ import {
 } from "features/game/types/animals";
 import { Label } from "components/ui/Label";
 import { getIngredients } from "./feedMixed";
+import { InventoryItemDetails } from "components/ui/layouts/InventoryItemDetails";
 import { getBulkMixRequirements } from "./getBulkMixRequirements";
 import { formatNumber } from "lib/utils/formatNumber";
 import { hasFeatureAccess } from "lib/flags";
@@ -50,6 +52,10 @@ const FOOD_TYPE_TERMS = {
   medicine: "feeder.foodTypes.medicine",
 } as const;
 
+const ANIMAL_FEED_BUFFS: AnimalFeedBuffName[] = ["Salt Lick", "Honey Treat"];
+
+type Tab = "food" | "automaticMixer" | "spices";
+
 export const FeederMachineModal: React.FC<Props> = ({
   show,
   onClose,
@@ -65,13 +71,22 @@ export const FeederMachineModal: React.FC<Props> = ({
   const [selectedName, setSelectedName] = useState<
     AnimalFoodName | AnimalMedicineName
   >("Hay");
-  const [tab, setTab] = useState<"food" | "automaticMixer">("food");
+  const [selectedSpice, setSelectedSpice] =
+    useState<AnimalFeedBuffName>("Honey Treat");
+  const [tab, setTab] = useState<Tab>("food");
   const [showMixInfo, setShowMixInfo] = useState(false);
   const { coins } = ANIMAL_FOODS[selectedName];
 
   const showBulkMixer = hasFeatureAccess(state, "BULK_MIXER");
 
   const { ingredients } = getIngredients({ state, name: selectedName });
+  const spices = ANIMAL_FEED_BUFFS.filter((item) =>
+    state.inventory[item]?.gt(0),
+  );
+  const hasSpices = spices.length > 0;
+  const selectedSpiceItem = spices.includes(selectedSpice)
+    ? selectedSpice
+    : spices[0];
   const { requests, feeds, animalsWaiting, freeFeedBoosts } =
     getBulkMixRequirements(state, building);
 
@@ -111,6 +126,11 @@ export const FeederMachineModal: React.FC<Props> = ({
 
   const onSelect = (item: AnimalFoodName | AnimalMedicineName) => {
     setSelectedName(item);
+    shortcutItem(item);
+  };
+
+  const onSelectSpice = (item: AnimalFeedBuffName) => {
+    setSelectedSpice(item);
     shortcutItem(item);
   };
 
@@ -274,6 +294,15 @@ export const FeederMachineModal: React.FC<Props> = ({
                     id: "automaticMixer" as const,
                     icon: ITEM_DETAILS["Mixed Grain"].image,
                     name: t("feeder.bulkMixer"),
+                  },
+                ]
+              : []),
+            ...(hasSpices
+              ? [
+                  {
+                    id: "spices" as const,
+                    icon: ITEM_DETAILS["Honey Treat"].image,
+                    name: t("spices"),
                   },
                 ]
               : []),
@@ -512,6 +541,40 @@ export const FeederMachineModal: React.FC<Props> = ({
                 </>
               )}
             </InnerPanel>
+          )}
+          {tab === "spices" && (
+            <SplitScreenView
+              panel={
+                <InventoryItemDetails
+                  game={state}
+                  details={{ item: selectedSpiceItem as InventoryItemName }}
+                />
+              }
+              content={
+                <div className="flex flex-col">
+                  <div className="flex flex-col">
+                    <Label
+                      type="default"
+                      icon={ITEM_DETAILS["Honey Treat"].image}
+                      className="mb-1"
+                    >
+                      {t("spices")}
+                    </Label>
+                    <div className="flex flex-wrap mb-2">
+                      {spices.map((item) => (
+                        <Box
+                          key={item}
+                          isSelected={selectedSpiceItem === item}
+                          onClick={() => onSelectSpice(item)}
+                          image={ITEM_DETAILS[item].image}
+                          count={state.inventory[item]}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              }
+            />
           )}
         </CloseButtonPanel>
       </div>

--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -1,4 +1,4 @@
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { CraftingRequirements } from "components/ui/layouts/CraftingRequirements";
 import { Modal } from "components/ui/Modal";
 import { SplitScreenView } from "components/ui/SplitScreenView";
@@ -12,7 +12,7 @@ import type {
   InventoryItemName,
 } from "features/game/types/game";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { getKeys } from "lib/object";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -54,7 +54,7 @@ const FOOD_TYPE_TERMS = {
 
 const ANIMAL_FEED_BUFFS: AnimalFeedBuffName[] = ["Salt Lick", "Honey Treat"];
 
-type Tab = "food" | "automaticMixer" | "spices";
+type Tab = "food" | "automaticMixer";
 
 export const FeederMachineModal: React.FC<Props> = ({
   show,
@@ -63,16 +63,13 @@ export const FeederMachineModal: React.FC<Props> = ({
 }) => {
   const { t } = useAppTranslation();
   const { gameService, shortcutItem, shortcutItems } = useContext(Context);
-  const [
-    {
-      context: { state },
-    },
-  ] = useActor(gameService);
+  const state = useSelector(gameService, (state) => state.context.state);
   const [selectedName, setSelectedName] = useState<
     AnimalFoodName | AnimalMedicineName
   >("Hay");
   const [selectedSpice, setSelectedSpice] =
     useState<AnimalFeedBuffName>("Honey Treat");
+  const [isSpiceSelected, setIsSpiceSelected] = useState(false);
   const [tab, setTab] = useState<Tab>("food");
   const [showMixInfo, setShowMixInfo] = useState(false);
   const { coins } = ANIMAL_FOODS[selectedName];
@@ -87,7 +84,7 @@ export const FeederMachineModal: React.FC<Props> = ({
   const selectedSpiceItem = spices.includes(selectedSpice)
     ? selectedSpice
     : undefined;
-  const nextAvailableSpice = selectedSpiceItem ?? spices[0];
+  const showSpiceDetails = isSpiceSelected && hasSpices && !!selectedSpiceItem;
   const { requests, feeds, animalsWaiting, freeFeedBoosts } =
     getBulkMixRequirements(state, building);
 
@@ -113,57 +110,6 @@ export const FeederMachineModal: React.FC<Props> = ({
     toggleFeed(item);
   };
 
-  // The spices tab disappears once the player runs out, so a stale "spices"
-  // selection has to fall back to the food tab rather than render an empty
-  // panel.
-  const activeTab = hasSpices ? tab : "food";
-
-  useEffect(() => {
-    if (tab !== "spices") {
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      if (!hasSpices) {
-        setTab("food");
-        shortcutItem(selectedName);
-        return;
-      }
-
-      if (nextAvailableSpice && nextAvailableSpice !== selectedSpice) {
-        setSelectedSpice(nextAvailableSpice);
-        shortcutItem(nextAvailableSpice);
-      }
-    });
-
-    return () => window.clearTimeout(timeout);
-  }, [
-    hasSpices,
-    nextAvailableSpice,
-    selectedName,
-    selectedSpice,
-    shortcutItem,
-    tab,
-  ]);
-
-  const setActiveTab: React.Dispatch<React.SetStateAction<Tab>> = (nextTab) => {
-    const resolvedTab =
-      typeof nextTab === "function" ? nextTab(activeTab) : nextTab;
-
-    if (resolvedTab === "spices" && !hasSpices) {
-      shortcutItem(selectedName);
-      setTab("food");
-      return;
-    }
-
-    if (resolvedTab === "spices" && nextAvailableSpice) {
-      setSelectedSpice(nextAvailableSpice);
-      shortcutItem(nextAvailableSpice);
-    }
-
-    setTab(resolvedTab);
-  };
-
   const groupedItems = getKeys(ANIMAL_FOODS).reduce(
     (acc, item) => {
       const type = ANIMAL_FOODS[item].type;
@@ -178,11 +124,13 @@ export const FeederMachineModal: React.FC<Props> = ({
 
   const onSelect = (item: AnimalFoodName | AnimalMedicineName) => {
     setSelectedName(item);
+    setIsSpiceSelected(false);
     shortcutItem(item);
   };
 
   const onSelectSpice = (item: AnimalFeedBuffName) => {
     setSelectedSpice(item);
+    setIsSpiceSelected(true);
     shortcutItem(item);
   };
 
@@ -349,46 +297,44 @@ export const FeederMachineModal: React.FC<Props> = ({
                   },
                 ]
               : []),
-            ...(hasSpices
-              ? [
-                  {
-                    id: "spices" as const,
-                    icon: ITEM_DETAILS["Honey Treat"].image,
-                    name: t("spices"),
-                  },
-                ]
-              : []),
           ]}
-          currentTab={activeTab}
-          setCurrentTab={setActiveTab}
+          currentTab={tab}
+          setCurrentTab={setTab}
         >
-          {activeTab === "food" && (
+          {tab === "food" && (
             <SplitScreenView
               panel={
-                <CraftingRequirements
-                  gameState={state}
-                  details={{ item: selectedName }}
-                  requirements={{
-                    coins,
-                    resources: ingredients,
-                  }}
-                  actionView={
-                    <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
-                      <Button
-                        disabled={lessFunds() || lessIngredients()}
-                        onClick={() => mix()}
-                      >
-                        {t("mix.one")}
-                      </Button>
-                      <Button
-                        disabled={lessFunds(10) || lessIngredients(10)}
-                        onClick={() => mix(10)}
-                      >
-                        {t("mix.ten")}
-                      </Button>
-                    </div>
-                  }
-                />
+                showSpiceDetails ? (
+                  <InventoryItemDetails
+                    game={state}
+                    details={{ item: selectedSpiceItem as InventoryItemName }}
+                  />
+                ) : (
+                  <CraftingRequirements
+                    gameState={state}
+                    details={{ item: selectedName }}
+                    requirements={{
+                      coins,
+                      resources: ingredients,
+                    }}
+                    actionView={
+                      <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
+                        <Button
+                          disabled={lessFunds() || lessIngredients()}
+                          onClick={() => mix()}
+                        >
+                          {t("mix.one")}
+                        </Button>
+                        <Button
+                          disabled={lessFunds(10) || lessIngredients(10)}
+                          onClick={() => mix(10)}
+                        >
+                          {t("mix.ten")}
+                        </Button>
+                      </div>
+                    }
+                  />
+                )
               }
               content={
                 <div className="flex flex-col">
@@ -401,7 +347,9 @@ export const FeederMachineModal: React.FC<Props> = ({
                         {items.map((item) => (
                           <Box
                             key={item.name}
-                            isSelected={selectedName === item.name}
+                            isSelected={
+                              !isSpiceSelected && selectedName === item.name
+                            }
                             onClick={() => onSelect(item.name)}
                             image={ITEM_DETAILS[item.name].image}
                             count={state.inventory[item.name]}
@@ -410,11 +358,35 @@ export const FeederMachineModal: React.FC<Props> = ({
                       </div>
                     </div>
                   ))}
+                  {hasSpices && (
+                    <div className="flex flex-col">
+                      <Label
+                        type="default"
+                        icon={ITEM_DETAILS["Honey Treat"].image}
+                        className="mb-1"
+                      >
+                        {t("spices")}
+                      </Label>
+                      <div className="flex flex-wrap mb-2">
+                        {spices.map((item) => (
+                          <Box
+                            key={item}
+                            isSelected={
+                              isSpiceSelected && selectedSpiceItem === item
+                            }
+                            onClick={() => onSelectSpice(item)}
+                            image={ITEM_DETAILS[item].image}
+                            count={state.inventory[item]}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               }
             />
           )}
-          {activeTab === "automaticMixer" && showBulkMixer && (
+          {tab === "automaticMixer" && showBulkMixer && (
             <InnerPanel className="flex flex-col gap-2 p-1 w-full">
               {freeFeeding ? (
                 <>
@@ -593,44 +565,6 @@ export const FeederMachineModal: React.FC<Props> = ({
                 </>
               )}
             </InnerPanel>
-          )}
-          {activeTab === "spices" && (
-            <SplitScreenView
-              panel={
-                selectedSpiceItem ? (
-                  <InventoryItemDetails
-                    game={state}
-                    details={{ item: selectedSpiceItem as InventoryItemName }}
-                  />
-                ) : (
-                  <></>
-                )
-              }
-              content={
-                <div className="flex flex-col">
-                  <div className="flex flex-col">
-                    <Label
-                      type="default"
-                      icon={ITEM_DETAILS["Honey Treat"].image}
-                      className="mb-1"
-                    >
-                      {t("spices")}
-                    </Label>
-                    <div className="flex flex-wrap mb-2">
-                      {spices.map((item) => (
-                        <Box
-                          key={item}
-                          isSelected={selectedSpiceItem === item}
-                          onClick={() => onSelectSpice(item)}
-                          image={ITEM_DETAILS[item].image}
-                          count={state.inventory[item]}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              }
-            />
           )}
         </CloseButtonPanel>
       </div>

--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -112,6 +112,19 @@ export const FeederMachineModal: React.FC<Props> = ({
     toggleFeed(item);
   };
 
+  // The spices tab disappears once the player runs out, so a stale "spices"
+  // selection has to fall back to the food tab rather than render an empty
+  // panel.
+  const activeTab = hasSpices ? tab : "food";
+  const setActiveTab: React.Dispatch<React.SetStateAction<Tab>> = (nextTab) => {
+    setTab((currentTab) => {
+      const resolvedTab =
+        typeof nextTab === "function" ? nextTab(currentTab) : nextTab;
+
+      return resolvedTab === "spices" && !hasSpices ? "food" : resolvedTab;
+    });
+  };
+
   const groupedItems = getKeys(ANIMAL_FOODS).reduce(
     (acc, item) => {
       const type = ANIMAL_FOODS[item].type;
@@ -307,10 +320,10 @@ export const FeederMachineModal: React.FC<Props> = ({
                 ]
               : []),
           ]}
-          currentTab={tab}
-          setCurrentTab={setTab}
+          currentTab={activeTab}
+          setCurrentTab={setActiveTab}
         >
-          {tab === "food" && (
+          {activeTab === "food" && (
             <SplitScreenView
               panel={
                 <CraftingRequirements
@@ -362,7 +375,7 @@ export const FeederMachineModal: React.FC<Props> = ({
               }
             />
           )}
-          {tab === "automaticMixer" && showBulkMixer && (
+          {activeTab === "automaticMixer" && showBulkMixer && (
             <InnerPanel className="flex flex-col gap-2 p-1 w-full">
               {freeFeeding ? (
                 <>
@@ -542,7 +555,7 @@ export const FeederMachineModal: React.FC<Props> = ({
               )}
             </InnerPanel>
           )}
-          {tab === "spices" && (
+          {activeTab === "spices" && (
             <SplitScreenView
               panel={
                 <InventoryItemDetails


### PR DESCRIPTION
## Summary
Adds a conditional Spices tab to the Feeder Machine so players can quickly find and select animal feed buffs from the animal-building context. The tab only appears when the player owns a relevant animal buff item and currently includes Salt Lick and Honey Treat.

## Context / motivation
Animal buffs made from salt are currently stored in the general inventory, which makes Honey Treat and Salt Lick hard to find when the player is already inside the Barn or Hen House. This change gives those usable animal buff items a contextual shortcut without changing buff application logic.

## How to test
1. Open a farm with a Barn or Hen House and a Feeder Machine.
2. Ensure the inventory has Salt Lick or Honey Treat.
3. Open the Feeder Machine and confirm the Spices tab appears.
4. Click the Spices tab and confirm only Salt Lick and/or Honey Treat are listed.
5. Select a spice item and confirm it becomes the active shortcut item for applying to animals.
6. Remove both Salt Lick and Honey Treat from inventory and confirm the Spices tab is hidden.

## Screenshots or screen recording
Required before merge: attach a Feeder Machine screenshot showing the new Spices tab with Salt Lick/Honey Treat.

## Related issues
<img width="1260" height="1280" alt="telegram-cloud-photo-size-2-5465380764049415123-y" src="https://github.com/user-attachments/assets/a04e035f-ffd0-45b6-be27-1aadb56c7019" />


## Validation
- `yarn tsc --noEmit --pretty false` currently fails on `src/features/world/scenes/BeachScene.ts:32` because `String.replaceAll` is not available under the current TypeScript lib target. The failure is unrelated to this PR; this PR changes only `src/features/feederMachine/FeederMachineModal.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Spices" tab to the feeder machine modal so users can view and select spices from their inventory; the tab appears only when spices are available and falls back to the main tab otherwise.
  * When viewing Spices, users see item details and inventory counts; selecting a spice triggers a quick-select action.
  * The original feeder-machine tab retains crafting actions like "mix one" and "mix ten".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->