### PR TITLE
[FIX] Record boostsUsedAt when feeding with Golden Cow/Sheep/Egg

### DIFF
--- a/src/features/game/events/landExpansion/feedAnimal.test.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.test.ts
@@ -2061,4 +2061,111 @@ describe("feedAnimal", () => {
 
     expect(state.inventory["Kernel Blend"]).toEqual(new Decimal(1.25));
   });
+
+  it("records Golden Cow in boostsUsedAt when feeding a cow for free", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...GAME_STATE,
+        collectibles: {
+          "Golden Cow": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...GAME_STATE.barn,
+          animals: {
+            "0": {
+              ...GAME_STATE.barn.animals["0"],
+              type: "Cow",
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Cow",
+        id: "0",
+      },
+    });
+
+    expect(state.boostsUsedAt?.["Golden Cow"]).toEqual(now);
+  });
+
+  it("records Golden Sheep in boostsUsedAt when feeding a sheep for free", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...GAME_STATE,
+        collectibles: {
+          "Golden Sheep": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        barn: {
+          ...GAME_STATE.barn,
+          animals: {
+            "0": {
+              ...GAME_STATE.barn.animals["0"],
+              type: "Sheep",
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Sheep",
+        id: "0",
+      },
+    });
+
+    expect(state.boostsUsedAt?.["Golden Sheep"]).toEqual(now);
+  });
+
+  it("records Gold Egg in boostsUsedAt when feeding a chicken for free", () => {
+    const state = feedAnimal({
+      createdAt: now,
+      state: {
+        ...GAME_STATE,
+        collectibles: {
+          "Gold Egg": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              readyAt: 0,
+              createdAt: 0,
+            },
+          ],
+        },
+        henHouse: {
+          ...GAME_STATE.henHouse,
+          animals: {
+            "0": {
+              ...GAME_STATE.henHouse.animals["0"],
+              experience: 0,
+            },
+          },
+        },
+      },
+      action: {
+        type: "animal.fed",
+        animal: "Chicken",
+        id: "0",
+      },
+    });
+
+    expect(state.boostsUsedAt?.["Gold Egg"]).toEqual(now);
+  });
 });

--- a/src/features/game/events/landExpansion/feedAnimal.ts
+++ b/src/features/game/events/landExpansion/feedAnimal.ts
@@ -267,7 +267,11 @@ export function feedAnimal({
 
     // Handle Golden Egg Free Food
     if (action.animal === "Chicken" && hasGoldenEggPlaced) {
-      boostsUsed.push({ name: "Gold Egg", value: "Free" });
+      copy.boostsUsedAt = updateBoostUsed({
+        game: copy,
+        boostNames: [{ name: "Gold Egg", value: "Free" }],
+        createdAt,
+      });
       return handleFreeFeeding({
         animal,
         animalType: action.animal,
@@ -278,7 +282,11 @@ export function feedAnimal({
 
     // Handle Golden Cow Free Food
     if (action.animal === "Cow" && hasGoldenCowPlaced) {
-      boostsUsed.push({ name: "Golden Cow", value: "Free" });
+      copy.boostsUsedAt = updateBoostUsed({
+        game: copy,
+        boostNames: [{ name: "Golden Cow", value: "Free" }],
+        createdAt,
+      });
       return handleFreeFeeding({
         animal,
         animalType: action.animal,
@@ -289,7 +297,11 @@ export function feedAnimal({
 
     // Handle Golden Sheep Free Food
     if (action.animal === "Sheep" && hasGoldenSheepPlaced) {
-      boostsUsed.push({ name: "Golden Sheep", value: "Free" });
+      copy.boostsUsedAt = updateBoostUsed({
+        game: copy,
+        boostNames: [{ name: "Golden Sheep", value: "Free" }],
+        createdAt,
+      });
       return handleFreeFeeding({
         animal,
         animalType: action.animal,


### PR DESCRIPTION
## Summary

Gold Egg, Golden Cow and Golden Sheep weren't writing `boostsUsedAt` when their free-feed boost was used. That bypasses the 1-day withdraw cooldown defined in `withdrawRestrictions.ts`. A player could place the NFT, use the free-feed, withdraw the NFT immediately, and move or trade it to another farm, repeating the same boost across farms without any cooldown ever locking the NFT in place.

## Context / motivation

`hasBoostRestriction` (in `src/features/game/types/withdrawRestrictions.ts`) is the gate the Withdraw flows use to block taking a boost item off the farm too soon after its boost was applied. It reads `boostsUsedAt[name]` and compares against the configured cooldown (defaults to 1 day if the name isn't listed in `BOOST_COOLDOWN_DAYS`). If `boostsUsedAt[name]` is `undefined`, it returns `{ isRestricted: false }`, so the NFT is free to leave.

In `src/features/game/events/landExpansion/feedAnimal.ts`, the three Golden free-feed branches push the boost name into a local `boostsUsed` array and then `return handleFreeFeeding(...)` immediately. `handleFreeFeeding` never touches `boostsUsedAt`. The `copy.boostsUsedAt = updateBoostUsed(...)` line that actually writes the timestamp only lives in the Barn Delight cure path and the regular feeding path. Both are unreachable from the Golden flow.

Result: `boostsUsedAt["Gold Egg" | "Golden Cow" | "Golden Sheep"]` was always `undefined`, so `hasBoostRestriction` always returned `isRestricted: false` for these three items, and the withdraw cooldown was effectively off.

The fix calls `updateBoostUsed` in each Golden branch before the early return. Same shape Barn Delight (line 235) and regular feeding (line 353) already use.

## How to test

1. Place a Golden Cow on the farm and feed a Cow with the free-feed boost.
2. Check `state.boostsUsedAt["Golden Cow"]`. It should equal the feed timestamp.
3. Open the Withdraw screen and try to withdraw the Golden Cow. It should be blocked for the next 24 h (default cooldown from `BOOST_COOLDOWN_DAYS`).
4. Same flow for Golden Sheep + Sheep and Gold Egg + Chicken.
5. `yarn test src/features/game/events/landExpansion/feedAnimal.test.ts`. 56 pass, including 3 new tests added in this PR that assert `boostsUsedAt[name]` is written after a free-feed.

## Screenshots or screen recording

N/A. Logic only.

## Related issues

N/A

---

## Checklist

### PR and scope
- [x] Title uses `[FIX]` prefix
- [x] I have read the contributing guidelines and agree to the T&Cs

### Code quality
- [x] Self-reviewed
- [x] No new comments added beyond what already existed in the file
- [x] No new warnings

### Tests
- [x] Tests added/updated for the change
- [x] `yarn test`, `yarn tsc`, `yarn lint` all pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases verifying proper boost tracking when using free feeding collectibles (Golden Cow, Golden Sheep, Gold Egg)

* **Bug Fixes**
  * Improved boost usage tracking for free feeding collectible effects to ensure correct recording of when boosts are consumed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7265)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->