### PR TITLE
[FEAT] swamp ascension expansion system

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -20,7 +20,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { ResizableBar } from "../ProgressBar";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
-import { expansionRequirements } from "features/game/events/landExpansion/revealLand";
+import { expansionRequirements } from "features/game/events/landExpansion/expandLand";
 import { Button } from "../Button";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useSpeedUpPayment } from "features/game/lib/useSpeedUpPayment";
@@ -36,6 +36,7 @@ import {
   useExpansionCoinCostWithVip,
   useVipAccess,
 } from "lib/utils/hooks/useVipAccess";
+import { hasFeatureAccess } from "lib/flags";
 /**
  * The props for the component.
  * @param gameState The game state.
@@ -228,7 +229,10 @@ export const Expanding: React.FC<{
     readyAt ?? 0,
   );
 
-  const hasAccess = !hasRequiredIslandExpansion(state.island.type, "desert");
+  const hasAccess = !hasRequiredIslandExpansion(
+    state.island.type,
+    hasFeatureAccess(state, "SWAMP_ASCENSION") ? "swamp" : "desert",
+  );
 
   const payment = useSpeedUpPayment({ readyAt, game: state });
   const cost =

--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -252,4 +252,96 @@ describe("expansionRequirements", () => {
       Wood: 1.5,
     });
   });
+
+  it("returns swamp formula requirements for swamp island with ascensionLevel 1", () => {
+    const HOUR = 60 * 60;
+    const { requirements, boostsUsed } = expansionRequirements({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(30),
+        },
+      },
+    });
+
+    // expansion = 30 + 1 = 31, first swamp ascension slot
+    expect(requirements?.resources).toEqual({
+      Crimstone: 30,
+      Oil: 50,
+      Obsidian: 3,
+    });
+    expect(requirements?.coins).toBe(5000);
+    expect(requirements?.seconds).toBe(7 * HOUR);
+    expect(boostsUsed).toHaveLength(0);
+  });
+
+  it("applies Grinx's Hammer halving to swamp resources (not Gem)", () => {
+    const { requirements, boostsUsed } = expansionRequirements({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(30),
+        },
+        collectibles: {
+          "Grinx's Hammer": [
+            {
+              coordinates: { x: 1, y: 1 },
+              createdAt: Date.now(),
+              id: "456",
+              readyAt: Date.now(),
+            },
+          ],
+        },
+      },
+    });
+
+    expect(requirements?.resources).toEqual({
+      Crimstone: 15,
+      Oil: 25,
+      Obsidian: 1.5,
+    });
+    expect(boostsUsed).toEqual([{ name: "Grinx's Hammer", value: "x0.5" }]);
+  });
+
+  it("returns undefined requirements when swamp expansion is beyond range (Basic Land 42)", () => {
+    const { requirements } = expansionRequirements({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(42),
+        },
+      },
+    });
+
+    // expansion = 42 + 1 = 43, outside the 31-42 swamp range → no requirements
+    expect(requirements).toBeUndefined();
+  });
+
+  it("returns swamp requirements at ascensionLevel 2 with scaled costs", () => {
+    const HOUR = 60 * 60;
+    const { requirements } = expansionRequirements({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 2 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(41),
+        },
+      },
+    });
+
+    // expansion 42, ascensionLevel 2: costs × 1.4
+    expect(requirements?.resources).toEqual({
+      Crimstone: 210,
+      Oil: 560,
+      Obsidian: 42,
+    });
+    expect(requirements?.seconds).toBe(84 * HOUR);
+  });
 });

--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -1,5 +1,5 @@
 import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
-import { expandLand } from "./expandLand";
+import { expandLand, expansionRequirements } from "./expandLand";
 import Decimal from "decimal.js-light";
 import { BB_TO_GEM_RATIO } from "features/game/types/game";
 
@@ -68,7 +68,7 @@ describe("expandLand", () => {
     ).toThrow("Upgrade your island to expand further");
   });
 
-  it("does not allow expanding volcano (terminal island) past its max", () => {
+  it("does not allow expanding volcano past its max (must upgrade)", () => {
     expect(() =>
       expandLand({
         action: {
@@ -81,7 +81,7 @@ describe("expandLand", () => {
           inventory: { "Basic Land": new Decimal(30) },
         },
       }),
-    ).toThrow("No more land expansions available");
+    ).toThrow("Upgrade your island to expand further");
   });
 
   it("requires player has sufficient coins", () => {
@@ -220,5 +220,36 @@ describe("expandLand", () => {
     });
 
     expect(state.farmActivity["Coins Spent"]).toBe(1152);
+  });
+});
+
+describe("expansionRequirements", () => {
+  it("returns normal expansion requirements", () => {
+    const { requirements } = expansionRequirements({ game: TEST_FARM });
+
+    expect(requirements?.resources).toEqual({
+      Wood: 3,
+    });
+  });
+  it("returns discounted expansion requirements with Grinx Hammer", () => {
+    const { requirements } = expansionRequirements({
+      game: {
+        ...TEST_FARM,
+        collectibles: {
+          "Grinx's Hammer": [
+            {
+              coordinates: { x: 1, y: 1 },
+              createdAt: Date.now(),
+              id: "123",
+              readyAt: Date.now(),
+            },
+          ],
+        },
+      },
+    });
+
+    expect(requirements?.resources).toEqual({
+      Wood: 1.5,
+    });
   });
 });

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -1,10 +1,15 @@
 import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { getKeys } from "lib/object";
-import type { GameState } from "features/game/types/game";
+import type { BoostName, GameState } from "features/game/types/game";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 
-import { expansionRequirements } from "./revealLand";
+import {
+  getExpansionRequirements,
+  getLand,
+  type Requirements,
+} from "features/game/types/expansions";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import { ISLAND_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequirements";
 import { produce } from "immer";
 import { trackFarmActivity } from "features/game/types/farmActivity";
@@ -26,14 +31,9 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
   return produce(state, (game) => {
     // At an island's expansion cap the player must upgrade to gain more land.
     // Legacy farms already beyond the cap may remain but cannot expand further.
-    // Volcano is the terminal island, so there is nothing to upgrade to.
     const maxExpansion = ISLAND_MAX_EXPANSION[game.island.type];
     if ((game.inventory["Basic Land"]?.toNumber() ?? 0) >= maxExpansion) {
-      throw new Error(
-        game.island.type === "volcano"
-          ? "No more land expansions available"
-          : "Upgrade your island to expand further",
-      );
+      throw new Error("Upgrade your island to expand further");
     }
 
     const bumpkin = game.bumpkin;
@@ -41,6 +41,11 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
     const { requirements, boostsUsed } = expansionRequirements({ game });
     if (!requirements) {
       throw new Error("No more land expansions available");
+    }
+
+    const land = getLand({ game });
+    if (!land) {
+      throw new Error("Land Does Not Exists");
     }
 
     if (game.expansionConstruction) {
@@ -113,3 +118,42 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
     return game;
   });
 }
+
+export const expansionRequirements = ({
+  game,
+}: {
+  game: GameState;
+}): {
+  requirements: Requirements | undefined;
+  boostsUsed: { name: BoostName; value: string }[];
+} => {
+  const level = (game.inventory["Basic Land"]?.toNumber() ?? 0) + 1;
+
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+
+  const requirements = getExpansionRequirements({
+    island: game.island.type,
+    expansion: level,
+    ascensionLevel: game.island.ascensionLevel,
+  });
+
+  if (!requirements) {
+    return { requirements: undefined, boostsUsed };
+  }
+
+  let resources = requirements.resources;
+
+  // Half resource costs
+  if (isCollectibleBuilt({ name: "Grinx's Hammer", game })) {
+    resources = getKeys(resources).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: key === "Gem" ? resources[key] : (resources[key] ?? 0) / 2,
+      }),
+      {},
+    );
+    boostsUsed.push({ name: "Grinx's Hammer", value: "x0.5" });
+  }
+
+  return { requirements: { ...requirements, resources }, boostsUsed };
+};

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -27,6 +27,15 @@ type Options = {
   createdAt?: number;
 };
 
+/**
+ * Initiates a land expansion for the player's game state.
+ *
+ * Validates expansion eligibility, deducts coins and required resources, records the expansion construction timer, and logs analytics events.
+ *
+ * @param createdAt - Timestamp when the expansion starts
+ * @returns The updated game state with the expansion construction in progress
+ * @throws When expansion cannot proceed due to validation failures such as reaching the island expansion cap, insufficient bumpkin level, insufficient resources or coins, or an expansion already in progress
+ */
 export function expandLand({ state, createdAt = Date.now() }: Options) {
   return produce(state, (game) => {
     // At an island's expansion cap the player must upgrade to gain more land.

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -30,11 +30,9 @@ type Options = {
 /**
  * Initiates a land expansion for the player's game state.
  *
- * Validates expansion eligibility, deducts coins and required resources, records the expansion construction timer, and logs analytics events.
- *
  * @param createdAt - Timestamp when the expansion starts
- * @returns The updated game state with the expansion construction in progress
- * @throws When expansion cannot proceed due to validation failures such as reaching the island expansion cap, insufficient bumpkin level, insufficient resources or coins, or an expansion already in progress
+ * @returns The updated game state
+ * @throws When the island expansion cap is reached, no expansions remain available, land is missing, an expansion is already in progress, the bumpkin level is insufficient, coins are insufficient, or any required resource is insufficient
  */
 export function expandLand({ state, createdAt = Date.now() }: Options) {
   return produce(state, (game) => {

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -2,6 +2,8 @@ import Decimal from "decimal.js-light";
 import { getBumpkinLevel } from "features/game/lib/level";
 import { getKeys } from "lib/object";
 import type { BoostName, GameState } from "features/game/types/game";
+import { ASCENSION_ISLANDS } from "features/game/types/game";
+import { hasFeatureAccess } from "lib/flags";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 
 import {
@@ -36,6 +38,16 @@ type Options = {
  */
 export function expandLand({ state, createdAt = Date.now() }: Options) {
   return produce(state, (game) => {
+    // Expanding ascension islands (swamp onward) is gated behind the flag — same
+    // as the upgrade that lands you there. Guards farms that reached an
+    // ascension island while the flag was on if it is later turned off.
+    if (
+      (ASCENSION_ISLANDS as readonly string[]).includes(game.island.type) &&
+      !hasFeatureAccess(game, "SWAMP_ASCENSION")
+    ) {
+      throw new Error("Swamp ascension is not yet available");
+    }
+
     // At an island's expansion cap the player must upgrade to gain more land.
     // Legacy farms already beyond the cap may remain but cannot expand further.
     const maxExpansion = ISLAND_MAX_EXPANSION[game.island.type];

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js-light";
-import { expansionRequirements, getRewards, revealLand } from "./revealLand";
+import { getRewards, revealLand } from "./revealLand";
 import {
   CRIMSTONE_RECOVERY_TIME,
   GOLD_RECOVERY_TIME,
@@ -18,37 +18,6 @@ import {
 import type { Nodes } from "features/game/expansion/lib/expansionNodes";
 import { BB_TO_GEM_RATIO, type FiniteResource } from "features/game/types/game";
 import { OIL_RESERVE_RECOVERY_TIME } from "./drillOilReserve";
-
-describe("expansionRequirements", () => {
-  it("returns normal expansion requirements", () => {
-    const { requirements } = expansionRequirements({ game: TEST_FARM });
-
-    expect(requirements?.resources).toEqual({
-      Wood: 3,
-    });
-  });
-  it("returns discounted expansion requirements with Grinx Hammer", () => {
-    const { requirements } = expansionRequirements({
-      game: {
-        ...TEST_FARM,
-        collectibles: {
-          "Grinx's Hammer": [
-            {
-              coordinates: { x: 1, y: 1 },
-              createdAt: Date.now(),
-              id: "123",
-              readyAt: Date.now(),
-            },
-          ],
-        },
-      },
-    });
-
-    expect(requirements?.resources).toEqual({
-      Wood: 1.5,
-    });
-  });
-});
 
 describe("getRewards", () => {
   it("returns rewards for previously built expansions", () => {

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -55,6 +55,17 @@ type Options = {
   createdAt?: number;
 };
 
+/**
+ * Completes a pending land expansion by populating the game board with entities and computing rewards.
+ *
+ * Establishes all entities from the revealed land layout, updates inventory counts, resets resource recovery timers, and calculates expansion rewards. Repositions the mushroom island if present and adds a Fire Pit building upon the 5th expansion.
+ *
+ * @param state - The current game state
+ * @param createdAt - Timestamp for entity and structure creation; defaults to `Date.now()`
+ * @returns The updated game state with new entities and calculated rewards
+ * @throws When expansion construction is not active
+ * @throws When the land layout cannot be found
+ */
 export function revealLand({ state, createdAt = Date.now() }: Options) {
   return produce(state, (game) => {
     if (!game.expansionConstruction) {
@@ -378,6 +389,12 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
   });
 }
 
+/**
+ * Generates airdrop rewards for expansion milestones and missing resources.
+ *
+ * @param createdAt - The timestamp for the airdrops
+ * @returns An array of airdrops to be granted to the player
+ */
 export function getRewards({
   game,
   createdAt,

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -390,10 +390,16 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
 }
 
 /**
- * Generates airdrop rewards for expansion milestones and missing resources.
+ * Generates airdrops for expansion milestones, refunds for returning players, and missing resource compensation.
  *
- * @param createdAt - The timestamp for the airdrops
- * @returns An array of airdrops to be granted to the player
+ * Grants milestone rewards at specific expansion counts on basic islands. On spring and desert islands,
+ * provides refunds if the player previously expanded further on a different island. Computes and grants
+ * any resources the player is missing based on the current expansion level, accounting for resources
+ * already promised but not yet collected.
+ *
+ * @param game - The game state to evaluate
+ * @param createdAt - The timestamp for created airdrops
+ * @returns An array of airdrops granted by this expansion
  */
 export function getRewards({
   game,

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -8,15 +8,13 @@ import {
   EXPANSION_REQUIREMENTS,
   getExpectedResources,
   getLand,
-  type Requirements,
 } from "features/game/types/expansions";
-import type { Airdrop, BoostName, GameState } from "features/game/types/game";
+import type { Airdrop, GameState } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
 
 import { getKeys } from "lib/object";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
 import { reAnchorToIsland } from "features/game/expansion/lib/island";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
 import type { CropName } from "features/game/types/crops";
 import { produce } from "immer";
 import {
@@ -379,41 +377,6 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
     return game;
   });
 }
-
-export const expansionRequirements = ({
-  game,
-}: {
-  game: GameState;
-}): {
-  requirements: Requirements | undefined;
-  boostsUsed: { name: BoostName; value: string }[];
-} => {
-  const level = (game.inventory["Basic Land"]?.toNumber() ?? 0) + 1;
-
-  const boostsUsed: { name: BoostName; value: string }[] = [];
-
-  const requirements = EXPANSION_REQUIREMENTS[game.island.type][level];
-
-  if (!requirements) {
-    return { requirements: undefined, boostsUsed };
-  }
-
-  let resources = requirements.resources;
-
-  // Half resource costs
-  if (isCollectibleBuilt({ name: "Grinx's Hammer", game })) {
-    resources = getKeys(resources).reduce(
-      (acc, key) => ({
-        ...acc,
-        [key]: key === "Gem" ? resources[key] : (resources[key] ?? 0) / 2,
-      }),
-      {},
-    );
-    boostsUsed.push({ name: "Grinx's Hammer", value: "x0.5" });
-  }
-
-  return { requirements: { ...requirements, resources }, boostsUsed };
-};
 
 export function getRewards({
   game,

--- a/src/features/game/events/landExpansion/speedUpExpansion.test.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.test.ts
@@ -113,6 +113,48 @@ describe("instantExpand", () => {
     ).toThrow("You can't speed up the expansion on this island");
   });
 
+  it("cannot speed up expansion on desert island (SWAMP_ASCENSION=false default)", () => {
+    // When SWAMP_ASCENSION feature flag is off (default in tests), the threshold
+    // is "desert", so desert and islands beyond it (volcano, swamp) are blocked.
+    expect(() =>
+      speedUpExpansion({
+        action: { type: "expansion.spedUp" },
+        state: {
+          ...INITIAL_FARM,
+          island: {
+            ...INITIAL_FARM.island,
+            type: "desert",
+          },
+          expansionConstruction: {
+            createdAt: 0,
+            readyAt: Date.now() + 1000,
+          },
+        },
+      }),
+    ).toThrow("You can't speed up the expansion on this island");
+  });
+
+  it("cannot speed up expansion on volcano island", () => {
+    // Volcano comes after desert in island order, so it is also blocked regardless
+    // of the SWAMP_ASCENSION feature flag state.
+    expect(() =>
+      speedUpExpansion({
+        action: { type: "expansion.spedUp" },
+        state: {
+          ...INITIAL_FARM,
+          island: {
+            ...INITIAL_FARM.island,
+            type: "volcano",
+          },
+          expansionConstruction: {
+            createdAt: 0,
+            readyAt: Date.now() + 1000,
+          },
+        },
+      }),
+    ).toThrow("You can't speed up the expansion on this island");
+  });
+
   describe("Dino Egg Trophy coin payment", () => {
     it("throws when paymentMethod is 'coins' without a placed Dino Egg Trophy", () => {
       expect(() =>

--- a/src/features/game/events/landExpansion/speedUpExpansion.test.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.test.ts
@@ -94,7 +94,7 @@ describe("instantExpand", () => {
 
     expect(state.expansionConstruction?.readyAt).toEqual(now);
   });
-  it("cannot speed up expansion on desert island", () => {
+  it("cannot speed up expansion on swamp island", () => {
     expect(() =>
       speedUpExpansion({
         action: { type: "expansion.spedUp" },
@@ -102,7 +102,7 @@ describe("instantExpand", () => {
           ...INITIAL_FARM,
           island: {
             ...INITIAL_FARM.island,
-            type: "desert",
+            type: "swamp",
           },
           expansionConstruction: {
             createdAt: 0,

--- a/src/features/game/events/landExpansion/speedUpExpansion.test.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.test.ts
@@ -1,6 +1,7 @@
 import { INITIAL_FARM } from "features/game/lib/constants";
 import { speedUpExpansion } from "./speedUpExpansion";
 import Decimal from "decimal.js-light";
+import { CONFIG } from "lib/config";
 
 describe("instantExpand", () => {
   it("requires expansion is in progress", () => {
@@ -113,46 +114,56 @@ describe("instantExpand", () => {
     ).toThrow("You can't speed up the expansion on this island");
   });
 
-  it("cannot speed up expansion on desert island (SWAMP_ASCENSION=false default)", () => {
-    // When SWAMP_ASCENSION feature flag is off (default in tests), the threshold
-    // is "desert", so desert and islands beyond it (volcano, swamp) are blocked.
-    expect(() =>
-      speedUpExpansion({
-        action: { type: "expansion.spedUp" },
-        state: {
-          ...INITIAL_FARM,
-          island: {
-            ...INITIAL_FARM.island,
-            type: "desert",
-          },
-          expansionConstruction: {
-            createdAt: 0,
-            readyAt: Date.now() + 1000,
-          },
-        },
-      }),
-    ).toThrow("You can't speed up the expansion on this island");
-  });
+  describe("when SWAMP_ASCENSION is off (mainnet)", () => {
+    // The flag is on by default in tests (amoy), so force mainnet to exercise
+    // the flag-off threshold ("desert"): desert and every island beyond it
+    // (volcano, swamp) are blocked from speeding up.
+    let previousNetwork: (typeof CONFIG)["NETWORK"];
+    beforeEach(() => {
+      previousNetwork = CONFIG.NETWORK;
+      CONFIG.NETWORK = "mainnet";
+    });
+    afterEach(() => {
+      CONFIG.NETWORK = previousNetwork;
+    });
 
-  it("cannot speed up expansion on volcano island", () => {
-    // Volcano comes after desert in island order, so it is also blocked regardless
-    // of the SWAMP_ASCENSION feature flag state.
-    expect(() =>
-      speedUpExpansion({
-        action: { type: "expansion.spedUp" },
-        state: {
-          ...INITIAL_FARM,
-          island: {
-            ...INITIAL_FARM.island,
-            type: "volcano",
+    it("cannot speed up expansion on desert island", () => {
+      expect(() =>
+        speedUpExpansion({
+          action: { type: "expansion.spedUp" },
+          state: {
+            ...INITIAL_FARM,
+            island: {
+              ...INITIAL_FARM.island,
+              type: "desert",
+            },
+            expansionConstruction: {
+              createdAt: 0,
+              readyAt: Date.now() + 1000,
+            },
           },
-          expansionConstruction: {
-            createdAt: 0,
-            readyAt: Date.now() + 1000,
+        }),
+      ).toThrow("You can't speed up the expansion on this island");
+    });
+
+    it("cannot speed up expansion on volcano island", () => {
+      expect(() =>
+        speedUpExpansion({
+          action: { type: "expansion.spedUp" },
+          state: {
+            ...INITIAL_FARM,
+            island: {
+              ...INITIAL_FARM.island,
+              type: "volcano",
+            },
+            expansionConstruction: {
+              createdAt: 0,
+              readyAt: Date.now() + 1000,
+            },
           },
-        },
-      }),
-    ).toThrow("You can't speed up the expansion on this island");
+        }),
+      ).toThrow("You can't speed up the expansion on this island");
+    });
   });
 
   describe("Dino Egg Trophy coin payment", () => {

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -21,6 +21,16 @@ type Options = {
   createdAt?: number;
 };
 
+/**
+ * Completes an in-progress expansion instantly by paying with gems or coins.
+ *
+ * @param action - Determines the payment method: "coins" to charge coins, or gems by default
+ * @returns The updated game state with the expansion completed
+ * @throws "Expansion not in progress" if no expansion is currently being constructed
+ * @throws "You can't speed up the expansion on this island" if the current island type doesn't support expansion speedup
+ * @throws "Expansion already complete" if the expansion is already done
+ * @throws "Insufficient Gems" if paying with gems and the player doesn't have enough
+ */
 export function speedUpExpansion({
   state,
   action,

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -8,6 +8,7 @@ import {
 } from "features/game/lib/getInstantGems";
 import Decimal from "decimal.js-light";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+import { hasFeatureAccess } from "lib/flags";
 
 export type InstantExpand = {
   type: "expansion.spedUp";
@@ -32,7 +33,12 @@ export function speedUpExpansion({
       throw new Error("Expansion not in progress");
     }
 
-    if (hasRequiredIslandExpansion(game.island.type, "desert")) {
+    if (
+      hasRequiredIslandExpansion(
+        game.island.type,
+        hasFeatureAccess(game, "SWAMP_ASCENSION") ? "swamp" : "desert",
+      )
+    ) {
       throw new Error("You can't speed up the expansion on this island");
     }
 

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -823,6 +823,15 @@ function desertUpgrade(state: GameState) {
   return game;
 }
 
+/**
+ * Upgrades the game state for the volcano island tier.
+ *
+ * Establishes the Mansion as the home structure, ensures minimum starting resources (excluding sunstone bonuses),
+ * and provides a welcome reward airdrop.
+ *
+ * @param state - The game state to upgrade
+ * @returns The updated game state configured for the volcano island
+ */
 function volcanoUpgrade(state: GameState) {
   const game = cloneDeep(state) as GameState;
   // Clear the manor
@@ -878,9 +887,9 @@ function volcanoUpgrade(state: GameState) {
 }
 
 /**
- * Sets up the game state for swamp island by clearing old home structures, adding a mansion, and ensuring minimum starting resources.
+ * Prepares the game state for swamp island by clearing previous home structures, adding a mansion, and ensuring minimum starting resources.
  *
- * @returns The updated game state ready for swamp island.
+ * @returns The updated game state for swamp island.
  */
 function swampUpgrade(state: GameState) {
   const game = cloneDeep(state) as GameState;

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -877,6 +877,11 @@ function volcanoUpgrade(state: GameState) {
   return game;
 }
 
+/**
+ * Sets up the game state for swamp island by clearing old home structures, adding a mansion, and ensuring minimum starting resources.
+ *
+ * @returns The updated game state ready for swamp island.
+ */
 function swampUpgrade(state: GameState) {
   const game = cloneDeep(state) as GameState;
   // Swamp keeps the Mansion from Volcano — clear any older homes defensively
@@ -985,9 +990,11 @@ const ISLAND_SETUP: Record<UpgradeTarget, IslandSetup> = {
 };
 
 /**
- * The island-agnostic part of moving a farm to a new island: wipe the old
- * farm, carry island history (incl. sunstones) forward, and lay out the fresh
- * starting island. The per-island bits are driven by `ISLAND_SETUP[target]`.
+ * Transitions a farm to a new island, establishing a fresh starting configuration.
+ *
+ * Clears the previous farm state, carries forward expansion history and sunstone counts, relocates mushrooms and social farming clutter to the new island's side island, applies target-island-specific setup (home adjustments, resource flooring, airdrops), and initializes all starting land, buildings, and resources. Per-island configurations are determined by `ISLAND_SETUP[target]`.
+ *
+ * @returns The transitioned game state with the new island fully initialized
  */
 function transitionToIsland({
   state,

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -32,7 +32,11 @@ import { placeBeehive } from "./placeBeehive";
 import { placeFlowerBed } from "./placeFlowerBed";
 import { placeLavaPit } from "./placeLavaPit";
 import { removeAll } from "./removeAll";
-import { TOTAL_EXPANSION_NODES } from "features/game/types/expansions";
+import {
+  TOTAL_EXPANSION_NODES,
+  getExpansionNodes,
+} from "features/game/types/expansions";
+import { SWAMP_BASE_EXPANSION } from "features/game/expansion/lib/ascension";
 import { ISLAND_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequirements";
 import { reAnchorToIsland } from "features/game/expansion/lib/island";
 
@@ -889,7 +893,16 @@ function swampUpgrade(state: GameState) {
   // Ensure they have the minimum resources to start the island with
   // Do not give bonus sunstones
   // Account for upgraded resources when checking minimums
-  const minimum = { ...TOTAL_EXPANSION_NODES.swamp[30], "Sunstone Rock": 0 };
+  // Carry-forward floor: base + every prior ascension's grants (ascensionLevel
+  // is already bumped to the level being entered by the time this runs).
+  const minimum = {
+    ...getExpansionNodes({
+      island: "swamp",
+      expansion: SWAMP_BASE_EXPANSION,
+      ascensionLevel: game.island.ascensionLevel,
+    }),
+    "Sunstone Rock": 0,
+  };
 
   getObjectEntries(minimum).forEach(([resource, amount]) => {
     const totalEquivalents = getTotalBaseResourceEquivalents(game, resource);
@@ -1051,9 +1064,11 @@ function transitionToIsland({
     ISLAND_MAX_EXPANSION[game.island.type],
   );
   const sunstonesForExpansion =
-    TOTAL_EXPANSION_NODES[game.island.type][expansionForNodeLookup]?.[
-      "Sunstone Rock"
-    ] ?? 0;
+    getExpansionNodes({
+      island: game.island.type,
+      expansion: expansionForNodeLookup,
+      ascensionLevel: game.island.ascensionLevel,
+    })["Sunstone Rock"] ?? 0;
 
   const maxSunstones = Math.max(
     sunstonesForExpansion,

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -25,7 +25,7 @@ import type {
   Inventory,
   Bumpkin,
 } from "features/game/types/game";
-import { expansionRequirements } from "features/game/events/landExpansion/revealLand";
+import { expansionRequirements } from "features/game/events/landExpansion/expandLand";
 import { translate } from "lib/i18n/translate";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ExpansionRequirements } from "components/ui/layouts/ExpansionRequirements";

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -1,0 +1,214 @@
+import type { Layout } from "features/game/types/expansions";
+import {
+  SWAMP_BASE_NODES,
+  getAscensionExpansionDelta,
+  getAscensionExpansionRequirements,
+  getAscensionLayout,
+  getAscensionNodes,
+} from "./ascension";
+import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
+
+const HOUR = 60 * 60;
+
+describe("swamp expansion requirements", () => {
+  it("expansion 1 of ascension 1 equals the curve start", () => {
+    expect(
+      getAscensionExpansionRequirements({ expansion: 31, ascensionLevel: 1 }),
+    ).toEqual({
+      resources: { Crimstone: 30, Oil: 50, Obsidian: 3 },
+      coins: 5000,
+      seconds: 7 * HOUR,
+      bumpkinLevel: 0,
+    });
+  });
+
+  it("expansion 12 of ascension 1 equals the curve end", () => {
+    expect(
+      getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 1 }),
+    ).toEqual({
+      resources: { Crimstone: 150, Oil: 400, Obsidian: 30 },
+      coins: 75000,
+      seconds: 84 * HOUR,
+      bumpkinLevel: 0,
+    });
+  });
+
+  it("rounds resources to the nearest integer and coins up to the nearest 10", () => {
+    // Expansion 32 (local e=2) of ascension 1. Curve coins = 8099.47 → 8100.
+    const req = getAscensionExpansionRequirements({
+      expansion: 32,
+      ascensionLevel: 1,
+    });
+    expect(req?.resources).toEqual({ Crimstone: 35, Oil: 65, Obsidian: 4 });
+    expect(req?.coins).toBe(8100);
+  });
+
+  it("scales cost by 1.4^(a-1) and keeps time ascension-invariant", () => {
+    expect(
+      getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 2 }),
+    ).toEqual({
+      resources: { Crimstone: 210, Oil: 560, Obsidian: 42 },
+      coins: 105000,
+      seconds: 84 * HOUR,
+      bumpkinLevel: 0,
+    });
+
+    expect(
+      getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 5 }),
+    ).toEqual({
+      resources: { Crimstone: 576, Oil: 1537, Obsidian: 115 },
+      coins: 288120,
+      seconds: 84 * HOUR,
+      bumpkinLevel: 0,
+    });
+  });
+
+  it("returns undefined outside the 31-42 expansion range", () => {
+    expect(
+      getAscensionExpansionRequirements({ expansion: 30, ascensionLevel: 1 }),
+    ).toBeUndefined();
+    expect(
+      getAscensionExpansionRequirements({ expansion: 43, ascensionLevel: 1 }),
+    ).toBeUndefined();
+  });
+});
+
+describe("swamp node drip", () => {
+  it("grants nothing at the base row (E = 0)", () => {
+    expect(
+      getAscensionExpansionDelta({ expansion: 30, ascensionLevel: 1 }),
+    ).toEqual({});
+  });
+
+  it("grants exactly one Lava/Beehive/Flower per ascension, on the final expansion", () => {
+    for (let a = 1; a <= 5; a++) {
+      let lava = 0;
+      let lavaExpansion = 0;
+      for (let expansion = 31; expansion <= 42; expansion++) {
+        const delta = getAscensionExpansionDelta({
+          expansion,
+          ascensionLevel: a,
+        });
+        if (delta["Lava Pit"]) {
+          lava += delta["Lava Pit"];
+          lavaExpansion = expansion;
+        }
+      }
+      expect(lava).toBe(1);
+      // Lava drip is capped at 12, so it only ever lands on the 42nd expansion.
+      expect(lavaExpansion).toBe(42);
+    }
+  });
+
+  it("keeps Sunstone pinned at the base floor (never drips)", () => {
+    expect(
+      getAscensionNodes({ expansion: 42, ascensionLevel: 5 })["Sunstone Rock"],
+    ).toBe(SWAMP_BASE_NODES["Sunstone Rock"]);
+  });
+});
+
+describe("swamp cumulative nodes (carry-forward)", () => {
+  it("row 30 is exactly the base floor", () => {
+    expect(getAscensionNodes({ expansion: 30, ascensionLevel: 1 })).toEqual(
+      SWAMP_BASE_NODES,
+    );
+  });
+
+  it("matches the end-of-ascension totals for a1 and a5", () => {
+    expect(getAscensionNodes({ expansion: 42, ascensionLevel: 1 })).toEqual({
+      "Crop Plot": 71,
+      Tree: 26,
+      "Stone Rock": 23,
+      "Fruit Patch": 19,
+      "Iron Rock": 15,
+      "Gold Rock": 9,
+      "Crimstone Rock": 7,
+      "Oil Reserve": 5,
+      "Lava Pit": 4,
+      Beehive: 4,
+      "Flower Bed": 4,
+      "Sunstone Rock": 13,
+    });
+
+    expect(getAscensionNodes({ expansion: 42, ascensionLevel: 5 })).toEqual({
+      "Crop Plot": 88,
+      Tree: 32,
+      "Stone Rock": 29,
+      "Fruit Patch": 30,
+      "Iron Rock": 21,
+      "Gold Rock": 13,
+      "Crimstone Rock": 15,
+      "Oil Reserve": 9,
+      "Lava Pit": 8,
+      Beehive: 8,
+      "Flower Bed": 8,
+      "Sunstone Rock": 13,
+    });
+  });
+});
+
+describe("swamp layout placement", () => {
+  const FIELD_TO_RESOURCE: Partial<
+    Record<keyof Layout, keyof typeof RESOURCE_DIMENSIONS>
+  > = {
+    plots: "Crop Plot",
+    trees: "Tree",
+    stones: "Stone Rock",
+    iron: "Iron Rock",
+    gold: "Gold Rock",
+    crimstones: "Crimstone Rock",
+    sunstones: "Sunstone Rock",
+    fruitPatches: "Fruit Patch",
+    flowerBeds: "Flower Bed",
+    beehives: "Beehive",
+    oilReserves: "Oil Reserve",
+    lavaPits: "Lava Pit",
+  };
+
+  it("places non-overlapping footprints fully inside the 6x6 block", () => {
+    for (let a = 1; a <= 5; a++) {
+      for (let expansion = 31; expansion <= 42; expansion++) {
+        const layout = getAscensionLayout({ expansion, ascensionLevel: a });
+        const occupied = new Set<string>();
+
+        (Object.keys(FIELD_TO_RESOURCE) as (keyof Layout)[]).forEach(
+          (field) => {
+            const coords = layout[field] as
+              | { x: number; y: number }[]
+              | undefined;
+            const resource = FIELD_TO_RESOURCE[field]!;
+            const { width, height } = RESOURCE_DIMENSIONS[resource];
+            (coords ?? []).forEach(({ x, y }) => {
+              // Footprint stays inside the local [-3, 3] x [-3, 3] block.
+              expect(x).toBeGreaterThanOrEqual(-3);
+              expect(x + width).toBeLessThanOrEqual(3);
+              expect(y).toBeLessThanOrEqual(3);
+              expect(y - height).toBeGreaterThanOrEqual(-3);
+
+              for (let i = 0; i < width; i++) {
+                for (let j = 0; j < height; j++) {
+                  const key = `${x + i},${y - j}`;
+                  expect(occupied.has(key)).toBe(false);
+                  occupied.add(key);
+                }
+              }
+            });
+          },
+        );
+      }
+    }
+  });
+
+  it("places exactly the dripped node counts", () => {
+    const layout = getAscensionLayout({ expansion: 42, ascensionLevel: 1 });
+    // E = 12: Crop, Tree, Stone, Fruit, Iron, Lava.
+    expect(layout.plots).toHaveLength(1);
+    expect(layout.trees).toHaveLength(1);
+    expect(layout.stones).toHaveLength(1);
+    expect(layout.fruitPatches).toHaveLength(1);
+    expect(layout.iron).toHaveLength(1);
+    expect(layout.lavaPits).toHaveLength(1);
+    expect(layout.gold).toHaveLength(0);
+    expect(layout.beehives).toHaveLength(0);
+  });
+});

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -80,23 +80,23 @@ describe("swamp node drip", () => {
     ).toEqual({});
   });
 
-  it("grants exactly one Lava/Beehive/Flower per ascension, on the final expansion", () => {
+  it("grants exactly one Lava/Beehive/Flower per ascension", () => {
     for (let a = 1; a <= 5; a++) {
-      let lava = 0;
-      let lavaExpansion = 0;
+      const totals: Partial<Record<string, number>> = {};
       for (let expansion = 31; expansion <= 42; expansion++) {
         const delta = getAscensionExpansionDelta({
           expansion,
           ascensionLevel: a,
         });
-        if (delta["Lava Pit"]) {
-          lava += delta["Lava Pit"];
-          lavaExpansion = expansion;
+        for (const [node, count] of Object.entries(delta)) {
+          totals[node] = (totals[node] ?? 0) + (count ?? 0);
         }
       }
-      expect(lava).toBe(1);
-      // Lava drip is capped at 12, so it only ever lands on the 42nd expansion.
-      expect(lavaExpansion).toBe(42);
+      // The cap-12 nodes are granted exactly once per ascension — now spread
+      // evenly rather than pinned to the final expansion.
+      expect(totals["Lava Pit"]).toBe(1);
+      expect(totals["Beehive"]).toBe(1);
+      expect(totals["Flower Bed"]).toBe(1);
     }
   });
 
@@ -199,16 +199,43 @@ describe("swamp layout placement", () => {
     }
   });
 
-  it("places exactly the dripped node counts", () => {
-    const layout = getAscensionLayout({ expansion: 42, ascensionLevel: 1 });
-    // E = 12: Crop, Tree, Stone, Fruit, Iron, Lava.
-    expect(layout.plots).toHaveLength(1);
-    expect(layout.trees).toHaveLength(1);
-    expect(layout.stones).toHaveLength(1);
-    expect(layout.fruitPatches).toHaveLength(1);
-    expect(layout.iron).toHaveLength(1);
-    expect(layout.lavaPits).toHaveLength(1);
-    expect(layout.gold).toHaveLength(0);
-    expect(layout.beehives).toHaveLength(0);
+  it("spreads nodes evenly — no empty expansion, totals preserved", () => {
+    for (let a = 1; a <= 5; a++) {
+      const startOfAscension = getAscensionNodes({
+        expansion: 30,
+        ascensionLevel: a,
+      });
+      const endOfAscension = getAscensionNodes({
+        expansion: 42,
+        ascensionLevel: a,
+      });
+      const dealt: Partial<Record<string, number>> = {};
+
+      for (let expansion = 31; expansion <= 42; expansion++) {
+        const delta = getAscensionExpansionDelta({
+          expansion,
+          ascensionLevel: a,
+        });
+        const count = Object.values(delta).reduce(
+          (sum, n) => sum + (n ?? 0),
+          0,
+        );
+        // No expansion is empty — nodes are dealt across all 12, not piled on 42.
+        expect(count).toBeGreaterThan(0);
+        for (const [node, n] of Object.entries(delta)) {
+          dealt[node] = (dealt[node] ?? 0) + (n ?? 0);
+        }
+      }
+
+      // Per-type totals are unchanged: the dealt counts equal the ascension's
+      // end-of-ascension floor minus its starting floor.
+      for (const node of Object.keys(
+        endOfAscension,
+      ) as (keyof typeof endOfAscension)[]) {
+        expect(dealt[node] ?? 0).toBe(
+          (endOfAscension[node] ?? 0) - (startOfAscension[node] ?? 0),
+        );
+      }
+    }
   });
 });

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -135,20 +135,6 @@ const PLACEMENT_ORDER: (keyof Nodes)[] = [
 const localExpansionIndex = (expansion: number): number =>
   expansion - SWAMP_BASE_EXPANSION;
 
-/**
- * Global, monotonic expansion counter across every ascension:
- *   E = (BasicLandCount - 30) + (ascensionLevel - 1) × 12
- * `expansion` is the *post-increment* Basic Land count (31…42), so arrival
- * (count 30) maps to E = 0 — which is deliberately never evaluated for drips
- * (0 % anything === 0 would grant one of everything).
- */
-export const getAscensionGlobalExpansion = (
-  expansion: number,
-  ascensionLevel: number,
-): number =>
-  localExpansionIndex(expansion) +
-  (ascensionLevel - 1) * SWAMP_EXPANSIONS_PER_ASCENSION;
-
 /** Effective drip for a node type at a given ascension (widened, then capped). */
 export const getAscensionNodeDrip = (
   node: keyof Nodes,
@@ -163,9 +149,78 @@ export const getAscensionNodeDrip = (
 };
 
 /**
- * Nodes granted by a single swamp expansion. Each type drops at most one node
- * (the modulo check is binary). Returns `{}` for anything that is not a real
- * swamp expansion (Basic Land outside 31…42), so the E = 0 base row stays clean.
+ * Total nodes of a type granted over one ascension's 12 expansions — the count
+ * of multiples of the effective drip in the ascension's global window. This is
+ * the unchanged "node formula": it equals the old sum of `globalE % drip === 0`.
+ */
+const getAscensionNodeTotal = (
+  node: keyof Nodes,
+  ascensionLevel: number,
+): number => {
+  const drip = getAscensionNodeDrip(node, ascensionLevel);
+  if (drip <= 0) return 0;
+  const span = SWAMP_EXPANSIONS_PER_ASCENSION;
+  return (
+    Math.floor((ascensionLevel * span) / drip) -
+    Math.floor(((ascensionLevel - 1) * span) / drip)
+  );
+};
+
+/** (√5 − 1) / 2 — a per-type phase that decorrelates equal-count nodes. */
+const GOLDEN_RATIO = 0.6180339887498949;
+
+/**
+ * Deals each ascension's dripped nodes *evenly* across its 12 expansions, so no
+ * expansion is empty and none is overloaded — instead of the old `E % drip`
+ * placement that piled the cap-12 nodes (Lava/Beehive/Flower) onto expansion 42.
+ *
+ * Per-type totals are exactly `getAscensionNodeTotal` (the node formula is
+ * unchanged); only *which* expansion each node lands on changes. Returns one
+ * delta per local expansion (index 0 = Basic Land 31). Deterministic — pure
+ * arithmetic plus a stable sort with an explicit tie-break — so FE and BE agree.
+ */
+const getAscensionSchedule = (
+  ascensionLevel: number,
+): Partial<Record<keyof Nodes, number>>[] => {
+  const span = SWAMP_EXPANSIONS_PER_ASCENSION;
+
+  // Spread each type's instances evenly in [0, 1); the golden-ratio per-type
+  // phase keeps equal-count types from landing on the same slots. Flower Bed is
+  // not dealt on its own — it rides along with Beehive so the two always unlock
+  // in the same expansion (they share a drip rate, so their counts always match).
+  const items: { pos: number; node: keyof Nodes; tie: number }[] = [];
+  getKeys(SWAMP_NODE_DRIP).forEach((node, t) => {
+    if (node === "Flower Bed") return;
+    const count = getAscensionNodeTotal(node, ascensionLevel);
+    const phase = (t * GOLDEN_RATIO) % 1;
+    for (let i = 0; i < count; i++) {
+      items.push({ pos: (i + phase) / count, node, tie: t });
+    }
+  });
+
+  items.sort((a, b) => a.pos - b.pos || a.tie - b.tie);
+
+  // Deal by rank: each expansion gets floor(N/span)…ceil(N/span) nodes.
+  const schedule: Partial<Record<keyof Nodes, number>>[] = Array.from(
+    { length: span },
+    () => ({}),
+  );
+  items.forEach((item, k) => {
+    const slot = Math.floor((k * span) / items.length); // 0…span-1
+    schedule[slot][item.node] = (schedule[slot][item.node] ?? 0) + 1;
+    // Beehive and Flower Bed unlock together as a pair.
+    if (item.node === "Beehive") {
+      schedule[slot]["Flower Bed"] = (schedule[slot]["Flower Bed"] ?? 0) + 1;
+    }
+  });
+
+  return schedule;
+};
+
+/**
+ * Nodes granted by a single swamp expansion — the evenly-dealt schedule slot.
+ * Returns `{}` for anything that is not a real swamp expansion (Basic Land
+ * outside 31…42), so the E = 0 base row stays clean.
  */
 export const getAscensionExpansionDelta = ({
   expansion,
@@ -176,18 +231,7 @@ export const getAscensionExpansionDelta = ({
 }): Partial<Record<keyof Nodes, number>> => {
   const e = localExpansionIndex(expansion);
   if (e < 1 || e > SWAMP_EXPANSIONS_PER_ASCENSION) return {};
-
-  const globalE = getAscensionGlobalExpansion(expansion, ascensionLevel);
-  const delta: Partial<Record<keyof Nodes, number>> = {};
-
-  getKeys(SWAMP_NODE_DRIP).forEach((node) => {
-    const drip = getAscensionNodeDrip(node, ascensionLevel);
-    if (drip > 0 && globalE % drip === 0) {
-      delta[node] = 1;
-    }
-  });
-
-  return delta;
+  return getAscensionSchedule(ascensionLevel)[e - 1];
 };
 
 const addDelta = (
@@ -217,21 +261,17 @@ export const getAscensionNodes = ({
 
   // Every prior ascension contributes its full 12 expansions.
   for (let prior = 1; prior < ascensionLevel; prior++) {
-    for (let c = SWAMP_FIRST_EXPANSION; c <= SWAMP_LAST_EXPANSION; c++) {
-      addDelta(
-        nodes,
-        getAscensionExpansionDelta({ expansion: c, ascensionLevel: prior }),
-      );
-    }
+    getAscensionSchedule(prior).forEach((delta) => addDelta(nodes, delta));
   }
 
-  // The current ascension up to the requested expansion.
-  const cap = Math.min(expansion, SWAMP_LAST_EXPANSION);
-  for (let c = SWAMP_FIRST_EXPANSION; c <= cap; c++) {
-    addDelta(
-      nodes,
-      getAscensionExpansionDelta({ expansion: c, ascensionLevel }),
-    );
+  // The current ascension up to (and including) the requested expansion.
+  const cap = Math.min(
+    localExpansionIndex(expansion),
+    SWAMP_EXPANSIONS_PER_ASCENSION,
+  );
+  const schedule = getAscensionSchedule(ascensionLevel);
+  for (let e = 1; e <= cap; e++) {
+    addDelta(nodes, schedule[e - 1]);
   }
 
   return nodes;

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -170,16 +170,18 @@ const getAscensionNodeTotal = (
 const GOLDEN_RATIO = 0.6180339887498949;
 
 /**
- * Deals each ascension's dripped nodes *evenly* across its 12 expansions, so no
- * expansion is empty and none is overloaded — instead of the old `E % drip`
- * placement that piled the cap-12 nodes (Lava/Beehive/Flower) onto expansion 42.
+ * Deals each ascension's dripped nodes *evenly* across its 12 expansions: each
+ * expansion gets ⌊N/12⌋…⌈N/12⌉ of the ascension's N nodes — never overloaded, and
+ * never empty while N ≥ 12 (which holds across the live ascension range, a ≤ 5).
+ * This replaces the old `E % drip` placement that piled the cap-12 nodes
+ * (Lava/Beehive/Flower) onto expansion 42.
  *
  * Per-type totals are exactly `getAscensionNodeTotal` (the node formula is
  * unchanged); only *which* expansion each node lands on changes. Returns one
  * delta per local expansion (index 0 = Basic Land 31). Deterministic — pure
  * arithmetic plus a stable sort with an explicit tie-break — so FE and BE agree.
  */
-const getAscensionSchedule = (
+const buildAscensionSchedule = (
   ascensionLevel: number,
 ): Partial<Record<keyof Nodes, number>>[] => {
   const span = SWAMP_EXPANSIONS_PER_ASCENSION;
@@ -214,6 +216,24 @@ const getAscensionSchedule = (
     }
   });
 
+  return schedule;
+};
+
+/**
+ * Memoized `buildAscensionSchedule` — the schedule is pure and keyed only by
+ * ascension level, but `getAscensionNodes` rebuilds it once per prior ascension.
+ * Callers only read the returned deltas, so sharing cached references is safe.
+ */
+const scheduleCache = new Map<number, Partial<Record<keyof Nodes, number>>[]>();
+
+const getAscensionSchedule = (
+  ascensionLevel: number,
+): Partial<Record<keyof Nodes, number>>[] => {
+  const cached = scheduleCache.get(ascensionLevel);
+  if (cached) return cached;
+
+  const schedule = buildAscensionSchedule(ascensionLevel);
+  scheduleCache.set(ascensionLevel, schedule);
   return schedule;
 };
 
@@ -364,7 +384,7 @@ export const getAscensionLayout = ({
   ascensionLevel: number;
 }): Layout => {
   const layout: Layout = {
-    id: `swamp_${expansion}`,
+    id: `swamp_${ascensionLevel}_${expansion}`,
     plots: [],
     trees: [],
     stones: [],

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -1,0 +1,392 @@
+import Decimal from "decimal.js-light";
+import type { Layout, Requirements } from "features/game/types/expansions";
+import type { Nodes } from "features/game/expansion/lib/expansionNodes";
+import type { Coordinates } from "features/game/expansion/components/MapPlacement";
+
+import {
+  RESOURCE_DIMENSIONS,
+  type ResourceName,
+} from "features/game/types/resources";
+import { getKeys } from "lib/object";
+
+/**
+ * Swamp is the first "ascension" island. Unlike the linear islands (basic →
+ * volcano) whose expansion costs, durations and layouts are hand-authored
+ * tables, swamp is fully formula-driven and parameterised by the player's
+ * ascension level (`game.island.ascensionLevel`, 1-indexed). Re-ascending wipes
+ * the farm back to the base floor and bumps the level, so the same 12 physical
+ * expansions (Basic Land 31→42) are replayed with steeper costs and sparser
+ * node grants each time.
+ *
+ * Everything here is pure (driven by `expansion` + `ascensionLevel`) so it can
+ * be unit-tested and mirrors the BE (`domain/land/expansions/ascension.ts`) 1:1.
+ */
+
+/** Basic Land count a player arrives on swamp with (set by `upgradeFarm`). */
+export const SWAMP_BASE_EXPANSION = 30;
+/** Number of expansions available per ascension (Basic Land 31…42). */
+export const SWAMP_EXPANSIONS_PER_ASCENSION = 12;
+/** First / last Basic Land count that is a real swamp expansion. */
+const SWAMP_FIRST_EXPANSION = SWAMP_BASE_EXPANSION + 1; // 31
+const SWAMP_LAST_EXPANSION =
+  SWAMP_BASE_EXPANSION + SWAMP_EXPANSIONS_PER_ASCENSION; // 42
+
+/** Per-ascension cost multiplier — `cost = floor(base × 1.4^(a-1))`. */
+const COST_GROWTH = 1.4;
+/** Shape of the within-island cost curve across the 12 expansions. */
+const COST_CURVE_EXPONENT = 1.3;
+/** Drip widens by this fraction per ascension, then is capped at 12. */
+const DRIP_WIDEN_PER_ASCENSION = 0.25;
+const DRIP_CAP = SWAMP_EXPANSIONS_PER_ASCENSION; // 12
+/** Each expansion's build time grows linearly: `e × 7h`. */
+const HOURS_PER_EXPANSION = 7;
+
+/**
+ * Bumpkin level required to expand on swamp. Stubbed at 0 (no gate) until the
+ * XP/level progression lands; wire the real per-expansion requirement then.
+ */
+// TODO: replace with the real level gate once swamp XP levels ship.
+const SWAMP_EXPANSION_BUMPKIN_LEVEL = 0;
+
+/**
+ * Expected resource totals when a player first lands on swamp (Basic Land 30).
+ * A curated floor, not derivable from layouts. Higher rows are this plus the
+ * dripped nodes. Single source of truth — `expansions.ts` imports it from here.
+ */
+export const SWAMP_BASE_NODES: Nodes = {
+  "Crop Plot": 65,
+  Tree: 23,
+  "Stone Rock": 20,
+  "Iron Rock": 13,
+  "Gold Rock": 8,
+  "Fruit Patch": 15,
+  "Crimstone Rock": 5,
+  "Sunstone Rock": 13,
+  "Oil Reserve": 4,
+  "Lava Pit": 3,
+  Beehive: 3,
+  "Flower Bed": 3,
+};
+
+/** `{ start, end }` of the cost curve for each charged resource + coins. */
+const SWAMP_COST_CURVE = {
+  Crimstone: { start: 30, end: 150 },
+  Oil: { start: 50, end: 400 },
+  Obsidian: { start: 3, end: 30 },
+} as const;
+const SWAMP_COIN_CURVE = { start: 5000, end: 75000 };
+
+/**
+ * Base drip rate per node type: how many expansions are needed before another
+ * node of that type is granted (a node drops when `globalE % drip === 0`).
+ * Sunstone has no drip — it stays pinned at the base floor forever.
+ */
+const SWAMP_NODE_DRIP: Record<keyof Nodes, number> = {
+  "Crop Plot": 2,
+  Tree: 4,
+  "Stone Rock": 4,
+  "Fruit Patch": 3,
+  "Iron Rock": 6,
+  "Gold Rock": 8,
+  "Crimstone Rock": 5,
+  "Oil Reserve": 8,
+  "Lava Pit": 12,
+  Beehive: 10,
+  "Flower Bed": 10,
+  "Sunstone Rock": 0,
+};
+
+/** Maps each node type to the `Layout` array it is placed into. */
+const NODE_TO_LAYOUT_FIELD: Record<keyof Nodes, keyof Layout> = {
+  "Crop Plot": "plots",
+  Tree: "trees",
+  "Stone Rock": "stones",
+  "Iron Rock": "iron",
+  "Gold Rock": "gold",
+  "Crimstone Rock": "crimstones",
+  "Sunstone Rock": "sunstones",
+  "Fruit Patch": "fruitPatches",
+  "Flower Bed": "flowerBeds",
+  Beehive: "beehives",
+  "Oil Reserve": "oilReserves",
+  "Lava Pit": "lavaPits",
+};
+
+/**
+ * Order nodes are placed in. Larger footprints first so they claim space before
+ * the 1×1 fillers, which keeps the deterministic first-fit packing tight.
+ */
+const PLACEMENT_ORDER: (keyof Nodes)[] = [
+  "Tree",
+  "Fruit Patch",
+  "Crimstone Rock",
+  "Oil Reserve",
+  "Lava Pit",
+  "Sunstone Rock",
+  "Flower Bed",
+  "Crop Plot",
+  "Stone Rock",
+  "Iron Rock",
+  "Gold Rock",
+  "Beehive",
+];
+
+/** Local index 1…12 of a swamp expansion (Basic Land 31→1 … 42→12). */
+const localExpansionIndex = (expansion: number): number =>
+  expansion - SWAMP_BASE_EXPANSION;
+
+/**
+ * Global, monotonic expansion counter across every ascension:
+ *   E = (BasicLandCount - 30) + (ascensionLevel - 1) × 12
+ * `expansion` is the *post-increment* Basic Land count (31…42), so arrival
+ * (count 30) maps to E = 0 — which is deliberately never evaluated for drips
+ * (0 % anything === 0 would grant one of everything).
+ */
+export const getAscensionGlobalExpansion = (
+  expansion: number,
+  ascensionLevel: number,
+): number =>
+  localExpansionIndex(expansion) +
+  (ascensionLevel - 1) * SWAMP_EXPANSIONS_PER_ASCENSION;
+
+/** Effective drip for a node type at a given ascension (widened, then capped). */
+export const getAscensionNodeDrip = (
+  node: keyof Nodes,
+  ascensionLevel: number,
+): number => {
+  const base = SWAMP_NODE_DRIP[node];
+  if (base <= 0) return 0;
+  const widened = Math.floor(
+    base * (1 + DRIP_WIDEN_PER_ASCENSION * (ascensionLevel - 1)),
+  );
+  return Math.min(widened, DRIP_CAP);
+};
+
+/**
+ * Nodes granted by a single swamp expansion. Each type drops at most one node
+ * (the modulo check is binary). Returns `{}` for anything that is not a real
+ * swamp expansion (Basic Land outside 31…42), so the E = 0 base row stays clean.
+ */
+export const getAscensionExpansionDelta = ({
+  expansion,
+  ascensionLevel,
+}: {
+  expansion: number;
+  ascensionLevel: number;
+}): Partial<Record<keyof Nodes, number>> => {
+  const e = localExpansionIndex(expansion);
+  if (e < 1 || e > SWAMP_EXPANSIONS_PER_ASCENSION) return {};
+
+  const globalE = getAscensionGlobalExpansion(expansion, ascensionLevel);
+  const delta: Partial<Record<keyof Nodes, number>> = {};
+
+  getKeys(SWAMP_NODE_DRIP).forEach((node) => {
+    const drip = getAscensionNodeDrip(node, ascensionLevel);
+    if (drip > 0 && globalE % drip === 0) {
+      delta[node] = 1;
+    }
+  });
+
+  return delta;
+};
+
+const addDelta = (
+  acc: Nodes,
+  delta: Partial<Record<keyof Nodes, number>>,
+): void => {
+  getKeys(delta).forEach((node) => {
+    acc[node] = (acc[node] ?? 0) + (delta[node] ?? 0);
+  });
+};
+
+/**
+ * Cumulative expected resource totals at a given swamp expansion + ascension.
+ * Carries forward: base floor + every prior ascension's full 12-expansion drip
+ * + the current ascension up to (and including) `expansion`. This matches the
+ * wipe-and-top-up-to-base behaviour in `swampUpgrade`, where re-ascending keeps
+ * the nodes already earned.
+ */
+export const getAscensionNodes = ({
+  expansion,
+  ascensionLevel,
+}: {
+  expansion: number;
+  ascensionLevel: number;
+}): Nodes => {
+  const nodes: Nodes = { ...SWAMP_BASE_NODES };
+
+  // Every prior ascension contributes its full 12 expansions.
+  for (let prior = 1; prior < ascensionLevel; prior++) {
+    for (let c = SWAMP_FIRST_EXPANSION; c <= SWAMP_LAST_EXPANSION; c++) {
+      addDelta(
+        nodes,
+        getAscensionExpansionDelta({ expansion: c, ascensionLevel: prior }),
+      );
+    }
+  }
+
+  // The current ascension up to the requested expansion.
+  const cap = Math.min(expansion, SWAMP_LAST_EXPANSION);
+  for (let c = SWAMP_FIRST_EXPANSION; c <= cap; c++) {
+    addDelta(
+      nodes,
+      getAscensionExpansionDelta({ expansion: c, ascensionLevel }),
+    );
+  }
+
+  return nodes;
+};
+
+/**
+ * Within-island cost curve, in full Decimal precision:
+ *   start + (end - start) × ((e-1)/11)^1.3
+ */
+const swampCostBase = (start: number, end: number, e: number): Decimal =>
+  new Decimal(start).plus(
+    new Decimal(end - start).mul(
+      new Decimal(e - 1)
+        .div(SWAMP_EXPANSIONS_PER_ASCENSION - 1)
+        .pow(COST_CURVE_EXPONENT),
+    ),
+  );
+
+/**
+ * Resource/coin/time requirements for a swamp expansion. `expansion` is the
+ * post-increment Basic Land count (31…42). Returns `undefined` outside that
+ * range. Costs scale `× 1.4^(a-1)`; resources are rounded to the nearest
+ * integer and coins are rounded UP to the nearest 10 (all in Decimal). Build
+ * time is `e × 7h`, ascension-invariant.
+ */
+export const getAscensionExpansionRequirements = ({
+  expansion,
+  ascensionLevel,
+}: {
+  expansion: number;
+  ascensionLevel: number;
+}): Requirements | undefined => {
+  const e = localExpansionIndex(expansion);
+  if (e < 1 || e > SWAMP_EXPANSIONS_PER_ASCENSION) return undefined;
+
+  const multiplier = new Decimal(COST_GROWTH).pow(ascensionLevel - 1);
+
+  // Resources round to the nearest integer; coins round UP to the nearest 10.
+  const scaleResource = (base: Decimal): number =>
+    base.mul(multiplier).toDecimalPlaces(0, Decimal.ROUND_HALF_UP).toNumber();
+  const scaleCoins = (base: Decimal): number =>
+    base
+      .mul(multiplier)
+      .div(10)
+      .toDecimalPlaces(0, Decimal.ROUND_UP)
+      .mul(10)
+      .toNumber();
+
+  return {
+    resources: {
+      Crimstone: scaleResource(
+        swampCostBase(
+          SWAMP_COST_CURVE.Crimstone.start,
+          SWAMP_COST_CURVE.Crimstone.end,
+          e,
+        ),
+      ),
+      Oil: scaleResource(
+        swampCostBase(SWAMP_COST_CURVE.Oil.start, SWAMP_COST_CURVE.Oil.end, e),
+      ),
+      Obsidian: scaleResource(
+        swampCostBase(
+          SWAMP_COST_CURVE.Obsidian.start,
+          SWAMP_COST_CURVE.Obsidian.end,
+          e,
+        ),
+      ),
+    },
+    coins: scaleCoins(
+      swampCostBase(SWAMP_COIN_CURVE.start, SWAMP_COIN_CURVE.end, e),
+    ),
+    seconds: e * HOURS_PER_EXPANSION * 60 * 60,
+    bumpkinLevel: SWAMP_EXPANSION_BUMPKIN_LEVEL,
+  };
+};
+
+/**
+ * Deterministic, footprint-aware placement of a single expansion's dripped
+ * nodes within its 6×6 land block. A node at `(x, y)` of size `w×h` occupies
+ * `[x, x+w) × [y-h, y]` (matching the collision engine), and every footprint is
+ * kept fully inside the local `[-3, 3] × [-3, 3]` block so it can never bleed
+ * into a neighbouring expansion. First-fit from the top-left guarantees the same
+ * coordinates on the client and server.
+ */
+export const getAscensionLayout = ({
+  expansion,
+  ascensionLevel,
+}: {
+  expansion: number;
+  ascensionLevel: number;
+}): Layout => {
+  const layout: Layout = {
+    id: `swamp_${expansion}`,
+    plots: [],
+    trees: [],
+    stones: [],
+    iron: [],
+    gold: [],
+    crimstones: [],
+    sunstones: [],
+    beehives: [],
+    flowerBeds: [],
+    fruitPatches: [],
+    oilReserves: [],
+    lavaPits: [],
+  };
+
+  const delta = getAscensionExpansionDelta({ expansion, ascensionLevel });
+  const occupied = new Set<string>();
+
+  const place = (width: number, height: number): Coordinates => {
+    // Top-to-bottom, left-to-right. y is the top edge (extends down by height),
+    // x the left edge (extends right by width).
+    for (let y = 3; y - height >= -3; y--) {
+      for (let x = -3; x + width <= 3; x++) {
+        let fits = true;
+        for (let i = 0; i < width && fits; i++) {
+          for (let j = 0; j < height && fits; j++) {
+            if (occupied.has(`${x + i},${y - j}`)) fits = false;
+          }
+        }
+        if (fits) {
+          for (let i = 0; i < width; i++) {
+            for (let j = 0; j < height; j++) {
+              occupied.add(`${x + i},${y - j}`);
+            }
+          }
+          return { x, y };
+        }
+      }
+    }
+    // Should be unreachable: a single expansion's drip never fills the block.
+    throw new Error(`Swamp layout: no room for ${width}x${height} node`);
+  };
+
+  PLACEMENT_ORDER.forEach((node) => {
+    const count = delta[node] ?? 0;
+    if (!count) return;
+    const { width, height } = RESOURCE_DIMENSIONS[node as ResourceName];
+    const field = NODE_TO_LAYOUT_FIELD[node];
+    for (let k = 0; k < count; k++) {
+      (layout[field] as Coordinates[]).push(place(width, height));
+    }
+  });
+
+  return layout;
+};
+
+/** The full set of swamp expansion layouts (31…42) for a given ascension. */
+export const ASCENSION_LAYOUTS = (
+  ascensionLevel: number,
+): Record<number, Layout> => {
+  const layouts: Record<number, Layout> = {};
+  for (let c = SWAMP_FIRST_EXPANSION; c <= SWAMP_LAST_EXPANSION; c++) {
+    layouts[c] = getAscensionLayout({ expansion: c, ascensionLevel });
+  }
+  return layouts;
+};

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -1,10 +1,3 @@
-import { BASIC_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequirements";
-import type { BumpkinLevel } from "features/game/lib/level";
-import {
-  EXPANSION_REQUIREMENTS,
-  TOTAL_EXPANSION_NODES,
-} from "features/game/types/expansions";
-import type { IslandType } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
 
 export type Nodes = Record<
@@ -40,21 +33,4 @@ export function isNode(value: string): value is keyof Nodes {
   ];
 
   return nodeTypes.includes(value as keyof Nodes);
-}
-
-export function getEnabledNodeCount(
-  bumpkinLevel: BumpkinLevel,
-  nodeType: string,
-  islandType: IslandType,
-): number {
-  const key = nodeType as keyof Nodes;
-
-  for (let expansions = 4; expansions <= BASIC_MAX_EXPANSION; ++expansions) {
-    if (
-      EXPANSION_REQUIREMENTS[islandType][expansions].bumpkinLevel > bumpkinLevel
-    )
-      return TOTAL_EXPANSION_NODES.basic[expansions][key];
-  }
-
-  return 0;
 }

--- a/src/features/game/expansion/lib/expansionNodes.ts
+++ b/src/features/game/expansion/lib/expansionNodes.ts
@@ -16,6 +16,11 @@ export type Nodes = Record<
   number
 >;
 
+/**
+ * Determines if a value is a valid node type.
+ *
+ * @returns `true` if the value is a valid node type, `false` otherwise.
+ */
 export function isNode(value: string): value is keyof Nodes {
   const nodeTypes: Array<keyof Nodes> = [
     "Crop Plot",

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -568,7 +568,7 @@ describe("getLand (ascension path)", () => {
       },
     });
     expect(land).not.toBeNull();
-    expect(land?.id).toBe("swamp_31");
+    expect(land?.id).toBe("swamp_1_31");
   });
 
   it("overrides static island branch when ascensionLevel > 0", () => {
@@ -585,7 +585,7 @@ describe("getLand (ascension path)", () => {
       },
     });
     expect(land).not.toBeNull();
-    expect(land?.id).toBe("swamp_31");
+    expect(land?.id).toBe("swamp_2_31");
   });
 
   it("places the dripped Crop Plot dealt to expansion 32", () => {

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -430,25 +430,25 @@ describe("getExpansionNodes", () => {
     expect(nodes).toEqual(SWAMP_BASE_NODES);
   });
 
-  it("returns base nodes unchanged at expansion 31 (e=1, no drip fires at globalE=1)", () => {
+  it("returns the base floor at the swamp arrival expansion (30)", () => {
     const nodes = getExpansionNodes({
       island: "swamp",
-      expansion: 31,
+      expansion: 30,
       ascensionLevel: 1,
     });
-    // globalE=1: no drip modulo hits at 1 for any node, so cumulative = base floor
+    // Expansion 30 is the arrival floor — no expansion has been granted yet.
     expect(nodes).toEqual(SWAMP_BASE_NODES);
   });
 
-  it("adds one Crop Plot at expansion 32 (e=2, globalE=2, drip=2 fires)", () => {
+  it("accumulates the full ascension-1 Crop Plot total by expansion 42", () => {
     const nodes = getExpansionNodes({
       island: "swamp",
-      expansion: 32,
+      expansion: 42,
       ascensionLevel: 1,
     });
-    expect(nodes["Crop Plot"]).toBe(SWAMP_BASE_NODES["Crop Plot"] + 1);
-    // All other node types unchanged from base
-    expect(nodes.Tree).toBe(SWAMP_BASE_NODES.Tree);
+    // Ascension 1 deals +6 Crop Plots across its 12 expansions; the even-spread
+    // distribution preserves the per-ascension totals.
+    expect(nodes["Crop Plot"]).toBe(SWAMP_BASE_NODES["Crop Plot"] + 6);
   });
 
   it("returns higher node totals for ascensionLevel 2 vs 1 at the same expansion", () => {
@@ -588,7 +588,7 @@ describe("getLand (ascension path)", () => {
     expect(land?.id).toBe("swamp_31");
   });
 
-  it("includes a dripped Crop Plot at expansion 32 (e=2 fires Crop Plot drip)", () => {
+  it("places the dripped Crop Plot dealt to expansion 32", () => {
     const land = getLand({
       game: {
         ...TEST_FARM,
@@ -601,8 +601,8 @@ describe("getLand (ascension path)", () => {
         },
       },
     });
-    // Expansion 32 (e=2) drips exactly 1 Crop Plot; expected total = base(65) + 1 = 66.
-    // With 0 owned, all 1 dripped plot should appear in the layout.
+    // The even-spread schedule deals exactly 1 Crop Plot to expansion 32. With 0
+    // owned, that dripped plot appears in the layout.
     expect(land?.plots).toHaveLength(1);
   });
 

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -4,9 +4,12 @@ import {
   LAND_4_LAYOUT,
   SPRING_LAND_5_LAYOUT,
   getExpectedResources,
+  getExpansionNodes,
+  getExpansionRequirements,
   getLand,
 } from "./expansions";
 import { upgradeRock } from "../events/landExpansion/upgradeRock";
+import { SWAMP_BASE_NODES } from "../expansion/lib/ascension";
 
 describe("getLand", () => {
   it("returns a basic land", () => {
@@ -404,5 +407,215 @@ describe("getExpectedResources", () => {
     });
 
     expect(resources["Sacred Tree"]).toEqual(1);
+  });
+});
+
+describe("getExpansionNodes", () => {
+  it("delegates to TOTAL_EXPANSION_NODES for a static island without ascensionLevel", () => {
+    const nodes = getExpansionNodes({
+      island: "basic",
+      expansion: 4,
+    });
+    // basic expansion 4 adds the first plots/trees from the hand-authored layout
+    expect(typeof nodes["Crop Plot"]).toBe("number");
+    expect(nodes["Crop Plot"]).toBeGreaterThan(0);
+  });
+
+  it("returns SWAMP_BASE_NODES for swamp expansion 30 at ascensionLevel 1", () => {
+    const nodes = getExpansionNodes({
+      island: "swamp",
+      expansion: 30,
+      ascensionLevel: 1,
+    });
+    expect(nodes).toEqual(SWAMP_BASE_NODES);
+  });
+
+  it("returns base nodes unchanged at expansion 31 (e=1, no drip fires at globalE=1)", () => {
+    const nodes = getExpansionNodes({
+      island: "swamp",
+      expansion: 31,
+      ascensionLevel: 1,
+    });
+    // globalE=1: no drip modulo hits at 1 for any node, so cumulative = base floor
+    expect(nodes).toEqual(SWAMP_BASE_NODES);
+  });
+
+  it("adds one Crop Plot at expansion 32 (e=2, globalE=2, drip=2 fires)", () => {
+    const nodes = getExpansionNodes({
+      island: "swamp",
+      expansion: 32,
+      ascensionLevel: 1,
+    });
+    expect(nodes["Crop Plot"]).toBe(SWAMP_BASE_NODES["Crop Plot"] + 1);
+    // All other node types unchanged from base
+    expect(nodes.Tree).toBe(SWAMP_BASE_NODES.Tree);
+  });
+
+  it("returns higher node totals for ascensionLevel 2 vs 1 at the same expansion", () => {
+    const nodesA1 = getExpansionNodes({
+      island: "swamp",
+      expansion: 42,
+      ascensionLevel: 1,
+    });
+    const nodesA2 = getExpansionNodes({
+      island: "swamp",
+      expansion: 42,
+      ascensionLevel: 2,
+    });
+    // Each successive ascension carries forward all prior drips, so totals grow
+    expect(nodesA2["Crop Plot"]).toBeGreaterThan(nodesA1["Crop Plot"]);
+    expect(nodesA2["Tree"]).toBeGreaterThan(nodesA1["Tree"]);
+  });
+
+  it("ascensionLevel 0 is treated the same as no ascensionLevel (static path)", () => {
+    const noAscension = getExpansionNodes({
+      island: "basic",
+      expansion: 4,
+    });
+    const zeroAscension = getExpansionNodes({
+      island: "basic",
+      expansion: 4,
+      ascensionLevel: 0,
+    });
+    expect(zeroAscension).toEqual(noAscension);
+  });
+});
+
+describe("getExpansionRequirements", () => {
+  it("returns static EXPANSION_REQUIREMENTS for a basic island expansion", () => {
+    const req = getExpansionRequirements({ island: "basic", expansion: 4 });
+    expect(req).toEqual({
+      resources: { Wood: 3 },
+      seconds: 5,
+      bumpkinLevel: 1,
+    });
+  });
+
+  it("returns undefined for a static island expansion outside the table (expansion 3)", () => {
+    const req = getExpansionRequirements({ island: "basic", expansion: 3 });
+    expect(req).toBeUndefined();
+  });
+
+  it("returns formula requirements for swamp expansion 31 at ascensionLevel 1", () => {
+    const HOUR = 60 * 60;
+    const req = getExpansionRequirements({
+      island: "swamp",
+      expansion: 31,
+      ascensionLevel: 1,
+    });
+    expect(req).toEqual({
+      resources: { Crimstone: 30, Oil: 50, Obsidian: 3 },
+      coins: 5000,
+      seconds: 7 * HOUR,
+      bumpkinLevel: 0,
+    });
+  });
+
+  it("returns undefined for swamp expansion 30 (below the swamp range) at ascensionLevel 1", () => {
+    const req = getExpansionRequirements({
+      island: "swamp",
+      expansion: 30,
+      ascensionLevel: 1,
+    });
+    expect(req).toBeUndefined();
+  });
+
+  it("returns undefined for swamp expansion 43 (above the swamp range) at ascensionLevel 1", () => {
+    const req = getExpansionRequirements({
+      island: "swamp",
+      expansion: 43,
+      ascensionLevel: 1,
+    });
+    expect(req).toBeUndefined();
+  });
+
+  it("scales costs by 1.4 at ascensionLevel 2 while keeping seconds unchanged", () => {
+    const HOUR = 60 * 60;
+    const req = getExpansionRequirements({
+      island: "swamp",
+      expansion: 42,
+      ascensionLevel: 2,
+    });
+    expect(req?.resources).toEqual({ Crimstone: 210, Oil: 560, Obsidian: 42 });
+    expect(req?.coins).toBe(105000);
+    expect(req?.seconds).toBe(84 * HOUR);
+  });
+
+  it("treats ascensionLevel 0 the same as no ascensionLevel (static path)", () => {
+    const noAscension = getExpansionRequirements({ island: "basic", expansion: 4 });
+    const zeroAscension = getExpansionRequirements({
+      island: "basic",
+      expansion: 4,
+      ascensionLevel: 0,
+    });
+    expect(zeroAscension).toEqual(noAscension);
+  });
+});
+
+describe("getLand (ascension path)", () => {
+  it("returns a non-null layout for a swamp island with ascensionLevel 1", () => {
+    const land = getLand({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(30),
+        },
+      },
+    });
+    expect(land).not.toBeNull();
+    expect(land?.id).toBe("swamp_31");
+  });
+
+  it("overrides static island branch when ascensionLevel > 0", () => {
+    // Even a known static island type is overridden by ascensionLevel > 0,
+    // because the ascension check comes after and always wins.
+    const land = getLand({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 2 },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(30),
+        },
+      },
+    });
+    expect(land).not.toBeNull();
+    expect(land?.id).toBe("swamp_31");
+  });
+
+  it("includes a dripped Crop Plot at expansion 32 (e=2 fires Crop Plot drip)", () => {
+    const land = getLand({
+      game: {
+        ...TEST_FARM,
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          // Set Crop Plot to 0 so all expected plots are available
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(31),
+          "Crop Plot": new Decimal(0),
+        },
+      },
+    });
+    // Expansion 32 (e=2) drips exactly 1 Crop Plot; expected total = base(65) + 1 = 66.
+    // With 0 owned, all 1 dripped plot should appear in the layout.
+    expect(land?.plots).toHaveLength(1);
+  });
+
+  it("returns null when island type is unknown (no branch matches) and ascensionLevel is absent", () => {
+    const land = getLand({
+      game: {
+        ...TEST_FARM,
+        // Swamp with no ascensionLevel: none of the static branches match and
+        // the ascension guard (ascensionLevel > 0) is also false.
+        island: { type: "swamp" },
+        inventory: {
+          ...TEST_FARM.inventory,
+          "Basic Land": new Decimal(30),
+        },
+      },
+    });
+    expect(land).toBeNull();
   });
 });

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -542,7 +542,10 @@ describe("getExpansionRequirements", () => {
   });
 
   it("treats ascensionLevel 0 the same as no ascensionLevel (static path)", () => {
-    const noAscension = getExpansionRequirements({ island: "basic", expansion: 4 });
+    const noAscension = getExpansionRequirements({
+      island: "basic",
+      expansion: 4,
+    });
     const zeroAscension = getExpansionRequirements({
       island: "basic",
       expansion: 4,

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -61,6 +61,13 @@ const isAdvancedResource = (
   return resource in ADVANCED_RESOURCES;
 };
 
+/**
+ * Calculates the cumulative expected resource node counts for a given expansion, accounting for purchases and upgrades.
+ *
+ * @param game - The current game state
+ * @param expansion - The expansion level
+ * @returns A mapping of resource names to their expected cumulative counts
+ */
 export function getExpectedResources({
   game,
   expansion,
@@ -117,6 +124,12 @@ export function getExpectedResources({
   return expectedResources;
 }
 
+/**
+ * Computes the layout for the player's next land expansion with resource availability constraints applied.
+ *
+ * @param game - The current game state
+ * @returns The next land expansion layout with resource placements capped by available resources, or `null` if no layout exists for the computed expansion
+ */
 export function getLand({ game }: { game: GameState }): Layout | null {
   const expansion = (game.inventory["Basic Land"]?.toNumber() ?? 0) + 1;
 
@@ -1996,10 +2009,12 @@ function countLayoutNodes(
 }
 
 /**
- * Derives the cumulative `Record<expansion, Nodes>` table for an island from its
- * per-expansion layouts. `base` is the "arrival" row — the expected totals when
- * a player first lands on the island (a curated floor, not derivable from
- * layouts) — and sits at the expansion directly below the first layout.
+ * Derives cumulative node counts for each expansion level on an island.
+ *
+ * @param base - Initial node counts when the island is first discovered.
+ * @param layouts - Per-expansion layout definitions.
+ * @returns A record mapping each expansion level to its cumulative node totals.
+ * @throws If `layouts` is empty.
  */
 export function deriveExpansionNodes(
   base: Nodes,

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -1,6 +1,16 @@
-import type { GameState, InventoryItemName, IslandType } from "./game";
+import type {
+  BasicIslandType,
+  GameState,
+  InventoryItemName,
+  IslandType,
+} from "./game";
 import type { Coordinates } from "../expansion/components/MapPlacement";
 import type { Nodes } from "../expansion/lib/expansionNodes";
+import {
+  getAscensionExpansionRequirements,
+  getAscensionLayout,
+  getAscensionNodes,
+} from "../expansion/lib/ascension";
 import { getKeys } from "lib/object";
 import {
   ADVANCED_RESOURCES,
@@ -58,8 +68,14 @@ export function getExpectedResources({
   game: GameState;
   expansion: number;
 }): Record<ResourceName, number> {
+  const baseNodes = getExpansionNodes({
+    island: game.island.type,
+    expansion,
+    ascensionLevel: game.island.ascensionLevel,
+  });
+
   const expectedResources: Record<ResourceName, number> = {
-    ...TOTAL_EXPANSION_NODES[game.island.type][expansion],
+    ...baseNodes,
     "Ancient Tree": 0,
     "Sacred Tree": 0,
     "Fused Stone Rock": 0,
@@ -120,6 +136,13 @@ export function getLand({ game }: { game: GameState }): Layout | null {
 
   if (game.island.type === "volcano") {
     land = VOLCANO_LAYOUTS()[expansion];
+  }
+
+  if ((game.island.ascensionLevel ?? 0) > 0) {
+    land = getAscensionLayout({
+      expansion,
+      ascensionLevel: game.island.ascensionLevel ?? 0,
+    });
   }
 
   if (!land) {
@@ -2008,7 +2031,10 @@ export function deriveExpansionNodes(
   return result;
 }
 
-export type ExpansionNode = Record<IslandType, Record<number, Nodes>>;
+// Only the static, hand-authored islands live here. Ascension islands (swamp
+// onward) are ascension-dependent and cannot be a static 2-D table — read them
+// via `getExpansionNodes` / `getAscensionNodes` instead.
+export type ExpansionNode = Record<BasicIslandType, Record<number, Nodes>>;
 
 const BASIC_BASE_NODES: Nodes = {
   "Crop Plot": 0,
@@ -2070,33 +2096,6 @@ const VOLCANO_BASE_NODES: Nodes = {
   "Flower Bed": 3,
 };
 
-const SWAMP_BASE_NODES: Nodes = {
-  "Crop Plot": 65,
-  Tree: 23,
-  "Stone Rock": 20,
-  "Iron Rock": 13,
-  "Gold Rock": 8,
-  "Fruit Patch": 15,
-  "Crimstone Rock": 5,
-  "Sunstone Rock": 13,
-  "Oil Reserve": 4,
-  "Lava Pit": 3,
-  Beehive: 3,
-  "Flower Bed": 3,
-};
-
-// TODO: temporary empty layouts so swamp clears tsc; replace with real swamp
-// layouts when the ascension system ships.
-const placeholderLayout = (id: string): Layout => ({
-  id,
-  plots: [],
-  fruitPatches: [],
-  gold: [],
-  iron: [],
-  stones: [],
-  trees: [],
-});
-
 export const TOTAL_EXPANSION_NODES: ExpansionNode = {
   // Basic only uses expansions 3-9: it's capped at 9 (see ISLAND_MAX_EXPANSION) and
   // the node table is read only when expanding/upgrading. Legacy farms still on the
@@ -2114,22 +2113,27 @@ export const TOTAL_EXPANSION_NODES: ExpansionNode = {
   spring: deriveExpansionNodes(SPRING_BASE_NODES, SPRING_LAYOUTS()),
   desert: deriveExpansionNodes(DESERT_BASE_NODES, DESERT_LAYOUTS()),
   volcano: deriveExpansionNodes(VOLCANO_BASE_NODES, VOLCANO_LAYOUTS()),
-  // TODO: will probably have a separate function that calculates the drip nodes
-  swamp: deriveExpansionNodes(SWAMP_BASE_NODES, {
-    31: placeholderLayout("31"),
-    32: placeholderLayout("32"),
-    33: placeholderLayout("33"),
-    34: placeholderLayout("34"),
-    35: placeholderLayout("35"),
-    36: placeholderLayout("36"),
-    37: placeholderLayout("37"),
-    38: placeholderLayout("38"),
-    39: placeholderLayout("39"),
-    40: placeholderLayout("40"),
-    41: placeholderLayout("41"),
-    42: placeholderLayout("42"),
-  }),
 };
+
+/**
+ * The single source of truth for "expected cumulative resource nodes at a given
+ * expansion". Ascension islands (swamp onward) are computed from the drip
+ * formula and depend on the ascension level; the static islands use the derived
+ * table. Always read node totals through here rather than indexing
+ * `TOTAL_EXPANSION_NODES` directly, so the ascension dimension is never dropped.
+ */
+export const getExpansionNodes = ({
+  island,
+  expansion,
+  ascensionLevel,
+}: {
+  island: IslandType;
+  expansion: number;
+  ascensionLevel?: number;
+}): Nodes =>
+  (ascensionLevel ?? 0) > 0
+    ? getAscensionNodes({ expansion, ascensionLevel: ascensionLevel ?? 0 })
+    : TOTAL_EXPANSION_NODES[island as BasicIslandType][expansion];
 
 export interface Requirements {
   resources: Partial<Record<InventoryItemName, number>>;
@@ -3294,8 +3298,11 @@ const VOLCANO_LAND_30_REQUIREMENTS: Requirements = {
   bumpkinLevel: 120,
 };
 
+// Only the static, hand-authored islands live here. Ascension islands (swamp
+// onward) are formula-driven and ascension-dependent — read them via
+// `getExpansionRequirements` / `getAscensionExpansionRequirements` instead.
 export const EXPANSION_REQUIREMENTS: Record<
-  IslandType,
+  BasicIslandType,
   Record<number, Requirements>
 > = {
   basic: {
@@ -3389,6 +3396,26 @@ export const EXPANSION_REQUIREMENTS: Record<
     29: VOLCANO_LAND_29_REQUIREMENTS,
     30: VOLCANO_LAND_30_REQUIREMENTS,
   },
-  // TODO: Add swamp land requirements when released
-  swamp: {},
 };
+
+/**
+ * The single source of truth for a given expansion's requirements. Ascension
+ * islands (swamp onward) are computed from the formula and depend on the
+ * ascension level; the static islands use the table. Always read through here
+ * rather than indexing `EXPANSION_REQUIREMENTS` directly.
+ */
+export const getExpansionRequirements = ({
+  island,
+  expansion,
+  ascensionLevel,
+}: {
+  island: IslandType;
+  expansion: number;
+  ascensionLevel?: number;
+}): Requirements | undefined =>
+  (ascensionLevel ?? 0) > 0
+    ? getAscensionExpansionRequirements({
+        expansion,
+        ascensionLevel: ascensionLevel ?? 0,
+      })
+    : EXPANSION_REQUIREMENTS[island as BasicIslandType][expansion];

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -62,11 +62,9 @@ const isAdvancedResource = (
 };
 
 /**
- * Calculates the cumulative expected resource node counts for a given expansion, accounting for purchases and upgrades.
+ * Determines expected resource node counts for an expansion, incorporating player purchases and upgrade conversions.
  *
- * @param game - The current game state
- * @param expansion - The expansion level
- * @returns A mapping of resource names to their expected cumulative counts
+ * @returns A mapping of resource names to expected cumulative node counts at the given expansion
  */
 export function getExpectedResources({
   game,
@@ -1993,7 +1991,11 @@ const LAYOUT_FIELD_TO_NODE = {
   lavaPits: "Lava Pit",
 } as const satisfies Partial<Record<keyof Layout, keyof Nodes>>;
 
-/** Counts the resource nodes placed by a single expansion's `Layout`. */
+/**
+ * Counts the resource nodes placed by a single expansion's `Layout`.
+ *
+ * @returns A record mapping node types to their counts in the layout.
+ */
 function countLayoutNodes(
   layout: Layout,
 ): Partial<Record<keyof Nodes, number>> {


### PR DESCRIPTION
## Summary
Adds the formula-driven expansion system for the swamp (ascension) island (front-end; mirrors sunflower-land-api).

- **Costs & time:** per-expansion Crimstone / Oil / Obsidian + coins from a cost curve scaled by ascension level (`× 1.4^(a-1)`); build time `e × 7h`, ascension-invariant.
- **Nodes:** drip-based resource grants with carry-forward cumulative totals, and deterministic, footprint-aware placement within each 6×6 land block.
- **Accessors:** `getExpansionNodes` / `getExpansionRequirements` centralise the static-vs-ascension branch; static `TOTAL_EXPANSION_NODES` / `EXPANSION_REQUIREMENTS` restricted to basic islands.
- **Rounding:** coins round **up to the nearest 10**, resources to the **nearest integer** (full `decimal.js-light` precision, including the fractional cost-curve exponent).
- **Refactor:** `expansionRequirements` moved into `expandLand.ts`.
- **UI:** the expansion panel / `UpcomingExpansion` surface swamp costs via the accessor; speed-up gated on swamp behind the `SWAMP_ASCENSION` flag.

## ⚠️ Not in this PR — level requirements
The per-expansion **Bumpkin level requirement is stubbed at 0** (no gate). The real level gate will be wired once the swamp XP / level progression lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a formula-driven swamp ascension system, including scaled expansion costs and deterministic node “drip” placement.
  * Upcoming expansion checks now use the updated expansion requirement logic and reflect ascension state and the active swamp feature flag.

* **Bug Fixes**
  * Improved validation by blocking land expansion when the target land is missing.
  * Expansion/speed-up eligibility now selects the correct required island type (swamp vs desert) based on the feature flag.
  * Grinx’s Hammer cost reductions now apply correctly to expansion requirements (with Gem excluded).

* **Tests**
  * Added/updated coverage for ascension requirements, node totals, layouts, and cost adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->