### PR TITLE
[microFIX] Keep marketplace favorite toggle below header

### DIFF
--- a/src/features/marketplace/components/TradeableInfo.tsx
+++ b/src/features/marketplace/components/TradeableInfo.tsx
@@ -206,7 +206,7 @@ export const TradeableImage: React.FC<{
             type="button"
             aria-label={favoriteLabel}
             title={favoriteLabel}
-            className="absolute top-4 right-4 z-10 h-8 w-8 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
+            className="absolute top-4 right-4 h-8 w-8 cursor-pointer border-0 bg-transparent p-0 hover:img-highlight"
             onClick={(event) => {
               event.stopPropagation();
               setFavoriteFeedback(isFavorite ? "removed" : "added");
@@ -218,7 +218,7 @@ export const TradeableImage: React.FC<{
           {favoriteFeedback && (
             <Label
               type={favoriteFeedback === "added" ? "success" : "default"}
-              className="absolute top-14 -right-6 z-10 pointer-events-none whitespace-nowrap"
+              className="absolute top-14 -right-6 z-[1] pointer-events-none whitespace-nowrap"
             >
               {favoriteFeedback === "added"
                 ? t("marketplace.addedToFavourites")


### PR DESCRIPTION
## Summary

<img height="600" alt="telegram-cloud-photo-size-2-5265128729917201278-y" src="https://github.com/user-attachments/assets/19a56d06-fb23-4dbe-94c0-4170f98aab63" />

Fixes the marketplace item detail favourite heart overlapping the mobile back/header panel while the page is scrolled.

## Context / motivation
The favourite toggle added in the Marketplace Favorites PR was positioned inside the tradeable image panel with the same z-index level as the sticky item header. On mobile, when the detail page scrolls, the heart icon could visually sit above the back/navigation panel instead of staying below it with the card content.

## Implementation
- Removed the elevated z-index from the favourite heart button inside TradeableInfo.
- Kept the temporary favourite feedback label above the image locally with a low z-index value so it still appears over the image but remains below sticky navigation/header layers.
- No marketplace favorites logic changed; this is a layering-only UI fix.

## How to test
1. Open Marketplace on mobile viewport.
2. Open any item detail page, for example a collectible.
3. Ensure the favourite heart appears in the image panel.
4. Scroll the page so the sticky back/header panel overlaps the image area.
5. Confirm the favourite heart no longer covers the back/header panel.
6. Toggle the favourite state and confirm the feedback label still appears over the image.

## Screenshots or screen recording
Required for this visual fix. Add the provided mobile screenshot as the before state and a new after screenshot after verification.

## Related issues
Follow-up to #7291.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted UI layering for the marketplace favorite button and feedback label to ensure correct visual stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->