### PR TITLE
[FEAT] Ascension Crystals — obtainable nodes that mine Ascension Shards

### DIFF
--- a/metadata/metadata.ts
+++ b/metadata/metadata.ts
@@ -2153,6 +2153,17 @@ export const OPEN_SEA_COLLECTIBLES: Record<InventoryItemName, Metadata> = {
       { trait_type: "Tradable", value: "No" },
     ],
   },
+  "Ascension Shard": {
+    name: "Ascension Shard",
+    description:
+      "A resource collected by mining ascension crystals.\n\nIt is used to upgrade existing skills.",
+    decimals: 18,
+    external_url: "https://docs.sunflower-land.com/getting-started/about",
+    attributes: [
+      { trait_type: "Purpose", value: "Resource" },
+      { trait_type: "Tradable", value: "No" },
+    ],
+  },
   Chicken: {
     name: "Chicken",
     description:
@@ -5121,6 +5132,15 @@ export const OPEN_SEA_COLLECTIBLES: Record<InventoryItemName, Metadata> = {
   },
   "Lava Pit": {
     description: "A source of obsidian",
+    decimals: 0,
+    external_url: "https://docs.sunflower-land.com/getting-started/about",
+    attributes: [
+      { trait_type: "Purpose", value: "Resource Node" },
+      { trait_type: "Tradable", value: "No" },
+    ],
+  },
+  "Ascension Crystal": {
+    description: "Upgrade skills",
     decimals: 0,
     external_url: "https://docs.sunflower-land.com/getting-started/about",
     attributes: [

--- a/src/features/game/actions/tradeLimits.ts
+++ b/src/features/game/actions/tradeLimits.ts
@@ -33,6 +33,7 @@ export type TradeResource = Extract<
       CommodityName,
       | "Diamond"
       | "Sunstone"
+      | "Ascension Shard"
       | "Oil"
       | "Obsidian"
       | "Refined Salt"

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -294,6 +294,18 @@ import {
   type MineSunstoneAction,
 } from "./landExpansion/mineSunstone";
 import {
+  placeAscensionCrystal,
+  type PlaceAscensionCrystalAction,
+} from "./landExpansion/placeAscensionCrystal";
+import {
+  moveAscensionCrystal,
+  type MoveAscensionCrystalAction,
+} from "./landExpansion/moveAscensionCrystal";
+import {
+  mineAscensionCrystal,
+  type MineAscensionCrystalAction,
+} from "./landExpansion/mineAscensionCrystal";
+import {
   type FlowerShopTradedAction,
   tradeFlowerShop,
 } from "./landExpansion/tradeFlowerShop";
@@ -640,6 +652,10 @@ import {
   type RemoveSunstoneAction,
 } from "./landExpansion/removeSunstone";
 import {
+  removeAscensionCrystal,
+  type RemoveAscensionCrystalAction,
+} from "./landExpansion/removeAscensionCrystal";
+import {
   removeLavaPit,
   type RemoveLavaPitAction,
 } from "./landExpansion/removeLavaPit";
@@ -807,6 +823,7 @@ export type PlayingEvent =
   | LandExpansionGoldMineAction
   | MineCrimstoneAction
   | MineSunstoneAction
+  | MineAscensionCrystalAction
   | ClaimAirdropAction
   | RecipeCookedAction
   | CollectRecipeAction
@@ -984,6 +1001,7 @@ export type PlacementEvent =
   | PlaceCrimstoneAction
   | PlaceFruitPatchAction
   | PlaceSunstoneAction
+  | PlaceAscensionCrystalAction
   | BuyDecorationAction
   | BuyMonumentAction
   | CraftCollectibleAction
@@ -997,6 +1015,7 @@ export type PlacementEvent =
   | MoveGoldAction
   | MoveCrimstoneAction
   | MoveSunstoneAction
+  | MoveAscensionCrystalAction
   | RemoveBuildingAction
   | RemoveCollectibleAction
   | PlaceNFTAction
@@ -1016,6 +1035,7 @@ export type PlacementEvent =
   | RemoveGoldAction
   | RemoveCrimstoneAction
   | RemoveSunstoneAction
+  | RemoveAscensionCrystalAction
   | RemoveLavaPitAction
   | RemoveOilReserveAction
   | RemovePlotAction
@@ -1097,6 +1117,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "goldRock.mined": landExpansionMineGold,
   "crimstoneRock.mined": mineCrimstone,
   "sunstoneRock.mined": mineSunstone,
+  "ascensionCrystal.mined": mineAscensionCrystal,
 
   "timber.chopped": landExpansionChop,
   "recipe.cooked": cook,
@@ -1300,6 +1321,8 @@ export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "flowerBed.placed": placeFlowerBed,
   "sunstone.placed": placeSunstone,
   "sunstone.moved": moveSunstone,
+  "ascensionCrystal.placed": placeAscensionCrystal,
+  "ascensionCrystal.moved": moveAscensionCrystal,
   "oilReserve.moved": moveOilReserve,
   "oilReserve.placed": placeOilReserve,
   "lavaPit.placed": placeLavaPit,
@@ -1310,6 +1333,7 @@ export const PLACEMENT_EVENTS: Handlers<PlacementEvent> = {
   "gold.removed": removeGold,
   "crimstone.removed": removeCrimstone,
   "sunstone.removed": removeSunstone,
+  "ascensionCrystal.removed": removeAscensionCrystal,
   "lavaPit.removed": removeLavaPit,
   "oilReserve.removed": removeOilReserve,
   "plot.removed": removePlot,

--- a/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
+++ b/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
@@ -1,0 +1,168 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import type { GameState, IslandType } from "features/game/types/game";
+import { getRewards } from "./revealLand";
+import { ASCENSION_BUMPKIN_LEVEL, upgrade } from "./upgradeFarm";
+import {
+  LEVEL_EXPERIENCE,
+  ascensionBaseline,
+  bandXp,
+} from "features/game/lib/level";
+
+/** Total Ascension Crystals offered by the missing-resources back-pay chest. */
+const backPaidCrystals = (game: GameState): number => {
+  const rewards = getRewards({ game, createdAt: Date.now() });
+  const chest = rewards.find((a) => a.id.startsWith("missing-resources"));
+  return (chest?.items["Ascension Crystal"] as number | undefined) ?? 0;
+};
+
+describe("Ascension Crystal back-pay (revealLand missing-node reconciliation)", () => {
+  // A swamp A1 player at Basic Land 33 (e=3) should have earned
+  // A0(3) + A1 upgrade(1) + 3 expansion nodes = 7 crystals.
+  const legacyA1 = (overrides: Partial<GameState> = {}): GameState => ({
+    ...INITIAL_FARM,
+    inventory: { ...INITIAL_FARM.inventory, "Basic Land": new Decimal(33) },
+    island: { type: "swamp", ascensionLevel: 1 },
+    ...overrides,
+  });
+
+  it("back-pays a legacy player the full expected crystals (0 owned, 0 mined)", () => {
+    expect(backPaidCrystals(legacyA1())).toBe(7);
+  });
+
+  it("does not resurrect crystals the player already mined", () => {
+    const game = legacyA1({
+      farmActivity: { "Ascension Crystal Mined": 7 },
+    });
+    expect(backPaidCrystals(game)).toBe(0);
+  });
+
+  it("respects the inventory + mined invariant (partial)", () => {
+    const game = legacyA1({
+      inventory: {
+        ...INITIAL_FARM.inventory,
+        "Basic Land": new Decimal(33),
+        "Ascension Crystal": new Decimal(4),
+      },
+      farmActivity: { "Ascension Crystal Mined": 3 },
+    });
+    expect(backPaidCrystals(game)).toBe(0);
+  });
+
+  it("only back-pays the shortfall (owns some, mined some)", () => {
+    const game = legacyA1({
+      inventory: {
+        ...INITIAL_FARM.inventory,
+        "Basic Land": new Decimal(33),
+        "Ascension Crystal": new Decimal(1),
+      },
+      farmActivity: { "Ascension Crystal Mined": 2 },
+    });
+    expect(backPaidCrystals(game)).toBe(4);
+  });
+});
+
+describe("Ascension Crystal upgrade-node grant (upgradeFarm)", () => {
+  const RESOURCES_FOR_ANY_COST = {
+    Gold: new Decimal(1_000_000),
+    Crimstone: new Decimal(1_000_000),
+    Oil: new Decimal(1_000_000),
+    Obsidian: new Decimal(1_000_000),
+  };
+
+  type Transition = {
+    from: IslandType;
+    ascensionLevel?: number;
+    basicLand: number;
+    experience: number;
+  };
+
+  const cases: [string, Transition][] = [
+    ["basic -> spring", { from: "basic", basicLand: 9, experience: 0 }],
+    ["spring -> desert", { from: "spring", basicLand: 16, experience: 0 }],
+    ["desert -> volcano", { from: "desert", basicLand: 25, experience: 0 }],
+    [
+      "volcano -> swamp",
+      {
+        from: "volcano",
+        basicLand: 30,
+        experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+      },
+    ],
+    [
+      "swamp -> spooky",
+      {
+        from: "swamp",
+        ascensionLevel: 1,
+        basicLand: 42,
+        experience: ascensionBaseline(1) + bandXp(1),
+      },
+    ],
+    [
+      "spooky -> crystal",
+      {
+        from: "spooky",
+        ascensionLevel: 2,
+        basicLand: 42,
+        experience: ascensionBaseline(2) + bandXp(2),
+      },
+    ],
+    [
+      "crystal -> moon",
+      {
+        from: "crystal",
+        ascensionLevel: 3,
+        basicLand: 42,
+        experience: ascensionBaseline(3) + bandXp(3),
+      },
+    ],
+    [
+      "moon -> marble",
+      {
+        from: "moon",
+        ascensionLevel: 4,
+        basicLand: 42,
+        experience: ascensionBaseline(4) + bandXp(4),
+      },
+    ],
+    [
+      "marble -> marble",
+      {
+        from: "marble",
+        ascensionLevel: 5,
+        basicLand: 42,
+        experience: ascensionBaseline(5) + bandXp(5),
+      },
+    ],
+  ];
+
+  it.each(cases)(
+    "grants exactly 1 crystal on %s",
+    (_label, { from, ascensionLevel, basicLand, experience }) => {
+      const state = upgrade({
+        farmId: 1,
+        action: { type: "farm.upgraded" },
+        state: {
+          ...INITIAL_FARM,
+          coins: 1_000_000_000,
+          bumpkin: { ...INITIAL_FARM.bumpkin!, experience },
+          island: {
+            type: from,
+            ...(ascensionLevel ? { ascensionLevel } : {}),
+          },
+          inventory: {
+            ...INITIAL_FARM.inventory,
+            ...RESOURCES_FOR_ANY_COST,
+            "Basic Land": new Decimal(basicLand),
+            "Ascension Crystal": new Decimal(0),
+          },
+        },
+        createdAt: Date.now(),
+      });
+
+      expect(
+        (state.inventory["Ascension Crystal"] ?? new Decimal(0)).toNumber(),
+      ).toBe(1);
+    },
+  );
+});

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
@@ -88,6 +88,23 @@ describe("mineAscensionCrystal", () => {
     ).toThrow(EVENT_ERRORS.NOT_PLACED);
   });
 
+  it("throws if the crystal is only partially placed (one coord missing)", () => {
+    expect(() =>
+      mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: { "Gold Pickaxe": new Decimal(1) },
+          ascensionCrystals: {
+            0: { ...GAME_STATE.ascensionCrystals[0], y: undefined },
+          },
+        },
+        action: { type: "ascensionCrystal.mined", index: "0" },
+        createdAt: Date.now(),
+      }),
+    ).toThrow(EVENT_ERRORS.NOT_PLACED);
+  });
+
   it("throws an error if no gold pickaxes are left", () => {
     expect(() =>
       mineAscensionCrystal({

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
@@ -1,0 +1,213 @@
+import Decimal from "decimal.js-light";
+import { TEST_FARM, INITIAL_BUMPKIN } from "../../lib/constants";
+import type { GameState } from "../../types/game";
+import {
+  ASCENSION_SHARDS_PER_MINE,
+  EVENT_ERRORS,
+  type MineAscensionCrystalAction,
+  mineAscensionCrystal,
+} from "./mineAscensionCrystal";
+
+const GAME_STATE: GameState = {
+  ...TEST_FARM,
+  ascensionCrystals: {
+    0: {
+      stone: {
+        minedAt: 0,
+      },
+      minesLeft: 1,
+      x: 1,
+      y: 1,
+    },
+    1: {
+      stone: {
+        minedAt: 0,
+      },
+      minesLeft: 1,
+      x: 4,
+      y: 1,
+    },
+  },
+};
+
+describe("mineAscensionCrystal", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it("throws an error if the bumpkin is missing", () => {
+    expect(() =>
+      mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: undefined as never,
+          inventory: { "Gold Pickaxe": new Decimal(1) },
+        },
+        createdAt: Date.now(),
+        action: { type: "ascensionCrystal.mined", index: "0" },
+      }),
+    ).toThrow(EVENT_ERRORS.NO_BUMPKIN);
+  });
+
+  it("throws an error if ascension crystal does not exist", () => {
+    expect(() =>
+      mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: {
+            "Gold Pickaxe": new Decimal(2),
+          },
+        },
+        createdAt: Date.now(),
+        action: {
+          type: "ascensionCrystal.mined",
+          index: "3",
+        },
+      }),
+    ).toThrow(EVENT_ERRORS.NO_ASCENSION_CRYSTAL);
+  });
+
+  it("throws an error if ascension crystal is not placed", () => {
+    expect(() =>
+      mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: GAME_STATE.bumpkin,
+          ascensionCrystals: {
+            0: {
+              ...GAME_STATE.ascensionCrystals[0],
+              x: undefined,
+              y: undefined,
+            },
+          },
+        },
+        action: { type: "ascensionCrystal.mined", index: "0" },
+        createdAt: Date.now(),
+      }),
+    ).toThrow(EVENT_ERRORS.NOT_PLACED);
+  });
+
+  it("throws an error if no gold pickaxes are left", () => {
+    expect(() =>
+      mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: INITIAL_BUMPKIN,
+          inventory: { "Gold Pickaxe": new Decimal(0) },
+        },
+        createdAt: Date.now(),
+        action: {
+          type: "ascensionCrystal.mined",
+          index: "0",
+        },
+      }),
+    ).toThrow(EVENT_ERRORS.NO_PICKAXES);
+  });
+
+  it("mines an ascension crystal, yielding shards and destroying the node", () => {
+    const payload = {
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Gold Pickaxe": new Decimal(1),
+          "Ascension Crystal": new Decimal(2),
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "ascensionCrystal.mined",
+        index: "0",
+      } as MineAscensionCrystalAction,
+    };
+
+    const game = mineAscensionCrystal(payload);
+
+    expect(game.inventory["Gold Pickaxe"]).toEqual(new Decimal(0));
+    expect(game.inventory["Ascension Shard"]).toEqual(
+      new Decimal(ASCENSION_SHARDS_PER_MINE),
+    );
+    // Single-use: the node is removed and the rock count decremented.
+    expect(game.ascensionCrystals["0"]).toBeUndefined();
+    expect(game.inventory["Ascension Crystal"]).toEqual(new Decimal(1));
+  });
+
+  it("adds to an existing Ascension Shard balance", () => {
+    const payload = {
+      state: {
+        ...GAME_STATE,
+        bumpkin: INITIAL_BUMPKIN,
+        inventory: {
+          "Gold Pickaxe": new Decimal(1),
+          "Ascension Crystal": new Decimal(2),
+          "Ascension Shard": new Decimal(5),
+        },
+      },
+      createdAt: Date.now(),
+      action: {
+        type: "ascensionCrystal.mined",
+        index: "0",
+      } as MineAscensionCrystalAction,
+    };
+
+    const game = mineAscensionCrystal(payload);
+
+    expect(game.inventory["Ascension Shard"]).toEqual(
+      new Decimal(5 + ASCENSION_SHARDS_PER_MINE),
+    );
+  });
+
+  describe("BumpkinActivity", () => {
+    it("increments Ascension Crystal Mined activity by 1", () => {
+      const createdAt = Date.now();
+      const game = mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN },
+          inventory: {
+            "Gold Pickaxe": new Decimal(3),
+            "Ascension Crystal": new Decimal(2),
+          },
+        },
+        createdAt,
+        action: {
+          type: "ascensionCrystal.mined",
+          index: "0",
+        } as MineAscensionCrystalAction,
+      });
+
+      expect(game.farmActivity["Ascension Crystal Mined"]).toBe(1);
+    });
+
+    it("increments Ascension Crystal Mined activity by 2", () => {
+      const createdAt = Date.now();
+      const state1 = mineAscensionCrystal({
+        state: {
+          ...GAME_STATE,
+          bumpkin: { ...INITIAL_BUMPKIN },
+          inventory: {
+            "Gold Pickaxe": new Decimal(3),
+            "Ascension Crystal": new Decimal(2),
+          },
+        },
+        createdAt,
+        action: {
+          type: "ascensionCrystal.mined",
+          index: "0",
+        } as MineAscensionCrystalAction,
+      });
+
+      const game = mineAscensionCrystal({
+        state: state1,
+        createdAt,
+        action: {
+          type: "ascensionCrystal.mined",
+          index: "1",
+        } as MineAscensionCrystalAction,
+      });
+
+      expect(game.farmActivity["Ascension Crystal Mined"]).toBe(2);
+    });
+  });
+});

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.ts
@@ -39,7 +39,7 @@ export function mineAscensionCrystal({ state, action }: Options): GameState {
       throw new Error(EVENT_ERRORS.NO_ASCENSION_CRYSTAL);
     }
 
-    if (ascensionCrystal.x === undefined && ascensionCrystal.y === undefined) {
+    if (ascensionCrystal.x === undefined || ascensionCrystal.y === undefined) {
       throw new Error(EVENT_ERRORS.NOT_PLACED);
     }
 

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.ts
@@ -1,0 +1,72 @@
+import Decimal from "decimal.js-light";
+import { trackFarmActivity } from "features/game/types/farmActivity";
+import type { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+/** Shards yielded by mining a single-use Ascension Crystal. */
+export const ASCENSION_SHARDS_PER_MINE = 10;
+
+export type MineAscensionCrystalAction = {
+  type: "ascensionCrystal.mined";
+  index: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: MineAscensionCrystalAction;
+  createdAt?: number;
+};
+
+export enum EVENT_ERRORS {
+  NO_PICKAXES = "No gold pickaxes left",
+  NO_BUMPKIN = "You do not have a Bumpkin",
+  NO_ASCENSION_CRYSTAL = "No ascension crystal found.",
+  NOT_PLACED = "Ascension crystal is not placed",
+}
+
+export function mineAscensionCrystal({ state, action }: Options): GameState {
+  return produce(state, (stateCopy) => {
+    const { bumpkin } = stateCopy;
+    const { index } = action;
+
+    if (!bumpkin) {
+      throw new Error(EVENT_ERRORS.NO_BUMPKIN);
+    }
+
+    const ascensionCrystal = stateCopy.ascensionCrystals[index];
+
+    if (!ascensionCrystal) {
+      throw new Error(EVENT_ERRORS.NO_ASCENSION_CRYSTAL);
+    }
+
+    if (ascensionCrystal.x === undefined && ascensionCrystal.y === undefined) {
+      throw new Error(EVENT_ERRORS.NOT_PLACED);
+    }
+
+    const toolAmount = stateCopy.inventory["Gold Pickaxe"] || new Decimal(0);
+
+    if (toolAmount.lessThan(1)) {
+      throw new Error(EVENT_ERRORS.NO_PICKAXES);
+    }
+
+    const amountInInventory =
+      stateCopy.inventory["Ascension Shard"] || new Decimal(0);
+
+    stateCopy.inventory["Gold Pickaxe"] = toolAmount.sub(1);
+    stateCopy.inventory["Ascension Shard"] = amountInInventory.add(
+      ASCENSION_SHARDS_PER_MINE,
+    );
+
+    // Single-use: mining destroys the rock.
+    delete stateCopy.ascensionCrystals[index];
+    stateCopy.inventory["Ascension Crystal"] =
+      stateCopy.inventory["Ascension Crystal"]?.sub(1);
+
+    stateCopy.farmActivity = trackFarmActivity(
+      "Ascension Crystal Mined",
+      stateCopy.farmActivity,
+    );
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/events/landExpansion/moveAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/moveAscensionCrystal.test.ts
@@ -1,0 +1,98 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import {
+  MOVE_ASCENSION_CRYSTAL_ERRORS,
+  moveAscensionCrystal,
+} from "./moveAscensionCrystal";
+
+describe("moveAscensionCrystal", () => {
+  it("does not move an ascension crystal with an invalid id", () => {
+    expect(() =>
+      moveAscensionCrystal({
+        state: {
+          ...TEST_FARM,
+          ascensionCrystals: {
+            1: {
+              x: 1,
+              y: 1,
+              stone: {
+                minedAt: 0,
+              },
+              minesLeft: 1,
+            },
+          },
+        },
+        action: {
+          type: "ascensionCrystal.moved",
+          id: "2",
+          coordinates: { x: 2, y: 2 },
+        },
+      }),
+    ).toThrow(MOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_PLACED);
+  });
+
+  it("moves an ascension crystal node", () => {
+    const gameState = moveAscensionCrystal({
+      state: {
+        ...TEST_FARM,
+        ascensionCrystals: {
+          "123": {
+            x: 1,
+            y: 1,
+            stone: {
+              minedAt: 0,
+            },
+            minesLeft: 1,
+          },
+          "456": {
+            x: 4,
+            y: 4,
+            stone: {
+              minedAt: 0,
+            },
+            minesLeft: 1,
+          },
+          "789": {
+            x: 8,
+            y: 8,
+            stone: {
+              minedAt: 0,
+            },
+            minesLeft: 1,
+          },
+        },
+      },
+      action: {
+        type: "ascensionCrystal.moved",
+        id: "123",
+        coordinates: { x: 2, y: 2 },
+      },
+    });
+
+    expect(gameState.ascensionCrystals).toEqual({
+      "123": {
+        x: 2,
+        y: 2,
+        stone: {
+          minedAt: 0,
+        },
+        minesLeft: 1,
+      },
+      "456": {
+        x: 4,
+        y: 4,
+        stone: {
+          minedAt: 0,
+        },
+        minesLeft: 1,
+      },
+      "789": {
+        x: 8,
+        y: 8,
+        stone: {
+          minedAt: 0,
+        },
+        minesLeft: 1,
+      },
+    });
+  });
+});

--- a/src/features/game/events/landExpansion/moveAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/moveAscensionCrystal.ts
@@ -1,0 +1,45 @@
+import type { Coordinates } from "features/game/expansion/components/MapPlacement";
+import type { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+export enum MOVE_ASCENSION_CRYSTAL_ERRORS {
+  NO_BUMPKIN = "You do not have a Bumpkin!",
+  ASCENSION_CRYSTAL_NOT_PLACED = "This ascension crystal is not placed!",
+}
+
+export type MoveAscensionCrystalAction = {
+  type: "ascensionCrystal.moved";
+  coordinates: Coordinates;
+  id: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: MoveAscensionCrystalAction;
+  createdAt?: number;
+};
+
+export function moveAscensionCrystal({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (stateCopy) => {
+    const { ascensionCrystals } = stateCopy;
+
+    if (stateCopy.bumpkin === undefined) {
+      throw new Error(MOVE_ASCENSION_CRYSTAL_ERRORS.NO_BUMPKIN);
+    }
+
+    if (!ascensionCrystals[action.id]) {
+      throw new Error(
+        MOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_PLACED,
+      );
+    }
+
+    ascensionCrystals[action.id].x = action.coordinates.x;
+    ascensionCrystals[action.id].y = action.coordinates.y;
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/events/landExpansion/placeAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/placeAscensionCrystal.test.ts
@@ -12,7 +12,7 @@ describe("placeAscensionCrystal", () => {
             y: 1,
           },
           id: "1",
-          name: "Stone Rock",
+          name: "Ascension Crystal",
           type: "ascensionCrystal.placed",
         },
         state: {

--- a/src/features/game/events/landExpansion/placeAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/placeAscensionCrystal.test.ts
@@ -1,0 +1,156 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import { placeAscensionCrystal } from "./placeAscensionCrystal";
+
+describe("placeAscensionCrystal", () => {
+  it("ensures ascension crystals are in inventory", () => {
+    expect(() =>
+      placeAscensionCrystal({
+        action: {
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+          id: "1",
+          name: "Stone Rock",
+          type: "ascensionCrystal.placed",
+        },
+        state: {
+          ...INITIAL_FARM,
+          inventory: {
+            "Ascension Crystal": new Decimal(0),
+          },
+        },
+      }),
+    ).toThrow("No ascension crystal available");
+  });
+
+  it("ensures ascension crystals are available", () => {
+    expect(() =>
+      placeAscensionCrystal({
+        action: {
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+          id: "1",
+          name: "Ascension Crystal",
+          type: "ascensionCrystal.placed",
+        },
+        state: {
+          ...INITIAL_FARM,
+          inventory: {
+            "Ascension Crystal": new Decimal(1),
+          },
+          ascensionCrystals: {
+            "123": {
+              createdAt: Date.now(),
+              stone: {
+                minedAt: 0,
+              },
+              minesLeft: 1,
+              x: 1,
+              y: 1,
+            },
+          },
+        },
+      }),
+    ).toThrow("No ascension crystal available");
+  });
+
+  it("places an ascension crystal", () => {
+    const state = placeAscensionCrystal({
+      action: {
+        coordinates: {
+          x: 2,
+          y: 2,
+        },
+        id: "1",
+        name: "Ascension Crystal",
+        type: "ascensionCrystal.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: {
+          "Ascension Crystal": new Decimal(2),
+        },
+        ascensionCrystals: {
+          "123": {
+            createdAt: Date.now(),
+            stone: {
+              minedAt: 0,
+            },
+            minesLeft: 1,
+            x: 0,
+            y: 0,
+          },
+        },
+      },
+    });
+
+    expect(state.ascensionCrystals).toEqual({
+      "1": {
+        createdAt: expect.any(Number),
+        stone: {
+          minedAt: 0,
+        },
+        minesLeft: 1,
+        x: 2,
+        y: 2,
+      },
+      "123": {
+        createdAt: expect.any(Number),
+        stone: {
+          minedAt: 0,
+        },
+        minesLeft: 1,
+        x: 0,
+        y: 0,
+      },
+    });
+  });
+
+  it("reinstates current progress when the rock was mined", () => {
+    const dateNow = Date.now();
+    const state = placeAscensionCrystal({
+      action: {
+        coordinates: {
+          x: 2,
+          y: 2,
+        },
+        id: "1", // ID doesn't matter since it's an existing rock
+        name: "Ascension Crystal",
+        type: "ascensionCrystal.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: {
+          "Ascension Crystal": new Decimal(2),
+        },
+        ascensionCrystals: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt: dateNow - 180000 },
+            removedAt: dateNow - 120000,
+            minesLeft: 1,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    expect(state.ascensionCrystals).toEqual({
+      "123": {
+        createdAt: expect.any(Number),
+        stone: {
+          minedAt: dateNow - 60000,
+        },
+        x: 2,
+        y: 2,
+        minesLeft: 1,
+      },
+    });
+  });
+});

--- a/src/features/game/events/landExpansion/placeAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/placeAscensionCrystal.ts
@@ -1,0 +1,80 @@
+import type { FiniteResource, GameState } from "features/game/types/game";
+import type { ResourceName } from "features/game/types/resources";
+import Decimal from "decimal.js-light";
+import { produce } from "immer";
+import type { Coordinates } from "features/game/expansion/components/MapPlacement";
+
+export type PlaceAscensionCrystalAction = {
+  type: "ascensionCrystal.placed";
+  name: ResourceName;
+  id: string;
+  coordinates: Coordinates;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: PlaceAscensionCrystalAction;
+  createdAt?: number;
+};
+
+export function placeAscensionCrystal({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (game) => {
+    const available = (
+      game.inventory["Ascension Crystal"] || new Decimal(0)
+    ).minus(
+      Object.values(game.ascensionCrystals).filter(
+        (rock) => rock.x !== undefined && rock.y !== undefined,
+      ).length,
+    );
+
+    if (available.lt(1)) {
+      throw new Error("No ascension crystal available");
+    }
+
+    const existingAscensionCrystal = Object.entries(
+      game.ascensionCrystals,
+    ).find(([_, rock]) => rock.x === undefined && rock.y === undefined);
+
+    if (existingAscensionCrystal) {
+      const [id, rock] = existingAscensionCrystal;
+      const updatedAscensionCrystal = {
+        ...rock,
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+      };
+
+      if (updatedAscensionCrystal.stone && updatedAscensionCrystal.removedAt) {
+        const existingProgress =
+          updatedAscensionCrystal.removedAt -
+          updatedAscensionCrystal.stone.minedAt;
+        updatedAscensionCrystal.stone.minedAt = createdAt - existingProgress;
+      }
+      delete updatedAscensionCrystal.removedAt;
+
+      game.ascensionCrystals[id] = updatedAscensionCrystal;
+
+      return game;
+    }
+
+    const newAscensionCrystal: FiniteResource = {
+      createdAt,
+      x: action.coordinates.x,
+      y: action.coordinates.y,
+      stone: {
+        minedAt: 0,
+      },
+      minesLeft: 1,
+    };
+
+    game.ascensionCrystals = {
+      ...game.ascensionCrystals,
+      [action.id]: newAscensionCrystal,
+    };
+
+    return game;
+  });
+}

--- a/src/features/game/events/landExpansion/removeAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/removeAscensionCrystal.test.ts
@@ -1,0 +1,65 @@
+import { INITIAL_FARM } from "features/game/lib/constants";
+import type { GameState } from "features/game/types/game";
+import {
+  removeAscensionCrystal,
+  REMOVE_ASCENSION_CRYSTAL_ERRORS,
+} from "./removeAscensionCrystal";
+
+const GAME_STATE: GameState = {
+  ...INITIAL_FARM,
+  ascensionCrystals: {
+    "0": {
+      stone: {
+        minedAt: 0,
+      },
+      createdAt: 0,
+      minesLeft: 1,
+    },
+    "2": {
+      stone: {
+        minedAt: 0,
+      },
+      createdAt: 0,
+      minesLeft: 1,
+      x: 1,
+      y: 0,
+    },
+  },
+};
+
+describe("removeAscensionCrystal", () => {
+  it("throws if the ascension crystal is not found", () => {
+    expect(() =>
+      removeAscensionCrystal({
+        state: GAME_STATE,
+        action: { type: "ascensionCrystal.removed", id: "1" },
+      }),
+    ).toThrow(REMOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_FOUND);
+  });
+
+  it("throws if the ascension crystal is not placed", () => {
+    expect(() =>
+      removeAscensionCrystal({
+        state: GAME_STATE,
+        action: { type: "ascensionCrystal.removed", id: "0" },
+      }),
+    ).toThrow(REMOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_PLACED);
+  });
+
+  it("removes an ascension crystal", () => {
+    const state = removeAscensionCrystal({
+      state: GAME_STATE,
+      action: { type: "ascensionCrystal.removed", id: "2" },
+    });
+    expect(state.ascensionCrystals["2"].x).toBeUndefined();
+    expect(state.ascensionCrystals["2"].y).toBeUndefined();
+  });
+
+  it("sets removedAt time", () => {
+    const state = removeAscensionCrystal({
+      state: GAME_STATE,
+      action: { type: "ascensionCrystal.removed", id: "2" },
+    });
+    expect(state.ascensionCrystals["2"].removedAt).toBeDefined();
+  });
+});

--- a/src/features/game/events/landExpansion/removeAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/removeAscensionCrystal.ts
@@ -1,0 +1,46 @@
+import { produce } from "immer";
+import type { GameState } from "features/game/types/game";
+
+export enum REMOVE_ASCENSION_CRYSTAL_ERRORS {
+  ASCENSION_CRYSTAL_NOT_FOUND = "Ascension crystal not found",
+  ASCENSION_CRYSTAL_NOT_PLACED = "Ascension crystal not placed",
+}
+
+export type RemoveAscensionCrystalAction = {
+  type: "ascensionCrystal.removed";
+  id: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: RemoveAscensionCrystalAction;
+  createdAt?: number;
+};
+
+export function removeAscensionCrystal({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options) {
+  return produce(state, (stateCopy) => {
+    const { ascensionCrystals } = stateCopy;
+    const ascensionCrystal = ascensionCrystals[action.id];
+    if (!ascensionCrystal) {
+      throw new Error(
+        REMOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_FOUND,
+      );
+    }
+
+    if (ascensionCrystal.x === undefined || ascensionCrystal.y === undefined) {
+      throw new Error(
+        REMOVE_ASCENSION_CRYSTAL_ERRORS.ASCENSION_CRYSTAL_NOT_PLACED,
+      );
+    }
+
+    delete ascensionCrystal.x;
+    delete ascensionCrystal.y;
+    ascensionCrystal.removedAt = createdAt;
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -121,6 +121,7 @@ describe("totalExpansions", () => {
       Tree: 3,
       "Oil Reserve": 0,
       "Lava Pit": 0,
+      "Ascension Crystal": 0,
     };
 
     let expansion = 4;

--- a/src/features/game/events/landExpansion/revealLand.test.ts
+++ b/src/features/game/events/landExpansion/revealLand.test.ts
@@ -72,6 +72,8 @@ describe("getRewards", () => {
           "Iron Rock": new Decimal(5),
           "Stone Rock": new Decimal(9),
           Tree: new Decimal(11),
+          // Spring island owes 1 A0 Ascension Crystal (back-pay).
+          "Ascension Crystal": new Decimal(1),
         },
         island: {
           type: "spring",

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -581,6 +581,7 @@ export function getRewards({
     "Tempered Iron Rock": 0,
     "Pure Gold Rock": 0,
     "Prime Gold Rock": 0,
+    "Ascension Crystal": 0,
   };
 
   const expected = getExpectedResources({

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -210,6 +210,23 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
       inventory["Sunstone Rock"] || new Decimal(0)
     ).add(land.sunstones?.length ?? 0);
 
+    // Add Ascension Crystals (single-use nodes; placed by getAscensionLayout on
+    // the first N expansions of an ascension band — see getExpansionCrystalCount).
+    if (land.ascensionCrystals?.length) {
+      game.ascensionCrystals = game.ascensionCrystals ?? {};
+      land.ascensionCrystals.forEach((coords) => {
+        game.ascensionCrystals[randomUUID()] = {
+          x: coords.x + origin.x,
+          y: coords.y + origin.y,
+          stone: { minedAt: 0 },
+          minesLeft: 1,
+        };
+      });
+      inventory["Ascension Crystal"] = (
+        inventory["Ascension Crystal"] || new Decimal(0)
+      ).add(land.ascensionCrystals.length);
+    }
+
     // Add bee hives
     land.beehives?.forEach((coords) => {
       const id = randomUUID();
@@ -624,6 +641,15 @@ export function getRewards({
         Math.max(0, lifetimeMines - minesOnLiveRocks) / SUNSTONE_MINES,
       );
       missing -= depleted;
+    }
+
+    // Ascension Crystals are single-use: each mine destroys exactly one crystal
+    // (and decrements the inventory, see mineAscensionCrystal). Subtract the
+    // crystals already mined so this back-pay airdrop never resurrects ones the
+    // player legitimately consumed. A legacy player (0 owned, 0 mined) receives
+    // the full expected amount.
+    if (key === "Ascension Crystal") {
+      missing -= game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
     }
 
     // They have the expected amount of resources

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -11,6 +11,7 @@ import {
 } from "features/game/types/expansions";
 import type { Airdrop, GameState } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
+import { hasFeatureAccess } from "lib/flags";
 
 import { getKeys } from "lib/object";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
@@ -212,7 +213,12 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
 
     // Add Ascension Crystals (single-use nodes; placed by getAscensionLayout on
     // the first N expansions of an ascension band — see getExpansionCrystalCount).
-    if (land.ascensionCrystals?.length) {
+    // Gated by the feature flag so the forward grant can never run while the
+    // ascension system is disabled (the back-pay reconciliation is gated too).
+    if (
+      hasFeatureAccess(game, "SWAMP_ASCENSION") &&
+      land.ascensionCrystals?.length
+    ) {
       game.ascensionCrystals = game.ascensionCrystals ?? {};
       land.ascensionCrystals.forEach((coords) => {
         game.ascensionCrystals[randomUUID()] = {

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1143,7 +1143,7 @@ describe("upgradeFarm", () => {
     // Keeps the Mansion as the home, laid out per the swamp layout
     expect(state.buildings.Manor).toBeUndefined();
     expect(state.inventory.Mansion).toEqual(new Decimal(1));
-    expect(state.buildings.Mansion?.[0].coordinates).toEqual({ x: 0, y: 15 });
+    expect(state.buildings.Mansion?.[0].coordinates).toEqual({ x: -3, y: 15 });
 
     // Lays out the swamp starting nodes, incl. the swamp-specific types
     expect(Object.keys(state.crops)).toHaveLength(65);

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -1212,6 +1212,18 @@ function transitionToIsland({
     createdAt,
     initialLandCoordinates: setup.initialCoordinates,
   });
+
+  // Grant the Ascension Crystal "upgrade node": 1 per island upgrade (the A0
+  // spring/desert/volcano grants and each ascension's upgrade node). Granted to
+  // inventory for the player to place; the per-expansion crystals auto-place via
+  // the ascension layout. Kept additive (never reset) so it stays in lockstep
+  // with getExpectedAscensionCrystals for the revealLand back-pay reconciliation.
+  if (hasFeatureAccess(game, "SWAMP_ASCENSION")) {
+    game.inventory["Ascension Crystal"] = (
+      game.inventory["Ascension Crystal"] ?? new Decimal(0)
+    ).add(1);
+  }
+
   game = cloneDeep(game);
 
   // Reset the biome upon transition

--- a/src/features/game/events/landExpansion/upgradeRock.ts
+++ b/src/features/game/events/landExpansion/upgradeRock.ts
@@ -27,6 +27,7 @@ export type UpgradeRockAction = {
     | "Iron Rock"
     | "Sunstone Rock"
     | "Crimstone Rock"
+    | "Ascension Crystal"
   >;
   id: string;
 };

--- a/src/features/game/expansion/Land.tsx
+++ b/src/features/game/expansion/Land.tsx
@@ -108,6 +108,14 @@ const _sunstonePositions = (state: MachineState) => {
     positions: getSortedResourcePositions(state.context.state.sunstones),
   };
 };
+const _ascensionCrystalPositions = (state: MachineState) => {
+  return {
+    ascensionCrystals: state.context.state.ascensionCrystals,
+    positions: getSortedResourcePositions(
+      state.context.state.ascensionCrystals,
+    ),
+  };
+};
 const _beehivePositions = (state: MachineState) => {
   return {
     beehives: state.context.state.beehives,
@@ -345,6 +353,11 @@ export const LandComponent: React.FC = () => {
   const { sunstones } = useSelector(
     gameService,
     _sunstonePositions,
+    comparePositions,
+  );
+  const { ascensionCrystals } = useSelector(
+    gameService,
+    _ascensionCrystalPositions,
     comparePositions,
   );
   const { beehives } = useSelector(
@@ -750,6 +763,38 @@ export const LandComponent: React.FC = () => {
       });
   }, [sunstones]);
 
+  const ascensionCrystalElements = useMemo(() => {
+    return getObjectEntries(ascensionCrystals)
+      .filter(
+        ([, crystal]) => crystal.x !== undefined && crystal.y !== undefined,
+      )
+      .map(([id, crystal], index) => {
+        const { x, y, oX, oY } = crystal;
+
+        return (
+          <MapPlacement
+            key={`ascension-crystal-${id}`}
+            x={x!}
+            y={y!}
+            oX={oX}
+            oY={oY}
+            {...RESOURCE_DIMENSIONS["Ascension Crystal"]}
+          >
+            <Resource
+              key={`ascension-crystal-${id}`}
+              name="Ascension Crystal"
+              createdAt={0}
+              readyAt={0}
+              id={id}
+              index={index}
+              x={x!}
+              y={y!}
+            />
+          </MapPlacement>
+        );
+      });
+  }, [ascensionCrystals]);
+
   const beehiveElements = useMemo(() => {
     return getObjectEntries(beehives)
       .filter(
@@ -1132,6 +1177,7 @@ export const LandComponent: React.FC = () => {
       ironElements,
       crimstoneElements,
       sunstoneElements,
+      ascensionCrystalElements,
       beehiveElements,
       flowerBedElements,
       fruitPatchElements,
@@ -1177,6 +1223,7 @@ export const LandComponent: React.FC = () => {
     ironElements,
     crimstoneElements,
     sunstoneElements,
+    ascensionCrystalElements,
     beehiveElements,
     flowerBedElements,
     fruitPatchElements,

--- a/src/features/game/expansion/components/resources/ascensionCrystal/AscensionCrystal.tsx
+++ b/src/features/game/expansion/components/resources/ascensionCrystal/AscensionCrystal.tsx
@@ -2,7 +2,10 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 
 import { Context } from "features/game/GameProvider";
 
-import type { InventoryItemName, Rock } from "features/game/types/game";
+import type {
+  FiniteResource,
+  InventoryItemName,
+} from "features/game/types/game";
 import { useSelector } from "@xstate/react";
 import type { MachineState } from "features/game/lib/gameMachine";
 import Decimal from "decimal.js-light";
@@ -22,9 +25,13 @@ const HasTool = (inventory: Partial<Record<InventoryItemName, Decimal>>) => {
 
 const selectInventory = (state: MachineState) => state.context.state.inventory;
 
-const compareResource = (prev?: Rock, next?: Rock) => {
-  return JSON.stringify(prev) === JSON.stringify(next);
-};
+// Cheap field comparator (avoids per-frame JSON.stringify in a resource-heavy
+// scene). Single-use nodes only change via mine/move, so these fields suffice.
+const compareResource = (prev?: FiniteResource, next?: FiniteResource) =>
+  prev?.minesLeft === next?.minesLeft &&
+  prev?.stone?.minedAt === next?.stone?.minedAt &&
+  prev?.x === next?.x &&
+  prev?.y === next?.y;
 
 interface Props {
   id: string;
@@ -36,9 +43,11 @@ export const AscensionCrystal: React.FC<Props> = ({ id }) => {
 
   const [touchCount, setTouchCount] = useState(0);
 
-  // When to hide the resource that pops out
-  const [collecting, setCollecting] = useState(false);
-  const harvested = useRef<number>(0);
+  // Drives the "popping out" animation. State (not a ref) so the render output
+  // never depends on mutable ref state — keeps React Compiler / concurrent
+  // rendering happy.
+  const [collectingAmount, setCollectingAmount] = useState(0);
+  const collectingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const divRef = useRef<HTMLDivElement>(null);
 
   const { play: miningFallAudio } = useSound("mining_fall");
@@ -53,6 +62,15 @@ export const AscensionCrystal: React.FC<Props> = ({ id }) => {
     document.addEventListener("click", handleClickOutside, true);
     return () => {
       document.removeEventListener("click", handleClickOutside, true);
+    };
+  }, []);
+
+  // Clear any pending animation timeout on unmount (mining deletes the node).
+  useEffect(() => {
+    return () => {
+      if (collectingTimeout.current) {
+        clearTimeout(collectingTimeout.current);
+      }
     };
   }, []);
 
@@ -88,22 +106,19 @@ export const AscensionCrystal: React.FC<Props> = ({ id }) => {
     setTouchCount(0);
   };
 
-  const mine = async () => {
+  const mine = () => {
     gameService.send("ascensionCrystal.mined", {
       index: id,
     });
 
-    if (showAnimations) {
-      setCollecting(true);
-      harvested.current = 1;
-    }
-
     miningFallAudio();
 
     if (showAnimations) {
-      await new Promise((res) => setTimeout(res, 3000));
-      setCollecting(false);
-      harvested.current = 0;
+      setCollectingAmount(1);
+      collectingTimeout.current = setTimeout(() => {
+        setCollectingAmount(0);
+        collectingTimeout.current = null;
+      }, 3000);
     }
   };
 
@@ -121,9 +136,9 @@ export const AscensionCrystal: React.FC<Props> = ({ id }) => {
       )}
 
       {/* Depleting resource animation */}
-      {collecting && (
+      {collectingAmount > 0 && (
         <DepletingSunstone
-          resourceAmount={harvested.current}
+          resourceAmount={collectingAmount}
           minesLeft={resource.minesLeft}
         />
       )}

--- a/src/features/game/expansion/components/resources/ascensionCrystal/AscensionCrystal.tsx
+++ b/src/features/game/expansion/components/resources/ascensionCrystal/AscensionCrystal.tsx
@@ -1,0 +1,132 @@
+import React, { useContext, useEffect, useRef, useState } from "react";
+
+import { Context } from "features/game/GameProvider";
+
+import type { InventoryItemName, Rock } from "features/game/types/game";
+import { useSelector } from "@xstate/react";
+import type { MachineState } from "features/game/lib/gameMachine";
+import Decimal from "decimal.js-light";
+import { canMine } from "features/game/lib/resourceNodes";
+import { useSound } from "lib/utils/hooks/useSound";
+
+// Placeholder art: reuses the Sunstone visuals until dedicated crystal art lands.
+import { DepletingSunstone } from "../sunstone/components/DepletingSunstone";
+import { RecoveredSunstone } from "../sunstone/components/RecoveredSunstone";
+
+const HITS = 3;
+const tool = "Gold Pickaxe";
+
+const HasTool = (inventory: Partial<Record<InventoryItemName, Decimal>>) => {
+  return (inventory[tool] ?? new Decimal(0)).gte(1);
+};
+
+const selectInventory = (state: MachineState) => state.context.state.inventory;
+
+const compareResource = (prev?: Rock, next?: Rock) => {
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+
+interface Props {
+  id: string;
+  index: number;
+}
+
+export const AscensionCrystal: React.FC<Props> = ({ id }) => {
+  const { gameService, shortcutItem, showAnimations } = useContext(Context);
+
+  const [touchCount, setTouchCount] = useState(0);
+
+  // When to hide the resource that pops out
+  const [collecting, setCollecting] = useState(false);
+  const harvested = useRef<number>(0);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const { play: miningFallAudio } = useSound("mining_fall");
+
+  // Reset the touch count when clicking outside of the component
+  useEffect(() => {
+    const handleClickOutside = (event: any) => {
+      if (divRef.current && !divRef.current.contains(event.target)) {
+        setTouchCount(0);
+      }
+    };
+    document.addEventListener("click", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("click", handleClickOutside, true);
+    };
+  }, []);
+
+  const resource = useSelector(
+    gameService,
+    (state) => state.context.state.ascensionCrystals[id],
+    compareResource,
+  );
+  const inventory = useSelector(
+    gameService,
+    selectInventory,
+    (prev, next) => HasTool(prev) === HasTool(next),
+  );
+
+  // Single-use: mining deletes the node, so the selector briefly returns
+  // undefined before this element unmounts. Bail out instead of crashing.
+  if (!resource) return null;
+
+  const hasTool = HasTool(inventory);
+  const mined = !canMine(resource, "Ascension Crystal");
+
+  const strike = () => {
+    if (!hasTool) return;
+
+    setTouchCount((count) => count + 1);
+    shortcutItem(tool);
+
+    // need to hit enough times to collect resource
+    if (touchCount < HITS - 1) return;
+
+    // can collect resources otherwise
+    mine();
+    setTouchCount(0);
+  };
+
+  const mine = async () => {
+    gameService.send("ascensionCrystal.mined", {
+      index: id,
+    });
+
+    if (showAnimations) {
+      setCollecting(true);
+      harvested.current = 1;
+    }
+
+    miningFallAudio();
+
+    if (showAnimations) {
+      await new Promise((res) => setTimeout(res, 3000));
+      setCollecting(false);
+      harvested.current = 0;
+    }
+  };
+
+  return (
+    <div className="relative w-full h-full">
+      {/* Resource ready to collect */}
+      {!mined && (
+        <div ref={divRef} className="absolute w-full h-full" onClick={strike}>
+          <RecoveredSunstone
+            hasTool={hasTool}
+            touchCount={touchCount}
+            minesLeft={resource.minesLeft}
+          />
+        </div>
+      )}
+
+      {/* Depleting resource animation */}
+      {collecting && (
+        <DepletingSunstone
+          resourceAmount={harvested.current}
+          minesLeft={resource.minesLeft}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -128,6 +128,7 @@ describe("swamp cumulative nodes (carry-forward)", () => {
       Beehive: 4,
       "Flower Bed": 4,
       "Sunstone Rock": 13,
+      "Ascension Crystal": 0,
     });
 
     expect(getAscensionNodes({ expansion: 42, ascensionLevel: 5 })).toEqual({
@@ -143,6 +144,7 @@ describe("swamp cumulative nodes (carry-forward)", () => {
       Beehive: 8,
       "Flower Bed": 8,
       "Sunstone Rock": 13,
+      "Ascension Crystal": 0,
     });
   });
 });

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -85,6 +85,7 @@ export const SWAMP_BASE_NODES: Nodes = {
   "Lava Pit": 3,
   Beehive: 3,
   "Flower Bed": 3,
+  "Ascension Crystal": 0,
 };
 
 /** `{ start, end }` of the cost curve for each charged resource + coins. */
@@ -113,6 +114,7 @@ const SWAMP_NODE_DRIP: Record<keyof Nodes, number> = {
   Beehive: 10,
   "Flower Bed": 10,
   "Sunstone Rock": 0,
+  "Ascension Crystal": 0,
 };
 
 /** Maps each node type to the `Layout` array it is placed into. */
@@ -129,6 +131,7 @@ const NODE_TO_LAYOUT_FIELD: Record<keyof Nodes, keyof Layout> = {
   Beehive: "beehives",
   "Oil Reserve": "oilReserves",
   "Lava Pit": "lavaPits",
+  "Ascension Crystal": "ascensionCrystals",
 };
 
 /**
@@ -419,6 +422,7 @@ export const getAscensionLayout = ({
     fruitPatches: [],
     oilReserves: [],
     lavaPits: [],
+    ascensionCrystals: [],
   };
 
   const delta = getAscensionExpansionDelta({ expansion, ascensionLevel });

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -7,6 +7,7 @@ import {
   RESOURCE_DIMENSIONS,
   type ResourceName,
 } from "features/game/types/resources";
+import type { IslandType } from "features/game/types/game";
 import { getKeys } from "lib/object";
 import {
   LEVELS_PER_ASCENSION,
@@ -44,6 +45,90 @@ const DRIP_WIDEN_PER_ASCENSION = 0.25;
 const DRIP_CAP = SWAMP_EXPANSIONS_PER_ASCENSION; // 12
 /** Each expansion's build time grows linearly: `e × 7h`. */
 const HOURS_PER_EXPANSION = 7;
+
+/**
+ * Ascension Crystal grants — a bolt-on resource, deliberately kept OUT of the
+ * drip model (`SWAMP_NODE_DRIP`/`SWAMP_BASE_NODES` stay 0 for it). Crystals are
+ * single-use (mined once for shards), so they are reconciled additively rather
+ * than via the cumulative `getAscensionNodes` floor (which would resurrect spent
+ * crystals through the `upgradeFarm` `minimum` top-up). See ASCENSION_SYSTEM.md.
+ *
+ * Schedule:
+ * - A0 (pre-ascension): 1 crystal on each spring/desert/volcano upgrade
+ *   (cumulative-by-island below; ascension islands inherit the full 3).
+ * - Per ascension A: 1 at the upgrade + 1 on each of the first
+ *   `min(A + 2, 12)` expansions of the band.
+ */
+const A0_CRYSTALS_BY_ISLAND: Record<IslandType, number> = {
+  basic: 0,
+  spring: 1,
+  desert: 2,
+  volcano: 3,
+  swamp: 3,
+  spooky: 3,
+  crystal: 3,
+  moon: 3,
+  marble: 3,
+};
+
+/** Expansion crystals granted across one ascension band: `min(A + 2, 12)`. */
+const getBandExpansionCrystalTotal = (ascensionLevel: number): number =>
+  Math.min(ascensionLevel + 2, SWAMP_EXPANSIONS_PER_ASCENSION);
+
+/**
+ * Crystals placed by revealing the expansion that brings the farm to
+ * `expansion` Basic Land tiles: 1 for each of the band's first `min(A+2,12)`
+ * expansions, otherwise 0 (and 0 off an ascension island).
+ */
+export const getExpansionCrystalCount = ({
+  ascensionLevel,
+  expansion,
+}: {
+  ascensionLevel: number;
+  expansion: number;
+}): number => {
+  const a = ascensionLevel ?? 0;
+  if (a < 1) return 0;
+  const e = expansion - SWAMP_BASE_EXPANSION; // 1..12
+  if (e < 1 || e > SWAMP_EXPANSIONS_PER_ASCENSION) return 0;
+  return e <= getBandExpansionCrystalTotal(a) ? 1 : 0;
+};
+
+/**
+ * Cumulative Ascension Crystals a player should have earned by their current
+ * progression. Single source of truth: forward placement increments inventory
+ * by this function's first-difference; `revealLand`'s missing-node airdrop
+ * backfills the remainder (legacy players who progressed before the feature).
+ */
+export const getExpectedAscensionCrystals = ({
+  islandType,
+  ascensionLevel,
+  basicLand,
+}: {
+  islandType: IslandType;
+  ascensionLevel: number;
+  basicLand: number;
+}): number => {
+  let total = A0_CRYSTALS_BY_ISLAND[islandType] ?? 0;
+
+  const a = ascensionLevel ?? 0;
+  // Every completed prior ascension granted 1 (upgrade) + its expansion nodes.
+  for (let prior = 1; prior < a; prior++) {
+    total += 1 + getBandExpansionCrystalTotal(prior);
+  }
+  // Current band: the upgrade node + the expansion nodes earned so far.
+  if (a >= 1) {
+    const e = Math.max(
+      0,
+      Math.min(
+        basicLand - SWAMP_BASE_EXPANSION,
+        SWAMP_EXPANSIONS_PER_ASCENSION,
+      ),
+    );
+    total += 1 + Math.min(e, getBandExpansionCrystalTotal(a));
+  }
+  return total;
+};
 
 /**
  * Within-ascension level (1..50, from `getAscensionLevel`) required to unlock each
@@ -462,6 +547,16 @@ export const getAscensionLayout = ({
       (layout[field] as Coordinates[]).push(place(width, height));
     }
   });
+
+  // Ascension Crystals are placed outside the drip schedule (see helpers above):
+  // 1 on each of the band's first `min(A+2,12)` expansions.
+  const crystals = getExpansionCrystalCount({ ascensionLevel, expansion });
+  const crystalDimensions = RESOURCE_DIMENSIONS["Ascension Crystal"];
+  for (let k = 0; k < crystals; k++) {
+    layout.ascensionCrystals!.push(
+      place(crystalDimensions.width, crystalDimensions.height),
+    );
+  }
 
   return layout;
 };

--- a/src/features/game/expansion/lib/ascensionCrystals.test.ts
+++ b/src/features/game/expansion/lib/ascensionCrystals.test.ts
@@ -1,0 +1,169 @@
+import {
+  getAscensionLayout,
+  getExpansionCrystalCount,
+  getExpectedAscensionCrystals,
+} from "./ascension";
+
+describe("getExpectedAscensionCrystals", () => {
+  it("grants nothing on basic land", () => {
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "basic",
+        ascensionLevel: 0,
+        basicLand: 9,
+      }),
+    ).toBe(0);
+  });
+
+  it("grants the cumulative A0 node on each pre-ascension island", () => {
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "spring",
+        ascensionLevel: 0,
+        basicLand: 16,
+      }),
+    ).toBe(1);
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "desert",
+        ascensionLevel: 0,
+        basicLand: 25,
+      }),
+    ).toBe(2);
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "volcano",
+        ascensionLevel: 0,
+        basicLand: 30,
+      }),
+    ).toBe(3);
+  });
+
+  it("grants A0 (3) + the upgrade node on arriving at A1 (e=0)", () => {
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "swamp",
+        ascensionLevel: 1,
+        basicLand: 30,
+      }),
+    ).toBe(4);
+  });
+
+  it("adds one per expansion across A1's first 3 expansions, then caps", () => {
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "swamp",
+        ascensionLevel: 1,
+        basicLand: 31,
+      }),
+    ).toBe(5);
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "swamp",
+        ascensionLevel: 1,
+        basicLand: 33,
+      }),
+    ).toBe(7);
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "swamp",
+        ascensionLevel: 1,
+        basicLand: 42,
+      }),
+    ).toBe(7);
+  });
+
+  it("carries completed bands forward cumulatively (A2 arrival)", () => {
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "spooky",
+        ascensionLevel: 2,
+        basicLand: 30,
+      }),
+    ).toBe(8);
+    expect(
+      getExpectedAscensionCrystals({
+        islandType: "spooky",
+        ascensionLevel: 2,
+        basicLand: 34,
+      }),
+    ).toBe(12);
+  });
+
+  it("caps the per-band expansion nodes at 12 from A10 onward", () => {
+    const a10End = getExpectedAscensionCrystals({
+      islandType: "marble",
+      ascensionLevel: 10,
+      basicLand: 42,
+    });
+    const a9End = getExpectedAscensionCrystals({
+      islandType: "marble",
+      ascensionLevel: 9,
+      basicLand: 42,
+    });
+    expect(a10End - a9End).toBe(13);
+
+    const a11End = getExpectedAscensionCrystals({
+      islandType: "marble",
+      ascensionLevel: 11,
+      basicLand: 42,
+    });
+    expect(a11End - a10End).toBe(13);
+  });
+});
+
+describe("getExpansionCrystalCount", () => {
+  it("is 0 off an ascension island", () => {
+    expect(getExpansionCrystalCount({ ascensionLevel: 0, expansion: 10 })).toBe(
+      0,
+    );
+  });
+
+  it("is 1 on each of a band's first N expansions, else 0", () => {
+    expect(getExpansionCrystalCount({ ascensionLevel: 1, expansion: 30 })).toBe(
+      0,
+    );
+    expect(getExpansionCrystalCount({ ascensionLevel: 1, expansion: 31 })).toBe(
+      1,
+    );
+    expect(getExpansionCrystalCount({ ascensionLevel: 1, expansion: 33 })).toBe(
+      1,
+    );
+    expect(getExpansionCrystalCount({ ascensionLevel: 1, expansion: 34 })).toBe(
+      0,
+    );
+    expect(getExpansionCrystalCount({ ascensionLevel: 2, expansion: 34 })).toBe(
+      1,
+    );
+    expect(getExpansionCrystalCount({ ascensionLevel: 2, expansion: 35 })).toBe(
+      0,
+    );
+  });
+});
+
+describe("getAscensionLayout — crystal placement", () => {
+  it("places one crystal on each of A1's first 3 expansions, none after", () => {
+    expect(
+      getAscensionLayout({ expansion: 31, ascensionLevel: 1 })
+        .ascensionCrystals,
+    ).toHaveLength(1);
+    expect(
+      getAscensionLayout({ expansion: 33, ascensionLevel: 1 })
+        .ascensionCrystals,
+    ).toHaveLength(1);
+    expect(
+      getAscensionLayout({ expansion: 34, ascensionLevel: 1 })
+        .ascensionCrystals,
+    ).toHaveLength(0);
+  });
+
+  it("placed crystal coordinates sit inside the 6x6 block", () => {
+    const layout = getAscensionLayout({ expansion: 31, ascensionLevel: 1 });
+    const [crystal] = layout.ascensionCrystals ?? [];
+    expect(crystal).toBeDefined();
+    expect(crystal.x).toBeGreaterThanOrEqual(-3);
+    expect(crystal.x + 2).toBeLessThanOrEqual(3);
+    expect(crystal.y).toBeLessThanOrEqual(3);
+    expect(crystal.y - 2).toBeGreaterThanOrEqual(-3);
+  });
+});

--- a/src/features/game/expansion/lib/deriveExpansionNodes.test.ts
+++ b/src/features/game/expansion/lib/deriveExpansionNodes.test.ts
@@ -34,6 +34,7 @@ const EXPECTED: Record<
       Beehive: 0,
       "Oil Reserve": 0,
       "Lava Pit": 0,
+      "Ascension Crystal": 0,
     },
     final: {
       "Crop Plot": 31,
@@ -48,6 +49,7 @@ const EXPECTED: Record<
       Beehive: 0,
       "Oil Reserve": 0,
       "Lava Pit": 0,
+      "Ascension Crystal": 0,
     },
   },
   spring: {
@@ -66,6 +68,7 @@ const EXPECTED: Record<
       "Oil Reserve": 0,
       "Flower Bed": 0,
       "Lava Pit": 0,
+      "Ascension Crystal": 0,
     },
     // spring[16] is the designed handoff into the desert arrival row
     // (== DESERT_BASE_NODES); legacy spring 17–20 were retired with the cap.
@@ -82,6 +85,7 @@ const EXPECTED: Record<
       "Flower Bed": 3,
       "Oil Reserve": 0,
       "Lava Pit": 0,
+      "Ascension Crystal": 0,
     },
   },
   desert: {
@@ -100,6 +104,7 @@ const EXPECTED: Record<
       "Lava Pit": 0,
       Beehive: 3,
       "Flower Bed": 3,
+      "Ascension Crystal": 0,
     },
     final: {
       "Crop Plot": 65,
@@ -114,6 +119,7 @@ const EXPECTED: Record<
       "Lava Pit": 0,
       Beehive: 3,
       "Flower Bed": 3,
+      "Ascension Crystal": 0,
     },
   },
   volcano: {
@@ -132,6 +138,7 @@ const EXPECTED: Record<
       "Lava Pit": 0,
       Beehive: 3,
       "Flower Bed": 3,
+      "Ascension Crystal": 0,
     },
     final: {
       "Crop Plot": 65,
@@ -146,6 +153,7 @@ const EXPECTED: Record<
       "Lava Pit": 3,
       Beehive: 3,
       "Flower Bed": 3,
+      "Ascension Crystal": 0,
     },
   },
 };

--- a/src/features/game/expansion/placeable/landscapingMachine.ts
+++ b/src/features/game/expansion/placeable/landscapingMachine.ts
@@ -26,8 +26,9 @@ import {
 import type { PlaceableLocation } from "features/game/types/collectibles";
 import type { NFTName } from "features/game/events/landExpansion/placeNFT";
 
-export const RESOURCE_PLACE_EVENTS: Partial<
-  Record<ResourceName, GameEventName<PlacementEvent>>
+export const RESOURCE_PLACE_EVENTS: Record<
+  Exclude<ResourceName, "Boulder">,
+  GameEventName<PlacementEvent>
 > = {
   Tree: "tree.placed",
   "Ancient Tree": "tree.placed",
@@ -49,6 +50,7 @@ export const RESOURCE_PLACE_EVENTS: Partial<
   "Sunstone Rock": "sunstone.placed",
   "Oil Reserve": "oilReserve.placed",
   "Lava Pit": "lavaPit.placed",
+  "Ascension Crystal": "ascensionCrystal.placed",
 };
 
 /**
@@ -66,7 +68,7 @@ export function placeEvent(
 ): GameEventName<PlacementEvent> {
   if (name in RESOURCES) {
     return RESOURCE_PLACE_EVENTS[
-      name as ResourceName
+      name as Exclude<ResourceName, "Boulder">
     ] as GameEventName<PlacementEvent>;
   }
 

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -143,6 +143,7 @@ function detectPlaceableCollision(
     flowers: { flowerBeds },
     oilReserves,
     farmHands,
+    ascensionCrystals,
   } = state;
 
   const placed = {
@@ -196,6 +197,7 @@ function detectPlaceableCollision(
     "Fruit Patch": fruitPatches,
     "Flower Bed": flowerBeds,
     Beehive: beehives,
+    "Ascension Crystal": ascensionCrystals,
   };
 
   const resourceBoundingBoxes = getObjectEntries(RESOURCE_TYPES).flatMap(

--- a/src/features/game/lib/constants.ts
+++ b/src/features/game/lib/constants.ts
@@ -257,6 +257,7 @@ export const INITIAL_RESOURCES: Pick<
   | "flowers"
   | "crimstones"
   | "sunstones"
+  | "ascensionCrystals"
   | "beehives"
   | "oilReserves"
 > = {
@@ -317,6 +318,7 @@ export const INITIAL_RESOURCES: Pick<
     flowerBeds: {},
   },
   sunstones: {},
+  ascensionCrystals: {},
   beehives: {},
   oilReserves: {},
 };
@@ -965,6 +967,7 @@ export const TEST_FARM: GameState = {
     },
   },
   sunstones: {},
+  ascensionCrystals: {},
   mushrooms: {
     spawnedAt: 0,
     mushrooms: {},
@@ -1139,6 +1142,7 @@ export const EMPTY: GameState = {
   oilReserves: {},
   trees: {},
   sunstones: {},
+  ascensionCrystals: {},
   farmActivity: {},
 
   milestones: {},

--- a/src/features/game/lib/resourceNodes.ts
+++ b/src/features/game/lib/resourceNodes.ts
@@ -105,6 +105,7 @@ export function canMine(
     "Tempered Iron Rock": IRON_RECOVERY_TIME,
     "Pure Gold Rock": GOLD_RECOVERY_TIME,
     "Prime Gold Rock": GOLD_RECOVERY_TIME,
+    "Ascension Crystal": 0,
   };
 
   const recoveryTime = resourceRecoveryTime[rockName];

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -95,6 +95,7 @@ export function makeGame(farm: any): GameState {
     crimstones: farm.crimstones ?? {},
     oilReserves: farm.oilReserves ?? {},
     sunstones: farm.sunstones ?? {},
+    ascensionCrystals: farm.ascensionCrystals ?? {},
     crops: farm.crops ?? {},
     fruitPatches: farm.fruitPatches ?? {},
     flowers: farm.flowers ?? {},

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -1969,6 +1969,7 @@ export type Layout = {
   fruitPatches?: Coordinates[];
   oilReserves?: Coordinates[];
   lavaPits?: Coordinates[];
+  ascensionCrystals?: Coordinates[];
 };
 
 // --- Expansion node counts (derived) -------------------------------------
@@ -2067,6 +2068,7 @@ const BASIC_BASE_NODES: Nodes = {
   Beehive: 0,
   "Oil Reserve": 0,
   "Lava Pit": 0,
+  "Ascension Crystal": 0,
 };
 
 const SPRING_BASE_NODES: Nodes = {
@@ -2082,6 +2084,7 @@ const SPRING_BASE_NODES: Nodes = {
   "Oil Reserve": 0,
   "Flower Bed": 0,
   "Lava Pit": 0,
+  "Ascension Crystal": 0,
 };
 
 const DESERT_BASE_NODES: Nodes = {
@@ -2097,6 +2100,7 @@ const DESERT_BASE_NODES: Nodes = {
   "Lava Pit": 0,
   Beehive: 3,
   "Flower Bed": 3,
+  "Ascension Crystal": 0,
 };
 
 const VOLCANO_BASE_NODES: Nodes = {
@@ -2112,6 +2116,7 @@ const VOLCANO_BASE_NODES: Nodes = {
   "Lava Pit": 0,
   Beehive: 3,
   "Flower Bed": 3,
+  "Ascension Crystal": 0,
 };
 
 export const TOTAL_EXPANSION_NODES: ExpansionNode = {

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -10,8 +10,10 @@ import {
   getAscensionExpansionRequirements,
   getAscensionLayout,
   getAscensionNodes,
+  getExpectedAscensionCrystals,
 } from "../expansion/lib/ascension";
 import { getKeys } from "lib/object";
+import { hasFeatureAccess } from "lib/flags";
 import type { LevelRequirement } from "features/game/lib/level";
 import {
   ADVANCED_RESOURCES,
@@ -119,6 +121,21 @@ export function getExpectedResources({
     expectedResources[resource] =
       (expectedResources[resource] ?? 0) + bought - burned + upgraded;
   });
+
+  // Ascension Crystals follow a custom grant schedule (outside the drip model)
+  // and only when the ascension feature is live. Override the base (0) with the
+  // cumulative expected so revealLand's missing-node airdrop can back-pay legacy
+  // players who progressed before the feature shipped.
+  expectedResources["Ascension Crystal"] = hasFeatureAccess(
+    game,
+    "SWAMP_ASCENSION",
+  )
+    ? getExpectedAscensionCrystals({
+        islandType: game.island.type,
+        ascensionLevel: game.island.ascensionLevel ?? 0,
+        basicLand: expansion,
+      })
+    : 0;
 
   return expectedResources;
 }

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1990,6 +1990,7 @@ export interface GameState {
   iron: Record<string, Rock>;
   crimstones: Record<string, FiniteResource>;
   sunstones: Record<string, FiniteResource>;
+  ascensionCrystals: Record<string, FiniteResource>;
   oilReserves: Record<string, OilReserve>;
 
   crops: Record<string, CropPlot>;

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -3531,7 +3531,7 @@ export const ITEM_DETAILS: Items = {
   // TODO: replace placeholder art once the Ascension Crystal asset lands.
   "Ascension Crystal": {
     image: sunstoneRock,
-    description: "Upgrade skills",
+    description: translate("description.ascensionCrystal"),
   },
   Tree: {
     image: SUNNYSIDE.resource.tree,

--- a/src/features/game/types/images.ts
+++ b/src/features/game/types/images.ts
@@ -1885,6 +1885,10 @@ export const ITEM_DETAILS: Items = {
     description: COMMODITIES.Sunstone.description,
     translatedName: translate("resource.sunstone"),
   },
+  "Ascension Shard": {
+    image: sunstone,
+    description: COMMODITIES["Ascension Shard"].description,
+  },
   Oil: {
     image: oil,
     description: COMMODITIES.Oil.description,
@@ -3523,6 +3527,11 @@ export const ITEM_DETAILS: Items = {
     image: lavaPit,
     description: translate("description.lava.pit"),
     translatedName: translate("node.lavaPit"),
+  },
+  // TODO: replace placeholder art once the Ascension Crystal asset lands.
+  "Ascension Crystal": {
+    image: sunstoneRock,
+    description: "Upgrade skills",
   },
   Tree: {
     image: SUNNYSIDE.resource.tree,

--- a/src/features/game/types/index.ts
+++ b/src/features/game/types/index.ts
@@ -434,6 +434,8 @@ export const KNOWN_IDS: Record<InventoryItemName, number> = {
   "Honey Treat": 668,
   "Spice Base": 669,
   "Spiced Cheese": 670,
+  "Ascension Crystal": 671,
+  "Ascension Shard": 672,
 
   "Green Thumb": 701,
   "Barn Manager": 702,

--- a/src/features/game/types/resources.ts
+++ b/src/features/game/types/resources.ts
@@ -29,6 +29,7 @@ export type CommodityName =
   | "Wild Mushroom"
   | "Magic Mushroom"
   | "Sunstone"
+  | "Ascension Shard"
   | "Oil"
   | "Obsidian"
   | "Salt"
@@ -92,6 +93,7 @@ export const COMMODITIES: Record<CommodityName, Commodity> = {
   "Refined Salt": {
     description: "Processed salt for pickling and advanced recipes",
   },
+  "Ascension Shard": { description: "" },
 };
 
 export const ANIMAL_RESOURCES: Record<AnimalResource, Commodity> = {
@@ -126,7 +128,8 @@ export type ResourceName =
   | "Sunstone Rock"
   | "Flower Bed"
   | "Oil Reserve"
-  | "Lava Pit";
+  | "Lava Pit"
+  | "Ascension Crystal";
 
 export type BasicResourceName =
   | "Stone Rock"
@@ -164,7 +167,8 @@ export type RockName =
   | GoldRockName
   | IronRockName
   | "Sunstone Rock"
-  | "Crimstone Rock";
+  | "Crimstone Rock"
+  | "Ascension Crystal";
 
 type ResourceUpgradeRequirements = Omit<Tool, "type"> & {
   tier: ResourceTier;
@@ -196,6 +200,7 @@ export const RESOURCES: Record<ResourceName, string> = {
   "Sunstone Rock": "Mine sunstone",
   "Oil Reserve": "Drill oil",
   "Lava Pit": "Craft obsidian",
+  "Ascension Crystal": "Upgrade skills",
 };
 
 export const ADVANCED_RESOURCES: Record<
@@ -339,6 +344,7 @@ type ResourceStateRecords = {
   "Tempered Iron Rock": Record<string, Rock>;
   "Pure Gold Rock": Record<string, Rock>;
   "Prime Gold Rock": Record<string, Rock>;
+  "Ascension Crystal": Record<string, FiniteResource>;
 };
 
 export const RESOURCE_STATE_ACCESSORS: {
@@ -366,6 +372,7 @@ export const RESOURCE_STATE_ACCESSORS: {
   "Tempered Iron Rock": (game) => game.iron,
   "Pure Gold Rock": (game) => game.gold,
   "Prime Gold Rock": (game) => game.gold,
+  "Ascension Crystal": (game) => game.ascensionCrystals,
 };
 
 export const RESOURCES_UPGRADES_TO: Partial<
@@ -542,6 +549,10 @@ export const RESOURCE_DIMENSIONS: Record<ResourceName, Dimensions> = {
   "Prime Gold Rock": {
     width: 1,
     height: 1,
+  },
+  "Ascension Crystal": {
+    width: 2,
+    height: 2,
   },
 };
 

--- a/src/features/game/types/resources.ts
+++ b/src/features/game/types/resources.ts
@@ -93,7 +93,7 @@ export const COMMODITIES: Record<CommodityName, Commodity> = {
   "Refined Salt": {
     description: "Processed salt for pickling and advanced recipes",
   },
-  "Ascension Shard": { description: "" },
+  "Ascension Shard": { description: translate("description.ascensionShard") },
 };
 
 export const ANIMAL_RESOURCES: Record<AnimalResource, Commodity> = {

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -62,7 +62,7 @@ import { getBudImage } from "lib/buds/types";
 
 export const RESOURCE_MOVE_EVENTS: Record<
   ResourceName,
-  GameEventName<PlacementEvent>
+  GameEventName<PlacementEvent> | null
 > = {
   Tree: "tree.moved",
   "Crop Plot": "crop.moved",
@@ -73,7 +73,7 @@ export const RESOURCE_MOVE_EVENTS: Record<
   "Fused Stone Rock": "stone.moved",
   "Reinforced Stone Rock": "stone.moved",
   "Crimstone Rock": "crimstone.moved",
-  Boulder: "tree.moved",
+  Boulder: null,
   Beehive: "beehive.moved",
   "Flower Bed": "flowerBed.moved",
   "Sunstone Rock": "sunstone.moved",
@@ -97,7 +97,11 @@ function getMoveAction(
   }
 
   if (name in RESOURCES) {
-    return RESOURCE_MOVE_EVENTS[name as ResourceName];
+    const event = RESOURCE_MOVE_EVENTS[name as ResourceName];
+    if (!event) {
+      throw new Error("No matching move event");
+    }
+    return event;
   }
 
   if (name in COLLECTIBLES_DIMENSIONS) {

--- a/src/features/island/collectibles/MovableComponent.tsx
+++ b/src/features/island/collectibles/MovableComponent.tsx
@@ -85,6 +85,7 @@ export const RESOURCE_MOVE_EVENTS: Record<
   "Tempered Iron Rock": "iron.moved",
   "Pure Gold Rock": "gold.moved",
   "Prime Gold Rock": "gold.moved",
+  "Ascension Crystal": "ascensionCrystal.moved",
 };
 
 function getMoveAction(
@@ -142,6 +143,7 @@ export const RESOURCES_REMOVE_ACTIONS: Record<
   "Tempered Iron Rock": "iron.removed",
   "Pure Gold Rock": "gold.removed",
   "Prime Gold Rock": "gold.removed",
+  "Ascension Crystal": "ascensionCrystal.removed",
 };
 
 function getOverlappingCollectibles({

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -19,6 +19,7 @@ import { Crimstone } from "features/game/expansion/components/resources/crimston
 import { Beehive } from "features/game/expansion/components/resources/beehive/Beehive";
 import { FlowerBed } from "../flowers/FlowerBed";
 import { Sunstone } from "features/game/expansion/components/resources/sunstone/Sunstone";
+import { AscensionCrystal } from "features/game/expansion/components/resources/ascensionCrystal/AscensionCrystal";
 import { OilReserve } from "features/game/expansion/components/resources/oilReserve/OilReserve";
 import { LavaPit } from "features/game/expansion/components/lavaPit/LavaPit";
 import { TREE_VARIANTS } from "../lib/alternateArt";
@@ -321,8 +322,8 @@ export const RESOURCE_COMPONENTS: Record<
   "Tempered Iron Rock": Iron,
   "Pure Gold Rock": Gold,
   "Prime Gold Rock": Gold,
-  // TODO: placeholder component — anchored groundwork, no instances spawn yet.
-  "Ascension Crystal": Sunstone,
+  // TODO: placeholder visuals (reuses Sunstone art) until dedicated crystal art.
+  "Ascension Crystal": AscensionCrystal,
 };
 
 const isLandscaping = (state: MachineState) => state.matches("landscaping");

--- a/src/features/island/resources/Resource.tsx
+++ b/src/features/island/resources/Resource.tsx
@@ -209,6 +209,18 @@ export const READONLY_RESOURCE_COMPONENTS = ({
         }}
       />
     ),
+    // TODO: placeholder art — anchored groundwork, no instances spawn yet.
+    "Ascension Crystal": () => (
+      <img
+        src={ITEM_DETAILS["Ascension Crystal"].image}
+        className="absolute h-auto w-full"
+        style={{
+          width: `${PIXEL_SCALE * 24}px`,
+          bottom: `${PIXEL_SCALE * 1}px`,
+          left: `${PIXEL_SCALE * 4}px`,
+        }}
+      />
+    ),
     "Lava Pit": () => (
       <img
         src={ITEM_DETAILS["Lava Pit"].image}
@@ -309,6 +321,8 @@ export const RESOURCE_COMPONENTS: Record<
   "Tempered Iron Rock": Iron,
   "Pure Gold Rock": Gold,
   "Prime Gold Rock": Gold,
+  // TODO: placeholder component — anchored groundwork, no instances spawn yet.
+  "Ascension Crystal": Sunstone,
 };
 
 const isLandscaping = (state: MachineState) => state.matches("landscaping");

--- a/src/features/marketplace/lib/getTradeType.ts
+++ b/src/features/marketplace/lib/getTradeType.ts
@@ -545,6 +545,8 @@ export const ITEM_TRADE_TYPES: {
     Crimstone: "instant",
     "Sunstone Rock": "instant",
     Sunstone: "instant",
+    "Ascension Crystal": "instant",
+    "Ascension Shard": "instant",
     Oil: "instant",
     "Oil Reserve": "instant",
     Obsidian: "instant",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -984,6 +984,8 @@
   "description.blueberry": "A Goblin's weakness",
   "description.orange": "Vitamin C to keep your Bumpkin Healthy",
   "description.apple": "Perfect for homemade Apple Pie",
+  "description.ascensionCrystal": "Mine to obtain Ascension Shards",
+  "description.ascensionShard": "Used to upgrade skills",
   "description.banana": "Oh banana!",
   "description.white.carrot": "A pale carrot with pale roots",
   "description.warty.goblin.pumpkin": "A whimsical, wart-covered pumpkin",


### PR DESCRIPTION
## Summary

Introduces **Ascension Crystals** — finite, single‑use resource nodes mined (with a Gold Pickaxe) for **10 Ascension Shards**, the non‑tradable currency of the Ascensions system. This PR makes them obtainable, placeable, mineable and renderable in‑game, plus a one‑time legacy back‑pay. Everything is gated behind the `SWAMP_ASCENSION` feature flag.

Pairs 1:1 with the backend PR: **sunflower-land/sunflower-land-api#3447** (the BE re‑validates the grant schedule and the new events server‑side).

## What's included

- **Resource + commodity:** `Ascension Crystal` (node → `game.ascensionCrystals`, 2×2, `KNOWN_IDS`, metadata, placeholder image) and `Ascension Shard` (commodity, explicitly **non‑tradable**).
- **Events:** `ascensionCrystal.placed` / `.moved` / `.mined` / `.removed`. Mining is single‑use: −1 Gold Pickaxe, +10 Ascension Shard, node destroyed.
- **Obtain path (behind flag):**
  - **A0:** 1 crystal on each of the Spring / Desert / Volcano upgrades.
  - **Per ascension A:** 1 at the upgrade + 1 on each of the first `min(A + 2, 12)` expansions.
- **Legacy back‑pay:** reuses the existing missing‑node airdrop in `revealLand`, with a mined‑depletion subtraction so already‑mined crystals are never resurrected.
- **In‑game render:** a `Land.tsx` `ascensionCrystalElements` block + a new `AscensionCrystal` component (placeholder reusing the sunstone visuals; reads `game.ascensionCrystals`, mines for shards, guards the post‑mine unmount).

## Design

A single pure source of truth, `getExpectedAscensionCrystals` (`expansion/lib/ascension.ts`), drives **both** forward placement (its first‑difference, via `getAscensionLayout`) and the back‑pay reconciliation (its absolute value, via `getExpectedResources`). Crystals are deliberately kept **out** of the drip machinery so the upgrade floor can't resurrect spent crystals. The FE mirrors the BE byte‑for‑byte.

## Bug fixes (surfaced while wiring placement)

The new resource fell through two hand‑maintained allowlists that `tsc` can't enforce:
- `RESOURCE_PLACE_EVENTS` (a `Partial` map) was missing `"Ascension Crystal"`, so placing one dispatched an **undefined** event type and XState threw on `event.type.indexOf` — fixed and the place/move/remove resource maps are now full `Record`s.
- The BE Joi `actions` schema rejected the new events (fixed in the paired BE PR).

## Testing

- Unit: `getExpectedAscensionCrystals`, `getExpansionCrystalCount`, layout placement.
- All **9 upgrade transitions** (basic→spring … marble→marble) grant exactly 1.
- `revealLand` reconciliation: legacy back‑pay, **no‑resurrect**, invariant.
- place / move / mine / remove event suites. All crystal suites green; `tsc --noEmit` clean.

## Notes / follow‑ups

- The upgrade/A0 crystal is granted to **inventory** (player places it from the landscaping menu); per‑expansion crystals auto‑place via the layout.
- **Placeholder art:** the node reuses the sunstone visuals and `ITEM_DETAILS` image — a drop‑in swap inside `AscensionCrystal.tsx` once dedicated crystal art lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **Ascension Shard** and **Ascension Crystal** to the game, including item details and localized descriptions.
  * Mine Ascension Crystals with a **Gold Pickaxe** to earn **10 Ascension Shards** per crystal.
  * Place, move, and remove Ascension Crystals on your map, with full collision and rendering support.
  * Gain Ascension Crystals through island progression/upgrade when enabled.

* **Bug Fixes**
  * Improved legacy back-pay reconciliation so already-mined crystals aren’t restored.

* **Tests**
  * Added coverage for mining, placing, moving, removing, and legacy reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->