### PR TITLE
[FEAT] Allow withdrawing placed/equipped items

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/features/game/components/bank/components/WithdrawBuds.tsx
+++ b/src/features/game/components/bank/components/WithdrawBuds.tsx
@@ -130,6 +130,9 @@ export const WithdrawBuds: React.FC<Props> = ({
       removeTrailingZeros: true,
     });
 
+    // A placed Bud is removed from the farm when withdrawn — warn on select.
+    const isPlaced = !!buds[budId]?.coordinates;
+
     return {
       key: `bud-${budId}`,
       id: budId,
@@ -138,6 +141,8 @@ export const WithdrawBuds: React.FC<Props> = ({
       iconClassName: BUD_ICON_CLASS,
       total: 1,
       unique: true,
+      safeWithdrawCount: isPlaced ? 0 : 1,
+      inUseWarning: isPlaced ? t("withdraw.placedBud.warning") : undefined,
       locked: isRestricted,
       lockReason: isRestricted
         ? t("withdraw.boostedItem.timeLeft", { time: cooldownText })

--- a/src/features/game/components/bank/components/WithdrawBuds.tsx
+++ b/src/features/game/components/bank/components/WithdrawBuds.tsx
@@ -42,10 +42,10 @@ export const WithdrawBuds: React.FC<Props> = ({
 
   const buds = state.buds ?? {};
 
+  // Placed buds can now be withdrawn (the backend removes the bud entirely),
+  // so they are no longer filtered out here.
   const [unselected, setUnselected] = useState<number[]>(
-    getKeys(buds)
-      .filter((budId) => !buds[budId].coordinates)
-      .map(Number),
+    getKeys(buds).map(Number),
   );
   const [selected, setSelected] = useState<number[]>([]);
 

--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -24,6 +24,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
 import { Context } from "features/game/GameProvider";
 import type { MachineState } from "features/game/lib/gameMachine";
+import { getChestItemCount } from "features/island/hud/components/inventory/utils/inventory";
 import { hasReputation, Reputation } from "features/game/lib/reputation";
 import { RequiredReputation } from "features/island/hud/components/reputation/Reputation";
 import { isFaceVerified } from "features/retreat/components/personhood/lib/faceRecognition";
@@ -246,12 +247,19 @@ export const WithdrawItems: React.FC<Props> = ({
       removeTrailingZeros: true,
     });
 
+    // Unplaced (chest) count — withdrawing beyond this removes placed copies.
+    const freeCount = getChestItemCount(state, itemName).toNumber();
+    const placedCount =
+      (state.inventory[itemName]?.toNumber() ?? 0) - freeCount;
+
     return {
       key: itemName,
       id: KNOWN_IDS[itemName],
       name: getTranslatedItemName(itemName),
       image: ITEM_DETAILS[itemName].image,
       total: inventoryCount + selectedCount,
+      freeCount,
+      inUseWarning: placedCount > 0 ? t("withdraw.placed.warning") : undefined,
       locked: isRestricted,
       lockReason: isRestricted
         ? t("withdraw.boostedItem.timeLeft", { time: cooldownText })
@@ -290,9 +298,7 @@ export const WithdrawItems: React.FC<Props> = ({
       withdrawDisabled={withdrawDisabled}
       walletAddress={wallet.getConnection() || "XXXX"}
       onBack={onBack}
-      intro={`${t("withdraw.restricted.description")} ${t(
-        "withdraw.placed.warning",
-      )}`}
+      intro={t("withdraw.restricted.description")}
     />
   );
 };

--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -290,7 +290,9 @@ export const WithdrawItems: React.FC<Props> = ({
       withdrawDisabled={withdrawDisabled}
       walletAddress={wallet.getConnection() || "XXXX"}
       onBack={onBack}
-      intro={t("withdraw.restricted.description")}
+      intro={`${t("withdraw.restricted.description")} ${t(
+        "withdraw.placed.warning",
+      )}`}
     />
   );
 };

--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -248,9 +248,9 @@ export const WithdrawItems: React.FC<Props> = ({
     });
 
     // Unplaced (chest) count — withdrawing beyond this removes placed copies.
-    const freeCount = getChestItemCount(state, itemName).toNumber();
+    const safeWithdrawCount = getChestItemCount(state, itemName).toNumber();
     const placedCount =
-      (state.inventory[itemName]?.toNumber() ?? 0) - freeCount;
+      (state.inventory[itemName]?.toNumber() ?? 0) - safeWithdrawCount;
 
     return {
       key: itemName,
@@ -258,7 +258,7 @@ export const WithdrawItems: React.FC<Props> = ({
       name: getTranslatedItemName(itemName),
       image: ITEM_DETAILS[itemName].image,
       total: inventoryCount + selectedCount,
-      freeCount,
+      safeWithdrawCount,
       inUseWarning: placedCount > 0 ? t("withdraw.placed.warning") : undefined,
       locked: isRestricted,
       lockReason: isRestricted

--- a/src/features/game/components/bank/components/WithdrawItems.tsx
+++ b/src/features/game/components/bank/components/WithdrawItems.tsx
@@ -18,7 +18,6 @@ import { toWei } from "web3-utils";
 import { wallet } from "lib/blockchain/wallet";
 
 import { getKeys } from "lib/object";
-import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { INVENTORY_RELEASES } from "features/game/types/withdrawables";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -100,8 +99,11 @@ export const WithdrawItems: React.FC<Props> = ({
       return acc;
     }, {} as Inventory);
 
+  // Placed collectibles can now be withdrawn (the backend trims placed
+  // instances to the inventory count on save), so the ceiling is the full
+  // inventory rather than the unplaced "chest" count.
   const [inventory, setInventory] = useState<Inventory>(() =>
-    capToWithdrawableLimit(getChestItems(state)),
+    capToWithdrawableLimit(state.inventory),
   );
   const [selected, setSelected] = useState<Inventory>({});
 

--- a/src/features/game/components/bank/components/WithdrawPets.tsx
+++ b/src/features/game/components/bank/components/WithdrawPets.tsx
@@ -51,10 +51,10 @@ export const WithdrawPets: React.FC<Props> = ({
 
   const nfts = state.pets?.nfts ?? {};
 
+  // Placed pets can now be withdrawn (the backend removes the pet NFT
+  // entirely), so they are no longer filtered out here.
   const [unselected, setUnselected] = useState<number[]>(
-    getKeys(nfts)
-      .filter((nftId) => !nfts[nftId].coordinates)
-      .map(Number),
+    getKeys(nfts).map(Number),
   );
   const [selected, setSelected] = useState<number[]>([]);
   const [confirmationStep, setConfirmationStep] = useState<1 | 2 | null>(null);

--- a/src/features/game/components/bank/components/WithdrawPets.tsx
+++ b/src/features/game/components/bank/components/WithdrawPets.tsx
@@ -249,6 +249,9 @@ export const WithdrawPets: React.FC<Props> = ({
             })
           : undefined;
 
+    // A placed pet is removed from the farm when withdrawn — warn on select.
+    const isPlaced = !!nfts[petId]?.coordinates;
+
     return {
       key: `pet-${petId}`,
       id: petId,
@@ -256,6 +259,8 @@ export const WithdrawPets: React.FC<Props> = ({
       image: getPetImage("happy", petId),
       total: 1,
       unique: true,
+      safeWithdrawCount: isPlaced ? 0 : 1,
+      inUseWarning: isPlaced ? t("withdraw.placedPet.warning") : undefined,
       locked,
       lockReason,
       status: isRestricted

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -205,11 +205,35 @@ export const WithdrawWearables: React.FC<Props> = ({
     ...selectedItems.filter((name) => !withdrawableItems.includes(name)),
   ];
 
+  // Count how many of each wearable are currently equipped across the Bumpkin
+  // and all farmhands — withdrawing beyond the unequipped (spare) count will
+  // unequip them.
+  const equippedCounts = [
+    state.bumpkin?.equipped ?? {},
+    ...Object.values(state.farmHands?.bumpkins ?? {}).map((f) => f.equipped),
+  ].reduce(
+    (acc, equipped) => {
+      Object.values(equipped).forEach((name) => {
+        if (!name) return;
+        acc[name] = (acc[name] ?? 0) + 1;
+      });
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+
   const entries: WithdrawEntry[] = entryNames.map((itemName) => {
     const wardrobeCount = wardrobe[itemName] ?? 0;
     const selectedCount = selected[itemName] ?? 0;
     const { isRestricted, cooldownTimeLeft } = getRestrictionStatus(itemName);
     const buffs = BUMPKIN_ITEM_BUFF_LABELS[itemName];
+
+    // Unequipped (spare) count — withdrawing beyond this unequips copies.
+    const equippedCount = equippedCounts[itemName] ?? 0;
+    const freeCount = Math.max(
+      (state.wardrobe[itemName] ?? 0) - equippedCount,
+      0,
+    );
 
     const cooldownText = secondsToString(cooldownTimeLeft / 1000, {
       length: "medium",
@@ -223,6 +247,9 @@ export const WithdrawWearables: React.FC<Props> = ({
       name: itemName,
       image: getImageUrl(ITEM_IDS[itemName]),
       total: wardrobeCount + selectedCount,
+      freeCount,
+      inUseWarning:
+        equippedCount > 0 ? t("withdraw.equipped.warning") : undefined,
       locked: isRestricted,
       lockReason: isRestricted
         ? t("withdraw.boostedItem.timeLeft", { time: cooldownText })
@@ -260,9 +287,7 @@ export const WithdrawWearables: React.FC<Props> = ({
       withdrawDisabled={withdrawDisabled}
       walletAddress={wallet.getConnection() || "XXXX"}
       onBack={onBack}
-      intro={`${t("withdraw.restricted.description")} ${t(
-        "withdraw.equipped.warning",
-      )}`}
+      intro={t("withdraw.restricted.description")}
     />
   );
 };

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -7,6 +7,7 @@ import { wallet } from "lib/blockchain/wallet";
 
 import { getKeys } from "lib/object";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { availableWardrobe } from "features/game/events/landExpansion/equip";
 import { type BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
 import { WEARABLE_RELEASES } from "features/game/types/withdrawables";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -205,22 +206,10 @@ export const WithdrawWearables: React.FC<Props> = ({
     ...selectedItems.filter((name) => !withdrawableItems.includes(name)),
   ];
 
-  // Count how many of each wearable are currently equipped across the Bumpkin
-  // and all farmhands — withdrawing beyond the unequipped (spare) count will
-  // unequip them.
-  const equippedCounts = [
-    state.bumpkin?.equipped ?? {},
-    ...Object.values(state.farmHands?.bumpkins ?? {}).map((f) => f.equipped),
-  ].reduce(
-    (acc, equipped) => {
-      Object.values(equipped).forEach((name) => {
-        if (!name) return;
-        acc[name] = (acc[name] ?? 0) + 1;
-      });
-      return acc;
-    },
-    {} as Record<string, number>,
-  );
+  // `availableWardrobe` is the project's source of truth for the unequipped
+  // (spare) count — reuse it rather than recomputing equipped counts here, so
+  // the warning threshold can't drift from equip rules.
+  const available = availableWardrobe(state);
 
   const entries: WithdrawEntry[] = entryNames.map((itemName) => {
     const wardrobeCount = wardrobe[itemName] ?? 0;
@@ -228,10 +217,10 @@ export const WithdrawWearables: React.FC<Props> = ({
     const { isRestricted, cooldownTimeLeft } = getRestrictionStatus(itemName);
     const buffs = BUMPKIN_ITEM_BUFF_LABELS[itemName];
 
-    // Unequipped (spare) count — withdrawing beyond this unequips copies.
-    const equippedCount = equippedCounts[itemName] ?? 0;
-    const freeCount = Math.max(
-      (state.wardrobe[itemName] ?? 0) - equippedCount,
+    // Withdrawing beyond the unequipped (spare) count will unequip copies.
+    const safeWithdrawCount = available[itemName] ?? 0;
+    const equippedCount = Math.max(
+      (state.wardrobe[itemName] ?? 0) - safeWithdrawCount,
       0,
     );
 
@@ -247,7 +236,7 @@ export const WithdrawWearables: React.FC<Props> = ({
       name: itemName,
       image: getImageUrl(ITEM_IDS[itemName]),
       total: wardrobeCount + selectedCount,
-      freeCount,
+      safeWithdrawCount,
       inUseWarning:
         equippedCount > 0 ? t("withdraw.equipped.warning") : undefined,
       locked: isRestricted,

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -260,7 +260,9 @@ export const WithdrawWearables: React.FC<Props> = ({
       withdrawDisabled={withdrawDisabled}
       walletAddress={wallet.getConnection() || "XXXX"}
       onBack={onBack}
-      intro={t("withdraw.restricted.description")}
+      intro={`${t("withdraw.restricted.description")} ${t(
+        "withdraw.equipped.warning",
+      )}`}
     />
   );
 };

--- a/src/features/game/components/bank/components/WithdrawWearables.tsx
+++ b/src/features/game/components/bank/components/WithdrawWearables.tsx
@@ -8,7 +8,6 @@ import { wallet } from "lib/blockchain/wallet";
 import { getKeys } from "lib/object";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { type BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
-import { availableWardrobe } from "features/game/events/landExpansion/equip";
 import { WEARABLE_RELEASES } from "features/game/types/withdrawables";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Context } from "features/game/GameProvider";
@@ -45,14 +44,13 @@ export const WithdrawWearables: React.FC<Props> = ({
   const { gameService } = useContext(Context);
   const state = useSelector(gameService, _state);
 
-  // Cap at `previousWardrobe + MAX_MINT_AMOUNT` to match the BE per-call
-  // mint cap. The backend mints any shortfall up to `MAX_MINT_AMOUNT` per
-  // item per call.
+  // Equipped wearables can now be withdrawn (the backend unequips them), so
+  // the ceiling is the full wardrobe count rather than the unequipped count.
+  // Cap at `previousWardrobe + MAX_MINT_AMOUNT` to match the BE per-call mint
+  // cap. The backend mints any shortfall up to `MAX_MINT_AMOUNT` per item.
   const getTrueAvailableWardrobe = () => {
-    const available = availableWardrobe(state);
-
-    return getKeys(available).reduce((acc, key) => {
-      const currentAmount = available[key] ?? 0;
+    return getKeys(state.wardrobe).reduce((acc, key) => {
+      const currentAmount = state.wardrobe[key] ?? 0;
       const onChain = state.previousWardrobe[key] ?? 0;
       acc[key] = Math.min(currentAmount, onChain + MAX_MINT_AMOUNT);
       return acc;

--- a/src/features/game/components/bank/components/withdraw/WithdrawItemDetail.tsx
+++ b/src/features/game/components/bank/components/withdraw/WithdrawItemDetail.tsx
@@ -95,8 +95,8 @@ export const WithdrawItemDetail: React.FC<Props> = ({
             />
           </div>
           {entry.inUseWarning &&
-            entry.freeCount !== undefined &&
-            selectedQty > entry.freeCount && (
+            entry.safeWithdrawCount !== undefined &&
+            selectedQty > entry.safeWithdrawCount && (
               <Label type="warning" icon={SUNNYSIDE.icons.expression_alerted}>
                 {entry.inUseWarning}
               </Label>

--- a/src/features/game/components/bank/components/withdraw/WithdrawItemDetail.tsx
+++ b/src/features/game/components/bank/components/withdraw/WithdrawItemDetail.tsx
@@ -83,16 +83,25 @@ export const WithdrawItemDetail: React.FC<Props> = ({
           {entry.lockReason}
         </Label>
       ) : (
-        <div className="flex items-center justify-between">
-          <span className="text-xs">
-            {inCartText ?? t("withdraw.inYourWithdrawal")}
-          </span>
-          <Stepper
-            value={selectedQty}
-            max={entry.total}
-            onChange={(value) => onSetQty(entry, value)}
-          />
-        </div>
+        <>
+          <div className="flex items-center justify-between">
+            <span className="text-xs">
+              {inCartText ?? t("withdraw.inYourWithdrawal")}
+            </span>
+            <Stepper
+              value={selectedQty}
+              max={entry.total}
+              onChange={(value) => onSetQty(entry, value)}
+            />
+          </div>
+          {entry.inUseWarning &&
+            entry.freeCount !== undefined &&
+            selectedQty > entry.freeCount && (
+              <Label type="warning" icon={SUNNYSIDE.icons.expression_alerted}>
+                {entry.inUseWarning}
+              </Label>
+            )}
+        </>
       )}
     </div>
   );

--- a/src/features/game/components/bank/components/withdraw/types.ts
+++ b/src/features/game/components/bank/components/withdraw/types.ts
@@ -41,15 +41,15 @@ export interface WithdrawEntry {
   /** Boost labels to surface in the detail panel. */
   buffs?: BuffLabel[];
   /**
-   * How many can be withdrawn without removing an in-use copy — i.e. the
-   * unplaced (collectibles) or unequipped (wearables) count. When the selected
-   * quantity exceeds this, withdrawing will remove placed collectibles from the
-   * farm/home/interior or unequip wearables from the Bumpkin/farmhands.
+   * How many can be withdrawn without affecting an in-use copy — i.e. the
+   * unplaced (collectibles) or unequipped (wearables) count, or 0 for a placed
+   * Bud/Pet. When the selected quantity exceeds this, withdrawing will remove
+   * placed collectibles/Buds/Pets from the farm or unequip wearables.
    */
-  freeCount?: number;
+  safeWithdrawCount?: number;
   /**
-   * Red warning shown in the detail panel when the selected quantity exceeds
-   * `freeCount` (e.g. "…will unequip it from your Bumpkin").
+   * Warning shown in the detail panel when the selected quantity exceeds
+   * `safeWithdrawCount` (e.g. "…will unequip it from your Bumpkin").
    */
   inUseWarning?: string;
 }

--- a/src/features/game/components/bank/components/withdraw/types.ts
+++ b/src/features/game/components/bank/components/withdraw/types.ts
@@ -40,4 +40,16 @@ export interface WithdrawEntry {
   description?: string;
   /** Boost labels to surface in the detail panel. */
   buffs?: BuffLabel[];
+  /**
+   * How many can be withdrawn without removing an in-use copy — i.e. the
+   * unplaced (collectibles) or unequipped (wearables) count. When the selected
+   * quantity exceeds this, withdrawing will remove placed collectibles from the
+   * farm/home/interior or unequip wearables from the Bumpkin/farmhands.
+   */
+  freeCount?: number;
+  /**
+   * Red warning shown in the detail panel when the selected quantity exceeds
+   * `freeCount` (e.g. "…will unequip it from your Bumpkin").
+   */
+  inUseWarning?: string;
 }

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4407,6 +4407,8 @@
   "withdraw.sync": "You can only withdraw items that you have synced to the blockchain.",
   "withdraw.notOnChain": "This item isn't on-chain yet. On-demand withdraw is coming soon.",
   "withdraw.restricted.description": "Some items cannot be withdrawn. Other items may be restricted when in use or still being built.",
+  "withdraw.placed.warning": "Withdrawing a placed collectible will remove it from your farm, home or interior.",
+  "withdraw.equipped.warning": "Withdrawing an equipped wearable will unequip it from your Bumpkin and farmhands.",
   "withdraw.detail.empty": "Select an item to see its details and whether you can withdraw it.",
   "withdraw.cart.empty": "Nothing added yet. Pick items from the grid.",
   "withdraw.yourWithdrawal": "Your withdrawal",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4409,6 +4409,8 @@
   "withdraw.restricted.description": "Some items cannot be withdrawn. Other items may be restricted when in use or still being built.",
   "withdraw.placed.warning": "Withdrawing a placed collectible will remove it from your farm, home or interior.",
   "withdraw.equipped.warning": "Withdrawing an equipped wearable will unequip it from your Bumpkin and farmhands.",
+  "withdraw.placedBud.warning": "This Bud is placed on your farm and will be removed when withdrawn.",
+  "withdraw.placedPet.warning": "This pet is placed on your farm and will be removed when withdrawn.",
   "withdraw.detail.empty": "Select an item to see its details and whether you can withdraw it.",
   "withdraw.cart.empty": "Nothing added yet. Pick items from the grid.",
   "withdraw.yourWithdrawal": "Your withdrawal",


### PR DESCRIPTION
## What

FE mirror of [sunflower-land-api#3419](https://github.com/sunflower-land/sunflower-land-api/pull/3419), which allows withdrawing items that are **placed** (collectibles / buds / pets) or **equipped** (wearables). The withdraw modals previously capped selectable amounts to the unplaced/unequipped count; this lifts those caps so placed/equipped items are selectable.

Warning to warn players if one of the items is in use. It won't block them from withdrawing however.
<img width="325" height="301" alt="image" src="https://github.com/user-attachments/assets/779a887f-cf87-4067-b25f-8a4e6af783d6" />

<img width="341" height="422" alt="image" src="https://github.com/user-attachments/assets/6892a802-8333-41e1-b3f5-c4e76d84f1c2" />


## Changes

- **WithdrawItems** — seed the selectable inventory from the full `state.inventory` instead of `getChestItems(state)` (which subtracts placed). The backend trims placed instances back to the inventory count on save.
- **WithdrawWearables** — ceiling is the full `state.wardrobe` instead of `availableWardrobe(state)` (which subtracts equipped). The backend unequips the withdrawn wearables.
- **WithdrawBuds / WithdrawPets** — stop filtering out placed (`coordinates`) entities. The backend deletes the bud/pet entirely on withdraw.

Everything else is unchanged: the per-call mint cap (`previousInventory`/`previousWardrobe` + `MAX_MINT_AMOUNT`), release-date filtering, and boost-cooldown gating all still apply.

## Notes

- No behavioural double-spend risk: the backend bounds on-chain minting via the `previous*` backing checks, and marketplace listings backed by a withdrawn item are cleared at purchase/offer time and by the hourly cleanup cron.
- These components have no unit tests; the withdraw logic is covered on the backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawal selection now considers your full inventory (including items previously considered "placed" or equipped) and more accurately reflects withdrawable counts.
  * Availability caps updated to use true on-hand amounts.

* **User Interface**
  * Quantity selector displays a clear warning and limits when withdrawing beyond the safe (unequipped/free) amount.

* **Localization**
  * Added warning texts for withdrawing placed collectibles and equipped wearables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->