### PR TITLE
[FEAT] Add Favorites to marketplace home panel

### DIFF
--- a/src/features/marketplace/components/MarketplaceHotNow.tsx
+++ b/src/features/marketplace/components/MarketplaceHotNow.tsx
@@ -143,6 +143,33 @@ export const MarketplaceHotNow: React.FC = () => {
                 </div>
               </ButtonPanel>
             </div>
+
+            <div className="w-full sm:w-1/3 xl:w-1/4 pr-1">
+              <ButtonPanel
+                className="w-full h-full"
+                onClick={() =>
+                  navigate(
+                    `${isWorldRoute ? "/world" : ""}/marketplace/favorites`,
+                  )
+                }
+              >
+                <div className="flex items-center">
+                  <img src={SUNNYSIDE.icons.heart} className="w-10 mr-2" />
+                  <div className="flex-1">
+                    <div className="flex justify-between items-center">
+                      <p>{t("marketplace.favorites")}</p>
+                      <img
+                        src={SUNNYSIDE.icons.chevron_right}
+                        className="h-4"
+                      />
+                    </div>
+                    <p className="text-xs">
+                      {t("marketplace.favoritesDescription")}
+                    </p>
+                  </div>
+                </div>
+              </ButtonPanel>
+            </div>
           </div>
         </div>
       </InnerPanel>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5927,6 +5927,7 @@
   "marketplace.cosmeticsDescription": "Decorate your farm with rare items",
   "marketplace.collections": "Collections",
   "marketplace.favorites": "Favorites",
+  "marketplace.favoritesDescription": "Quickly access your favorite items",
   "marketplace.favorites.beta": "This is in beta mode. Favourites are stored locally on your device - switching devices will change this list",
   "marketplace.addToFavorites": "Add to favorites",
   "marketplace.addToFavoriteIcon": "Add to",


### PR DESCRIPTION
## What

Surfaces the existing **Favorites** view as a fourth card on the "Welcome to the Marketplace" home panel, alongside Resources, Power ups & Cosmetics — a community request (cocoa, in Discord).

The card uses the heart icon, links to the existing `/marketplace/favorites` route (works in both the standalone and `/world` marketplace), and mirrors the layout of its sibling cards. The Favorites feature itself already exists (route, `Favourites.tsx`, and a left-sidebar entry) — this just promotes it onto the home panel.

## Changes

- **`MarketplaceHotNow.tsx`** — add a Favorites `ButtonPanel` card to the welcome panel.
- **`dictionary.json`** — add `marketplace.favoritesDescription` (_"Quickly access your favorite items"_); reuses the existing `marketplace.favorites` label. Other locale files are propagated by the `[BOT] Update translations` job.

## Notes

The four cards form a clean single row at `xl` (`xl:w-1/4`); at tablet widths they wrap 3 + 1, consistent with the existing card breakpoints. Happy to switch all four to `sm:w-1/2` for a 2×2 tablet layout if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a favorites navigation card to the marketplace interface, featuring a heart icon for easy identification. Users can now quickly access their saved favorite items from this dedicated navigation link.
  * Implemented comprehensive localization support for the favorites feature with translated descriptions available across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->