### PR TITLE
[FIX] Correction of a typo in the description of saltCrystalFlower

### DIFF
--- a/src/lib/i18n/dictionaries/ru.json
+++ b/src/lib/i18n/dictionaries/ru.json
@@ -8810,7 +8810,7 @@
   "obsidianShrine.noEligiblePlots": "Нет грядок для удобрения",
   "obsidianShrine.noEligiblePatches": "Нет фруктовых грядок для удобрения",
   "obsidianShrine.eligible": "Подходит: {{count}}",
-  "description.saltCrystalFlower.boost": "5% шанс получить +1 FLOWER",
+  "description.saltCrystalFlower.boost": "5% шанс получить +1 Цветок",
   "playerEconomyEditor.tab.data": "Данные",
   "playerEconomyEditor.dataTab.suppliesHeading": "Запасы",
   "playerEconomyEditor.dataTab.playersHeading": "Игроки",


### PR DESCRIPTION
The players thought that the bonus referred to the "Flower" token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Russian localization for Salt Crystal Flower reward description to use proper localized terminology instead of English token name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7259)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->