### PR TITLE
[FEAT] Mask Google email in settings + hide while visiting

### DIFF
--- a/src/features/auth/components/LinkedGooglePanel.tsx
+++ b/src/features/auth/components/LinkedGooglePanel.tsx
@@ -18,6 +18,7 @@ import { SignMessageBody } from "features/wallet/components/SignMessage";
 import { removeJWT } from "features/auth/actions/social";
 import { useNow } from "lib/utils/hooks/useNow";
 import { getRelativeTime } from "lib/utils/time";
+import { maskEmail } from "lib/utils/maskEmail";
 import { SUNNYSIDE } from "assets/sunnyside";
 import type { ContentComponentProps } from "../../island/hud/components/settings-menu/types";
 
@@ -87,6 +88,7 @@ export const LinkedGooglePanel: React.FC<Partial<ContentComponentProps>> = ({
     null | "enable" | "disable"
   >(null);
   const [showInlineConfirm, setShowInlineConfirm] = useState(false);
+  const [revealEmail, setRevealEmail] = useState(false);
 
   // Wallet sign-message succeeded → dispatch the toggle event directly.
   // Doing this in the callback (rather than via an effect keyed off
@@ -241,7 +243,22 @@ export const LinkedGooglePanel: React.FC<Partial<ContentComponentProps>> = ({
               </span>
               <Label type="default">{t("linkedAccounts.role.signIn")}</Label>
             </div>
-            <p className="text-xs break-all mt-1">{socialDetails.email}</p>
+            <p
+              className="text-xs break-all mt-1 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                setRevealEmail((prev) => !prev);
+              }}
+              title={t(
+                revealEmail
+                  ? "linkedAccounts.googleSignIn.hideEmail"
+                  : "linkedAccounts.googleSignIn.revealEmail",
+              )}
+            >
+              {revealEmail
+                ? socialDetails.email
+                : maskEmail(socialDetails.email)}
+            </p>
             {signedInLine && (
               <p className="text-xs italic opacity-75 mt-1">{signedInLine}</p>
             )}

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -1236,7 +1236,11 @@ export function startGame(authContext: AuthContext) {
                 visitorNftId: (context) => context.nftId,
                 // Stash the visitor's own socialDetails so the UI on the
                 // visited farm can't read their email; restored by END_VISIT.
-                visitorSocialDetails: (context) => context.socialDetails,
+                // Preserve any existing stash so a visit-to-visit hop (without
+                // END_VISIT in between) doesn't overwrite the original value
+                // with the already-cleared `undefined`.
+                visitorSocialDetails: (context) =>
+                  context.visitorSocialDetails ?? context.socialDetails,
                 socialDetails: () => undefined,
                 hasHelpedPlayerToday: (_, event) =>
                   event.data.hasHelpedPlayerToday,

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -193,6 +193,11 @@ export interface Context {
   visitorId?: number;
   visitorState?: GameState;
   visitorNftId?: number;
+  // Stash for the visitor's own socialDetails while they're on another
+  // farm. Cleared into `socialDetails` on END_VISIT so we don't leak
+  // their email through the LinkedAccounts UI while visiting, and don't
+  // need a refetch on the way back.
+  visitorSocialDetails?: SocialDetails;
   hasHelpedPlayerToday?: boolean;
   totalHelpedToday?: number;
   apiKey?: string;
@@ -634,7 +639,9 @@ const EFFECT_STATES = Object.values(STATE_MACHINE_EFFECTS).reduce(
                     event.data.data?.farmAddress ?? context.farmAddress,
                   // Effects run while visiting another farm return the
                   // visited farm's response payload. Never let that
-                  // overwrite the visitor's own socialDetails.
+                  // overwrite socialDetails — visitor's own value is
+                  // stashed in `visitorSocialDetails` and restored on
+                  // END_VISIT, so we just leave the active field alone.
                   socialDetails: context.visitorId
                     ? context.socialDetails
                     : resolveSocialDetails(
@@ -662,7 +669,9 @@ const EFFECT_STATES = Object.values(STATE_MACHINE_EFFECTS).reduce(
                     event.data.data?.farmAddress ?? context.farmAddress,
                   // Effects run while visiting another farm return the
                   // visited farm's response payload. Never let that
-                  // overwrite the visitor's own socialDetails.
+                  // overwrite socialDetails — visitor's own value is
+                  // stashed in `visitorSocialDetails` and restored on
+                  // END_VISIT, so we just leave the active field alone.
                   socialDetails: context.visitorId
                     ? context.socialDetails
                     : resolveSocialDetails(
@@ -1225,6 +1234,10 @@ export function startGame(authContext: AuthContext) {
                 visitorState: (_, event) => event.data.visitorState,
                 nftId: (_, event) => event.data.visitedFarmNftId,
                 visitorNftId: (context) => context.nftId,
+                // Stash the visitor's own socialDetails so the UI on the
+                // visited farm can't read their email; restored by END_VISIT.
+                visitorSocialDetails: (context) => context.socialDetails,
+                socialDetails: () => undefined,
                 hasHelpedPlayerToday: (_, event) =>
                   event.data.hasHelpedPlayerToday,
                 totalHelpedToday: (_, event) => event.data.totalHelpedToday,
@@ -1266,6 +1279,8 @@ export function startGame(authContext: AuthContext) {
                 state: context.visitorState,
                 farmId: context.visitorId,
                 nftId: context.visitorNftId,
+                socialDetails: context.visitorSocialDetails,
+                visitorSocialDetails: undefined,
                 actions: [],
               })),
             },

--- a/src/features/island/hud/components/settings-menu/linked-accounts/LinkedAccounts.tsx
+++ b/src/features/island/hud/components/settings-menu/linked-accounts/LinkedAccounts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useSelector } from "@xstate/react";
 
 import { Label, LabelType } from "components/ui/Label";
@@ -52,6 +52,9 @@ interface RowProps {
   onClick?: () => void;
   /** Allow the row to remain clickable when in the "linked" state — for providers that have a manage panel. */
   clickableWhenLinked?: boolean;
+  /** Optional click handler bound to the subtext only (stops propagation). Used for click-to-reveal. */
+  onSubtextClick?: () => void;
+  subtextTitle?: string;
 }
 
 const ProviderRow: React.FC<RowProps> = ({
@@ -63,6 +66,8 @@ const ProviderRow: React.FC<RowProps> = ({
   subtext,
   onClick,
   clickableWhenLinked,
+  onSubtextClick,
+  subtextTitle,
 }) => {
   const { t } = useAppTranslation();
   const disabled =
@@ -85,7 +90,22 @@ const ProviderRow: React.FC<RowProps> = ({
       <p className="text-xs italic mt-1 ml-1 opacity-75">{rationale}</p>
 
       <div className="flex items-center justify-between gap-2 mt-1">
-        <p className="text-xs break-all ml-1">{subtext}</p>
+        <p
+          className={`text-xs break-all ml-1 ${
+            onSubtextClick ? "cursor-pointer" : ""
+          }`}
+          onClick={
+            onSubtextClick
+              ? (e) => {
+                  e.stopPropagation();
+                  onSubtextClick();
+                }
+              : undefined
+          }
+          title={subtextTitle}
+        >
+          {subtext}
+        </p>
         {showManageHint && (
           <img
             src={SUNNYSIDE.icons.chevron_right}
@@ -111,6 +131,8 @@ export const LinkedAccounts: React.FC<ContentComponentProps> = ({
   const linkingSocial = useSelector(gameService, _linkingSocial);
   const linkingSocialFailed = useSelector(gameService, _linkingSocialFailed);
 
+  const [revealWallet, setRevealWallet] = useState(false);
+
   const walletStatus: RowStatus = linkingWallet
     ? "linking"
     : linkingWalletFailed
@@ -129,7 +151,9 @@ export const LinkedAccounts: React.FC<ContentComponentProps> = ({
 
   const walletSubtext =
     walletStatus === "linked" && linkedWallet
-      ? maskWalletAddress(linkedWallet)
+      ? revealWallet
+        ? linkedWallet
+        : maskWalletAddress(linkedWallet)
       : walletStatus === "linking"
         ? t("linkedAccounts.waitingForWallet")
         : walletStatus === "failed"
@@ -180,6 +204,20 @@ export const LinkedAccounts: React.FC<ContentComponentProps> = ({
         status={walletStatus}
         subtext={walletSubtext}
         onClick={() => onSubMenuClick("linkAccountWallet")}
+        onSubtextClick={
+          walletStatus === "linked" && linkedWallet
+            ? () => setRevealWallet((prev) => !prev)
+            : undefined
+        }
+        subtextTitle={
+          walletStatus === "linked" && linkedWallet
+            ? t(
+                revealWallet
+                  ? "linkedAccounts.hideWallet"
+                  : "linkedAccounts.revealWallet",
+              )
+            : undefined
+        }
       />
 
       <ProviderRow

--- a/src/features/island/hud/components/settings-menu/linked-accounts/LinkedAccounts.tsx
+++ b/src/features/island/hud/components/settings-menu/linked-accounts/LinkedAccounts.tsx
@@ -10,6 +10,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import type { TranslationKeys } from "lib/i18n/dictionaries/types";
 import { Context as GameContext } from "features/game/GameProvider";
 import { MachineState } from "features/game/lib/gameMachine";
+import { maskEmail } from "lib/utils/maskEmail";
 import { ContentComponentProps } from "../GameOptions";
 
 const _linkedWallet = (state: MachineState) => state.context.linkedWallet;
@@ -27,17 +28,6 @@ const maskWalletAddress = (address: string): string => {
   if (address.length <= 10) return address;
 
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
-};
-
-const maskEmail = (email: string): string => {
-  const [local, domain] = email.split("@");
-  if (!domain) return email;
-  const visibleLocal = local.slice(0, Math.min(2, local.length));
-  const localMask = "*".repeat(Math.max(3, local.length - visibleLocal.length));
-  const tld = domain.includes(".") ? domain.slice(domain.lastIndexOf(".")) : "";
-  const domainBody = tld ? domain.slice(0, -tld.length) : domain;
-  const domainMask = "*".repeat(Math.max(3, domainBody.length));
-  return `${visibleLocal}${localMask}@${domainMask}${tld}`;
 };
 
 type RowStatus = "linked" | "notLinked" | "linking" | "failed";
@@ -81,11 +71,7 @@ const ProviderRow: React.FC<RowProps> = ({
   const showManageHint = status === "linked" && clickableWhenLinked;
 
   return (
-    <ButtonPanel
-      variant="card"
-      disabled={disabled}
-      onClick={disabled ? undefined : onClick}
-    >
+    <ButtonPanel variant="card" onClick={disabled ? undefined : onClick}>
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1 flex-wrap">
           <Label type="default" icon={icon}>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2124,6 +2124,8 @@
   "linkedAccounts.googleSignIn.turnOff": "Turn off",
   "linkedAccounts.googleSignIn.signedInThisDevice": "Signed in on this device",
   "linkedAccounts.googleSignIn.lastSignedInThisDevice": "Last signed in {{time}} · this device",
+  "linkedAccounts.googleSignIn.revealEmail": "Show full email",
+  "linkedAccounts.googleSignIn.hideEmail": "Hide email",
   "linkedAccounts.googleLoginEnabled": "Allow login with Google",
   "linkedAccounts.linkWalletFirst": "Link a wallet first so you can still log in.",
   "linkedAccounts.disableGoogleSelfWarning": "You are currently logged in via Google. Disabling will log you out. Continue?",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2126,6 +2126,8 @@
   "linkedAccounts.googleSignIn.lastSignedInThisDevice": "Last signed in {{time}} · this device",
   "linkedAccounts.googleSignIn.revealEmail": "Show full email",
   "linkedAccounts.googleSignIn.hideEmail": "Hide email",
+  "linkedAccounts.revealWallet": "Show full address",
+  "linkedAccounts.hideWallet": "Hide address",
   "linkedAccounts.googleLoginEnabled": "Allow login with Google",
   "linkedAccounts.linkWalletFirst": "Link a wallet first so you can still log in.",
   "linkedAccounts.disableGoogleSelfWarning": "You are currently logged in via Google. Disabling will log you out. Continue?",

--- a/src/lib/utils/maskEmail.ts
+++ b/src/lib/utils/maskEmail.ts
@@ -1,0 +1,24 @@
+/**
+ * Mask the local part of an email while leaving the domain visible
+ * (e.g. `johndoeow@example.com` → `jo*****ow@example.com`). Keeps the
+ * first two and last two characters of the local part only when it is
+ * at least 7 chars long; for shorter locals, just the first two are
+ * shown so we don't reveal most of a short address (e.g. `elias` →
+ * `el***`, not `el*as`). Padding stays at ≥ 3 asterisks so very short
+ * locals still look masked.
+ */
+export const maskEmail = (email: string): string => {
+  const [local, domain] = email.split("@");
+  if (!domain) return email;
+
+  if (local.length >= 7) {
+    const head = local.slice(0, 2);
+    const tail = local.slice(-2);
+    const stars = "*".repeat(local.length - 4);
+    return `${head}${stars}${tail}@${domain}`;
+  }
+
+  const head = local.slice(0, Math.min(2, local.length));
+  const stars = "*".repeat(Math.max(3, local.length - head.length));
+  return `${head}${stars}@${domain}`;
+};

--- a/src/lib/utils/maskEmail.ts
+++ b/src/lib/utils/maskEmail.ts
@@ -1,24 +1,34 @@
 /**
- * Mask the local part of an email while leaving the domain visible
- * (e.g. `johndoeow@example.com` → `jo*****ow@example.com`). Keeps the
- * first two and last two characters of the local part only when it is
- * at least 7 chars long; for shorter locals, just the first two are
- * shown so we don't reveal most of a short address (e.g. `elias` →
- * `el***`, not `el*as`). Padding stays at ≥ 3 asterisks so very short
- * locals still look masked.
+ * Mask an email address. The local part is always masked; the domain
+ * is kept visible only when it is `gmail.com` (extremely common, so
+ * revealing it leaks little), otherwise the domain is masked with the
+ * same algorithm — corporate / personal domains are identifying.
+ *
+ * Masking rule for each part:
+ * - length ≥ 7 → keep the first two and last two characters
+ *   (e.g. `johndoeow` → `jo*****ow`, `sunflower-land.com` →
+ *   `su**************om`).
+ * - length < 7 → reveal only the first two and pad with at least three
+ *   asterisks (e.g. `elias` → `el***`).
  */
+const maskPart = (part: string): string => {
+  if (part.length >= 7) {
+    const head = part.slice(0, 2);
+    const tail = part.slice(-2);
+    const stars = "*".repeat(part.length - 4);
+    return `${head}${stars}${tail}`;
+  }
+  const head = part.slice(0, Math.min(2, part.length));
+  const stars = "*".repeat(Math.max(3, part.length - head.length));
+  return `${head}${stars}`;
+};
+
 export const maskEmail = (email: string): string => {
   const [local, domain] = email.split("@");
   if (!domain) return email;
 
-  if (local.length >= 7) {
-    const head = local.slice(0, 2);
-    const tail = local.slice(-2);
-    const stars = "*".repeat(local.length - 4);
-    return `${head}${stars}${tail}@${domain}`;
-  }
-
-  const head = local.slice(0, Math.min(2, local.length));
-  const stars = "*".repeat(Math.max(3, local.length - head.length));
-  return `${head}${stars}@${domain}`;
+  const maskedLocal = maskPart(local);
+  const maskedDomain =
+    domain.toLowerCase() === "gmail.com" ? domain : maskPart(domain);
+  return `${maskedLocal}@${maskedDomain}`;
 };


### PR DESCRIPTION
## Summary

- Mask the linked Google email in the LinkedAccounts row and the LinkedGooglePanel ("manage Google") card.
  - Local part is always masked. Locals ≥ 7 chars keep first/last 2 (`johndoeow` → `jo*****ow`); shorter locals show only the first 2 (`elias` → `el***`).
  - Domain is left visible only when it's `gmail.com`; other domains (corporate / personal) are masked with the same algorithm (e.g. `sunflower-land.com` → `su**************om`).
- Click the masked email in the manage panel to toggle between masked and full view (with a tooltip).
- Click the masked wallet address in the LinkedAccounts wallet row to expand to the full address; click again to re-mask.
- While visiting another player's farm, stash the visitor's own `socialDetails` on `gameMachine` context (`visitorSocialDetails`) and clear `context.socialDetails`. Restored on `END_VISIT` — no refetch, no BE change. The settings button is hidden in visit mode, so this is a defence-in-depth change: nothing else in the codebase can read the visitor's email out of context while they're on someone else's farm, and the stash/restore avoids the need for a `/session` refetch on return.

The visited friend's `socialDetails` is **not** in the `/visit/:id` response today — `socialDetails` lives on `Farm`, not `GameState`, and `makeFarmForVisit` only returns the `GameState`. So no BE change was needed for that concern.

<img width="514" height="363" alt="image" src="https://github.com/user-attachments/assets/20c015ab-7455-442b-8ea6-43823da99c2d" />


## Test plan

### Masking and reveal (own farm)
- [ ] Open Settings → Account → Linked Accounts on your own farm.
  - Google row shows masked email.
  - Wallet row shows masked address (e.g. `0x3E84...dAc2`).
- [ ] Click the masked wallet address in the wallet row → it expands to the full `0x…` address; tooltip shows "Hide address". Click again → re-masks. Clicking the address does **not** navigate to the link-wallet sub-menu.
- [ ] Verify masking rules for the email:
  - Local ≥ 7 chars: `jo*****ow@gmail.com` (last 2 visible).
  - Local < 7 chars: `el***@gmail.com` (only first 2 visible).
  - Non-gmail domain: `el***@su**************om` (domain masked with the same rule).
- [ ] Click the Google row → Manage panel opens. Email is masked by default.
- [ ] Click the masked email in the manage panel → reveals the full address; tooltip swaps to "Hide email". Click again → re-masks.
- [ ] Toggle "Allow Google sign-in" off then on. Confirm the flow still works on your own farm (no regression).

### Visit-mode socialDetails stash (gameMachine)
The settings button is hidden in visit mode, so verify via React/XState devtools (or temporarily log `context`):
- [ ] On your own farm, confirm `gameService.state.context.socialDetails` is your account's value and `visitorSocialDetails` is undefined.
- [ ] Visit another farm (URL `/visit/:id` or in-game UI). Confirm `context.socialDetails` is now `undefined` and `context.visitorSocialDetails` holds your stashed value.
- [ ] Return via END_VISIT. Confirm `context.socialDetails` is restored and `context.visitorSocialDetails` is `undefined` again — no `/session` refetch should fire in the network panel.
- [ ] Visit another farm twice in a row (visit A → visit B without ending) and then END_VISIT. `socialDetails` should still restore correctly from the original stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle controls to reveal or mask Google sign-in emails and linked wallet addresses (masked by default), with updated UI text.
  * Added email-masking behavior for safer display of addresses.
  * Improved privacy when visiting other players' farms by preserving the visitor's identity (visitor info not exposed while visiting).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->