### PR TITLE
feat!: surface boostsUsed from getCookingAmount

### DIFF
--- a/src/features/game/events/landExpansion/collectRecipe.test.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.test.ts
@@ -312,4 +312,119 @@ describe("collect Recipes", () => {
 
     expect(state.inventory["Boiled Eggs"]).toEqual(new Decimal(3));
   });
+
+  describe("boostsUsedAt tracking", () => {
+    it("records Double Nom in boostsUsedAt when it adds yield", () => {
+      const state = collectRecipe({
+        farmId,
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Fire Pit": [
+              {
+                id: "123",
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                readyAt: 0,
+                crafting: [
+                  {
+                    name: "Boiled Eggs",
+                    readyAt: dateNow - 5 * 1000,
+                    skills: { "Double Nom": true },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipes.collected",
+          building: "Fire Pit",
+          buildingId: "123",
+        },
+        createdAt: dateNow,
+      });
+
+      expect(state.boostsUsedAt?.["Double Nom"]).toBe(dateNow);
+    });
+
+    it("records Fiery Jackpot in boostsUsedAt on a deterministic prng hit", () => {
+      const state = collectRecipe({
+        farmId,
+        state: {
+          ...GAME_STATE,
+          buildings: {
+            "Fire Pit": [
+              {
+                id: "123",
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                readyAt: 0,
+                crafting: [
+                  {
+                    name: "Boiled Eggs",
+                    readyAt: dateNow - 5 * 1000,
+                  },
+                ],
+              },
+            ],
+          },
+          bumpkin: {
+            ...GAME_STATE.bumpkin,
+            skills: { "Fiery Jackpot": 1 },
+          } as GameState["bumpkin"],
+          farmActivity: {
+            "Boiled Eggs Cooked": getPrngCounter(
+              "Boiled Eggs",
+              "Fiery Jackpot",
+              20,
+            ),
+          },
+        },
+        action: {
+          type: "recipes.collected",
+          building: "Fire Pit",
+          buildingId: "123",
+        },
+        createdAt: dateNow,
+      });
+
+      expect(state.boostsUsedAt?.["Fiery Jackpot"]).toBe(dateNow);
+    });
+
+    it("leaves boostsUsedAt undefined when no cooking boost fires", () => {
+      const fresh: GameState = { ...GAME_STATE, boostsUsedAt: undefined };
+
+      const state = collectRecipe({
+        farmId,
+        state: {
+          ...fresh,
+          buildings: {
+            "Fire Pit": [
+              {
+                id: "123",
+                coordinates: { x: 1, y: 1 },
+                createdAt: 0,
+                readyAt: 0,
+                crafting: [
+                  {
+                    name: "Boiled Eggs",
+                    readyAt: dateNow - 5 * 1000,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        action: {
+          type: "recipes.collected",
+          building: "Fire Pit",
+          buildingId: "123",
+        },
+        createdAt: dateNow,
+      });
+
+      expect(state.boostsUsedAt).toBeUndefined();
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -3,13 +3,18 @@ import { KNOWN_IDS } from "features/game/types";
 import { BuildingName } from "features/game/types/buildings";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 
-import { BuildingProduct, GameState } from "features/game/types/game";
+import {
+  BoostName,
+  BuildingProduct,
+  GameState,
+} from "features/game/types/game";
 import { produce } from "immer";
 import { translate } from "lib/i18n/translate";
 import { prngChance } from "lib/prng";
-import { isCookingBuilding } from "./cook";
+import { isCookingBuilding } from "./isCookingBuilding";
 import { isWearableActive } from "features/game/lib/wearables";
 import { assertCookableName } from "features/game/types/consumables";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type CollectRecipeAction = {
   type: "recipes.collected";
@@ -36,13 +41,15 @@ export const getCookingAmount = ({
   farmId: number;
   counter: number;
   game: GameState;
-}): number => {
+}): { amount: number; boostsUsed: { name: BoostName; value: string }[] } => {
   const recipeName = assertCookableName(recipe.name);
   let amount = 1;
+  const boostsUsed: { name: BoostName; value: string }[] = [];
 
   // Double Nom - Guarantee +1 food
   if (recipe.skills?.["Double Nom"] && isCookingBuilding(building)) {
     amount += 1;
+    boostsUsed.push({ name: "Double Nom", value: "+1" });
   }
 
   // Fiery Jackpot - 20% Chance to double the amount from Fire Pit
@@ -58,6 +65,7 @@ export const getCookingAmount = ({
     })
   ) {
     amount += 1;
+    boostsUsed.push({ name: "Fiery Jackpot", value: "+1" });
   }
 
   if (
@@ -71,9 +79,10 @@ export const getCookingAmount = ({
     })
   ) {
     amount += 1;
+    boostsUsed.push({ name: "Master Chef's Cleaver", value: "+1" });
   }
 
-  return amount;
+  return { amount, boostsUsed };
 };
 
 export function collectRecipe({
@@ -112,7 +121,7 @@ export function collectRecipe({
       if (recipe.readyAt <= createdAt) {
         const cookableName = assertCookableName(recipe.name);
 
-        const amount = getCookingAmount({
+        const { amount, boostsUsed } = getCookingAmount({
           building: action.building,
           game,
           recipe,
@@ -126,6 +135,12 @@ export function collectRecipe({
           `${cookableName} Cooked`,
           game.farmActivity,
         );
+
+        game.boostsUsedAt = updateBoostUsed({
+          game,
+          boostNames: boostsUsed,
+          createdAt,
+        });
 
         return acc;
       }

--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -136,11 +136,13 @@ export function collectRecipe({
           game.farmActivity,
         );
 
-        game.boostsUsedAt = updateBoostUsed({
-          game,
-          boostNames: boostsUsed,
-          createdAt,
-        });
+        if (boostsUsed.length > 0) {
+          game.boostsUsedAt = updateBoostUsed({
+            game,
+            boostNames: boostsUsed,
+            createdAt,
+          });
+        }
 
         return acc;
       }

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -272,11 +272,13 @@ export function cook({
         stateCopy.farmActivity,
       );
 
-      stateCopy.boostsUsedAt = updateBoostUsed({
-        game: stateCopy,
-        boostNames: boostsUsed,
-        createdAt,
-      });
+      if (boostsUsed.length > 0) {
+        stateCopy.boostsUsedAt = updateBoostUsed({
+          game: stateCopy,
+          boostNames: boostsUsed,
+          createdAt,
+        });
+      }
 
       return stateCopy;
     }

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -23,6 +23,7 @@ import { BUILDING_DAILY_OIL_CAPACITY } from "./supplyCookingOil";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import { getCookingAmount } from "./collectRecipe";
+import { isCookingBuilding } from "./isCookingBuilding";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 
 export type RecipeCookedAction = {
@@ -55,11 +56,11 @@ export const BUILDING_OIL_BOOSTS: (
   Deli: skills["Fry Frenzy"] ? 0.6 : 0.4,
 });
 
-export function isCookingBuilding(
-  building: BuildingName,
-): building is CookingBuildingName {
-  return Object.keys(BUILDING_DAILY_OIL_CAPACITY).includes(building);
-}
+// `isCookingBuilding` lives in ./isCookingBuilding so cook.ts and
+// collectRecipe.ts can both import it without forming a Vite-fragile
+// circular import. Re-exported here for backwards compatibility with
+// downstream callers.
+export { isCookingBuilding };
 
 export function getCookingOilBoost(
   item: CookableName,
@@ -251,7 +252,7 @@ export function cook({
     );
 
     if (isInstantFishRecipe(item)) {
-      const amount = getCookingAmount({
+      const { amount, boostsUsed } = getCookingAmount({
         building: requiredBuilding,
         game: stateCopy,
         recipe: {
@@ -270,6 +271,12 @@ export function cook({
         `${item} Cooked`,
         stateCopy.farmActivity,
       );
+
+      stateCopy.boostsUsedAt = updateBoostUsed({
+        game: stateCopy,
+        boostNames: boostsUsed,
+        createdAt,
+      });
 
       return stateCopy;
     }

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -14,12 +14,8 @@ import {
 import { getCookingTime } from "features/game/expansion/lib/boosts";
 import { setPrecision } from "lib/utils/formatNumber";
 import { translate } from "lib/i18n/translate";
-import {
-  BuildingName,
-  CookingBuildingName,
-} from "features/game/types/buildings";
+import { CookingBuildingName } from "features/game/types/buildings";
 import { produce } from "immer";
-import { BUILDING_DAILY_OIL_CAPACITY } from "./supplyCookingOil";
 import { hasVipAccess } from "features/game/lib/vipAccess";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import { getCookingAmount } from "./collectRecipe";
@@ -55,12 +51,6 @@ export const BUILDING_OIL_BOOSTS: (
   Bakery: 0.35,
   Deli: skills["Fry Frenzy"] ? 0.6 : 0.4,
 });
-
-// `isCookingBuilding` lives in ./isCookingBuilding so cook.ts and
-// collectRecipe.ts can both import it without forming a Vite-fragile
-// circular import. Re-exported here for backwards compatibility with
-// downstream callers.
-export { isCookingBuilding };
 
 export function getCookingOilBoost(
   item: CookableName,

--- a/src/features/game/events/landExpansion/isCookingBuilding.ts
+++ b/src/features/game/events/landExpansion/isCookingBuilding.ts
@@ -1,0 +1,12 @@
+import { BuildingName, CookingBuildingName } from "features/game/types/buildings";
+import { BUILDING_DAILY_OIL_CAPACITY } from "./supplyCookingOil";
+
+// Lives in its own file so `collectRecipe.ts` can import it without
+// pulling in the rest of `cook.ts` — that bigger module imports
+// `getCookingAmount` from `collectRecipe`, and the bi-directional
+// import is fragile under Vite HMR.
+export function isCookingBuilding(
+  building: BuildingName,
+): building is CookingBuildingName {
+  return Object.keys(BUILDING_DAILY_OIL_CAPACITY).includes(building);
+}

--- a/src/features/game/events/landExpansion/speedUpRecipe.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.ts
@@ -119,11 +119,13 @@ export function speedUpRecipe({
       game.farmActivity,
     );
 
-    game.boostsUsedAt = updateBoostUsed({
-      game,
-      boostNames: boostsUsed,
-      createdAt,
-    });
+    if (boostsUsed.length > 0) {
+      game.boostsUsedAt = updateBoostUsed({
+        game,
+        boostNames: boostsUsed,
+        createdAt,
+      });
+    }
 
     return game;
   });

--- a/src/features/game/events/landExpansion/speedUpRecipe.ts
+++ b/src/features/game/events/landExpansion/speedUpRecipe.ts
@@ -18,6 +18,7 @@ import {
   makeGemHistory,
   SpeedUpPaymentMethod,
 } from "features/game/lib/getInstantGems";
+import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 
 export type InstantCookRecipe = {
   type: "recipe.spedUp";
@@ -90,7 +91,7 @@ export function speedUpRecipe({
     }
     const cookableName = assertCookableName(recipe.name);
 
-    const amount = getCookingAmount({
+    const { amount, boostsUsed } = getCookingAmount({
       building: action.buildingName,
       game,
       recipe,
@@ -117,6 +118,12 @@ export function speedUpRecipe({
       `${cookableName} Cooked`,
       game.farmActivity,
     );
+
+    game.boostsUsedAt = updateBoostUsed({
+      game,
+      boostNames: boostsUsed,
+      createdAt,
+    });
 
     return game;
   });

--- a/src/features/island/buildings/components/building/BuildingOilTank.tsx
+++ b/src/features/island/buildings/components/building/BuildingOilTank.tsx
@@ -16,7 +16,6 @@ import { BUILDING_DAILY_OIL_CAPACITY } from "features/game/events/landExpansion/
 import {
   BUILDING_DAILY_OIL_CONSUMPTION,
   BUILDING_OIL_BOOSTS,
-  isCookingBuilding,
 } from "features/game/events/landExpansion/cook";
 import { Context } from "features/game/GameProvider";
 import { ModalOverlay } from "components/ui/ModalOverlay";
@@ -26,6 +25,7 @@ import { formatNumber } from "lib/utils/formatNumber";
 import Decimal from "decimal.js-light";
 import { Box } from "components/ui/Box";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
+import { isCookingBuilding } from "features/game/events/landExpansion/isCookingBuilding";
 
 interface OilTankProps {
   buildingName: BuildingName;


### PR DESCRIPTION
## Summary

- `getCookingAmount` now returns `{ amount, boostsUsed }` instead of a bare `number`. Mirrors the shape `getProcessedResourceAmount` returned after #7260.
- The three in-tree callers (`collectRecipe`, `cook` instant-fish branch, `speedUpRecipe`) destructure the new return and forward the boost names through `updateBoostUsed` so cooking boosts are now tracked on the player's `boostsUsedAt` record.

## Why

Two motivations:

1. **No more re-deriving boost conditions externally.** Callers that need to know *which* boosts fired (e.g. an overview dashboard showing per-slot boost dropdowns) had to either replicate the function's conditions locally or skip the feature. Replication is fragile — the moment a new boost is added here, the external copy drifts and the dashboard silently lies. Returning the list is the clean fix.

2. **Cooking boosts are now audit-trail-tracked.** Previously cooking applied Double Nom / Fiery Jackpot / Master Chef's Cleaver silently with no `boostsUsedAt` entry, which made cooldown-gated boosts (and the boost-cooldown timeline as a whole) inconsistent with how processed-resource / animal / composter collectors already report through `updateBoostUsed`. This PR closes that gap.

## Breaking change

Callers of `getCookingAmount` must destructure `{ amount, boostsUsed }` instead of treating the return as a bare number. The three in-tree callers are updated in this PR.

## Test plan

- [ ] Existing `collectRecipe` / `cook` / `speedUpRecipe` unit tests pass — yield amounts are unchanged for every existing scenario.
- [ ] New: after cooking a recipe with Double Nom / Fiery Jackpot / Master Chef's Cleaver active, confirm `boostsUsedAt` contains the relevant entries with the createdAt of the collect event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boost usage is now recorded when cooking, instant-cooking, and speeding up recipes so boost triggers are tracked with collections.

* **Refactor**
  * Cooking-related helpers were reorganized for clearer usage across components and cooking flows.

* **Tests**
  * Added tests verifying boost recording behavior, deterministic jackpot handling, and no-record cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7261)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->