### PR TITLE
[BALANCE] Rebalance swamp ascension expansion economy

### DIFF
--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -318,9 +318,9 @@ describe("expansionRequirements", () => {
 
     // expansion = 30 + 1 = 31, first swamp ascension slot
     expect(requirements?.resources).toEqual({
-      Crimstone: 30,
+      Crimstone: 10,
       Oil: 50,
-      Obsidian: 3,
+      Obsidian: 2,
     });
     expect(requirements?.coins).toBe(5000);
     expect(requirements?.seconds).toBe(7 * HOUR);
@@ -350,9 +350,9 @@ describe("expansionRequirements", () => {
     });
 
     expect(requirements?.resources).toEqual({
-      Crimstone: 15,
+      Crimstone: 5,
       Oil: 25,
-      Obsidian: 1.5,
+      Obsidian: 1,
     });
     expect(boostsUsed).toEqual([{ name: "Grinx's Hammer", value: "x0.5" }]);
   });
@@ -386,11 +386,11 @@ describe("expansionRequirements", () => {
       },
     });
 
-    // expansion 42, ascensionLevel 2: costs × 1.4
+    // expansion 42, ascensionLevel 2: costs × 1.3
     expect(requirements?.resources).toEqual({
-      Crimstone: 210,
-      Oil: 560,
-      Obsidian: 42,
+      Crimstone: 65,
+      Oil: 520,
+      Obsidian: 26,
     });
     expect(requirements?.seconds).toBe(84 * HOUR);
   });

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -116,12 +116,12 @@ describe("ascension node drip widening (cap vs uncap)", () => {
     expect(getAscensionNodeDrip("Oil Reserve", 5)).toBe(24); // floor(12 * 2)
     expect(getAscensionNodeDrip("Beehive", 5)).toBe(20); // floor(10 * 2)
     expect(getAscensionNodeDrip("Crimstone Rock", 5)).toBe(16); // floor(8 * 2)
+    expect(getAscensionNodeDrip("Sunstone Rock", 5)).toBe(20); // floor(10 * 2)
   });
 
   it("clamps capped nodes at the 12 drip cap", () => {
-    // Widened would be 16 (Gold) and 20 (Sunstone) — both clamp to 12.
+    // Gold Rock widened would be 16 → clamps to 12.
     expect(getAscensionNodeDrip("Gold Rock", 5)).toBe(12);
-    expect(getAscensionNodeDrip("Sunstone Rock", 5)).toBe(12);
   });
 
   it("keeps zero-drip nodes at zero (never widens)", () => {
@@ -166,7 +166,7 @@ describe("swamp cumulative nodes (carry-forward)", () => {
       "Lava Pit": 4,
       Beehive: 7,
       "Flower Bed": 7,
-      "Sunstone Rock": 18,
+      "Sunstone Rock": 17,
       "Ascension Crystal": 0,
     });
   });

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -4,6 +4,7 @@ import {
   getAscensionExpansionDelta,
   getAscensionExpansionRequirements,
   getAscensionLayout,
+  getAscensionNodeDrip,
   getAscensionNodes,
 } from "./ascension";
 import { RESOURCE_DIMENSIONS } from "features/game/types/resources";
@@ -15,7 +16,7 @@ describe("swamp expansion requirements", () => {
     expect(
       getAscensionExpansionRequirements({ expansion: 31, ascensionLevel: 1 }),
     ).toEqual({
-      resources: { Crimstone: 30, Oil: 50, Obsidian: 3 },
+      resources: { Crimstone: 10, Oil: 50, Obsidian: 2 },
       coins: 5000,
       seconds: 7 * HOUR,
       bumpkinLevel: { ascension: 1, level: 1 },
@@ -26,7 +27,7 @@ describe("swamp expansion requirements", () => {
     expect(
       getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 1 }),
     ).toEqual({
-      resources: { Crimstone: 150, Oil: 400, Obsidian: 30 },
+      resources: { Crimstone: 50, Oil: 400, Obsidian: 20 },
       coins: 75000,
       seconds: 84 * HOUR,
       bumpkinLevel: { ascension: 1, level: 45 },
@@ -39,16 +40,16 @@ describe("swamp expansion requirements", () => {
       expansion: 32,
       ascensionLevel: 1,
     });
-    expect(req?.resources).toEqual({ Crimstone: 35, Oil: 65, Obsidian: 4 });
+    expect(req?.resources).toEqual({ Crimstone: 12, Oil: 65, Obsidian: 3 });
     expect(req?.coins).toBe(8100);
   });
 
-  it("scales cost by 1.4^(a-1) and keeps time ascension-invariant", () => {
+  it("scales cost by 1.3^(a-1) and keeps time ascension-invariant", () => {
     expect(
       getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 2 }),
     ).toEqual({
-      resources: { Crimstone: 210, Oil: 560, Obsidian: 42 },
-      coins: 105000,
+      resources: { Crimstone: 65, Oil: 520, Obsidian: 26 },
+      coins: 97500,
       seconds: 84 * HOUR,
       bumpkinLevel: { ascension: 2, level: 45 },
     });
@@ -56,8 +57,8 @@ describe("swamp expansion requirements", () => {
     expect(
       getAscensionExpansionRequirements({ expansion: 42, ascensionLevel: 5 }),
     ).toEqual({
-      resources: { Crimstone: 576, Oil: 1537, Obsidian: 115 },
-      coins: 288120,
+      resources: { Crimstone: 143, Oil: 1142, Obsidian: 57 },
+      coins: 214210,
       seconds: 84 * HOUR,
       bumpkinLevel: { ascension: 5, level: 45 },
     });
@@ -80,7 +81,7 @@ describe("swamp node drip", () => {
     ).toEqual({});
   });
 
-  it("grants exactly one Lava/Beehive/Flower per ascension", () => {
+  it("grants Beehive and Flower Bed together (paired) each ascension", () => {
     for (let a = 1; a <= 5; a++) {
       const totals: Partial<Record<string, number>> = {};
       for (let expansion = 31; expansion <= 42; expansion++) {
@@ -92,18 +93,40 @@ describe("swamp node drip", () => {
           totals[node] = (totals[node] ?? 0) + (count ?? 0);
         }
       }
-      // The cap-12 nodes are granted exactly once per ascension — now spread
-      // evenly rather than pinned to the final expansion.
-      expect(totals["Lava Pit"]).toBe(1);
-      expect(totals["Beehive"]).toBe(1);
-      expect(totals["Flower Bed"]).toBe(1);
+      // Beehive and Flower Bed share a drip and always unlock as a pair.
+      expect(totals["Beehive"] ?? 0).toBe(totals["Flower Bed"] ?? 0);
     }
   });
 
-  it("keeps Sunstone pinned at the base floor (never drips)", () => {
+  it("drips Sunstone above the base floor across ascensions", () => {
     expect(
       getAscensionNodes({ expansion: 42, ascensionLevel: 5 })["Sunstone Rock"],
-    ).toBe(SWAMP_BASE_NODES["Sunstone Rock"]);
+    ).toBeGreaterThan(SWAMP_BASE_NODES["Sunstone Rock"]);
+  });
+});
+
+describe("ascension node drip widening (cap vs uncap)", () => {
+  it("returns the base drip at ascension 1", () => {
+    expect(getAscensionNodeDrip("Crimstone Rock", 1)).toBe(8);
+  });
+
+  it("widens uncapped nodes past the 12 cap at higher ascensions", () => {
+    // NO_DRIP_CAP_NODES keep widening: floor(base * (1 + 0.25 * (a - 1))).
+    expect(getAscensionNodeDrip("Lava Pit", 2)).toBe(20); // floor(16 * 1.25)
+    expect(getAscensionNodeDrip("Oil Reserve", 5)).toBe(24); // floor(12 * 2)
+    expect(getAscensionNodeDrip("Beehive", 5)).toBe(20); // floor(10 * 2)
+    expect(getAscensionNodeDrip("Crimstone Rock", 5)).toBe(16); // floor(8 * 2)
+  });
+
+  it("clamps capped nodes at the 12 drip cap", () => {
+    // Widened would be 16 (Gold) and 20 (Sunstone) — both clamp to 12.
+    expect(getAscensionNodeDrip("Gold Rock", 5)).toBe(12);
+    expect(getAscensionNodeDrip("Sunstone Rock", 5)).toBe(12);
+  });
+
+  it("keeps zero-drip nodes at zero (never widens)", () => {
+    expect(getAscensionNodeDrip("Ascension Crystal", 1)).toBe(0);
+    expect(getAscensionNodeDrip("Ascension Crystal", 5)).toBe(0);
   });
 });
 
@@ -122,12 +145,12 @@ describe("swamp cumulative nodes (carry-forward)", () => {
       "Fruit Patch": 19,
       "Iron Rock": 15,
       "Gold Rock": 9,
-      "Crimstone Rock": 7,
+      "Crimstone Rock": 6,
       "Oil Reserve": 5,
-      "Lava Pit": 4,
+      "Lava Pit": 3,
       Beehive: 4,
       "Flower Bed": 4,
-      "Sunstone Rock": 13,
+      "Sunstone Rock": 14,
       "Ascension Crystal": 0,
     });
 
@@ -138,12 +161,12 @@ describe("swamp cumulative nodes (carry-forward)", () => {
       "Fruit Patch": 30,
       "Iron Rock": 21,
       "Gold Rock": 13,
-      "Crimstone Rock": 15,
-      "Oil Reserve": 9,
-      "Lava Pit": 8,
-      Beehive: 8,
-      "Flower Bed": 8,
-      "Sunstone Rock": 13,
+      "Crimstone Rock": 9,
+      "Oil Reserve": 8,
+      "Lava Pit": 4,
+      Beehive: 7,
+      "Flower Bed": 7,
+      "Sunstone Rock": 18,
       "Ascension Crystal": 0,
     });
   });
@@ -201,7 +224,7 @@ describe("swamp layout placement", () => {
     }
   });
 
-  it("spreads nodes evenly — no empty expansion, totals preserved", () => {
+  it("deals dripped nodes across the band — per-type totals preserved", () => {
     for (let a = 1; a <= 5; a++) {
       const startOfAscension = getAscensionNodes({
         expansion: 30,
@@ -218,12 +241,8 @@ describe("swamp layout placement", () => {
           expansion,
           ascensionLevel: a,
         });
-        const count = Object.values(delta).reduce(
-          (sum, n) => sum + (n ?? 0),
-          0,
-        );
-        // No expansion is empty — nodes are dealt across all 12, not piled on 42.
-        expect(count).toBeGreaterThan(0);
+        // At higher ascensions the widened drips can leave some expansions
+        // empty; that's fine — only the per-type band totals must be preserved.
         for (const [node, n] of Object.entries(delta)) {
           dealt[node] = (dealt[node] ?? 0) + (n ?? 0);
         }

--- a/src/features/game/expansion/lib/ascension.test.ts
+++ b/src/features/game/expansion/lib/ascension.test.ts
@@ -82,6 +82,7 @@ describe("swamp node drip", () => {
   });
 
   it("grants Beehive and Flower Bed together (paired) each ascension", () => {
+    let grandTotalBeehive = 0;
     for (let a = 1; a <= 5; a++) {
       const totals: Partial<Record<string, number>> = {};
       for (let expansion = 31; expansion <= 42; expansion++) {
@@ -93,9 +94,14 @@ describe("swamp node drip", () => {
           totals[node] = (totals[node] ?? 0) + (count ?? 0);
         }
       }
-      // Beehive and Flower Bed share a drip and always unlock as a pair.
+      // Beehive and Flower Bed share a drip and always unlock as a pair. A band
+      // can drip 0 of each (the floor doesn't grow every ascension), but the two
+      // must always match.
       expect(totals["Beehive"] ?? 0).toBe(totals["Flower Bed"] ?? 0);
+      grandTotalBeehive += totals["Beehive"] ?? 0;
     }
+    // Guard against a vacuous pass: the pair must actually drip across the range.
+    expect(grandTotalBeehive).toBeGreaterThan(0);
   });
 
   it("drips Sunstone above the base floor across ascensions", () => {

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -242,6 +242,7 @@ const NO_DRIP_CAP_NODES: (keyof Nodes)[] = [
   "Beehive",
   "Flower Bed",
   "Oil Reserve",
+  "Sunstone Rock",
   "Crimstone Rock",
   "Lava Pit",
 ];

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -36,11 +36,11 @@ const SWAMP_FIRST_EXPANSION = SWAMP_BASE_EXPANSION + 1; // 31
 const SWAMP_LAST_EXPANSION =
   SWAMP_BASE_EXPANSION + SWAMP_EXPANSIONS_PER_ASCENSION; // 42
 
-/** Per-ascension cost multiplier — `cost = floor(base × 1.4^(a-1))`. */
+/** Per-ascension cost multiplier — `cost = floor(base × 1.3^(a-1))`. */
 const COST_GROWTH = 1.3;
 /** Shape of the within-island cost curve across the 12 expansions. */
 const COST_CURVE_EXPONENT = 1.3;
-/** Drip widens by this fraction per ascension, then is capped at 12. */
+/** Drip widens by this fraction per ascension; capped at 12 except for `NO_DRIP_CAP_NODES`. */
 const DRIP_WIDEN_PER_ASCENSION = 0.25;
 const DRIP_CAP = SWAMP_EXPANSIONS_PER_ASCENSION; // 12
 /** Each expansion's build time grows linearly: `e × 7h`. */

--- a/src/features/game/expansion/lib/ascension.ts
+++ b/src/features/game/expansion/lib/ascension.ts
@@ -37,7 +37,7 @@ const SWAMP_LAST_EXPANSION =
   SWAMP_BASE_EXPANSION + SWAMP_EXPANSIONS_PER_ASCENSION; // 42
 
 /** Per-ascension cost multiplier — `cost = floor(base × 1.4^(a-1))`. */
-const COST_GROWTH = 1.4;
+const COST_GROWTH = 1.3;
 /** Shape of the within-island cost curve across the 12 expansions. */
 const COST_CURVE_EXPONENT = 1.3;
 /** Drip widens by this fraction per ascension, then is capped at 12. */
@@ -175,9 +175,9 @@ export const SWAMP_BASE_NODES: Nodes = {
 
 /** `{ start, end }` of the cost curve for each charged resource + coins. */
 const SWAMP_COST_CURVE = {
-  Crimstone: { start: 30, end: 150 },
+  Crimstone: { start: 10, end: 50 },
   Oil: { start: 50, end: 400 },
-  Obsidian: { start: 3, end: 30 },
+  Obsidian: { start: 2, end: 20 },
 } as const;
 const SWAMP_COIN_CURVE = { start: 5000, end: 75000 };
 
@@ -193,12 +193,12 @@ const SWAMP_NODE_DRIP: Record<keyof Nodes, number> = {
   "Fruit Patch": 3,
   "Iron Rock": 6,
   "Gold Rock": 8,
-  "Crimstone Rock": 5,
-  "Oil Reserve": 8,
-  "Lava Pit": 12,
+  "Crimstone Rock": 8,
+  "Oil Reserve": 12,
+  "Lava Pit": 16,
   Beehive: 10,
   "Flower Bed": 10,
-  "Sunstone Rock": 0,
+  "Sunstone Rock": 10,
   "Ascension Crystal": 0,
 };
 
@@ -238,6 +238,14 @@ const PLACEMENT_ORDER: (keyof Nodes)[] = [
   "Beehive",
 ];
 
+const NO_DRIP_CAP_NODES: (keyof Nodes)[] = [
+  "Beehive",
+  "Flower Bed",
+  "Oil Reserve",
+  "Crimstone Rock",
+  "Lava Pit",
+];
+
 /** Local index 1…12 of a swamp expansion (Basic Land 31→1 … 42→12). */
 const localExpansionIndex = (expansion: number): number =>
   expansion - SWAMP_BASE_EXPANSION;
@@ -252,6 +260,11 @@ export const getAscensionNodeDrip = (
   const widened = Math.floor(
     base * (1 + DRIP_WIDEN_PER_ASCENSION * (ascensionLevel - 1)),
   );
+
+  if (NO_DRIP_CAP_NODES.includes(node)) {
+    return widened;
+  }
+
   return Math.min(widened, DRIP_CAP);
 };
 

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -504,7 +504,7 @@ describe("getExpansionRequirements", () => {
       ascensionLevel: 1,
     });
     expect(req).toEqual({
-      resources: { Crimstone: 30, Oil: 50, Obsidian: 3 },
+      resources: { Crimstone: 10, Oil: 50, Obsidian: 2 },
       coins: 5000,
       seconds: 7 * HOUR,
       bumpkinLevel: { ascension: 1, level: 1 },
@@ -529,15 +529,15 @@ describe("getExpansionRequirements", () => {
     expect(req).toBeUndefined();
   });
 
-  it("scales costs by 1.4 at ascensionLevel 2 while keeping seconds unchanged", () => {
+  it("scales costs by 1.3 at ascensionLevel 2 while keeping seconds unchanged", () => {
     const HOUR = 60 * 60;
     const req = getExpansionRequirements({
       island: "swamp",
       expansion: 42,
       ascensionLevel: 2,
     });
-    expect(req?.resources).toEqual({ Crimstone: 210, Oil: 560, Obsidian: 42 });
-    expect(req?.coins).toBe(105000);
+    expect(req?.resources).toEqual({ Crimstone: 65, Oil: 520, Obsidian: 26 });
+    expect(req?.coins).toBe(97500);
     expect(req?.seconds).toBe(84 * HOUR);
   });
 


### PR DESCRIPTION
## Summary
Rebalances the swamp (first ascension island) expansion economy to ease the resource sink — particularly Crimstone and Obsidian, which were far out of line with what a player can produce.

### Cost changes (`ascension.ts`)
- Per-ascension cost growth **1.4 → 1.3** (compounds, so the deepest ascensions benefit most)
- Crimstone curve **30-150 → 10-50**
- Obsidian curve **3-30 → 2-20**

### Node changes
- Retuned swamp drips: Crimstone Rock 8, Oil Reserve 12, Lava Pit 16, Sunstone Rock 10
- Sunstone Rock now drips (was pinned at its base floor)
- High-value nodes — Crimstone Rock, Oil Reserve, Lava Pit, Beehive, Flower Bed, **Sunstone Rock** — widen past the 12-drip cap via `NO_DRIP_CAP_NODES`

### Tests
- Refreshed pinned swamp cost / node-total expectations in `ascension.test.ts`
- Reworked assertions invalidated by the change (Sunstone now drips & is uncapped; Beehive/Flower pairing; empty expansions allowed at high ascension)
- Added `getAscensionNodeDrip` cap-vs-uncap coverage
- Updated swamp cost expectations in `expandLand.test.ts` and `expansions.test.ts`

Full FE suite green.

> Mirrored 1:1 on the backend (`sunflower-land-api`) in a companion PR — production constants and test coverage are kept in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Changes**
  * Rebalanced swamp expansion requirements across ascension levels, reducing Crimstone and Obsidian costs while keeping Oil unchanged.
  * Lowered the ascension cost growth multiplier (1.4 → 1.3), updating how expansion costs scale at higher ascensions.
  * Updated swamp node drip behavior: increased base drip intervals, adjusted when Sunstone begins dripping, and modified drip cap handling for specific node types.

* **Tests**
  * Updated unit test expectations to match the revised swamp cost and drip tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->