### PR TITLE
[FIX] Correct beehive honey readiness UI

### DIFF
--- a/src/features/game/expansion/components/resources/beehive/Beehive.tsx
+++ b/src/features/game/expansion/components/resources/beehive/Beehive.tsx
@@ -117,15 +117,18 @@ export const Beehive: React.FC<Props> = ({ id }) => {
   }, [honeyReady, beehiveService]);
 
   const handleHarvestHoney = () => {
-    if (hive.swarm && honeyReady) {
+    setShowHoneyLevelModal(false);
+
+    const hadSwarm = hive.swarm;
+    const state = gameService.send("beehive.harvested", { id });
+    const updatedHive = state.context.state.beehives[id];
+
+    if (hadSwarm && updatedHive?.swarm === false) {
       setShowSwarmModal(true);
     }
 
-    setShowHoneyLevelModal(false);
-
-    const state = gameService.send("beehive.harvested", { id });
     beehiveService.send("HARVEST_HONEY", {
-      updatedHive: state.context.state.beehives[id],
+      updatedHive,
     });
   };
 

--- a/src/features/game/expansion/components/resources/beehive/beehiveMachine.test.ts
+++ b/src/features/game/expansion/components/resources/beehive/beehiveMachine.test.ts
@@ -33,6 +33,12 @@ describe("beehiveMachine", () => {
     currentSpeed: 0,
   };
 
+  const partialContext: BeehiveContext = {
+    ...context,
+    hive: partialHive,
+    honeyProduced: DEFAULT_HONEY_PRODUCTION_TIME / 2,
+  };
+
   it("exits honey ready when the synced hive is no longer full", () => {
     const service = interpret(beehiveMachine.withContext(context)).start();
 
@@ -40,9 +46,46 @@ describe("beehiveMachine", () => {
 
     service.send("UPDATE_HIVE", { updatedHive: partialHive });
 
+    expect(service.getSnapshot().matches("hiveBuzzing")).toBe(true);
     expect(service.getSnapshot().matches("honeyReady")).toBe(false);
     expect(service.getSnapshot().context.honeyProduced).toBe(
       DEFAULT_HONEY_PRODUCTION_TIME / 2,
+    );
+
+    service.stop();
+  });
+
+  it("keeps honey ready when the synced hive is still full", () => {
+    const service = interpret(beehiveMachine.withContext(context)).start();
+
+    expect(service.getSnapshot().matches("honeyReady")).toBe(true);
+
+    service.send("UPDATE_HIVE", { updatedHive: fullHive });
+
+    expect(service.getSnapshot().matches("honeyReady")).toBe(true);
+    expect(service.getSnapshot().context.honeyProduced).toBe(
+      DEFAULT_HONEY_PRODUCTION_TIME,
+    );
+
+    service.stop();
+  });
+
+  it("starts buzzing when honey is partial and reaches honey ready after a full hive sync", () => {
+    const service = interpret(
+      beehiveMachine.withContext(partialContext),
+    ).start();
+
+    expect(service.getSnapshot().matches("hiveBuzzing")).toBe(true);
+    expect(service.getSnapshot().context.honeyProduced).toBe(
+      DEFAULT_HONEY_PRODUCTION_TIME / 2,
+    );
+
+    service.send("UPDATE_HIVE", { updatedHive: fullHive });
+    service.send("BUZZ");
+
+    expect(service.getSnapshot().matches("honeyReady")).toBe(true);
+    expect(service.getSnapshot().context.honeyProduced).toBe(
+      DEFAULT_HONEY_PRODUCTION_TIME,
     );
 
     service.stop();

--- a/src/features/game/expansion/components/resources/beehive/beehiveMachine.test.ts
+++ b/src/features/game/expansion/components/resources/beehive/beehiveMachine.test.ts
@@ -1,0 +1,50 @@
+import { interpret } from "xstate";
+
+import { TEST_FARM } from "features/game/lib/constants";
+import { DEFAULT_HONEY_PRODUCTION_TIME } from "features/game/lib/updateBeehives";
+import { Beehive } from "features/game/types/game";
+
+import { BeehiveContext, beehiveMachine } from "./beehiveMachine";
+
+describe("beehiveMachine", () => {
+  const fullHive: Beehive = {
+    x: 1,
+    y: 1,
+    swarm: true,
+    honey: {
+      produced: DEFAULT_HONEY_PRODUCTION_TIME,
+      updatedAt: Date.now(),
+    },
+    flowers: [],
+  };
+
+  const partialHive: Beehive = {
+    ...fullHive,
+    honey: {
+      ...fullHive.honey,
+      produced: DEFAULT_HONEY_PRODUCTION_TIME / 2,
+    },
+  };
+
+  const context: BeehiveContext = {
+    gameState: TEST_FARM,
+    hive: fullHive,
+    honeyProduced: DEFAULT_HONEY_PRODUCTION_TIME,
+    currentSpeed: 0,
+  };
+
+  it("exits honey ready when the synced hive is no longer full", () => {
+    const service = interpret(beehiveMachine.withContext(context)).start();
+
+    expect(service.getSnapshot().matches("honeyReady")).toBe(true);
+
+    service.send("UPDATE_HIVE", { updatedHive: partialHive });
+
+    expect(service.getSnapshot().matches("honeyReady")).toBe(false);
+    expect(service.getSnapshot().context.honeyProduced).toBe(
+      DEFAULT_HONEY_PRODUCTION_TIME / 2,
+    );
+
+    service.stop();
+  });
+});

--- a/src/features/game/expansion/components/resources/beehive/beehiveMachine.ts
+++ b/src/features/game/expansion/components/resources/beehive/beehiveMachine.ts
@@ -61,6 +61,26 @@ export type MachineInterpreter = Interpreter<
   BeehiveState
 >;
 
+const isFlowerProducing = (attachedFlower?: AttachedFlower) => {
+  if (!attachedFlower) return false;
+  if (attachedFlower.attachedAt > Date.now()) return false;
+  if (attachedFlower.attachedUntil < Date.now()) return false;
+
+  return true;
+};
+
+const getSyncedHiveContext = (hive: Beehive) => {
+  const attachedFlower = getActiveFlower(hive);
+
+  return {
+    hive,
+    honeyProduced: getCurrentHoneyProduced(hive),
+    currentSpeed: getCurrentSpeed(hive),
+    attachedFlower,
+    isProducing: isFlowerProducing(attachedFlower),
+  };
+};
+
 export const beehiveMachine = createMachine<
   BeehiveContext,
   BeehiveEvent,
@@ -150,6 +170,10 @@ export const beehiveMachine = createMachine<
       },
       honeyReady: {
         on: {
+          UPDATE_HIVE: {
+            target: "prepareHive",
+            actions: "updateHive",
+          },
           HARVEST_HONEY: {
             target: "prepareHive",
             actions: "harvestHoney",
@@ -175,29 +199,17 @@ export const beehiveMachine = createMachine<
       checkAndUpdateHoney: assign({
         honeyProduced: ({ hive }) => getCurrentHoneyProduced(hive),
         currentSpeed: ({ hive }) => getCurrentSpeed(hive),
-        isProducing: ({ attachedFlower }) => {
-          if (!attachedFlower) return false;
-          if (attachedFlower.attachedAt > Date.now()) return false;
-          if (attachedFlower.attachedUntil < Date.now()) return false;
-
-          return true;
-        },
+        isProducing: ({ attachedFlower }) => isFlowerProducing(attachedFlower),
       }),
       updateActiveFlower: assign({
         attachedFlower: ({ hive }) => getActiveFlower(hive),
       }),
-      updateHive: assign({
-        hive: (_, event) => {
-          return (event as UpdateHive).updatedHive;
-        },
-      }),
-      harvestHoney: assign({
-        hive: (_, event) => {
-          return (event as UpdateHive).updatedHive;
-        },
-        honeyProduced: (_, event) =>
-          (event as UpdateHive).updatedHive.honey.produced,
-      }),
+      updateHive: assign((_, event) =>
+        getSyncedHiveContext((event as UpdateHive).updatedHive),
+      ),
+      harvestHoney: assign((_, event) =>
+        getSyncedHiveContext((event as HarvestHoney).updatedHive),
+      ),
       removeActiveFlower: assign((_) => ({
         attachedFlower: undefined,
       })),


### PR DESCRIPTION
## Summary
Fixes a beehive UI desync where hives could appear visually full and show the Bee Swarm dialog even when the actual harvested honey amount was partial. The UI now syncs beehive readiness from the latest hive state and only shows the Bee Swarm modal when the swarm was actually consumed by the harvest event.

## Context / motivation
I reported case where a beehive looked full, but harvesting returned less than one full honey jar, for example `+0.43`. In the same flow, the Bee Swarm modal could appear even though crop plots were not pollinated.

<img  height="500" alt="telegram-cloud-photo-size-2-5217442609972846254-y" src="https://github.com/user-attachments/assets/58835092-eb17-4c7b-8cff-427f92711ad3" />
<img  height="500" alt="telegram-cloud-photo-size-2-5217442609972846255-y" src="https://github.com/user-attachments/assets/4402d460-fc11-46d0-bff6-8a2272cc6403" />
<img height="500" alt="telegram-cloud-photo-size-2-5217442609972846256-y" src="https://github.com/user-attachments/assets/335db956-2f34-41e3-842d-22391cf97d09" />

The game event logic is already correct: `harvestBeehive` only applies swarm pollination when `honeyProduced >= 1`. The issue was in the local beehive UI state machine. Once it entered `honeyReady`, it did not handle `UPDATE_HIVE`, so the visual ready state could stay stale after the underlying hive data changed.

## How to test
1. Open a farm with an active beehive that has a swarm and partial honey production.
2. Confirm the hive does not visually appear as full when synced hive data is below one full honey jar.
3. Harvest partial honey and confirm the Bee Swarm modal does not appear.
4. Harvest a genuinely full hive with a swarm and confirm the Bee Swarm modal still appears and crop plots receive the swarm state.
5. Run `npm run build -- --mode development`.

Note: the focused Jest command could not run in this local checkout because `esbuild-runner/jest` is missing from `node_modules`. A regression test was added for the beehive state-machine sync path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed harvest flow so the honey modal closes immediately and swarm alerts appear only when a swarm actually ends.

* **Refactor**
  * Improved beehive state synchronization and update flow to keep hive, honey production, and attached-flower status consistent.

* **Tests**
  * Expanded unit tests to cover multiple beehive state scenarios and transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->