### PR TITLE
[FEAT] Require Bumpkin level 150 to ascend to swamp island

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1,6 +1,11 @@
 import { INITIAL_FARM, TEST_FARM } from "features/game/lib/constants";
-import { upgrade, getAscensionUpgradeCost } from "./upgradeFarm";
+import {
+  upgrade,
+  getAscensionUpgradeCost,
+  ASCENSION_BUMPKIN_LEVEL,
+} from "./upgradeFarm";
 import Decimal from "decimal.js-light";
+import { LEVEL_EXPERIENCE } from "features/game/lib/level";
 import { getLand, TOTAL_EXPANSION_NODES } from "features/game/types/expansions";
 import { getIslandSpawnPositions } from "features/game/expansion/lib/island";
 
@@ -1101,6 +1106,10 @@ describe("upgradeFarm", () => {
       state: {
         ...INITIAL_FARM,
         coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
         island: {
           type: "volcano",
         },
@@ -1144,6 +1153,37 @@ describe("upgradeFarm", () => {
     expect(Object.keys(state.beehives)).toHaveLength(3);
     expect(Object.keys(state.flowers.flowerBeds)).toHaveLength(3);
     expect(Object.keys(state.lavaPits)).toHaveLength(3);
+  });
+
+  it("requires the minimum Bumpkin level to ascend to swamp island", () => {
+    expect(() =>
+      upgrade({
+        farmId,
+        action: {
+          type: "farm.upgraded",
+        },
+        state: {
+          ...INITIAL_FARM,
+          coins: 10000,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            // One XP short of the required ascension level
+            experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL] - 1,
+          },
+          island: {
+            type: "volcano",
+          },
+          inventory: {
+            ...INITIAL_FARM.inventory,
+            "Basic Land": new Decimal(30),
+            Crimstone: new Decimal(100),
+            Oil: new Decimal(100),
+            Obsidian: new Decimal(10),
+          },
+        },
+        createdAt: Date.now(),
+      }),
+    ).toThrow("Player has not met the level requirements");
   });
 
   it("scales the ascension upgrade cost with level", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -13,6 +13,7 @@ import type {
 } from "features/game/types/game";
 import { ASCENSION_ISLANDS } from "features/game/types/game";
 import { hasFeatureAccess } from "lib/flags";
+import { getBumpkinLevel } from "features/game/lib/level";
 import {
   getTotalBaseResourceEquivalents,
   topUpResourceToMinimum,
@@ -711,6 +712,9 @@ const ASCENSION_UPGRADE_BASE_ITEMS: Partial<Record<InventoryItemName, number>> =
   };
 const ASCENSION_UPGRADE_BASE_COINS = 5000;
 
+/** Minimum Bumpkin level required to ascend into an ascension island (swamp onward). */
+export const ASCENSION_BUMPKIN_LEVEL = 150;
+
 export function getAscensionUpgradeCost(ascensionLevel: number): {
   items: Inventory;
   coins: number;
@@ -1120,6 +1124,14 @@ export function upgrade({ state, createdAt = Date.now(), farmId }: Options) {
 
   if (targetIsAscension && !hasFeatureAccess(game, "SWAMP_ASCENSION")) {
     throw new Error("Swamp ascension is not yet available");
+  }
+
+  // Ascension islands require a minimum Bumpkin level to access.
+  if (
+    targetIsAscension &&
+    getBumpkinLevel(game.bumpkin?.experience ?? 0) < ASCENSION_BUMPKIN_LEVEL
+  ) {
+    throw new Error("Player has not met the level requirements");
   }
 
   const { items, coins } = targetIsAscension

--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -19,7 +19,9 @@ import {
   ISLAND_UPGRADE,
   isLandUpgradable,
   getAscensionUpgradeCost,
+  ASCENSION_BUMPKIN_LEVEL,
 } from "features/game/events/landExpansion/upgradeFarm";
+import { getBumpkinLevel } from "features/game/lib/level";
 import type { CollectibleName } from "features/game/types/craftables";
 import { getKeys } from "lib/object";
 import { createPortal } from "react-dom";
@@ -87,7 +89,7 @@ const IslandUpgraderModal: React.FC<{
 
   const [showConfirmation, setShowConfirmation] = useState(false);
 
-  const { island, inventory, collectibles, home, coins } =
+  const { island, inventory, collectibles, home, coins, bumpkin } =
     gameState.context.state;
   const upgrade = isLandUpgradable(island.type)
     ? ISLAND_UPGRADE[island.type]
@@ -106,6 +108,11 @@ const IslandUpgraderModal: React.FC<{
   const isAscensionUpgrade =
     !!nextIsland &&
     (ASCENSION_ISLANDS as readonly string[]).includes(nextIsland);
+
+  // Ascension islands also require a minimum Bumpkin level.
+  const hasRequiredLevel =
+    !isAscensionUpgrade ||
+    getBumpkinLevel(bumpkin?.experience ?? 0) >= ASCENSION_BUMPKIN_LEVEL;
 
   if (showConfirmation) {
     return (
@@ -232,6 +239,18 @@ const IslandUpgraderModal: React.FC<{
                 </Label>
               )}
 
+              {!hasRequiredLevel && (
+                <Label
+                  icon={SUNNYSIDE.icons.player}
+                  type="danger"
+                  className="whitespace-nowrap"
+                >
+                  {t("islandupgrade.levelRequired", {
+                    level: ASCENSION_BUMPKIN_LEVEL,
+                  })}
+                </Label>
+              )}
+
               {hasUnexpiredItemsPlaced() && (
                 <Label icon={SUNNYSIDE.icons.expression_alerted} type="danger">
                   {t("islandupgrade.tempItemWarning")}
@@ -263,7 +282,12 @@ const IslandUpgraderModal: React.FC<{
         )}
       </div>
       <Button
-        disabled={!hasUpgrade || !hasResources || remainingExpansions > 0}
+        disabled={
+          !hasUpgrade ||
+          !hasResources ||
+          !hasRequiredLevel ||
+          remainingExpansions > 0
+        }
         onClick={() => setShowConfirmation(true)}
       >
         {t("continue")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2802,6 +2802,7 @@
   "islandupgrade.tempItemWarning": "Active totems/hourglasses will be burned",
   "islandupgrade.expansionsRemaining": "{{remaining}} Expansions Remaining",
   "islandupgrade.comingSoon": "Coming soon - {{date}}",
+  "islandupgrade.levelRequired": "Level {{level}} required",
   "islandupgrade.confirmation": "Would you like to upgrade? You will start on a small island with all of your items.",
   "islandupgrade.ascendIsland": "Ascend Island",
   "islandupgrade.ascendIntro": "A greater island awaits. Ascend to unlock exotic resources and a new chapter for your farm.",


### PR DESCRIPTION
## What

Adds a **Bumpkin level 150** requirement to ascend into an ascension island (swamp onward), on top of the existing expansion, resource, coin, and `SWAMP_ASCENSION` feature-flag gates.

## Changes

- **`upgradeFarm.ts`** — exports `ASCENSION_BUMPKIN_LEVEL = 150`; `upgrade()` throws `"Player has not met the level requirements"` when the target is an ascension island and the player is below the required level. Basic-island upgrades are unaffected.
- **`IslandUpgrader.tsx`** — shows a `"Level 150 required"` danger label and disables the Continue button when the level isn't met (`hasRequiredLevel`).
- **i18n** — adds `islandupgrade.levelRequired` to `dictionary.json` (bot propagates locales).
- **Tests** — seeds the existing "upgrades to swamp island" test with a level-150 Bumpkin; adds a test asserting it throws one XP short of level 150.

## Notes

The level gate is a flat constant applied to every ascension upgrade. When ascension levels land, this is intended to become a per-level `getAscensionLevelRequirement(ascensionLevel)`, paralleling `getAscensionUpgradeCost`.

Backend mirror: sunflower-land/sunflower-land-api companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ascension island upgrades (Swamp and beyond) now require players to reach Bumpkin Level 150.
  * Island upgrader interface displays required level information and prevents upgrades when level requirements aren't met.

* **Localization**
  * Added localization support for displaying upgrade level requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->