### PR TITLE
[FEAT] Always animate Maneki Neko by removing idle state image

### DIFF
--- a/src/features/island/collectibles/components/ManekiNeko.tsx
+++ b/src/features/island/collectibles/components/ManekiNeko.tsx
@@ -2,7 +2,6 @@ import { useActor } from "@xstate/react";
 import React, { useContext, useEffect, useState } from "react";
 
 import manekiNekoShaking from "assets/sfts/maneki_neko.gif";
-import manekiNeko from "assets/sfts/maneki_neko_idle.gif";
 import shadow from "assets/npcs/shadow16px.png";
 import { SUNNYSIDE } from "assets/sunnyside";
 
@@ -119,7 +118,7 @@ export const ManekiNekoImage: React.FC<Props> = ({ id, open }) => {
           className="absolute pointer-events-none"
         />
         <img
-          src={open ? manekiNekoShaking : manekiNeko}
+          src={manekiNekoShaking}
           style={{
             width: `${PIXEL_SCALE * 16}px`,
             bottom: `${PIXEL_SCALE * 2}px`,


### PR DESCRIPTION
## Summary
- Maneki Neko now always displays the shaking animation instead of switching between idle and shaking states
- Previously the animation only played when the popover was open (on click); now it plays continuously
- Removed unused import of `maneki_neko_idle.gif`

## Test plan
- [ ] Place a Maneki Neko on the farm and verify the shaking animation plays without any interaction
- [ ] Click the Maneki Neko and confirm the popover opens and shake/reveal still works normally
- [ ] Verify the ready indicator (alert icon) still shows when the daily shake is available


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maneki Neko now consistently displays the shaking animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->