### PR TITLE
[FEAT] Economy launch

### DIFF
--- a/src/features/economyHub/EconomyHub.tsx
+++ b/src/features/economyHub/EconomyHub.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from "react";
+import React, { useCallback, useContext, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 import useSWR from "swr";
 import { useActor, useSelector } from "@xstate/react";
@@ -26,11 +26,8 @@ import {
   marketplaceEconomiesPageSwrKey,
 } from "features/marketplace/actions/loadEconomiesMarketplaceData";
 
-import { RewardsWidget } from "./components/RewardsWidget";
-import { CreateEconomyWidget } from "./components/CreateEconomyWidget";
 import { TopTradeablesWidget } from "./components/TopTradeablesWidget";
 import { MinigameList } from "./components/MinigameList";
-import { mapEconomyOfferToExchangeRow } from "./lib/mapEconomyOffers";
 
 const _state = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => Number(state.context.farmId);
@@ -97,21 +94,6 @@ export const EconomyHub: React.FC = () => {
   const items = tradeablesData?.items ?? [];
   const economies = economiesData?.economies ?? [];
 
-  const labelBySlug = useMemo(
-    () => Object.fromEntries(economies.map((e) => [e.slug, e.label])),
-    [economies],
-  );
-
-  const exchanges = useMemo(() => {
-    const offers = economiesData?.exchanges ?? [];
-    return offers.map((offer) =>
-      mapEconomyOfferToExchangeRow(
-        offer,
-        labelBySlug[offer.slug] ?? offer.slug,
-      ),
-    );
-  }, [economiesData?.exchanges, labelBySlug]);
-
   // When the player returns to the hub (e.g. after closing a minigame
   // iframe), force-refetch so counters and leaderboards reflect any
   // changes that happened while they were playing.
@@ -177,8 +159,6 @@ export const EconomyHub: React.FC = () => {
         {/* Body: skinny left column + wide right column. */}
         <div className="flex flex-col lg:flex-row gap-2 pb-4">
           <div className="w-full lg:w-1/5">
-            <RewardsWidget exchanges={exchanges} />
-            <CreateEconomyWidget />
             <TopTradeablesWidget items={items} isLoading={tradeablesLoading} />
           </div>
 

--- a/src/features/marketplace/components/TradeableList.tsx
+++ b/src/features/marketplace/components/TradeableList.tsx
@@ -73,7 +73,9 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showItemInUseWarning, setShowItemInUseWarning] = useState(false);
   const [price, setPrice] = useState(0);
-  const [quantity, setQuantity] = useState(0);
+  const [quantity, setQuantity] = useState(
+    display.type === "economies" ? 1 : 0,
+  );
   /** Number of identical listings to create (1–20). Only for resources */
   const [multiple, setMultiple] = useState(1);
 
@@ -113,6 +115,9 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
   const isResource =
     isTradeResource(display.name as InventoryItemName) &&
     display.type === "collectibles";
+
+  const isEconomyToken = display.type === "economies";
+  const ECONOMY_MAX_QUANTITY = 1000;
 
   const hasReputationOrDailyQuota = hasTradeReputation || dailyListings < 1;
 
@@ -344,6 +349,28 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
       ) : (
         <>
           <div className="flex flex-col p-2">
+            {isEconomyToken && (
+              <>
+                <Label type="default" className="mb-1">
+                  {t("marketplace.quantity")}
+                </Label>
+                <div className="my-2 -mx-2">
+                  <NumberInput
+                    value={quantity}
+                    onValueChange={(decimal) =>
+                      setQuantity(
+                        Math.min(
+                          ECONOMY_MAX_QUANTITY,
+                          Math.max(1, Math.floor(decimal.toNumber())),
+                        ),
+                      )
+                    }
+                    maxDecimalPlaces={0}
+                    isOutOfRange={quantity > available || quantity < 1}
+                  />
+                </div>
+              </>
+            )}
             <Label type="default" icon={sflIcon}>
               {t("bumpkinTrade.price")}
             </Label>
@@ -433,7 +460,11 @@ export const TradeableListItem: React.FC<TradeableListItemProps> = ({
           <div className="flex space-x-1">
             <Button onClick={onClose}>{t("close")}</Button>
             <Button
-              disabled={!price || accountTradedRecently}
+              disabled={
+                !price ||
+                accountTradedRecently ||
+                (isEconomyToken && (quantity < 1 || quantity > available))
+              }
               onClick={submitListing}
               className="relative"
             >

--- a/src/features/minigame/components/MinigameShopListBody.tsx
+++ b/src/features/minigame/components/MinigameShopListBody.tsx
@@ -32,6 +32,13 @@ export const MinigameShopListBody: React.FC<Props> = ({
   className,
 }) => {
   const { t } = useAppTranslation();
+
+  const sortedItems = [...items].sort((a, b) => {
+    const aReached = isShopItemMaxCallsReached(a) ? 1 : 0;
+    const bReached = isShopItemMaxCallsReached(b) ? 1 : 0;
+    return aReached - bReached;
+  });
+
   return (
     <div
       className={
@@ -39,7 +46,7 @@ export const MinigameShopListBody: React.FC<Props> = ({
         "flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto md:max-h-none"
       }
     >
-      {items.map((item) => {
+      {sortedItems.map((item) => {
         const maxCallsReached = isShopItemMaxCallsReached(item);
         const supplyBlocked = item.supplyBlocked === true;
         const canAfford = canAffordShopItem(item, balances);
@@ -68,11 +75,11 @@ export const MinigameShopListBody: React.FC<Props> = ({
                 style={{ imageRendering: "pixelated" }}
               />
             </div>
-            <div className="min-w-0 flex-1 self-center py-0.5">
+            <div className="min-w-0 flex-1 self-center py-0.5 overflow-hidden">
               <div className="truncate text-sm leading-snug">{item.name}</div>
               <div
                 className={classNames(
-                  "mt-1 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs leading-normal",
+                  "mt-1 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-xs leading-normal max-h-10 overflow-hidden",
                   !maxCallsReached &&
                     !supplyBlocked &&
                     !canAfford &&

--- a/src/features/playerEconomyEditor/components/EconomySiteFilesUpload.tsx
+++ b/src/features/playerEconomyEditor/components/EconomySiteFilesUpload.tsx
@@ -20,7 +20,7 @@ function formatSiteIndexTime(iso: string): string {
   });
 }
 
-const MAX_FILES = 200;
+const MAX_FILES = 300;
 
 /** Browser `file.type` is often empty; map common extensions when guessing. */
 const EXT_TO_MIME: Record<string, string> = {

--- a/src/features/world/ui/portals/PortalChooser.tsx
+++ b/src/features/world/ui/portals/PortalChooser.tsx
@@ -1,6 +1,9 @@
 import React, { useContext, useState } from "react";
-import { ButtonPanel } from "components/ui/Panel";
+import { useNavigate } from "react-router";
+import { ButtonPanel, ColorPanel, Panel } from "components/ui/Panel";
 import { Label } from "components/ui/Label";
+import { Modal } from "components/ui/Modal";
+import { Button } from "components/ui/Button";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ChickenRescue } from "./ChickenRescue";
 import { CropsAndChickens } from "./CropsAndChickens";
@@ -89,8 +92,10 @@ export const PortalChooser: React.FC<{ onClose: () => void }> = ({
   onClose,
 }) => {
   const { t } = useAppTranslation();
+  const navigate = useNavigate();
   const [selectedGame, setSelectedGame] = useState<MinigameName>();
   const [showIntro, setShowIntro] = useState(!hasReadIntro());
+  const [showEconomyConfirm, setShowEconomyConfirm] = useState(false);
   const { gameService } = useContext(GameContext);
 
   if (
@@ -142,30 +147,77 @@ export const PortalChooser: React.FC<{ onClose: () => void }> = ({
   }
 
   return (
-    <CloseButtonPanel onClose={onClose} bumpkinParts={NPC_WEARABLES["billy"]}>
-      <div className="flex flex-col items-center">
-        <div className="p-2">
-          <Label type="default" icon={SUNNYSIDE.icons.player}>
-            {`Choose your adventure!`}
-          </Label>
-        </div>
+    <>
+      <CloseButtonPanel onClose={onClose} bumpkinParts={NPC_WEARABLES["billy"]}>
+        <div className="flex flex-col items-center">
+          <div className="p-2">
+            <Label type="default" icon={SUNNYSIDE.icons.player}>
+              {`Choose your adventure!`}
+            </Label>
+          </div>
 
-        <div className="flex flex-col gap-1 w-full">
-          {PORTAL_OPTIONS.map(({ id, npc, title, description }) => (
-            <ButtonPanel
-              key={id}
-              className="flex flex-row items-center gap-2"
-              onClick={() => setSelectedGame(id)}
-            >
-              {npc && <NPCIcon parts={NPC_WEARABLES[npc]} />}
-              <div className="flex flex-col items-start gap-1">
-                <span className="text-sm">{title}</span>
-                <span className="text-xs mt-1">{description}</span>
-              </div>
-            </ButtonPanel>
-          ))}
+          <div className="flex flex-col gap-1 w-full">
+            {PORTAL_OPTIONS.map(({ id, npc, title, description }) => (
+              <ButtonPanel
+                key={id}
+                className="flex flex-row items-center gap-2"
+                onClick={() => setSelectedGame(id)}
+              >
+                {npc && <NPCIcon parts={NPC_WEARABLES[npc]} />}
+                <div className="flex flex-col items-start gap-1">
+                  <span className="text-sm">{title}</span>
+                  <span className="text-xs mt-1">{description}</span>
+                </div>
+              </ButtonPanel>
+            ))}
+          </div>
+
+          <ColorPanel
+            type="vibrant"
+            className="flex items-center gap-2 p-2 mt-2 w-full cursor-pointer hover:brightness-110"
+            onClick={() => setShowEconomyConfirm(true)}
+          >
+            <img
+              src={SUNNYSIDE.icons.search}
+              className="shrink-0"
+              style={{ width: "20px", height: "20px" }}
+            />
+            <p className="text-xs flex-1 leading-tight">
+              {t("portal.economyMinigames.banner")}
+            </p>
+          </ColorPanel>
         </div>
-      </div>
-    </CloseButtonPanel>
+      </CloseButtonPanel>
+
+      <Modal
+        show={showEconomyConfirm}
+        onHide={() => setShowEconomyConfirm(false)}
+      >
+        <Panel>
+          <div className="p-1">
+            <Label type="danger" className="mb-2">
+              {t("are.you.sure")}
+            </Label>
+            <p className="text-xs mb-3 leading-snug">
+              {t("portal.economyMinigames.disclaimer")}
+            </p>
+            <div className="flex gap-1">
+              <Button onClick={() => setShowEconomyConfirm(false)}>
+                {t("cancel")}
+              </Button>
+              <Button
+                onClick={() => {
+                  setShowEconomyConfirm(false);
+                  onClose();
+                  navigate("/economy-hub");
+                }}
+              >
+                {t("confirm")}
+              </Button>
+            </div>
+          </div>
+        </Panel>
+      </Modal>
+    </>
   );
 };

--- a/src/features/world/ui/portals/PortalChooser.tsx
+++ b/src/features/world/ui/portals/PortalChooser.tsx
@@ -182,9 +182,12 @@ export const PortalChooser: React.FC<{ onClose: () => void }> = ({
               className="shrink-0"
               style={{ width: "20px", height: "20px" }}
             />
-            <p className="text-xs flex-1 leading-tight">
-              {t("portal.economyMinigames.banner")}
-            </p>
+            <div className="flex-1">
+              <p className="text-xs leading-tight">
+                {t("portal.economyMinigames.banner")}
+              </p>
+              <p className="text-xs underline mt-0.5">{"View more"}</p>
+            </div>
           </ColorPanel>
         </div>
       </CloseButtonPanel>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6391,6 +6391,8 @@
   "portal.memory.description": "Flip cards, find matches and try to beat the clock in this memory challenge!",
   "portal.chaacsTemple.title": "Chaac's Temple",
   "portal.chaacsTemple.description": "Enter the temple, defy the odds and solve Chaac's memory challenge.",
+  "portal.economyMinigames.banner": "New player minigames have just launched! This is in beta mode",
+  "portal.economyMinigames.disclaimer": "These games are not maintained or supported by the SFL team - proceed at your own risk.",
   "recipes.upNext": "Up Next",
   "recipes.addToQueue": "Add to queue",
   "recipes.queue": "Queue",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -6391,6 +6391,8 @@
   "portal.memory.description": "Flip cards, find matches and try to beat the clock in this memory challenge!",
   "portal.chaacsTemple.title": "Chaac's Temple",
   "portal.chaacsTemple.description": "Enter the temple, defy the odds and solve Chaac's memory challenge.",
+  "portal.economyMinigames.banner": "New player minigames have just launched! This is in beta mode",
+  "portal.economyMinigames.disclaimer": "These games are not maintained or supported by the SFL team - proceed at your own risk.",
   "recipes.upNext": "Up Next",
   "recipes.addToQueue": "Add to queue",
   "recipes.queue": "Queue",


### PR DESCRIPTION
# Pull request description

Adds a few tweaks and allows players to access the economies players have built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation to Economy Hub from portal with confirmation dialog
  * Added quantity controls for economy token listings with defined maximum limits

* **Improvements**
  * Redesigned Economy Hub layout to highlight top tradeable items
  * Increased file upload batch limit from 200 to 300
  * Improved minigame shop item sorting to deprioritize unavailable items
  * Added localization text for economy minigames portal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunflower-land/sunflower-land/pull/7290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->