### PR TITLE
[FIX] Crafting Box queue bugs (durations, instant proc, cancel guard, uncollected discount)

### DIFF
--- a/src/features/game/events/landExpansion/cancelQueuedCrafting.test.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedCrafting.test.ts
@@ -741,4 +741,137 @@ describe("cancelQueuedCrafting", () => {
     // Locked (zero) duration is kept instead of being recomputed from the recipe.
     expect(result[1].readyAt).toEqual(instantReadyAt);
   });
+
+  // Review finding: an instant Fox Shrine proc is "ready" out of order (its
+  // readyAt is in the past while a longer craft ahead of it is still going). A
+  // later real craft must chain off when the box is actually free, NOT off the
+  // instant proc's stale readyAt (which would discount it).
+  it("does not discount a later craft chained behind an instant proc when an item is cancelled", () => {
+    const now = Date.now();
+    const twoHours = 2 * 60 * 60 * 1000;
+
+    const state = cancelQueuedCrafting({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Crafting Box": [
+            {
+              id: "123",
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+        inventory: { Leather: new Decimal(0), Wool: new Decimal(0) },
+        farmActivity: { "Doll Crafting Started": 4 },
+        craftingBox: {
+          status: "crafting",
+          queue: [
+            {
+              id: "doll-1",
+              name: "Doll",
+              startedAt: now,
+              readyAt: now + twoHours,
+              type: "collectible",
+            },
+            {
+              id: "doll-instant",
+              name: "Doll",
+              startedAt: now,
+              readyAt: now,
+              type: "collectible",
+            },
+            {
+              id: "doll-2",
+              name: "Doll",
+              startedAt: now + twoHours,
+              readyAt: now + 2 * twoHours,
+              type: "collectible",
+            },
+            {
+              id: "doll-3",
+              name: "Doll",
+              startedAt: now + 2 * twoHours,
+              readyAt: now + 3 * twoHours,
+              type: "collectible",
+            },
+          ],
+          recipes: { Doll: { ...RECIPES.Doll } },
+        },
+      },
+      action: { type: "crafting.cancelled", queueItemId: "doll-2" },
+      createdAt: now,
+      farmId,
+    });
+
+    const queue = state.craftingBox.queue!;
+    const instant = queue.find((q) => q.id === "doll-instant");
+    const doll3 = queue.find((q) => q.id === "doll-3");
+    // Instant proc stays ready; doll-3 starts when doll-1 finishes (now+2h) and
+    // takes its full 2h -> now+4h, NOT now+2h chained off the instant.
+    expect(instant?.readyAt).toEqual(now);
+    expect(doll3?.readyAt).toEqual(now + 2 * twoHours);
+  });
+
+  // Review finding: an in-progress craft must not be dragged earlier by an
+  // already-ready instant proc sitting in front of it in the queue.
+  it("does not move an in-progress craft earlier than an instant proc queued before it", () => {
+    const now = Date.now();
+    const hour = 60 * 60 * 1000;
+    const twoHours = 2 * hour;
+
+    const state = cancelQueuedCrafting({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Crafting Box": [
+            {
+              id: "123",
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+        inventory: { Leather: new Decimal(0), Wool: new Decimal(0) },
+        farmActivity: { "Doll Crafting Started": 3 },
+        craftingBox: {
+          status: "crafting",
+          queue: [
+            {
+              id: "doll-instant",
+              name: "Doll",
+              startedAt: now - hour,
+              readyAt: now - hour,
+              type: "collectible",
+            },
+            {
+              id: "doll-1",
+              name: "Doll",
+              startedAt: now,
+              readyAt: now + twoHours,
+              type: "collectible",
+            },
+            {
+              id: "doll-2",
+              name: "Doll",
+              startedAt: now + twoHours,
+              readyAt: now + 2 * twoHours,
+              type: "collectible",
+            },
+          ],
+          recipes: { Doll: { ...RECIPES.Doll } },
+        },
+      },
+      action: { type: "crafting.cancelled", queueItemId: "doll-2" },
+      createdAt: now,
+      farmId,
+    });
+
+    const doll1 = state.craftingBox.queue!.find((q) => q.id === "doll-1");
+    // doll-1 is actively crafting; cancelling a later item must not pull it
+    // earlier by chaining off the instant proc's past readyAt.
+    expect(doll1?.readyAt).toEqual(now + twoHours);
+  });
 });

--- a/src/features/game/events/landExpansion/cancelQueuedCrafting.test.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedCrafting.test.ts
@@ -567,7 +567,6 @@ describe("cancelQueuedCrafting", () => {
     const expectedQueue = recalculateCraftingQueue({
       queue: updatedQueue,
       game: gameAfterDecrement,
-      farmId,
     });
 
     const result = cancelQueuedCrafting({
@@ -589,5 +588,157 @@ describe("cancelQueuedCrafting", () => {
     expect(result.craftingBox.queue?.[1].readyAt).toEqual(
       expectedQueue[1].readyAt,
     );
+  });
+
+  // Bug #2: cancelling a later queued item must not re-derive the currently
+  // crafting item's time from the *current* boost state. The duration is locked
+  // in when the item is queued.
+  it("keeps the in-progress item's locked readyAt when a later item is cancelled", () => {
+    const now = Date.now();
+    const hour = 60 * 60 * 1000;
+    // Doll's base recipe time is 2h, but this item was queued while a crafting
+    // speed boost was active, so its locked duration is only 1h.
+    const dollReadyAt = now + hour;
+    const doll2ReadyAt = dollReadyAt + 2 * hour;
+
+    const state = cancelQueuedCrafting({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Crafting Box": [
+            {
+              id: "123",
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+        inventory: { Leather: new Decimal(0), Wool: new Decimal(0) },
+        farmActivity: { "Doll Crafting Started": 2 },
+        craftingBox: {
+          status: "crafting",
+          queue: [
+            {
+              id: "doll-1",
+              name: "Doll",
+              readyAt: dollReadyAt,
+              startedAt: now,
+              type: "collectible",
+            },
+            {
+              id: "doll-2",
+              name: "Doll",
+              readyAt: doll2ReadyAt,
+              startedAt: dollReadyAt,
+              type: "collectible",
+            },
+          ],
+          recipes: { Doll: { ...RECIPES.Doll } },
+        },
+      },
+      action: { type: "crafting.cancelled", queueItemId: "doll-2" },
+      createdAt: now,
+      farmId,
+    });
+
+    expect(state.craftingBox.queue).toHaveLength(1);
+    expect(state.craftingBox.queue?.[0].id).toBe("doll-1");
+    // Must stay at the locked 1h, not be recomputed to the full 2h recipe time.
+    expect(state.craftingBox.queue?.[0].readyAt).toEqual(dollReadyAt);
+  });
+
+  // Bug #4: the "currently being crafted" guard must compare by id, not readyAt.
+  it("cancels a later pending item that shares a readyAt with the in-progress item", () => {
+    const now = Date.now();
+    const sharedReadyAt = now + 60 * 60 * 1000;
+    // doll-current is actively crafting (ready in 1h). doll-pending is an
+    // instant item queued behind it, so it becomes ready exactly when the
+    // current craft finishes — the two share a readyAt. Cancelling the pending
+    // item must be allowed.
+    const state = cancelQueuedCrafting({
+      state: {
+        ...INITIAL_FARM,
+        buildings: {
+          "Crafting Box": [
+            {
+              id: "123",
+              coordinates: { x: 0, y: 0 },
+              createdAt: 0,
+              readyAt: 0,
+            },
+          ],
+        },
+        inventory: { Leather: new Decimal(0), Wool: new Decimal(0) },
+        farmActivity: { "Doll Crafting Started": 2 },
+        craftingBox: {
+          status: "crafting",
+          queue: [
+            {
+              id: "doll-current",
+              name: "Doll",
+              readyAt: sharedReadyAt,
+              startedAt: now,
+              type: "collectible",
+            },
+            {
+              id: "doll-pending",
+              name: "Doll",
+              readyAt: sharedReadyAt,
+              startedAt: sharedReadyAt,
+              type: "collectible",
+            },
+          ],
+          recipes: { Doll: { ...RECIPES.Doll } },
+        },
+      },
+      action: { type: "crafting.cancelled", queueItemId: "doll-pending" },
+      createdAt: now,
+      farmId,
+    });
+
+    expect(state.craftingBox.queue).toHaveLength(1);
+    expect(state.craftingBox.queue?.[0].id).toBe("doll-current");
+  });
+
+  // Bug #3: recalculating must not re-derive crafting time (which on the buggy
+  // path re-rolls the Fox Shrine prng). An item that rolled the instant proc
+  // when queued has a locked (zero) duration and must stay instant, even though
+  // its recipe time is 2h.
+  it("does not resurrect a Fox Shrine instant item's time when recalculating", () => {
+    const now = Date.now();
+    const twoHours = 2 * 60 * 60 * 1000;
+    const instantReadyAt = now; // this Doll rolled the Fox Shrine instant proc
+
+    const result = recalculateCraftingQueue({
+      queue: [
+        {
+          id: "doll-in-progress",
+          name: "Doll",
+          readyAt: now + twoHours,
+          startedAt: now,
+          type: "collectible",
+        },
+        {
+          id: "doll-instant",
+          name: "Doll",
+          readyAt: instantReadyAt,
+          startedAt: instantReadyAt,
+          type: "collectible",
+        },
+      ],
+      game: {
+        ...INITIAL_FARM,
+        farmActivity: { "Doll Crafting Started": 2 },
+        craftingBox: {
+          status: "crafting",
+          queue: [],
+          recipes: { Doll: { ...RECIPES.Doll } },
+        },
+      },
+    });
+
+    // Locked (zero) duration is kept instead of being recomputed from the recipe.
+    expect(result[1].readyAt).toEqual(instantReadyAt);
   });
 });

--- a/src/features/game/events/landExpansion/cancelQueuedCrafting.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedCrafting.ts
@@ -41,6 +41,14 @@ export function recalculateCraftingQueue({
 
   const result = [...queue];
 
+  // The crafting box is free once the latest real (box-occupying) craft has
+  // finished. Track that time instead of chaining off the immediately-preceding
+  // item: a Fox Shrine instant proc is "ready" out of order (its readyAt can be
+  // in the past while a longer craft ahead of it is still going), and it does
+  // not occupy the box — so later crafts must wait for the real craft, not
+  // inherit the instant's stale readyAt.
+  let boxFreeAt: number | null = null;
+
   for (let i = 0; i < result.length; i++) {
     const item = result[i];
     const recipe = getRecipeByName(item.name, game);
@@ -52,19 +60,27 @@ export function recalculateCraftingQueue({
     // speeding up an earlier item shifts the rest, without re-deriving durations
     // from the current (possibly changed) boost state or re-rolling the prng.
     const lockedDuration = item.readyAt - item.startedAt;
-    const startAt = i === 0 ? item.startedAt : result[i - 1].readyAt;
 
+    let startedAt: number;
     let readyAt: number;
     if (i === 0 && firstItemReadyAt !== undefined) {
+      startedAt = item.startedAt;
       readyAt = firstItemReadyAt;
+      boxFreeAt = readyAt;
     } else if (lockedDuration === 0) {
-      // Instant items stay ready at their original time.
+      // Instant craft: stays ready at its original time and does not occupy the
+      // box, so it neither moves nor delays the crafts after it.
+      startedAt = item.startedAt;
       readyAt = item.readyAt;
     } else {
-      readyAt = startAt + lockedDuration;
+      // Real craft: starts when the box is next free (after the previous real
+      // craft), or keeps its own start if it is the first to occupy the box.
+      startedAt = boxFreeAt ?? item.startedAt;
+      readyAt = startedAt + lockedDuration;
+      boxFreeAt = readyAt;
     }
 
-    result[i] = { ...item, startedAt: startAt, readyAt };
+    result[i] = { ...item, startedAt, readyAt };
   }
 
   return result;

--- a/src/features/game/events/landExpansion/cancelQueuedCrafting.ts
+++ b/src/features/game/events/landExpansion/cancelQueuedCrafting.ts
@@ -1,14 +1,7 @@
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
-import type {
-  CraftingQueueItem,
-  GameState,
-  InventoryItemName,
-} from "features/game/types/game";
+import type { CraftingQueueItem, GameState } from "features/game/types/game";
 import { type Recipe, RECIPES } from "features/game/lib/crafting";
-import { type BumpkinItem, ITEM_IDS } from "features/game/types/bumpkin";
-import { KNOWN_IDS } from "features/game/types";
-import { getBoostedCraftingTime } from "./startCrafting";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 
 export type CancelQueuedCraftingAction = {
@@ -38,12 +31,10 @@ function getRecipeByName(name: string, game: GameState): Recipe | undefined {
 export function recalculateCraftingQueue({
   queue,
   game,
-  farmId = 0,
   firstItemReadyAt,
 }: {
   queue: CraftingQueueItem[];
   game: GameState;
-  farmId?: number;
   firstItemReadyAt?: number;
 }): CraftingQueueItem[] {
   if (queue.length === 0) return [];
@@ -55,37 +46,22 @@ export function recalculateCraftingQueue({
     const recipe = getRecipeByName(item.name, game);
     if (!recipe) continue;
 
-    let readyAt: number;
+    // Each item's crafting duration is locked in when it is queued — it already
+    // reflects any boosts or Fox Shrine instant procs that were active at that
+    // moment. Only the chain of start times is recomputed so that removing or
+    // speeding up an earlier item shifts the rest, without re-deriving durations
+    // from the current (possibly changed) boost state or re-rolling the prng.
+    const lockedDuration = item.readyAt - item.startedAt;
     const startAt = i === 0 ? item.startedAt : result[i - 1].readyAt;
 
-    const countSameRecipeFromEnd = result
-      .slice(i)
-      .filter((q) => q.name === item.name).length;
-    const counter = Math.max(
-      0,
-      (game.farmActivity?.[`${recipe.name} Crafting Started`] ?? 0) -
-        countSameRecipeFromEnd,
-    );
-
-    const { seconds: recipeTime } = getBoostedCraftingTime({
-      game,
-      time: recipe.time,
-      prngArgs: {
-        farmId,
-        itemId:
-          recipe.type === "collectible"
-            ? KNOWN_IDS[recipe.name as InventoryItemName]
-            : ITEM_IDS[recipe.name as BumpkinItem],
-        counter,
-      },
-    });
-
+    let readyAt: number;
     if (i === 0 && firstItemReadyAt !== undefined) {
       readyAt = firstItemReadyAt;
-    } else if (recipeTime === 0) {
+    } else if (lockedDuration === 0) {
+      // Instant items stay ready at their original time.
       readyAt = item.readyAt;
     } else {
-      readyAt = startAt + recipeTime;
+      readyAt = startAt + lockedDuration;
     }
 
     result[i] = { ...item, startedAt: startAt, readyAt };
@@ -105,7 +81,6 @@ export function cancelQueuedCrafting({
   state,
   action,
   createdAt = Date.now(),
-  farmId = 0,
 }: Options): GameState {
   return produce(state, (game) => {
     const { queueItemId } = action;
@@ -123,7 +98,7 @@ export function cancelQueuedCrafting({
 
     const currentCraftingItem = getCurrentCraftingItem(queue, createdAt);
 
-    if (currentCraftingItem?.readyAt === item.readyAt) {
+    if (currentCraftingItem?.id === item.id) {
       throw new Error(
         `Item ${item.name} with readyAt ${item.readyAt} is currently being crafted`,
       );
@@ -165,7 +140,6 @@ export function cancelQueuedCrafting({
     game.craftingBox.queue = recalculateCraftingQueue({
       queue: updatedQueue,
       game,
-      farmId,
     });
 
     if (game.craftingBox.queue.length === 0) {

--- a/src/features/game/events/landExpansion/speedUpCrafting.test.ts
+++ b/src/features/game/events/landExpansion/speedUpCrafting.test.ts
@@ -1,6 +1,9 @@
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { RECIPES } from "features/game/lib/crafting";
-import { recalculateCraftingQueue } from "./cancelQueuedCrafting";
+import {
+  recalculateCraftingQueue,
+  cancelQueuedCrafting,
+} from "./cancelQueuedCrafting";
 import { speedUpCrafting } from "./speedUpCrafting";
 import Decimal from "decimal.js-light";
 import { getInstantGems } from "features/game/lib/getInstantGems";
@@ -552,6 +555,102 @@ describe("speedUpCrafting", () => {
     // 1h duration (not re-derived to the full 2h recipe time).
     expect(result.craftingBox.queue?.[0].readyAt).toEqual(now);
     expect(result.craftingBox.queue?.[1].readyAt).toEqual(now + hour);
+  });
+
+  // Reported flow: speed up the current doll (it becomes ready), then cancel a
+  // different queued doll. The sped-up doll must stay ready — it must NOT start
+  // crafting again. (Regression guard for the locked-duration fix.)
+  it("keeps a sped-up doll ready after another queued doll is cancelled", () => {
+    const now = Date.now();
+    const farmId = 1;
+    const twoHours = 2 * 60 * 60 * 1000;
+    const halfHour = 30 * 60 * 1000;
+
+    const dollRecipe = {
+      name: "Doll" as const,
+      type: "collectible" as const,
+      time: twoHours,
+      ingredients: [
+        { collectible: "Leather" as const },
+        { collectible: "Wool" as const },
+        { collectible: "Leather" as const },
+        { collectible: "Wool" as const },
+        { collectible: "Wool" as const },
+        { collectible: "Wool" as const },
+        { collectible: "Leather" as const },
+        { collectible: "Wool" as const },
+        { collectible: "Leather" as const },
+      ],
+    };
+
+    // DollA: 30 min into its 2h craft (1.5h left). DollB in progress, DollC pending.
+    const state: GameState = {
+      ...INITIAL_FARM,
+      inventory: {
+        Gem: new Decimal(1000),
+        "Beta Pass": new Decimal(1),
+        Leather: new Decimal(0),
+        Wool: new Decimal(0),
+      },
+      buildings: {
+        "Crafting Box": [
+          { id: "123", coordinates: { x: 0, y: 0 }, createdAt: 0, readyAt: 0 },
+        ],
+      },
+      farmActivity: { "Doll Crafting Started": 3 },
+      vip: { bundles: [], expiresAt: now + 86400000 },
+      craftingBox: {
+        status: "crafting",
+        queue: [
+          {
+            id: "doll-a",
+            name: "Doll",
+            startedAt: now - halfHour,
+            readyAt: now + (twoHours - halfHour),
+            type: "collectible",
+          },
+          {
+            id: "doll-b",
+            name: "Doll",
+            startedAt: now + (twoHours - halfHour),
+            readyAt: now + (twoHours - halfHour) + twoHours,
+            type: "collectible",
+          },
+          {
+            id: "doll-c",
+            name: "Doll",
+            startedAt: now + (twoHours - halfHour) + twoHours,
+            readyAt: now + (twoHours - halfHour) + 2 * twoHours,
+            type: "collectible",
+          },
+        ],
+        recipes: { Doll: dollRecipe },
+      },
+    };
+
+    // 1) Speed up the current doll (DollA) -> ready now.
+    const spedUp = speedUpCrafting({
+      state,
+      action: { type: "crafting.spedUp" },
+      createdAt: now,
+      farmId,
+    });
+    expect(
+      spedUp.craftingBox.queue?.find((q) => q.id === "doll-a")?.readyAt,
+    ).toEqual(now);
+
+    // 2) Cancel a different doll (DollC).
+    const afterCancel = cancelQueuedCrafting({
+      state: spedUp,
+      action: { type: "crafting.cancelled", queueItemId: "doll-c" },
+      createdAt: now,
+      farmId,
+    });
+
+    const dollA = afterCancel.craftingBox.queue?.find((q) => q.id === "doll-a");
+    // The ready doll must stay ready, not revert to a full 2h craft.
+    expect(dollA?.readyAt).toEqual(now);
+    expect(dollA?.readyAt).toBeLessThanOrEqual(now);
   });
 
   it("updates gem history", () => {

--- a/src/features/game/events/landExpansion/speedUpCrafting.test.ts
+++ b/src/features/game/events/landExpansion/speedUpCrafting.test.ts
@@ -478,7 +478,6 @@ describe("speedUpCrafting", () => {
     const expectedRecalculated = recalculateCraftingQueue({
       queue: inProgressItems,
       game: state,
-      farmId,
       firstItemReadyAt: now,
     });
 
@@ -496,6 +495,63 @@ describe("speedUpCrafting", () => {
     expect(result.craftingBox.queue?.[1].readyAt).toEqual(
       expectedRecalculated[1].readyAt,
     );
+  });
+
+  // Bug #2: speeding up the current craft must not re-derive following items'
+  // durations from the current boost state — each item's duration is locked in
+  // when it is queued.
+  it("keeps following items' locked durations when speeding up the current craft", () => {
+    const now = Date.now();
+    const farmId = 1;
+    const hour = 60 * 60 * 1000;
+    // Both Dolls have a 2h base recipe time, but doll-2 was queued under a
+    // crafting-speed boost, so its locked duration is only 1h.
+    const doll1ReadyAt = now + 2 * hour;
+    const doll2ReadyAt = doll1ReadyAt + hour;
+
+    const state: GameState = {
+      ...INITIAL_FARM,
+      inventory: { Gem: new Decimal(1000), "Beta Pass": new Decimal(1) },
+      buildings: {
+        "Crafting Box": [
+          { id: "123", coordinates: { x: 0, y: 0 }, createdAt: 0, readyAt: 0 },
+        ],
+      },
+      farmActivity: { "Doll Crafting Started": 2 },
+      vip: { bundles: [], expiresAt: now + 86400000 },
+      craftingBox: {
+        status: "crafting",
+        queue: [
+          {
+            id: "doll-1",
+            name: "Doll",
+            readyAt: doll1ReadyAt,
+            startedAt: now,
+            type: "collectible",
+          },
+          {
+            id: "doll-2",
+            name: "Doll",
+            readyAt: doll2ReadyAt,
+            startedAt: doll1ReadyAt,
+            type: "collectible",
+          },
+        ],
+        recipes: { Doll: { ...RECIPES.Doll } },
+      },
+    };
+
+    const result = speedUpCrafting({
+      state,
+      action: { type: "crafting.spedUp" },
+      createdAt: now,
+      farmId,
+    });
+
+    // doll-1 sped up to now; doll-2 now starts immediately and keeps its locked
+    // 1h duration (not re-derived to the full 2h recipe time).
+    expect(result.craftingBox.queue?.[0].readyAt).toEqual(now);
+    expect(result.craftingBox.queue?.[1].readyAt).toEqual(now + hour);
   });
 
   it("updates gem history", () => {

--- a/src/features/game/events/landExpansion/speedUpCrafting.ts
+++ b/src/features/game/events/landExpansion/speedUpCrafting.ts
@@ -25,7 +25,6 @@ export function speedUpCrafting({
   state,
   action,
   createdAt = Date.now(),
-  farmId = 0,
 }: Options): GameState {
   return produce(state, (game) => {
     if (action.type !== "crafting.spedUp") {
@@ -74,7 +73,6 @@ export function speedUpCrafting({
       const recalculated = recalculateCraftingQueue({
         queue: inProgressItems,
         game,
-        farmId,
         firstItemReadyAt: createdAt,
       });
 

--- a/src/features/game/events/landExpansion/startCrafting.test.ts
+++ b/src/features/game/events/landExpansion/startCrafting.test.ts
@@ -1126,4 +1126,80 @@ describe("startCrafting", () => {
     expect(instantItem.readyAt).toBe(now);
     expect(instantItem.startedAt).toBe(now);
   });
+
+  // A finished craft left uncollected keeps occupying a queue slot with a
+  // readyAt in the past. A new craft must start "now", not chain off that past
+  // readyAt — otherwise the elapsed wait is discounted from (or makes instant)
+  // the next craft.
+  it("does not discount the next craft when a finished item is left uncollected", () => {
+    const now = Date.now();
+    const twoHours = 2 * 60 * 60 * 1000;
+    // Doll #1 finished 4h ago but was never collected.
+    const finishedReadyAt = now - 4 * 60 * 60 * 1000;
+
+    gameState.vip = { bundles: [], expiresAt: now + 86400000 };
+    gameState.inventory = {
+      Leather: new Decimal(10),
+      Wool: new Decimal(10),
+    };
+    gameState.farmActivity = { "Doll Crafting Started": 1 };
+    gameState.craftingBox = {
+      status: "crafting",
+      queue: [
+        {
+          id: "doll-finished",
+          name: "Doll",
+          startedAt: finishedReadyAt - twoHours,
+          readyAt: finishedReadyAt,
+          type: "collectible",
+        },
+      ],
+      recipes: {
+        Doll: {
+          name: "Doll",
+          type: "collectible",
+          ingredients: [
+            { collectible: "Leather" },
+            { collectible: "Wool" },
+            { collectible: "Leather" },
+            { collectible: "Wool" },
+            { collectible: "Wool" },
+            { collectible: "Wool" },
+            { collectible: "Leather" },
+            { collectible: "Wool" },
+            { collectible: "Leather" },
+          ],
+          time: 2 * 60 * 60 * 1000,
+        },
+      },
+    };
+
+    const action: StartCraftingAction = {
+      type: "crafting.started",
+      queueItemId: "doll-2",
+      ingredients: [
+        { collectible: "Leather" },
+        { collectible: "Wool" },
+        { collectible: "Leather" },
+        { collectible: "Wool" },
+        { collectible: "Wool" },
+        { collectible: "Wool" },
+        { collectible: "Leather" },
+        { collectible: "Wool" },
+        { collectible: "Leather" },
+      ],
+    };
+
+    const newState = startCrafting({
+      state: gameState,
+      action,
+      createdAt: now,
+      farmId,
+    });
+
+    const newItem = newState.craftingBox.queue?.find((q) => q.id === "doll-2");
+    // Must start now and take the full 2h — not inherit the 4h waited.
+    expect(newItem?.startedAt).toBe(now);
+    expect(newItem?.readyAt).toBe(now + twoHours);
+  });
 });

--- a/src/features/game/events/landExpansion/startCrafting.ts
+++ b/src/features/game/events/landExpansion/startCrafting.ts
@@ -192,10 +192,14 @@ export function startCrafting({
       return copy;
     }
 
-    const recipeStartAt =
-      effectiveQueue.length > 0
-        ? effectiveQueue[effectiveQueue.length - 1].readyAt
-        : createdAt;
+    // Start when the crafting box next becomes free: the latest readyAt across
+    // the queue, but never before now. Finished-but-uncollected items keep a
+    // readyAt in the past, so without clamping to createdAt the elapsed wait
+    // would be discounted from (or instantly complete) the new craft.
+    const recipeStartAt = effectiveQueue.reduce(
+      (latest, queued) => Math.max(latest, queued.readyAt),
+      createdAt,
+    );
 
     const { seconds: recipeTime, boostsUsed } = getBoostedCraftingTime({
       game: state,


### PR DESCRIPTION
## Summary

Fixes four correctness bugs in the Crafting Box queue.

Bugs **A–C** share one root cause: `recalculateCraftingQueue` (the chokepoint used by both **cancel** and **speed-up**) re-derived each item's crafting time on every recalc instead of preserving the time locked in when the item was queued. Bug **D** is the player-reported exploit and lives in **`startCrafting`**.

Backend companion PR: **sunflower-land/sunflower-land-api#3423** (identical logic, mirrored).

## Bugs fixed

### Bug A — Queued craft times floated with current boosts
`recalculateCraftingQueue` recomputed every item's duration via `getBoostedCraftingTime` against the **live** game state. If a boost (Time Warp Totem, Super Totem, Sol & Luna, Architect Ruler, Fox Shrine) was active when an item was queued but had since expired (or was added), recalc rewrote the item's `readyAt`:

- **Cancel:** index 0 (the item *currently crafting*) was recomputed as `startedAt + currentBoostedTime`, so cancelling a *later* queued item could change the finish time of the craft actively in progress.
- **Speed-up:** following items were recomputed with current boosts — handing players free time (boost added) or stealing paid-for boosted time (boost expired).

### Bug B — Fox Shrine instant proc was re-rolled on recalc
The same recompute fed a reconstructed prng counter (`farmActivity - countSameRecipeFromEnd`) back into the Fox Shrine roll. That counter drifts when `cancel` decrements `farmActivity` / removes an item, and when `speedUp` recalcs over a subset of the queue. Result: an item that rolled the 10% instant proc when queued could be re-rolled into a full timed craft (or vice-versa) just by cancelling/speeding up something else.

### Bug C — Cancel guard compared `readyAt` instead of `id`
The "currently being crafted" guard used `currentCraftingItem?.readyAt === item.readyAt`. Because instant procs set `readyAt = createdAt` regardless of queue position, two queue entries can share a `readyAt`, so the guard could block cancellation of the wrong item. Now compares `id`.

### Bug D — Uncollected finished craft discounts the next craft (reported exploit)
A finished craft left **uncollected** keeps occupying a queue slot with a `readyAt` in the **past**. `startCrafting` chained the next craft off that past `readyAt`:

```ts
const recipeStartAt = effectiveQueue.length > 0
  ? effectiveQueue[effectiveQueue.length - 1].readyAt   // ← can be in the past
  : createdAt;
```

So the time the player waited before collecting was deducted from the new craft — and if they waited longer than the craft duration, the new craft completed **instantly**. This is the bug a player reported (Doll → wait 4–5h → next Doll is discounted/instant). It needs a free queue slot, so it's effectively **VIP-only** (non-VIP's single slot is blocked by the uncollected item).

## The fix

- **A/B/C:** Each queued item's duration (`readyAt - startedAt`) already encodes every boost and prng result locked in at queue time. `recalculateCraftingQueue` now preserves that locked duration and only re-chains start times; instant items (`lockedDuration === 0`) stay ready at their original time. The boost/prng/`farmId` machinery (and now-unused imports) was removed from recalc. The cancel guard now compares by `id`.
- **D:** A new craft now starts at `max(createdAt, latest queued readyAt)` so it can never begin in the past:

```ts
const recipeStartAt = effectiveQueue.reduce(
  (latest, queued) => Math.max(latest, queued.readyAt),
  createdAt,
);
```

(Using the max across the queue, rather than just the last item, also fixes ordering when a Fox-Shrine instant proc isn't the latest-finishing item.)

### Bug E — Instant procs occupied the box in `recalculateCraftingQueue` (review follow-up)
Recalc chained each item off the *immediately-preceding* item's `readyAt`. A Fox Shrine instant proc is "ready" out of order (its `readyAt` can be in the past while a longer craft ahead of it is still going), so a later craft inherited the instant's stale `readyAt` and was **discounted**, and an in-progress craft queued behind an instant could be pulled **earlier**. Fixed by tracking when the box is next free (the latest real-craft `readyAt`) and chaining real crafts off that; instant crafts keep their own time and don't occupy the box. Product decision: instant procs **stay immediately ready** even when queued behind a longer craft (matches the existing `startCrafting` behaviour).

## Tests

Added tests that **fail on the current code and pass after the fix** (verified by stashing each source change and re-running):

- `cancelQueuedCrafting.test.ts`
  - *keeps the in-progress item's locked readyAt when a later item is cancelled* (A)
  - *cancels a later pending item that shares a readyAt with the in-progress item* (C)
  - *does not resurrect a Fox Shrine instant item's time when recalculating* (B)
  - *does not discount a later craft chained behind an instant proc when an item is cancelled* (E)
  - *does not move an in-progress craft earlier than an instant proc queued before it* (E)
- `speedUpCrafting.test.ts`
  - *keeps following items' locked durations when speeding up the current craft* (A)
  - *keeps a sped-up doll ready after another queued doll is cancelled* (A/B — replays the reported speed-up → cancel flow; the sped-up item must not start crafting again)
- `startCrafting.test.ts`
  - *does not discount the next craft when a finished item is left uncollected* (D)

### How to test

```bash
yarn jest src/features/game/events/landExpansion/startCrafting.test.ts \
          src/features/game/events/landExpansion/cancelQueuedCrafting.test.ts \
          src/features/game/events/landExpansion/speedUpCrafting.test.ts \
          src/features/game/events/landExpansion/collectCrafting.test.ts
```

All crafting suites pass (67 tests). `eslint` and `tsc --noEmit` are clean on the changed files.

### Manual repro — Bug D (the reported one)
1. As a VIP, craft a Doll and let it finish. **Don't collect it.**
2. Wait several hours (longer than the craft time).
3. Craft another Doll. **Before:** it's instantly ready / heavily discounted. **After:** it starts now and takes the full time.

### Manual repro — Bug A
1. Equip a crafting-speed booster (e.g. Sol & Luna) and queue a craft so its `readyAt` reflects the reduced time.
2. Queue a second craft, then unequip the booster.
3. Cancel the second craft. **Before:** the first (in-progress) craft's timer jumps to the un-boosted duration. **After:** it stays at its locked time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
