### PR TITLE
[FIX] Show projects in interior quick panel

### DIFF
--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -469,7 +469,6 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
       label: "Projects",
       emptyLabel: "No projects available.",
       icon: ITEM_DETAILS["Farmer's Monument"].image,
-      farmOnly: true,
       hasItems: monuments.length > 0 || villageProjects.length > 0,
     },
     {


### PR DESCRIPTION
## Summary

Shows the `Projects` tab in the quick drag and drop panel while inside buildings, so monument/project items that are already placeable indoors remain reachable from the same UI.

## Context / motivation

The quick panel was hiding `Projects` inside the house by marking the tab as `farmOnly`. 
<img width="946" height="360" alt="image" src="https://github.com/user-attachments/assets/eb466524-22af-4eac-a7aa-39b2ccee97c9" />

That made the UI inconsistent: monuments/projects can already be placed in homes/interiors, but the quick panel removed the entry point once the player entered a building.

This change removes `farmOnly: true` only from the `Projects` tab. `Resources` and `Buildings` remain farm-only.

This is safe because the lower-level systems already support home projects:

- Placement supports `home`, `interior`, and `level_one` collectible placement.
- Project reducer coverage already includes starting a project from `home.collectibles`.
- Social help logic already accounts for pending home projects.

## How to test

1. Open the quick drag and drop panel on the farm and confirm `Projects` is still visible.
2. Enter a building/home and open the quick drag and drop panel.
3. Confirm `Projects` is visible alongside the interior-safe tabs.
4. Confirm unrelated farm-only tabs, such as `Resources` and `Buildings`, remain hidden indoors.

Validation run locally:

- `npx tsc --noEmit --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Projects tab in the Landscaping Quick Panel is now accessible across all location types, not just farms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->