### PR TITLE
[FIX] Keep Karkinos boost label visible

### DIFF
--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -295,21 +295,17 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
       boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
     },
   ],
-  Karkinos: (game) => [
-    ...(isCollectibleBuilt({ game, name: "Cabbage Boy" })
-      ? []
-      : ([
-          {
-            shortDescription: translate("description.Karkinos.boost"),
-            labelType: "success",
-            boostTypeIcon: powerup,
-            boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
-          },
-          {
-            shortDescription: translate("description.Karkinos.warning"),
-            labelType: "danger",
-          },
-        ] as BuffLabel[])),
+  Karkinos: () => [
+    {
+      shortDescription: translate("description.Karkinos.boost"),
+      labelType: "success",
+      boostTypeIcon: powerup,
+      boostedItemIcon: CROP_LIFECYCLE["Basic Biome"].Cabbage.crop,
+    },
+    {
+      shortDescription: translate("description.Karkinos.warning"),
+      labelType: "danger",
+    },
   ],
   "Golden Cauliflower": () => [
     {


### PR DESCRIPTION


## Summary
Fixes Karkinos boost communication so it behaves consistently with other collectibles whose effects can be overridden by stronger collectibles. Karkinos now always displays its boost label and its conflict warning, keeping it grouped as a Boost item instead of falling back into Decorations when Cabbage Boy is active.



## Context / motivation

Karkinos still has an active gameplay effect: it gives `+0.1 Cabbage` when placed and ready, unless Cabbage Boy is active. The issue was UI communication. When Cabbage Boy was present, Karkinos returned an empty buff-label array, so players could see only the flavor description and the chest/quick panel could classify it as a decoration rather than a boost item.

<img width="656" height="300" alt="image" src="https://github.com/user-attachments/assets/bcbc363f-fa28-420e-af5c-c6c76d3e39e0" />

it's affected marketplace description
<img width="545" height="570" alt="image" src="https://github.com/user-attachments/assets/80afe533-3f9c-42e7-af1f-0d603f7c465e" />


Other collectibles with overlapping effects do not hide all buff labels. For example, Scarecrow, Nancy, Woody the Beaver, and Apprentice Beaver continue to show their boost information plus a warning such as `Disabled if Kuebiko Active` or `Disabled if Foreman Beaver Active`. This PR brings Karkinos in line with that existing pattern.

<img width="361" height="208" alt="image" src="https://github.com/user-attachments/assets/428a3f74-db3b-4559-ac19-9b625313c81e" />

<img width="535" height="343" alt="image" src="https://github.com/user-attachments/assets/d8befcd2-447c-4eae-8224-43e8adb9f872" />


## What changed

- Karkinos now always shows `+0.1 Cabbage`.
- Karkinos now always shows `Disabled if Cabbage Boy Active`.
- The gameplay logic is unchanged: Cabbage Boy still takes priority over Karkinos during cabbage harvests.
- Because Karkinos now always has buff labels, it remains in Boosts sections instead of being grouped with Decorations when Cabbage Boy is active.

## How to test

1. Open the chest or landscaping quick panel with Karkinos in inventory and no Cabbage Boy placed.
2. Confirm Karkinos appears under Boosts and shows `+0.1 Cabbage` plus the warning label.
3. Place/activate Cabbage Boy.
4. Confirm Karkinos still appears under Boosts and still shows the warning.
5. Harvest cabbage with both active and confirm gameplay still follows the existing priority: Cabbage Boy applies instead of Karkinos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Karkinos collectible item now consistently displays its power-up and warning information with the boosted item icon, independent of other collectibles in your collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->