### PR TITLE
[FEAT] Design UX improvements

### DIFF
--- a/src/features/game/events/landExpansion/importHomeItems.test.ts
+++ b/src/features/game/events/landExpansion/importHomeItems.test.ts
@@ -1,0 +1,147 @@
+import Decimal from "decimal.js-light";
+import { TEST_FARM } from "features/game/lib/constants";
+import type { GameState, PlacedItem } from "features/game/types/game";
+import { getHomeImportPlan, type HomeImportPlan } from "./importHomeItems";
+import { removeCollectible } from "./removeCollectible";
+import { placeCollectible } from "./placeCollectible";
+
+// The default TEST_FARM is on the `basic` island, whose interior is a 6x6
+// room (36 placeable tiles, x ∈ [3,8], y ∈ [2,7] in layout coords).
+const ROOM_TILES = 36;
+
+const bears = (count: number): PlacedItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `bear-${i}`,
+    // Coordinates in the OLD home — values are irrelevant, import reassigns them.
+    coordinates: { x: i, y: i },
+  }));
+
+// A placed item is owned, so the inventory count must reflect it — otherwise
+// placeCollectible (reused by the import loop) would refuse to re-place it.
+const baseState = (homeBears: number): GameState => ({
+  ...TEST_FARM,
+  inventory: {
+    ...TEST_FARM.inventory,
+    "Basic Bear": new Decimal(homeBears),
+  },
+  home: { collectibles: { "Basic Bear": bears(homeBears) } },
+  interior: { ground: { collectibles: {} } },
+});
+
+const placedCount = (items?: PlacedItem[]) =>
+  (items ?? []).filter((i) => i.coordinates).length;
+
+/**
+ * Mirrors exactly what the migration panel does on confirm: for each planned
+ * placement, dig the item up from the old home then place it on the target
+ * floor, threading the resulting state through each step.
+ */
+const applyPlan = (state: GameState, plan: HomeImportPlan): GameState =>
+  plan.placements.reduce((acc, { name, id, location, coordinates }) => {
+    const dugUp = removeCollectible({
+      state: acc,
+      action: { type: "collectible.removed", name, id, location: "home" },
+    });
+    return placeCollectible({
+      state: dugUp,
+      action: { type: "collectible.placed", name, id, coordinates, location },
+    });
+  }, state);
+
+describe("getHomeImportPlan", () => {
+  it("plans a spot for every placed home item that fits", () => {
+    const plan = getHomeImportPlan(baseState(3));
+    expect(plan.total).toBe(3);
+    expect(plan.placements).toHaveLength(3);
+    expect(plan.unplaced).toHaveLength(0);
+  });
+
+  it("assigns a distinct, non-overlapping spot to every item", () => {
+    const plan = getHomeImportPlan(baseState(5));
+    const keys = plan.placements.map(
+      (p) => `${p.coordinates.x},${p.coordinates.y}`,
+    );
+    expect(new Set(keys).size).toBe(plan.placements.length);
+  });
+
+  it("marks items that do not fit as unplaced", () => {
+    const overflow = ROOM_TILES + 1;
+    const plan = getHomeImportPlan(baseState(overflow));
+    expect(plan.total).toBe(overflow);
+    expect(plan.placements).toHaveLength(ROOM_TILES);
+    expect(plan.unplaced).toHaveLength(1);
+  });
+
+  it("overflows onto level_one once the ground floor is full and upstairs is unlocked", () => {
+    const total = ROOM_TILES + 4;
+    const state: GameState = {
+      ...baseState(total),
+      interior: {
+        ground: { collectibles: {} },
+        expansion: "level-one-start",
+        level_one: { collectibles: {} },
+      },
+    };
+
+    const plan = getHomeImportPlan(state);
+    expect(
+      plan.placements.filter((p) => p.location === "interior"),
+    ).toHaveLength(ROOM_TILES);
+    expect(
+      plan.placements.filter((p) => p.location === "level_one"),
+    ).toHaveLength(4);
+    expect(plan.unplaced).toHaveLength(0);
+  });
+
+  it("ignores old-home items that were never placed (no coordinates)", () => {
+    const state: GameState = {
+      ...baseState(0),
+      home: { collectibles: { "Basic Bear": [{ id: "unplaced-bear" }] } },
+    };
+    expect(getHomeImportPlan(state).total).toBe(0);
+  });
+});
+
+describe("import apply loop (collectible.removed + collectible.placed)", () => {
+  it("moves placed home items onto the interior ground floor", () => {
+    const state = baseState(3);
+    const next = applyPlan(state, getHomeImportPlan(state));
+
+    // All three left the old home (no placed items remain there)...
+    expect(placedCount(next.home.collectibles["Basic Bear"])).toBe(0);
+
+    // ...and landed on the ground floor with fresh coordinates.
+    const placed = next.interior.ground.collectibles["Basic Bear"] ?? [];
+    expect(placed).toHaveLength(3);
+    placed.forEach((item) => expect(item.coordinates).toBeDefined());
+  });
+
+  it("leaves items that do not fit in the old home", () => {
+    const state = baseState(ROOM_TILES + 1);
+    const next = applyPlan(state, getHomeImportPlan(state));
+
+    expect(next.interior.ground.collectibles["Basic Bear"]).toHaveLength(
+      ROOM_TILES,
+    );
+    expect(placedCount(next.home.collectibles["Basic Bear"])).toBe(1);
+  });
+
+  it("overflows onto level_one when the ground floor is full", () => {
+    const total = ROOM_TILES + 4;
+    const state: GameState = {
+      ...baseState(total),
+      interior: {
+        ground: { collectibles: {} },
+        expansion: "level-one-start",
+        level_one: { collectibles: {} },
+      },
+    };
+    const next = applyPlan(state, getHomeImportPlan(state));
+
+    expect(next.interior.ground.collectibles["Basic Bear"]).toHaveLength(
+      ROOM_TILES,
+    );
+    expect(next.interior.level_one?.collectibles["Basic Bear"]).toHaveLength(4);
+    expect(placedCount(next.home.collectibles["Basic Bear"])).toBe(0);
+  });
+});

--- a/src/features/game/events/landExpansion/importHomeItems.ts
+++ b/src/features/game/events/landExpansion/importHomeItems.ts
@@ -1,0 +1,137 @@
+import { produce } from "immer";
+import {
+  type CollectibleName,
+  COLLECTIBLES_DIMENSIONS,
+} from "../../types/craftables";
+import type { GameState } from "features/game/types/game";
+import { getObjectEntries } from "lib/object";
+import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
+import { INTERIOR_CANVAS } from "features/game/expansion/placeable/lib/interiorLayouts";
+
+/** The two interior surfaces an old-home item can be imported onto, tried in
+ *  order: the ground floor first, then the upstairs floor (if unlocked). */
+const IMPORT_LOCATIONS = ["interior", "level_one"] as const;
+export type ImportLocation = (typeof IMPORT_LOCATIONS)[number];
+
+export type ImportPlacement = {
+  name: CollectibleName;
+  id: string;
+  location: ImportLocation;
+  coordinates: { x: number; y: number };
+};
+
+export type HomeImportPlan = {
+  /** Items that found a spot, with the floor + coordinates they'll land on. */
+  placements: ImportPlacement[];
+  /** Items that had nowhere to go and will stay in the old home. */
+  unplaced: Array<{ name: CollectibleName; id: string }>;
+  /** Total number of placed old-home items considered. */
+  total: number;
+};
+
+/**
+ * Scans a single interior floor for the first non-colliding spot that fits an
+ * item of the given name.
+ *
+ * Order is top-left reading order: top row first (back wall), left → right,
+ * working down toward the entrance. Coordinates are returned in the same
+ * canvas-centred ("placeable") space the rest of the placement system uses —
+ * `detectCollision` translates them to the bottom-left layout grid internally
+ * and validates both the floor tiles and overlap with existing items.
+ */
+function findInteriorSpot(
+  state: GameState,
+  name: CollectibleName,
+  location: ImportLocation,
+): { x: number; y: number } | undefined {
+  const dimensions = COLLECTIBLES_DIMENSIONS[name];
+  if (!dimensions) return undefined;
+
+  const { width, height } = dimensions;
+  const halfWidth = INTERIOR_CANVAS.width / 2;
+  const halfHeight = INTERIOR_CANVAS.height / 2;
+
+  // Layout grid: x ∈ [0, width-1], y ∈ [1, height] (y identifies the top row).
+  for (let yLayout = INTERIOR_CANVAS.height; yLayout >= 1; yLayout--) {
+    for (let xLayout = 0; xLayout < INTERIOR_CANVAS.width; xLayout++) {
+      const position = {
+        x: xLayout - halfWidth,
+        y: yLayout - halfHeight,
+        width,
+        height,
+      };
+
+      const collision = detectCollision({ state, position, location, name });
+      if (!collision) {
+        return { x: position.x, y: position.y };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Pushes a minimal placed item onto a floor so subsequent scans treat the
+ *  spot as occupied. Used while building the plan on a scratch draft. */
+function markOccupied(state: GameState, placement: ImportPlacement): void {
+  const collectibles =
+    placement.location === "interior"
+      ? state.interior.ground.collectibles
+      : state.interior.level_one?.collectibles;
+
+  if (!collectibles) return;
+
+  const items = (collectibles[placement.name] ??= []);
+  items.push({ id: placement.id, coordinates: placement.coordinates });
+}
+
+/**
+ * Works out where every placed item in the old `home` would land if instantly
+ * imported into the new interior. Items are placed one-by-one onto the ground
+ * floor, falling through to level_one (when unlocked) only once the ground
+ * floor can't fit them. Each assigned spot is marked occupied so later items
+ * don't stack on top of earlier ones.
+ *
+ * Pure — it works on an immer scratch draft and never mutates `state`. Shared
+ * by the import modal (for the "won't fit" count) and the apply loop, which
+ * dispatches a `collectible.removed` (dig up) + `collectible.placed` pair per
+ * placement so the import reuses the existing, server-recognised events instead
+ * of a bespoke reducer. See `ImportHomeButton`.
+ */
+export function getHomeImportPlan(state: GameState): HomeImportPlan {
+  const homeItems: Array<{ name: CollectibleName; id: string }> = [];
+  getObjectEntries(state.home.collectibles).forEach(([name, items]) => {
+    (items ?? []).forEach((item) => {
+      if (item.coordinates) homeItems.push({ name, id: item.id });
+    });
+  });
+
+  const placements: ImportPlacement[] = [];
+  const unplaced: Array<{ name: CollectibleName; id: string }> = [];
+
+  produce(state, (draft) => {
+    for (const { name, id } of homeItems) {
+      let placement: ImportPlacement | undefined;
+
+      for (const location of IMPORT_LOCATIONS) {
+        // Upstairs only exists once the first interior upgrade is bought.
+        if (location === "level_one" && !draft.interior.level_one) continue;
+
+        const spot = findInteriorSpot(draft, name, location);
+        if (spot) {
+          placement = { name, id, location, coordinates: spot };
+          break;
+        }
+      }
+
+      if (placement) {
+        placements.push(placement);
+        markOccupied(draft, placement);
+      } else {
+        unplaced.push({ name, id });
+      }
+    }
+  });
+
+  return { placements, unplaced, total: homeItems.length };
+}

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -34,6 +34,7 @@ import {
 import { InteriorGridOverlay } from "./components/InteriorGridOverlay";
 import { UpgradeButton } from "./components/UpgradeButton";
 import { ImportHomeButton } from "./components/ImportHomeButton";
+import { InteriorWelcomeModal } from "./components/InteriorWelcomeModal";
 import { Bud } from "features/island/buds/Bud";
 import { PetNFT } from "features/island/pets/PetNFT";
 import { FarmHand } from "features/island/farmhand/FarmHand";
@@ -442,6 +443,8 @@ export const Interior: React.FC = () => {
 
       {!landscaping && <Hud isFarming location="interior" />}
       {landscaping && <LandscapingHud location="interior" />}
+
+      {!landscaping && <InteriorWelcomeModal />}
     </>
   );
 };

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -33,6 +33,7 @@ import {
 } from "./lib/interiorBackgrounds";
 import { InteriorGridOverlay } from "./components/InteriorGridOverlay";
 import { UpgradeButton } from "./components/UpgradeButton";
+import { ImportHomeButton } from "./components/ImportHomeButton";
 import { Bud } from "features/island/buds/Bud";
 import { PetNFT } from "features/island/pets/PetNFT";
 import { FarmHand } from "features/island/farmhand/FarmHand";
@@ -368,6 +369,28 @@ export const Interior: React.FC = () => {
                   <InteriorBumpkins location="interior" />
                 </div>
               </div>
+              {/*
+                Import-from-old-home button, pinned to the top-right corner of
+                the house layout. Anchored to the background image's top edge so
+                it sits on the room rather than floating in the black canvas
+                gutter. Self-hides when the old home has no items left.
+              */}
+              {!landscaping && (
+                <div
+                  data-prevent-drag-scroll
+                  className="absolute z-30"
+                  style={{
+                    right: `${PIXEL_SCALE * 6}px`,
+                    top: `${
+                      canvasHeightPx -
+                      INTERIOR_BACKGROUND_NATIVE.height * PIXEL_SCALE +
+                      PIXEL_SCALE * 6
+                    }px`,
+                  }}
+                >
+                  <ImportHomeButton />
+                </div>
+              )}
 
               <LandscapingGrid />
 

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -387,6 +387,8 @@ export const LevelOne: React.FC = () => {
                   >
                     <InteriorBumpkins location="level_one" />
                   </div>
+                </div>
+              )}
               {/*
                 Import-from-old-home button, pinned to the top-right corner of
                 the house layout (anchored to the background image's top edge).

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -31,6 +31,7 @@ import {
 } from "./lib/interiorBackgrounds";
 import { LevelOneGridOverlay } from "./components/LevelOneGridOverlay";
 import { UpgradeButton } from "./components/UpgradeButton";
+import { ImportHomeButton } from "./components/ImportHomeButton";
 import { Bud } from "features/island/buds/Bud";
 import { PetNFT } from "features/island/pets/PetNFT";
 import { FarmHand } from "features/island/farmhand/FarmHand";
@@ -386,6 +387,25 @@ export const LevelOne: React.FC = () => {
                   >
                     <InteriorBumpkins location="level_one" />
                   </div>
+              {/*
+                Import-from-old-home button, pinned to the top-right corner of
+                the house layout (anchored to the background image's top edge).
+                Self-hides when the old home has no items left to import.
+              */}
+              {!landscaping && (
+                <div
+                  data-prevent-drag-scroll
+                  className="absolute z-30"
+                  style={{
+                    right: `${PIXEL_SCALE * 6}px`,
+                    top: `${
+                      canvasHeightPx -
+                      HOME_EXPANSION_BACKGROUND_NATIVE.height * PIXEL_SCALE +
+                      PIXEL_SCALE * 6
+                    }px`,
+                  }}
+                >
+                  <ImportHomeButton />
                 </div>
               )}
 

--- a/src/features/interior/components/HomeImportMigration.tsx
+++ b/src/features/interior/components/HomeImportMigration.tsx
@@ -1,0 +1,311 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+import Decimal from "decimal.js-light";
+
+import { Context } from "features/game/GameProvider";
+import { Button } from "components/ui/Button";
+import { Box } from "components/ui/Box";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { Label } from "components/ui/Label";
+import { ResizableBar } from "components/ui/ProgressBar";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { getObjectEntries } from "lib/object";
+import type { GameState } from "features/game/types/game";
+import type { CollectibleName } from "features/game/types/craftables";
+import { getHomeImportPlan } from "features/game/events/landExpansion/importHomeItems";
+
+/** How many items are dug-up-and-placed per narrated batch. */
+const BATCH_SIZE = 50;
+
+/** Minimum time each batch is shown for, so the player can read the message
+ *  ("Importing 50 items") and watch the room fill in before the next batch. */
+const BATCH_DISPLAY_MS = 3000;
+
+/** Per-item pause while placing within a batch, so items trickle in rather
+ *  than all popping at once. Clamped so a small batch still finishes promptly. */
+const MIN_ITEM_DELAY_MS = 25;
+const MAX_ITEM_DELAY_MS = 120;
+
+type Phase = "idle" | "running" | "done";
+
+type Leftover = { name: CollectibleName; count: number };
+
+const chunk = <T,>(items: T[], size: number): T[][] => {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+/** Placed collectibles still sitting in the old home, aggregated by name —
+ *  i.e. everything the import couldn't move (didn't fit or couldn't be dug up). */
+const getHomeLeftover = (state: GameState): Leftover[] =>
+  getObjectEntries(state.home.collectibles)
+    .map(([name, items]) => ({
+      name,
+      count: (items ?? []).filter((i) => i.coordinates).length,
+    }))
+    .filter((l) => l.count > 0);
+
+export type HomeImport = {
+  phase: Phase;
+  /** Begin the batched migration. No-op if already running. */
+  start: () => void;
+  /** Return to the idle phase (call when the modal closes). */
+  reset: () => void;
+  progress: {
+    message: string;
+    percentage: number;
+    completed: number;
+    total: number;
+    batchCount: number;
+    batchesDone: number;
+    activeBatch: number;
+  };
+  /** Items left behind once the migration finishes. */
+  leftover: Leftover[];
+};
+
+/**
+ * Owns the batched home → interior migration: each item is "dug up" from the old
+ * home and "placed" on the new floor by dispatching the existing
+ * `collectible.removed` + `collectible.placed` events. Items run in batches of
+ * {@link BATCH_SIZE}, each batch held for ~{@link BATCH_DISPLAY_MS} with items
+ * trickling in, so the room visibly populates behind the modal.
+ *
+ * Shared by the top-right import button and the on-entry welcome panel.
+ */
+export function useHomeImport(): HomeImport {
+  const { gameService } = useContext(Context);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [total, setTotal] = useState(0);
+  const [completed, setCompleted] = useState(0);
+  const [batchCount, setBatchCount] = useState(0);
+  const [batchesDone, setBatchesDone] = useState(0);
+  const [activeBatch, setActiveBatch] = useState(-1);
+  const [leftover, setLeftover] = useState<Leftover[]>([]);
+
+  const aborted = useRef(false);
+  const running = useRef(false);
+
+  useEffect(
+    () => () => {
+      aborted.current = true;
+    },
+    [],
+  );
+
+  const start = async () => {
+    if (running.current) return;
+
+    const state = gameService.getSnapshot().context.state;
+    const plan = getHomeImportPlan(state);
+    const batches = chunk(plan.placements, BATCH_SIZE);
+
+    running.current = true;
+    aborted.current = false;
+    setTotal(plan.placements.length);
+    setCompleted(0);
+    setBatchCount(batches.length);
+    setBatchesDone(0);
+    setActiveBatch(-1);
+    setPhase("running");
+
+    let placed = 0;
+
+    for (let i = 0; i < batches.length; i++) {
+      if (aborted.current) return;
+
+      const batch = batches[i];
+      setActiveBatch(i);
+
+      const itemDelay = clamp(
+        Math.floor(BATCH_DISPLAY_MS / batch.length),
+        MIN_ITEM_DELAY_MS,
+        MAX_ITEM_DELAY_MS,
+      );
+      const startedAt = Date.now();
+
+      for (const { name, id, location, coordinates } of batch) {
+        if (aborted.current) return;
+        try {
+          // Dig up from the old home (strips coordinates → back in the pool)...
+          gameService.send({
+            type: "collectible.removed",
+            name,
+            id,
+            location: "home",
+          });
+          // ...then place on the new floor (moves the now-loose home item).
+          gameService.send({
+            type: "collectible.placed",
+            name,
+            id,
+            coordinates,
+            location,
+          });
+        } catch {
+          // Skip an item that can't be dug up/placed (e.g. an in-use item).
+        }
+        placed += 1;
+        setCompleted(placed);
+        await wait(itemDelay);
+      }
+
+      // Keep the batch's message up for the full window even if it placed fast.
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < BATCH_DISPLAY_MS) await wait(BATCH_DISPLAY_MS - elapsed);
+
+      if (aborted.current) return;
+      setBatchesDone(i + 1);
+    }
+
+    running.current = false;
+    if (aborted.current) return;
+    setActiveBatch(-1);
+    setLeftover(getHomeLeftover(gameService.getSnapshot().context.state));
+    setPhase("done");
+  };
+
+  const reset = () => {
+    if (running.current) return;
+    setPhase("idle");
+    setTotal(0);
+    setCompleted(0);
+    setBatchCount(0);
+    setBatchesDone(0);
+    setActiveBatch(-1);
+    setLeftover([]);
+  };
+
+  // "Importing 50 items" for the first batch, "...another 50 items" after.
+  const activeBatchSize =
+    activeBatch >= 0
+      ? Math.min(BATCH_SIZE, total - activeBatch * BATCH_SIZE)
+      : 0;
+  const message =
+    activeBatch <= 0
+      ? `Importing ${activeBatchSize} items`
+      : `Importing another ${activeBatchSize} items`;
+  const percentage = total > 0 ? (completed / total) * 100 : 100;
+
+  return {
+    phase,
+    start: () => void start(),
+    reset,
+    progress: {
+      message,
+      percentage,
+      completed,
+      total,
+      batchCount,
+      batchesDone,
+      activeBatch,
+    },
+    leftover,
+  };
+}
+
+export const MigrationRunningPanel: React.FC<{
+  progress: HomeImport["progress"];
+}> = ({ progress }) => {
+  const {
+    message,
+    percentage,
+    completed,
+    total,
+    batchCount,
+    batchesDone,
+    activeBatch,
+  } = progress;
+
+  return (
+    <div className="p-1 flex flex-col gap-2">
+      {/* Narrated status — changes with each batch. */}
+      <div className="flex items-center gap-2">
+        <img
+          src={SUNNYSIDE.icons.timer}
+          className="w-4 h-4 animate-pulsate"
+          alt=""
+        />
+        <span className="text-sm">{`${message}...`}</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <ResizableBar
+          percentage={percentage}
+          type="progress"
+          outerDimensions={{ width: 40, height: 8 }}
+        />
+        <span className="text-xs whitespace-nowrap">{`${completed}/${total}`}</span>
+      </div>
+
+      <div className="flex flex-col gap-1 max-h-32 overflow-y-auto scrollable pr-1">
+        {Array.from({ length: batchCount }).map((_, i) => {
+          const done = i < batchesDone;
+          const active = i === activeBatch && !done;
+          return (
+            <div key={i} className="flex items-center gap-2 text-xs">
+              {done ? (
+                <img
+                  src={SUNNYSIDE.icons.confirm}
+                  className="w-4 h-4"
+                  alt="Done"
+                />
+              ) : (
+                <img
+                  src={SUNNYSIDE.icons.timer}
+                  className={`w-4 h-4 ${active ? "animate-pulsate" : "opacity-40"}`}
+                  alt={active ? "Importing" : "Pending"}
+                />
+              )}
+              <span className={done || active ? "" : "opacity-60"}>
+                {`Batch ${i + 1} of ${batchCount}`}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const MigrationDonePanel: React.FC<{
+  imported: number;
+  leftover: Leftover[];
+  onClose: () => void;
+}> = ({ imported, leftover, onClose }) => (
+  <CloseButtonPanel onClose={onClose} title="Import complete">
+    <div className="p-2 flex flex-col gap-2 items-center mb-1">
+      <img src={SUNNYSIDE.icons.confirm} className="w-8" alt="Complete" />
+      <p className="text-sm text-center">
+        {imported > 0
+          ? `Imported ${imported} item${imported === 1 ? "" : "s"} into your new home.`
+          : "Nothing could be imported."}
+      </p>
+
+      {leftover.length > 0 && (
+        <div className="flex flex-col gap-1 items-center w-full">
+          <Label type="warning">{"These items could not be moved"}</Label>
+          <div className="flex flex-wrap justify-center">
+            {leftover.map(({ name, count }) => (
+              <Box
+                key={name}
+                image={ITEM_DETAILS[name].image}
+                count={new Decimal(count)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+    <Button onClick={onClose}>{"Close"}</Button>
+  </CloseButtonPanel>
+);

--- a/src/features/interior/components/ImportHomeButton.tsx
+++ b/src/features/interior/components/ImportHomeButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useSelector } from "@xstate/react";
 
 import { Context } from "features/game/GameProvider";
@@ -8,66 +8,44 @@ import { Modal } from "components/ui/Modal";
 import { Panel } from "components/ui/Panel";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { Label } from "components/ui/Label";
-import { ResizableBar } from "components/ui/ProgressBar";
-import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getObjectEntries } from "lib/object";
+import { hasFeatureAccess } from "lib/flags";
 import {
   getHomeImportPlan,
   type HomeImportPlan,
 } from "features/game/events/landExpansion/importHomeItems";
-
-/** How many items are dug-up-and-placed per narrated batch. */
-const BATCH_SIZE = 50;
-
-/** Minimum time each batch is shown for, so the player can read the message
- *  ("Importing 50 items") and watch the room fill in before the next batch. */
-const BATCH_DISPLAY_MS = 3000;
-
-/** Per-item pause while placing within a batch, so items trickle in rather
- *  than all popping at once. Clamped so a small batch still finishes promptly. */
-const MIN_ITEM_DELAY_MS = 25;
-const MAX_ITEM_DELAY_MS = 120;
-
-type Phase = "confirm" | "running" | "done";
+import {
+  MigrationDonePanel,
+  MigrationRunningPanel,
+  useHomeImport,
+} from "./HomeImportMigration";
 
 const _hasHomeItems = (state: MachineState) =>
   getObjectEntries(state.context.state.home.collectibles).some(([, items]) =>
     (items ?? []).some((item) => !!item.coordinates),
   );
 
-const chunk = <T,>(items: T[], size: number): T[][] => {
-  const batches: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    batches.push(items.slice(i, i + size));
-  }
-  return batches;
-};
-
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.max(min, Math.min(max, value));
+// Migration is a beta-only mechanic.
+const _canMigrate = (state: MachineState) =>
+  hasFeatureAccess(state.context.state, "HOME_ITEM_MIGRATION");
 
 /**
- * "Import items" button + migration panel, pinned to the top-right of the house
+ * "Import items" button + migration modal, pinned to the top-right of the house
  * layout by the caller (Interior / LevelOne). The button always shows while the
  * old `home` still has any placed items.
  *
- * Confirming runs the import as a batched migration: each item is "dug up" from
- * the old home and "placed" on the new floor by dispatching the existing
- * `collectible.removed` + `collectible.placed` events — no bespoke import event.
- * Items are processed in batches of {@link BATCH_SIZE}, pausing between batches
- * so the room visibly populates behind the (backdrop-less) modal while a
- * progress bar and per-batch checklist track how it's going.
+ * Confirming runs the shared batched migration (see {@link useHomeImport}) — no
+ * bespoke import event; it reuses `collectible.removed` + `collectible.placed`.
  */
 export const ImportHomeButton: React.FC = () => {
   const { gameService } = useContext(Context);
 
   const hasHomeItems = useSelector(gameService, _hasHomeItems);
+  const canMigrate = useSelector(gameService, _canMigrate);
   const [open, setOpen] = useState(false);
 
-  if (!hasHomeItems) return null;
+  if (!hasHomeItems || !canMigrate) return null;
 
   return (
     <>
@@ -84,127 +62,35 @@ const ImportHomeFlow: React.FC<{ open: boolean; onClose: () => void }> = ({
   onClose,
 }) => {
   const { gameService } = useContext(Context);
-
-  const [phase, setPhase] = useState<Phase>("confirm");
+  const { phase, start, reset, progress, leftover } = useHomeImport();
   const [plan, setPlan] = useState<HomeImportPlan | null>(null);
-  const [batchCount, setBatchCount] = useState(0);
-  const [batchesDone, setBatchesDone] = useState(0);
-  const [activeBatch, setActiveBatch] = useState(-1);
-  const [completed, setCompleted] = useState(0);
 
-  // Set while the component is unmounted / closed so an in-flight migration
-  // stops touching React state.
-  const aborted = useRef(false);
-
-  // (Re)initialise the flow each time it opens — compute the plan up front from
-  // a live snapshot so the confirm screen and the batching agree.
+  // Compute the plan up front from a live snapshot so the confirm screen's
+  // counts match what the migration will do.
   useEffect(() => {
     if (!open) return;
-    aborted.current = false;
-    setPhase("confirm");
-    setBatchesDone(0);
-    setActiveBatch(-1);
-    setCompleted(0);
+    reset();
     setPlan(getHomeImportPlan(gameService.getSnapshot().context.state));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  useEffect(() => {
-    return () => {
-      aborted.current = true;
-    };
-  }, []);
-
-  const total = plan?.placements.length ?? 0;
-  const wontFit = plan?.unplaced.length ?? 0;
-
-  const runImport = async () => {
-    if (!plan || plan.placements.length === 0) return;
-
-    const batches = chunk(plan.placements, BATCH_SIZE);
-    setBatchCount(batches.length);
-    setBatchesDone(0);
-    setCompleted(0);
-    setPhase("running");
-
-    let placed = 0;
-
-    for (let i = 0; i < batches.length; i++) {
-      if (aborted.current) return;
-
-      const batch = batches[i];
-      setActiveBatch(i);
-
-      // Spread this batch's placements across the display window so items
-      // trickle into the room behind the modal instead of all at once.
-      const itemDelay = clamp(
-        Math.floor(BATCH_DISPLAY_MS / batch.length),
-        MIN_ITEM_DELAY_MS,
-        MAX_ITEM_DELAY_MS,
-      );
-      const startedAt = Date.now();
-
-      for (const { name, id, location, coordinates } of batch) {
-        if (aborted.current) return;
-        try {
-          // Dig up from the old home (strips coordinates → back in the pool)...
-          gameService.send({
-            type: "collectible.removed",
-            name,
-            id,
-            location: "home",
-          });
-          // ...then place on the new floor (moves the now-loose home item).
-          gameService.send({
-            type: "collectible.placed",
-            name,
-            id,
-            coordinates,
-            location,
-          });
-        } catch {
-          // Skip an item that can't be dug up/placed (e.g. an in-use item).
-        }
-        placed += 1;
-        setCompleted(placed);
-        await wait(itemDelay);
-      }
-
-      // Keep the batch's message up for the full window even if it placed fast.
-      const elapsed = Date.now() - startedAt;
-      if (elapsed < BATCH_DISPLAY_MS) await wait(BATCH_DISPLAY_MS - elapsed);
-
-      if (aborted.current) return;
-      setBatchesDone(i + 1);
-    }
-
-    if (!aborted.current) {
-      setActiveBatch(-1);
-      setPhase("done");
-    }
+  const handleClose = () => {
+    reset();
+    onClose();
   };
 
-  const percentage = total > 0 ? (completed / total) * 100 : 0;
-
-  // "Importing 50 items" for the first batch, "...another 50 items" after.
-  const activeBatchSize =
-    activeBatch >= 0
-      ? Math.min(BATCH_SIZE, total - activeBatch * BATCH_SIZE)
-      : 0;
-  const runningMessage =
-    activeBatch <= 0
-      ? `Importing ${activeBatchSize} items`
-      : `Importing another ${activeBatchSize} items`;
+  const willFit = plan?.placements.length ?? 0;
+  const wontFit = plan?.unplaced.length ?? 0;
 
   return (
     <Modal
       show={open}
       // No backdrop once we start so the player can watch the room fill in.
-      backdrop={phase === "confirm"}
-      onHide={phase === "running" ? undefined : onClose}
+      backdrop={phase === "idle"}
+      onHide={phase === "running" ? undefined : handleClose}
     >
-      {phase === "confirm" && (
-        <CloseButtonPanel onClose={onClose} title="Import items">
+      {phase === "idle" && (
+        <CloseButtonPanel onClose={handleClose} title="Import items">
           <div className="p-2 flex flex-col gap-3 mb-1">
             <p className="text-sm">
               {
@@ -213,7 +99,7 @@ const ImportHomeFlow: React.FC<{ open: boolean; onClose: () => void }> = ({
             </p>
             <div className="flex flex-col gap-1">
               <Label type="default">
-                {`${total} item${total === 1 ? "" : "s"} will be imported`}
+                {`${willFit} item${willFit === 1 ? "" : "s"} will be imported`}
               </Label>
               {wontFit > 0 && (
                 <Label type="warning">
@@ -224,110 +110,25 @@ const ImportHomeFlow: React.FC<{ open: boolean; onClose: () => void }> = ({
               )}
             </div>
           </div>
-          <Button disabled={total === 0} onClick={runImport}>
-            {total === 0 ? "Nothing to import" : "Import"}
+          <Button disabled={willFit === 0} onClick={start}>
+            {willFit === 0 ? "Nothing to import" : "Import"}
           </Button>
         </CloseButtonPanel>
       )}
 
       {phase === "running" && (
         <Panel>
-          <MigrationProgress
-            message={runningMessage}
-            percentage={percentage}
-            completed={completed}
-            total={total}
-            batchCount={batchCount}
-            batchesDone={batchesDone}
-            activeBatch={activeBatch}
-          />
+          <MigrationRunningPanel progress={progress} />
         </Panel>
       )}
 
       {phase === "done" && (
-        <CloseButtonPanel onClose={onClose} title="Import complete">
-          <div className="p-2 flex flex-col gap-2 items-center mb-1">
-            <img src={SUNNYSIDE.icons.confirm} className="w-8" alt="Complete" />
-            <p className="text-sm text-center">
-              {`Imported ${total} item${total === 1 ? "" : "s"} into your new home.`}
-            </p>
-            {wontFit > 0 && (
-              <Label type="warning">
-                {`${wontFit} item${
-                  wontFit === 1 ? "" : "s"
-                } didn't fit and stayed in your old home`}
-              </Label>
-            )}
-          </div>
-          <Button onClick={onClose}>{"Close"}</Button>
-        </CloseButtonPanel>
+        <MigrationDonePanel
+          imported={progress.total}
+          leftover={leftover}
+          onClose={handleClose}
+        />
       )}
     </Modal>
   );
 };
-
-const MigrationProgress: React.FC<{
-  message: string;
-  percentage: number;
-  completed: number;
-  total: number;
-  batchCount: number;
-  batchesDone: number;
-  activeBatch: number;
-}> = ({
-  message,
-  percentage,
-  completed,
-  total,
-  batchCount,
-  batchesDone,
-  activeBatch,
-}) => (
-  <div className="p-1 flex flex-col gap-2">
-    {/* Narrated status — changes with each batch. */}
-    <div className="flex items-center gap-2">
-      <img
-        src={SUNNYSIDE.icons.timer}
-        className="w-4 h-4 animate-pulsate"
-        alt=""
-      />
-      <span className="text-sm">{`${message}...`}</span>
-    </div>
-
-    <div className="flex items-center gap-2">
-      <ResizableBar
-        percentage={percentage}
-        type="progress"
-        outerDimensions={{ width: 40, height: 8 }}
-      />
-      <span className="text-xs whitespace-nowrap">{`${completed}/${total}`}</span>
-    </div>
-
-    <div className="flex flex-col gap-1 max-h-32 overflow-y-auto scrollable pr-1">
-      {Array.from({ length: batchCount }).map((_, i) => {
-        const done = i < batchesDone;
-        const active = i === activeBatch && !done;
-        return (
-          <div key={i} className="flex items-center gap-2 text-xs">
-            {done ? (
-              <img
-                src={SUNNYSIDE.icons.confirm}
-                className="w-4 h-4"
-                alt="Done"
-              />
-            ) : (
-              <img
-                src={SUNNYSIDE.icons.timer}
-                className={`w-4 h-4 ${active ? "animate-pulsate" : "opacity-40"}`}
-                alt={active ? "Importing" : "Pending"}
-              />
-            )}
-            <span className={done || active ? "" : "opacity-60"}>
-              {`Batch ${i + 1} of ${batchCount}`}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  </div>
-);

--- a/src/features/interior/components/ImportHomeButton.tsx
+++ b/src/features/interior/components/ImportHomeButton.tsx
@@ -1,0 +1,333 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+import { useSelector } from "@xstate/react";
+
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import { Button } from "components/ui/Button";
+import { Modal } from "components/ui/Modal";
+import { Panel } from "components/ui/Panel";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { Label } from "components/ui/Label";
+import { ResizableBar } from "components/ui/ProgressBar";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { getObjectEntries } from "lib/object";
+import {
+  getHomeImportPlan,
+  type HomeImportPlan,
+} from "features/game/events/landExpansion/importHomeItems";
+
+/** How many items are dug-up-and-placed per narrated batch. */
+const BATCH_SIZE = 50;
+
+/** Minimum time each batch is shown for, so the player can read the message
+ *  ("Importing 50 items") and watch the room fill in before the next batch. */
+const BATCH_DISPLAY_MS = 3000;
+
+/** Per-item pause while placing within a batch, so items trickle in rather
+ *  than all popping at once. Clamped so a small batch still finishes promptly. */
+const MIN_ITEM_DELAY_MS = 25;
+const MAX_ITEM_DELAY_MS = 120;
+
+type Phase = "confirm" | "running" | "done";
+
+const _hasHomeItems = (state: MachineState) =>
+  getObjectEntries(state.context.state.home.collectibles).some(([, items]) =>
+    (items ?? []).some((item) => !!item.coordinates),
+  );
+
+const chunk = <T,>(items: T[], size: number): T[][] => {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+/**
+ * "Import items" button + migration panel, pinned to the top-right of the house
+ * layout by the caller (Interior / LevelOne). The button always shows while the
+ * old `home` still has any placed items.
+ *
+ * Confirming runs the import as a batched migration: each item is "dug up" from
+ * the old home and "placed" on the new floor by dispatching the existing
+ * `collectible.removed` + `collectible.placed` events — no bespoke import event.
+ * Items are processed in batches of {@link BATCH_SIZE}, pausing between batches
+ * so the room visibly populates behind the (backdrop-less) modal while a
+ * progress bar and per-batch checklist track how it's going.
+ */
+export const ImportHomeButton: React.FC = () => {
+  const { gameService } = useContext(Context);
+
+  const hasHomeItems = useSelector(gameService, _hasHomeItems);
+  const [open, setOpen] = useState(false);
+
+  if (!hasHomeItems) return null;
+
+  return (
+    <>
+      <div style={{ width: `${PIXEL_SCALE * 64}px` }}>
+        <Button onClick={() => setOpen(true)}>{"Import items"}</Button>
+      </div>
+      <ImportHomeFlow open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+const ImportHomeFlow: React.FC<{ open: boolean; onClose: () => void }> = ({
+  open,
+  onClose,
+}) => {
+  const { gameService } = useContext(Context);
+
+  const [phase, setPhase] = useState<Phase>("confirm");
+  const [plan, setPlan] = useState<HomeImportPlan | null>(null);
+  const [batchCount, setBatchCount] = useState(0);
+  const [batchesDone, setBatchesDone] = useState(0);
+  const [activeBatch, setActiveBatch] = useState(-1);
+  const [completed, setCompleted] = useState(0);
+
+  // Set while the component is unmounted / closed so an in-flight migration
+  // stops touching React state.
+  const aborted = useRef(false);
+
+  // (Re)initialise the flow each time it opens — compute the plan up front from
+  // a live snapshot so the confirm screen and the batching agree.
+  useEffect(() => {
+    if (!open) return;
+    aborted.current = false;
+    setPhase("confirm");
+    setBatchesDone(0);
+    setActiveBatch(-1);
+    setCompleted(0);
+    setPlan(getHomeImportPlan(gameService.getSnapshot().context.state));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      aborted.current = true;
+    };
+  }, []);
+
+  const total = plan?.placements.length ?? 0;
+  const wontFit = plan?.unplaced.length ?? 0;
+
+  const runImport = async () => {
+    if (!plan || plan.placements.length === 0) return;
+
+    const batches = chunk(plan.placements, BATCH_SIZE);
+    setBatchCount(batches.length);
+    setBatchesDone(0);
+    setCompleted(0);
+    setPhase("running");
+
+    let placed = 0;
+
+    for (let i = 0; i < batches.length; i++) {
+      if (aborted.current) return;
+
+      const batch = batches[i];
+      setActiveBatch(i);
+
+      // Spread this batch's placements across the display window so items
+      // trickle into the room behind the modal instead of all at once.
+      const itemDelay = clamp(
+        Math.floor(BATCH_DISPLAY_MS / batch.length),
+        MIN_ITEM_DELAY_MS,
+        MAX_ITEM_DELAY_MS,
+      );
+      const startedAt = Date.now();
+
+      for (const { name, id, location, coordinates } of batch) {
+        if (aborted.current) return;
+        try {
+          // Dig up from the old home (strips coordinates → back in the pool)...
+          gameService.send({
+            type: "collectible.removed",
+            name,
+            id,
+            location: "home",
+          });
+          // ...then place on the new floor (moves the now-loose home item).
+          gameService.send({
+            type: "collectible.placed",
+            name,
+            id,
+            coordinates,
+            location,
+          });
+        } catch {
+          // Skip an item that can't be dug up/placed (e.g. an in-use item).
+        }
+        placed += 1;
+        setCompleted(placed);
+        await wait(itemDelay);
+      }
+
+      // Keep the batch's message up for the full window even if it placed fast.
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < BATCH_DISPLAY_MS) await wait(BATCH_DISPLAY_MS - elapsed);
+
+      if (aborted.current) return;
+      setBatchesDone(i + 1);
+    }
+
+    if (!aborted.current) {
+      setActiveBatch(-1);
+      setPhase("done");
+    }
+  };
+
+  const percentage = total > 0 ? (completed / total) * 100 : 0;
+
+  // "Importing 50 items" for the first batch, "...another 50 items" after.
+  const activeBatchSize =
+    activeBatch >= 0
+      ? Math.min(BATCH_SIZE, total - activeBatch * BATCH_SIZE)
+      : 0;
+  const runningMessage =
+    activeBatch <= 0
+      ? `Importing ${activeBatchSize} items`
+      : `Importing another ${activeBatchSize} items`;
+
+  return (
+    <Modal
+      show={open}
+      // No backdrop once we start so the player can watch the room fill in.
+      backdrop={phase === "confirm"}
+      onHide={phase === "running" ? undefined : onClose}
+    >
+      {phase === "confirm" && (
+        <CloseButtonPanel onClose={onClose} title="Import items">
+          <div className="p-2 flex flex-col gap-3 mb-1">
+            <p className="text-sm">
+              {
+                "You still have items in your old home. Would you like to instantly import them into your new land? The layout will not be preserved."
+              }
+            </p>
+            <div className="flex flex-col gap-1">
+              <Label type="default">
+                {`${total} item${total === 1 ? "" : "s"} will be imported`}
+              </Label>
+              {wontFit > 0 && (
+                <Label type="warning">
+                  {`${wontFit} item${
+                    wontFit === 1 ? " won't" : "s won't"
+                  } fit and will stay in your old home`}
+                </Label>
+              )}
+            </div>
+          </div>
+          <Button disabled={total === 0} onClick={runImport}>
+            {total === 0 ? "Nothing to import" : "Import"}
+          </Button>
+        </CloseButtonPanel>
+      )}
+
+      {phase === "running" && (
+        <Panel>
+          <MigrationProgress
+            message={runningMessage}
+            percentage={percentage}
+            completed={completed}
+            total={total}
+            batchCount={batchCount}
+            batchesDone={batchesDone}
+            activeBatch={activeBatch}
+          />
+        </Panel>
+      )}
+
+      {phase === "done" && (
+        <CloseButtonPanel onClose={onClose} title="Import complete">
+          <div className="p-2 flex flex-col gap-2 items-center mb-1">
+            <img src={SUNNYSIDE.icons.confirm} className="w-8" alt="Complete" />
+            <p className="text-sm text-center">
+              {`Imported ${total} item${total === 1 ? "" : "s"} into your new home.`}
+            </p>
+            {wontFit > 0 && (
+              <Label type="warning">
+                {`${wontFit} item${
+                  wontFit === 1 ? "" : "s"
+                } didn't fit and stayed in your old home`}
+              </Label>
+            )}
+          </div>
+          <Button onClick={onClose}>{"Close"}</Button>
+        </CloseButtonPanel>
+      )}
+    </Modal>
+  );
+};
+
+const MigrationProgress: React.FC<{
+  message: string;
+  percentage: number;
+  completed: number;
+  total: number;
+  batchCount: number;
+  batchesDone: number;
+  activeBatch: number;
+}> = ({
+  message,
+  percentage,
+  completed,
+  total,
+  batchCount,
+  batchesDone,
+  activeBatch,
+}) => (
+  <div className="p-1 flex flex-col gap-2">
+    {/* Narrated status — changes with each batch. */}
+    <div className="flex items-center gap-2">
+      <img
+        src={SUNNYSIDE.icons.timer}
+        className="w-4 h-4 animate-pulsate"
+        alt=""
+      />
+      <span className="text-sm">{`${message}...`}</span>
+    </div>
+
+    <div className="flex items-center gap-2">
+      <ResizableBar
+        percentage={percentage}
+        type="progress"
+        outerDimensions={{ width: 40, height: 8 }}
+      />
+      <span className="text-xs whitespace-nowrap">{`${completed}/${total}`}</span>
+    </div>
+
+    <div className="flex flex-col gap-1 max-h-32 overflow-y-auto scrollable pr-1">
+      {Array.from({ length: batchCount }).map((_, i) => {
+        const done = i < batchesDone;
+        const active = i === activeBatch && !done;
+        return (
+          <div key={i} className="flex items-center gap-2 text-xs">
+            {done ? (
+              <img
+                src={SUNNYSIDE.icons.confirm}
+                className="w-4 h-4"
+                alt="Done"
+              />
+            ) : (
+              <img
+                src={SUNNYSIDE.icons.timer}
+                className={`w-4 h-4 ${active ? "animate-pulsate" : "opacity-40"}`}
+                alt={active ? "Importing" : "Pending"}
+              />
+            )}
+            <span className={done || active ? "" : "opacity-60"}>
+              {`Batch ${i + 1} of ${batchCount}`}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  </div>
+);

--- a/src/features/interior/components/InteriorWelcomeModal.tsx
+++ b/src/features/interior/components/InteriorWelcomeModal.tsx
@@ -1,0 +1,118 @@
+import React, { useContext, useState } from "react";
+import { useSelector } from "@xstate/react";
+
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import { Button } from "components/ui/Button";
+import { Modal } from "components/ui/Modal";
+import { Panel } from "components/ui/Panel";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { getObjectEntries } from "lib/object";
+import { hasFeatureAccess } from "lib/flags";
+import type { GameState } from "features/game/types/game";
+import {
+  MigrationDonePanel,
+  MigrationRunningPanel,
+  useHomeImport,
+} from "./HomeImportMigration";
+
+const hasPlaced = (collectibles: GameState["home"]["collectibles"]) =>
+  getObjectEntries(collectibles).some(([, items]) =>
+    (items ?? []).some((item) => !!item.coordinates),
+  );
+
+// Show the migrate prompt only to beta testers who still have old-home items.
+const _canMigrateHomeItems = (state: MachineState) =>
+  hasFeatureAccess(state.context.state, "HOME_ITEM_MIGRATION") &&
+  hasPlaced(state.context.state.home.collectibles);
+
+/** True when neither interior floor has any placed collectible. */
+const isInteriorEmpty = (state: GameState) => {
+  const ground = hasPlaced(state.interior.ground.collectibles);
+  const levelOne = state.interior.level_one
+    ? hasPlaced(state.interior.level_one.collectibles)
+    : false;
+  return !ground && !levelOne;
+};
+
+/**
+ * One-off welcome shown when the player enters an empty interior. Introduces the
+ * feature and, if they still have items in their old home, offers to migrate
+ * them across (reusing the shared batched migration). Mounted by Interior.tsx.
+ */
+export const InteriorWelcomeModal: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const { phase, start, reset, progress, leftover } = useHomeImport();
+
+  const showMigrate = useSelector(gameService, _canMigrateHomeItems);
+
+  // Capture emptiness at mount (entry) so placing items mid-session doesn't
+  // re-trigger the welcome; it only ever shows on a fresh, empty entry.
+  const [open, setOpen] = useState(() =>
+    isInteriorEmpty(gameService.getSnapshot().context.state),
+  );
+
+  const handleClose = () => {
+    reset();
+    setOpen(false);
+  };
+
+  return (
+    <Modal
+      show={open}
+      // No backdrop once the migration starts so the room fills in behind it.
+      backdrop={phase === "idle"}
+      onHide={phase === "running" ? undefined : handleClose}
+    >
+      {phase === "idle" && (
+        <CloseButtonPanel onClose={handleClose} title="Welcome home">
+          <div className="p-2 flex flex-col gap-2 mb-1">
+            <p className="text-sm">
+              {
+                "Welcome to the new interior. Here you can place items and upgrade to new rooms as you explore new islands."
+              }
+            </p>
+            <p className="text-xs italic">
+              {
+                "Decorate each floor however you like — it's your own cozy corner of the farm."
+              }
+            </p>
+
+            {showMigrate && (
+              <div className="flex flex-col gap-2 mt-1">
+                <p className="text-xs">
+                  {
+                    "You have items in your old home. Would you like to move them across?"
+                  }
+                </p>
+              </div>
+            )}
+          </div>
+
+          {showMigrate ? (
+            <div className="flex space-x-1">
+              <Button onClick={handleClose}>{"Maybe later"}</Button>
+              <Button onClick={start}>{"Move them across"}</Button>
+            </div>
+          ) : (
+            <Button onClick={handleClose}>{"Let's go"}</Button>
+          )}
+        </CloseButtonPanel>
+      )}
+
+      {phase === "running" && (
+        <Panel>
+          <MigrationRunningPanel progress={progress} />
+        </Panel>
+      )}
+
+      {phase === "done" && (
+        <MigrationDonePanel
+          imported={progress.total}
+          leftover={leftover}
+          onClose={handleClose}
+        />
+      )}
+    </Modal>
+  );
+};

--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -51,6 +51,7 @@ import type { NFTName } from "features/game/events/landExpansion/placeNFT";
 import { LandscapingChest } from "./components/LandscapingChest";
 import classNames from "classnames";
 import { LandscapingQuickPanel } from "./components/LandscapingQuickPanel";
+import { InteriorFloorNav } from "features/interior/components/InteriorFloorNav";
 
 const compareBalance = (prev: Decimal, next: Decimal) => {
   return prev.eq(next);
@@ -221,6 +222,20 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
       <div className="absolute right-0 top-0 p-2.5">
         <Balances sfl={balance} coins={coins} gems={gems ?? new Decimal(0)} />
       </div>
+
+      {/*
+        Floor navigation stays available while landscaping the interior so the
+        player can move between floors without leaving edit mode. The matching
+        in-world arrows are hidden during landscaping (see Interior/LevelOne),
+        so these HUD buttons are the only way to switch floors here.
+      */}
+      {(location === "interior" || location === "level_one") && (
+        <div className="absolute bottom-0 p-2.5 left-0 flex flex-col space-y-2.5">
+          <InteriorFloorNav
+            floor={location === "interior" ? "ground" : "level_one"}
+          />
+        </div>
+      )}
 
       {removalMode && (
         <>

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -151,6 +151,9 @@ const FEATURE_FLAGS = {
 
   BOOSTS_DISPLAY: betaFeatureFlag,
 
+  // Importing leftover items from the old home into the new interior.
+  HOME_ITEM_MIGRATION: betaFeatureFlag,
+
   SWAMP_ASCENSION: testnetFeatureFlag,
 } satisfies Record<string, FeatureFlag>;
 


### PR DESCRIPTION
# Pull request description

1. Show the level buttons while in design mode
2. Add a temporary 'import' button to move your items into the new house.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an “Import items” action to move placed collectibles from the old home into the interior when landscaping is off and migration is enabled.
  * Import is now planned ahead and executed as a batched migration with a confirm → running → done modal, including an overflow summary (overflow goes to level one when unlocked).
* **UI Updates**
  * Added top-right Import buttons in Interior and Level One layouts, plus an empty-interior welcome modal that guides the migration when applicable.
  * Added interior floor navigation to the landscaping HUD during interior/level-one editing.
* **Tests**
  * Added unit tests covering import planning and the migration apply flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->