### PR TITLE
[FIX] Mushrooms and trash spawn on placed Bumpkin

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -205,7 +205,112 @@ describe("detectCollisions", () => {
 
     expect(hasCollision).toBe(true);
   });
+
+  it("returns true if a collision is detected with a farmhand placed on the farm", () => {
+    const state: GameState = clearPlaceables(cloneDeep(TEST_FARM));
+    state.farmHands = {
+      bumpkins: {
+        "fh-1": {
+          equipped: state.bumpkin.equipped,
+          coordinates: { x: 1, y: 1 },
+          location: "farm",
+        },
+      },
+    };
+
+    const hasCollision = detectCollision({
+      state,
+      position: { x: 1, y: 1, height: 1, width: 1 },
+      location: "farm",
+      name: "Abandoned Bear",
+    });
+
+    expect(hasCollision).toBe(true);
+  });
+
+  it("returns true if a collision is detected with the bumpkin placed on the farm", () => {
+    const state: GameState = clearPlaceables(cloneDeep(TEST_FARM));
+    state.bumpkin.coordinates = { x: 1, y: 1 };
+    state.bumpkin.location = "farm";
+
+    const hasCollision = detectCollision({
+      state,
+      position: { x: 1, y: 1, height: 1, width: 1 },
+      location: "farm",
+      name: "Abandoned Bear",
+    });
+
+    expect(hasCollision).toBe(true);
+  });
+
+  it("returns false when placing the bumpkin on its own coordinates (self-collision excluded)", () => {
+    const state: GameState = clearPlaceables(cloneDeep(TEST_FARM));
+    state.bumpkin.coordinates = { x: 1, y: 1 };
+    state.bumpkin.location = "farm";
+
+    const hasCollision = detectCollision({
+      state,
+      position: { x: 1, y: 1, height: 1, width: 1 },
+      location: "farm",
+      name: "Bumpkin",
+    });
+
+    expect(hasCollision).toBe(false);
+  });
+
+  it("returns false if the bumpkin is placed at home and a placeable is added on the farm at the same coordinates", () => {
+    const state: GameState = clearPlaceables(cloneDeep(TEST_FARM));
+    state.bumpkin.coordinates = { x: 1, y: 1 };
+    state.bumpkin.location = "home";
+
+    const hasCollision = detectCollision({
+      state,
+      position: { x: 1, y: 1, height: 1, width: 1 },
+      location: "farm",
+      name: "Abandoned Bear",
+    });
+
+    expect(hasCollision).toBe(false);
+  });
+
+  it("returns false if the bumpkin has no coordinates set", () => {
+    const state: GameState = clearPlaceables(cloneDeep(TEST_FARM));
+    delete state.bumpkin.coordinates;
+    delete state.bumpkin.location;
+
+    const hasCollision = detectCollision({
+      state,
+      position: { x: 1, y: 1, height: 1, width: 1 },
+      location: "farm",
+      name: "Abandoned Bear",
+    });
+
+    expect(hasCollision).toBe(false);
+  });
 });
+
+function clearPlaceables(state: GameState): GameState {
+  state.collectibles = {};
+  state.buildings = {};
+  state.crops = {};
+  state.trees = {};
+  state.stones = {};
+  state.gold = {};
+  state.iron = {};
+  state.crimstones = {};
+  state.sunstones = {};
+  state.oilReserves = {};
+  state.lavaPits = {};
+  state.fruitPatches = {};
+  state.beehives = {};
+  state.flowers = { discovered: {}, flowerBeds: {} };
+  state.buds = {};
+  state.pets = { common: {}, nfts: {} };
+  state.farmHands = { bumpkins: {} };
+  state.airdrops = [];
+  state.mushrooms = { spawnedAt: 0, mushrooms: {} };
+  return state;
+}
 
 describe("isWithinAOE", () => {
   const plotDimensions: Dimensions = { ...RESOURCE_DIMENSIONS["Crop Plot"] };

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -247,12 +247,28 @@ function detectPlaceableCollision(
       width: 1,
     }));
 
+  // Main bumpkin on the farm, exclude when placing/moving the bumpkin itself
+  const bumpkinBoundingBox =
+    name !== "Bumpkin" &&
+    state.bumpkin?.coordinates &&
+    state.bumpkin?.location === "farm"
+      ? [
+          {
+            x: state.bumpkin.coordinates.x,
+            y: state.bumpkin.coordinates.y,
+            height: 1,
+            width: 1,
+          },
+        ]
+      : [];
+
   const boundingBoxes = [
     ...placeableBounds,
     ...resourceBoundingBoxes,
     ...budsBoundingBox,
     ...petNFTBoundingBox,
     ...farmHandBoundingBox,
+    ...bumpkinBoundingBox,
   ];
 
   return boundingBoxes.some((resourceBoundingBox) =>


### PR DESCRIPTION
## Summary
- The farm-level `detectPlaceableCollision` was checking placed Farmhands but not the player's own placed Bumpkin. As a result, mushrooms and clutter (dung/weed) could spawn on the tile under a placed Bumpkin, even though the home-side detection already handled this correctly.
- Add a `bumpkinBoundingBox` to `detectPlaceableCollision`, mirroring the home-side pattern at [collisionDetection.ts:502](src/features/game/expansion/placeable/lib/collisionDetection.ts:502). Includes the `name !== "Bumpkin"` self-collision guard so the player can still place/move their own avatar.
- Side benefit: also stops players from placing collectibles, buildings, resources, etc. on top of their Bumpkin.

Matching fix in the API repo (where the spawn logic actually runs): https://github.com/sunflower-land/sunflower-land-api/pull/3400.

## Test plan
- [x] Added 5 unit tests in `collisionDetection.test.ts` covering: bumpkin blocks farm placement, farmhand blocks farm placement (previously uncovered), self-collision excluded when `name === "Bumpkin"`, home-located bumpkin doesn't block farm spawns, unplaced bumpkin doesn't block.
- [x] All 74 client collision tests pass.
- [ ] Manual: place Bumpkin, wait for mushroom/clutter spawn, verify nothing lands on the Bumpkin tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision detection for farm placements to properly account for the bumpkin position when determining valid placement locations.

* **Tests**
  * Added collision detection test coverage for various placeable scenarios, including farmhand placement, self-collision exclusion, and bumpkin positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->