### PR TITLE
[FEAT] Add Digging shortcut to WorldMap and explicit Beach default spawn

### DIFF
--- a/src/features/island/hud/components/deliveries/WorldMap.tsx
+++ b/src/features/island/hud/components/deliveries/WorldMap.tsx
@@ -310,7 +310,7 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           border: showDebugBorders ? "2px solid red" : "",
           position: "absolute",
           left: "22%",
-          bottom: "24%",
+          bottom: "15%",
         }}
         className={`flex justify-center items-center ${
           level >= 4 ? "cursor-pointer" : "cursor-not-allowed"
@@ -318,7 +318,9 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         onClick={() => {
           if (level < 4) return;
           travel.play();
-          navigate("/world/beach");
+          navigate("/world/beach", {
+            state: { previousSceneId: "default" },
+          });
           onClose();
         }}
       >
@@ -347,6 +349,57 @@ export const WorldMap: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         ) : (
           <span className="map-text text-xxs sm:text-sm">
             {t("world.beach")}
+          </span>
+        )}
+      </div>
+
+      {/* Digging — north-west of the beach hot-spot, same level gate */}
+      <div
+        style={{
+          width: "10%",
+          height: "16%",
+          border: showDebugBorders ? "2px solid red" : "",
+          position: "absolute",
+          left: "22%",
+          bottom: "45%",
+        }}
+        className={`flex justify-center items-center ${
+          level >= 4 ? "cursor-pointer" : "cursor-not-allowed"
+        }`}
+        onClick={() => {
+          if (level < 4) return;
+          travel.play();
+          navigate("/world/beach", {
+            state: { previousSceneId: "digging" },
+          });
+          onClose();
+        }}
+      >
+        {level < 4 ? (
+          isMobile ? (
+            <img
+              src={SUNNYSIDE.icons.lock}
+              className="h-4 sm:h-6 ml-1 img-highlight"
+              onClick={() => {
+                setShowPopup(true);
+                setReqLvl(4);
+                setTimeout(() => {
+                  setShowPopup(false);
+                }, 1300);
+              }}
+            />
+          ) : (
+            <Label
+              type="default"
+              icon={SUNNYSIDE.icons.lock}
+              className="text-sm"
+            >
+              {t("world.lvl.requirement", { lvl: 4 })}
+            </Label>
+          )
+        ) : (
+          <span className="map-text text-xxs sm:text-sm">
+            {t("world.digging")}
           </span>
         )}
       </div>

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -33,7 +33,7 @@ import { EquipBumpkinAction } from "features/game/events/landExpansion/equip";
 import { Label } from "components/ui/Label";
 import { CommunityModals } from "./ui/CommunityModalManager";
 import { CommunityToasts } from "./ui/CommunityToastManager";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { prepareAPI } from "features/community/lib/CommunitySDK";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 
@@ -66,7 +66,7 @@ import { MachineState as GameMachineState } from "features/game/lib/gameMachine"
 import { RewardModal } from "features/social/RewardModal";
 import { WaveModal } from "features/social/WaveModal";
 import { Discovery } from "features/social/Discovery";
-import { SPAWNS } from "./lib/spawn";
+import { SPAWNS, SpawnFromId } from "./lib/spawn";
 import { PlayerInteractionMenu } from "./ui/player/PlayerInteractionMenu";
 
 const _roomState = (state: MachineState) => state.value;
@@ -132,6 +132,7 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
   const [loaded, setLoaded] = useState(false);
 
   const navigate = useNavigate();
+  const location = useLocation();
 
   const game = useRef<Game>(undefined);
 
@@ -210,6 +211,17 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
     game.current.registry.set("gameService", gameService);
     game.current.registry.set("id", loggedInFarmId);
     game.current.registry.set("initialScene", scene);
+    // Consumed once by the first BaseScene to compute its spawn — see
+    // BaseScene.create(). Lets a navigation like
+    // navigate("/world/beach", { state: { previousSceneId: "digging" } })
+    // pick the right SPAWNS entry on the very first scene load, not just
+    // on subsequent route changes.
+    const bootPreviousSceneId = (
+      location.state as { previousSceneId?: SpawnFromId } | null
+    )?.previousSceneId;
+    if (bootPreviousSceneId) {
+      game.current.registry.set("initialPreviousSceneId", bootPreviousSceneId);
+    }
     game.current.registry.set("navigate", navigate);
     game.current.registry.set("selectedItem", selectedItem);
     game.current.registry.set("shortcutItem", shortcutItem);
@@ -266,22 +278,40 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
       // Corn maze pauses when game is over so we need to filter for active and paused scenes.
       .filter((s) => s.scene.isActive() || s.scene.isPaused())[0];
 
-    const previousSceneId =
+    const previousSceneOverride = (
+      location.state as { previousSceneId?: SpawnFromId } | null
+    )?.previousSceneId;
+
+    // The auto-derived previous scene is always a real SceneId — used both
+    // as the SPAWNS lookup key (when no override is supplied) and as the
+    // value sent to the mmo machine on SWITCH_SCENE.
+    const autoDerivedPreviousSceneId =
       (game.current?.scene.getScenes(true)[0]?.scene.key as SceneId) ?? scene;
-    const spawn = SPAWNS()[route][previousSceneId] ?? SPAWNS()[route].default;
+    // The spawn-lookup key may be a non-scene sentinel like "digging" or
+    // "default" supplied via location.state.
+    const spawnFromKey = previousSceneOverride ?? autoDerivedPreviousSceneId;
+    const spawn = SPAWNS()[route][spawnFromKey] ?? SPAWNS()[route].default;
 
     if (activeScene && activeScene.scene.key !== route) {
       activeScene.scene.start(route);
       mmoService.send("SWITCH_SCENE", {
         sceneId: route,
-        previousSceneId,
+        previousSceneId: autoDerivedPreviousSceneId,
         playerCoordinates: {
           x: spawn.x,
           y: spawn.y,
         },
       });
+    } else if (activeScene && previousSceneOverride) {
+      // Same-scene teleport: caller asked for a specific spawn while already
+      // in this scene. Move the local player; the existing position-sync loop
+      // broadcasts the new position to the server.
+      const baseScene = activeScene as unknown as {
+        currentPlayer?: { setPosition: (x: number, y: number) => void };
+      };
+      baseScene.currentPlayer?.setPosition(spawn.x, spawn.y);
     }
-  }, [route]);
+  }, [route, location.key]);
 
   useEffect(() => {
     // Listen to moderation events

--- a/src/features/world/Phaser.tsx
+++ b/src/features/world/Phaser.tsx
@@ -269,6 +269,10 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
     game.current?.registry.set("selectedItem", selectedItem);
   }, [selectedItem]);
 
+  const previousSceneOverride = (
+    location.state as { previousSceneId?: SpawnFromId } | null
+  )?.previousSceneId;
+
   // When route changes, switch scene
   useEffect(() => {
     if (!loaded || !route) return;
@@ -277,10 +281,6 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
       .getScenes(false)
       // Corn maze pauses when game is over so we need to filter for active and paused scenes.
       .filter((s) => s.scene.isActive() || s.scene.isPaused())[0];
-
-    const previousSceneOverride = (
-      location.state as { previousSceneId?: SpawnFromId } | null
-    )?.previousSceneId;
 
     // The auto-derived previous scene is always a real SceneId — used both
     // as the SPAWNS lookup key (when no override is supplied) and as the
@@ -293,6 +293,18 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
     const spawn = SPAWNS()[route][spawnFromKey] ?? SPAWNS()[route].default;
 
     if (activeScene && activeScene.scene.key !== route) {
+      // Stash the override so the destination scene's BaseScene.create() can
+      // resolve the same SPAWNS entry we just resolved here. Without this,
+      // create() would only see mmoService.context.previousSceneId (the
+      // auto-derived SceneId) and pick the wrong spawn for sentinels like
+      // "digging" or "default".
+      if (previousSceneOverride) {
+        game.current?.registry.set(
+          "initialPreviousSceneId",
+          previousSceneOverride,
+        );
+      }
+
       activeScene.scene.start(route);
       mmoService.send("SWITCH_SCENE", {
         sceneId: route,
@@ -311,7 +323,7 @@ export const PhaserComponent: React.FC<Props> = ({ mmoService, route }) => {
       };
       baseScene.currentPlayer?.setPosition(spawn.x, spawn.y);
     }
-  }, [route, location.key]);
+  }, [route, location.key, previousSceneOverride]);
 
   useEffect(() => {
     // Listen to moderation events

--- a/src/features/world/lib/spawn.ts
+++ b/src/features/world/lib/spawn.ts
@@ -1,9 +1,14 @@
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
 import { SceneId } from "../mmoMachine";
 
+// `"default"` is a sentinel WorldMap callers use to mean "always use the
+// scene's `default` spawn", overriding the auto-derived previous scene.
+// `"digging"` is a non-scene shortcut that maps to a specific beach spawn.
+export type SpawnFromId = SceneId | "digging" | "default";
+
 export type SpawnLocation = Record<
   SceneId,
-  { default: Coordinates } & Partial<Record<SceneId, Coordinates>>
+  { default: Coordinates } & Partial<Record<SpawnFromId, Coordinates>>
 >;
 
 const randomXOffset = Math.random() * 60;
@@ -138,6 +143,10 @@ export const SPAWNS: () => SpawnLocation = () => ({
       y: 736,
     },
     kingdom: {
+      x: 532,
+      y: 257,
+    },
+    digging: {
       x: 532,
       y: 257,
     },

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -350,7 +350,19 @@ export abstract class BaseScene extends Phaser.Scene {
         this.initialiseControls();
       }
 
-      const from = this.mmoService?.state.context.previousSceneId as SceneId;
+      // Boot-time override stashed by Phaser.tsx when the world component
+      // was mounted via `navigate(..., { state: { previousSceneId } })`.
+      // Used once for the very first scene load (the route-change effect in
+      // Phaser.tsx handles subsequent navigations).
+      const initialPreviousSceneId = this.registry.get(
+        "initialPreviousSceneId",
+      ) as string | undefined;
+      if (initialPreviousSceneId) {
+        this.registry.remove("initialPreviousSceneId");
+      }
+
+      const from = (initialPreviousSceneId ??
+        this.mmoService?.state.context.previousSceneId) as SceneId;
 
       let spawn = this.options.player.spawn;
 

--- a/src/features/world/scenes/BaseScene.ts
+++ b/src/features/world/scenes/BaseScene.ts
@@ -11,7 +11,7 @@ import { npcModalManager } from "../ui/NPCModals";
 import { BumpkinParts } from "lib/utils/tokenUriBuilder";
 import { EventObject } from "xstate";
 import { isTouchDevice } from "../lib/device";
-import { SPAWNS } from "../lib/spawn";
+import { SPAWNS, SpawnFromId } from "../lib/spawn";
 import { AudioController, WalkAudioController } from "../lib/AudioController";
 import { createErrorLogger } from "lib/errorLogger";
 import { Coordinates } from "features/game/expansion/components/MapPlacement";
@@ -356,18 +356,22 @@ export abstract class BaseScene extends Phaser.Scene {
       // Phaser.tsx handles subsequent navigations).
       const initialPreviousSceneId = this.registry.get(
         "initialPreviousSceneId",
-      ) as string | undefined;
+      ) as SpawnFromId | undefined;
       if (initialPreviousSceneId) {
         this.registry.remove("initialPreviousSceneId");
       }
 
-      const from = (initialPreviousSceneId ??
-        this.mmoService?.state.context.previousSceneId) as SceneId;
+      const from: SpawnFromId | undefined =
+        initialPreviousSceneId ??
+        this.mmoService?.getSnapshot().context.previousSceneId ??
+        undefined;
 
       let spawn = this.options.player.spawn;
 
       if (SPAWNS()[this.sceneId]) {
-        spawn = SPAWNS()[this.sceneId][from] ?? SPAWNS()[this.sceneId].default;
+        spawn =
+          (from && SPAWNS()[this.sceneId][from]) ??
+          SPAWNS()[this.sceneId].default;
       }
 
       this.createPlayer({

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4346,6 +4346,7 @@
   "world.intro.seven": "No harrasment, swearing or bullying. Thank you for respecting others.",
   "world.plaza": "Plaza",
   "world.beach": "Beach",
+  "world.digging": "Digging",
   "world.woodlands": "Woodlands",
   "world.retreat": "Retreat",
   "world.home": "Home",


### PR DESCRIPTION
## Summary

<img width="776" height="550" alt="image" src="https://github.com/user-attachments/assets/c8e7063f-febd-4933-be1f-374f73ac75a4" />


- Adds a **Digging** hot-spot on the WorldMap (level 4 gate, same as Beach) that spawns the player at `(532, 257)` on the beach — same coords as the existing kingdom→beach warp.
- Makes the **Beach** hot-spot always land at the default beach spawn `(528, 736)`, including an in-scene teleport when the player is already on beach (previously a no-op).
- Both buttons use a new `location.state.previousSceneId` override mechanism. When the player is already in the destination scene the player is teleported in place via `currentPlayer.setPosition` instead of restarting the scene.
- The override is also picked up on the very first scene load (e.g. navigating from `/`) via a one-shot registry value, so the spawn is correct even when Phaser is mounting fresh and `mmoService.context.previousSceneId` is still `null`.

## Behavioural changes

- WorldMap → Beach now always lands at `(528, 736)`. Previously, clicking Beach from the kingdom scene used to land at `(532, 257)` because the spawn-lookup auto-derived `previousSceneId = "kingdom"`. The in-world kingdom→beach warp is unchanged and still uses `(532, 257)`.

## Test plan

- [ ] From Plaza → click **Digging** → arrive on beach at `(532, 257)` with the usual scene-fade.
- [ ] From south beach default spawn → open WorldMap → click **Digging** → bumpkin snaps to `(532, 257)` with no scene reload.
- [ ] From north beach `(532, 257)` → open WorldMap → click **Beach** → bumpkin snaps to `(528, 736)` with no scene reload.
- [ ] From Home `/` → click **Digging** → land at `(532, 257)` (regression check on the boot-time override).
- [ ] From Home `/` → click **Beach** → land at default `(528, 736)`.
- [ ] Walk through the in-world kingdom→beach warp → still lands at `(532, 257)` (unchanged).
- [ ] Existing translations untouched outside of the new `world.digging` key in `dictionary.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Digging" hotspot on the world map (same level requirement as Beach); interacts with existing locked UI and opens the Beach area when available.
  * Improved navigation and spawn behavior: navigation now preserves previous-location context for more accurate player placement and supports same-location teleporting without fully reloading the scene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->