### PR TITLE
[FIX] Add Water Tools label to workbench guide

### DIFF
--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -110,6 +110,9 @@ const LAND_NODES_WITH_RECOVERY: LandNodeWithRecovery[] = [
     getRecovery: ({ game }) => getOilRecoveryTimeForDisplay({ game }),
     resourceLabelKey: "resource.oilRecoveryTime",
   },
+];
+
+const WATER_NODES_WITH_RECOVERY: LandNodeWithRecovery[] = [
   {
     nodeImage: saltNodeStage3,
     nodeIconWidth: ICON_SIZE - 2,
@@ -154,6 +157,21 @@ export const ToolsGuide: React.FC = () => {
             node={node}
             state={state}
             alternateBg={index % 2 === 0}
+            showBoostsKey={showBoostsKey}
+            setShowBoostsKey={setShowBoostsKey}
+          />
+        ))}
+        <div className="w-full py-0.5">
+          <Label type="default" className="mb-0.5">
+            {t("waterTools")}
+          </Label>
+        </div>
+        {WATER_NODES_WITH_RECOVERY.map((node, index) => (
+          <NodeRow
+            key={`${node.toolName}-${node.resourceName}`}
+            node={node}
+            state={state}
+            alternateBg={(index + LAND_NODES_WITH_RECOVERY.length) % 2 === 0}
             showBoostsKey={showBoostsKey}
             setShowBoostsKey={setShowBoostsKey}
           />

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -161,8 +161,8 @@ export const ToolsGuide: React.FC = () => {
             setShowBoostsKey={setShowBoostsKey}
           />
         ))}
-        <div className="w-full py-0.5">
-          <Label type="default" className="mb-0.5">
+        <div className="w-full pt-2 pb-0">
+          <Label type="default">
             {t("waterTools")}
           </Label>
         </div>

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -162,9 +162,7 @@ export const ToolsGuide: React.FC = () => {
           />
         ))}
         <div className="w-full pt-2 pb-0">
-          <Label type="default">
-            {t("waterTools")}
-          </Label>
+          <Label type="default">{t("waterTools")}</Label>
         </div>
         {WATER_NODES_WITH_RECOVERY.map((node, index) => (
           <NodeRow


### PR DESCRIPTION
## Summary
- Separates Salt Rake from the Land Tools guide section.
- Adds a Water Tools label above the Salt Rake row in the Workbench Guide.
- Keeps the existing Salt Rake row layout, cooldown display, and boosts panel behavior unchanged.

## Problem
Salt Rake is a water tool in the Workbench Tools tab, but in the Guide tab it appeared under the Land Tools label. This made the Guide structure inconsistent with the actual tool grouping.

<img width="443" height="107" alt="image" src="https://github.com/user-attachments/assets/351041b9-af30-4796-a857-20416da8c2c4" />


## Testing
- Ran git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Water Tools section to the Tools Guide UI, separating water-based tools from land tools and labeling each section for clarity.
  * Moved Salt from the land tools list into the new Water Tools category for improved resource discoverability and organization.

* **Bug Fixes**
  * Adjusted alternating row styling so backgrounds align correctly across land and water lists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7256)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->