### PR TITLE
[FEAT] UX improve island viewport behavior after inside scenes

### DIFF
--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -45,6 +45,7 @@ import {
   getSortedResourcePositions,
   getSortedCollectiblePositions,
 } from "./lib/utils";
+import { restoreIslandScrollPosition } from "./lib/islandScroll";
 import { Clutter } from "features/island/clutter/Clutter";
 import { PetNFT } from "features/island/pets/PetNFT";
 import { WaterTrapSpot } from "features/island/fisherman/WaterTrapSpot";
@@ -422,6 +423,8 @@ export const LandComponent: React.FC = () => {
   const [scrollIntoView] = useScrollIntoView();
 
   useLayoutEffect(() => {
+    if (restoreIslandScrollPosition()) return;
+
     scrollIntoView(Section.GenesisBlock, "auto");
   }, []);
 

--- a/src/features/game/expansion/lib/islandScroll.ts
+++ b/src/features/game/expansion/lib/islandScroll.ts
@@ -1,0 +1,87 @@
+const PAGE_SCROLL_CONTAINER_CLASS = "page-scroll-container";
+const ISLAND_SCROLL_STORAGE_KEY = "sunflower-land:island-scroll";
+
+type SavedIslandScrollPosition = {
+  left: number;
+  top: number;
+};
+
+const getIslandScrollKey = (pathname: string) => {
+  const visitMatch = pathname.match(/^\/visit\/([^/]+)/);
+
+  if (visitMatch) {
+    return `${ISLAND_SCROLL_STORAGE_KEY}:visit:${visitMatch[1]}`;
+  }
+
+  return `${ISLAND_SCROLL_STORAGE_KEY}:own`;
+};
+
+const getPageScrollContainer = () =>
+  document.getElementsByClassName(PAGE_SCROLL_CONTAINER_CLASS)[0] as
+    | HTMLElement
+    | undefined;
+
+const removeSavedIslandScrollPosition = (key: string) => {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Ignore storage errors so viewport restoration never blocks rendering.
+  }
+};
+
+export const saveIslandScrollPosition = () => {
+  if (typeof window === "undefined") return;
+
+  const scrollContainer = getPageScrollContainer();
+
+  if (!scrollContainer) return;
+
+  const scrollPosition: SavedIslandScrollPosition = {
+    left: scrollContainer.scrollLeft,
+    top: scrollContainer.scrollTop,
+  };
+
+  try {
+    sessionStorage.setItem(
+      getIslandScrollKey(window.location.pathname),
+      JSON.stringify(scrollPosition),
+    );
+  } catch {
+    // Ignore storage errors so navigation into inside scenes can continue.
+  }
+};
+
+export const restoreIslandScrollPosition = () => {
+  if (typeof window === "undefined") return false;
+
+  const scrollContainer = getPageScrollContainer();
+  const key = getIslandScrollKey(window.location.pathname);
+
+  if (!scrollContainer) return false;
+
+  try {
+    const savedScrollPosition = sessionStorage.getItem(key);
+
+    if (!savedScrollPosition) return false;
+
+    const { left, top } = JSON.parse(
+      savedScrollPosition,
+    ) as SavedIslandScrollPosition;
+
+    requestAnimationFrame(() => {
+      scrollContainer.scrollTo({
+        left,
+        top,
+        behavior: "auto",
+      });
+    });
+
+    removeSavedIslandScrollPosition(key);
+
+    return true;
+  } catch {
+    removeSavedIslandScrollPosition(key);
+
+    return false;
+  }
+};

--- a/src/features/island/buildings/components/building/barn/Barn.tsx
+++ b/src/features/island/buildings/components/building/barn/Barn.tsx
@@ -15,6 +15,7 @@ import { getCurrentBiome } from "features/island/biomes/biomes";
 import type { LandBiomeName } from "features/island/biomes/biomes";
 import { isAnimalNeedingLove } from "features/game/events/landExpansion/loveAnimal";
 import classNames from "classnames";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 export const BARN_IMAGES: Record<
   LandBiomeName,
@@ -151,6 +152,7 @@ export const Barn: React.FC<BuildingProps> = ({ isBuilt, island, season }) => {
     if (isBuilt) {
       // Add future on click actions here
       barnAudio();
+      saveIslandScrollPosition();
       navigate("/barn");
     }
   };

--- a/src/features/island/buildings/components/building/greenhouse/Greenhouse.tsx
+++ b/src/features/island/buildings/components/building/greenhouse/Greenhouse.tsx
@@ -14,6 +14,7 @@ import type { GreenHouseFruitName } from "features/game/types/fruits";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { GREENHOUSE_VARIANTS } from "features/island/lib/alternateArt";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const selectReadyPlants = (state: MachineState) => {
   const pots = state.context.state.greenhouse.pots;
@@ -53,6 +54,7 @@ export const Greenhouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
 
   const handleClick = () => {
     if (isBuilt) {
+      saveIslandScrollPosition();
       navigate("/greenhouse");
 
       // Add future on click actions here

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -13,6 +13,7 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { useNow } from "lib/utils/hooks/useNow";
 import { isAnimalNeedingLove } from "features/game/events/landExpansion/loveAnimal";
 import classNames from "classnames";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _hasHungryChickens = (state: MachineState) => {
   return Object.values(state.context.state.henHouse.animals).some(
@@ -55,6 +56,7 @@ export const ChickenHouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
     if (isBuilt) {
       // Add future on click actions here
       barnAudio();
+      saveIslandScrollPosition();
 
       navigate("/hen-house");
       return;

--- a/src/features/island/buildings/components/building/house/House.tsx
+++ b/src/features/island/buildings/components/building/house/House.tsx
@@ -16,6 +16,7 @@ import { getHelpRequired } from "features/game/types/monuments";
 import { HomeBumpkins } from "./HomeBumpkins";
 import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 import { getHomeRoute } from "features/island/buildings/lib/getHomeRoute";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _game = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -31,6 +32,7 @@ export const House: React.FC<BuildingProps> = ({ isBuilt, season }) => {
 
   const handleClick = () => {
     if (isBuilt) {
+      saveIslandScrollPosition();
       navigate(getHomeRoute({ game, isVisiting, farmId }));
       return;
     }

--- a/src/features/island/buildings/components/building/manor/Manor.tsx
+++ b/src/features/island/buildings/components/building/manor/Manor.tsx
@@ -16,6 +16,7 @@ import { getHelpRequired } from "features/game/types/monuments";
 import { HomeBumpkins } from "../house/HomeBumpkins";
 import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 import { getHomeRoute } from "features/island/buildings/lib/getHomeRoute";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _game = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -31,6 +32,7 @@ export const Manor: React.FC<BuildingProps> = ({ isBuilt, season }) => {
 
   const handleClick = () => {
     if (isBuilt) {
+      saveIslandScrollPosition();
       navigate(getHomeRoute({ game, isVisiting, farmId }));
       return;
     }

--- a/src/features/island/buildings/components/building/mansion/Mansion.tsx
+++ b/src/features/island/buildings/components/building/mansion/Mansion.tsx
@@ -16,6 +16,7 @@ import { getHelpRequired } from "features/game/types/monuments";
 import { HomeBumpkins } from "../house/HomeBumpkins";
 import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 import { getHomeRoute } from "features/island/buildings/lib/getHomeRoute";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _game = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -31,6 +32,7 @@ export const Mansion: React.FC<BuildingProps> = ({ isBuilt, season }) => {
 
   const handleClick = () => {
     if (isBuilt) {
+      saveIslandScrollPosition();
       navigate(getHomeRoute({ game, isVisiting: visiting, farmId }));
       // Add future on click actions here
       return;

--- a/src/features/island/buildings/components/building/petHouse/PetHouse.tsx
+++ b/src/features/island/buildings/components/building/petHouse/PetHouse.tsx
@@ -12,6 +12,7 @@ import { getHelpRequired } from "features/game/types/monuments";
 import { isPetNapping, type PetName } from "features/game/types/pets";
 import { useNow } from "lib/utils/hooks/useNow";
 import type { GameState } from "features/game/types/game";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _farmId = (state: MachineState) => state.context.farmId;
 const _petHouseLevel = (state: MachineState) =>
@@ -53,6 +54,8 @@ export const PetHouse: React.FC = () => {
   const hasNappingPet = useNappingPetInPetHouse(game);
 
   const handlePetHouseClick = () => {
+    saveIslandScrollPosition();
+
     if (visiting) {
       const targetPath = `/visit/${farmId}/pet-house`;
       navigate(targetPath);

--- a/src/features/island/buildings/components/building/tent/Tent.tsx
+++ b/src/features/island/buildings/components/building/tent/Tent.tsx
@@ -19,6 +19,7 @@ import type { OnChainBumpkin } from "lib/blockchain/BumpkinDetails";
 import { useVisiting } from "lib/utils/visitUtils";
 import { useNavigate } from "react-router";
 import { getHomeRoute } from "features/island/buildings/lib/getHomeRoute";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const selectBuildings = (state: MachineState) => state.context.state.buildings;
 
@@ -48,6 +49,7 @@ export const Tent: React.FC<BuildingProps> = ({ buildingId, isBuilt }) => {
 
   const handleClick = () => {
     if (isBuilt && bumpkin) {
+      saveIslandScrollPosition();
       const { state, farmId } = gameService.getSnapshot().context;
       navigate(getHomeRoute({ game: state, isVisiting, farmId }));
       setShowModal(true);

--- a/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
+++ b/src/features/island/buildings/components/building/townCenter/TownCenter.tsx
@@ -14,6 +14,7 @@ import type { MachineState } from "features/game/lib/gameMachine";
 import { HomeBumpkins } from "../house/HomeBumpkins";
 import { DailyReward } from "features/game/expansion/components/dailyReward/DailyReward";
 import { getHomeRoute } from "features/island/buildings/lib/getHomeRoute";
+import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
 const _game = (state: MachineState) => state.context.state;
 const _farmId = (state: MachineState) => state.context.farmId;
@@ -28,6 +29,7 @@ export const TownCenter: React.FC<BuildingProps> = ({ isBuilt }) => {
 
   const handleClick = () => {
     if (isBuilt) {
+      saveIslandScrollPosition();
       navigate(getHomeRoute({ game, isVisiting, farmId }));
 
       // Add future on click actions here


### PR DESCRIPTION
## Problem

Currently, when a player exits a building with an inside scene, the island viewport is centered back on the middle of the island via `scrollIntoView(Section.GenesisBlock, "auto")`.

This is a small but noticeable friction point when buildings are placed near the edges of the island: after leaving the inside scene, the player is no longer looking at the place they opened the building from.

It is especially frustrating during friend cleanup flows. For example, if a friend has a Pet House near a small island with dung and weed, opening the Pet House for cleanup and then exiting sends the camera back to the island center instead of preserving the cleanup area.

## What changed

This PR saves the island viewport position before entering inside scenes and restores it when returning to the island. That makes the interaction feel smoother because the player returns to the same viewport position they had before opening the building.

The behavior works for both:

- the player’s own main island
- visiting/friend cleanup flows, including opening a friend’s Pet House

Scroll positions are stored separately for the player’s own island and visited farms, so viewport state does not leak between different islands.

## Tested offline
Tested on dev farm configuration with a Pet House with Barkley placed inside

https://github.com/user-attachments/assets/e64a59dc-2df0-4dc2-bf58-017d37edc46d

## Validation

- `npx eslint --quiet ...`
- `npx tsc --noEmit --pretty false`
- `curl -I http://localhost:3000/` -> `HTTP/1.1 200 OK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Island scroll position is saved when entering buildings and restored when returning to the island, preserving your previous view and improving navigation continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
