### PR TITLE
[Fix] power skill ready indicators

### DIFF
--- a/src/features/island/hud/components/PowerSkills.tsx
+++ b/src/features/island/hud/components/PowerSkills.tsx
@@ -152,7 +152,7 @@ const PowerSkillsContent: React.FC<{
     createdAt: now,
   });
 
-  const isPowerSkillReady = (skill: BumpkinSkillRevamp) => {
+  const isPowerSkillCooldownReady = (skill: BumpkinSkillRevamp) => {
     if (!skill.power) return false;
 
     const skillName = skill.name as BumpkinRevampSkillName;
@@ -163,13 +163,7 @@ const PowerSkillsContent: React.FC<{
     const nextSkillUse =
       (previousPowerUseAt?.[skillName] ?? 0) + boostedCooldown;
 
-    if (nextSkillUse >= now) return false;
-
-    return !powerSkillDisabledConditions({
-      state,
-      skillTree: skill,
-      createdAt: now,
-    }).disabled;
+    return nextSkillUse < now;
   };
 
   return (
@@ -377,7 +371,7 @@ const PowerSkillsContent: React.FC<{
                       }}
                       tier={requirements.tier}
                       npc={npc}
-                      isReady={isPowerSkillReady(skill)}
+                      isReady={isPowerSkillCooldownReady(skill)}
                       secondaryImage={
                         boosts.debuff
                           ? tradeOffs
@@ -434,7 +428,7 @@ const PowerSkillsContent: React.FC<{
                       }}
                       tier={requirements.tier}
                       npc={npc}
-                      isReady={isPowerSkillReady(skill)}
+                      isReady={isPowerSkillCooldownReady(skill)}
                       secondaryImage={
                         boosts.debuff
                           ? tradeOffs


### PR DESCRIPTION
## Problem

The external Power Skills entry point shows an alert when a power skill cooldown is ready, but the skill list inside the modal only showed the ready indicator when the skill was both off cooldown and currently usable.

This created a mismatch for skills such as Grease Lightning: the outside alert appeared when the cooldown was ready, but the internal card did not show as ready if there were no oil reserves currently refilling. In that state the skill is correctly blocked by an additional condition, but the cooldown itself is still available.

## Changes

- Renamed the internal card readiness helper to clarify that it checks cooldown readiness.
- Updated Power Skill cards to show the ready indicator when their cooldown is complete, regardless of extra usage conditions.
- Kept existing disabled-condition logic for the selected skill details and Use button, so blocked skills still cannot be used and still show their blocking reason.

## Verification

- yarn tsc --noEmit --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Power Skills readiness indicator now displays based on cooldown timing alone, providing clearer visibility of when each skill will be available next.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->