### PR TITLE
[FEAT] Open server picker from social feed

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -51,6 +51,9 @@ import { Detail } from "./actions/getFollowNetworkDetails";
 import { useNow } from "lib/utils/hooks/useNow";
 import Decimal from "decimal.js-light";
 import { getHelpLimit } from "features/game/types/monuments";
+import { Modal } from "components/ui/Modal";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { PickServer } from "features/island/hud/components/settings-menu/plaza-settings/PickServer";
 
 type Props = {
   type: "world" | "local";
@@ -130,6 +133,7 @@ export const Feed: React.FC<Props> = ({
   const feedRef = useRef<HTMLDivElement>(null);
   const [selectedFilter, setSelectedFilter] = useState<FeedFilter>(getFilter());
   const [searchResults, setSearchResults] = useState<Detail[]>([]);
+  const [showPickServer, setShowPickServer] = useState(false);
 
   const username = useSelector(gameService, _username);
   const token = useSelector(authService, _token);
@@ -275,6 +279,10 @@ export const Feed: React.FC<Props> = ({
     setShowFeed(false);
   };
 
+  const handleServerLabelClick = () => {
+    setShowPickServer(true);
+  };
+
   const showMobileFeed = showFeed && isMobile;
   const showDesktopFeed = showFeed && !isMobile;
   const hideMobileFeed = !showFeed && isMobile;
@@ -293,6 +301,14 @@ export const Feed: React.FC<Props> = ({
       )}
       divRef={feedRef}
     >
+      <Modal show={showPickServer} onHide={() => setShowPickServer(false)}>
+        <CloseButtonPanel
+          title={t("gameOptions.plazaSettings.pickServer")}
+          onClose={() => setShowPickServer(false)}
+        >
+          <PickServer onClose={() => setShowPickServer(false)} />
+        </CloseButtonPanel>
+      </Modal>
       <div className="flex flex-col gap-2 h-full w-full">
         <div className="sticky top-0 flex flex-col z-10 bg-[#e4a672]">
           <div className="flex items-center gap-2 pb-1">
@@ -313,12 +329,14 @@ export const Feed: React.FC<Props> = ({
                 {cheersAvailable.toNumber()}
               </Label>
               {serverLabel && (
-                <span
-                  className="min-w-0 max-w-[56px] shrink truncate text-xxs"
+                <button
+                  type="button"
+                  className="min-w-0 max-w-[56px] shrink cursor-pointer truncate bg-transparent p-0 text-left text-xxs hover:underline"
                   title={serverLabel}
+                  onClick={handleServerLabelClick}
                 >
                   {serverLabel}
-                </span>
+                </button>
               )}
             </div>
             <img


### PR DESCRIPTION
## Summary
- Make the shortened server label in the Social Feed header clickable.
- Open the existing Plaza Settings Pick Server modal directly from the label.
- Reuse the existing PickServer component so server fetching, default server saving, and live MMO server switching stay on the current production path.

## Problem
Players can see their current Plaza server in the Social Feed header, but changing it requires navigating through Game Options -> Plaza Settings -> Change server.

## Solution
Clicking the server label now opens the existing Pick Server flow. The modal has the same server list and selection behavior as the current settings menu entry. It opens directly at the server picker, so only the close button is shown; there is no back arrow because no parent settings screen is mounted.

<img width="740" height="539" alt="image" src="https://github.com/user-attachments/assets/8a755f8a-2009-4143-a979-44f8e9c98d63" />


## Testing
- eslint --quiet src/features/social/Feed.tsx
- git diff --check

Note: full yarn tsc currently fails on an unrelated existing baseline issue in src/features/world/scenes/BeachScene.ts: replaceAll requires an ES2021 lib target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server selection interface improved: clicking the server label now opens a modal where you can select a different server. The modal can be easily closed when done.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->