### PR TITLE
[CHORE] Extract getRegularMaxDigs/getRemainingDigs into desert.ts

### DIFF
--- a/src/features/game/types/desert.ts
+++ b/src/features/game/types/desert.ts
@@ -2,6 +2,8 @@ import { getKeys } from "lib/object";
 import type { GameState, InventoryItemName } from "./game";
 import { type ChapterName, getCurrentChapter } from "./chapters";
 import type { BeachBountyChapterArtefact } from "./treasure";
+import { isCollectibleBuilt } from "../lib/collectibleBuilt";
+import { isWearableActive } from "../lib/wearables";
 
 export const DESERT_GRID_HEIGHT = 10;
 export const DESERT_GRID_WIDTH = 10;
@@ -389,3 +391,56 @@ export function getTreasureCount({ game }: { game: GameState }) {
 
   return count;
 }
+
+/**
+ * The base number of digs available per day, before today's `extraDigs`,
+ * including the boosts granted by placed collectibles and active wearables.
+ */
+export const getRegularMaxDigs = (game: GameState) => {
+  let maxDigs = 25;
+
+  if (isCollectibleBuilt({ name: "Heart of Davy Jones", game })) {
+    maxDigs += 20;
+  }
+
+  if (
+    isCollectibleBuilt({
+      name: "Pharaoh Chicken",
+      game,
+    })
+  ) {
+    maxDigs += 1;
+  }
+
+  if (isWearableActive({ name: "Bionic Drill", game })) {
+    maxDigs += 5;
+  }
+
+  if (isCollectibleBuilt({ name: "Meerkat", game })) {
+    maxDigs += 5;
+  }
+
+  return maxDigs;
+};
+
+/**
+ * How many digs the player has left today: their boosted daily max minus
+ * holes already dug, plus any purchased `extraDigs`.
+ */
+export const getRemainingDigs = (game: GameState) => {
+  const { desert } = game;
+  const dugCount = desert.digging.grid.length;
+  const extraDigs = desert.digging.extraDigs ?? 0;
+  const regularMaxDigs = getRegularMaxDigs(game);
+  let digsLeft = regularMaxDigs - dugCount;
+
+  // This is the case where a player has bought and used extra digs
+  // The dug count is higher than the regular max digs
+  if (digsLeft < 0) {
+    digsLeft = 0;
+  }
+
+  digsLeft += extraDigs;
+
+  return digsLeft;
+};

--- a/src/features/island/hud/components/DesertDiggingDisplay.tsx
+++ b/src/features/island/hud/components/DesertDiggingDisplay.tsx
@@ -3,57 +3,10 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { useActor } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import type { GameState } from "features/game/types/game";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { Modal } from "components/ui/Modal";
 import { Digby } from "features/world/ui/beach/Digby";
 import { useTranslation } from "react-i18next";
-import { isWearableActive } from "features/game/lib/wearables";
-
-export const getRegularMaxDigs = (game: GameState) => {
-  let maxDigs = 25;
-
-  if (isCollectibleBuilt({ name: "Heart of Davy Jones", game })) {
-    maxDigs += 20;
-  }
-
-  if (
-    isCollectibleBuilt({
-      name: "Pharaoh Chicken",
-      game,
-    })
-  ) {
-    maxDigs += 1;
-  }
-
-  if (isWearableActive({ name: "Bionic Drill", game })) {
-    maxDigs += 5;
-  }
-
-  if (isCollectibleBuilt({ name: "Meerkat", game })) {
-    maxDigs += 5;
-  }
-
-  return maxDigs;
-};
-
-export const getRemainingDigs = (game: GameState) => {
-  const { desert } = game;
-  const dugCount = desert.digging.grid.length;
-  const extraDigs = desert.digging.extraDigs ?? 0;
-  const regularMaxDigs = getRegularMaxDigs(game);
-  let digsLeft = regularMaxDigs - dugCount;
-
-  // This is the case where a player has bought and used extra digs
-  // The dug count is higher than the regular max digs
-  if (digsLeft < 0) {
-    digsLeft = 0;
-  }
-
-  digsLeft += extraDigs;
-
-  return digsLeft;
-};
+import { getRemainingDigs } from "features/game/types/desert";
 
 export const DesertDiggingDisplay = () => {
   const { gameService } = useContext(Context);

--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -14,6 +14,7 @@ import {
   DESERT_GRID_HEIGHT,
   DESERT_GRID_WIDTH,
   getArtefactsFound,
+  getRemainingDigs,
   hasClaimedReward,
   secondsTillDesertStorm,
 } from "features/game/types/desert";
@@ -23,7 +24,6 @@ import { hasReadDesertNotice as hasReadDesertNotice } from "../ui/beach/DesertNo
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import Decimal from "decimal.js-light";
 import { isTouchDevice } from "../lib/device";
-import { getRemainingDigs } from "features/island/hud/components/DesertDiggingDisplay";
 import { hasReadDigbyIntro } from "../ui/beach/Digby";
 import { isWearableActive } from "features/game/lib/wearables";
 import type { EventObject } from "xstate/lib/types";

--- a/src/features/world/ui/beach/Digby.tsx
+++ b/src/features/world/ui/beach/Digby.tsx
@@ -6,6 +6,7 @@ import {
   type DiggingFormation,
   DIGGING_FORMATIONS,
   getArtefactsFound,
+  getRemainingDigs,
   CHAPTER_ARTEFACT,
   hasClaimedReward,
   type DiggingFormationName,
@@ -32,7 +33,6 @@ import { type BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { pixelDarkBorderStyle } from "features/game/lib/style";
 import type { CollectibleName } from "features/game/types/craftables";
 import Decimal from "decimal.js-light";
-import { getRemainingDigs } from "features/island/hud/components/DesertDiggingDisplay";
 import { BUMPKIN_ITEM_BUFF_LABELS } from "features/game/types/bumpkinItemBuffs";
 import { ResizableBar } from "components/ui/ProgressBar";
 import { Revealed } from "features/game/components/Revealed";


### PR DESCRIPTION
## What

Move the two digs-left helpers — `getRegularMaxDigs` and `getRemainingDigs` — out of the `DesertDiggingDisplay` HUD component and into `features/game/types/desert.ts`, next to the other digging helpers (`getTreasuresFound`, `getArtefactsFound`, `getTreasureCount`).

`DesertDiggingDisplay`, `BeachScene`, and `Digby` now import `getRemainingDigs` from `desert.ts`.

## Why

These two functions are pure game logic (`GameState` in, a number out) but currently live in a React component module. That means any non-UI consumer that just wants "how many digs are left" has to import the whole HUD component — dragging `GameProvider`, `Digby`, modals, and the rest of the React/Phaser graph along with it.

Moving them to the pure `desert.ts` lets tooling compute remaining digs cleanly. (Concretely: the community [Sunflower Land Overview](https://github.com/eliasSFL/sunflower-land-overview) dashboard wants to show a player's digs-left on a read-only `/digging` page, and re-implementing the boost math locally would silently rot whenever a new dig boost lands here.)

## Notes

- **No behaviour change.** The functions are moved verbatim; only their location and three import sites changed.
- `desert.ts` now imports `isCollectibleBuilt` / `isWearableActive` from `../lib/*`; no import cycle (those libs don't import `desert.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Desert digging calculations moved to a centralized utility, ensuring consistent remaining-digs and max-digs displays across the HUD, beach scene, and NPC interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->