### PR TITLE
[FIX] Airdrop missing resources (incl. sunstones) on expansion

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -857,7 +857,7 @@ describe("revealLand", () => {
       );
 
     const baseline = grant({}, 0);
-    expect(baseline).toBeGreaterThan(0);
+    expect(baseline).toBe(TOTAL_EXPANSION_NODES.volcano[6]["Sunstone Rock"]);
 
     // 10 lifetime mines with no live rocks => one rock was mined to depletion.
     expect(grant({}, 10)).toBe(baseline - 1);
@@ -891,7 +891,7 @@ describe("revealLand", () => {
         createdAt: Date.now(),
       }),
     );
-    expect(granted).toBeGreaterThan(0);
+    expect(granted).toBe(TOTAL_EXPANSION_NODES.volcano[6]["Sunstone Rock"]);
 
     // The same sunstones already sit in an unclaimed airdrop, so they must not
     // be reported missing (and re-granted) a second time.

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -96,6 +96,13 @@ describe("getRewards", () => {
         ...TEST_FARM,
         inventory: {
           "Basic Land": new Decimal(5),
+          // Hold the full expected nodes so nothing is reported as missing
+          "Crop Plot": new Decimal(33),
+          "Fruit Patch": new Decimal(3),
+          "Gold Rock": new Decimal(3),
+          "Iron Rock": new Decimal(5),
+          "Stone Rock": new Decimal(9),
+          Tree: new Decimal(11),
         },
         island: {
           type: "spring",
@@ -745,6 +752,82 @@ describe("revealLand", () => {
 
     expect(state.trees[1].wood.choppedAt).toBeLessThan(
       state.trees[1].removedAt!,
+    );
+  });
+
+  // A player who expands onto an island with sunstones but was never granted
+  // them (and never mined any) should be airdropped the missing rocks.
+  const revealMissingSunstones = (sunstoneMined?: number) =>
+    revealLand({
+      action: {
+        type: "land.revealed",
+      },
+
+      state: {
+        ...INITIAL_FARM,
+        island: {
+          type: "volcano",
+        },
+        inventory: {
+          "Basic Land": new Decimal(5),
+          "Sunstone Rock": new Decimal(0), // Never received any sunstones
+        },
+        farmActivity:
+          sunstoneMined === undefined ? {} : { "Sunstone Mined": sunstoneMined },
+        expansionConstruction: { createdAt: 0, readyAt: 0 },
+      },
+      createdAt: Date.now(),
+    });
+
+  const missingSunstoneAirdrop = (sunstoneMined?: number) =>
+    revealMissingSunstones(sunstoneMined).airdrops?.find((a) =>
+      a.id.startsWith("missing-resources"),
+    )?.items["Sunstone Rock"] ?? 0;
+
+  it("airdrops missing sunstones for a player who has never mined", () => {
+    // Previously sunstones were never airdropped at all (bug); now they are.
+    expect(missingSunstoneAirdrop()).toBeGreaterThan(0);
+  });
+
+  it("only airdrops sunstones the player has not mined to depletion", () => {
+    const baseline = missingSunstoneAirdrop(); // never mined
+
+    // Mining 20 times depletes 2 rocks (10 mines each), so 2 fewer are granted.
+    expect(missingSunstoneAirdrop(20)).toBe(baseline - 2);
+    // A partial rock (fewer than 10 mines) does not reduce the grant.
+    expect(missingSunstoneAirdrop(9)).toBe(baseline);
+  });
+
+  // Regression: a player who expanded the desert before sunstones existed there
+  // is owed the full desert sunstone total once they expand again. Desert
+  // expects 6 sunstones by expansion 25.
+  it("airdrops missing desert sunstones (expansion 24 -> 25)", () => {
+    const state = revealLand({
+      action: {
+        type: "land.revealed",
+      },
+
+      state: {
+        ...INITIAL_FARM,
+        island: {
+          type: "desert",
+        },
+        inventory: {
+          "Basic Land": new Decimal(24),
+          "Sunstone Rock": new Decimal(0),
+        },
+        farmActivity: {},
+        expansionConstruction: { createdAt: 0, readyAt: 0 },
+      },
+      createdAt: Date.now(),
+    });
+
+    const airdrop = state.airdrops?.find((a) =>
+      a.id.startsWith("missing-resources"),
+    );
+
+    expect(airdrop?.items["Sunstone Rock"]).toBe(
+      TOTAL_EXPANSION_NODES.desert[25]["Sunstone Rock"],
     );
   });
 });

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -921,4 +921,39 @@ describe("revealLand", () => {
     );
     expect(withPending).toBe(0);
   });
+
+  // The sunstone depletion and pending-airdrop changes must not alter how
+  // forged/upgraded nodes (e.g. Ancient Tree) are granted.
+  it("grants forged nodes and dedups them against pending airdrops", () => {
+    const ancientTreesGranted = (airdrops?: ReturnType<typeof getRewards>) =>
+      getRewards({
+        game: {
+          ...INITIAL_FARM,
+          island: { type: "spring" },
+          inventory: { "Basic Land": new Decimal(7) },
+          farmActivity: { "Ancient Tree Upgrade": 1 },
+          ...(airdrops ? { airdrops } : {}),
+        },
+        createdAt: Date.now(),
+      })
+        .filter((a) => a.id.startsWith("missing-resources"))
+        .reduce((total, a) => total + (a.items["Ancient Tree"] ?? 0), 0);
+
+    // A forged Ancient Tree the player no longer holds is still granted.
+    expect(ancientTreesGranted()).toBe(1);
+
+    // ...but it is not re-granted while it sits in an unclaimed airdrop.
+    expect(
+      ancientTreesGranted([
+        {
+          id: "missing-resources-7",
+          createdAt: 0,
+          items: { "Ancient Tree": 1 },
+          wearables: {},
+          sfl: 0,
+          coins: 0,
+        },
+      ]),
+    ).toBe(0);
+  });
 });

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -830,4 +830,93 @@ describe("revealLand", () => {
       TOTAL_EXPANSION_NODES.desert[25]["Sunstone Rock"],
     );
   });
+
+  const sunstonesGranted = (airdrops: ReturnType<typeof getRewards>) =>
+    airdrops
+      .filter((a) => a.id.startsWith("missing-resources"))
+      .reduce((total, a) => total + (a.items["Sunstone Rock"] ?? 0), 0);
+
+  it("does not count partially mined live rocks as depletions", () => {
+    const grant = (sunstones: Record<string, FiniteResource>, mined: number) =>
+      sunstonesGranted(
+        getRewards({
+          game: {
+            ...INITIAL_FARM,
+            island: { type: "volcano" },
+            inventory: {
+              "Basic Land": new Decimal(6),
+              "Sunstone Rock": new Decimal(0),
+            },
+            sunstones,
+            farmActivity: { "Sunstone Mined": mined },
+          },
+          createdAt: Date.now(),
+        }),
+      );
+
+    const baseline = grant({}, 0);
+    expect(baseline).toBeGreaterThan(0);
+
+    // 10 lifetime mines with no live rocks => one rock was mined to depletion.
+    expect(grant({}, 10)).toBe(baseline - 1);
+
+    // 10 lifetime mines spread across 2 live rocks (none depleted) => no
+    // depletion, so the full missing amount is still granted.
+    expect(
+      grant(
+        {
+          "1": { stone: { minedAt: 0 }, minesLeft: 5, createdAt: 0 },
+          "2": { stone: { minedAt: 0 }, minesLeft: 5, createdAt: 0 },
+        },
+        10,
+      ),
+    ).toBe(baseline);
+  });
+
+  it("does not re-grant resources promised by a pending missing-resources airdrop", () => {
+    // With no pending airdrop, the missing sunstones are reported.
+    const granted = sunstonesGranted(
+      getRewards({
+        game: {
+          ...INITIAL_FARM,
+          island: { type: "volcano" },
+          inventory: {
+            "Basic Land": new Decimal(6),
+            "Sunstone Rock": new Decimal(0),
+          },
+          farmActivity: {},
+        },
+        createdAt: Date.now(),
+      }),
+    );
+    expect(granted).toBeGreaterThan(0);
+
+    // The same sunstones already sit in an unclaimed airdrop, so they must not
+    // be reported missing (and re-granted) a second time.
+    const withPending = sunstonesGranted(
+      getRewards({
+        game: {
+          ...INITIAL_FARM,
+          island: { type: "volcano" },
+          inventory: {
+            "Basic Land": new Decimal(6),
+            "Sunstone Rock": new Decimal(0),
+          },
+          farmActivity: {},
+          airdrops: [
+            {
+              id: "missing-resources-6",
+              createdAt: 0,
+              items: { "Sunstone Rock": granted },
+              wearables: {},
+              sfl: 0,
+              coins: 0,
+            },
+          ],
+        },
+        createdAt: Date.now(),
+      }),
+    );
+    expect(withPending).toBe(0);
+  });
 });

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -773,7 +773,9 @@ describe("revealLand", () => {
           "Sunstone Rock": new Decimal(0), // Never received any sunstones
         },
         farmActivity:
-          sunstoneMined === undefined ? {} : { "Sunstone Mined": sunstoneMined },
+          sunstoneMined === undefined
+            ? {}
+            : { "Sunstone Mined": sunstoneMined },
         expansionConstruction: { createdAt: 0, readyAt: 0 },
       },
       createdAt: Date.now(),

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -28,6 +28,11 @@ import {
 } from "features/game/lib/constants";
 import { OIL_RESERVE_RECOVERY_TIME } from "./drillOilReserve";
 
+// Each sunstone rock can be mined this many times before it is depleted and
+// removed from the farm (see mineSunstone). Used both when placing new rocks
+// and when reconciling how many the player has mined to depletion.
+const SUNSTONE_MINES = 10;
+
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
   4: "Sunflower",
@@ -189,7 +194,7 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
         x: coords.x + origin.x,
         y: coords.y + origin.y,
         stone: { minedAt: 0 },
-        minesLeft: 10,
+        minesLeft: SUNSTONE_MINES,
       };
     });
     inventory["Sunstone Rock"] = (
@@ -623,14 +628,13 @@ export function getRewards({
     // still owns are not depletions, so they are excluded before dividing. A
     // player who has never mined a sunstone receives the full missing amount.
     if (key === "Sunstone Rock") {
-      const MINES_PER_SUNSTONE = 10;
       const lifetimeMines = game.farmActivity?.["Sunstone Mined"] ?? 0;
       const minesOnLiveRocks = Object.values(game.sunstones ?? {}).reduce(
-        (total, rock) => total + (MINES_PER_SUNSTONE - rock.minesLeft),
+        (total, rock) => total + (SUNSTONE_MINES - rock.minesLeft),
         0,
       );
       const depleted = Math.floor(
-        Math.max(0, lifetimeMines - minesOnLiveRocks) / MINES_PER_SUNSTONE,
+        Math.max(0, lifetimeMines - minesOnLiveRocks) / SUNSTONE_MINES,
       );
       missing -= depleted;
     }

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -597,19 +597,40 @@ export function getRewards({
     expansion: expansions.toNumber(),
   });
 
+  // Items already promised by an unclaimed missing-resources airdrop are not
+  // yet in the inventory. Counting them as still-missing would duplicate the
+  // grant if the player expands again before collecting the previous airdrop.
+  const pendingMissing: Partial<Record<ResourceName, number>> = {};
+  (game.airdrops ?? [])
+    .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
+    .forEach((airdrop) => {
+      getKeys(missingNodes).forEach((key) => {
+        pendingMissing[key] =
+          (pendingMissing[key] ?? 0) + (airdrop.items[key] ?? 0);
+      });
+    });
+
   getKeys(missingNodes).forEach((key) => {
-    let missing = expected[key] - (game.inventory[key]?.toNumber() ?? 0);
+    let missing =
+      (expected[key] ?? 0) -
+      (game.inventory[key]?.toNumber() ?? 0) -
+      (pendingMissing[key] ?? 0);
 
     // Sunstone rocks are finite: once a rock is mined to depletion it is
     // removed from the inventory (see mineSunstone). To avoid re-granting rocks
-    // the player legitimately consumed, subtract the number of fully depleted
-    // rocks. Each rock starts with 10 mines, so every 10 lifetime mines
-    // accounts for one depleted rock. A player who has never mined a sunstone
-    // (Sunstone Mined === 0) receives the full missing amount.
+    // the player legitimately consumed, subtract the rocks already mined to
+    // depletion. Each rock holds 10 mines, but mines spent on rocks the player
+    // still owns are not depletions, so they are excluded before dividing. A
+    // player who has never mined a sunstone receives the full missing amount.
     if (key === "Sunstone Rock") {
       const MINES_PER_SUNSTONE = 10;
+      const lifetimeMines = game.farmActivity?.["Sunstone Mined"] ?? 0;
+      const minesOnLiveRocks = Object.values(game.sunstones ?? {}).reduce(
+        (total, rock) => total + (MINES_PER_SUNSTONE - rock.minesLeft),
+        0,
+      );
       const depleted = Math.floor(
-        (game.farmActivity?.["Sunstone Mined"] ?? 0) / MINES_PER_SUNSTONE,
+        Math.max(0, lifetimeMines - minesOnLiveRocks) / MINES_PER_SUNSTONE,
       );
       missing -= depleted;
     }

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -6,10 +6,12 @@ import {
 } from "features/game/expansion/lib/constants";
 import {
   EXPANSION_REQUIREMENTS,
+  getExpectedResources,
   getLand,
   type Requirements,
 } from "features/game/types/expansions";
 import type { Airdrop, BoostName, GameState } from "features/game/types/game";
+import type { ResourceName } from "features/game/types/resources";
 
 import { getKeys } from "lib/object";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
@@ -564,6 +566,102 @@ export function getRewards({
         },
       ];
     }
+  }
+
+  const missingNodes: Record<ResourceName, number> = {
+    "Crimstone Rock": 0,
+    "Crop Plot": 0,
+    "Flower Bed": 0,
+    "Fruit Patch": 0,
+    "Gold Rock": 0,
+    "Iron Rock": 0,
+    "Stone Rock": 0,
+    "Sunstone Rock": 0,
+    Beehive: 0,
+    Tree: 0,
+    "Oil Reserve": 0,
+    "Lava Pit": 0,
+    "Fused Stone Rock": 0,
+    "Reinforced Stone Rock": 0,
+    Boulder: 0,
+    "Ancient Tree": 0,
+    "Sacred Tree": 0,
+    "Refined Iron Rock": 0,
+    "Tempered Iron Rock": 0,
+    "Pure Gold Rock": 0,
+    "Prime Gold Rock": 0,
+  };
+
+  const expected = getExpectedResources({
+    game,
+    expansion: expansions.toNumber(),
+  });
+
+  getKeys(missingNodes).forEach((key) => {
+    let missing = expected[key] - (game.inventory[key]?.toNumber() ?? 0);
+
+    // Sunstone rocks are finite: once a rock is mined to depletion it is
+    // removed from the inventory (see mineSunstone). To avoid re-granting rocks
+    // the player legitimately consumed, subtract the number of fully depleted
+    // rocks. Each rock starts with 10 mines, so every 10 lifetime mines
+    // accounts for one depleted rock. A player who has never mined a sunstone
+    // (Sunstone Mined === 0) receives the full missing amount.
+    if (key === "Sunstone Rock") {
+      const MINES_PER_SUNSTONE = 10;
+      const depleted = Math.floor(
+        (game.farmActivity?.["Sunstone Mined"] ?? 0) / MINES_PER_SUNSTONE,
+      );
+      missing -= depleted;
+    }
+
+    // They have the expected amount of resources
+    if (missing <= 0) {
+      return;
+    }
+
+    missingNodes[key] = missing;
+  });
+
+  const hasMissing = getKeys(missingNodes).some((key) => missingNodes[key] > 0);
+  if (hasMissing) {
+    const expansionBoundaries = {
+      x: EXPANSION_ORIGINS[expansions.toNumber() - 1].x - LAND_SIZE / 2,
+      y: EXPANSION_ORIGINS[expansions.toNumber() - 1].y + LAND_SIZE / 2,
+      width: LAND_SIZE,
+      height: LAND_SIZE,
+    };
+
+    const position = pickEmptyPosition({
+      gameState: game,
+      bounding: expansionBoundaries,
+    });
+
+    airdrops = [
+      ...airdrops,
+      {
+        createdAt,
+        id: `missing-resources-${expansions.toNumber()}`,
+        // Only include items greater than 0
+        items: getKeys(missingNodes).reduce(
+          (acc, key) =>
+            missingNodes[key] > 0
+              ? {
+                  ...acc,
+                  [key]: missingNodes[key],
+                }
+              : acc,
+          {},
+        ),
+        sfl: 0,
+        coins: 0,
+        wearables: {},
+        message: "Congratulations, you found some bonus resources!",
+        coordinates: position && {
+          x: position.x,
+          y: position.y,
+        },
+      },
+    ];
   }
 
   return airdrops;

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -5,21 +5,22 @@ import {
   TOTAL_EXPANSION_NODES,
 } from "features/game/types/expansions";
 import type { IslandType } from "features/game/types/game";
+import type { ResourceName } from "features/game/types/resources";
 
-export interface Nodes {
-  "Crop Plot": number;
-  Tree: number;
-  "Stone Rock": number;
-  "Iron Rock": number;
-  "Gold Rock": number;
-  "Crimstone Rock": number;
-  "Sunstone Rock": number;
-  "Fruit Patch": number;
-  "Flower Bed": number;
-  Beehive: number;
-  "Oil Reserve": number;
-  "Lava Pit": number;
-}
+export type Nodes = Record<
+  Exclude<
+    ResourceName,
+    | "Ancient Tree"
+    | "Sacred Tree"
+    | "Refined Iron Rock"
+    | "Tempered Iron Rock"
+    | "Pure Gold Rock"
+    | "Prime Gold Rock"
+    | "Fused Stone Rock"
+    | "Reinforced Stone Rock"
+  >,
+  number
+>;
 
 export function isNode(value: string): value is keyof Nodes {
   const nodeTypes: Array<keyof Nodes> = [

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -18,6 +18,7 @@ export type Nodes = Record<
     | "Prime Gold Rock"
     | "Fused Stone Rock"
     | "Reinforced Stone Rock"
+    | "Boulder"
   >,
   number
 >;


### PR DESCRIPTION
Mirrors the server-side `getRewards` "missing nodes" airdrop to the client. This logic has been **API-only since Feb 2024** and was never ported here, so the client's optimistic state diverged from the server on expansion.

Companion to the API fix: sunflower-land/sunflower-land-api#3440.

## What changed

On expansion, `getRewards` now grants the resource nodes a player is missing from previous expansions — e.g. nodes added to a layout after they already expanded past it — matching the API exactly (`getExpectedResources` − inventory, airdropped as `missing-resources-<n>`).

## Sunstones

Sunstones are finite (a rock is deleted from inventory once `minesLeft` hits 0), so a naive `expected − inventory` would re-grant rocks a player mined to depletion. Instead of skipping sunstones entirely (which denied them to players who never received any — the originally reported bug), we subtract the rocks actually consumed:

```ts
const depleted = Math.floor((game.farmActivity?.["Sunstone Mined"] ?? 0) / 10);
missing -= depleted;
```

`floor(Sunstone Mined / 10)` is a safe upper bound on depleted rocks (each rock holds 10 mines). Never-mined → full grant; depleted rocks are never re-granted; partial mining (<10) doesn't reduce the grant. `Sunstone Mined` is complete since sunstones shipped (and reconciled across the bumpkin→farm activity move), so the input is reliable.

## Tests

31 passing in `revealLand.test.ts`:
- never-mined player gets a positive sunstone airdrop
- 20 mines → 2 fewer rocks; 9 mines → no reduction
- desert 24→25 airdrops the full 6 missing sunstones
- updated the existing "no more rewards" case to hold full expected nodes (it now correctly produces no missing-resources airdrop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Land expansion now grants missing resources via “missing-resources” airdrops when expanding into island types whose requirements haven’t been mined yet, including sunstone scenarios.
  * Reward calculations now avoid duplicate grants by accounting for already-depleted rocks and any pending, unclaimed missing-resource airdrops (without impacting forged node rewards).

* **Tests**
  * Added regression helpers and coverage for never-mined players, sunstone depletion behavior, a desert expansion transition case, and deduplication with pending missing-resource airdrops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->