### PR TITLE
fix(BulkSellModal): prevent 50% button from generating invalid sell state

### DIFF
--- a/src/components/ui/BulkSellModal.tsx
+++ b/src/components/ui/BulkSellModal.tsx
@@ -44,7 +44,15 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
     maxDecimalPlaces,
   );
 
-  const isHalfDisabled = itemAmount.lessThan(minValid.mul(2));
+  const safeHalf = Decimal.min(
+    Decimal.max(
+      setPrecision(itemAmount.mul(0.5), maxDecimalPlaces),
+      minValid,
+    ),
+    itemAmount,
+  );
+
+  const isHalfDisabled = safeHalf.lessThanOrEqualTo(0);
 
   return (
     <Modal show={show} onHide={onHide}>
@@ -62,17 +70,7 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
             />
             <Button
               disabled={isHalfDisabled}
-              onClick={() => {
-                const half = setPrecision(
-                  itemAmount.mul(0.5),
-                  maxDecimalPlaces,
-                );
-                const safeValue = Decimal.min(
-                  Decimal.max(half, minValid),
-                  itemAmount,
-                );
-                setCustomAmount(safeValue);
-              }}
+              onClick={() => setCustomAmount(safeHalf)}
               className="ml-2 px-1 py-1 w-auto"
             >
               {`50%`}

--- a/src/components/ui/BulkSellModal.tsx
+++ b/src/components/ui/BulkSellModal.tsx
@@ -39,6 +39,13 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
   const isOutOfRange =
     customAmount.greaterThan(itemAmount) || customAmount.lessThanOrEqualTo(0);
 
+  const minValid = setPrecision(
+    new Decimal(1).div(10 ** maxDecimalPlaces),
+    maxDecimalPlaces,
+  );
+
+  const isHalfDisabled = itemAmount.lessThan(minValid.mul(2));
+
   return (
     <Modal show={show} onHide={onHide}>
       <Panel className="w-4/5 m-auto" bumpkinParts={bumpkinParts}>
@@ -54,11 +61,18 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
               onValueChange={setCustomAmount}
             />
             <Button
-              onClick={() =>
-                setCustomAmount(
-                  setPrecision(itemAmount.mul(0.5), maxDecimalPlaces),
-                )
-              }
+              disabled={isHalfDisabled}
+              onClick={() => {
+                const half = setPrecision(
+                  itemAmount.mul(0.5),
+                  maxDecimalPlaces,
+                );
+                const safeValue = Decimal.min(
+                  Decimal.max(half, minValid),
+                  itemAmount,
+                );
+                setCustomAmount(safeValue);
+              }}
               className="ml-2 px-1 py-1 w-auto"
             >
               {`50%`}
@@ -71,11 +85,11 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
             </Button>
           </div>
           <div className="inline-flex items-center">
-            {`${t("bumpkinTrade.youWillReceive")}: ${coinAmount}`}
+            {`${t("bumpkinTrade.youWillReceive")}: ${setPrecision(coinAmount, maxDecimalPlaces)}`}
             <img src={coins} alt="coins" className="ml-2 mt-1" />
           </div>
         </div>
-        <div className="flex justify-content-around mt-2 space-x-1">
+        <div className="flex justify-around mt-2 space-x-1">
           <Button onClick={onCancel}>{t("cancel")}</Button>
           <Button disabled={isOutOfRange} onClick={onSell}>
             {t("sell")}

--- a/src/components/ui/BulkSellModal.tsx
+++ b/src/components/ui/BulkSellModal.tsx
@@ -44,13 +44,9 @@ export const BulkSellModal: React.FC<BulkSellProps> = ({
     maxDecimalPlaces,
   );
 
-  const safeHalf = Decimal.min(
-    Decimal.max(
-      setPrecision(itemAmount.mul(0.5), maxDecimalPlaces),
-      minValid,
-    ),
-    itemAmount,
-  );
+  const half = setPrecision(itemAmount.mul(0.5), maxDecimalPlaces);
+  const clampedUp = half.greaterThan(minValid) ? half : minValid;
+  const safeHalf = clampedUp.greaterThan(itemAmount) ? itemAmount : clampedUp;
 
   const isHalfDisabled = safeHalf.lessThanOrEqualTo(0);
 


### PR DESCRIPTION
Fix 50% button silently disabling Sell when itemAmount rounds to zero after precision clamp, unify disabled logic with safeHalf computation, fix coinAmount formatting and invalid Tailwind class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The 50% quick-select button is now disabled when choosing it would produce an invalid or too-small amount.
  * Displayed "you will receive" amounts are now formatted with improved precision for clearer receipts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->