### PR TITLE
[FIX] Add refresh action to boundary errors

### DIFF
--- a/src/features/auth/components/ErrorBoundary.tsx
+++ b/src/features/auth/components/ErrorBoundary.tsx
@@ -18,6 +18,10 @@ class ErrorBoundary extends Component<Props, State> {
     error: null,
   };
 
+  private refreshPage = () => {
+    window.location.reload();
+  };
+
   public static getDerivedStateFromError(error: Error): State {
     // Update state so the next render will show the fallback UI.
     return { error };
@@ -40,6 +44,7 @@ class ErrorBoundary extends Component<Props, State> {
               <BoundaryError
                 error={this.state.error.message}
                 stack={this.state.error.stack}
+                onAcknowledge={this.refreshPage}
               />
             </Panel>
           </Modal>

--- a/src/features/auth/components/SomethingWentWrong.tsx
+++ b/src/features/auth/components/SomethingWentWrong.tsx
@@ -198,9 +198,7 @@ export const BoundaryError: React.FC<BoundaryErrorProps> = ({
           {t("error.connection.two")}
         </p>
       </div>
-      {onAcknowledge && (
-        <Button onClick={onAcknowledge}>{t("try.again")}</Button>
-      )}
+      {onAcknowledge && <Button onClick={onAcknowledge}>{t("refresh")}</Button>}
 
       <SystemMessageWidget />
     </>


### PR DESCRIPTION
Pr added refresh action to this modal

<img width="1138" height="704" alt="image" src="https://github.com/user-attachments/assets/bc0699bc-6c6e-4338-b7d6-69a3a01e6c8a" />


## Summary
Adds a visible Refresh action to the generic BoundaryError modal so players can reload the page directly from a blocking runtime error state and check whether the issue was transient.

## Context / motivation
There are two related blocking error flows in the client:

- MultipleDevices already shows a Refresh button and sends the player through the existing refresh path.
- BoundaryError is used by the React ErrorBoundary for runtime errors outside the auth/game state machines. It displayed diagnostics and Get help, but did not provide a direct way to retry from the modal.

This made the recovery path inconsistent: players seeing a BoundaryError had to know to manually refresh the browser, even though many of these errors can be caused by transient connection or stale-client state. Adding Refresh gives users a clear first recovery action before contacting support.

## Implementation
- ErrorBoundary now passes an onAcknowledge callback into BoundaryError.
- For ErrorBoundary, the callback uses window.location.reload() because this path can happen outside the game/auth state machines, so service.send("REFRESH") is not guaranteed to exist.
- BoundaryError now labels the acknowledgement button as Refresh, matching the action and the MultipleDevices modal wording.
- Existing state-machine driven SomethingWentWrong behavior is preserved: it still sends REFRESH through the current auth/game service when that service exists.

## How to test
1. Trigger a generic React runtime error that is caught by ErrorBoundary.
2. Confirm the BoundaryError modal shows the diagnostic information, Get help, and a Refresh button.
3. Click Refresh and confirm the page reloads.
4. Trigger a normal SomethingWentWrong state-machine error and confirm the button still sends the existing REFRESH action.
5. Confirm MultipleDevices still shows its existing Refresh button.

## Screenshots or screen recording
Required because this is a UI recovery change. Add before/after screenshots of the BoundaryError modal showing the new Refresh button.

## Related issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error acknowledgment now triggers a page refresh.
  * Updated error dialog button label from "try again" to "refresh".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->