### PR TITLE
[FEAT] Show animal maturity boost details

### DIFF
--- a/src/components/ui/layouts/BoostsDisplay.tsx
+++ b/src/components/ui/layouts/BoostsDisplay.tsx
@@ -113,6 +113,7 @@ export const BoostsDisplay: React.FC<{
   onClick: () => void;
   className?: string;
   portalAlign?: "left" | "center" | "right";
+  portalPlacement?: "auto" | "above" | "below";
   /** When provided, renders in a portal to avoid clipping by scroll containers. Positions above trigger when it would clip below. */
   anchorRef?: React.RefObject<HTMLElement | null>;
 }> = ({
@@ -122,6 +123,7 @@ export const BoostsDisplay: React.FC<{
   onClick,
   className,
   portalAlign = "right",
+  portalPlacement = "auto",
   anchorRef,
 }) => {
   const { t } = useAppTranslation();
@@ -165,7 +167,10 @@ export const BoostsDisplay: React.FC<{
       setAnchorVisible(visible);
       if (!visible) return;
       const spaceBelow = window.innerHeight - rect.bottom;
-      const positionAbove = spaceBelow < BOOSTS_PANEL_ESTIMATED_HEIGHT;
+      const positionAbove =
+        portalPlacement === "above" ||
+        (portalPlacement === "auto" &&
+          spaceBelow < BOOSTS_PANEL_ESTIMATED_HEIGHT);
 
       const horizontalStyle =
         portalAlign === "center"
@@ -227,7 +232,7 @@ export const BoostsDisplay: React.FC<{
         el.removeEventListener("scroll", scheduleUpdate),
       );
     };
-  }, [show, anchorRef, portalAlign]);
+  }, [show, anchorRef, portalAlign, portalPlacement]);
 
   const panelContent = (
     <AnimatedPanel

--- a/src/components/ui/layouts/CraftingRequirements.tsx
+++ b/src/components/ui/layouts/CraftingRequirements.tsx
@@ -13,6 +13,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import React, {
   type Dispatch,
   type SetStateAction,
+  useRef,
   useState,
   type JSX,
 } from "react";
@@ -213,6 +214,7 @@ export const CraftingRequirements: React.FC<Props> = ({
 }: Props) => {
   const { t } = useAppTranslation();
   const [showIngredients, setShowIngredients] = useState(false);
+  const timeBoostsRef = useRef<HTMLDivElement>(null);
   const getStock = () => {
     if (!stock) return <></>;
 
@@ -510,6 +512,7 @@ export const CraftingRequirements: React.FC<Props> = ({
               ) {
                 return (
                   <div
+                    ref={timeBoostsRef}
                     className="flex flex-row sm:flex-col items-center cursor-pointer"
                     onClick={() => setShowTimeBoosts(!showTimeBoosts)}
                   >
@@ -529,6 +532,9 @@ export const CraftingRequirements: React.FC<Props> = ({
                         show={showTimeBoosts}
                         state={gameState}
                         onClick={() => setShowTimeBoosts((prev) => !prev)}
+                        anchorRef={timeBoostsRef}
+                        portalAlign="center"
+                        portalPlacement="above"
                       />
                     )}
                   </div>

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -25,7 +25,10 @@ import { Label } from "components/ui/Label";
 import coinsIcon from "assets/icons/coins.webp";
 import brush from "assets/animals/brush.webp";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import { makeAnimalBuildingKey } from "features/game/lib/animals";
+import {
+  getAnimalMaturityTimeForDisplay,
+  makeAnimalBuildingKey,
+} from "features/game/lib/animals";
 import { AnimalBounties } from "features/barn/components/AnimalBounties";
 import { SpeakingModal } from "features/game/components/SpeakingModal";
 import { NPC_WEARABLES } from "lib/npcs";
@@ -77,6 +80,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
   const [currentTab, setCurrentTab] = useState<Tab>(
     !hasReadGuide() ? "guide" : "buy",
   );
+  const [showTimeBoosts, setShowTimeBoosts] = useState(false);
 
   const state = useSelector(gameService, _state);
   const bumpkin = useSelector(gameService, _bumpkin);
@@ -118,6 +122,11 @@ export const AnimalBuildingModal: React.FC<Props> = ({
   const atMaxCapacity =
     getTotalAnimalsInBuilding() >=
     getBoostedAnimalCapacity(buildingKey, state).capacity;
+
+  const maturityTime = getAnimalMaturityTimeForDisplay({
+    animalType: selectedName,
+    game: state,
+  });
 
   if (showIntro) {
     return (
@@ -194,8 +203,13 @@ export const AnimalBuildingModal: React.FC<Props> = ({
               requirements={{
                 coins: ANIMALS[selectedName].coins,
                 showCoinsIfFree: true,
+                timeSeconds: Math.ceil(maturityTime.maturityTimeMs / 1000),
+                baseTimeSeconds: Math.ceil(maturityTime.baseTimeMs / 1000),
+                timeBoostsUsed: maturityTime.boostsUsed,
                 level: ANIMALS[selectedName].levelRequired,
               }}
+              showTimeBoosts={showTimeBoosts}
+              setShowTimeBoosts={setShowTimeBoosts}
               label={
                 atMaxCapacity ? (
                   <Label type="danger">
@@ -225,7 +239,10 @@ export const AnimalBuildingModal: React.FC<Props> = ({
                   <Box
                     isSelected={selectedName === name}
                     key={name}
-                    onClick={() => setSelectedName(name)}
+                    onClick={() => {
+                      setSelectedName(name);
+                      setShowTimeBoosts(false);
+                    }}
                     image={ITEM_DETAILS[name].image}
                     showOverlay={!hasRequiredLevel()}
                     secondaryImage={

--- a/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
+++ b/src/features/game/expansion/components/animals/AnimalBuildingModal.tsx
@@ -254,7 +254,7 @@ export const AnimalBuildingModal: React.FC<Props> = ({
               </div>
               <Label
                 type={atMaxCapacity ? "danger" : "info"}
-                className="absolute bottom-3 sm:bottom-2 left-2"
+                className="mt-1 sm:mt-0 sm:absolute sm:bottom-2 sm:left-2"
               >
                 {`${getTotalAnimalsInBuilding()}/${
                   getBoostedAnimalCapacity(buildingKey, state).capacity

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -705,3 +705,28 @@ export function getBoostedAwakeAt({
   // Add the boosted duration to the created time
   return { awakeAt: createdAt + totalDuration, boostsUsed };
 }
+
+export function getAnimalMaturityTimeForDisplay({
+  animalType,
+  game,
+}: {
+  animalType: AnimalType;
+  game: GameState;
+}): {
+  baseTimeMs: number;
+  maturityTimeMs: number;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
+  const createdAt = 0;
+  const { awakeAt, boostsUsed } = getBoostedAwakeAt({
+    animalType,
+    createdAt,
+    game,
+  });
+
+  return {
+    baseTimeMs: ANIMAL_SLEEP_DURATION,
+    maturityTimeMs: awakeAt - createdAt,
+    boostsUsed,
+  };
+}


### PR DESCRIPTION
https://discord.com/channels/880987707214544966/1459008366809448519/1460476213243023381
<img width="584" height="343" alt="image" src="https://github.com/user-attachments/assets/d35b3612-42a2-4110-b2f6-57f72c8e7961" />

<img width="932" height="1058" alt="telegram-cloud-photo-size-2-5285534042231086694-y" src="https://github.com/user-attachments/assets/7f6b39b5-e03e-40f8-aaa5-9f1f05e76de7" />

<img width="878" height="888" alt="telegram-cloud-photo-size-2-5285534042231086703-y" src="https://github.com/user-attachments/assets/c029c3fc-9549-4ab8-bc0c-2e657c93c13a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animal purchase interface now displays maturity timing for selected animals and enables time boost application during the purchasing process.
  * Enhanced portal positioning for time boost displays with improved above/below placement controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->