### PR TITLE
[FEAT] Reel pack pricing: linear ramp then double

### DIFF
--- a/src/features/game/events/landExpansion/castRod.test.ts
+++ b/src/features/game/events/landExpansion/castRod.test.ts
@@ -3,9 +3,9 @@ import {
   INITIAL_FARM,
   TEST_FARM,
 } from "features/game/lib/constants";
-import { castRod, getReelsPackGemPrice } from "./castRod";
+import { castRod, getReelPackPrice, getReelsPackGemPrice } from "./castRod";
 import Decimal from "decimal.js-light";
-import type { Bumpkin } from "features/game/types/game";
+import type { Bumpkin, GameState } from "features/game/types/game";
 import { type Chum, getDailyFishingLimit } from "features/game/types/fishing";
 import { CHAPTERS } from "features/game/types/chapters";
 
@@ -103,7 +103,8 @@ describe("castRod", () => {
         ...INITIAL_FARM,
         inventory: {
           ...INITIAL_FARM.inventory,
-          Gem: new Decimal(70),
+          // 3 packs from a fresh day: 5 + 10 + 15 = 30 Gems
+          Gem: new Decimal(30),
           Rod: new Decimal(1),
           Earthworm: new Decimal(1),
         },
@@ -135,7 +136,8 @@ describe("castRod", () => {
         ...INITIAL_FARM,
         inventory: {
           ...INITIAL_FARM.inventory,
-          Gem: new Decimal(10),
+          // First pack of the day costs 5 Gems
+          Gem: new Decimal(5),
           Rod: new Decimal(1),
           Earthworm: new Decimal(1),
         },
@@ -855,7 +857,7 @@ describe("castRod", () => {
         ...INITIAL_FARM,
         inventory: {
           ...INITIAL_FARM.inventory,
-          Gem: new Decimal(70), // 10 + 20 + 40 = 70 for 3 packs
+          Gem: new Decimal(30), // 5 + 10 + 15 = 30 for 3 packs
           Rod: new Decimal(1),
           Earthworm: new Decimal(1),
         },
@@ -1008,67 +1010,89 @@ describe("getDailyFishingLimit", () => {
   });
 });
 
+describe("getReelPackPrice", () => {
+  it("ramps linearly for the first four packs then doubles", () => {
+    // Index = packs already bought today -> price of the next pack
+    expect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(getReelPackPrice)).toEqual([
+      5, 10, 15, 20, 40, 80, 160, 320, 640, 1280,
+    ]);
+  });
+});
+
 describe("getReelsPackGemPrice", () => {
-  it("returns the correct price for 1 pack", () => {
-    const price = getReelsPackGemPrice({
-      state: farm,
-      packs: 1,
-    });
-    expect(price).toEqual(10);
+  const createdAt = new Date("2026-01-15T00:00:00.000Z").getTime();
+  const today = "2026-01-15";
+
+  const stateWithPacksBought = (timesBoughtToday: number): GameState => ({
+    ...INITIAL_FARM,
+    fishing: {
+      ...INITIAL_FARM.fishing,
+      extraReels: {
+        count: 0,
+        timesBought: { [today]: timesBoughtToday },
+      },
+    },
   });
 
-  it("increases price of gems by 2x after buying once", () => {
-    const now = new Date();
-    const today = now.toISOString().split("T")[0];
-    const price = getReelsPackGemPrice({
-      state: {
-        ...INITIAL_FARM,
-        inventory: {
-          ...INITIAL_FARM.inventory,
-          Gem: new Decimal(10),
-        },
-        fishing: {
-          wharf: {},
-          dailyAttempts: {
-            [today]: 20,
-          },
-          extraReels: {
-            timesBought: {
-              [today]: 1,
-            },
-            count: 0,
-          },
-        },
-      },
-      packs: 1,
-      createdAt: Date.now(),
-    });
-    expect(price).toEqual(20);
+  it("charges 5 Gems for the first pack of the day", () => {
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(0),
+        packs: 1,
+        createdAt,
+      }),
+    ).toEqual(5);
   });
 
-  it("scales price exponentially across multiple packs in one purchase", () => {
-    const now = new Date();
-    const today = now.toISOString().split("T")[0];
-    const price = getReelsPackGemPrice({
-      state: {
-        ...INITIAL_FARM,
-        fishing: {
-          wharf: {},
-          dailyAttempts: {
-            [today]: 20,
-          },
-          extraReels: {
-            timesBought: {
-              [today]: 2,
-            },
-            count: 0,
-          },
-        },
-      },
-      packs: 3,
-      createdAt: Date.now(),
-    });
-    // Prices: 40, 80, 160 => total 280
-    expect(price).toEqual(280);
+  it("ramps linearly by 5 across the first four packs", () => {
+    // 5 + 10 + 15 + 20
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(0),
+        packs: 4,
+        createdAt,
+      }),
+    ).toEqual(50);
+  });
+
+  it("doubles the price once past the fourth pack", () => {
+    // Fifth pack of the day
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(4),
+        packs: 1,
+        createdAt,
+      }),
+    ).toEqual(40);
+    // Sixth pack of the day
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(5),
+        packs: 1,
+        createdAt,
+      }),
+    ).toEqual(80);
+  });
+
+  it("sums the curve across multiple packs bought together", () => {
+    // Already bought 2 today; buying 3 more -> 15 + 20 + 40
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(2),
+        packs: 3,
+        createdAt,
+      }),
+    ).toEqual(75);
+  });
+
+  it("matches the cumulative cost of buying all ten packs in a day", () => {
+    // 5,10,15,20,40,80,160,320,640,1280 => 2570
+    expect(
+      getReelsPackGemPrice({
+        state: stateWithPacksBought(0),
+        packs: 10,
+        createdAt,
+      }),
+    ).toEqual(2570);
   });
 });

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -73,6 +73,23 @@ export function getRodCost({
   return { rodCost, boostsUsed };
 }
 
+export const REEL_PACK_BASE_PRICE = 5;
+// Packs at the start of each day that ramp linearly before the price doubles
+export const REEL_PACK_LINEAR_COUNT = 4;
+
+/**
+ * Gem price of a single reel pack based on how many were already bought today.
+ * The first 4 packs ramp linearly (5, 10, 15, 20), then the price doubles for
+ * every pack after (40, 80, 160, ...).
+ */
+export function getReelPackPrice(timesBought: number): number {
+  if (timesBought < REEL_PACK_LINEAR_COUNT) {
+    return REEL_PACK_BASE_PRICE * (timesBought + 1);
+  }
+
+  return REEL_PACK_BASE_PRICE * 2 ** (timesBought - 1);
+}
+
 export function getReelsPackGemPrice({
   state,
   packs,
@@ -87,15 +104,12 @@ export function getReelsPackGemPrice({
   const { extraReels = { count: 0 } } = state.fishing;
   const { timesBought = {} } = extraReels;
 
-  const basePrice = 10;
-  const gemMultiplier = 2;
-
   const timesBoughtToday = timesBought[today] ?? 0;
 
   // Sum the cost of each pack at the incremented price scale
   let totalPrice = 0;
   for (let i = 0; i < packs; i++) {
-    totalPrice += basePrice * gemMultiplier ** (timesBoughtToday + i);
+    totalPrice += getReelPackPrice(timesBoughtToday + i);
   }
 
   return totalPrice;

--- a/src/features/game/events/landExpansion/castRod.ts
+++ b/src/features/game/events/landExpansion/castRod.ts
@@ -154,6 +154,7 @@ export function castRod({
       const gemPrice = getReelsPackGemPrice({
         state,
         packs: action.reelPacksToBuy,
+        createdAt,
       });
       const gemsInventory = game.inventory.Gem ?? new Decimal(0);
 


### PR DESCRIPTION
## What

Reworks the gem cost of fishing reel packs (extra daily casts).

The first four reel packs bought each day now ramp **linearly** — 5, 10, 15, 20 Gems — then **double** for every pack after (40, 80, 160, 320…). Previously every pack doubled from a base of 10 (10, 20, 40, 80…), making early extra reels noticeably more expensive.

| Pack # | Old | New |
|---|---|---|
| 1 | 10 | 5 |
| 2 | 20 | 10 |
| 3 | 40 | 15 |
| 4 | 80 | 20 |
| 5 | 160 | 40 |
| 6 | 320 | 80 |
| 7 | 640 | 160 |

## How

- Extracts a pure `getReelPackPrice(timesBought)` curve from `getReelsPackGemPrice`; the aggregator still sums the curve across packs bought together.
- Mirrors the change on the backend (sunflower-land-api PR to follow).
- Updates the existing gem-balance assertions and adds tests for the linear ramp, the double past the fourth pack, and the full daily cumulative (2570 for all 10 packs).

The fisherman UI and i18n need no changes — the displayed price is already fully dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated reel-pack gem pricing to use a new model: linear scaling for the first four purchases, then exponential doubling for additional packs.
  * Pricing now correctly reflects the day of the cast action when calculating pack costs.
* **Tests**
  * Expanded and adjusted unit tests to validate the updated reel-pack pricing curve and multi-pack purchase totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->