### PR TITLE
[FIX] Fix Power Hour AOE crop yield

### DIFF
--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -6,6 +6,7 @@ import { harvest } from "./harvest";
 import { CROPS } from "features/game/types/crops";
 import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
+import { applyBuff } from "features/game/types/buffs";
 
 const dateNow = Date.now();
 const GAME_STATE: GameState = {
@@ -1551,6 +1552,64 @@ describe("harvest", () => {
       expect(state.inventory.Cabbage).toEqual(new Decimal(1.2));
     });
 
+    it("stacks Power hour, Bee Swarm, Sprout Mix and Scary Mike after Power hour speeds up an existing crop", () => {
+      const cropTime = CROPS["Cabbage"].harvestSeconds * 1000;
+      const remainingTime = 30 * 60 * 1000;
+      const plantedAt = dateNow + remainingTime - cropTime;
+      const stateWithPowerHour = applyBuff({
+        buff: "Power hour",
+        game: {
+          ...GAME_STATE,
+          bumpkin: TEST_BUMPKIN,
+          inventory: { "Cabbage Seed": new Decimal(1) },
+          season: { season: "spring", startedAt: 0 },
+          collectibles: {
+            "Scary Mike": [
+              {
+                id: "123",
+                createdAt: dateNow,
+                coordinates: { x: 0, y: 0 },
+                readyAt: dateNow - 12 * 60 * 1000,
+              },
+            ],
+          },
+          aoe: {
+            "Scary Mike": {
+              0: {
+                "-2": plantedAt,
+              },
+            },
+          },
+          crops: {
+            [firstId]: {
+              ...GAME_STATE.crops[firstId],
+              x: 0,
+              y: -2,
+              crop: {
+                name: "Cabbage",
+                plantedAt,
+              },
+              fertiliser: {
+                name: "Sprout Mix",
+                fertilisedAt: dateNow - 1000,
+              },
+              beeSwarm: { count: 1, swarmActivatedAt: dateNow - 1000 },
+            },
+          },
+        },
+        now: dateNow,
+      });
+
+      const state = harvest({
+        state: stateWithPowerHour,
+        createdAt: dateNow + remainingTime / 2,
+        action: { type: "crop.harvested", index: firstId },
+      });
+
+      expect(state.crops[firstId].crop).toBeUndefined();
+      expect(state.inventory.Cabbage?.toNumber()).toBeCloseTo(1.8);
+    });
+
     it("applies the bud boost", () => {
       const state = harvest({
         state: {
@@ -2835,6 +2894,64 @@ describe("harvest", () => {
       });
       expect(state.crops[firstId].crop).toBeUndefined();
       expect(state.inventory.Eggplant).toEqual(new Decimal(1.2));
+    });
+
+    it("stacks Power hour, Bee Swarm, Sprout Mix and Laurie the Chuckle Crow after Power hour speeds up an existing crop", () => {
+      const cropTime = CROPS["Eggplant"].harvestSeconds * 1000;
+      const remainingTime = 30 * 60 * 1000;
+      const plantedAt = dateNow + remainingTime - cropTime;
+      const stateWithPowerHour = applyBuff({
+        buff: "Power hour",
+        game: {
+          ...GAME_STATE,
+          bumpkin: TEST_BUMPKIN,
+          inventory: { "Eggplant Seed": new Decimal(1) },
+          season: { season: "summer", startedAt: 0 },
+          collectibles: {
+            "Laurie the Chuckle Crow": [
+              {
+                id: "123",
+                createdAt: dateNow,
+                coordinates: { x: 0, y: 0 },
+                readyAt: dateNow - 12 * 60 * 1000,
+              },
+            ],
+          },
+          aoe: {
+            "Laurie the Chuckle Crow": {
+              0: {
+                "-2": plantedAt,
+              },
+            },
+          },
+          crops: {
+            [firstId]: {
+              ...GAME_STATE.crops[firstId],
+              x: 0,
+              y: -2,
+              crop: {
+                name: "Eggplant",
+                plantedAt,
+              },
+              fertiliser: {
+                name: "Sprout Mix",
+                fertilisedAt: dateNow - 1000,
+              },
+              beeSwarm: { count: 1, swarmActivatedAt: dateNow - 1000 },
+            },
+          },
+        },
+        now: dateNow,
+      });
+
+      const state = harvest({
+        state: stateWithPowerHour,
+        createdAt: dateNow + remainingTime / 2,
+        action: { type: "crop.harvested", index: firstId },
+      });
+
+      expect(state.crops[firstId].crop).toBeUndefined();
+      expect(state.inventory.Eggplant?.toNumber()).toBeCloseTo(1.8);
     });
 
     it("gives +1 to Corn in AOE when Queen Cornelia is placed and ready", () => {

--- a/src/features/game/types/buffs.test.ts
+++ b/src/features/game/types/buffs.test.ts
@@ -1,0 +1,64 @@
+import Decimal from "decimal.js-light";
+
+import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import { CROPS } from "features/game/types/crops";
+import { GameState } from "features/game/types/game";
+import { applyBuff } from "./buffs";
+
+const dateNow = Date.now();
+
+describe("applyBuff", () => {
+  it("moves Basic Scarecrow AOE availability when Power hour speeds up an existing crop", () => {
+    const cropTime = CROPS["Sunflower"].harvestSeconds * 1000;
+    const remainingTime = 30 * 1000;
+    const timeReduction = remainingTime / 2;
+    const plantedAt = dateNow + remainingTime - cropTime;
+    const readyAt = dateNow + remainingTime;
+
+    const state: GameState = {
+      ...INITIAL_FARM,
+      bumpkin: TEST_BUMPKIN,
+      inventory: { "Sunflower Seed": new Decimal(1) },
+      collectibles: {
+        "Basic Scarecrow": [
+          {
+            id: "123",
+            createdAt: dateNow,
+            coordinates: { x: 0, y: 0 },
+            readyAt: dateNow - 12 * 60 * 1000,
+          },
+        ],
+      },
+      aoe: {
+        "Basic Scarecrow": {
+          0: {
+            "-2": readyAt,
+          },
+        },
+      },
+      crops: {
+        0: {
+          createdAt: dateNow,
+          x: 0,
+          y: -2,
+          crop: {
+            name: "Sunflower",
+            plantedAt,
+          },
+        },
+      },
+    };
+
+    const stateWithPowerHour = applyBuff({
+      buff: "Power hour",
+      game: state,
+      now: dateNow,
+    });
+
+    expect(stateWithPowerHour.crops[0].crop?.boostedTime).toBe(timeReduction);
+    expect(stateWithPowerHour.aoe["Basic Scarecrow"]?.[0]?.["-2"]).toBe(
+      dateNow + timeReduction,
+    );
+  });
+});

--- a/src/features/game/types/buffs.ts
+++ b/src/features/game/types/buffs.ts
@@ -69,7 +69,30 @@ export function applyBuff({
         const readyAt =
           plot.crop.plantedAt + CROPS[plot.crop.name].harvestSeconds * 1000;
         const remainingTime = readyAt - now;
-        plot.crop.plantedAt -= remainingTime / 2;
+
+        if (remainingTime > 0) {
+          const timeReduction = remainingTime / 2;
+          plot.crop.plantedAt -= timeReduction;
+          plot.crop.boostedTime = (plot.crop.boostedTime ?? 0) + timeReduction;
+
+          const basicScarecrow = gameClone.collectibles["Basic Scarecrow"]?.[0];
+          if (
+            basicScarecrow?.coordinates &&
+            plot.x !== undefined &&
+            plot.y !== undefined
+          ) {
+            const dx = plot.x - basicScarecrow.coordinates.x;
+            const dy = plot.y - basicScarecrow.coordinates.y;
+            const availableAt = gameClone.aoe["Basic Scarecrow"]?.[dx]?.[dy];
+
+            if (availableAt) {
+              gameClone.aoe["Basic Scarecrow"]![dx]![dy] = Math.max(
+                now,
+                availableAt - timeReduction,
+              );
+            }
+          }
+        }
       }
     });
 

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1310,7 +1310,6 @@ import { LOVE_ANIMAL_TOOLS, TREASURE_TOOLS, WORKBENCH_TOOLS } from "./tools";
 import { translate } from "lib/i18n/translate";
 import { LANDSCAPING_DECORATIONS } from "./decorations";
 import { SELLABLE_TREASURES } from "./treasure";
-import { TREASURE_COLLECTIBLE_ITEM } from "./collectibles";
 import { ANIMAL_FOODS } from "./animals";
 import { PROCESSED_RESOURCES } from "./processedFood";
 
@@ -5835,15 +5834,15 @@ export const ITEM_DETAILS: Items = {
   },
   "Adrift Ark": {
     image: adriftArk,
-    description: TREASURE_COLLECTIBLE_ITEM["Adrift Ark"].description,
+    description: translate("description.adrift.ark"),
   },
   Castellan: {
     image: castellan,
-    description: TREASURE_COLLECTIBLE_ITEM.Castellan.description,
+    description: translate("description.castellan"),
   },
   "Sunlit Citadel": {
     image: sunlitCitadel,
-    description: TREASURE_COLLECTIBLE_ITEM["Sunlit Citadel"].description,
+    description: translate("description.sunlit.citadel"),
   },
   "Pharaoh Gnome": {
     image: pharaohGnome,
@@ -5871,11 +5870,11 @@ export const ITEM_DETAILS: Items = {
   },
   "Baobab Tree": {
     image: baobabTree,
-    description: TREASURE_COLLECTIBLE_ITEM["Baobab Tree"].description,
+    description: translate("description.baobab.tree"),
   },
   Camel: {
     image: camel,
-    description: TREASURE_COLLECTIBLE_ITEM.Camel.description,
+    description: translate("description.camel"),
   },
   "Tomato Bombard": {
     image: tomatoBombard,


### PR DESCRIPTION
## Summary

- Tracks Power Hour speed-up in crop.boostedTime when an already planted crop is accelerated.
- Moves Basic Scarecrow AOE availability earlier by the same Power Hour time reduction, so the shortened harvest time and AOE cooldown stay aligned.
- Removes the runtime images.ts -> collectibles.ts dependency for treasure descriptions, fixing the Adrift Ark import-cycle crash seen in CI.

## Root cause

Power Hour moved plantedAt backwards but left boostedTime unchanged. Harvest-yield AOE scarecrows calculate cooldown from base harvest time minus boostedTime, so a crop could become harvestable before the AOE bonus cell was considered ready.

## Validation

- VITE_NETWORK=amoy npx jest src/features/game/events/landExpansion/harvest.test.ts src/features/game/events/landExpansion/feedAnimal.test.ts src/features/game/events/landExpansion/stoneMine.test.ts src/features/game/events/landExpansion/plant.test.ts --runInBand
- VITE_NETWORK=amoy npx jest src/features/game/events/landExpansion/plantFlower.test.ts src/features/game/events/landExpansion/completeSocialTask.test.ts --runInBand
- VITE_NETWORK=amoy yarn test no longer reproduces the Adrift Ark failure locally; my local full parallel and sequential runs later hit a Jest/Node SIGSEGV without a test assertion, while the individually reported suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Power hour interaction so its time reduction stacks correctly with other speed/yield effects and updates related availability timings.
* **Tests**
  * Added unit tests verifying stacking behavior of Power hour with multiple speed/yield effects and confirming expected harvest outcomes.
* **Documentation**
  * Updated item descriptions to use centralized translation keys for several treasure collectibles and items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->