### PR TITLE
[FEAT] Renew items (part2 — Weather protection)

### DIFF
--- a/src/features/game/components/RenewCollectible.tsx
+++ b/src/features/game/components/RenewCollectible.tsx
@@ -99,7 +99,7 @@ const RenewCollectibleContent: React.FC<{
           </Label>
           <p className="text-xs">
             {isWeatherItem
-              ? `Renew ${name} to prepare for the next weather event.`
+              ? t("renew.weather.expired.message", { name })
               : t("renew.expired.message", { name })}
           </p>
         </>

--- a/src/features/game/components/RenewCollectible.tsx
+++ b/src/features/game/components/RenewCollectible.tsx
@@ -9,12 +9,17 @@ import { Context } from "../GameProvider";
 import { useSelector } from "@xstate/react";
 import type { MachineState } from "../lib/gameMachine";
 import type { PlaceableLocation } from "../types/collectibles";
-import type { GameState, Inventory } from "../types/game";
-import type { InventoryRenewableCollectibleName } from "../lib/renewableCollectibles";
+import type { GameState, Inventory, InventoryItemName } from "../types/game";
+import {
+  canRenewWeatherCollectible,
+  getWeatherRenewalRequirements,
+  isWeatherProtectionCollectible,
+  type InventoryRenewableCollectibleName,
+} from "../lib/renewableCollectibles";
 import { COLLECTIBLE_BUFF_LABELS } from "../types/collectibleItemBuffs";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import Decimal from "decimal.js-light";
 import { getChestItems } from "features/island/hud/components/inventory/utils/inventory";
-import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 type Props = {
   show: boolean;
@@ -42,6 +47,11 @@ export const RenewCollectible: React.FC<Props> = ({
   };
 
   const handleRemove = () => {
+    if (isWeatherProtectionCollectible(name)) {
+      gameService.send("collectible.removed", { name, location, id });
+      return;
+    }
+
     gameService.send("collectible.burned", { name, location, id });
   };
 
@@ -69,17 +79,30 @@ const RenewCollectibleContent: React.FC<{
 }> = ({ handleRenew, handleRemove, name, inventory, gameState }) => {
   const { t } = useAppTranslation();
   const available = inventory[name] ?? new Decimal(0);
-  const canRenew = available.gte(1);
+  const isWeatherItem = isWeatherProtectionCollectible(name);
+  const weatherRequirements = isWeatherItem
+    ? getWeatherRenewalRequirements({ game: gameState, name })
+    : undefined;
+  const canRenew = isWeatherItem
+    ? canRenewWeatherCollectible({ game: gameState, name })
+    : available.gte(1);
+
   const buffLabels = COLLECTIBLE_BUFF_LABELS[name]?.(gameState);
+  const showShrineLikeDisabledRenewOnly = isWeatherItem && !canRenew;
 
   return (
     <>
       <div className="flex flex-col gap-2 p-1">
-        <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
-          {t("shrine.expired", { name })}
-        </Label>
-
-        <p className="text-xs">{t("renew.expired.message", { name })}</p>
+        <>
+          <Label type="danger" icon={SUNNYSIDE.icons.stopwatch}>
+            {t("shrine.expired", { name })}
+          </Label>
+          <p className="text-xs">
+            {isWeatherItem
+              ? `Renew ${name} to prepare for the next weather event.`
+              : t("renew.expired.message", { name })}
+          </p>
+        </>
 
         {buffLabels && (
           <div className="flex flex-wrap gap-2">
@@ -102,21 +125,53 @@ const RenewCollectibleContent: React.FC<{
         )}
 
         <div className="flex flex-wrap p-2 gap-2">
-          <RequirementLabel
-            type="item"
-            item={name}
-            balance={available}
-            requirement={new Decimal(1)}
-          />
+          {isWeatherItem && weatherRequirements ? (
+            <>
+              {Object.entries(weatherRequirements.resources ?? {}).map(
+                ([itemName, requirement]) => (
+                  <RequirementLabel
+                    key={`${name}-${itemName}`}
+                    type="item"
+                    item={itemName as InventoryItemName}
+                    balance={
+                      gameState.inventory[itemName as InventoryItemName] ??
+                      new Decimal(0)
+                    }
+                    requirement={requirement ?? new Decimal(0)}
+                  />
+                ),
+              )}
+              <RequirementLabel
+                type="coins"
+                balance={gameState.coins}
+                requirement={weatherRequirements.coins ?? 0}
+              />
+            </>
+          ) : (
+            <RequirementLabel
+              type="item"
+              item={name}
+              balance={available}
+              requirement={new Decimal(1)}
+            />
+          )}
         </div>
       </div>
 
-      <div className="flex justify-between gap-1">
-        <Button onClick={handleRemove}>{t("remove")}</Button>
-        <Button onClick={handleRenew} disabled={!canRenew}>
-          {t("renew")}
-        </Button>
-      </div>
+      {showShrineLikeDisabledRenewOnly ? (
+        <div className="flex justify-between gap-1">
+          <Button onClick={handleRenew} disabled>
+            {t("renew")}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex justify-between gap-1">
+          <Button onClick={handleRenew} disabled={!canRenew}>
+            {t("renew")}
+          </Button>
+          <Button onClick={handleRemove}>{t("remove")}</Button>
+        </div>
+      )}
     </>
   );
 };

--- a/src/features/game/events/landExpansion/renewCollectible.test.ts
+++ b/src/features/game/events/landExpansion/renewCollectible.test.ts
@@ -163,4 +163,35 @@ describe("renewCollectible", () => {
       }),
     ).toThrow("Insufficient Coins");
   });
+
+  it("does not renew a weather collectible without enough weather shop ingredients", () => {
+    expect(() =>
+      renewCollectible({
+        state: {
+          ...TEST_FARM,
+          coins: 500,
+          inventory: {
+            Wood: new Decimal(30),
+            Leather: new Decimal(1),
+          },
+          collectibles: {
+            "Tornado Pinwheel": [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                createdAt: now - 1000,
+              },
+            ],
+          },
+        },
+        action: {
+          type: "collectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Insufficient ingredient: Leather");
+  });
 });

--- a/src/features/game/events/landExpansion/renewCollectible.test.ts
+++ b/src/features/game/events/landExpansion/renewCollectible.test.ts
@@ -66,4 +66,101 @@ describe("renewCollectible", () => {
       }),
     ).toThrow("Collectible is still active");
   });
+
+  it("renews a spent weather collectible in place", () => {
+    const state = renewCollectible({
+      state: {
+        ...TEST_FARM,
+        coins: 500,
+        inventory: {
+          Wood: new Decimal(30),
+          Leather: new Decimal(5),
+        },
+        collectibles: {
+          "Tornado Pinwheel": [
+            {
+              id: "1",
+              coordinates: { x: 0, y: 0 },
+              createdAt: now - 1000,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "collectible.renewed",
+        name: "Tornado Pinwheel",
+        location: "farm",
+        id: "1",
+      },
+      createdAt: now,
+    });
+
+    expect(state.inventory.Wood).toEqual(new Decimal(0));
+    expect(state.inventory.Leather).toEqual(new Decimal(0));
+    expect(state.coins).toEqual(400);
+    expect(
+      state.collectibles["Tornado Pinwheel"]?.[0].createdAt,
+    ).toBeUndefined();
+  });
+
+  it("does not renew a weather collectible that has not been spent", () => {
+    expect(() =>
+      renewCollectible({
+        state: {
+          ...TEST_FARM,
+          coins: 500,
+          inventory: {
+            Wood: new Decimal(30),
+            Leather: new Decimal(5),
+          },
+          collectibles: {
+            "Tornado Pinwheel": [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
+        },
+        action: {
+          type: "collectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Collectible is still active");
+  });
+
+  it("does not renew a weather collectible without weather shop resources", () => {
+    expect(() =>
+      renewCollectible({
+        state: {
+          ...TEST_FARM,
+          coins: 50,
+          inventory: {
+            Wood: new Decimal(10),
+            Leather: new Decimal(1),
+          },
+          collectibles: {
+            "Tornado Pinwheel": [
+              {
+                id: "1",
+                coordinates: { x: 0, y: 0 },
+                createdAt: now - 1000,
+              },
+            ],
+          },
+        },
+        action: {
+          type: "collectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Insufficient Coins");
+  });
 });

--- a/src/features/game/events/landExpansion/renewCollectible.ts
+++ b/src/features/game/events/landExpansion/renewCollectible.ts
@@ -4,8 +4,10 @@ import type { CollectibleName } from "features/game/types/craftables";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import {
+  getWeatherRenewalRequirements,
   hasCollectibleExpired,
   isInventoryRenewableCollectible,
+  isWeatherProtectionCollectible,
   type InventoryRenewableCollectibleName,
 } from "features/game/lib/renewableCollectibles";
 import { isPetCollectible } from "./placeCollectible";
@@ -68,6 +70,37 @@ export function renewCollectible({
       throw new Error("Collectible is still active");
     }
 
+    if (isWeatherProtectionCollectible(action.name)) {
+      const requirements = getWeatherRenewalRequirements({
+        game: stateCopy,
+        name: action.name,
+      });
+
+      if (stateCopy.coins < (requirements.coins ?? 0)) {
+        throw new Error("Insufficient Coins");
+      }
+
+      Object.entries(requirements.resources ?? {}).forEach(
+        ([ingredient, amount]) => {
+          const balance =
+            stateCopy.inventory[ingredient as CollectibleName] ??
+            new Decimal(0);
+
+          if (balance.lt(amount)) {
+            throw new Error(`Insufficient ingredient: ${ingredient}`);
+          }
+
+          stateCopy.inventory[ingredient as CollectibleName] =
+            balance.sub(amount);
+        },
+      );
+
+      stateCopy.coins -= requirements.coins ?? 0;
+      delete collectibleToRenew.createdAt;
+
+      return stateCopy;
+    }
+
     const available = stateCopy.inventory[action.name] ?? new Decimal(0);
 
     if (available.lt(1)) {
@@ -75,6 +108,7 @@ export function renewCollectible({
     }
 
     stateCopy.inventory[action.name] = available.sub(1);
+
     collectibleToRenew.createdAt = createdAt;
 
     return stateCopy;

--- a/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
+++ b/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
@@ -10,6 +10,7 @@ import {
   getWeatherShop,
   type WeatherShopItem,
 } from "features/game/types/calendar";
+import { hasUsableWeatherProtectionCollectible } from "features/game/lib/renewableCollectibles";
 import { getKeys } from "lib/object";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -74,7 +75,10 @@ export const WeatherShop: React.FC<Props> = ({ onClose }) => {
 
   const weatherShop = getWeatherShop(island.type);
   const hasCoins = coins >= weatherShop[selected].price;
-  const hasItem = !!inventory[selected];
+  const hasUsableItem = hasUsableWeatherProtectionCollectible({
+    game: state,
+    name: selected,
+  });
 
   const itemIngredients = weatherShop[selected].ingredients(
     state.bumpkin.skills,
@@ -112,7 +116,7 @@ export const WeatherShop: React.FC<Props> = ({ onClose }) => {
                 coins: weatherShop[selected].price,
               }}
               actionView={
-                hasItem ? undefined : (
+                hasUsableItem ? undefined : (
                   <Button
                     disabled={!hasCoins || lessIngredients()}
                     onClick={craft}

--- a/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
+++ b/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
@@ -10,7 +10,10 @@ import {
   getWeatherShop,
   type WeatherShopItem,
 } from "features/game/types/calendar";
-import { hasUsableWeatherProtectionCollectible } from "features/game/lib/renewableCollectibles";
+import {
+  getSpentWeatherProtectionCollectible,
+  hasUsableWeatherProtectionCollectible,
+} from "features/game/lib/renewableCollectibles";
 import { getKeys } from "lib/object";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
@@ -49,8 +52,21 @@ export const WeatherShop: React.FC<Props> = ({ onClose }) => {
 
   const state = useSelector(gameService, _state);
   const { coins, inventory, island } = state;
+  const spentPlacedItem = getSpentWeatherProtectionCollectible({
+    game: state,
+    name: selected,
+  });
 
   const craft = () => {
+    if (spentPlacedItem) {
+      gameService.send("collectible.renewed", {
+        name: selected,
+        location: spentPlacedItem.location,
+        id: spentPlacedItem.id,
+      });
+      return;
+    }
+
     gameService.send("tool.crafted", {
       tool: selected,
     });

--- a/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
+++ b/src/features/game/expansion/components/temperateSeason/WeatherShop.tsx
@@ -137,7 +137,7 @@ export const WeatherShop: React.FC<Props> = ({ onClose }) => {
                     disabled={!hasCoins || lessIngredients()}
                     onClick={craft}
                   >
-                    {t("buy")}
+                    {spentPlacedItem ? t("renew") : t("buy")}
                   </Button>
                 )
               }

--- a/src/features/game/lib/renewableCollectibles.test.ts
+++ b/src/features/game/lib/renewableCollectibles.test.ts
@@ -1,0 +1,15 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import { getWeatherRenewalRequirements } from "./renewableCollectibles";
+
+describe("getWeatherRenewalRequirements", () => {
+  it("throws a controlled error when a weather shop entry is missing", () => {
+    expect(() =>
+      getWeatherRenewalRequirements({
+        game: TEST_FARM,
+        name: "Missing Weather Item" as never,
+      }),
+    ).toThrow(
+      "Missing weather collectible entry for Missing Weather Item on island type basic",
+    );
+  });
+});

--- a/src/features/game/lib/renewableCollectibles.ts
+++ b/src/features/game/lib/renewableCollectibles.ts
@@ -88,6 +88,13 @@ export const getWeatherRenewalRequirements = ({
   name: WeatherProtectionCollectibleName;
 }): WeatherRenewalRequirements => {
   const weatherItem = getWeatherShop(game.island.type)[name as WeatherShopItem];
+
+  if (!weatherItem) {
+    throw new Error(
+      `Missing weather collectible entry for ${name} on island type ${game.island.type}`,
+    );
+  }
+
   return {
     coins: weatherItem.price,
     resources: weatherItem.ingredients(

--- a/src/features/game/lib/renewableCollectibles.ts
+++ b/src/features/game/lib/renewableCollectibles.ts
@@ -5,6 +5,7 @@ import type {
   InventoryItemName,
   PlacedItem,
 } from "features/game/types/game";
+import type { PlaceableLocation } from "features/game/types/collectibles";
 import {
   getWeatherShop,
   type WeatherShopItem,
@@ -134,4 +135,43 @@ export const hasUsableWeatherProtectionCollectible = ({
       !collectible.removedAt &&
       !hasCollectibleExpired({ name, collectible }),
   );
+};
+
+export const getSpentWeatherProtectionCollectible = ({
+  game,
+  name,
+}: {
+  game: GameState;
+  name: WeatherProtectionCollectibleName;
+}): { id: string; location: PlaceableLocation } | undefined => {
+  const locations: Array<{
+    location: PlaceableLocation;
+    collectibles: GameState["collectibles"];
+  }> = [
+    { location: "farm", collectibles: game.collectibles },
+    { location: "home", collectibles: game.home.collectibles },
+    {
+      location: "interior",
+      collectibles: game.interior?.ground.collectibles ?? {},
+    },
+    {
+      location: "level_one",
+      collectibles: game.interior?.level_one?.collectibles ?? {},
+    },
+  ];
+
+  for (const { location, collectibles } of locations) {
+    const match = collectibles[name]?.find(
+      (collectible) =>
+        !!collectible.coordinates &&
+        !collectible.removedAt &&
+        hasCollectibleExpired({ name, collectible }),
+    );
+
+    if (match) {
+      return { id: match.id, location };
+    }
+  }
+
+  return undefined;
 };

--- a/src/features/game/lib/renewableCollectibles.ts
+++ b/src/features/game/lib/renewableCollectibles.ts
@@ -1,6 +1,30 @@
+import Decimal from "decimal.js-light";
 import type { CollectibleName } from "features/game/types/craftables";
-import type { PlacedItem } from "features/game/types/game";
+import type {
+  GameState,
+  InventoryItemName,
+  PlacedItem,
+} from "features/game/types/game";
+import {
+  getWeatherShop,
+  type WeatherShopItem,
+} from "features/game/types/calendar";
 import { EXPIRY_COOLDOWNS } from "./collectibleBuilt";
+
+type WeatherRenewalRequirements = {
+  coins: number;
+  resources: Partial<Record<InventoryItemName, Decimal>>;
+};
+
+export const WEATHER_PROTECTION_COLLECTIBLES = [
+  "Tornado Pinwheel",
+  "Mangrove",
+  "Thermal Stone",
+  "Protective Pesticide",
+] as const;
+
+export type WeatherProtectionCollectibleName =
+  (typeof WEATHER_PROTECTION_COLLECTIBLES)[number];
 
 export const INVENTORY_RENEWABLE_COLLECTIBLES = [
   "Time Warp Totem",
@@ -12,10 +36,18 @@ export const INVENTORY_RENEWABLE_COLLECTIBLES = [
   "Blossom Hourglass",
   "Fisher's Hourglass",
   "Ore Hourglass",
+  ...WEATHER_PROTECTION_COLLECTIBLES,
 ] as const;
 
 export type InventoryRenewableCollectibleName =
   (typeof INVENTORY_RENEWABLE_COLLECTIBLES)[number];
+
+export const isWeatherProtectionCollectible = (
+  name: CollectibleName,
+): name is WeatherProtectionCollectibleName =>
+  WEATHER_PROTECTION_COLLECTIBLES.includes(
+    name as WeatherProtectionCollectibleName,
+  );
 
 export const isInventoryRenewableCollectible = (
   name: CollectibleName,
@@ -33,6 +65,10 @@ export const hasCollectibleExpired = ({
   collectible: PlacedItem;
   now?: number;
 }) => {
+  if (isWeatherProtectionCollectible(name)) {
+    return !!collectible.createdAt;
+  }
+
   const cooldown = EXPIRY_COOLDOWNS[name];
 
   if (!cooldown) {
@@ -40,4 +76,40 @@ export const hasCollectibleExpired = ({
   }
 
   return (collectible.createdAt ?? 0) + cooldown <= now;
+};
+
+export const getWeatherRenewalRequirements = ({
+  game,
+  name,
+}: {
+  game: GameState;
+  name: WeatherProtectionCollectibleName;
+}): WeatherRenewalRequirements => {
+  const weatherItem = getWeatherShop(game.island.type)[name as WeatherShopItem];
+  return {
+    coins: weatherItem.price,
+    resources: weatherItem.ingredients(
+      (game.bumpkin?.skills ?? {}) as never,
+    ) as Partial<Record<InventoryItemName, Decimal>>,
+  };
+};
+
+export const canRenewWeatherCollectible = ({
+  game,
+  name,
+}: {
+  game: GameState;
+  name: WeatherProtectionCollectibleName;
+}) => {
+  const requirements = getWeatherRenewalRequirements({ game, name });
+
+  if (game.coins < requirements.coins) {
+    return false;
+  }
+
+  return Object.entries(requirements.resources).every(([item, amount]) =>
+    (game.inventory[item as InventoryItemName] ?? new Decimal(0)).gte(
+      amount ?? new Decimal(0),
+    ),
+  );
 };

--- a/src/features/game/lib/renewableCollectibles.ts
+++ b/src/features/game/lib/renewableCollectibles.ts
@@ -10,6 +10,7 @@ import {
   type WeatherShopItem,
 } from "features/game/types/calendar";
 import { EXPIRY_COOLDOWNS } from "./collectibleBuilt";
+import { getCollectiblesAcrossLocations } from "./getCollectiblesAcrossLocations";
 
 type WeatherRenewalRequirements = {
   coins: number;
@@ -111,5 +112,26 @@ export const canRenewWeatherCollectible = ({
     (game.inventory[item as InventoryItemName] ?? new Decimal(0)).gte(
       amount ?? new Decimal(0),
     ),
+  );
+};
+
+export const hasUsableWeatherProtectionCollectible = ({
+  game,
+  name,
+}: {
+  game: GameState;
+  name: WeatherProtectionCollectibleName;
+}) => {
+  const inventoryCount = game.inventory[name] ?? new Decimal(0);
+
+  if (inventoryCount.gt(0)) {
+    return true;
+  }
+
+  return getCollectiblesAcrossLocations(game, name).some(
+    (collectible) =>
+      !!collectible.coordinates &&
+      !collectible.removedAt &&
+      !hasCollectibleExpired({ name, collectible }),
   );
 };

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -394,6 +394,7 @@ import { DeepSeaSlug } from "./components/DeepSeaSlug";
 import { CrystalShrimp } from "./components/CrystalShrimp";
 import { BED_FARMHAND_COUNT } from "features/game/types/beds";
 import type { BedName } from "features/game/types/game";
+import { WeatherProtection } from "./components/WeatherProtection";
 
 export const COLLECTIBLE_COMPONENTS: Record<
   CollectibleName | "Bud" | "Pet" | "PetNFT",
@@ -441,6 +442,16 @@ export const COLLECTIBLE_COMPONENTS: Record<
   "Dr Cow": DrCow,
   "Nurse Sheep": NurseSheep,
   "Pink Dolphin": PinkDolphin,
+  "Tornado Pinwheel": (props) => (
+    <WeatherProtection {...props} name="Tornado Pinwheel" />
+  ),
+  Mangrove: (props) => <WeatherProtection {...props} name="Mangrove" />,
+  "Thermal Stone": (props) => (
+    <WeatherProtection {...props} name="Thermal Stone" />
+  ),
+  "Protective Pesticide": (props) => (
+    <WeatherProtection {...props} name="Protective Pesticide" />
+  ),
   Lunalist: Lunalist,
   "Frozen Cow": FrozenCow,
   "Frozen Sheep": FrozenSheep,

--- a/src/features/island/collectibles/components/WeatherProtection.tsx
+++ b/src/features/island/collectibles/components/WeatherProtection.tsx
@@ -1,0 +1,100 @@
+import React, { useContext, useState } from "react";
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import { useVisiting } from "lib/utils/visitUtils";
+import { SFTDetailPopover } from "components/ui/SFTDetailPopover";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { setImageWidth } from "lib/images";
+import type { CollectibleProps } from "../Collectible";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { RenewCollectible } from "features/game/components/RenewCollectible";
+import type { MachineState } from "features/game/lib/gameMachine";
+import {
+  canRenewWeatherCollectible,
+  type WeatherProtectionCollectibleName,
+} from "features/game/lib/renewableCollectibles";
+
+const _gameState = (state: MachineState) => state.context.state;
+
+type Props = CollectibleProps & {
+  name: WeatherProtectionCollectibleName;
+};
+
+export const WeatherProtection: React.FC<Props> = ({
+  name,
+  id,
+  location,
+  createdAt,
+}) => {
+  const { gameService, showAnimations } = useContext(Context);
+  const { isVisiting } = useVisiting();
+  const gameState = useSelector(gameService, _gameState);
+  const [showRenewModal, setShowRenewModal] = useState(false);
+
+  const hasExpired = !!createdAt;
+  const canRenew = canRenewWeatherCollectible({ game: gameState, name });
+
+  if (hasExpired) {
+    return (
+      <>
+        <div onClick={isVisiting ? undefined : () => setShowRenewModal(true)}>
+          <div
+            className="flex justify-center absolute w-full pointer-events-none z-30"
+            style={{
+              top: `${PIXEL_SCALE * -12}px`,
+            }}
+          >
+            <img
+              src={SUNNYSIDE.icons.expression_alerted}
+              className={showAnimations ? "ready" : ""}
+              style={{
+                width: `${PIXEL_SCALE * 4}px`,
+                opacity: canRenew ? 1 : 0.85,
+              }}
+            />
+          </div>
+
+          <img
+            src={ITEM_DETAILS[name].image}
+            className="absolute left-1/2 transform -translate-x-1/2"
+            alt={name}
+            style={{
+              maxWidth: "none",
+              bottom: 0,
+              filter: "grayscale(100%)",
+            }}
+            onLoad={(e) => {
+              setImageWidth(e.currentTarget);
+            }}
+          />
+        </div>
+
+        <RenewCollectible
+          show={showRenewModal}
+          onHide={() => setShowRenewModal(false)}
+          name={name}
+          id={id}
+          location={location}
+        />
+      </>
+    );
+  }
+
+  return (
+    <SFTDetailPopover name={name}>
+      <img
+        src={ITEM_DETAILS[name].image}
+        className="absolute left-1/2 transform -translate-x-1/2"
+        alt={name}
+        style={{
+          maxWidth: "none",
+          bottom: 0,
+        }}
+        onLoad={(e) => {
+          setImageWidth(e.currentTarget);
+        }}
+      />
+    </SFTDetailPopover>
+  );
+};

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -26,6 +26,7 @@
   "confirm.renew": "Confirm Renew",
   "confirm.renew.message": "Are you sure you want to renew {{name}}?",
   "renew.expired.message": "{{name}} has expired. You can renew it to extend its duration.",
+  "renew.weather.expired.message": "Renew {{name}} to prepare for the next weather event.",
   "shrine.expired": "{{name}} Expired",
   "drink": "Drink",
   "eat": "Eat",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -26,6 +26,7 @@
   "confirm.renew": "Confirm Renew",
   "confirm.renew.message": "Are you sure you want to renew {{name}}?",
   "renew.expired.message": "{{name}} has expired. You can renew it to extend its duration.",
+  "renew.weather.expired.message": "Renew {{name}} to prepare for the next weather event.",
   "shrine.expired": "{{name}} Expired",
   "drink": "Drink",
   "eat": "Eat",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -26,7 +26,6 @@
   "confirm.renew": "Confirm Renew",
   "confirm.renew.message": "Are you sure you want to renew {{name}}?",
   "renew.expired.message": "{{name}} has expired. You can renew it to extend its duration.",
-  "renew.weather.expired.message": "Renew {{name}} to prepare for the next weather event.",
   "shrine.expired": "{{name}} Expired",
   "drink": "Drink",
   "eat": "Eat",


### PR DESCRIPTION
## Summary
This PR adds renew-in-place UX for expired weather protection collectibles: `Tornado Pinwheel`, `Mangrove`, `Thermal Stone`, and `Protective Pesticide`. Instead of disappearing into a removal-only flow, expired weather items now stay on the map in a spent state, open a renew modal on click, and can be renewed in place using the same object instance.

## Problem
Shrines, totems, and hourglasses already(almost) support an in-world expired -> renew flow. Weather protection items did not. That made the world state feel inconsistent:
- the player places a weather item on the map,
- the effect gets consumed,
- but the item lifecycle in UI did not mirror the shrine pattern.

We are aligning weather items to the same gameplay communication model:
- active while useful,
- expired in place after use,
- renewable from the same location.

## What changed
### Frontend renew-in-place flow
- Added weather protection collectibles to the renewable collectible model.
- Added a dedicated `WeatherProtection` collectible renderer for map behavior.
- Expired weather items now:
  - remain on the map,
  - render in grayscale,
  - show the alert marker,
  - open a renew modal on click.

### Renew modal behavior
- Weather items reuse the shared renew modal.
- The modal shows the collectible buffs and renewal requirements.
- If resources are insufficient, behavior now matches shrine UX more closely:
  - the player still gets the modal,
  - `Renew` is disabled,
  - the item remains visibly expired in place.

### Renewal pricing source
Weather renewal cost is not hardcoded in the modal.
It is derived from the same weather-shop data the game already uses for purchase pricing:
- `getWeatherShop(game.island.type)`
- island-specific multiplier is preserved automatically
- ingredient + coin requirements come from the current weather-shop config

So this implementation inherits the real purchase price logic, including island-dependent pricing.

<img width="370" height="231" alt="image" src="https://github.com/user-attachments/assets/5be11af3-86bb-444f-8456-c8cea9f6f6be" />

<img width="624" height="253" alt="image" src="https://github.com/user-attachments/assets/8474730d-5df3-489a-b8aa-c9cdea40b40c" />


## Files changed
- `src/features/game/components/RenewCollectible.tsx`
- `src/features/game/events/landExpansion/renewCollectible.ts`
- `src/features/game/events/landExpansion/renewCollectible.test.ts`
- `src/features/game/lib/renewableCollectibles.ts`
- `src/features/island/collectibles/CollectibleCollection.tsx`
- `src/features/island/collectibles/components/WeatherProtection.tsx`



# **this pr wouldnt work and shouldnt merged without backend dependency**
This PR includes the frontend UX and frontend-side event handling, but production correctness still depends on backend exposing/maintaining the weather item lifecycle explicitly.

Discussion notes prepared for backend are summarized here:
- weather protection today is effectively driven by `calendar.<event>.protected`
- frontend does not currently own the authoritative link between a consumed weather event and the placed weather collectible that provided it
- to make renew-in-place fully safe on prod, backend should expose the relation between:
  - the protectable calendar event,
  - the placed weather collectible,
  - and whether that collectible is now expired after being consumed

Minimal backend need:
1. keep returning `calendar.<event>.protected`
2. expose which placed weather collectible provided that protection
3. after the event is consumed, mark that placed collectible as expired instead of leaving frontend to infer it indirectly

[weather-renew-backend-notes.md](https://github.com/user-attachments/files/29013561/weather-renew-backend-notes.md)


Without that contract, frontend has to guess the lifecycle boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added renewal flows for expired renewable collectibles, including a renewal/removal modal with eligibility-based requirements.
  * Weather protection collectibles now renew using skill-based ingredient + coin costs, and the weather shop can renew an already spent weather protection when available.
  * Updated collectible visuals and interactions to surface renewal vs removal and show appropriate indicators.
* **Tests**
  * Added Jest coverage for renewal success and failure cases (active/expired, insufficient coins, insufficient ingredients).
* **Documentation**
  * Added i18n messaging for weather renewal guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->