### PR TITLE
[CHORE] Show cheered players in social feed

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -90,6 +90,8 @@ const _farmId = (state: MachineState) =>
 const _cheersAvailable = (state: MachineState) =>
   (state.context.visitorState ?? state.context.state).inventory["Cheer"] ??
   new Decimal(0);
+const _cheersGiven = (state: MachineState) =>
+  (state.context.visitorState ?? state.context.state).socialFarming.cheersGiven;
 const _totalHelpedToday = (state: MachineState) =>
   state.context.totalHelpedToday;
 const _game = (state: MachineState) =>
@@ -139,6 +141,7 @@ export const Feed: React.FC<Props> = ({
   const token = useSelector(authService, _token);
   const farmId = useSelector(gameService, _farmId);
   const cheersAvailable = useSelector(gameService, _cheersAvailable);
+  const cheersGiven = useSelector(gameService, _cheersGiven);
   const totalHelpedToday = useSelector(gameService, _totalHelpedToday);
   const game = useSelector(gameService, _game);
   const helpLimit = getHelpLimit({ game });
@@ -246,6 +249,20 @@ export const Feed: React.FC<Props> = ({
     gameService,
     "helpingFarm",
     "helpingFarmSuccess",
+    mutate,
+  );
+
+  useOnMachineTransition(
+    gameService,
+    "cheeringFarm",
+    "cheeringFarmSuccess",
+    mutate,
+  );
+
+  useOnMachineTransition(
+    gameService,
+    "cheeringFarmVisiting",
+    "cheeringFarmVisitingSuccess",
     mutate,
   );
 
@@ -458,6 +475,7 @@ export const Feed: React.FC<Props> = ({
             loadMore={loadMore}
             onInteractionClick={handleInteractionClick}
             filter={selectedFilter}
+            cheersGiven={cheersGiven}
           />
         )}
       </div>
@@ -508,6 +526,24 @@ const HelpIconWithPopover: React.FC<{
   );
 };
 
+const CheerGivenIcon: React.FC = () => {
+  return (
+    <div
+      className="flex h-8 w-10 items-center justify-center cursor-default"
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onClickCapture={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <img src={cheer} className="w-5 h-5" alt="" />
+    </div>
+  );
+};
+
 type FeedContentProps = {
   feed: Interaction[];
   following: number[];
@@ -519,6 +555,10 @@ type FeedContentProps = {
   onInteractionClick: (interaction: Interaction) => void;
   onFollowClick: (id: number) => void;
   loadMore: () => void;
+  cheersGiven: {
+    date: string;
+    farms: number[];
+  };
 };
 
 const FeedContent: React.FC<FeedContentProps> = ({
@@ -532,6 +572,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
   hasMore,
   loadMore,
   filter,
+  cheersGiven,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
@@ -584,6 +625,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     e.stopPropagation();
     onFollowClick(id);
   };
+  const today = new Date().toISOString().split("T")[0];
 
   if (isLoadingInitialData) {
     return <FeedSkeleton />;
@@ -616,6 +658,10 @@ const FeedContent: React.FC<FeedContentProps> = ({
               : () => onInteractionClick(interaction);
           const isFollowing = following.includes(interaction.sender.id);
           const isAtMaxFollowing = !isFollowing && following.length >= 5000;
+          const hasCheeredThemToday =
+            interaction.type === "cheer" &&
+            cheersGiven.date === today &&
+            cheersGiven.farms.includes(interaction.sender.id);
 
           return (
             <div
@@ -669,6 +715,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
                           helpedThemToday={interaction.helpedThemToday}
                         />
                       )}
+                      {hasCheeredThemToday && <CheerGivenIcon />}
                     </div>
                   </div>
                   {!isAtMaxFollowing && (


### PR DESCRIPTION
<img width="278" height="315" alt="image" src="https://github.com/user-attachments/assets/ef2f188b-a38a-4d2b-b1f2-dd8e68ce7721" />

 Summary
Adds a visual Rocket indicator to Social Feed cheer events when the player(you) has already cheered that farm today. 

##Context / Motivation
Help events already show a hand icon when the player has also helped that farm today, making reciprocal help easy to spot. Cheer events did not have an equivalent indicator, so players could not quickly tell which farms they had already cheered back from the feed.

What Changed

Reads today’s socialFarming.cheersGiven.farms from game state.
Shows the cheer icon on cheer feed rows when the sender’s farm ID is in today’s cheered farms list.
Refreshes feed data after farm.cheered succeeds, including both own-farm and visiting-farm cheer flows.
Keeps the icon non-interactive and prevents clicks on it from opening the player details modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed interactions now display a visual indicator when you've cheered that farm, helping you track your daily support activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->