### PR TITLE
[REVERT] Remove plot hover boost panel and suppress popover during fertilise

### DIFF
--- a/src/features/island/common/TimerPopover.tsx
+++ b/src/features/island/common/TimerPopover.tsx
@@ -3,13 +3,6 @@ import React from "react";
 import { InnerPanel } from "components/ui/Panel";
 import classNames from "classnames";
 import { secondsToString } from "lib/utils/time";
-import { BoostName, GameState } from "features/game/types/game";
-import {
-  getBoostIcon,
-  getBoostLabel,
-} from "components/ui/layouts/BoostsDisplay";
-import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { hasFeatureAccess } from "lib/flags";
 
 interface Props {
   showPopover: boolean;
@@ -18,13 +11,7 @@ interface Props {
   timeLeft: number;
   secondaryImage?: string | undefined;
   secondaryDescription?: string;
-  boosts?: { name: BoostName; value: string }[];
-  chanceBoosts?: { name: BoostName; value: string; chance: number }[];
-  state?: GameState;
 }
-
-const formatChance = (chance: number): string =>
-  Number.isInteger(chance) ? `${chance}%` : `${chance.toFixed(1)}%`;
 
 export const TimerPopover: React.FC<Props> = ({
   showPopover,
@@ -33,11 +20,7 @@ export const TimerPopover: React.FC<Props> = ({
   timeLeft,
   secondaryImage,
   secondaryDescription,
-  boosts,
-  chanceBoosts,
-  state,
 }) => {
-  const { t } = useAppTranslation();
   const hasSecondRow = secondaryImage != null || secondaryDescription != null;
 
   return (
@@ -66,43 +49,6 @@ export const TimerPopover: React.FC<Props> = ({
         <span className="flex-1 text-center font-secondary">
           {secondsToString(timeLeft, { length: "medium" })}
         </span>
-        {!!state &&
-          hasFeatureAccess(state, "BOOSTS_DISPLAY") &&
-          boosts?.map((buff) => {
-            const label = getBoostLabel(buff.name, t);
-            return (
-              <div key={buff.name} className="flex items-center max-w-[10rem]">
-                <img
-                  src={getBoostIcon(buff.name, state)}
-                  alt={label}
-                  className="w-4 h-4 mr-1 flex-shrink-0 object-contain"
-                />
-                <span className="truncate text-xxs">
-                  {`${buff.value} ${label}`}
-                </span>
-              </div>
-            );
-          })}
-        {!!state &&
-          hasFeatureAccess(state, "BOOSTS_DISPLAY") &&
-          chanceBoosts?.map((buff) => {
-            const label = getBoostLabel(buff.name, t);
-            return (
-              <div
-                key={`chance-${buff.name}`}
-                className="flex items-center max-w-[10rem]"
-              >
-                <img
-                  src={getBoostIcon(buff.name, state)}
-                  alt={label}
-                  className="w-4 h-4 mr-1 flex-shrink-0 object-contain"
-                />
-                <span className="text-xxs">
-                  {`${buff.value} ${label} (${formatChance(buff.chance)})`}
-                </span>
-              </div>
-            );
-          })}
       </div>
     </InnerPanel>
   );

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -21,6 +21,7 @@ import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { useNow } from "lib/utils/hooks/useNow";
 import { getCropYieldAmount } from "features/game/events/landExpansion/harvest";
+import { CROP_COMPOST } from "features/game/types/composters";
 
 interface Props {
   cropName?: CropName;
@@ -95,7 +96,8 @@ export const FertilePlot: React.FC<Props> = ({
   touchCount,
   showTimers,
 }) => {
-  const { gameService } = useContext(Context);
+  const { gameService, selectedItem } = useContext(Context);
+  const isApplyingFertiliser = !!selectedItem && selectedItem in CROP_COMPOST;
 
   const island = useSelector(gameService, _island);
   const calendar = useSelector(gameService, _calendar);
@@ -139,6 +141,10 @@ export const FertilePlot: React.FC<Props> = ({
   }, [cropName, showTimerPopover, game, plot, readyAt]);
 
   const handleMouseEnter = () => {
+    // Suppress the boost/timer popover while the player is applying a crop
+    // fertiliser — the tooltip would block the click target and isn't useful
+    // to that flow.
+    if (isApplyingFertiliser) return;
     // show details if field is growing
     if (isGrowing) {
       // set state to show details
@@ -270,7 +276,7 @@ export const FertilePlot: React.FC<Props> = ({
           <TimerPopover
             image={ITEM_DETAILS[cropName].image}
             description={cropName}
-            showPopover={showTimerPopover}
+            showPopover={showTimerPopover && !isApplyingFertiliser}
             timeLeft={timeLeft}
             boosts={plotBoosts}
             chanceBoosts={plotChanceBoosts}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -97,7 +97,11 @@ export const FertilePlot: React.FC<Props> = ({
   showTimers,
 }) => {
   const { gameService, selectedItem } = useContext(Context);
-  const isApplyingFertiliser = !!selectedItem && selectedItem in CROP_COMPOST;
+  // Only treat the player as "applying fertiliser" when the plot is still
+  // empty — applying onto an already-fertilised plot is a no-op, so the
+  // tooltip should still show in that case.
+  const isApplyingFertiliser =
+    !!selectedItem && selectedItem in CROP_COMPOST && !fertiliser;
 
   const island = useSelector(gameService, _island);
   const calendar = useSelector(gameService, _calendar);

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -169,7 +169,8 @@ export const FertilePlot: React.FC<Props> = ({
     >
       <div
         className={classNames("w-full h-full relative", {
-          "cursor-pointer hover:img-highlight": !stage || stage === "ready",
+          "cursor-pointer hover:img-highlight":
+            !stage || stage === "ready" || isApplyingFertiliser,
         })}
       >
         {/* Crop base image */}

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -13,14 +13,13 @@ import bee from "assets/icons/bee.webp";
 
 import { TimerPopover } from "../../common/TimerPopover";
 import classNames from "classnames";
-import { CropFertiliser, CropPlot, GameState } from "features/game/types/game";
+import { CropFertiliser, CropPlot } from "features/game/types/game";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { getActiveCalendarEvent } from "features/game/types/calendar";
-import { MachineState, selectGameState } from "features/game/lib/gameMachine";
+import { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { useNow } from "lib/utils/hooks/useNow";
-import { getCropYieldAmount } from "features/game/events/landExpansion/harvest";
 import { CROP_COMPOST } from "features/game/types/composters";
 
 interface Props {
@@ -35,19 +34,6 @@ interface Props {
 
 const _island = (state: MachineState) => state.context.state.island;
 const _calendar = (state: MachineState) => state.context.state.calendar;
-
-// Custom equality so FertilePlot only rerenders when a slice that affects
-// yield-boost computation changes. Immer preserves references for untouched
-// slices, so reference comparison is enough.
-const isGameEqualForBoosts = (a: GameState, b: GameState) =>
-  a.collectibles === b.collectibles &&
-  a.bumpkin === b.bumpkin &&
-  a.inventory === b.inventory &&
-  a.season === b.season &&
-  a.calendar === b.calendar &&
-  a.aoe === b.aoe &&
-  a.buds === b.buds &&
-  a.faction === b.faction;
 
 const clampPercentage = (value: number) => Math.min(Math.max(value, 0), 100);
 
@@ -105,7 +91,6 @@ export const FertilePlot: React.FC<Props> = ({
 
   const island = useSelector(gameService, _island);
   const calendar = useSelector(gameService, _calendar);
-  const game = useSelector(gameService, selectGameState, isGameEqualForBoosts);
 
   const [showTimerPopover, setShowTimerPopover] = useState(false);
   const { harvestSeconds, readyAt } = useMemo(
@@ -130,19 +115,6 @@ export const FertilePlot: React.FC<Props> = ({
   const stage = getGrowthStage(cropName, growPercentage);
 
   const isSunshower = getActiveCalendarEvent({ calendar }) === "sunshower";
-
-  const { plotBoosts, plotChanceBoosts } = useMemo(() => {
-    if (!cropName || !showTimerPopover) {
-      return { plotBoosts: [], plotChanceBoosts: [] };
-    }
-    const { boostsUsed, chanceBoostsUsed } = getCropYieldAmount({
-      game,
-      plot,
-      crop: cropName,
-      createdAt: readyAt,
-    });
-    return { plotBoosts: boostsUsed, plotChanceBoosts: chanceBoostsUsed };
-  }, [cropName, showTimerPopover, game, plot, readyAt]);
 
   const handleMouseEnter = () => {
     // Suppress the boost/timer popover while the player is applying a crop
@@ -283,9 +255,6 @@ export const FertilePlot: React.FC<Props> = ({
             description={cropName}
             showPopover={showTimerPopover && !isApplyingFertiliser}
             timeLeft={timeLeft}
-            boosts={plotBoosts}
-            chanceBoosts={plotChanceBoosts}
-            state={game}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Reverts the boost rows added to the crop-plot hover popover in #7241. Beta testers reported the panel was too noisy / intrusive on the farm view, so the popover goes back to the pre-#7241 form (crop name + remaining time only).
- Keeps the small fertilise-flow UX improvement that was started on this branch: while a `CropCompostName` (Sprout Mix / Rapid Root / Sproutroot Surprise) is the active shortcut and the hovered plot is **not** already fertilised, the timer popover is suppressed and the plot shows a pointer cursor so it's obvious which plots will accept the click.
- The shared helpers extracted in #7241 (`getBoostIcon` / `getBoostLabel` in `BoostsDisplay`, optional `prngArgs` and `chanceBoostsUsed` on `getCropYieldAmount`) stay in place — only the plot-tooltip surface is removed, so other panels can still use them.

## Changes
**`src/features/island/common/TimerPopover.tsx`**
- Remove the `boosts` / `chanceBoosts` / `state` props, the icon/label imports, the `formatChance` helper, and the two boost row maps. The component is back to crop name + remaining time, with the optional secondary row preserved for existing callers.

**`src/features/island/plots/components/FertilePlot.tsx`**
- Remove the `selectGameState` subscription, `isGameEqualForBoosts` custom equality, the `getCropYieldAmount` `useMemo`, and the `boosts` / `chanceBoosts` / `state` props passed to `TimerPopover`.
- Read `selectedItem` from `Context` and compute `isApplyingFertiliser = !!selectedItem && selectedItem in CROP_COMPOST && !fertiliser`.
- `handleMouseEnter` early-returns when `isApplyingFertiliser` so newly-hovered plots don't open the popover; `showPopover` on `<TimerPopover>` is `showTimerPopover && !isApplyingFertiliser` so the popover fades out cleanly if the player swaps to a fertiliser while a plot is already hovered.
- `cursor-pointer hover:img-highlight` now also applies when `isApplyingFertiliser` is true, so plots that will accept the click look interactive even mid-growth.

## Test plan
- [ ] Hover any growing crop with no shortcut selected — popover shows crop name + time only (no boost rows)
- [ ] Pick up Sprout Mix / Rapid Root / Sproutroot Surprise, hover an unfertilised growing plot — popover does not appear, plot shows pointer cursor
- [ ] Apply fertiliser, then hover the same plot still holding the same fertiliser — popover appears (no-op click, so we want the info visible)
- [ ] Switch back to a non-fertiliser shortcut (seed, tool) — popover behaves normally again
- [ ] Pick up a fertiliser while a popover is already open — popover fades out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed the timer/boost popover and hover highlight while applying compost to fertile plots, preventing accidental popovers and visual interruptions during composting.
  * Disabled plot hover styling during compost application to reduce distraction and enable uninterrupted farming actions.

* **Refactor**
  * Simplified the timer popover to show primary/optional secondary info and time only; boost/chance displays were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->