### PR TITLE
[FIX] Bee swarm boostsUsed ignored stack count

### DIFF
--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -752,15 +752,20 @@ export function getCropYieldAmount({
   }
 
   if (plot?.beeSwarm) {
-    let beeSwarmBonus = 0.2;
-    boostsUsed.push({ name: "Bee Swarm Bonus", value: "+0.2" });
+    const count = plot.beeSwarm.count;
+    let perSwarm = 0.2;
+    boostsUsed.push({
+      name: "Bee Swarm Bonus",
+      value: `+${(0.2 * count).toFixed(1)}`,
+    });
     if (skills["Pollen Power Up"]) {
-      beeSwarmBonus += 0.1;
-      boostsUsed.push({ name: "Pollen Power Up", value: "+0.1" });
+      perSwarm += 0.1;
+      boostsUsed.push({
+        name: "Pollen Power Up",
+        value: `+${(0.1 * count).toFixed(1)}`,
+      });
     }
-    // Multiply by the amount of stacked beeswarms
-    beeSwarmBonus *= plot.beeSwarm.count;
-    amount += beeSwarmBonus;
+    amount += perSwarm * count;
   }
 
   if (crop === "Soybean" && isCollectibleBuilt({ name: "Soybliss", game })) {


### PR DESCRIPTION
## Summary

`getCropYieldAmount` records the Bee Swarm Bonus / Pollen Power Up entries in `boostsUsed` as flat `"+0.2"` / `"+0.1"`, but the actual contribution to `amount` is multiplied by `plot.beeSwarm.count`. With multiple stacked swarms the displayed values understated the real boost.

For example, with `count: 3` and Pollen Power Up active, the harvest gains `+0.9`, but the boost panel showed `+0.2` and `+0.1`.

## Change

Multiply the displayed value by `count` so the recorded boost matches what was added to `amount`. The amount math itself is unchanged.

## Test plan

- [x] Existing test `gives +0.2 beeSwarm bonus when Pollen Power Up skill and beeSwarm on plot` (count: 1) still passes — math is identical at count=1.
- [ ] Manual: harvest a plot with a stacked bee swarm (count > 1) and confirm the Bee Swarm Bonus / Pollen Power Up entries in boostsUsed match the actual yield delta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted bee swarm yield calculations for harvest crops.
  * Fixed Pollen Power Up bonus to only display when the skill is active.
  * Updated bonus scaling calculations to properly account for swarm counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->