### PR TITLE
[FEAT] Refactor PlayerModalManager to support multiple listeners

### DIFF
--- a/src/features/social/PlayerModal.tsx
+++ b/src/features/social/PlayerModal.tsx
@@ -111,10 +111,11 @@ export const PlayerModal: React.FC<Props> = ({
   const player = data?.data;
 
   useEffect(() => {
-    playerModalManager.listen((npc) => {
+    const unsubscribe = playerModalManager.listen((npc) => {
       setInitialPlayer(npc.farmId);
       setShowPlayerModal(true);
     });
+    return unsubscribe;
   }, [loggedInFarmId, setInitialPlayer]);
 
   useEffect(() => {

--- a/src/features/social/lib/playerModalManager.ts
+++ b/src/features/social/lib/playerModalManager.ts
@@ -10,16 +10,20 @@ export type PlayerModalPlayer = {
 };
 
 class PlayerModalManager {
-  private listener?: (player: PlayerModalPlayer) => void;
+  private readonly listeners = new Set<(player: PlayerModalPlayer) => void>();
 
   public open(player: PlayerModalPlayer) {
-    if (this.listener) {
-      this.listener(player);
-    }
+    this.listeners.forEach((cb) => {
+      cb(player);
+    });
   }
 
-  public listen(cb: (player: PlayerModalPlayer) => void) {
-    this.listener = cb;
+  /** Subscribe to open events; call the returned function on unmount. */
+  public listen(cb: (player: PlayerModalPlayer) => void): () => void {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
   }
 }
 


### PR DESCRIPTION
# Description

Fixes #issue 
Player profile from search after visiting marketplace

## Summary

Opening the marketplace mounted a second PlayerModal, which registered with playerModalManager and replaced the farm’s listener. Closing the marketplace unmounted that modal but never cleared the manager, so open() still called a stale callback on an unmounted instance and the farm modal never opened.

### Changes

playerModalManager: Support multiple subscribers via a Set; listen() returns an unsubscribe function.
PlayerModal: Return that unsubscribe from the useEffect that subscribes so each instance removes itself on unmount.

# What needs to be tested by the reviewer?

Please describe how this can be tested

Open marketplace from the farm, then exit back to the farm.
Open social → player search → pick a result.
Confirm the player profile modal opens (same flow without marketplace first should still work).


# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event subscription cleanup in the player modal to prevent memory leaks when the modal closes or updates.

* **Refactor**
  * Enhanced event listener system to support multiple concurrent subscribers, providing better reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->