### PR TITLE
[FEAT] Add skip order shortcut to NPC delivery modal

### DIFF
--- a/src/features/game/events/landExpansion/skipOrder.test.ts
+++ b/src/features/game/events/landExpansion/skipOrder.test.ts
@@ -134,7 +134,7 @@ describe("skipOrder", () => {
     ).toBeDefined();
   });
 
-  it("increments the skippedAt count", async () => {
+  it("increments the existing skipped count", async () => {
     const id = "ORDER";
 
     const order: Order = {
@@ -151,6 +151,7 @@ describe("skipOrder", () => {
         ...GAME_STATE,
         delivery: {
           ...GAME_STATE.delivery,
+          skippedCount: 2,
           orders: [order],
         },
       },
@@ -160,6 +161,38 @@ describe("skipOrder", () => {
       },
     });
 
-    expect(state.delivery.skippedCount).toBe(1);
+    expect(state.delivery.skippedCount).toBe(3);
+  });
+
+  it("increments the per-NPC skipped count", async () => {
+    const id = "ORDER";
+
+    const order: Order = {
+      from: "betty",
+      createdAt: 0,
+      id,
+      items: {},
+      readyAt: 0,
+      reward: {},
+    };
+
+    const state = skipOrder({
+      state: {
+        ...GAME_STATE,
+        npcs: {
+          betty: { deliveryCount: 5, skippedCount: 1 },
+        },
+        delivery: {
+          ...GAME_STATE.delivery,
+          orders: [order],
+        },
+      },
+      action: {
+        type: "order.skipped",
+        id,
+      },
+    });
+
+    expect(state.npcs?.betty?.skippedCount).toBe(2);
   });
 });

--- a/src/features/game/events/landExpansion/skipOrder.test.ts
+++ b/src/features/game/events/landExpansion/skipOrder.test.ts
@@ -134,6 +134,66 @@ describe("skipOrder", () => {
     ).toBeDefined();
   });
 
+  it("throws an error if the order is already completed", () => {
+    const id = "ORDER";
+
+    const order: Order = {
+      from: "betty",
+      createdAt: 0,
+      id,
+      items: {},
+      readyAt: 0,
+      reward: {},
+      completedAt: 123,
+    };
+
+    expect(() =>
+      skipOrder({
+        state: {
+          ...GAME_STATE,
+          delivery: {
+            ...GAME_STATE.delivery,
+            orders: [order],
+          },
+        },
+        action: {
+          type: "order.skipped",
+          id,
+        },
+      }),
+    ).toThrow(`Order already completed`);
+  });
+
+  it("throws an error if the order is not ready yet", () => {
+    const id = "ORDER";
+
+    const order: Order = {
+      from: "betty",
+      createdAt: 0,
+      id,
+      items: {},
+      readyAt: 2000,
+      reward: {},
+    };
+
+    expect(() =>
+      skipOrder({
+        state: {
+          ...GAME_STATE,
+          delivery: {
+            ...GAME_STATE.delivery,
+            orders: [order],
+          },
+        },
+        action: {
+          type: "order.skipped",
+          id,
+        },
+        createdAt: 1000,
+      }),
+    ).toThrow(`Order ${id} is not ready yet`);
+  });
+
   it("increments the existing skipped count", async () => {
     const id = "ORDER";
 

--- a/src/features/game/events/landExpansion/skipOrder.ts
+++ b/src/features/game/events/landExpansion/skipOrder.ts
@@ -24,6 +24,11 @@ export function skipOrder({
 
     if (!order) throw new Error(`Order ${action.id} not found`);
 
+    if (order.completedAt) throw new Error(`Order already completed`);
+
+    if (order.readyAt > createdAt)
+      throw new Error(`Order ${action.id} is not ready yet`);
+
     if (
       getDayOfYear(new Date(createdAt)) ===
         getDayOfYear(new Date(order.createdAt)) &&
@@ -42,7 +47,16 @@ export function skipOrder({
     game.delivery.orders = populateOrders(game, createdAt, true);
 
     game.delivery.skippedAt = createdAt;
-    game.delivery.skippedCount = game.delivery.skippedCount ?? 0 + 1;
+    game.delivery.skippedCount = (game.delivery.skippedCount ?? 0) + 1;
+
+    const npcs = game.npcs ?? {};
+    const npc = npcs[order.from] ?? { deliveryCount: 0 };
+    npc.skippedCount = (npc.skippedCount ?? 0) + 1;
+
+    game.npcs = {
+      ...npcs,
+      [order.from]: npc,
+    };
 
     return game;
   });

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1236,6 +1236,7 @@ export type NPCS = Partial<Record<NPCName, NPCData>>;
 export type NPCData = {
   deliveryCount: number;
   deliveryCompletedAt?: number;
+  skippedCount?: number;
   questCompletedAt?: number;
   friendship?: {
     updatedAt: number;

--- a/src/features/world/ui/TypingMessage.tsx
+++ b/src/features/world/ui/TypingMessage.tsx
@@ -64,10 +64,13 @@ export const InlineDialogue: React.FC<{
   }, [message, trail, currentIndex]);
 
   return (
-    <div className="relative">
-      <div className="text-sm absolute inset-0">{displayedMessage}</div>
-      {/* Render a hidden message so the container gets the correct height initially */}
-      <div className="text-sm opacity-0">{message}</div>
+    <div className="grid">
+      <div className="text-sm col-start-1 row-start-1">{displayedMessage}</div>
+      {/* Render a hidden message in the same grid cell so the container reserves
+          the full height up front without the visible text overflowing it. */}
+      <div className="text-sm col-start-1 row-start-1 invisible" aria-hidden>
+        {message}
+      </div>
     </div>
   );
 };

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -43,6 +43,7 @@ import {
 } from "features/game/types/chapters";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
+import { getDayOfYear, secondsTillReset } from "lib/utils/time";
 import {
   BUMPKIN_FLOWER_BONUSES,
   DEFAULT_FLOWER_POINTS,
@@ -733,9 +734,21 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
 
   const game = gameState.context.state;
   const [showFlowers, setShowFlowers] = useState(false);
+  const [showSkipDialog, setShowSkipDialog] = useState(false);
   const [gift, setGift] = useState<Airdrop>();
 
   const delivery = game.delivery.orders.find((order) => order.from === npc);
+
+  const canSkip =
+    !!delivery &&
+    getDayOfYear(new Date(now)) !== getDayOfYear(new Date(delivery.createdAt));
+
+  const skip = () => {
+    setShowSkipDialog(false);
+    gameService.send("order.skipped", { id: delivery?.id });
+    gameService.send("SAVE");
+    onClose?.();
+  };
 
   const { holiday } = getBumpkinHoliday({ now });
 
@@ -847,6 +860,41 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
     );
   }
 
+  if (showSkipDialog) {
+    return (
+      <InnerPanel>
+        <div className="flex-1 space-y-2 p-1">
+          <p className="text-xs">{t("orderhelp.Skip.hour")}</p>
+          {canSkip && <p className="text-xs">{t("choose.wisely")}</p>}
+          {!canSkip && (
+            <>
+              <p className="text-xs font-secondary">
+                {`${t("orderhelp.SkipIn")}:`}
+              </p>
+              <div className="flex-1">
+                <RequirementLabel
+                  type="time"
+                  waitSeconds={secondsTillReset()}
+                />
+              </div>
+            </>
+          )}
+        </div>
+        {canSkip && (
+          <div className="flex flex-col gap-1">
+            <Button onClick={() => setShowSkipDialog(false)}>
+              {t("orderhelp.NoRight")}
+            </Button>
+            <Button onClick={skip}>{t("skip.order")}</Button>
+          </div>
+        )}
+        {!canSkip && (
+          <Button onClick={() => setShowSkipDialog(false)}>{t("back")}</Button>
+        )}
+      </InnerPanel>
+    );
+  }
+
   return (
     <>
       {showFlowers && (
@@ -950,6 +998,18 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
                     hasRequirementsCheck={() => true}
                     onDeliver={deliver}
                   />
+                  {!delivery.completedAt &&
+                    !isLocked &&
+                    !missingRequiredReputation &&
+                    delivery.readyAt <= now && (
+                      <p
+                        className="underline font-secondary text-xxs pb-1 pt-0.5 cursor-pointer hover:text-blue-500"
+                        onClick={() => setShowSkipDialog(true)}
+                      >
+                        {t("skip.order")}
+                        {"?"}
+                      </p>
+                    )}
                 </>
               )}
               {deliveryFrozen && (

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -741,11 +741,19 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
 
   const canSkip =
     !!delivery &&
-    getDayOfYear(new Date(now)) !== getDayOfYear(new Date(delivery.createdAt));
+    (getDayOfYear(new Date(now)) !==
+      getDayOfYear(new Date(delivery.createdAt)) ||
+      new Date(now).getFullYear() !==
+        new Date(delivery.createdAt).getFullYear());
 
-  const skip = () => {
+  const skippableDelivery =
+    delivery && !delivery.completedAt && delivery.readyAt <= now && canSkip
+      ? delivery
+      : undefined;
+
+  const skip = (id: string) => {
     setShowSkipDialog(false);
-    gameService.send("order.skipped", { id: delivery?.id });
+    gameService.send("order.skipped", { id });
     gameService.send("SAVE");
     onClose?.();
   };
@@ -874,18 +882,22 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
               <div className="flex-1">
                 <RequirementLabel
                   type="time"
-                  waitSeconds={secondsTillReset()}
+                  waitSeconds={secondsTillReset(now)}
                 />
               </div>
             </>
           )}
         </div>
         {canSkip && (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-row gap-1">
             <Button onClick={() => setShowSkipDialog(false)}>
               {t("orderhelp.NoRight")}
             </Button>
-            <Button onClick={skip}>{t("skip.order")}</Button>
+            {skippableDelivery && (
+              <Button onClick={() => skip(skippableDelivery.id)}>
+                {t("skip.order")}
+              </Button>
+            )}
           </div>
         )}
         {!canSkip && (
@@ -1002,13 +1014,14 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
                     !isLocked &&
                     !missingRequiredReputation &&
                     delivery.readyAt <= now && (
-                      <p
-                        className="underline font-secondary text-xxs pb-1 pt-0.5 cursor-pointer hover:text-blue-500"
+                      <button
+                        type="button"
+                        className="text-left underline font-secondary text-xxs p-0 pb-1 pt-0.5 bg-transparent border-0 cursor-pointer hover:text-blue-500 focus-visible:text-blue-500"
                         onClick={() => setShowSkipDialog(true)}
                       >
                         {t("skip.order")}
                         {"?"}
-                      </p>
+                      </button>
                     )}
                 </>
               )}

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -44,6 +44,7 @@ import {
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
 import { getDayOfYear, secondsTillReset } from "lib/utils/time";
+import { Loading } from "features/auth/components";
 import {
   BUMPKIN_FLOWER_BONUSES,
   DEFAULT_FLOWER_POINTS,
@@ -751,11 +752,21 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
       ? delivery
       : undefined;
 
+  // Keep the loading screen up from the moment the player skips until the
+  // autosave settles and the server returns the fresh set of orders.
+  const isAutosaving = gameState.matches("autosaving");
+  const [isSkipping, setIsSkipping] = useState(false);
+  const [wasAutosaving, setWasAutosaving] = useState(isAutosaving);
+  if (wasAutosaving !== isAutosaving) {
+    setWasAutosaving(isAutosaving);
+    if (!isAutosaving) setIsSkipping(false);
+  }
+
   const skip = (id: string) => {
     setShowSkipDialog(false);
+    setIsSkipping(true);
     gameService.send("order.skipped", { id });
     gameService.send("SAVE");
-    onClose?.();
   };
 
   const { holiday } = getBumpkinHoliday({ now });
@@ -868,45 +879,6 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
     );
   }
 
-  if (showSkipDialog) {
-    return (
-      <InnerPanel>
-        <div className="flex-1 space-y-2 p-1">
-          <p className="text-xs">{t("orderhelp.Skip.hour")}</p>
-          {canSkip && <p className="text-xs">{t("choose.wisely")}</p>}
-          {!canSkip && (
-            <>
-              <p className="text-xs font-secondary">
-                {`${t("orderhelp.SkipIn")}:`}
-              </p>
-              <div className="flex-1">
-                <RequirementLabel
-                  type="time"
-                  waitSeconds={secondsTillReset(now)}
-                />
-              </div>
-            </>
-          )}
-        </div>
-        {canSkip && (
-          <div className="flex flex-row gap-1">
-            <Button onClick={() => setShowSkipDialog(false)}>
-              {t("orderhelp.NoRight")}
-            </Button>
-            {skippableDelivery && (
-              <Button onClick={() => skip(skippableDelivery.id)}>
-                {t("skip.order")}
-              </Button>
-            )}
-          </div>
-        )}
-        {!canSkip && (
-          <Button onClick={() => setShowSkipDialog(false)}>{t("back")}</Button>
-        )}
-      </InnerPanel>
-    );
-  }
-
   return (
     <>
       {showFlowers && (
@@ -951,111 +923,160 @@ export const BumpkinDelivery: React.FC<Props> = ({ onClose, npc }) => {
           </InnerPanel>
 
           <InnerPanel className="mb-1">
-            <div className="px-2 ">
-              <div className="flex flex-col justify-between items-stretch mb-2 gap-1">
-                <div className="flex flex-row justify-between w-full">
-                  {getActiveCalendarEvent({
-                    calendar: gameState.context.state.calendar,
-                  }) === "doubleDelivery" && !hasClaimedBonus ? (
-                    <Label type="vibrant" icon={lightning}>
-                      {t("double.rewards.delivery")}
-                    </Label>
-                  ) : (
-                    <Label
-                      type="default"
-                      icon={SUNNYSIDE.icons.expression_chat}
-                    >
-                      {t("delivery")}
-                    </Label>
-                  )}
-
-                  {isLocked && (
-                    <Label type="danger" secondaryIcon={SUNNYSIDE.icons.player}>
-                      {t("warning.level.required", {
-                        lvl: NPC_DELIVERY_LEVELS[npc as DeliveryNpcName],
-                      })}
-                    </Label>
-                  )}
-
-                  {delivery?.completedAt && (
-                    <Label
-                      style={{ whiteSpace: "nowrap" }}
-                      type="success"
-                      secondaryIcon={SUNNYSIDE.icons.confirm}
-                    >
-                      {t("completed")}
-                    </Label>
-                  )}
-                </div>
+            {isSkipping ? (
+              <div className="flex-1 p-2">
+                <Loading
+                  className="text-center mb-0.5 mt-1 text-sm loading"
+                  text={t("skipping")}
+                />
               </div>
-              {!delivery && !isLocked && (
-                <p className="text-xs mb-1">{t("no.delivery.avl")}</p>
-              )}
-
-              {isLocked && (
-                <>
-                  <p className="text-xs mb-2">
-                    {t("bumpkin.delivery.proveYourself", {
-                      missingLevels: missingLevels,
-                    })}
-                  </p>
-                </>
-              )}
-
-              {delivery && !deliveryFrozen && (
-                <>
-                  <OrderCard
-                    game={gameState.context.state}
-                    order={delivery as Order}
-                    hasRequirementsCheck={() => true}
-                    onDeliver={deliver}
-                  />
-                  {!delivery.completedAt &&
-                    !isLocked &&
-                    !missingRequiredReputation &&
-                    delivery.readyAt <= now && (
-                      <button
-                        type="button"
-                        className="text-left underline font-secondary text-xxs p-0 pb-1 pt-0.5 bg-transparent border-0 cursor-pointer hover:text-blue-500 focus-visible:text-blue-500"
-                        onClick={() => setShowSkipDialog(true)}
+            ) : showSkipDialog ? (
+              <div className="flex-1 space-y-2 p-1">
+                <p className="text-xs">{t("orderhelp.Skip.hour")}</p>
+                {canSkip && <p className="text-xs">{t("choose.wisely")}</p>}
+                {!canSkip && (
+                  <>
+                    <p className="text-xs font-secondary">
+                      {`${t("orderhelp.SkipIn")}:`}
+                    </p>
+                    <div className="flex-1">
+                      <RequirementLabel
+                        type="time"
+                        waitSeconds={secondsTillReset(now)}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="px-2 ">
+                <div className="flex flex-col justify-between items-stretch mb-2 gap-1">
+                  <div className="flex flex-row justify-between w-full">
+                    {getActiveCalendarEvent({
+                      calendar: gameState.context.state.calendar,
+                    }) === "doubleDelivery" && !hasClaimedBonus ? (
+                      <Label type="vibrant" icon={lightning}>
+                        {t("double.rewards.delivery")}
+                      </Label>
+                    ) : (
+                      <Label
+                        type="default"
+                        icon={SUNNYSIDE.icons.expression_chat}
                       >
-                        {t("skip.order")}
-                        {"?"}
-                      </button>
+                        {t("delivery")}
+                      </Label>
                     )}
-                </>
-              )}
-              {deliveryFrozen && (
-                <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
-                  {t("orderhelp.ticket.deliveries.closed")}
-                </Label>
-              )}
-            </div>
+
+                    {isLocked && (
+                      <Label
+                        type="danger"
+                        secondaryIcon={SUNNYSIDE.icons.player}
+                      >
+                        {t("warning.level.required", {
+                          lvl: NPC_DELIVERY_LEVELS[npc as DeliveryNpcName],
+                        })}
+                      </Label>
+                    )}
+
+                    {delivery?.completedAt && (
+                      <Label
+                        style={{ whiteSpace: "nowrap" }}
+                        type="success"
+                        secondaryIcon={SUNNYSIDE.icons.confirm}
+                      >
+                        {t("completed")}
+                      </Label>
+                    )}
+                  </div>
+                </div>
+                {!delivery && !isLocked && (
+                  <p className="text-xs mb-1">{t("no.delivery.avl")}</p>
+                )}
+
+                {isLocked && (
+                  <>
+                    <p className="text-xs mb-2">
+                      {t("bumpkin.delivery.proveYourself", {
+                        missingLevels: missingLevels,
+                      })}
+                    </p>
+                  </>
+                )}
+
+                {delivery && !deliveryFrozen && (
+                  <>
+                    <OrderCard
+                      game={gameState.context.state}
+                      order={delivery as Order}
+                      hasRequirementsCheck={() => true}
+                      onDeliver={deliver}
+                    />
+                    {!delivery.completedAt &&
+                      !isLocked &&
+                      !missingRequiredReputation &&
+                      delivery.readyAt <= now && (
+                        <button
+                          type="button"
+                          className="text-left underline font-secondary text-xxs p-0 pb-1 pt-0.5 bg-transparent border-0 cursor-pointer hover:text-blue-500 focus-visible:text-blue-500"
+                          onClick={() => setShowSkipDialog(true)}
+                        >
+                          {t("skip.order")}
+                          {"?"}
+                        </button>
+                      )}
+                  </>
+                )}
+                {deliveryFrozen && (
+                  <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
+                    {t("orderhelp.ticket.deliveries.closed")}
+                  </Label>
+                )}
+              </div>
+            )}
           </InnerPanel>
           {missingRequiredReputation && (
             <RequiredReputation reputation={Reputation.Cropkeeper} />
           )}
-          <div className="flex mt-1">
-            {acceptGifts && (
-              <Button className="mr-1" onClick={() => setShowFlowers(true)}>
-                {t("gift")}
+          {isSkipping ? null : showSkipDialog ? (
+            canSkip ? (
+              <div className="flex flex-row gap-1">
+                <Button onClick={() => setShowSkipDialog(false)}>
+                  {t("orderhelp.NoRight")}
+                </Button>
+                {skippableDelivery && (
+                  <Button onClick={() => skip(skippableDelivery.id)}>
+                    {t("skip.order")}
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <Button onClick={() => setShowSkipDialog(false)}>
+                {t("back")}
               </Button>
-            )}
+            )
+          ) : (
+            <div className="flex mt-1">
+              {acceptGifts && (
+                <Button className="mr-1" onClick={() => setShowFlowers(true)}>
+                  {t("gift")}
+                </Button>
+              )}
 
-            <Button
-              disabled={
-                !delivery ||
-                !hasDelivery ||
-                !!delivery?.completedAt ||
-                isLocked ||
-                missingRequiredReputation ||
-                deliveryFrozen
-              }
-              onClick={deliver}
-            >
-              {t("deliver")}
-            </Button>
-          </div>
+              <Button
+                disabled={
+                  !delivery ||
+                  !hasDelivery ||
+                  !!delivery?.completedAt ||
+                  isLocked ||
+                  missingRequiredReputation ||
+                  deliveryFrozen
+                }
+                onClick={deliver}
+              >
+                {t("deliver")}
+              </Button>
+            </div>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
## Summary
- Adds a **"Skip Order?"** shortcut directly inside the in-world NPC delivery modal (`BumpkinDelivery`), so players no longer have to open the codex to skip a delivery. This reduces a small but repeated friction point — especially for new players and anyone who doesn't go 100% during a chapter and skips often.
- The shortcut reuses the exact same confirmation flow, cooldown logic, and `order.skipped` event as the existing codex skip, so behavior is consistent across both entry points.

## Backend parity / bug fixes
While wiring this up, the skip reducer (`skipOrder.ts`) was hardened to match the authoritative backend logic:
- **Fix `skippedCount` increment** — operator precedence bug (`?? 0 + 1` parsed as `?? (0 + 1)`) meant the global skip counter stuck at `1` forever. Now `(skippedCount ?? 0) + 1`.
- **Mirror backend guards** — reject skipping orders that are already completed or not yet ready (the backend already throws on these; the client didn't, which could cause a save rejection now that the modal can surface non-ready orders).
- **Per-NPC `skippedCount`** — now incremented to match the API.

The skip link in the modal is also gated on the order being ready, not completed, unlocked, and reputation-met, so it never offers a skip the backend would reject.

## Notes
- The corresponding `sunflower-land-api` logic was reviewed and already correct — no API change needed.

## Test plan
- [x] `skipOrder` unit tests pass (strengthened the increment test + added a per-NPC increment test)
- [x] Typecheck, ESLint, and Prettier clean
- [ ] Manually verify in-world: approach an NPC, confirm "Skip Order?" appears for a ready/incomplete order, the confirm dialog shows (with countdown when on cooldown), and skipping works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add time-limited "skip order" flow with dialog, countdown, and skip confirmation.
  * Show skip action in delivery UI when eligible.

* **Bug Fixes**
  * Prevent skipping orders that are completed or not yet ready.
  * Correctly increment global and per-NPC skip counters and persist them.

* **Tests**
  * Expanded tests covering skip failure cases and per-NPC/global skip counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->