### PR TITLE
[FEAT] Salt Crystal Bed unlocks a 12th farmhand

### DIFF
--- a/src/features/game/lib/crafting.ts
+++ b/src/features/game/lib/crafting.ts
@@ -73,7 +73,10 @@ export const CRAFTABLE_BEARS: Record<CraftableBearName, object> = {
 
 export type RecipeCollectibleName = Extract<
   | RecipeCraftableName
-  | Exclude<BedName, "Double Bed" | "Messy Bed" | "Pearl Bed">
+  | Exclude<
+      BedName,
+      "Double Bed" | "Messy Bed" | "Pearl Bed" | "Salt Crystal Bed"
+    >
   | DollName
   | CraftableBearName,
   InventoryItemName

--- a/src/features/game/types/beds.test.ts
+++ b/src/features/game/types/beds.test.ts
@@ -1,0 +1,20 @@
+import { BED_FARMHAND_COUNT } from "./beds";
+import { getKeys } from "lib/object";
+
+describe("BED_FARMHAND_COUNT", () => {
+  it("grants a 12th farmhand slot when Salt Crystal Bed is owned", () => {
+    expect(BED_FARMHAND_COUNT["Salt Crystal Bed"]).toEqual(12);
+  });
+
+  it("makes Salt Crystal Bed the highest-tier bed (sorts last by slot count)", () => {
+    const sorted = getKeys(BED_FARMHAND_COUNT).sort(
+      (a, b) => BED_FARMHAND_COUNT[a] - BED_FARMHAND_COUNT[b],
+    );
+    expect(sorted[sorted.length - 1]).toEqual("Salt Crystal Bed");
+  });
+
+  it("assigns a unique slot count to every bed", () => {
+    const counts = Object.values(BED_FARMHAND_COUNT);
+    expect(new Set(counts).size).toEqual(counts.length);
+  });
+});

--- a/src/features/game/types/beds.ts
+++ b/src/features/game/types/beds.ts
@@ -12,4 +12,5 @@ export const BED_FARMHAND_COUNT: Record<BedName, number> = {
   "Double Bed": 9,
   "Messy Bed": 10,
   "Pearl Bed": 11,
+  "Salt Crystal Bed": 12,
 };

--- a/src/features/game/types/collectibles.ts
+++ b/src/features/game/types/collectibles.ts
@@ -151,7 +151,6 @@ export type SoldOutCollectibleName =
   | "Crystal Altar"
   | "Dino Egg Trophy"
   | "Salt Lamp"
-  | "Salt Crystal Bed"
   | "World Map Rug"
   | "Ripped Salt Bag";
 

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1068,7 +1068,7 @@ const bedsDimension = getKeys(BED_FARMHAND_COUNT).reduce(
     ...previous,
     [bedName]: { width: 1, height: 1 },
   }),
-  {} as Record<Exclude<BedName, "Double Bed">, Dimensions>,
+  {} as Record<Exclude<BedName, "Double Bed" | "Pearl Bed">, Dimensions>,
 );
 
 export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
@@ -1309,7 +1309,6 @@ export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   "Crystal Altar": { width: 3, height: 2 },
   "Dino Egg Trophy": { width: 2, height: 1 },
   "Salt Lamp": { width: 1, height: 1 },
-  "Salt Crystal Bed": { width: 1, height: 1 },
   "World Map Rug": { width: 3, height: 2 },
   "Ripped Salt Bag": { width: 1, height: 1 },
 

--- a/src/features/game/types/craftables.ts
+++ b/src/features/game/types/craftables.ts
@@ -1063,13 +1063,15 @@ const flagsDimension = getKeys(FLAGS).reduce(
   {} as Record<Flag, Dimensions>,
 );
 
-const bedsDimension = getKeys(BED_FARMHAND_COUNT).reduce(
-  (previous, bedName) => ({
-    ...previous,
-    [bedName]: { width: 1, height: 1 },
-  }),
-  {} as Record<Exclude<BedName, "Double Bed" | "Pearl Bed">, Dimensions>,
-);
+const bedsDimension = getKeys(BED_FARMHAND_COUNT)
+  .filter((bedName) => bedName !== "Double Bed" && bedName !== "Pearl Bed")
+  .reduce(
+    (previous, bedName) => ({
+      ...previous,
+      [bedName]: { width: 1, height: 1 },
+    }),
+    {} as Record<Exclude<BedName, "Double Bed" | "Pearl Bed">, Dimensions>,
+  );
 
 export const COLLECTIBLES_DIMENSIONS: Record<CollectibleName, Dimensions> = {
   // Salesman Items

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1114,7 +1114,8 @@ export type BedName =
   | "Royal Bed"
   | "Pearl Bed"
   | "Double Bed"
-  | "Messy Bed";
+  | "Messy Bed"
+  | "Salt Crystal Bed";
 
 export type RecipeCraftableName =
   | "Cushion"

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -814,7 +814,6 @@ export const COLLECTIBLE_COMPONENTS: Record<
   ),
   "Dino Egg Trophy": () => <TemplateCollectible name="Dino Egg Trophy" />,
   "Salt Lamp": () => <TemplateCollectible name="Salt Lamp" />,
-  "Salt Crystal Bed": () => <TemplateCollectible name="Salt Crystal Bed" />,
   "World Map Rug": () => <TemplateCollectible name="World Map Rug" />,
   "Ripped Salt Bag": () => <TemplateCollectible name="Ripped Salt Bag" />,
   "Poseidon's Throne": (props: CollectibleProps) => (

--- a/src/features/island/collectibles/components/Bed.tsx
+++ b/src/features/island/collectibles/components/Bed.tsx
@@ -33,6 +33,7 @@ export const BED_WIDTH: Record<BedName, number> = {
   "Pearl Bed": 26,
   "Double Bed": 24,
   "Messy Bed": 17,
+  "Salt Crystal Bed": 18,
 };
 
 export const BED_HEIGHT: Record<BedName, number> = {
@@ -47,6 +48,7 @@ export const BED_HEIGHT: Record<BedName, number> = {
   "Pearl Bed": 30,
   "Double Bed": 18,
   "Messy Bed": 20,
+  "Salt Crystal Bed": 28,
 };
 
 const _farmhands = (state: MachineState) =>


### PR DESCRIPTION
## Summary
- Move \`Salt Crystal Bed\` into the \`BedName\` type so it now grants an extra farmhand slot (slot 12, highest tier).
- Render Salt Crystal Bed through the \`Bed\` component (was \`TemplateCollectible\`), so it gets the sleep-to-unlock interaction like every other bed. Its dimensions now come from the auto-generated \`bedsDimension\` map instead of the manual entry in \`COLLECTIBLES_DIMENSIONS\`.
- Removed it from \`SoldOutCollectibleName\` (now categorised as a bed) and excluded from \`RecipeCollectibleName\` (matches Pearl Bed's treatment — it's a premium/chapter reward, not a crafted recipe).

Pairs with the BE PR that mirrors the \`BedName\` change so the unlock validation accepts the 12th bed.

## Test plan
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn jest src/features/game/types/beds.test.ts\` — new data tests confirm Salt Crystal Bed is slot 12 and sorts as the highest-tier bed
- [ ] Place Salt Crystal Bed in-game and confirm the sleep-to-unlock icon shows when an extra farmhand slot is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Salt Crystal Bed" as a new collectible bed option—provides 12 farmhand slots and has updated dimensions for island placement.

* **Tests**
  * Added test coverage validating bed slot counts, confirming "Salt Crystal Bed" maps to 12, is highest-tier by slots, and that bed slot counts are unique.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->