### PR TITLE
[FEAT] Renew items (part 2 — weather items)

### DIFF
--- a/src/features/game/components/RenewWeatherCollectible.tsx
+++ b/src/features/game/components/RenewWeatherCollectible.tsx
@@ -1,0 +1,158 @@
+import { IngredientsPopover } from "components/ui/IngredientsPopover";
+import { Modal } from "components/ui/Modal";
+import { RequirementLabel } from "components/ui/RequirementsLabel";
+import Decimal from "decimal.js-light";
+import React, { useContext, useState } from "react";
+import { getKeys } from "lib/object";
+import { Label } from "components/ui/Label";
+import { Button } from "components/ui/Button";
+import { Context } from "../GameProvider";
+import type { PlaceableLocation } from "../types/collectibles";
+import type { MachineState } from "../lib/gameMachine";
+import { useSelector } from "@xstate/react";
+import type { GameState, Inventory } from "../types/game";
+import { getWeatherShop, type WeatherShopItem } from "../types/calendar";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { CloseButtonPanel } from "./CloseablePanel";
+
+type Props = {
+  show: boolean;
+  onHide: () => void;
+  name: WeatherShopItem;
+  id: string;
+  location: PlaceableLocation;
+};
+
+const _inventory = (state: MachineState) => state.context.state.inventory;
+const _coinBalance = (state: MachineState) => state.context.state.coins;
+const _gameState = (state: MachineState) => state.context.state;
+
+export const RenewWeatherCollectible: React.FC<Props> = ({
+  show,
+  onHide,
+  name,
+  id,
+  location,
+}) => {
+  const { gameService } = useContext(Context);
+
+  const inventory = useSelector(gameService, _inventory);
+  const coinBalance = useSelector(gameService, _coinBalance);
+  const gameState = useSelector(gameService, _gameState);
+
+  const handleRenew = () => {
+    gameService.send("weatherCollectible.renewed", { name, location, id });
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <CloseButtonPanel onClose={onHide}>
+        <RenewWeatherCollectibleContent
+          handleRenew={handleRenew}
+          name={name}
+          inventory={inventory}
+          coinBalance={coinBalance}
+          gameState={gameState}
+        />
+      </CloseButtonPanel>
+    </Modal>
+  );
+};
+
+const RenewWeatherCollectibleContent: React.FC<{
+  handleRenew: () => void;
+  name: WeatherShopItem;
+  inventory: Inventory;
+  coinBalance: number;
+  gameState: GameState;
+}> = ({ handleRenew, name, inventory, coinBalance, gameState }) => {
+  const { t } = useAppTranslation();
+  const [showIngredients, setShowIngredients] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  // Renewal costs the same as buying a new one from the Weather Shop.
+  const shopItem = getWeatherShop(gameState.island.type)[name];
+  const requirements = shopItem.ingredients();
+  const coinCost = shopItem.price;
+
+  const canRenew = () => {
+    if (coinBalance < coinCost) return false;
+
+    return getKeys(requirements).every(
+      (itemName) =>
+        inventory[itemName]?.gte(requirements[itemName] ?? new Decimal(0)) ??
+        false,
+    );
+  };
+
+  const isRenewable = canRenew();
+
+  return (
+    <>
+      <div className="flex flex-col gap-2 p-1">
+        {showConfirmation && (
+          <>
+            <Label type="warning">{t("confirm.renew")}</Label>
+            <p className="text-xs">{t("confirm.renew.message", { name })}</p>
+          </>
+        )}
+        {!showConfirmation && (
+          <>
+            <Label type="danger">
+              {t("weatherCollectible.used", { name })}
+            </Label>
+            <p className="text-xs">
+              {t("weatherCollectible.renew.message", { name })}
+            </p>
+          </>
+        )}
+        <div
+          className="flex flex-wrap p-2 gap-2 cursor-pointer"
+          onClick={() => setShowIngredients(!showIngredients)}
+        >
+          <IngredientsPopover
+            show={showIngredients}
+            ingredients={getKeys(requirements)}
+            onClick={() => setShowIngredients(false)}
+          />
+          {coinCost > 0 && (
+            <RequirementLabel
+              type="coins"
+              balance={coinBalance}
+              requirement={coinCost}
+            />
+          )}
+          {getKeys(requirements).map((itemName) => {
+            return (
+              <RequirementLabel
+                key={itemName}
+                type="item"
+                item={itemName}
+                balance={inventory[itemName] ?? new Decimal(0)}
+                requirement={requirements[itemName] ?? new Decimal(0)}
+              />
+            );
+          })}
+        </div>
+      </div>
+      {showConfirmation && (
+        <div className="flex justify-between gap-1">
+          <Button onClick={() => setShowConfirmation(false)}>
+            {t("cancel")}
+          </Button>
+          <Button onClick={handleRenew}>{t("renew")}</Button>
+        </div>
+      )}
+      {!showConfirmation && (
+        <div className="flex justify-between gap-1">
+          <Button
+            onClick={() => setShowConfirmation(true)}
+            disabled={!isRenewable}
+          >
+            {t("renew")}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -756,6 +756,10 @@ import {
   type RenewCollectibleAction,
 } from "./landExpansion/renewCollectible";
 import {
+  renewWeatherCollectible,
+  type RenewWeatherCollectibleAction,
+} from "./landExpansion/renewWeatherCollectible";
+import {
   placeWaterTrap,
   type PlaceWaterTrapAction,
 } from "./landExpansion/placeWaterTrap";
@@ -980,6 +984,7 @@ export type PlayingEvent =
   | BulkFertilisePlotAction
   | RenewPetShrineAction
   | RenewCollectibleAction
+  | RenewWeatherCollectibleAction
   | CollectWaterTrapAction
   | PlaceWaterTrapAction
   | PlaceFarmHandAction
@@ -1188,6 +1193,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "land.revealed": revealLand,
   "collectible.burned": burnCollectible,
   "collectible.renewed": renewCollectible,
+  "weatherCollectible.renewed": renewWeatherCollectible,
   "bonus.claimed": claimBonus,
   "dailyReward.claimed": claimDailyReward,
   "compost.accelerated": accelerateComposter,

--- a/src/features/game/events/landExpansion/craftTool.test.ts
+++ b/src/features/game/events/landExpansion/craftTool.test.ts
@@ -430,4 +430,65 @@ describe("craftTool", () => {
 
     expect(state.coins).toEqual(100 - 20 * 0.8 * 0.9);
   });
+
+  describe("weather items", () => {
+    it("crafts a weather item when the player does not own one", () => {
+      const state = craftTool({
+        state: {
+          ...GAME_STATE,
+          coins: 1000,
+          inventory: {
+            Wood: new Decimal(100),
+            Leather: new Decimal(100),
+          },
+        },
+        action: {
+          type: "tool.crafted",
+          tool: "Tornado Pinwheel",
+        },
+      });
+
+      expect(state.inventory["Tornado Pinwheel"]).toStrictEqual(new Decimal(1));
+    });
+
+    it("does not craft a weather item if the player already owns one", () => {
+      expect(() =>
+        craftTool({
+          state: {
+            ...GAME_STATE,
+            coins: 1000,
+            inventory: {
+              Wood: new Decimal(100),
+              Leather: new Decimal(100),
+              "Tornado Pinwheel": new Decimal(1),
+            },
+          },
+          action: {
+            type: "tool.crafted",
+            tool: "Tornado Pinwheel",
+          },
+        }),
+      ).toThrow("You can only have one of this weather item");
+    });
+
+    it("does not allow crafting two weather items at once", () => {
+      expect(() =>
+        craftTool({
+          state: {
+            ...GAME_STATE,
+            coins: 1000,
+            inventory: {
+              Wood: new Decimal(100),
+              Leather: new Decimal(100),
+            },
+          },
+          action: {
+            type: "tool.crafted",
+            tool: "Tornado Pinwheel",
+            amount: 2,
+          },
+        }),
+      ).toThrow("You can only have one of this weather item");
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/craftTool.ts
+++ b/src/features/game/events/landExpansion/craftTool.ts
@@ -117,6 +117,14 @@ export function craftTool({ state, action }: Options) {
     throw new Error("Tool is disabled");
   }
 
+  const isWeatherItem = action.tool in getWeatherShop(stateCopy.island.type);
+  if (
+    isWeatherItem &&
+    (stateCopy.inventory[action.tool] ?? new Decimal(0)).add(amount).gt(1)
+  ) {
+    throw new Error("You can only have one of this weather item");
+  }
+
   if (!hasRequiredIslandExpansion(stateCopy.island.type, requiredIsland)) {
     throw new Error("You do not have the required island expansion");
   }

--- a/src/features/game/events/landExpansion/renewWeatherCollectible.test.ts
+++ b/src/features/game/events/landExpansion/renewWeatherCollectible.test.ts
@@ -93,6 +93,25 @@ describe("renewWeatherCollectible", () => {
     ).toThrow("Collectible is not used");
   });
 
+  it("throws if the collectible is used but not placed", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: usedPinwheelFarm({
+          collectibles: {
+            "Tornado Pinwheel": [{ id: "1", used: true }],
+          },
+        }),
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Collectible is not placed");
+  });
+
   it("throws if the player has insufficient coins", () => {
     expect(() =>
       renewWeatherCollectible({

--- a/src/features/game/events/landExpansion/renewWeatherCollectible.test.ts
+++ b/src/features/game/events/landExpansion/renewWeatherCollectible.test.ts
@@ -1,0 +1,200 @@
+import Decimal from "decimal.js-light";
+import { TEST_FARM } from "../../lib/constants";
+import type { GameState } from "../../types/game";
+import { renewWeatherCollectible } from "./renewWeatherCollectible";
+
+describe("renewWeatherCollectible", () => {
+  const now = Date.now();
+
+  const usedPinwheelFarm = (overrides?: Partial<GameState>): GameState => ({
+    ...TEST_FARM,
+    coins: 1000,
+    inventory: {
+      Wood: new Decimal(100),
+      Leather: new Decimal(100),
+      "Tornado Pinwheel": new Decimal(1),
+    },
+    collectibles: {
+      "Tornado Pinwheel": [
+        {
+          id: "1",
+          coordinates: { x: 1, y: 1 },
+          readyAt: now,
+          used: true,
+        },
+      ],
+    },
+    ...overrides,
+  });
+
+  it("throws if the collectible is not a weather protection item", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: TEST_FARM,
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Fox Shrine" as any,
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Not a weather protection collectible");
+  });
+
+  it("throws if the collectible is not placed", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: { ...TEST_FARM, collectibles: {} },
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Invalid collectible");
+  });
+
+  it("throws if the id does not match", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: usedPinwheelFarm(),
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "does-not-exist",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Collectible does not exist");
+  });
+
+  it("throws if the collectible is not used", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: usedPinwheelFarm({
+          collectibles: {
+            "Tornado Pinwheel": [
+              { id: "1", coordinates: { x: 1, y: 1 }, readyAt: now },
+            ],
+          },
+        }),
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Collectible is not used");
+  });
+
+  it("throws if the player has insufficient coins", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: usedPinwheelFarm({ coins: 0 }),
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Insufficient Coins");
+  });
+
+  it("throws if the player has insufficient ingredients", () => {
+    expect(() =>
+      renewWeatherCollectible({
+        state: usedPinwheelFarm({
+          inventory: { "Tornado Pinwheel": new Decimal(1) },
+        }),
+        action: {
+          type: "weatherCollectible.renewed",
+          name: "Tornado Pinwheel",
+          location: "farm",
+          id: "1",
+        },
+        createdAt: now,
+      }),
+    ).toThrow("Insufficient ingredient: Wood");
+  });
+
+  it("clears the used flag and charges the shop cost", () => {
+    const state = renewWeatherCollectible({
+      state: usedPinwheelFarm(),
+      action: {
+        type: "weatherCollectible.renewed",
+        name: "Tornado Pinwheel",
+        location: "farm",
+        id: "1",
+      },
+      createdAt: now,
+    });
+
+    expect(state.collectibles["Tornado Pinwheel"]?.[0].used).toBeUndefined();
+    expect(state.coins).toEqual(1000 - 100);
+    expect(state.inventory.Wood).toEqual(new Decimal(70));
+    expect(state.inventory.Leather).toEqual(new Decimal(95));
+  });
+
+  it("scales the renewal cost by the island multiplier", () => {
+    const state = renewWeatherCollectible({
+      state: usedPinwheelFarm({
+        island: { ...TEST_FARM.island, type: "volcano" },
+      }),
+      action: {
+        type: "weatherCollectible.renewed",
+        name: "Tornado Pinwheel",
+        location: "farm",
+        id: "1",
+      },
+      createdAt: now,
+    });
+
+    // volcano multiplier is 2.5 -> 250 coins, 75 Wood, 12.5 Leather
+    expect(state.coins).toEqual(1000 - 250);
+    expect(state.inventory.Wood).toEqual(new Decimal(25));
+    expect(state.inventory.Leather).toEqual(new Decimal(87.5));
+  });
+
+  it("renews a collectible placed in the interior", () => {
+    const state = renewWeatherCollectible({
+      state: usedPinwheelFarm({
+        collectibles: {},
+        interior: {
+          ...TEST_FARM.interior,
+          ground: {
+            ...TEST_FARM.interior.ground,
+            collectibles: {
+              "Tornado Pinwheel": [
+                {
+                  id: "1",
+                  coordinates: { x: 1, y: 1 },
+                  readyAt: now,
+                  used: true,
+                },
+              ],
+            },
+          },
+        },
+      }),
+      action: {
+        type: "weatherCollectible.renewed",
+        name: "Tornado Pinwheel",
+        location: "interior",
+        id: "1",
+      },
+      createdAt: now,
+    });
+
+    expect(
+      state.interior.ground.collectibles["Tornado Pinwheel"]?.[0].used,
+    ).toBeUndefined();
+  });
+});

--- a/src/features/game/events/landExpansion/renewWeatherCollectible.ts
+++ b/src/features/game/events/landExpansion/renewWeatherCollectible.ts
@@ -1,0 +1,91 @@
+import { produce } from "immer";
+import { Decimal } from "decimal.js-light";
+import { getKeys } from "lib/object";
+import type { GameState } from "features/game/types/game";
+import type { PlaceableLocation } from "features/game/types/collectibles";
+import {
+  getWeatherShop,
+  type WeatherShopItem,
+} from "features/game/types/calendar";
+import { isWeatherProtectionCollectible } from "features/game/lib/weatherProtectionCollectibles";
+
+export type RenewWeatherCollectibleAction = {
+  type: "weatherCollectible.renewed";
+  name: WeatherShopItem;
+  location: PlaceableLocation;
+  id: string;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: RenewWeatherCollectibleAction;
+  createdAt?: number;
+};
+
+export function renewWeatherCollectible({ state, action }: Options): GameState {
+  return produce(state, (game) => {
+    if (!isWeatherProtectionCollectible(action.name)) {
+      throw new Error("Not a weather protection collectible");
+    }
+
+    const collectibleGroup =
+      action.location === "home"
+        ? game.home.collectibles[action.name]
+        : action.location === "interior"
+          ? game.interior.ground.collectibles[action.name]
+          : action.location === "level_one"
+            ? game.interior.level_one?.collectibles[action.name]
+            : game.collectibles[action.name];
+
+    if (!collectibleGroup) {
+      throw new Error("Invalid collectible");
+    }
+
+    const collectibleToRenew = collectibleGroup.find(
+      (collectible) => collectible.id === action.id,
+    );
+
+    if (!collectibleToRenew) {
+      throw new Error("Collectible does not exist");
+    }
+
+    if (!collectibleToRenew.used) {
+      throw new Error("Collectible is not used");
+    }
+
+    // Renewal costs the same as buying a new one from the Weather Shop, scaled
+    // by the player's current island.
+    const shopItem = getWeatherShop(game.island.type)[action.name];
+    const coinCost = shopItem.price;
+    const requirements = shopItem.ingredients();
+
+    if (game.coins < coinCost) {
+      throw new Error("Insufficient Coins");
+    }
+
+    const subtractedInventory = getKeys(requirements).reduce(
+      (inventory, ingredientName) => {
+        const count = inventory[ingredientName] || new Decimal(0);
+        const totalAmount = requirements[ingredientName] || new Decimal(0);
+
+        if (count.lessThan(totalAmount)) {
+          throw new Error(`Insufficient ingredient: ${ingredientName}`);
+        }
+
+        inventory[ingredientName] = count.sub(totalAmount);
+
+        return inventory;
+      },
+      { ...game.inventory },
+    );
+
+    game.inventory = subtractedInventory;
+    game.coins -= coinCost;
+
+    // Clear the used flag to restore protection (the weather-item equivalent of
+    // resetting a cooldown timestamp).
+    delete collectibleToRenew.used;
+
+    return game;
+  });
+}

--- a/src/features/game/events/landExpansion/renewWeatherCollectible.ts
+++ b/src/features/game/events/landExpansion/renewWeatherCollectible.ts
@@ -49,12 +49,17 @@ export function renewWeatherCollectible({ state, action }: Options): GameState {
       throw new Error("Collectible does not exist");
     }
 
+    if (!collectibleToRenew.coordinates) {
+      throw new Error("Collectible is not placed");
+    }
+
     if (!collectibleToRenew.used) {
       throw new Error("Collectible is not used");
     }
 
-    // Renewal costs the same as buying a new one from the Weather Shop, scaled
-    // by the player's current island.
+    // Renewal costs the base Weather Shop price (scaled by the player's current
+    // island), matching renewPetShrine — craft-time discounts are intentionally
+    // not applied.
     const shopItem = getWeatherShop(game.island.type)[action.name];
     const coinCost = shopItem.price;
     const requirements = shopItem.ingredients();

--- a/src/features/game/lib/collectibleBuilt.test.ts
+++ b/src/features/game/lib/collectibleBuilt.test.ts
@@ -242,4 +242,25 @@ describe("Super Totem Built", () => {
 
     expect(isBuilt).toBe(false);
   });
+
+  it("returns false if a placed weather collectible has been used", () => {
+    const isBuilt = isCollectibleBuilt({
+      game: {
+        ...TEST_FARM,
+        collectibles: {
+          "Tornado Pinwheel": [
+            {
+              id: "123",
+              coordinates: { x: 1, y: 1 },
+              readyAt: Date.now() - 10000,
+              used: true,
+            },
+          ],
+        },
+      },
+      name: "Tornado Pinwheel",
+    });
+
+    expect(isBuilt).toBe(false);
+  });
 });

--- a/src/features/game/lib/collectibleBuilt.ts
+++ b/src/features/game/lib/collectibleBuilt.ts
@@ -15,8 +15,12 @@ export function isCollectibleBuilt({
   name: CollectibleName;
   game: GameState;
 }) {
-  const isReady = (placed: { readyAt?: number; coordinates?: unknown }) =>
-    (placed.readyAt ?? 0) <= Date.now() && !!placed.coordinates;
+  const isReady = (placed: {
+    readyAt?: number;
+    coordinates?: unknown;
+    used?: boolean;
+  }) =>
+    (placed.readyAt ?? 0) <= Date.now() && !!placed.coordinates && !placed.used;
 
   const placedAcrossLocations = getCollectiblesAcrossLocations(game, name).some(
     isReady,

--- a/src/features/game/lib/getCollectiblesAcrossLocations.ts
+++ b/src/features/game/lib/getCollectiblesAcrossLocations.ts
@@ -21,10 +21,11 @@ export function getCollectiblesAcrossLocations<N extends CollectibleName>(
   },
   name: N,
 ): NonNullable<Collectibles[N]> {
-  return [
+  const collectibles: NonNullable<Collectibles[N]> = [
     ...(game.collectibles[name] ?? []),
     ...(game.home.collectibles[name] ?? []),
     ...(game.interior?.ground.collectibles[name] ?? []),
     ...(game.interior?.level_one?.collectibles[name] ?? []),
-  ] as NonNullable<Collectibles[N]>;
+  ];
+  return collectibles;
 }

--- a/src/features/game/lib/weatherProtectionCollectibles.ts
+++ b/src/features/game/lib/weatherProtectionCollectibles.ts
@@ -1,6 +1,8 @@
+import type { Draft } from "immer";
 import type { CollectibleName } from "../types/craftables";
 import type { WeatherShopItem } from "../types/calendar";
 import type { GameState } from "../types/game";
+import { getCollectiblesAcrossLocations } from "./getCollectiblesAcrossLocations";
 
 /**
  * Weather-protection collectibles. Each one is a single-use shield against its
@@ -21,26 +23,20 @@ export const isWeatherProtectionCollectible = (
   WEATHER_PROTECTION_COLLECTIBLES.includes(name as WeatherShopItem);
 
 /**
- * Marks every placed instance of a weather-protection collectible as `used`
- * across all map locations, leaving the inventory entry intact. Operates on an
- * immer draft.
+ * Marks every active (placed and ready) instance of a weather-protection
+ * collectible as `used`, across all map locations, leaving the inventory entry
+ * intact. Operates on an immer draft.
  */
 export const markWeatherCollectibleUsed = (
-  game: GameState,
+  game: Draft<GameState>,
   name: WeatherShopItem,
+  createdAt: number,
 ): void => {
-  const groups = [
-    game.collectibles[name],
-    game.home.collectibles[name],
-    game.interior.ground.collectibles[name],
-    game.interior.level_one?.collectibles[name],
-  ];
+  getCollectiblesAcrossLocations(game, name).forEach((placed) => {
+    const isReady = (placed.readyAt ?? 0) <= createdAt;
 
-  groups.forEach((group) => {
-    group?.forEach((placed) => {
-      if (placed.coordinates) {
-        placed.used = true;
-      }
-    });
+    if (placed.coordinates && isReady && !placed.used) {
+      placed.used = true;
+    }
   });
 };

--- a/src/features/game/lib/weatherProtectionCollectibles.ts
+++ b/src/features/game/lib/weatherProtectionCollectibles.ts
@@ -1,0 +1,46 @@
+import type { CollectibleName } from "../types/craftables";
+import type { WeatherShopItem } from "../types/calendar";
+import type { GameState } from "../types/game";
+
+/**
+ * Weather-protection collectibles. Each one is a single-use shield against its
+ * matching calendar weather event. When the event triggers, the placed item is
+ * marked `used` (see {@link markWeatherCollectibleUsed}) rather than deleted, and
+ * can be restored via the `weatherCollectible.renewed` event.
+ */
+export const WEATHER_PROTECTION_COLLECTIBLES: readonly WeatherShopItem[] = [
+  "Tornado Pinwheel",
+  "Mangrove",
+  "Thermal Stone",
+  "Protective Pesticide",
+];
+
+export const isWeatherProtectionCollectible = (
+  name: CollectibleName,
+): name is WeatherShopItem =>
+  WEATHER_PROTECTION_COLLECTIBLES.includes(name as WeatherShopItem);
+
+/**
+ * Marks every placed instance of a weather-protection collectible as `used`
+ * across all map locations, leaving the inventory entry intact. Operates on an
+ * immer draft.
+ */
+export const markWeatherCollectibleUsed = (
+  game: GameState,
+  name: WeatherShopItem,
+): void => {
+  const groups = [
+    game.collectibles[name],
+    game.home.collectibles[name],
+    game.interior.ground.collectibles[name],
+    game.interior.level_one?.collectibles[name],
+  ];
+
+  groups.forEach((group) => {
+    group?.forEach((placed) => {
+      if (placed.coordinates) {
+        placed.used = true;
+      }
+    });
+  });
+};

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -914,6 +914,11 @@ export type PlacedItem = {
   processing?: BuildingProduct[];
   oil?: number;
   flipped?: boolean;
+  /**
+   * Weather-protection collectible (e.g. Tornado Pinwheel) consumed by its
+   * calendar event. Stays placed/owned but grants no protection until renewed.
+   */
+  used?: boolean;
 };
 
 export type ShakeItem = PlacedItem & { shakenAt?: number };

--- a/src/features/island/collectibles/CollectibleCollection.tsx
+++ b/src/features/island/collectibles/CollectibleCollection.tsx
@@ -382,6 +382,7 @@ import { AnemoneFlower } from "./components/AnemoneFlower";
 import { Poseidon } from "./components/Poseidon";
 import { Project } from "./components/Project";
 import { PetShrine } from "./components/PetShrine";
+import { WeatherProtection } from "./components/WeatherProtection";
 import { ObsidianShrine } from "./components/ObsidianShrine";
 import { Pet } from "../pets/Pet";
 import { type PetName, PET_TYPES } from "features/game/types/pets";
@@ -600,6 +601,21 @@ export const COLLECTIBLE_COMPONENTS: Record<
   "Cyborg Bear": CyborgBear,
   "Maneki Neko": ManekiNeko,
   "Pablo The Bunny": PabloBunny,
+
+  // Weather protection (override the TemplateCollectible default so the
+  // greyed-out "used" state + renew flow renders)
+  "Tornado Pinwheel": (props: CollectibleProps) => (
+    <WeatherProtection {...props} name="Tornado Pinwheel" />
+  ),
+  Mangrove: (props: CollectibleProps) => (
+    <WeatherProtection {...props} name="Mangrove" />
+  ),
+  "Thermal Stone": (props: CollectibleProps) => (
+    <WeatherProtection {...props} name="Thermal Stone" />
+  ),
+  "Protective Pesticide": (props: CollectibleProps) => (
+    <WeatherProtection {...props} name="Protective Pesticide" />
+  ),
 
   // Treasure
   "Abandoned Bear": AbandonedBear,

--- a/src/features/island/collectibles/components/WeatherProtection.tsx
+++ b/src/features/island/collectibles/components/WeatherProtection.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import { useVisiting } from "lib/utils/visitUtils";
@@ -16,26 +16,38 @@ type Props = CollectibleProps & {
   name: WeatherShopItem;
 };
 
+const selectWeatherProtectionUsed = (
+  state: MachineState,
+  name: WeatherShopItem,
+  id: string,
+  location: CollectibleProps["location"],
+) => {
+  const game = state.context.state;
+  const group =
+    location === "home"
+      ? game.home.collectibles[name]
+      : location === "interior"
+        ? game.interior.ground.collectibles[name]
+        : location === "level_one"
+          ? game.interior.level_one?.collectibles[name]
+          : game.collectibles[name];
+
+  return !!group?.find((collectible) => collectible.id === id)?.used;
+};
+
 export const WeatherProtection: React.FC<Props> = ({ name, id, location }) => {
   const { gameService, showAnimations } = useContext(Context);
   const { isVisiting } = useVisiting();
   const [showRenewModal, setShowRenewModal] = useState(false);
 
-  const _isUsed = (state: MachineState) => {
-    const game = state.context.state;
-    const group =
-      location === "home"
-        ? game.home.collectibles[name]
-        : location === "interior"
-          ? game.interior.ground.collectibles[name]
-          : location === "level_one"
-            ? game.interior.level_one?.collectibles[name]
-            : game.collectibles[name];
-
-    return !!group?.find((collectible) => collectible.id === id)?.used;
-  };
-
-  const isUsed = useSelector(gameService, _isUsed);
+  const isUsed = useSelector(
+    gameService,
+    useCallback(
+      (state: MachineState) =>
+        selectWeatherProtectionUsed(state, name, id, location),
+      [name, id, location],
+    ),
+  );
 
   if (isUsed) {
     return (

--- a/src/features/island/collectibles/components/WeatherProtection.tsx
+++ b/src/features/island/collectibles/components/WeatherProtection.tsx
@@ -1,0 +1,104 @@
+import React, { useContext, useState } from "react";
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import { useVisiting } from "lib/utils/visitUtils";
+import { SFTDetailPopover } from "components/ui/SFTDetailPopover";
+import { ITEM_DETAILS } from "features/game/types/images";
+import { setImageWidth } from "lib/images";
+import type { CollectibleProps } from "../Collectible";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { RenewWeatherCollectible } from "features/game/components/RenewWeatherCollectible";
+import type { MachineState } from "features/game/lib/gameMachine";
+import type { WeatherShopItem } from "features/game/types/calendar";
+
+type Props = CollectibleProps & {
+  name: WeatherShopItem;
+};
+
+export const WeatherProtection: React.FC<Props> = ({ name, id, location }) => {
+  const { gameService, showAnimations } = useContext(Context);
+  const { isVisiting } = useVisiting();
+  const [showRenewModal, setShowRenewModal] = useState(false);
+
+  const _isUsed = (state: MachineState) => {
+    const game = state.context.state;
+    const group =
+      location === "home"
+        ? game.home.collectibles[name]
+        : location === "interior"
+          ? game.interior.ground.collectibles[name]
+          : location === "level_one"
+            ? game.interior.level_one?.collectibles[name]
+            : game.collectibles[name];
+
+    return !!group?.find((collectible) => collectible.id === id)?.used;
+  };
+
+  const isUsed = useSelector(gameService, _isUsed);
+
+  if (isUsed) {
+    return (
+      <>
+        <div
+          className={isVisiting ? undefined : "cursor-pointer"}
+          onClick={isVisiting ? undefined : () => setShowRenewModal(true)}
+        >
+          <div
+            className="flex justify-center absolute w-full pointer-events-none z-30"
+            style={{
+              top: `${PIXEL_SCALE * -12}px`,
+            }}
+          >
+            <img
+              src={SUNNYSIDE.icons.expression_alerted}
+              className={showAnimations ? "ready" : ""}
+              style={{
+                width: `${PIXEL_SCALE * 4}px`,
+              }}
+            />
+          </div>
+
+          <img
+            src={ITEM_DETAILS[name].image}
+            className="absolute left-1/2 transform -translate-x-1/2"
+            alt={name}
+            style={{
+              maxWidth: "none",
+              bottom: 0,
+              filter: "grayscale(100%)",
+            }}
+            onLoad={(e) => {
+              setImageWidth(e.currentTarget);
+            }}
+          />
+        </div>
+
+        <RenewWeatherCollectible
+          show={showRenewModal}
+          onHide={() => setShowRenewModal(false)}
+          name={name}
+          id={id}
+          location={location}
+        />
+      </>
+    );
+  }
+
+  return (
+    <SFTDetailPopover name={name}>
+      <img
+        src={ITEM_DETAILS[name].image}
+        className="absolute left-1/2 transform -translate-x-1/2"
+        alt={name}
+        style={{
+          maxWidth: "none",
+          bottom: 0,
+        }}
+        onLoad={(e) => {
+          setImageWidth(e.currentTarget);
+        }}
+      />
+    </SFTDetailPopover>
+  );
+};

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -27,6 +27,8 @@
   "confirm.renew.message": "Are you sure you want to renew {{name}}?",
   "renew.expired.message": "{{name}} has expired. You can renew it to extend its duration.",
   "shrine.expired": "{{name}} Expired",
+  "weatherCollectible.used": "{{name}} Used",
+  "weatherCollectible.renew.message": "{{name}} protected your farm and was used up. Renew it to be protected again.",
   "drink": "Drink",
   "eat": "Eat",
   "resource.wood": "Wood",


### PR DESCRIPTION
## What

Part 2 of the renew-items work: makes the four weather-protection collectibles renewable instead of single-use-then-deleted.

When a calendar weather event triggers, the matching protection item (Tornado Pinwheel / Mangrove / Thermal Stone / Protective Pesticide) is now **marked `used`** instead of being deleted. It stays on the farm (greyed-out) and in the inventory, but no longer provides protection until renewed. Renewing charges the Weather Shop cost (island-scaled) and clears the flag.

## Changes (FE)

- `PlacedItem.used?: boolean`; `isCollectibleBuilt` treats a `used` item as not built.
- `weatherProtectionCollectibles.ts` — item list + `isWeatherProtectionCollectible` guard + `markWeatherCollectibleUsed` helper.
- New `weatherCollectible.renewed` event (`renewWeatherCollectible`) wired into the event registry.
- `WeatherProtection` component (greyed-out used state + renew prompt) registered in `CollectibleCollection`; new `RenewWeatherCollectible` modal.
- `craftTool`: cap weather-item crafting at one owned, so a used item must be renewed rather than re-bought.
- i18n keys in `dictionary.json` only.

## Backend

Pairs with the matching **sunflower-land-api** PR (same branch). Both must deploy together — consumption now marks `used` server-side, so old FE would mis-render a used item.

## Testing

- `renewWeatherCollectible` unit tests: charges cost incl. island multiplier, clears `used`, error paths (not used / insufficient coins / insufficient ingredients / non-weather name / each location).
- `isCollectibleBuilt` returns false for a `used` item.
- `craftTool` one-owned cap tests.
- `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather collectibles consumed by weather events can now be renewed via a dedicated renewal flow.
  * Renewal includes a confirmation modal with coin restoration cost and ingredient requirement checks.
  * Weather protection icons visually show “used” status and enable renewal when eligible.
* **Bug Fixes**
  * Crafting now blocks attempts to create more than one of the same weather item.
  * “Built” status now treats used weather collectibles as not built until renewal.
* **Documentation**
  * Added localization strings for “used” and renewal messaging.
* **Tests**
  * Added/expanded test coverage for weather crafting and renewal success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->