### PR TITLE
[REF] make counter required in getProcessedResourceAmount

### DIFF
--- a/src/features/game/events/landExpansion/collectProcessedResource.test.ts
+++ b/src/features/game/events/landExpansion/collectProcessedResource.test.ts
@@ -6,6 +6,7 @@ import { GameState } from "features/game/types/game";
 import {
   collectProcessedResource,
   CollectProcessedResourceAction,
+  getProcessedResourceAmount,
 } from "./collectProcessedResource";
 import { ProcessingBuildingName } from "features/game/types/buildings";
 
@@ -279,6 +280,110 @@ describe("collectProcessedFood", () => {
         farmId,
       });
       expect(updated.inventory["Fish Flake"]).toEqual(new Decimal(1));
+    });
+  });
+
+  describe("getProcessedResourceAmount counter override", () => {
+    const auraState: GameState = {
+      ...SPRING_STATE,
+      bumpkin: {
+        ...SPRING_STATE.bumpkin!,
+        equipped: {
+          ...SPRING_STATE.bumpkin!.equipped,
+          aura: "Bubble Aura",
+        },
+      },
+    };
+
+    // Predictor scenario: two pending same-resource jobs are forecast in a
+    // single batch by passing successive counter values. Each counter must
+    // drive its own independent Bubble Aura roll — they must not correlate.
+    it("uses the explicit counter so adjacent values can produce different rolls", () => {
+      const { prngChance } = jest.requireActual(
+        "lib/prng",
+      ) as typeof import("lib/prng");
+      const { KNOWN_IDS } = jest.requireActual(
+        "features/game/types",
+      ) as typeof import("features/game/types");
+      const farmId = 42;
+
+      let hitCounter = -1;
+      let missCounter = -1;
+      for (let c = 0; c < 500; c++) {
+        const roll = prngChance({
+          farmId,
+          itemId: KNOWN_IDS["Fish Flake"],
+          counter: c,
+          chance: 20,
+          criticalHitName: "Bubble Aura",
+        });
+        if (roll && hitCounter === -1) hitCounter = c;
+        if (!roll && missCounter === -1) missCounter = c;
+        if (hitCounter !== -1 && missCounter !== -1) break;
+      }
+      expect(hitCounter).toBeGreaterThanOrEqual(0);
+      expect(missCounter).toBeGreaterThanOrEqual(0);
+
+      const hit = getProcessedResourceAmount({
+        game: auraState,
+        resource: "Fish Flake",
+        farmId,
+        counter: hitCounter,
+      });
+      const miss = getProcessedResourceAmount({
+        game: auraState,
+        resource: "Fish Flake",
+        farmId,
+        counter: missCounter,
+      });
+
+      expect(hit.amount).toEqual(new Decimal(2));
+      expect(hit.boostsUsed).toEqual([{ name: "Bubble Aura", value: "+1" }]);
+      expect(miss.amount).toEqual(new Decimal(1));
+      expect(miss.boostsUsed).toEqual([]);
+    });
+
+    it("ignores farmActivity when an explicit counter is passed", () => {
+      const { prngChance } = jest.requireActual(
+        "lib/prng",
+      ) as typeof import("lib/prng");
+      const { KNOWN_IDS } = jest.requireActual(
+        "features/game/types",
+      ) as typeof import("features/game/types");
+      const farmId = 42;
+
+      let hitCounter = -1;
+      let missCounter = -1;
+      for (let c = 0; c < 500; c++) {
+        const roll = prngChance({
+          farmId,
+          itemId: KNOWN_IDS["Fish Flake"],
+          counter: c,
+          chance: 20,
+          criticalHitName: "Bubble Aura",
+        });
+        if (roll && hitCounter === -1) hitCounter = c;
+        if (!roll && missCounter === -1) missCounter = c;
+        if (hitCounter !== -1 && missCounter !== -1) break;
+      }
+
+      // farmActivity says the hit counter, but caller threads the miss counter.
+      const stateWithHitActivity: GameState = {
+        ...auraState,
+        farmActivity: {
+          ...auraState.farmActivity,
+          "Fish Flake Processed": hitCounter,
+        },
+      };
+
+      const result = getProcessedResourceAmount({
+        game: stateWithHitActivity,
+        resource: "Fish Flake",
+        farmId,
+        counter: missCounter,
+      });
+      expect(result.amount).toEqual(new Decimal(1));
+      expect(result.boostsUsed).toEqual([]);
     });
   });
 });

--- a/src/features/game/events/landExpansion/collectProcessedResource.ts
+++ b/src/features/game/events/landExpansion/collectProcessedResource.ts
@@ -38,11 +38,10 @@ export function getProcessedResourceAmount({
   game: GameState;
   resource: ProcessedResource;
   farmId: number;
-  // PRNG counter seed for the Bubble Aura roll. Callers that don't
-  // care about precise batch prediction can pass
-  // `game.farmActivity[`${resource} Processed`] ?? 0`; callers that
-  // predict a batch of pending jobs thread their own per-slot counter
-  // so successive same-resource jobs roll independent dice.
+  // Processed count for this resource *before* this item is collected.
+  // In-game callers pass `farmActivity[`${resource} Processed`] ?? 0`.
+  // Batch predictors must increment this per same-resource slot so
+  // successive jobs roll independent Bubble Aura dice.
   counter: number;
 }): { amount: Decimal; boostsUsed: { name: BoostName; value: string }[] } {
   let amount = new Decimal(1);

--- a/src/features/game/events/landExpansion/collectProcessedResource.ts
+++ b/src/features/game/events/landExpansion/collectProcessedResource.ts
@@ -33,10 +33,17 @@ export function getProcessedResourceAmount({
   game,
   resource,
   farmId,
+  counter,
 }: {
   game: GameState;
   resource: ProcessedResource;
   farmId: number;
+  // PRNG counter seed for the Bubble Aura roll. Callers that don't
+  // care about precise batch prediction can pass
+  // `game.farmActivity[`${resource} Processed`] ?? 0`; callers that
+  // predict a batch of pending jobs thread their own per-slot counter
+  // so successive same-resource jobs roll independent dice.
+  counter: number;
 }): { amount: Decimal; boostsUsed: { name: BoostName; value: string }[] } {
   let amount = new Decimal(1);
   const boostsUsed: { name: BoostName; value: string }[] = [];
@@ -46,7 +53,7 @@ export function getProcessedResourceAmount({
     prngChance({
       farmId,
       itemId: KNOWN_IDS[resource],
-      counter: game.farmActivity[`${resource} Processed`] ?? 0,
+      counter,
       chance: 20,
       criticalHitName: "Bubble Aura",
     })
@@ -98,10 +105,12 @@ export function collectProcessedResource({
     const boostsUsed: { name: BoostName; value: string }[] = [];
 
     ready.forEach((processed) => {
+      const resource = processed.name as ProcessedResource;
       const { amount, boostsUsed: itemBoosts } = getProcessedResourceAmount({
         game,
-        resource: processed.name as ProcessedResource,
+        resource,
         farmId,
+        counter: game.farmActivity[`${resource} Processed`] ?? 0,
       });
       boostsUsed.push(...itemBoosts);
 

--- a/src/features/game/events/landExpansion/speedUpProcessing.ts
+++ b/src/features/game/events/landExpansion/speedUpProcessing.ts
@@ -81,10 +81,12 @@ export const speedUpProcessing = ({
       game = makeGemHistory({ game, amount: gems, createdAt });
     }
 
+    const resource = currentProcessingItem.name as ProcessedResource;
     const { amount, boostsUsed } = getProcessedResourceAmount({
       game,
-      resource: currentProcessingItem.name as ProcessedResource,
+      resource,
       farmId,
+      counter: game.farmActivity[`${resource} Processed`] ?? 0,
     });
 
     game.inventory[currentProcessingItem.name] = (


### PR DESCRIPTION
## Summary

- `getProcessedResourceAmount` now **requires** a `counter` argument (previously seeded internally from `farmActivity`).
- Both in-tree callers (`collectProcessedResource`, `speedUpProcessing`) are updated to pass `game.farmActivity[\`${resource} Processed\`] ?? 0`, preserving prior runtime behaviour.

## Why

Today the function seeds its PRNG counter from `farmActivity` directly, so any caller predicting a *batch* of pending Fish Market jobs ends up rolling every same-resource slot against the same counter — Bubble Aura appears to fire on all of them or none, never advancing one slot at a time. External predictors (overview dashboards, speed-up-quote helpers, future bulk-collect support) need to thread their own per-slot counter.

Counter is required rather than optional because the optional default hid the bug — explicit is safer when there are only two call sites to update.

## Breaking change

Callers of `getProcessedResourceAmount` must pass `counter`. The two in-tree callers are updated in this PR.

## Test plan

- [ ] Existing `collectProcessedResource` / `speedUpProcessing` unit tests pass — behaviour is unchanged when the explicit counter matches what `farmActivity` would have provided.
- [ ] Manual: confirm Bubble Aura roll outcome matches `prngChance` invoked with the same `farmId / itemId / counter` triple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Processing now uses per-item counters for randomness that affects Bubble Aura boosts, improving consistency and allowing explicit counter overrides without changing gameplay balance.
* **Tests**
  * Added tests to validate counter overrides and independent randomness per processed item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7260)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->