### PR TITLE
[FEAT] surface boostsUsed from generateDeliveryTickets

### DIFF
--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1949,54 +1949,62 @@ describe("deliver", () => {
 
   it("surfaces boostsUsed entries for each contributing source", () => {
     // Bull Run chapter (Cowboy Hat is a chapter ticket boost item).
+    // Fake timers are required: `getActiveCalendarEvent` reads the real
+    // clock to gate the Double Delivery window. Restore real timers in
+    // the finally so this test does not leak state into later tests.
     const mockDate = new Date("2024-11-25T00:00:01Z");
+    const now = mockDate.getTime();
     jest.useFakeTimers();
     jest.setSystemTime(mockDate);
-    const now = mockDate.getTime();
-    const game: GameState = {
-      ...INITIAL_FARM,
-      inventory: {
-        ...INITIAL_FARM.inventory,
-        "Lifetime Farmer Banner": new Decimal(1),
-      },
-      bumpkin: {
-        ...TEST_BUMPKIN,
-        equipped: {
-          ...TEST_BUMPKIN.equipped,
-          hat: "Cowboy Hat",
+
+    try {
+      const game: GameState = {
+        ...INITIAL_FARM,
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Lifetime Farmer Banner": new Decimal(1),
         },
-      },
-      npcs: {},
-      calendar: {
-        dates: [
-          {
-            name: "doubleDelivery",
-            date: new Date(now).toISOString().substring(0, 10),
+        bumpkin: {
+          ...TEST_BUMPKIN,
+          equipped: {
+            ...TEST_BUMPKIN.equipped,
+            hat: "Cowboy Hat",
           },
-        ],
-        doubleDelivery: {
-          triggeredAt: now,
-          startedAt: now,
         },
-      },
-    };
+        npcs: {},
+        calendar: {
+          dates: [
+            {
+              name: "doubleDelivery",
+              date: new Date(now).toISOString().substring(0, 10),
+            },
+          ],
+          doubleDelivery: {
+            triggeredAt: now,
+            startedAt: now,
+          },
+        },
+      };
 
-    const { amount, boostsUsed } = generateDeliveryTickets({
-      game,
-      npc: "pumpkin' pete",
-      now,
-    });
+      const { amount, boostsUsed } = generateDeliveryTickets({
+        game,
+        npc: "pumpkin' pete",
+        now,
+      });
 
-    // base 1 + VIP 2 + Cowboy Hat 1 = 4, then doubleDelivery * 2 = 8.
-    expect(amount).toEqual(8);
-    expect(boostsUsed).toEqual(
-      expect.arrayContaining([
-        { name: "VIP Access", value: "+2" },
-        { name: "Cowboy Hat", value: "+1" },
-        { name: "Double Delivery", value: "x2" },
-      ]),
-    );
-    expect(boostsUsed).toHaveLength(3);
+      // base 1 + VIP 2 + Cowboy Hat 1 = 4, then doubleDelivery * 2 = 8.
+      expect(amount).toEqual(8);
+      expect(boostsUsed).toEqual(
+        expect.arrayContaining([
+          { name: "VIP Access", value: "+2" },
+          { name: "Cowboy Hat", value: "+1" },
+          { name: "Double Delivery", value: "x2" },
+        ]),
+      );
+      expect(boostsUsed).toHaveLength(3);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("returns empty boostsUsed for a coin NPC", () => {

--- a/src/features/game/events/landExpansion/deliver.test.ts
+++ b/src/features/game/events/landExpansion/deliver.test.ts
@@ -1943,8 +1943,78 @@ describe("deliver", () => {
         game,
         npc: "betty",
         now,
-      }),
+      }).amount,
     ).toEqual(0);
+  });
+
+  it("surfaces boostsUsed entries for each contributing source", () => {
+    // Bull Run chapter (Cowboy Hat is a chapter ticket boost item).
+    const mockDate = new Date("2024-11-25T00:00:01Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(mockDate);
+    const now = mockDate.getTime();
+    const game: GameState = {
+      ...INITIAL_FARM,
+      inventory: {
+        ...INITIAL_FARM.inventory,
+        "Lifetime Farmer Banner": new Decimal(1),
+      },
+      bumpkin: {
+        ...TEST_BUMPKIN,
+        equipped: {
+          ...TEST_BUMPKIN.equipped,
+          hat: "Cowboy Hat",
+        },
+      },
+      npcs: {},
+      calendar: {
+        dates: [
+          {
+            name: "doubleDelivery",
+            date: new Date(now).toISOString().substring(0, 10),
+          },
+        ],
+        doubleDelivery: {
+          triggeredAt: now,
+          startedAt: now,
+        },
+      },
+    };
+
+    const { amount, boostsUsed } = generateDeliveryTickets({
+      game,
+      npc: "pumpkin' pete",
+      now,
+    });
+
+    // base 1 + VIP 2 + Cowboy Hat 1 = 4, then doubleDelivery * 2 = 8.
+    expect(amount).toEqual(8);
+    expect(boostsUsed).toEqual(
+      expect.arrayContaining([
+        { name: "VIP Access", value: "+2" },
+        { name: "Cowboy Hat", value: "+1" },
+        { name: "Double Delivery", value: "x2" },
+      ]),
+    );
+    expect(boostsUsed).toHaveLength(3);
+  });
+
+  it("returns empty boostsUsed for a coin NPC", () => {
+    const now = new Date("2026-02-20T00:00:01Z").getTime();
+    const game: GameState = {
+      ...INITIAL_FARM,
+      npcs: {},
+      calendar: { dates: [] },
+    };
+
+    const { amount, boostsUsed } = generateDeliveryTickets({
+      game,
+      npc: "betty",
+      now,
+    });
+
+    expect(amount).toEqual(0);
+    expect(boostsUsed).toEqual([]);
   });
 
   it("returns 0 tickets for coin NPC even when double delivery is active", () => {
@@ -1966,7 +2036,7 @@ describe("deliver", () => {
       },
     };
 
-    const tickets = generateDeliveryTickets({
+    const { amount: tickets } = generateDeliveryTickets({
       game,
       npc: "betty",
       now,

--- a/src/features/game/events/landExpansion/deliver.ts
+++ b/src/features/game/events/landExpansion/deliver.ts
@@ -64,14 +64,16 @@ export function generateDeliveryTickets({
   game: GameState;
   npc: NPCName;
   now: number;
-}) {
+}): { amount: number; boostsUsed: { name: BoostName; value: string }[] } {
   let amount = 0;
+  const boostsUsed: { name: BoostName; value: string }[] = [];
 
   if (isTicketNPC(npc)) {
     amount = TICKET_REWARDS[npc];
 
     if (hasVipAccess({ game, now })) {
       amount += 2;
+      boostsUsed.push({ name: "VIP Access", value: "+2" });
     }
 
     const chapter = getCurrentChapter(now);
@@ -81,17 +83,19 @@ export function generateDeliveryTickets({
       if (isCollectible(item)) {
         if (isCollectibleBuilt({ game, name: item })) {
           amount += 1;
+          boostsUsed.push({ name: item, value: "+1" });
         }
       } else {
         if (isWearableActive({ game, name: item })) {
           amount += 1;
+          boostsUsed.push({ name: item, value: "+1" });
         }
       }
     });
   }
 
   if (!amount) {
-    return 0;
+    return { amount: 0, boostsUsed };
   }
 
   const completedAt = game.npcs?.[npc]?.deliveryCompletedAt;
@@ -108,9 +112,10 @@ export function generateDeliveryTickets({
     !hasClaimedBonus
   ) {
     amount *= 2;
+    boostsUsed.push({ name: "Double Delivery", value: "x2" });
   }
 
-  return amount;
+  return { amount, boostsUsed };
 }
 
 export type DeliverOrderAction = {
@@ -330,6 +335,7 @@ export function getOrderSellPrice<T>(
     !hasClaimedBonus
   ) {
     mul *= 2;
+    boostsUsed.push({ name: "Double Delivery", value: "x2" });
   }
 
   if (order.reward.sfl) {
@@ -402,7 +408,7 @@ export function deliverOrder({
 
     const isQuestTicketOrder = !!TICKET_REWARDS[order.from as QuestNPCName];
 
-    const tickets = generateDeliveryTickets({
+    const { amount: tickets } = generateDeliveryTickets({
       game,
       npc: order.from,
       now: createdAt,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1806,7 +1806,8 @@ export type SpecialBoostName =
   | "Tier 3 Bonus"
   | "Streak Bonus"
   | "Bee Swarm Bonus"
-  | "Building Oil";
+  | "Building Oil"
+  | "Double Delivery";
 
 export type BoostUsedAt = Partial<Record<BoostName, number>>;
 

--- a/src/features/island/delivery/components/OrderCard.tsx
+++ b/src/features/island/delivery/components/OrderCard.tsx
@@ -64,7 +64,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
   const todayDate = new Date(now).toISOString().split("T")[0];
   const isHoliday = holiday === todayDate;
 
-  const baseTickets = generateDeliveryTickets({
+  const { amount: baseTickets } = generateDeliveryTickets({
     game: state,
     npc: npcName,
     now,

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -247,7 +247,7 @@ export const DeliveryOrders: React.FC<Props> = ({
     .sort((a, b) => (NPC_DELIVERY_LEVELS[a] > NPC_DELIVERY_LEVELS[b] ? 1 : -1))
     .find((npc) => level < (NPC_DELIVERY_LEVELS?.[npc] ?? 0));
 
-  const baseTickets = generateDeliveryTickets({
+  const { amount: baseTickets } = generateDeliveryTickets({
     game: state,
     npc: previewOrder.from,
     now,

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -96,7 +96,7 @@ const OrderCard: React.FC<{
   const { holiday } = getBumpkinHoliday({ now });
   const isHoliday = holiday === new Date(now).toISOString().split("T")[0];
 
-  const baseTickets = generateDeliveryTickets({
+  const { amount: baseTickets } = generateDeliveryTickets({
     game,
     npc: order.from,
     now,
@@ -791,7 +791,7 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
   const positive = useRandomItem(dialogue.positiveDelivery);
   const noOrder = useRandomItem(dialogue.noOrder);
 
-  const baseTickets = generateDeliveryTickets({
+  const { amount: baseTickets } = generateDeliveryTickets({
     game,
     npc,
     now,


### PR DESCRIPTION
## Summary

- `generateDeliveryTickets` now returns `{ amount, boostsUsed: { name, value }[] }` so callers can render *which* boosts contributed without re-deriving the VIP / chapter-item / Double Delivery conditions.
- Same shape pattern as `getOrderSellPrice` and `getCookingAmount` (#7261).
- Pushes `"Double Delivery"` onto `getOrderSellPrice.boostsUsed` too — the calendar-event multiplier was previously silent in that function's boost list even though it doubled the reward. Adds `"Double Delivery"` to `SpecialBoostName`.
- Updates all four direct callers (`BumpkinDelivery.tsx`, `Orders.tsx`, `OrderCard.tsx`, in-file reducer) to destructure `.amount`.

## Why

External predictors (and the in-game Bumpkin delivery panel itself, if a future PR wants to show a boost breakdown) need the boost list to render reward boost icons consistently with cooking / order-sell-price. Today the only options are replicate the conditions locally or skip the feature — replication silently rots the moment a new boost lands here.

## Breaking change

Callers of `generateDeliveryTickets` must destructure `{ amount, boostsUsed }` instead of treating the return as a bare number. All in-repo callers are updated in this PR.

## Test plan

- [x] `npx jest deliver.test.ts` — 59/59 pass, including two new tests:
  - asserts `boostsUsed` contains VIP Access / Cowboy Hat / Double Delivery entries with correct `value` strings, and the multiplied `amount` matches `(base + flat) * 2`
  - asserts `boostsUsed` is empty for a coin NPC
- [x] `npx tsc --noEmit -p .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Double Delivery" boost and surfaced all active boost sources in delivery results (e.g., VIP, wearable bonuses).

* **Refactor**
  * Delivery calculation now returns a structured result with ticket amount and list of applied boosts; UI now reads the ticket amount from that structure.

* **Tests**
  * Tests updated to validate the new result shape, boost listings, doubled amounts, and coin-NPC zero-ticket behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7263)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->