### PR TITLE
[FIX] Reduce PWA cache limits to prevent mobile storage eviction

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronized]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronized]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -101,7 +101,7 @@ const protectedBaseHref = hasProtectedPath
   ? `${normalizedProtectedUrl.origin}${normalizedProtectedPath}/`
   : null;
 
-// Accept any request whose absolute URL or pathname aligns with a known protected category.
+// Accept requests whose absolute URL or pathname aligns with a known protected category.
 const isProtectedCategoryUrl = (url: URL) =>
   protectedCategoryMatchers.some(
     ({ urlPrefix, pathPrefix }) =>

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -8,6 +8,7 @@ import { registerRoute } from "workbox-routing";
 import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 import { StaleWhileRevalidate } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
 import { CONFIG } from "./lib/config";
 import { getMessaging, isSupported } from "firebase/messaging/sw";
 import { onBackgroundMessage } from "firebase/messaging/sw";
@@ -53,7 +54,19 @@ const PROTECTED_IMAGE_CATEGORIES = [
   "volcano",
   "world",
 ] as const;
+// Cache limits are intentionally conservative to prevent mobile browsers from
+// evicting the entire origin's storage when quota is exceeded. A smaller cache
+// that persists reliably is better than a large one the OS wipes between sessions.
+// - 30 days: assets rarely change between chapters (~3 months); no need to expire sooner.
+// - 300 entries: no category except "land" has more than ~150 unique assets.
+// - 500 for land: it has ~420 unique tile/cloud/background sprites.
 const THIRTY_DAYS_IN_SECONDS = 60 * 60 * 24 * 30;
+const MAX_ENTRIES_DEFAULT = 300;
+const MAX_ENTRIES_LAND = 500;
+
+// Bump this version to trigger a one-time runtime cache purge on activation.
+// This gives devices stuck with bloated caches a clean slate.
+const CACHE_VERSION = 1;
 // Resolve the protected asset base URL into a consistent origin/path pair so routing
 // works whether the config is absolute (https://cdn/.../game-assets) or relative (/game-assets).
 const normalizedProtectedUrl = (() => {
@@ -114,6 +127,34 @@ self.addEventListener("message", (event) => {
   }
 });
 
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const versionCache = await caches.open("sw-cache-version");
+      const versionResponse = await versionCache.match("version");
+      const parsedVersion = versionResponse
+        ? parseInt(await versionResponse.text(), 10)
+        : 0;
+      const storedVersion = Number.isFinite(parsedVersion) ? parsedVersion : 0;
+
+      if (storedVersion < CACHE_VERSION) {
+        const names = await caches.keys();
+        await Promise.all(
+          names
+            .filter(
+              (name) =>
+                name.startsWith("protected-") ||
+                name === "game-assets" ||
+                name === "testnet-assets",
+            )
+            .map((name) => caches.delete(name)),
+        );
+        await versionCache.put("version", new Response(String(CACHE_VERSION)));
+      }
+    })(),
+  );
+});
+
 // Precaching strategy
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);
@@ -127,9 +168,11 @@ if (import.meta.env.PROD) {
       new StaleWhileRevalidate({
         cacheName: `protected-${category}`,
         plugins: [
+          new CacheableResponsePlugin({ statuses: [200] }),
           new ExpirationPlugin({
             maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
-            maxEntries: 2000,
+            maxEntries:
+              category === "land" ? MAX_ENTRIES_LAND : MAX_ENTRIES_DEFAULT,
             purgeOnQuotaError: true,
           }),
         ],
@@ -145,9 +188,10 @@ if (import.meta.env.PROD) {
       new StaleWhileRevalidate({
         cacheName: "protected-misc",
         plugins: [
+          new CacheableResponsePlugin({ statuses: [200] }),
           new ExpirationPlugin({
             maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
-            maxEntries: 2000,
+            maxEntries: MAX_ENTRIES_DEFAULT,
             purgeOnQuotaError: true,
           }),
         ],
@@ -164,9 +208,10 @@ if (import.meta.env.PROD) {
     new StaleWhileRevalidate({
       cacheName: `${gameAssetsCacheName}`,
       plugins: [
+        new CacheableResponsePlugin({ statuses: [200] }),
         new ExpirationPlugin({
           maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
-          maxEntries: 2000,
+          maxEntries: MAX_ENTRIES_DEFAULT,
           purgeOnQuotaError: true,
         }),
       ],

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -151,6 +151,8 @@ self.addEventListener("activate", (event) => {
         );
         await versionCache.put("version", new Response(String(CACHE_VERSION)));
       }
+
+      await self.clients.claim();
     })(),
   );
 });

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -170,7 +170,7 @@ if (import.meta.env.PROD) {
       new StaleWhileRevalidate({
         cacheName: `protected-${category}`,
         plugins: [
-          new CacheableResponsePlugin({ statuses: [200] }),
+          new CacheableResponsePlugin({ statuses: [0, 200] }),
           new ExpirationPlugin({
             maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
             maxEntries:
@@ -190,7 +190,7 @@ if (import.meta.env.PROD) {
       new StaleWhileRevalidate({
         cacheName: "protected-misc",
         plugins: [
-          new CacheableResponsePlugin({ statuses: [200] }),
+          new CacheableResponsePlugin({ statuses: [0, 200] }),
           new ExpirationPlugin({
             maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
             maxEntries: MAX_ENTRIES_DEFAULT,
@@ -210,7 +210,7 @@ if (import.meta.env.PROD) {
     new StaleWhileRevalidate({
       cacheName: `${gameAssetsCacheName}`,
       plugins: [
-        new CacheableResponsePlugin({ statuses: [200] }),
+        new CacheableResponsePlugin({ statuses: [0, 200] }),
         new ExpirationPlugin({
           maxAgeSeconds: THIRTY_DAYS_IN_SECONDS,
           maxEntries: MAX_ENTRIES_DEFAULT,


### PR DESCRIPTION
## Summary

PWA updates. Reduces maxEntries from 2000 to 300 (500 for land), adds CacheableResponsePlugin to reject opaque/error responses, and adds a versioned one-time cache purge on activation to give existing devices a clean slate.

## Context / motivation

Mobile browsers were wiping the entire cache when storage quota was exceeded, causing assets to re-fetch on every session.

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Caching now only stores successful responses and reduces per-category storage limits for more predictable usage.
  * Preserves existing cache age policy while tightening storage per asset category.
  * Added a one-time cache cleanup during activation to remove outdated cached assets and migrate to the new scheme.
  * CI workflow updated to run verification on both newly opened and updated pull requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7249)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->