### PR TITLE
[FIX] Interior/level_one parity with home

### DIFF
--- a/src/features/game/events/claimAirdrop.ts
+++ b/src/features/game/events/claimAirdrop.ts
@@ -125,6 +125,10 @@ export function claimAirdrop({
               // Only pet collectibles can be in petHouse
               if (!isPetCollectible(itemName)) return [];
               return game.petHouse?.pets?.[itemName] ?? [];
+            } else if (location === "interior") {
+              return game.interior?.ground.collectibles[itemName] ?? [];
+            } else if (location === "level_one") {
+              return game.interior?.level_one?.collectibles[itemName] ?? [];
             } else {
               return game.collectibles[itemName] ?? [];
             }

--- a/src/features/game/events/landExpansion/burnCollectible.test.ts
+++ b/src/features/game/events/landExpansion/burnCollectible.test.ts
@@ -97,6 +97,61 @@ describe("burnCollectible", () => {
     expect(state.interior.ground.collectibles).toEqual({});
   });
 
+  it("burns a Hourglass in level one", () => {
+    const state = burnCollectible({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Gourmet Hourglass": new Decimal(2),
+        },
+        interior: {
+          ground: { collectibles: {} },
+          level_one: {
+            collectibles: {
+              "Gourmet Hourglass": [
+                {
+                  coordinates: { x: 0, y: 0 },
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                },
+              ],
+            },
+          },
+        },
+      },
+      action: {
+        id: "1",
+        location: "level_one",
+        name: "Gourmet Hourglass",
+        type: "collectible.burned",
+      },
+    });
+
+    expect(state.inventory["Gourmet Hourglass"]).toEqual(new Decimal(1));
+    expect(state.interior.level_one?.collectibles).toEqual({});
+  });
+
+  it("throws when burning in level one if it is not unlocked", () => {
+    expect(() =>
+      burnCollectible({
+        state: {
+          ...TEST_FARM,
+          inventory: {
+            "Gourmet Hourglass": new Decimal(2),
+          },
+          interior: { ground: { collectibles: {} } },
+        },
+        action: {
+          id: "1",
+          location: "level_one",
+          name: "Gourmet Hourglass",
+          type: "collectible.burned",
+        },
+      }),
+    ).toThrow("Level one floor has not been unlocked");
+  });
+
   it("burns a Hourglass in the farm", () => {
     const state = burnCollectible({
       state: {

--- a/src/features/game/events/landExpansion/burnCollectible.test.ts
+++ b/src/features/game/events/landExpansion/burnCollectible.test.ts
@@ -60,6 +60,43 @@ describe("burnCollectible", () => {
     expect(state.home.collectibles).toEqual({});
   });
 
+  it("burns a Hourglass in the interior", () => {
+    const state = burnCollectible({
+      state: {
+        ...TEST_FARM,
+        inventory: {
+          "Gourmet Hourglass": new Decimal(2),
+        },
+        interior: {
+          ground: {
+            collectibles: {
+              "Gourmet Hourglass": [
+                {
+                  coordinates: {
+                    x: 0,
+                    y: 0,
+                  },
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                },
+              ],
+            },
+          },
+        },
+      },
+      action: {
+        id: "1",
+        location: "interior",
+        name: "Gourmet Hourglass",
+        type: "collectible.burned",
+      },
+    });
+
+    expect(state.inventory["Gourmet Hourglass"]).toEqual(new Decimal(1));
+    expect(state.interior.ground.collectibles).toEqual({});
+  });
+
   it("burns a Hourglass in the farm", () => {
     const state = burnCollectible({
       state: {

--- a/src/features/game/events/landExpansion/burnCollectible.ts
+++ b/src/features/game/events/landExpansion/burnCollectible.ts
@@ -65,6 +65,14 @@ export function burnCollectible({
           );
         }
         return stateCopy.petHouse.pets[name];
+      } else if (location === "interior") {
+        return stateCopy.interior.ground.collectibles[name];
+      } else if (location === "level_one") {
+        const levelOne = stateCopy.interior.level_one;
+        if (!levelOne) {
+          throw new Error("Level one floor has not been unlocked");
+        }
+        return levelOne.collectibles[name];
       } else {
         return stateCopy.collectibles[name];
       }
@@ -104,6 +112,10 @@ export function burnCollectible({
           );
         }
         delete stateCopy.petHouse.pets[action.name];
+      } else if (action.location === "interior") {
+        delete stateCopy.interior.ground.collectibles[action.name];
+      } else if (action.location === "level_one") {
+        delete stateCopy.interior.level_one!.collectibles[action.name];
       } else {
         delete stateCopy.collectibles[action.name];
       }
@@ -117,6 +129,11 @@ export function burnCollectible({
           );
         }
         stateCopy.petHouse.pets[action.name] = collectibleGroup;
+      } else if (action.location === "interior") {
+        stateCopy.interior.ground.collectibles[action.name] = collectibleGroup;
+      } else if (action.location === "level_one") {
+        stateCopy.interior.level_one!.collectibles[action.name] =
+          collectibleGroup;
       } else {
         stateCopy.collectibles[action.name] = collectibleGroup;
       }

--- a/src/features/game/events/landExpansion/leaveFaction.test.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.test.ts
@@ -120,6 +120,43 @@ describe("leaveFaction", () => {
     expect(state.inventory["Goblin Faction Banner"]).toBeUndefined();
   });
 
+  it("removes a banner placed in the interior", () => {
+    const state = leaveFaction({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Goblin Faction Banner": new Decimal(1),
+        },
+        interior: {
+          ground: {
+            collectibles: {
+              "Goblin Faction Banner": [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
+          },
+        },
+        faction: {
+          name: "goblins",
+          history: {},
+          pledgedAt: 1200100,
+        },
+      },
+      action: {
+        type: "faction.left",
+      },
+    });
+
+    expect(
+      state.interior.ground.collectibles["Goblin Faction Banner"],
+    ).toBeUndefined();
+  });
+
   it("throws error when trying to leave faction before 24 hours", () => {
     const now = Date.now();
 

--- a/src/features/game/events/landExpansion/leaveFaction.test.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.test.ts
@@ -157,6 +157,44 @@ describe("leaveFaction", () => {
     ).toBeUndefined();
   });
 
+  it("removes a banner placed in level one", () => {
+    const state = leaveFaction({
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Goblin Faction Banner": new Decimal(1),
+        },
+        interior: {
+          ground: { collectibles: {} },
+          level_one: {
+            collectibles: {
+              "Goblin Faction Banner": [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
+          },
+        },
+        faction: {
+          name: "goblins",
+          history: {},
+          pledgedAt: 1200100,
+        },
+      },
+      action: {
+        type: "faction.left",
+      },
+    });
+
+    expect(
+      state.interior.level_one?.collectibles["Goblin Faction Banner"],
+    ).toBeUndefined();
+  });
+
   it("throws error when trying to leave faction before 24 hours", () => {
     const now = Date.now();
 

--- a/src/features/game/events/landExpansion/leaveFaction.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.ts
@@ -44,6 +44,8 @@ export function leaveFaction({
       delete game.inventory[name];
       delete game.collectibles[name];
       delete game.home.collectibles[name];
+      delete game.interior.ground.collectibles[name];
+      delete game.interior.level_one?.collectibles[name];
     });
 
     return game;

--- a/src/features/game/events/landExpansion/leaveFaction.ts
+++ b/src/features/game/events/landExpansion/leaveFaction.ts
@@ -44,8 +44,8 @@ export function leaveFaction({
       delete game.inventory[name];
       delete game.collectibles[name];
       delete game.home.collectibles[name];
-      delete game.interior.ground.collectibles[name];
-      delete game.interior.level_one?.collectibles[name];
+      delete game.interior?.ground.collectibles[name];
+      delete game.interior?.level_one?.collectibles[name];
     });
 
     return game;

--- a/src/features/game/events/landExpansion/renewPetShrine.ts
+++ b/src/features/game/events/landExpansion/renewPetShrine.ts
@@ -29,7 +29,11 @@ export function renewPetShrine({
     const collectibleGroup =
       action.location === "home"
         ? stateCopy.home.collectibles[action.name]
-        : stateCopy.collectibles[action.name];
+        : action.location === "interior"
+          ? stateCopy.interior.ground.collectibles[action.name]
+          : action.location === "level_one"
+            ? stateCopy.interior.level_one?.collectibles[action.name]
+            : stateCopy.collectibles[action.name];
 
     if (!collectibleGroup) {
       throw new Error("Invalid collectible");

--- a/src/features/game/events/landExpansion/speedUpCollectible.test.ts
+++ b/src/features/game/events/landExpansion/speedUpCollectible.test.ts
@@ -123,6 +123,42 @@ describe("speedUpCollectible", () => {
     expect(state.collectibles["Basic Scarecrow"]![0].readyAt).toEqual(now);
   });
 
+  it("speeds up a collectible placed in the interior", () => {
+    const now = Date.now();
+    const state = speedUpCollectible({
+      action: {
+        type: "collectible.spedUp",
+        id: "123",
+        name: "Basic Scarecrow",
+      },
+      createdAt: now,
+      state: {
+        ...INITIAL_FARM,
+        inventory: {
+          Gem: new Decimal(100),
+        },
+        interior: {
+          ground: {
+            collectibles: {
+              "Basic Scarecrow": [
+                {
+                  coordinates: { x: 0, y: 0 },
+                  createdAt: 100,
+                  id: "123",
+                  readyAt: Date.now() + 1000,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      state.interior.ground.collectibles["Basic Scarecrow"]![0].readyAt,
+    ).toEqual(now);
+  });
+
   it("records gem history under the createdAt date key (cross-day)", () => {
     const createdAt = new Date("2024-06-15T12:00:00Z").getTime();
     const dateKey = "2024-06-15";

--- a/src/features/game/events/landExpansion/speedUpCollectible.ts
+++ b/src/features/game/events/landExpansion/speedUpCollectible.ts
@@ -2,6 +2,7 @@ import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import type { CollectibleName } from "features/game/types/craftables";
 import Decimal from "decimal.js-light";
+import { getCollectiblesAcrossLocations } from "features/game/lib/collectibleBuilt";
 import {
   chargeCoinsForSpeedUp,
   getInstantGems,
@@ -28,7 +29,8 @@ export function speedUpCollectible({
   createdAt = Date.now(),
 }: Options): GameState {
   return produce(state, (game) => {
-    const collectible = game.collectibles[action.name]?.find(
+    // A collectible can live on any placement surface — search them all by id.
+    const collectible = getCollectiblesAcrossLocations(game, action.name).find(
       (item) => item.id === action.id,
     );
 

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -12,6 +12,7 @@ import {
 } from "features/game/types/consumables";
 import {
   EXPIRY_COOLDOWNS,
+  getCollectiblesAcrossLocations,
   isTemporaryCollectibleActive,
   isCollectibleBuilt,
 } from "features/game/lib/collectibleBuilt";
@@ -143,12 +144,10 @@ const applyTempCollectibleBoost = ({
   const active = isTemporaryCollectibleActive({ name: collectibleName, game });
   if (!active) return seconds;
 
-  const activeItems = [
-    ...(game.collectibles[collectibleName] ?? []),
-    ...(game.home.collectibles[collectibleName] ?? []),
-    ...(game.interior?.ground.collectibles[collectibleName] ?? []),
-    ...(game.interior?.level_one?.collectibles[collectibleName] ?? []),
-  ].filter((item) => item.coordinates && !item.removedAt);
+  const activeItems = getCollectiblesAcrossLocations(
+    game,
+    collectibleName,
+  ).filter((item) => item.coordinates && !item.removedAt);
   if (activeItems.length === 0) return seconds;
 
   const newestItem = activeItems.sort((a, b) => b.createdAt! - a.createdAt!)[0];

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -485,56 +485,9 @@ function detectHomeCollision({
       }));
   });
 
-  const budsBoundingBox = Object.values(state.buds ?? {})
-    .filter((bud) => !!bud.coordinates && bud.location === "home")
-    .map((item) => ({
-      x: item.coordinates!.x,
-      y: item.coordinates!.y,
-      height: 1,
-      width: 1,
-    }));
-
-  const petNFTBoundingBox = Object.values(state.pets?.nfts ?? {})
-    .filter((petNFT) => !!petNFT.coordinates && petNFT.location === "home")
-    .map((item) => ({
-      x: item.coordinates!.x,
-      y: item.coordinates!.y,
-      height: PET_NFT_DIMENSIONS.height,
-      width: PET_NFT_DIMENSIONS.width,
-    }));
-
-  const farmHandBoundingBox = Object.values(state.farmHands.bumpkins ?? {})
-    .filter(
-      (farmHand) => !!farmHand.coordinates && farmHand.location === "home",
-    )
-    .map((farmHand) => ({
-      x: farmHand.coordinates!.x,
-      y: farmHand.coordinates!.y,
-      height: 1,
-      width: 1,
-    }));
-
-  // Main bumpkin inside, exclude when placing/moving the bumpkin itself
-  const bumpkinBoundingBox =
-    name !== "Bumpkin" &&
-    state.bumpkin?.coordinates &&
-    state.bumpkin?.location === "home"
-      ? [
-          {
-            x: state.bumpkin.coordinates.x,
-            y: state.bumpkin.coordinates.y,
-            height: 1,
-            width: 1,
-          },
-        ]
-      : [];
-
   const boundingBoxes = [
     ...placeableBounds,
-    ...budsBoundingBox,
-    ...petNFTBoundingBox,
-    ...farmHandBoundingBox,
-    ...bumpkinBoundingBox,
+    ...placedEntityBoundingBoxes(state, "home", name),
   ];
 
   return boundingBoxes.some((resourceBoundingBox) =>
@@ -802,6 +755,69 @@ function detectLandCornerCollision(
  * once before the layout lookup and treat everything else (overlap check) in
  * the canvas-center convention since collectibles store their coords there.
  */
+/**
+ * Bounding boxes for the non-collectible entities (buds, pet NFTs, farm hands
+ * and the main bumpkin) placed on a given indoor surface. Shared by the home,
+ * interior and level_one collision checks so each surface collides with these
+ * the same way.
+ */
+function placedEntityBoundingBoxes(
+  state: GameState,
+  location: PlaceableLocation,
+  name: LandscapingPlaceable,
+): BoundingBox[] {
+  const budsBoundingBox = Object.values(state.buds ?? {})
+    .filter((bud) => !!bud.coordinates && bud.location === location)
+    .map((item) => ({
+      x: item.coordinates!.x,
+      y: item.coordinates!.y,
+      height: 1,
+      width: 1,
+    }));
+
+  const petNFTBoundingBox = Object.values(state.pets?.nfts ?? {})
+    .filter((petNFT) => !!petNFT.coordinates && petNFT.location === location)
+    .map((item) => ({
+      x: item.coordinates!.x,
+      y: item.coordinates!.y,
+      height: PET_NFT_DIMENSIONS.height,
+      width: PET_NFT_DIMENSIONS.width,
+    }));
+
+  const farmHandBoundingBox = Object.values(state.farmHands.bumpkins ?? {})
+    .filter(
+      (farmHand) => !!farmHand.coordinates && farmHand.location === location,
+    )
+    .map((farmHand) => ({
+      x: farmHand.coordinates!.x,
+      y: farmHand.coordinates!.y,
+      height: 1,
+      width: 1,
+    }));
+
+  // Main bumpkin inside, exclude when placing/moving the bumpkin itself
+  const bumpkinBoundingBox =
+    name !== "Bumpkin" &&
+    state.bumpkin?.coordinates &&
+    state.bumpkin?.location === location
+      ? [
+          {
+            x: state.bumpkin.coordinates.x,
+            y: state.bumpkin.coordinates.y,
+            height: 1,
+            width: 1,
+          },
+        ]
+      : [];
+
+  return [
+    ...budsBoundingBox,
+    ...petNFTBoundingBox,
+    ...farmHandBoundingBox,
+    ...bumpkinBoundingBox,
+  ];
+}
+
 function detectInteriorCollision({
   state,
   position,
@@ -851,7 +867,12 @@ function detectInteriorCollision({
       }));
   });
 
-  return placeableBounds.some((box) => isOverlapping(position, box));
+  const boundingBoxes = [
+    ...placeableBounds,
+    ...placedEntityBoundingBoxes(state, "interior", name),
+  ];
+
+  return boundingBoxes.some((box) => isOverlapping(position, box));
 }
 
 /**
@@ -913,7 +934,12 @@ function detectLevelOneCollision({
       }));
   });
 
-  return placeableBounds.some((box) => isOverlapping(position, box));
+  const boundingBoxes = [
+    ...placeableBounds,
+    ...placedEntityBoundingBoxes(state, "level_one", name),
+  ];
+
+  return boundingBoxes.some((box) => isOverlapping(position, box));
 }
 
 export function detectCollision({

--- a/src/features/game/lib/collectibleBuilt.ts
+++ b/src/features/game/lib/collectibleBuilt.ts
@@ -1,9 +1,34 @@
 import type { HourglassType } from "features/island/collectibles/components/Hourglass";
 import type { CollectibleName } from "../types/craftables";
 import { getKeys } from "lib/object";
-import type { GameState } from "../types/game";
+import type { Collectibles, GameState } from "../types/game";
 import { PET_SHRINES, type PetShrineName } from "../types/pets";
 import { isPetCollectible } from "../events/landExpansion/placeCollectible";
+
+/**
+ * Every instance of a collectible gathered from the four collectible surfaces:
+ * farm, home, interior ground and interior level_one. The pet house is excluded
+ * (it stores pets, keyed by PetName). Instances are returned as-is — callers
+ * filter by `coordinates` / `readyAt` / `createdAt` as needed.
+ */
+export function getCollectiblesAcrossLocations<N extends CollectibleName>(
+  game: {
+    collectibles: Collectibles;
+    home: { collectibles: Collectibles };
+    interior?: {
+      ground: { collectibles: Collectibles };
+      level_one?: { collectibles: Collectibles };
+    };
+  },
+  name: N,
+): NonNullable<Collectibles[N]> {
+  return [
+    ...(game.collectibles[name] ?? []),
+    ...(game.home.collectibles[name] ?? []),
+    ...(game.interior?.ground.collectibles[name] ?? []),
+    ...(game.interior?.level_one?.collectibles[name] ?? []),
+  ] as NonNullable<Collectibles[N]>;
+}
 
 export function isCollectibleBuilt({
   name,
@@ -15,23 +40,14 @@ export function isCollectibleBuilt({
   const isReady = (placed: { readyAt?: number; coordinates?: unknown }) =>
     (placed.readyAt ?? 0) <= Date.now() && !!placed.coordinates;
 
-  const placedOnFarm = game.collectibles[name]?.some(isReady);
-  const placedInHome = game.home.collectibles[name]?.some(isReady);
-  const placedInInterior =
-    game.interior?.ground.collectibles[name]?.some(isReady);
-  const placedInLevelOne =
-    game.interior?.level_one?.collectibles[name]?.some(isReady);
+  const placedAcrossLocations = getCollectiblesAcrossLocations(game, name).some(
+    isReady,
+  );
 
   const placedInPetHouse =
-    isPetCollectible(name) && game.petHouse.pets[name]?.some(isReady);
+    isPetCollectible(name) && !!game.petHouse.pets[name]?.some(isReady);
 
-  return (
-    !!placedOnFarm ||
-    !!placedInHome ||
-    !!placedInInterior ||
-    !!placedInLevelOne ||
-    !!placedInPetHouse
-  );
+  return placedAcrossLocations || placedInPetHouse;
 }
 
 export type TemporaryCollectibleName = Extract<
@@ -80,13 +96,8 @@ export function isTemporaryCollectibleActive({
   game: GameState;
 }) {
   const cooldown = EXPIRY_COOLDOWNS[name];
-  const stillFresh = (placed: { createdAt?: number }) =>
-    (placed.createdAt ?? 0) + cooldown > Date.now();
 
-  return (
-    !!game.collectibles[name]?.some(stillFresh) ||
-    !!game.home.collectibles[name]?.some(stillFresh) ||
-    !!game.interior?.ground.collectibles[name]?.some(stillFresh) ||
-    !!game.interior?.level_one?.collectibles[name]?.some(stillFresh)
+  return getCollectiblesAcrossLocations(game, name).some(
+    (placed) => (placed.createdAt ?? 0) + cooldown > Date.now(),
   );
 }

--- a/src/features/game/lib/collectibleBuilt.ts
+++ b/src/features/game/lib/collectibleBuilt.ts
@@ -1,34 +1,12 @@
 import type { HourglassType } from "features/island/collectibles/components/Hourglass";
 import type { CollectibleName } from "../types/craftables";
 import { getKeys } from "lib/object";
-import type { Collectibles, GameState } from "../types/game";
+import type { GameState } from "../types/game";
 import { PET_SHRINES, type PetShrineName } from "../types/pets";
 import { isPetCollectible } from "../events/landExpansion/placeCollectible";
+import { getCollectiblesAcrossLocations } from "./getCollectiblesAcrossLocations";
 
-/**
- * Every instance of a collectible gathered from the four collectible surfaces:
- * farm, home, interior ground and interior level_one. The pet house is excluded
- * (it stores pets, keyed by PetName). Instances are returned as-is — callers
- * filter by `coordinates` / `readyAt` / `createdAt` as needed.
- */
-export function getCollectiblesAcrossLocations<N extends CollectibleName>(
-  game: {
-    collectibles: Collectibles;
-    home: { collectibles: Collectibles };
-    interior?: {
-      ground: { collectibles: Collectibles };
-      level_one?: { collectibles: Collectibles };
-    };
-  },
-  name: N,
-): NonNullable<Collectibles[N]> {
-  return [
-    ...(game.collectibles[name] ?? []),
-    ...(game.home.collectibles[name] ?? []),
-    ...(game.interior?.ground.collectibles[name] ?? []),
-    ...(game.interior?.level_one?.collectibles[name] ?? []),
-  ] as NonNullable<Collectibles[N]>;
-}
+export { getCollectiblesAcrossLocations };
 
 export function isCollectibleBuilt({
   name,

--- a/src/features/game/lib/getCollectiblesAcrossLocations.ts
+++ b/src/features/game/lib/getCollectiblesAcrossLocations.ts
@@ -1,0 +1,30 @@
+import type { CollectibleName } from "../types/craftables";
+import type { Collectibles } from "../types/game";
+
+/**
+ * Every instance of a collectible gathered from the four collectible surfaces:
+ * farm, home, interior ground and interior level_one. The pet house is excluded
+ * (it stores pets, keyed by PetName). Instances are returned as-is — callers
+ * filter by `coordinates` / `readyAt` / `createdAt` as needed.
+ *
+ * Lives in its own module with only type imports so low-level files such as
+ * `types/beds` can reuse it without creating an import cycle.
+ */
+export function getCollectiblesAcrossLocations<N extends CollectibleName>(
+  game: {
+    collectibles: Collectibles;
+    home: { collectibles: Collectibles };
+    interior?: {
+      ground: { collectibles: Collectibles };
+      level_one?: { collectibles: Collectibles };
+    };
+  },
+  name: N,
+): NonNullable<Collectibles[N]> {
+  return [
+    ...(game.collectibles[name] ?? []),
+    ...(game.home.collectibles[name] ?? []),
+    ...(game.interior?.ground.collectibles[name] ?? []),
+    ...(game.interior?.level_one?.collectibles[name] ?? []),
+  ] as NonNullable<Collectibles[N]>;
+}

--- a/src/features/game/types/beds.test.ts
+++ b/src/features/game/types/beds.test.ts
@@ -24,39 +24,38 @@ describe("BED_FARMHAND_COUNT", () => {
 
 describe("getPlacedBedNames", () => {
   it("counts a bed placed in the interior ground floor", () => {
-    const interiorGround: Collectibles = { "Basic Bed": placed() };
-
-    const result = getPlacedBedNames([
-      undefined,
-      undefined,
-      interiorGround,
-      undefined,
-    ]);
+    const result = getPlacedBedNames({
+      collectibles: {},
+      home: { collectibles: {} },
+      interior: { ground: { collectibles: { "Basic Bed": placed() } } },
+    });
 
     expect(result.has("Basic Bed")).toBe(true);
   });
 
   it("counts a bed placed on the interior level_one floor", () => {
-    const levelOne: Collectibles = { "Sturdy Bed": placed() };
-
-    const result = getPlacedBedNames([
-      undefined,
-      undefined,
-      undefined,
-      levelOne,
-    ]);
+    const result = getPlacedBedNames({
+      collectibles: {},
+      home: { collectibles: {} },
+      interior: {
+        ground: { collectibles: {} },
+        level_one: { collectibles: { "Sturdy Bed": placed() } },
+      },
+    });
 
     expect(result.has("Sturdy Bed")).toBe(true);
   });
 
   it("merges and dedupes bed types across every placement surface", () => {
-    const farm: Collectibles = { "Basic Bed": placed() };
-    const home: Collectibles = { "Floral Bed": placed() };
-    // Same bed type placed both on the farm and the interior — counted once.
-    const interiorGround: Collectibles = { "Basic Bed": placed() };
-    const levelOne: Collectibles = { "Pearl Bed": placed() };
-
-    const result = getPlacedBedNames([farm, home, interiorGround, levelOne]);
+    const result = getPlacedBedNames({
+      collectibles: { "Basic Bed": placed() },
+      home: { collectibles: { "Floral Bed": placed() } },
+      interior: {
+        // Same bed type placed both on the farm and the interior — counted once.
+        ground: { collectibles: { "Basic Bed": placed() } },
+        level_one: { collectibles: { "Pearl Bed": placed() } },
+      },
+    });
 
     expect(result).toEqual(new Set(["Basic Bed", "Floral Bed", "Pearl Bed"]));
   });
@@ -67,14 +66,17 @@ describe("getPlacedBedNames", () => {
       "Basic Bed": placed(),
     };
 
-    const result = getPlacedBedNames([farm]);
+    const result = getPlacedBedNames({
+      collectibles: farm,
+      home: { collectibles: {} },
+    });
 
     expect(result).toEqual(new Set(["Basic Bed"]));
   });
 
   it("returns an empty set when no beds are placed anywhere", () => {
     expect(
-      getPlacedBedNames([undefined, undefined, undefined, undefined]),
+      getPlacedBedNames({ collectibles: {}, home: { collectibles: {} } }),
     ).toEqual(new Set());
   });
 });

--- a/src/features/game/types/beds.ts
+++ b/src/features/game/types/beds.ts
@@ -1,3 +1,4 @@
+import { getCollectiblesAcrossLocations } from "features/game/lib/getCollectiblesAcrossLocations";
 import { getKeys } from "lib/object";
 import type { BedName, Collectibles } from "./game";
 
@@ -16,24 +17,21 @@ export const BED_FARMHAND_COUNT: Record<BedName, number> = {
   "Salt Crystal Bed": 12,
 };
 
-const EMPTY_COLLECTIBLES: Collectibles = {};
-
 /**
- * The distinct bed types placed across the given placement surfaces.
- *
- * Farm hand capacity is driven by the number of distinct beds placed, so a bed
- * must count no matter where it lives — the farm (`collectibles`), the home
- * interior (`home.collectibles`) or the /interior floors (`interior.ground`
- * and `interior.level_one`). Pass every relevant surface; `undefined` ones
- * (e.g. a not-yet-unlocked level) are skipped.
+ * The distinct bed types placed across every placement surface — the farm, the
+ * home, and both /interior floors. Farm hand capacity is driven by this count,
+ * so a bed counts no matter where it lives.
  */
-export const getPlacedBedNames = (
-  placements: Array<Collectibles | undefined>,
-): Set<BedName> =>
+export const getPlacedBedNames = (game: {
+  collectibles: Collectibles;
+  home: { collectibles: Collectibles };
+  interior?: {
+    ground: { collectibles: Collectibles };
+    level_one?: { collectibles: Collectibles };
+  };
+}): Set<BedName> =>
   new Set(
-    placements.flatMap((collectibles) =>
-      getKeys(collectibles ?? EMPTY_COLLECTIBLES).filter(
-        (name): name is BedName => name in BED_FARMHAND_COUNT,
-      ),
+    getKeys(BED_FARMHAND_COUNT).filter(
+      (bedName) => getCollectiblesAcrossLocations(game, bedName).length > 0,
     ),
   );

--- a/src/features/home/components/BedsMigrationModal.tsx
+++ b/src/features/home/components/BedsMigrationModal.tsx
@@ -60,12 +60,16 @@ export const BedsMigrationModal: React.FC<Props> = ({ show, onHide }) => {
   const max = Object.keys(BED_FARMHAND_COUNT).length;
 
   // Beds placed anywhere count — farm, home interior and both /interior floors.
-  const uniqueBeds = getPlacedBedNames([
+  const uniqueBeds = getPlacedBedNames({
     collectibles,
-    homeCollectibles,
-    interiorCollectibles,
-    levelOneCollectibles,
-  ]);
+    home: { collectibles: homeCollectibles },
+    interior: {
+      ground: { collectibles: interiorCollectibles },
+      level_one: levelOneCollectibles
+        ? { collectibles: levelOneCollectibles }
+        : undefined,
+    },
+  });
 
   const beds = getKeys(BED_FARMHAND_COUNT)
     .sort((a, b) => BED_FARMHAND_COUNT[a] - BED_FARMHAND_COUNT[b])

--- a/src/features/home/components/InteriorBumpkins.tsx
+++ b/src/features/home/components/InteriorBumpkins.tsx
@@ -60,12 +60,16 @@ export const InteriorBumpkins: React.FC = () => {
   const max = Object.keys(BED_FARMHAND_COUNT).length;
 
   // Beds placed anywhere count — farm, home interior and both /interior floors.
-  const uniqueBeds = getPlacedBedNames([
+  const uniqueBeds = getPlacedBedNames({
     collectibles,
-    homeCollectibles,
-    interiorCollectibles,
-    levelOneCollectibles,
-  ]);
+    home: { collectibles: homeCollectibles },
+    interior: {
+      ground: { collectibles: interiorCollectibles },
+      level_one: levelOneCollectibles
+        ? { collectibles: levelOneCollectibles }
+        : undefined,
+    },
+  });
 
   const beds = getKeys(BED_FARMHAND_COUNT)
     .sort((a, b) => BED_FARMHAND_COUNT[a] - BED_FARMHAND_COUNT[b])

--- a/src/features/island/collectibles/components/Bed.tsx
+++ b/src/features/island/collectibles/components/Bed.tsx
@@ -96,12 +96,16 @@ export const Bed: React.FC<BedProps> = ({ name }) => {
   // Limit: main bumpkin + farmhands must not exceed bed count (e.g. 11 beds = 1 main + 10 farmhands max)
   const bumpkinCount = getKeys(farmhands).length + 1;
   // Beds placed anywhere count — farm, home interior and both /interior floors.
-  const uniqueBeds = getPlacedBedNames([
+  const uniqueBeds = getPlacedBedNames({
     collectibles,
-    homeCollectibles,
-    interiorCollectibles,
-    levelOneCollectibles,
-  ]);
+    home: { collectibles: homeCollectibles },
+    interior: {
+      ground: { collectibles: interiorCollectibles },
+      level_one: levelOneCollectibles
+        ? { collectibles: levelOneCollectibles }
+        : undefined,
+    },
+  });
 
   // Sort best bed first (highest BED_FARMHAND_COUNT = Pearl Bed) so the next unlock targets it
   const beds = getKeys(BED_FARMHAND_COUNT)

--- a/src/features/island/pets/lib/petShared.test.ts
+++ b/src/features/island/pets/lib/petShared.test.ts
@@ -1,0 +1,56 @@
+import Decimal from "decimal.js-light";
+import { TEST_FARM } from "features/game/lib/constants";
+import type { GameState } from "features/game/types/game";
+import { isPetExcludedByMissingPetHouse } from "./petShared";
+
+describe("isPetExcludedByMissingPetHouse", () => {
+  it("excludes a pet only placed in the pet house when the Pet House building is not placed", () => {
+    const game: GameState = {
+      ...TEST_FARM,
+      inventory: {
+        Barkley: new Decimal(1),
+      },
+      petHouse: {
+        level: 1,
+        pets: {
+          Barkley: [{ id: "1", createdAt: 0, coordinates: { x: 0, y: 0 } }],
+        },
+      },
+    };
+
+    expect(isPetExcludedByMissingPetHouse({ pet: "Barkley", game })).toBe(true);
+  });
+
+  it("does not exclude a pet that is also placed in the interior", () => {
+    const game: GameState = {
+      ...TEST_FARM,
+      inventory: {
+        Barkley: new Decimal(2),
+      },
+      petHouse: {
+        level: 1,
+        pets: {
+          Barkley: [{ id: "1", createdAt: 0, coordinates: { x: 0, y: 0 } }],
+        },
+      },
+      interior: {
+        ground: {
+          collectibles: {
+            Barkley: [
+              {
+                id: "2",
+                createdAt: 0,
+                readyAt: 0,
+                coordinates: { x: 1, y: 1 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(isPetExcludedByMissingPetHouse({ pet: "Barkley", game })).toBe(
+      false,
+    );
+  });
+});

--- a/src/features/island/pets/lib/petShared.ts
+++ b/src/features/island/pets/lib/petShared.ts
@@ -1,6 +1,7 @@
 import { ITEM_DETAILS } from "features/game/types/images";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getObjectEntries } from "lib/object";
+import { getCollectiblesAcrossLocations } from "features/game/lib/getCollectiblesAcrossLocations";
 import { type PetName, isPetNFTRevealed } from "features/game/types/pets";
 import type { MachineState } from "features/game/lib/gameMachine";
 import type { GameState } from "features/game/types/game";
@@ -218,11 +219,9 @@ export const isPetExcludedByMissingPetHouse = ({
     return game.pets?.nfts?.[pet]?.location === "petHouse";
   }
 
-  const placedOutsidePetHouse =
-    game.collectibles[pet]?.some((p) => !!p.coordinates) ||
-    game.home.collectibles[pet]?.some((p) => !!p.coordinates) ||
-    game.interior?.ground.collectibles[pet]?.some((p) => !!p.coordinates) ||
-    game.interior?.level_one?.collectibles[pet]?.some((p) => !!p.coordinates);
+  const placedOutsidePetHouse = getCollectiblesAcrossLocations(game, pet).some(
+    (p) => !!p.coordinates,
+  );
   const placedInPetHouse = game.petHouse?.pets[pet]?.some(
     (p) => !!p.coordinates,
   );

--- a/src/features/island/pets/lib/petShared.ts
+++ b/src/features/island/pets/lib/petShared.ts
@@ -220,7 +220,9 @@ export const isPetExcludedByMissingPetHouse = ({
 
   const placedOutsidePetHouse =
     game.collectibles[pet]?.some((p) => !!p.coordinates) ||
-    game.home.collectibles[pet]?.some((p) => !!p.coordinates);
+    game.home.collectibles[pet]?.some((p) => !!p.coordinates) ||
+    game.interior?.ground.collectibles[pet]?.some((p) => !!p.coordinates) ||
+    game.interior?.level_one?.collectibles[pet]?.some((p) => !!p.coordinates);
   const placedInPetHouse = game.petHouse?.pets[pet]?.some(
     (p) => !!p.coordinates,
   );


### PR DESCRIPTION
> 🔗 **Paired with BE:** sunflower-land/sunflower-land-api#3426

## Why

Companion to the BE PR. The FE was mostly the reference for interior parity, but a few handlers/helpers were also missing the interior, and collision needed the same entity extension.

## Issues

- Some handlers ignored interior-placed collectibles — burn, renew pet shrine, speed-up, airdrop removal.
- `leaveFaction` didn't clear banners from the interior.
- Pet-house exclusion didn't count interior-placed pets.
- Indoor collision didn't account for buds / pet NFTs / farm hands / bumpkin.

## Changes

- Interactions search every surface: burn, renew pet shrine, speed-up, airdrop removal.
- `leaveFaction` clears faction banners from interior/level_one.
- `petShared`: pet-house exclusion counts the interior.
- Collision: buds / pet NFTs / farm hands / bumpkin collide in interior/level_one (shared helper; home DRYed up).
- New `getCollectiblesAcrossLocations` helper; deduped cook/boosts temp-boost + speed-up.

## Tests

- Regression tests added; touched suites + a broad harvest/plant/cook/mining batch green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded collectible placement to include interior ground and an additional interior floor.
  * Centralized collectible lookup across all placement locations.

* **Bug Fixes**
  * Fixed collectible removal, burning, renewal and speed-up to work across all interior placements.
  * Improved indoor collision checks to consider more placed entities.
  * Updated pet-house exclusion, temporary boosts, and bed-detection/UI to account for interior placements.

* **Tests**
  * Added unit tests covering new interior placement behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->