### PR TITLE
[FIX] Add ownerChanged to FaceRecognitionEvent + sort isFaceVerified by createdAt

### DIFF
--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -2201,7 +2201,8 @@ export type FaceRecognitionEvent =
         faceId: string;
         farmId: number;
       }[];
-    };
+    }
+  | { event: "reverifyRequired"; createdAt: number };
 
 export interface Context {
   state?: GameState;

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -2202,7 +2202,7 @@ export type FaceRecognitionEvent =
         farmId: number;
       }[];
     }
-  | { event: "reverifyRequired"; createdAt: number };
+  | { event: "ownerChanged"; createdAt: number };
 
 export interface Context {
   state?: GameState;

--- a/src/features/retreat/components/personhood/lib/faceRecognition.test.ts
+++ b/src/features/retreat/components/personhood/lib/faceRecognition.test.ts
@@ -1,0 +1,131 @@
+import { GameState } from "features/game/types/game";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import { isFaceVerified } from "./faceRecognition";
+
+describe("isFaceVerified", () => {
+  it("returns true when game.verified is true, regardless of faceRecognition", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: true,
+    };
+
+    expect(isFaceVerified({ game })).toBe(true);
+  });
+
+  it("returns true when game.verified is true even with no successful history", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: true,
+      faceRecognition: {
+        history: [{ event: "failed", createdAt: 1_000_000, confidence: 0.1 }],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(true);
+  });
+
+  it("returns false when faceRecognition is undefined and not verified", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: undefined,
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("returns false when history is empty", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: { history: [] },
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("returns true when the latest event is 'succeeded'", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "failed", createdAt: 1_000_000, confidence: 0.1 },
+          { event: "succeeded", createdAt: 2_000_000, confidence: 0.99 },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(true);
+  });
+
+  it("returns false when the latest event is 'failed'", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "succeeded", createdAt: 1_000_000, confidence: 0.99 },
+          { event: "failed", createdAt: 2_000_000, confidence: 0.1 },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("returns false when the latest event is 'duplicate'", () => {
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "succeeded", createdAt: 1_000_000, confidence: 0.99 },
+          {
+            event: "duplicate",
+            createdAt: 2_000_000,
+            duplicates: [{ similarity: 99, faceId: "face-1", farmId: 42 }],
+          },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("returns false when the latest event is 'ownerChanged'", () => {
+    // After an ownership change, the appended `ownerChanged` event
+    // supersedes any prior `succeeded` entry — the new owner has not
+    // proven they are the same person.
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "succeeded", createdAt: 1_000_000, confidence: 0.99 },
+          { event: "ownerChanged", createdAt: 2_000_000 },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("determines the latest event by createdAt, not by array order", () => {
+    // The 'succeeded' entry has the highest createdAt, so the user
+    // should be verified even if it appears earlier in the array.
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "succeeded", createdAt: 3_000_000, confidence: 0.99 },
+          { event: "failed", createdAt: 1_000_000, confidence: 0.1 },
+          { event: "failed", createdAt: 2_000_000, confidence: 0.1 },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(true);
+  });
+});

--- a/src/features/retreat/components/personhood/lib/faceRecognition.test.ts
+++ b/src/features/retreat/components/personhood/lib/faceRecognition.test.ts
@@ -111,6 +111,42 @@ describe("isFaceVerified", () => {
     expect(isFaceVerified({ game })).toBe(false);
   });
 
+  it("resolves createdAt ties in favour of the entry appended later", () => {
+    // Append-only history: when two entries share the same
+    // millisecond, the one appended later wins so an `ownerChanged`
+    // appended right after a `succeeded` still flips to unverified.
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: {
+        history: [
+          { event: "succeeded", createdAt: 1_000_000, confidence: 0.99 },
+          { event: "ownerChanged", createdAt: 1_000_000 },
+        ],
+      },
+    };
+
+    expect(isFaceVerified({ game })).toBe(false);
+  });
+
+  it("does not mutate the history array", () => {
+    const history = [
+      { event: "ownerChanged" as const, createdAt: 3_000_000 },
+      { event: "failed" as const, createdAt: 1_000_000, confidence: 0.1 },
+      { event: "succeeded" as const, createdAt: 2_000_000, confidence: 0.99 },
+    ];
+    const snapshot = [...history];
+    const game: GameState = {
+      ...INITIAL_FARM,
+      verified: false,
+      faceRecognition: { history },
+    };
+
+    isFaceVerified({ game });
+
+    expect(game.faceRecognition?.history).toEqual(snapshot);
+  });
+
   it("determines the latest event by createdAt, not by array order", () => {
     // The 'succeeded' entry has the highest createdAt, so the user
     // should be verified even if it appears earlier in the array.

--- a/src/features/retreat/components/personhood/lib/faceRecognition.ts
+++ b/src/features/retreat/components/personhood/lib/faceRecognition.ts
@@ -13,8 +13,9 @@ export function isFaceVerified({ game }: { game: GameState }) {
     return false;
   }
 
-  const lastAttempt =
-    faceRecognition.history[faceRecognition.history.length - 1];
+  const lastAttempt = faceRecognition.history.sort(
+    (a, b) => b.createdAt - a.createdAt,
+  )[0];
 
   return lastAttempt.event === "succeeded";
 }

--- a/src/features/retreat/components/personhood/lib/faceRecognition.ts
+++ b/src/features/retreat/components/personhood/lib/faceRecognition.ts
@@ -13,9 +13,13 @@ export function isFaceVerified({ game }: { game: GameState }) {
     return false;
   }
 
-  const lastAttempt = faceRecognition.history.sort(
-    (a, b) => b.createdAt - a.createdAt,
-  )[0];
+  // Non-mutating max-by-createdAt. Using `>=` so that when timestamps
+  // tie, the entry appended later in the array wins — important for
+  // append-only history where an `ownerChanged` event with the same
+  // millisecond as a prior `succeeded` must still stale verification.
+  const lastAttempt = faceRecognition.history.reduce((latest, attempt) =>
+    attempt.createdAt >= latest.createdAt ? attempt : latest,
+  );
 
   return lastAttempt.event === "succeeded";
 }


### PR DESCRIPTION
## Summary
Mirrors the BE type and helper changes in [sunflower-land-api#3402](https://github.com/sunflower-land/sunflower-land-api/pull/3402). The BE appends `{ event: "ownerChanged", createdAt }` to `faceRecognition.history` on every farm ownership change, which means the FE must (1) recognise the new variant and (2) pick the latest history entry by timestamp rather than array position so the new owner is correctly shown as unverified.

- Add `ownerChanged` variant to the `FaceRecognitionEvent` union.
- `isFaceVerified` now sorts `history` by `createdAt` (desc) and reads the first entry, instead of reading the last array element. Same semantics as the BE.
- New unit test file `faceRecognition.test.ts` covering `isFaceVerified` across all event variants and the sort-by-`createdAt` behavior.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn jest src/features/retreat/components/personhood/lib/faceRecognition.test.ts` — 9 passing
- [ ] Verify on staging once BE is deployed: an ownership-changed farm shows up as unverified in any UI gated by `isFaceVerified` (withdraw items/wearables/FLOWER, marketplace listing/accept, Rocketman, TransferAccount, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new face re-verification outcome to support additional authentication scenarios.

* **Bug Fixes**
  * Verification now reliably uses the most recent recognition attempt (deterministic tie-breaking) and avoids mutating history when determining status.

* **Tests**
  * Added unit tests covering verification outcomes, history ordering, tie-breaking, and non-mutation of recognition history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->