### PR TITLE
[FEAT] Bonus design improvements

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -10,6 +10,7 @@ import { COLLECTIBLES_DIMENSIONS } from "../types/craftables";
 import { getKeys } from "lib/object";
 import { LandBase } from "./components/LandBase";
 import { UpcomingExpansion } from "./components/UpcomingExpansion";
+import { useLandscapingGridBackgroundImage } from "features/island/landscaping/LandscapingGrid";
 import { BUILDINGS_DIMENSIONS, type Home } from "../types/buildings";
 import { Building } from "features/island/buildings/components/building/Building";
 import { Collectible } from "features/island/collectibles/Collectible";
@@ -315,6 +316,7 @@ export const LandComponent: React.FC = () => {
   const island = useSelector(gameService, _island);
   const season = useSelector(gameService, _season);
   const expansionCount = useSelector(gameService, _expansionCount);
+  const gridBackgroundImage = useLandscapingGridBackgroundImage();
   const { crops, positions: cropPositions } = useSelector(
     gameService,
     _cropPositions,
@@ -1226,9 +1228,7 @@ export const LandComponent: React.FC = () => {
               )}
               style={{
                 backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
-                backgroundImage: `
-            linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
-            linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
+                backgroundImage: gridBackgroundImage,
               }}
             />
 

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -112,6 +112,13 @@ export interface Context {
   moving?: { id: string; name: LandscapingPlaceable };
 
   maximum?: number;
+
+  /**
+   * Bulk-removal mode. When true, the landscaping HUD collapses to a single
+   * "exit" button and a red banner, and any click on a placed item dispatches
+   * the matching `*.removed` event directly instead of selecting the item.
+   */
+  removalMode?: boolean;
 }
 
 type SelectEvent = {
@@ -193,6 +200,7 @@ export type BlockchainEvent =
   | RemoveEvent
   | RemoveAllEvent
   | FlipEvent
+  | { type: "TOGGLE_REMOVAL_MODE" }
   | { type: "CANCEL" }
   | { type: "BACK" };
 
@@ -314,6 +322,14 @@ export const landscapingMachine = createMachine<
             },
             BUILD: {
               target: "idle",
+            },
+            TOGGLE_REMOVAL_MODE: {
+              actions: assign({
+                removalMode: (context) => !context.removalMode,
+                // Entering removal mode should also clear any current
+                // selection so the floating action row goes away.
+                moving: (_) => undefined,
+              }),
             },
             REMOVE_ALL: {
               target: "idle",

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -825,14 +825,15 @@ function detectInteriorCollision({
     return true;
   }
 
-  // Decorations (everything except utility NPCs) can be stacked freely on
-  // any valid interior tile — players should be able to pixel-perfect arrange
-  // collectibles without collision getting in the way.
-  if (name !== "FarmHand" && name !== "Bumpkin") {
+  // 2. Overlap check — interior placements must not overlap any other
+  // collectible already placed in the room. Existing overlaps in saved
+  // state are left alone; this only blocks new placements/moves that
+  // would land on top of something. Rugs / tiles (NON_COLLIDING_OBJECTS)
+  // are still free to overlap anything.
+  if (NON_COLLIDING_OBJECTS.includes(name as InventoryItemName)) {
     return false;
   }
 
-  // Utility NPCs (FarmHand, Bumpkin) still check against each other.
   const placed = state.interior.ground.collectibles;
   const collidingItems = getKeys(placed).filter(
     (itemName) => !NON_COLLIDING_OBJECTS.includes(itemName),
@@ -889,9 +890,9 @@ function detectLevelOneCollision({
     return true;
   }
 
-  // Same decoration-first policy as the ground floor: only FarmHand and
-  // Bumpkin are utility items that need to avoid overlapping each other.
-  if (name !== "FarmHand" && name !== "Bumpkin") {
+  // Same overlap policy as the ground floor — see detectInteriorCollision
+  // for rationale. Rugs / tiles can still stack freely.
+  if (NON_COLLIDING_OBJECTS.includes(name as InventoryItemName)) {
     return false;
   }
 

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -34,6 +34,7 @@ import {
 import { Bud } from "features/island/buds/Bud";
 import { InteriorBumpkins } from "./components/InteriorBumpkins";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { useLandscapingGridBackgroundImage } from "features/island/landscaping/LandscapingGrid";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
 import { NPC_WEARABLES } from "lib/npcs";
 import { EXTERIOR_ISLAND_BG } from "features/barn/BarnInside";
@@ -121,6 +122,7 @@ export const Home: React.FC = () => {
   const buds = useSelector(gameService, _buds);
   const petNFTs = useSelector(gameService, _petNFTs);
   const island = useSelector(gameService, _island);
+  const gridBackgroundImage = useLandscapingGridBackgroundImage();
   const homeFarmHands = useSelector(gameService, _homeFarmHands);
   const { collectibles, positions: homeCollectiblePositions } = useSelector(
     gameService,
@@ -343,9 +345,7 @@ export const Home: React.FC = () => {
                   width: `${bounds.height * GRID_WIDTH_PX}px`,
 
                   backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
-                  backgroundImage: `
-            linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
-            linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
+                  backgroundImage: gridBackgroundImage,
                 }}
               />
 

--- a/src/features/home/components/BedsMigrationModal.tsx
+++ b/src/features/home/components/BedsMigrationModal.tsx
@@ -85,12 +85,7 @@ export const BedsMigrationModal: React.FC<Props> = ({ show, onHide }) => {
                 (f) => f.equipped,
               )[i];
               return (
-                <BedCell
-                  bed={bed}
-                  equipment={equipment}
-                  isPlaced
-                  key={bed}
-                />
+                <BedCell bed={bed} equipment={equipment} isPlaced key={bed} />
               );
             })}
             {getKeys(BED_FARMHAND_COUNT)

--- a/src/features/home/components/BedsMigrationModal.tsx
+++ b/src/features/home/components/BedsMigrationModal.tsx
@@ -1,0 +1,158 @@
+import React, { useContext } from "react";
+import { useSelector } from "@xstate/react";
+
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import { getKeys } from "lib/object";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { BED_FARMHAND_COUNT } from "features/game/types/beds";
+import { BED_WIDTH } from "features/island/collectibles/components/Bed";
+import { NPCIcon } from "features/island/bumpkin/components/NPC";
+
+import { Modal } from "components/ui/Modal";
+import { Panel } from "components/ui/Panel";
+import { Button } from "components/ui/Button";
+import { Label } from "components/ui/Label";
+
+import type { BedName } from "features/game/types/game";
+import type { BumpkinParts } from "lib/utils/tokenUriBuilder";
+
+const _bumpkin = (state: MachineState) => state.context.state.bumpkin;
+const _farmHands = (state: MachineState) =>
+  state.context.state.farmHands.bumpkins;
+const _collectibles = (state: MachineState) => state.context.state.collectibles;
+const _homeCollectibles = (state: MachineState) =>
+  state.context.state.home.collectibles;
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+}
+
+/**
+ * Beds-migration modal listing every bed type the player needs to craft to
+ * unlock more farm hands, along with the current occupancy. Lives in
+ * features/home for historical reasons but is rendered from both the Home
+ * page (via InteriorBumpkins) and the Interior HUD (via InteriorBedsButton).
+ */
+export const BedsMigrationModal: React.FC<Props> = ({ show, onHide }) => {
+  const { t } = useAppTranslation();
+  const { gameService } = useContext(Context);
+
+  const bumpkin = useSelector(gameService, _bumpkin);
+  const farmHands = useSelector(gameService, _farmHands);
+  const collectibles = useSelector(gameService, _collectibles);
+  const homeCollectibles = useSelector(gameService, _homeCollectibles);
+
+  const count = getKeys(farmHands).length + 1;
+  const max = Object.keys(BED_FARMHAND_COUNT).length;
+
+  const uniqueBeds = new Set<BedName>([
+    ...(getKeys(collectibles).filter(
+      (n) => n in BED_FARMHAND_COUNT,
+    ) as BedName[]),
+    ...(getKeys(homeCollectibles).filter(
+      (n) => n in BED_FARMHAND_COUNT,
+    ) as BedName[]),
+  ]);
+
+  const beds = getKeys(BED_FARMHAND_COUNT)
+    .sort((a, b) => BED_FARMHAND_COUNT[a] - BED_FARMHAND_COUNT[b])
+    .filter((bedName) => uniqueBeds.has(bedName));
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Panel>
+        <div className="p-1 flex justify-between">
+          <Label type="default" icon={ITEM_DETAILS["Basic Bed"].image}>
+            {t("bedsMigration.label")}
+          </Label>
+          <Label type="default" icon={SUNNYSIDE.icons.player}>
+            {t("bedsMigration.farmHandCount", { count, max })}
+          </Label>
+        </div>
+        <div className="flex p-2 flex-col space-y-1 mb-2 text-xs">
+          <span>{t("bedsMigration.bedsNeededDescription")}</span>
+          <span>{t("bedsMigration.bedsNeededDescription2")}</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <div className="grid grid-cols-4 mb-2 w-full">
+            {beds.map((bed, i) => {
+              const equipment = [bumpkin, ...Object.values(farmHands)].map(
+                (f) => f.equipped,
+              )[i];
+              return (
+                <BedCell
+                  bed={bed}
+                  equipment={equipment}
+                  isPlaced
+                  key={bed}
+                />
+              );
+            })}
+            {getKeys(BED_FARMHAND_COUNT)
+              .filter((bed) => !beds.includes(bed))
+              .map((bed, i) => {
+                const equipment = [bumpkin, ...Object.values(farmHands)]
+                  .map((f) => f.equipped)
+                  .slice(beds.length)[i];
+                return (
+                  <BedCell
+                    bed={bed}
+                    equipment={equipment}
+                    isPlaced={false}
+                    key={bed}
+                  />
+                );
+              })}
+          </div>
+        </div>
+
+        <Button onClick={onHide}>{t("close")}</Button>
+      </Panel>
+    </Modal>
+  );
+};
+
+const BedCell: React.FC<{
+  bed: BedName;
+  equipment?: BumpkinParts;
+  isPlaced: boolean;
+}> = ({ bed, equipment, isPlaced }) => {
+  const { t } = useAppTranslation();
+
+  return (
+    <div className="flex flex-col items-center w-full" key={bed}>
+      <Label type={isPlaced ? (equipment ? "warning" : "success") : "default"}>
+        <span className="text-xxs">
+          {isPlaced
+            ? equipment
+              ? t("bedsMigration.status.occupied")
+              : t("bedsMigration.status.unoccupied")
+            : t("bedsMigration.status.notPlaced")}
+        </span>
+      </Label>
+      <span className="text-xxs text-center">{bed.split(" ")[0]}</span>
+      <span className="text-xxs text-center mb-1">{bed.split(" ")[1]}</span>
+
+      <div
+        className="flex justify-center relative"
+        style={{ width: `${22 * PIXEL_SCALE}px` }}
+      >
+        <img
+          src={ITEM_DETAILS[bed].image}
+          style={{ width: `${BED_WIDTH[bed] * PIXEL_SCALE}px` }}
+          className={isPlaced ? "opacity-100" : "opacity-50"}
+        />
+        {equipment && (
+          <div className="absolute">
+            <NPCIcon key={JSON.stringify(equipment)} parts={equipment} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useLayoutEffect, useMemo, type JSX } from "react";
-import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 import { useNavigate, useSearchParams } from "react-router";
 import ScrollContainer from "react-indiana-drag-scroll";

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -18,6 +18,7 @@ import { LandscapingHud } from "features/island/hud/LandscapingHud";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { hasFeatureAccess } from "lib/flags";
 import { Button } from "components/ui/Button";
+import { LandscapingGrid } from "features/island/landscaping/LandscapingGrid";
 import {
   NON_COLLIDING_OBJECTS,
   FURNITURE_OBJECTS,
@@ -332,21 +333,7 @@ export const Interior: React.FC = () => {
 
               {debug && <InteriorGridOverlay island={island.type} />}
 
-              <div
-                className={classNames(
-                  "absolute inset-0 pointer-events-none transition-opacity z-10",
-                  {
-                    "opacity-0": !landscaping,
-                    "opacity-100": landscaping,
-                  },
-                )}
-                style={{
-                  backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
-                  backgroundImage: `
-                    linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
-                    linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
-                }}
-              />
+              <LandscapingGrid />
 
               {landscaping && <Placeable location="interior" />}
 

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useLayoutEffect, useMemo, type JSX } from "react";
-import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 import { useNavigate, useSearchParams } from "react-router";
 import ScrollContainer from "react-indiana-drag-scroll";

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -17,6 +17,7 @@ import { Hud } from "features/island/hud/Hud";
 import { LandscapingHud } from "features/island/hud/LandscapingHud";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { hasFeatureAccess } from "lib/flags";
+import { LandscapingGrid } from "features/island/landscaping/LandscapingGrid";
 import {
   NON_COLLIDING_OBJECTS,
   FURNITURE_OBJECTS,
@@ -352,21 +353,7 @@ export const LevelOne: React.FC = () => {
 
               {debug && <LevelOneGridOverlay tier={expansion} />}
 
-              <div
-                className={classNames(
-                  "absolute inset-0 pointer-events-none transition-opacity z-10",
-                  {
-                    "opacity-0": !landscaping,
-                    "opacity-100": landscaping,
-                  },
-                )}
-                style={{
-                  backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
-                  backgroundImage: `
-                    linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
-                    linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
-                }}
-              />
+              <LandscapingGrid />
 
               {landscaping && <Placeable location="level_one" />}
 

--- a/src/features/interior/components/InteriorBedsButton.tsx
+++ b/src/features/interior/components/InteriorBedsButton.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { RoundButton } from "components/ui/RoundButton";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { BedsMigrationModal } from "features/home/components/BedsMigrationModal";
+
+import plusIcon from "assets/icons/plus.png";
+
+/**
+ * Bottom-most button in the right-side HUD column on the interior floors.
+ * Opens the beds-migration modal (which shows which beds the player still
+ * needs to craft to unlock more farm hands).
+ *
+ * Visual: player icon as the primary glyph, with a small "+" badge in the
+ * top-right corner to signal the "add another farm hand" affordance.
+ */
+export const InteriorBedsButton: React.FC = () => {
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <RoundButton onClick={() => setShow(true)}>
+        <img
+          src={SUNNYSIDE.icons.player}
+          className="absolute group-active:translate-y-[2px]"
+          style={{
+            width: `${PIXEL_SCALE * 13}px`,
+            left: `${PIXEL_SCALE * 4.5}px`,
+            top: `${PIXEL_SCALE * 4.5}px`,
+          }}
+        />
+        <img
+          src={plusIcon}
+          className="absolute"
+          style={{
+            width: `${PIXEL_SCALE * 7}px`,
+            right: `${PIXEL_SCALE * -1}px`,
+            top: `${PIXEL_SCALE * -1}px`,
+          }}
+        />
+      </RoundButton>
+
+      <BedsMigrationModal show={show} onHide={() => setShow(false)} />
+    </>
+  );
+};

--- a/src/features/interior/components/InteriorFloorNav.tsx
+++ b/src/features/interior/components/InteriorFloorNav.tsx
@@ -1,0 +1,100 @@
+import React, { useContext } from "react";
+import classNames from "classnames";
+import { useNavigate } from "react-router";
+import { useSelector } from "@xstate/react";
+
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import { RoundButton } from "components/ui/RoundButton";
+import { SUNNYSIDE } from "assets/sunnyside";
+
+interface Props {
+  /** Which floor the player is currently viewing. */
+  floor: "ground" | "level_one";
+}
+
+const _expansion = (state: MachineState) =>
+  state.context.state.interior.expansion;
+
+/**
+ * Stacked up/down floor-navigation buttons for the interior HUD.
+ *
+ * Sits above the back-to-farm TravelButton in the bottom-left HUD column.
+ * Up = go to /level_one (shows a lock and is disabled when the player
+ * hasn't bought their first upgrade). Down = go back to /interior. The
+ * arrow pointing away from any reachable floor is rendered disabled rather
+ * than hidden so the button layout stays stable across floors.
+ */
+export const InteriorFloorNav: React.FC<Props> = ({ floor }) => {
+  const { gameService } = useContext(Context);
+  const navigate = useNavigate();
+
+  const expansion = useSelector(gameService, _expansion);
+  const levelOneUnlocked = !!expansion;
+
+  const onGround = floor === "ground";
+  const onLevelOne = floor === "level_one";
+
+  // On ground floor: up navigates to level_one (or shows lock if unlocked).
+  // On level_one: up has nowhere higher to go.
+  const upDisabled = onGround ? !levelOneUnlocked : true;
+  // On level_one: down returns to ground. On ground: nowhere lower.
+  const downDisabled = onLevelOne ? false : true;
+
+  const goUp = () => {
+    if (upDisabled) return;
+    navigate("/level_one");
+  };
+
+  const goDown = () => {
+    if (downDisabled) return;
+    navigate("/interior");
+  };
+
+  return (
+    <>
+      <RoundButton
+        onClick={upDisabled ? undefined : goUp}
+        disabled={upDisabled}
+        className={classNames({ "opacity-60": upDisabled })}
+      >
+        <img
+          src={SUNNYSIDE.icons.arrow_up}
+          className="absolute group-active:translate-y-[2px]"
+          style={{
+            width: `${PIXEL_SCALE * 11}px`,
+            left: `${PIXEL_SCALE * 5.5}px`,
+            top: `${PIXEL_SCALE * 3}px`,
+          }}
+        />
+        {onGround && !levelOneUnlocked && (
+          <img
+            src={SUNNYSIDE.icons.lock}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 8}px`,
+              right: `${PIXEL_SCALE * -1}px`,
+              bottom: `${PIXEL_SCALE * -1}px`,
+            }}
+          />
+        )}
+      </RoundButton>
+      <RoundButton
+        onClick={downDisabled ? undefined : goDown}
+        disabled={downDisabled}
+        className={classNames({ "opacity-60": downDisabled })}
+      >
+        <img
+          src={SUNNYSIDE.icons.arrow_down}
+          className="absolute group-active:translate-y-[2px]"
+          style={{
+            width: `${PIXEL_SCALE * 11}px`,
+            left: `${PIXEL_SCALE * 5.5}px`,
+            top: `${PIXEL_SCALE * 4}px`,
+          }}
+        />
+      </RoundButton>
+    </>
+  );
+};

--- a/src/features/interior/lib/upgradeRequirements.ts
+++ b/src/features/interior/lib/upgradeRequirements.ts
@@ -24,33 +24,75 @@ export const HOME_EXPANSION_UPGRADE_REQUIREMENTS: Record<
   HomeExpansionTier,
   UpgradeCost
 > = {
+  // Level 0 → 1 — unlock the Level One Floor
   "level-one-start": {
-    // Unlock the Level One Floor
-    coins: 1_000,
-    inventory: { Wood: new Decimal(2500) },
+    coins: 1_500,
+    inventory: {
+      Wood: new Decimal(650),
+      Stone: new Decimal(230),
+    },
   },
+  // Level 1 → 2
   "level-one-2": {
-    coins: 10_000,
-    inventory: { Stone: new Decimal(2000) },
+    coins: 3_000,
+    inventory: {
+      Wood: new Decimal(850),
+      Stone: new Decimal(500),
+      Iron: new Decimal(25),
+    },
   },
+  // Level 2 → 3
   "level-one-3": {
-    coins: 50_000,
-    inventory: { Iron: new Decimal(500), Obsidian: new Decimal(1) },
+    coins: 6_000,
+    inventory: {
+      Wood: new Decimal(1_000),
+      Stone: new Decimal(800),
+      Iron: new Decimal(80),
+      Gold: new Decimal(10),
+    },
   },
+  // Level 3 → 4
   "level-one-4": {
-    coins: 100_000,
-    inventory: { Gold: new Decimal(100), Obsidian: new Decimal(5) },
+    coins: 12_000,
+    inventory: {
+      Wood: new Decimal(1_200),
+      Stone: new Decimal(1_000),
+      Iron: new Decimal(180),
+      Gold: new Decimal(40),
+      Crimstone: new Decimal(8),
+    },
   },
+  // Level 4 → 5
   "level-one-5": {
-    coins: 150_000,
-    inventory: { Crimstone: new Decimal(100), Obsidian: new Decimal(10) },
+    coins: 22_000,
+    inventory: {
+      Wood: new Decimal(1_350),
+      Stone: new Decimal(1_200),
+      Iron: new Decimal(300),
+      Gold: new Decimal(100),
+      Crimstone: new Decimal(30),
+    },
   },
+  // Level 5 → 6
   "level-one-6": {
-    coins: 250_000,
-    inventory: { Gold: new Decimal(250), Wood: new Decimal(5000) },
+    coins: 40_000,
+    inventory: {
+      Wood: new Decimal(1_500),
+      Stone: new Decimal(1_400),
+      Iron: new Decimal(450),
+      Gold: new Decimal(220),
+      Crimstone: new Decimal(75),
+    },
   },
+  // Level 6 → 7 (Premium)
   "level-one-full": {
-    coins: 500_000,
-    inventory: { Crimstone: new Decimal(250), Obsidian: new Decimal(35) },
+    coins: 65_000,
+    inventory: {
+      Wood: new Decimal(1_800),
+      Stone: new Decimal(1_700),
+      Iron: new Decimal(600),
+      Gold: new Decimal(400),
+      Crimstone: new Decimal(120),
+    },
   },
 };

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -455,6 +455,20 @@ export const MoveableComponent: React.FC<
     state.matches({ editing: "placing" }),
   );
 
+  const isRemovalMode = useSelector(
+    landscapingMachine,
+    (state) => !!state.context.removalMode,
+  );
+
+  // Exiting removal mode should clear any in-flight warning modal for this
+  // item, otherwise the dialog could resurface the next time the player
+  // selects this same item in normal mode.
+  useEffect(() => {
+    if (!isRemovalMode) {
+      setShowRemoveConfirmation(false);
+    }
+  }, [isRemovalMode]);
+
   const isSelected = movingItem?.id === id && movingItem?.name === name;
 
   // Elevate the nearest MapPlacement ancestor when selected so the disc panel
@@ -695,6 +709,26 @@ export const MoveableComponent: React.FC<
     } else {
       setShowRemoveConfirmation(true);
     }
+  };
+
+  // Mobile-safe finalise-removal path used by the Kuebiko / Hungry Caterpillar
+  // warning modals. Bypasses `remove()`'s `!isMobile && removeAction` gate so
+  // the modal's Remove button works in bulk removal mode on touch devices.
+  const confirmRemoveFromModal = () => {
+    const action = getRemoveAction(
+      name,
+      Date.now(),
+      selectedCollectible,
+      location,
+    );
+    setShowRemoveConfirmation(false);
+    if (!action) return;
+    landscapingMachine.send("REMOVE", {
+      event: action,
+      id,
+      name,
+      location,
+    });
   };
 
   useEffect(() => {
@@ -1106,11 +1140,46 @@ export const MoveableComponent: React.FC<
       // Also disable if there are overlaps and this item isn't selected
       // Disable while pixel-perfect mode is active so on-screen arrows aren't fighting the drag
       disabled={
-        (isMobile && !isSelected) || shouldDisableDrag || isPixelPerfectMode
+        (isMobile && !isSelected) ||
+        shouldDisableDrag ||
+        isPixelPerfectMode ||
+        isRemovalMode
       }
       onMouseDown={() => {
         // Mobile must click first, before dragging
         if (closeCurrentOverlapMenu) closeCurrentOverlapMenu();
+
+        // Bulk-removal mode: clicking a placed item dispatches its remove
+        // event directly and skips selection. The HUD stays in removal mode
+        // afterwards so the player can keep tapping to clear items.
+        if (isRemovalMode) {
+          const action = getRemoveAction(
+            name,
+            Date.now(),
+            selectedCollectible,
+            location,
+          );
+          // Restricted items (Manor, Town Center, House, Mansion, locked
+          // limited items in cooldown) — getRemoveAction returns null and the
+          // click is a no-op.
+          if (!action) {
+            return;
+          }
+          // Kuebiko and Hungry Caterpillar carry a warning about the gameplay
+          // side-effect of removing them — surface the same modal here so the
+          // bulk flow doesn't silently lose them.
+          if (name === "Kuebiko" || name === "Hungry Caterpillar") {
+            setShowRemoveConfirmation(true);
+            return;
+          }
+          landscapingMachine.send("REMOVE", {
+            event: action,
+            id,
+            name,
+            location,
+          });
+          return;
+        }
 
         if (isMobile && !isActive.current) {
           isActive.current = true;
@@ -1301,8 +1370,12 @@ export const MoveableComponent: React.FC<
           <div
             className="absolute z-20 flex"
             style={{
-              right: `${PIXEL_SCALE * -(hasRemovalAction ? 34 : 12)}px`,
-              bottom: `calc(100% + ${PIXEL_SCALE * 2}px)`,
+              // Anchor the action row's bottom-left to the item's top-right
+              // corner so the buttons start at the item's right edge and
+              // flow further right, never overlapping the item's footprint.
+              left: "100%",
+              bottom: "100%",
+              transform: `translate(0, ${PIXEL_SCALE * -2}px)`,
             }}
           >
             <div
@@ -1384,18 +1457,6 @@ export const MoveableComponent: React.FC<
                 />
               </div>
             )}
-            {showRemoveConfirmation && name === "Kuebiko" && (
-              <RemoveKuebikoModal
-                onClose={() => setShowRemoveConfirmation(false)}
-                onRemove={() => remove()}
-              />
-            )}
-            {showRemoveConfirmation && name === "Hungry Caterpillar" && (
-              <RemoveHungryCaterpillarModal
-                onClose={() => setShowRemoveConfirmation(false)}
-                onRemove={() => remove()}
-              />
-            )}
             {hasRemovalAction && (
               <div
                 className="group relative cursor-pointer"
@@ -1434,6 +1495,23 @@ export const MoveableComponent: React.FC<
               </div>
             )}
           </div>
+        )}
+        {/*
+          Warning modals for items with gameplay side-effects when removed.
+          Rendered outside the `isSelected` action-row above so they also
+          appear in bulk-removal mode, where there is no selection.
+        */}
+        {showRemoveConfirmation && name === "Kuebiko" && (
+          <RemoveKuebikoModal
+            onClose={() => setShowRemoveConfirmation(false)}
+            onRemove={isRemovalMode ? confirmRemoveFromModal : remove}
+          />
+        )}
+        {showRemoveConfirmation && name === "Hungry Caterpillar" && (
+          <RemoveHungryCaterpillarModal
+            onClose={() => setShowRemoveConfirmation(false)}
+            onRemove={isRemovalMode ? confirmRemoveFromModal : remove}
+          />
         )}
         {/*
           Selection tint anchored to the integer collision tile. The entity can

--- a/src/features/island/hud/Hud.tsx
+++ b/src/features/island/hud/Hud.tsx
@@ -27,6 +27,8 @@ import {
   getPowerSkills,
 } from "features/game/types/bumpkinSkills";
 import { LandscapeButton } from "./components/LandscapeButton";
+import { InteriorFloorNav } from "features/interior/components/InteriorFloorNav";
+import { InteriorBedsButton } from "features/interior/components/InteriorBedsButton";
 import { StreamCountdown } from "./components/streamCountdown/StreamCountdown";
 import { HudBumpkin } from "./components/bumpkinProfile/HudBumpkin";
 import { WorldFeedButton } from "features/social/components/WorldFeedButton";
@@ -110,6 +112,8 @@ const HudComponent: React.FC<{
         <WorldFeedButton showFeed={showFeed} setShowFeed={setShowFeed} />
         {hasPowerSkills && <PowerSkillsButton />}
         <MarketplaceButton />
+        {location === "interior" && <InteriorFloorNav floor="ground" />}
+        {location === "level_one" && <InteriorFloorNav floor="level_one" />}
         <TravelButton location={location} />
       </div>
       <div className="absolute bottom-0 pb-2 pl-3 left-16 flex flex-col space-y-2.5">
@@ -164,6 +168,9 @@ const HudComponent: React.FC<{
           hideActions={false}
           location={location}
         />
+        {(location === "interior" || location === "level_one") && (
+          <InteriorBedsButton />
+        )}
       </div>
 
       <div className="absolute bottom-0 p-2 right-0 flex flex-col space-y-2.5">

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -51,6 +51,7 @@ import type { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { LandscapingChest } from "./components/LandscapingChest";
 import classNames from "classnames";
 import { LandscapingQuickPanel } from "./components/LandscapingQuickPanel";
+import { InteriorFloorNav } from "features/interior/components/InteriorFloorNav";
 
 const compareBalance = (prev: Decimal, next: Decimal) => {
   return prev.eq(next);
@@ -76,6 +77,7 @@ const needsHelp = (state: GameMachineState) => {
 
 const selectMovingItem = (state: MachineState) => state.context.moving;
 const isIdle = (state: MachineState) => state.matches({ editing: "idle" });
+const selectRemovalMode = (state: MachineState) => !!state.context.removalMode;
 
 const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
   location,
@@ -122,6 +124,12 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
 
   const selectedItem = useSelector(child, selectMovingItem);
   const idle = useSelector(child, isIdle);
+  const removalMode = useSelector(child, selectRemovalMode);
+
+  const toggleRemovalMode = () => {
+    button.play();
+    child.send("TOGGLE_REMOVAL_MODE");
+  };
   const gameState = useSelector(gameService, (state) => state.context.state);
   const farmHandIds = getKeys(gameState.farmHands.bumpkins);
   const hasNoBuildings = !gameState.buildings["Water Well"];
@@ -215,8 +223,52 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
         <Balances sfl={balance} coins={coins} gems={gems ?? new Decimal(0)} />
       </div>
 
+      {removalMode && (
+        <>
+          <div className="absolute left-1/2 -translate-x-1/2 top-2.5 z-50">
+            <Label type="danger">{"Removal mode"}</Label>
+          </div>
+          <div
+            className="absolute flex z-50 flex-col"
+            style={{
+              width: `${PIXEL_SCALE * 22}px`,
+              right: `${PIXEL_SCALE * 3}px`,
+              top: `${PIXEL_SCALE * 31}px`,
+            }}
+          >
+            <RoundButton onClick={toggleRemovalMode}>
+              <img
+                src={SUNNYSIDE.icons.cancel}
+                className="absolute group-active:translate-y-[2px]"
+                style={{
+                  top: `${PIXEL_SCALE * 5.5}px`,
+                  left: `${PIXEL_SCALE * 5.5}px`,
+                  width: `${PIXEL_SCALE * 11}px`,
+                }}
+              />
+            </RoundButton>
+          </div>
+        </>
+      )}
+
+      {!removalMode &&
+        (location === "interior" || location === "level_one") && (
+          <div
+            className="absolute z-50 flex flex-col space-y-3.5"
+            style={{
+              left: `${PIXEL_SCALE * 3}px`,
+              bottom: `${PIXEL_SCALE * 3}px`,
+              width: `${PIXEL_SCALE * 22}px`,
+            }}
+          >
+            <InteriorFloorNav
+              floor={location === "level_one" ? "level_one" : "ground"}
+            />
+          </div>
+        )}
+
       <>
-        {idle && (
+        {idle && !removalMode && (
           <>
             <div
               className="absolute flex z-50 flex-col"
@@ -373,6 +425,18 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
                 />
               </RoundButton>
 
+              <RoundButton className="mb-3.5" onClick={toggleRemovalMode}>
+                <img
+                  src={ITEM_DETAILS["Rusty Shovel"].image}
+                  className="absolute group-active:translate-y-[2px]"
+                  style={{
+                    top: `${PIXEL_SCALE * 4}px`,
+                    left: `${PIXEL_SCALE * 4}px`,
+                    width: `${PIXEL_SCALE * 14}px`,
+                  }}
+                />
+              </RoundButton>
+
               {/* {farmHandIds.length > 0 && (
                 <>
                   {farmHandIds.map((id) => (
@@ -519,12 +583,16 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
         </div>
       )}
 
-      <LandscapingQuickPanel
-        location={location}
-        onQuickDragChange={setQuickDragging}
-      />
+      {!removalMode && (
+        <LandscapingQuickPanel
+          location={location}
+          onQuickDragChange={setQuickDragging}
+        />
+      )}
 
-      {!quickDragging && <PlaceableController location={location} />}
+      {!removalMode && !quickDragging && (
+        <PlaceableController location={location} />
+      )}
     </HudContainer>
   );
 };

--- a/src/features/island/landscaping/LandscapingGrid.tsx
+++ b/src/features/island/landscaping/LandscapingGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useSyncExternalStore } from "react";
 import classNames from "classnames";
 import { useSelector } from "@xstate/react";
 
@@ -7,46 +7,49 @@ import { GRID_WIDTH_PX } from "features/game/lib/constants";
 import type { MachineState as GameMachineState } from "features/game/lib/gameMachine";
 import type { MachineInterpreter } from "features/game/expansion/placeable/landscapingMachine";
 
-const _landscaping = (state: GameMachineState) =>
-  state.matches("landscaping");
+const _landscaping = (state: GameMachineState) => state.matches("landscaping");
 
 export const GRID_LINE_DEFAULT = "rgb(255 255 255 / 17%)";
 export const GRID_LINE_REMOVAL = "rgb(220 38 38 / 55%)";
+
+const NOOP_UNSUBSCRIBE = () => {};
 
 /**
  * Subscribes to the spawned `landscaping` child machine's `removalMode`
  * context flag. Returns false whenever the player is not currently in
  * landscaping (so callers can safely render even outside landscaping mode).
  *
- * Uses a manual subscription rather than `useSelector(child, …)` because the
+ * Uses `useSyncExternalStore` rather than `useSelector(child, …)` because the
  * child actor only exists while the parent gameMachine is in the landscaping
  * state — useSelector would throw if the actor is undefined.
  */
 export function useLandscapingRemovalMode(): boolean {
   const { gameService } = useContext(Context);
   const landscaping = useSelector(gameService, _landscaping);
-  const [removalMode, setRemovalMode] = useState(false);
 
-  useEffect(() => {
-    if (!landscaping) {
-      setRemovalMode(false);
-      return;
-    }
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      if (!landscaping) return NOOP_UNSUBSCRIBE;
+      const child = gameService.getSnapshot().children.landscaping as
+        | MachineInterpreter
+        | undefined;
+      if (!child) return NOOP_UNSUBSCRIBE;
+      const sub = child.subscribe(notify);
+      return () => sub.unsubscribe();
+    },
+    [landscaping, gameService],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!landscaping) return false;
     const child = gameService.getSnapshot().children.landscaping as
       | MachineInterpreter
       | undefined;
-    if (!child) {
-      setRemovalMode(false);
-      return;
-    }
-    setRemovalMode(!!child.getSnapshot()?.context.removalMode);
-    const sub = child.subscribe((state) => {
-      setRemovalMode(!!state.context.removalMode);
-    });
-    return () => sub.unsubscribe();
+    if (!child) return false;
+    return !!child.getSnapshot()?.context.removalMode;
   }, [landscaping, gameService]);
 
-  return removalMode;
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
 /**

--- a/src/features/island/landscaping/LandscapingGrid.tsx
+++ b/src/features/island/landscaping/LandscapingGrid.tsx
@@ -1,0 +1,88 @@
+import React, { useContext, useEffect, useState } from "react";
+import classNames from "classnames";
+import { useSelector } from "@xstate/react";
+
+import { Context } from "features/game/GameProvider";
+import { GRID_WIDTH_PX } from "features/game/lib/constants";
+import type { MachineState as GameMachineState } from "features/game/lib/gameMachine";
+import type { MachineInterpreter } from "features/game/expansion/placeable/landscapingMachine";
+
+const _landscaping = (state: GameMachineState) =>
+  state.matches("landscaping");
+
+export const GRID_LINE_DEFAULT = "rgb(255 255 255 / 17%)";
+export const GRID_LINE_REMOVAL = "rgb(220 38 38 / 55%)";
+
+/**
+ * Subscribes to the spawned `landscaping` child machine's `removalMode`
+ * context flag. Returns false whenever the player is not currently in
+ * landscaping (so callers can safely render even outside landscaping mode).
+ *
+ * Uses a manual subscription rather than `useSelector(child, …)` because the
+ * child actor only exists while the parent gameMachine is in the landscaping
+ * state — useSelector would throw if the actor is undefined.
+ */
+export function useLandscapingRemovalMode(): boolean {
+  const { gameService } = useContext(Context);
+  const landscaping = useSelector(gameService, _landscaping);
+  const [removalMode, setRemovalMode] = useState(false);
+
+  useEffect(() => {
+    if (!landscaping) {
+      setRemovalMode(false);
+      return;
+    }
+    const child = gameService.getSnapshot().children.landscaping as
+      | MachineInterpreter
+      | undefined;
+    if (!child) {
+      setRemovalMode(false);
+      return;
+    }
+    setRemovalMode(!!child.getSnapshot()?.context.removalMode);
+    const sub = child.subscribe((state) => {
+      setRemovalMode(!!state.context.removalMode);
+    });
+    return () => sub.unsubscribe();
+  }, [landscaping, gameService]);
+
+  return removalMode;
+}
+
+/**
+ * Helper that returns the `linear-gradient(...)` value the landscaping grid
+ * should paint with. Lets callers compose their own inline-style block while
+ * still picking up the red overlay when bulk-removal mode is active.
+ */
+export function useLandscapingGridBackgroundImage(): string {
+  const removalMode = useLandscapingRemovalMode();
+  const color = removalMode ? GRID_LINE_REMOVAL : GRID_LINE_DEFAULT;
+  return `linear-gradient(to right, ${color} 1px, transparent 1px),
+          linear-gradient(to bottom, ${color} 1px, transparent 1px)`;
+}
+
+/**
+ * Tile-grid overlay for landscaping surfaces whose grid fills the whole
+ * container (interior / level_one). Uses `absolute inset-0` and animates
+ * opacity in/out as the player enters/leaves landscaping. Locations whose
+ * grid needs custom positioning (farm, home, petHouse) should keep their
+ * own div and just consume `useLandscapingGridBackgroundImage()`.
+ */
+export const LandscapingGrid: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const landscaping = useSelector(gameService, _landscaping);
+  const backgroundImage = useLandscapingGridBackgroundImage();
+
+  return (
+    <div
+      className={classNames(
+        "absolute inset-0 pointer-events-none transition-opacity z-10",
+        landscaping ? "opacity-100" : "opacity-0",
+      )}
+      style={{
+        backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
+        backgroundImage,
+      }}
+    />
+  );
+};

--- a/src/features/petHouse/PetHouseInside.tsx
+++ b/src/features/petHouse/PetHouseInside.tsx
@@ -29,6 +29,7 @@ import { VisitingHud } from "features/island/hud/VisitingHud";
 import { PetHouseModal } from "features/island/buildings/components/building/petHouse/PetHouseModal";
 import { PlayerModal } from "features/social/PlayerModal";
 import { hasFeatureAccess } from "lib/flags";
+import { useLandscapingGridBackgroundImage } from "features/island/landscaping/LandscapingGrid";
 
 import followIcon from "assets/icons/follow.webp";
 
@@ -80,6 +81,7 @@ export const PetHouseInside: React.FC = () => {
   const petNFTs = useSelector(gameService, _petNFTs);
   const pets = useSelector(gameService, _petHousePets);
   const biome = useSelector(gameService, _biome);
+  const gridBackgroundImage = useLandscapingGridBackgroundImage();
 
   const level = petHouse.level;
   const nextLevel = Math.min(level + 1, 3);
@@ -222,9 +224,7 @@ export const PetHouseInside: React.FC = () => {
                 width: `${bounds.width * GRID_WIDTH_PX}px`,
 
                 backgroundSize: `${GRID_WIDTH_PX}px ${GRID_WIDTH_PX}px`,
-                backgroundImage: `
-            linear-gradient(to right, rgb(255 255 255 / 17%) 1px, transparent 1px),
-            linear-gradient(to bottom, rgb(255 255 255 / 17%) 1px, transparent 1px)`,
+                backgroundImage: gridBackgroundImage,
               }}
             />
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5534,7 +5534,7 @@
   "unlock.farmhandRevealing": "Unlocking farmhand...",
   "unlock.farmhandSuccess": "Farmhand unlocked! Your new helper is ready to work.",
   "bedsMigration.bedsNeeded": "Beds Needed!",
-  "bedsMigration.bedsNeededDescription": "Farm hands need beds in order to work on the farm.",
+  "bedsMigration.bedsNeededDescription": "Unlock extra Bumpkins for your farm by crafting beds at the Crafting Box.",
   "bedsMigration.bedsNeededDescription2": "Each unique bed can sleep one farm hand.",
   "bedsMigration.bedsNeededDescription3": "Place beds to hire more farmhands!",
   "bedsMigration.status.occupied": "Occupied",


### PR DESCRIPTION
# Pull request description

Feedback on the new interiors addressed:

1. Improve buttons so they don't overlap
2. Make it easier to navigate floors
3. Add the 'Bed' modal to the interior
4. SFT placed at the same position bug
5. Made bulk removal much easier with 'removal mode' (one tap to dig up)

<img width="1526" height="820" alt="Screenshot 2026-06-01 at 4 55 47 pm" src="https://github.com/user-attachments/assets/e11c70e4-85ed-47ad-be5f-bcc50a0ea63d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk-removal mode for landscaping with a red grid overlay and global grid component used across home, interior, and pet house.
  * Interior floor navigation and a beds button HUD; Beds Migration modal to manage beds and bumpkin/farm-hand capacity.
  * In-item removal flow improved for mobile/touch with confirm/remove handling.

* **Bug Fixes**
  * Stricter interior collision rules to prevent unwanted overlaps.

* **Chores**
  * Updated home expansion upgrade requirements and beds migration text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->