### PR TITLE
[FIX] Boosted flower separate from decoration 

### DIFF
--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -17,7 +17,6 @@ import {
   placeEvent,
 } from "features/game/expansion/placeable/landscapingMachine";
 import type { PlaceableLocation } from "features/game/types/collectibles";
-import type { InventoryItemName } from "features/game/types/game";
 import { getKeys } from "lib/object";
 import {
   getChestBuds,
@@ -26,13 +25,13 @@ import {
   getChestItems,
   getChestPets,
 } from "./inventory/utils/inventory";
+import { hasBoost } from "./inventory/utils/boosts";
 import { RESOURCES, type ResourceName } from "features/game/types/resources";
 import {
   BUILDINGS,
   BUILDINGS_DIMENSIONS,
   type BuildingName,
 } from "features/game/types/buildings";
-import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { BANNERS } from "features/game/types/banners";
 import { BED_FARMHAND_COUNT } from "features/game/types/beds";
 import { MONUMENTS, REWARD_ITEMS } from "features/game/types/monuments";
@@ -369,12 +368,8 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const weatherItems = collectibleNames.filter(
     (name) => name in WEATHER_SHOP_ITEM_COSTS,
   );
-  const hasBoost = (name: InventoryItemName) =>
-    name in COLLECTIBLE_BUFF_LABELS &&
-    (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0;
-
   const flowers = getChestFlowers(collectibleNames).filter(
-    (name) => !hasBoost(name),
+    (name) => !hasBoost(name, state),
   );
   const dolls = collectibleNames.filter((name) => name in DOLLS);
   const pets = collectibleNames.filter((name) => name in PET_TYPES);
@@ -391,7 +386,7 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const petsSet = new Set(pets);
 
   const boosts = collectibleNames
-    .filter(hasBoost)
+    .filter((name) => hasBoost(name, state))
     .filter(
       (name) =>
         !resourcesSet.has(name) &&

--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -17,6 +17,7 @@ import {
   placeEvent,
 } from "features/game/expansion/placeable/landscapingMachine";
 import type { PlaceableLocation } from "features/game/types/collectibles";
+import type { InventoryItemName } from "features/game/types/game";
 import { getKeys } from "lib/object";
 import {
   getChestBuds,
@@ -368,7 +369,13 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const weatherItems = collectibleNames.filter(
     (name) => name in WEATHER_SHOP_ITEM_COSTS,
   );
-  const flowers = getChestFlowers(collectibleNames);
+  const hasBoost = (name: InventoryItemName) =>
+    name in COLLECTIBLE_BUFF_LABELS &&
+    (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0;
+
+  const flowers = getChestFlowers(collectibleNames).filter(
+    (name) => !hasBoost(name),
+  );
   const dolls = collectibleNames.filter((name) => name in DOLLS);
   const pets = collectibleNames.filter((name) => name in PET_TYPES);
 
@@ -384,11 +391,7 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   const petsSet = new Set(pets);
 
   const boosts = collectibleNames
-    .filter(
-      (name) =>
-        name in COLLECTIBLE_BUFF_LABELS &&
-        (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0,
-    )
+    .filter(hasBoost)
     .filter(
       (name) =>
         !resourcesSet.has(name) &&

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -376,7 +376,13 @@ export const Chest: React.FC<Props> = ({
     (name) => name in WEATHER_SHOP_ITEM_COSTS,
   );
 
-  const flowers = getChestFlowers(collectibleNames);
+  const hasBoost = (name: InventoryItemName) =>
+    name in COLLECTIBLE_BUFF_LABELS &&
+    (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0;
+
+  const flowers = getChestFlowers(collectibleNames).filter(
+    (name) => !hasBoost(name),
+  );
   const dolls = collectibleNames.filter((name) => name in DOLLS);
   const pets = collectibleNames.filter((name) => name in PET_TYPES);
 
@@ -393,11 +399,7 @@ export const Chest: React.FC<Props> = ({
   const flowersSet = new Set(flowers);
 
   const boosts = collectibleNames
-    .filter(
-      (name) =>
-        name in COLLECTIBLE_BUFF_LABELS &&
-        (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0,
-    )
+    .filter(hasBoost)
     .filter(
       (name) =>
         !resourcesSet.has(name) &&

--- a/src/features/island/hud/components/inventory/Chest.tsx
+++ b/src/features/island/hud/components/inventory/Chest.tsx
@@ -15,6 +15,7 @@ import {
   getChestItems,
   getChestPets,
 } from "./utils/inventory";
+import { hasBoost } from "./utils/boosts";
 import type Decimal from "decimal.js-light";
 import { Button } from "components/ui/Button";
 
@@ -32,7 +33,6 @@ import { RESOURCES } from "features/game/types/resources";
 import { type BuildingName, BUILDINGS } from "features/game/types/buildings";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
-import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import {
   BUSH_VARIANTS,
@@ -376,12 +376,8 @@ export const Chest: React.FC<Props> = ({
     (name) => name in WEATHER_SHOP_ITEM_COSTS,
   );
 
-  const hasBoost = (name: InventoryItemName) =>
-    name in COLLECTIBLE_BUFF_LABELS &&
-    (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0;
-
   const flowers = getChestFlowers(collectibleNames).filter(
-    (name) => !hasBoost(name),
+    (name) => !hasBoost(name, state),
   );
   const dolls = collectibleNames.filter((name) => name in DOLLS);
   const pets = collectibleNames.filter((name) => name in PET_TYPES);
@@ -399,7 +395,7 @@ export const Chest: React.FC<Props> = ({
   const flowersSet = new Set(flowers);
 
   const boosts = collectibleNames
-    .filter(hasBoost)
+    .filter((name) => hasBoost(name, state))
     .filter(
       (name) =>
         !resourcesSet.has(name) &&

--- a/src/features/island/hud/components/inventory/utils/boosts.ts
+++ b/src/features/island/hud/components/inventory/utils/boosts.ts
@@ -1,0 +1,6 @@
+import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
+import type { GameState, InventoryItemName } from "features/game/types/game";
+
+export const hasBoost = (name: InventoryItemName, state: GameState) =>
+  name in COLLECTIBLE_BUFF_LABELS &&
+  (COLLECTIBLE_BUFF_LABELS[name]?.(state) ?? []).length > 0;


### PR DESCRIPTION
Fix to https://github.com/sunflower-land/sunflower-land/pull/7198 and https://github.com/sunflower-land/sunflower-land/pull/7262

## Problem
After flower grouping was added to the chest and quick drag-and-drop panel, flowers with gameplay boosts were grouped under Flowers instead of Boosts.

## Solution
- Keep using the existing boost source of truth: COLLECTIBLE_BUFF_LABELS.
- Exclude boosted flowers from the Flowers group.
- Let those same items flow into the existing Boosts group logic in both the chest and quick drag panel.

This avoids maintaining a separate manual list of boosted flowers and keeps future boosted flowers categorized automatically when they receive buff labels.

## Testing
- git diff --check
- yarn tsc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized inventory item categorization logic to ensure consistent classification of boosts across the island interface. Items are now consistently identified as boosts or flowers based on a shared determination method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->