### PR TITLE
[FEAT] Help all pets in Pet House with a single click when visiting

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -735,6 +735,10 @@ import { type NeglectPetAction, neglectPet } from "./pets/neglectPet";
 import { petPet, type PetPetAction } from "./pets/petPet";
 import { fetchPet, type FetchPetAction } from "./pets/fetchPet";
 import { helpPets, type HelpPetsAction } from "./visiting/helpPets";
+import {
+  helpAllPetsInHouse,
+  type HelpAllPetsInHouseAction,
+} from "./visiting/helpAllPetsInHouse";
 import { type BulkPlantAction, bulkPlant } from "./landExpansion/bulkPlant";
 import {
   bulkHarvest,
@@ -1003,7 +1007,8 @@ export type PlayingEvent =
 export type LocalVisitingEvent =
   | CollectGarbageAction
   | HelpProjectAction
-  | HelpPetsAction;
+  | HelpPetsAction
+  | HelpAllPetsInHouseAction;
 
 export type VisitingEvent = IncreaseHelpLimitAction | LocalVisitingEvent;
 
@@ -1296,6 +1301,7 @@ export const LOCAL_VISITING_EVENTS: Handlers<LocalVisitingEvent> = {
   "garbage.collected": collectGarbage,
   "project.helped": helpProject,
   "pet.visitingPets": helpPets,
+  "pet.helpAllPetsInHouse": helpAllPetsInHouse,
 };
 
 export const VISITING_EVENTS: Handlers<VisitingEvent> = {

--- a/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
 import type { GameState } from "features/game/types/game";
+import type { PetName } from "features/game/types/pets";
 import { helpAllPetsInHouse } from "./helpAllPetsInHouse";
 
 const baseVisitor: GameState = { ...INITIAL_FARM };
@@ -32,7 +33,9 @@ describe("helpAllPetsInHouse", () => {
         state: {
           ...INITIAL_FARM,
           buildings: petHousePlaced,
-          pets: { common: { Barkley: { ...basePet, name: "Barkley" } } },
+          pets: {
+            common: { Barkley: { ...basePet, name: "Barkley" as PetName } },
+          },
           petHouse: {
             level: 1,
             pets: {
@@ -54,7 +57,9 @@ describe("helpAllPetsInHouse", () => {
       helpAllPetsInHouse({
         state: {
           ...INITIAL_FARM,
-          pets: { common: { Barkley: { ...basePet, name: "Barkley" } } },
+          pets: {
+            common: { Barkley: { ...basePet, name: "Barkley" as PetName } },
+          },
           petHouse: {
             level: 1,
             pets: {
@@ -78,8 +83,8 @@ describe("helpAllPetsInHouse", () => {
         buildings: petHousePlaced,
         pets: {
           common: {
-            Barkley: { ...basePet, name: "Barkley" },
-            Meowchi: { ...basePet, name: "Meowchi" },
+            Barkley: { ...basePet, name: "Barkley" as PetName },
+            Meowchi: { ...basePet, name: "Meowchi" as PetName },
           },
         },
         petHouse: {
@@ -108,8 +113,12 @@ describe("helpAllPetsInHouse", () => {
         buildings: petHousePlaced,
         pets: {
           common: {
-            Barkley: { ...basePet, name: "Barkley", visitedAt: now - 1000 },
-            Meowchi: { ...basePet, name: "Meowchi" },
+            Barkley: {
+              ...basePet,
+              name: "Barkley" as PetName,
+              visitedAt: now - 1000,
+            },
+            Meowchi: { ...basePet, name: "Meowchi" as PetName },
           },
         },
         petHouse: {
@@ -191,8 +200,8 @@ describe("helpAllPetsInHouse", () => {
       buildings: petHousePlaced,
       pets: {
         common: {
-          Barkley: { ...basePet, name: "Barkley" },
-          Meowchi: { ...basePet, name: "Meowchi" },
+          Barkley: { ...basePet, name: "Barkley" as PetName },
+          Meowchi: { ...basePet, name: "Meowchi" as PetName },
         },
       },
       petHouse: {

--- a/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
@@ -1,0 +1,217 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import type { GameState } from "features/game/types/game";
+import { helpAllPetsInHouse } from "./helpAllPetsInHouse";
+
+const baseVisitor: GameState = { ...INITIAL_FARM };
+
+const basePet = {
+  experience: 0,
+  energy: 0,
+  pettedAt: 0,
+  requests: { food: [], fedAt: 0 },
+};
+
+const petHousePlaced = {
+  "Pet House": [
+    {
+      id: "ph",
+      createdAt: 0,
+      readyAt: 0,
+      coordinates: { x: 1, y: 1 },
+    },
+  ],
+};
+
+describe("helpAllPetsInHouse", () => {
+  const now = Date.now();
+
+  it("throws when help limit is already reached", () => {
+    expect(() =>
+      helpAllPetsInHouse({
+        state: {
+          ...INITIAL_FARM,
+          buildings: petHousePlaced,
+          pets: { common: { Barkley: { ...basePet, name: "Barkley" } } },
+          petHouse: {
+            level: 1,
+            pets: {
+              Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+            },
+          },
+        },
+        visitorState: baseVisitor,
+        action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 10 },
+        createdAt: now,
+      }),
+    ).toThrow("Help limit reached");
+  });
+
+  it("throws when Pet House building is not placed", () => {
+    expect(() =>
+      helpAllPetsInHouse({
+        state: {
+          ...INITIAL_FARM,
+          pets: { common: { Barkley: { ...basePet, name: "Barkley" } } },
+          petHouse: {
+            level: 1,
+            pets: {
+              Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+            },
+          },
+        },
+        visitorState: baseVisitor,
+        action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 0 },
+        createdAt: now,
+      }),
+    ).toThrow("Pet House is not placed");
+  });
+
+  it("awards XP and marks all common pets in pet house as visited", () => {
+    const [state] = helpAllPetsInHouse({
+      state: {
+        ...INITIAL_FARM,
+        buildings: petHousePlaced,
+        pets: {
+          common: {
+            Barkley: { ...basePet, name: "Barkley" },
+            Meowchi: { ...basePet, name: "Meowchi" },
+          },
+        },
+        petHouse: {
+          level: 1,
+          pets: {
+            Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+            Meowchi: [{ id: "2", createdAt: now, coordinates: { x: 1, y: 0 } }],
+          },
+        },
+      },
+      visitorState: baseVisitor,
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 0 },
+      createdAt: now,
+    });
+
+    expect(state.pets?.common?.Barkley?.experience).toEqual(5);
+    expect(state.pets?.common?.Barkley?.visitedAt).toEqual(now);
+    expect(state.pets?.common?.Meowchi?.experience).toEqual(5);
+    expect(state.pets?.common?.Meowchi?.visitedAt).toEqual(now);
+  });
+
+  it("skips pets already visited today", () => {
+    const [state] = helpAllPetsInHouse({
+      state: {
+        ...INITIAL_FARM,
+        buildings: petHousePlaced,
+        pets: {
+          common: {
+            Barkley: { ...basePet, name: "Barkley", visitedAt: now - 1000 },
+            Meowchi: { ...basePet, name: "Meowchi" },
+          },
+        },
+        petHouse: {
+          level: 1,
+          pets: {
+            Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+            Meowchi: [{ id: "2", createdAt: now, coordinates: { x: 1, y: 0 } }],
+          },
+        },
+      },
+      visitorState: baseVisitor,
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 0 },
+      createdAt: now,
+    });
+
+    expect(state.pets?.common?.Barkley?.experience).toEqual(0);
+    expect(state.pets?.common?.Meowchi?.experience).toEqual(5);
+    expect(state.pets?.common?.Meowchi?.visitedAt).toEqual(now);
+  });
+
+  it("awards XP and marks NFT pets in pet house as visited", () => {
+    const [state] = helpAllPetsInHouse({
+      state: {
+        ...INITIAL_FARM,
+        buildings: petHousePlaced,
+        pets: {
+          nfts: {
+            1: {
+              ...basePet,
+              id: 1,
+              name: "Pet #1",
+              coordinates: { x: 0, y: 0 },
+              location: "petHouse" as const,
+            },
+          },
+        },
+      },
+      visitorState: baseVisitor,
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 0 },
+      createdAt: now,
+    });
+
+    expect(state.pets?.nfts?.[1]?.experience).toEqual(5);
+    expect(state.pets?.nfts?.[1]?.visitedAt).toEqual(now);
+  });
+
+  it("skips NFT pets not in the pet house", () => {
+    const [state] = helpAllPetsInHouse({
+      state: {
+        ...INITIAL_FARM,
+        buildings: petHousePlaced,
+        pets: {
+          nfts: {
+            1: {
+              ...basePet,
+              id: 1,
+              name: "Pet #1",
+              coordinates: { x: 0, y: 0 },
+              location: "farm" as const,
+            },
+          },
+        },
+      },
+      visitorState: baseVisitor,
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 0 },
+      createdAt: now,
+    });
+
+    expect(state.pets?.nfts?.[1]?.visitedAt).toBeUndefined();
+  });
+
+  it("does not exceed help limit when multiple pets are present", () => {
+    const stateWithManyPets = {
+      ...INITIAL_FARM,
+      inventory: {
+        ...INITIAL_FARM.inventory,
+        "Pet House": new Decimal(1),
+      },
+      buildings: petHousePlaced,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" },
+          Meowchi: { ...basePet, name: "Meowchi" },
+        },
+      },
+      petHouse: {
+        level: 1,
+        pets: {
+          Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+          Meowchi: [{ id: "2", createdAt: now, coordinates: { x: 1, y: 0 } }],
+        },
+      },
+    };
+
+    // Default help limit is 10; setting totalHelpedToday to 9 means only 1 more pet can be helped
+    const [state] = helpAllPetsInHouse({
+      state: stateWithManyPets,
+      visitorState: baseVisitor,
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 9 },
+      createdAt: now,
+    });
+
+    const barkleyVisited = !!state.pets?.common?.Barkley?.visitedAt;
+    const meowchiVisited = !!state.pets?.common?.Meowchi?.visitedAt;
+
+    // Only one of the two pets should be helped (limit was 1 remaining)
+    expect(barkleyVisited !== meowchiVisited).toBe(true);
+  });
+});

--- a/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
@@ -36,7 +36,9 @@ describe("helpAllPetsInHouse", () => {
           petHouse: {
             level: 1,
             pets: {
-              Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+              Barkley: [
+                { id: "1", createdAt: now, coordinates: { x: 0, y: 0 } },
+              ],
             },
           },
         },
@@ -56,7 +58,9 @@ describe("helpAllPetsInHouse", () => {
           petHouse: {
             level: 1,
             pets: {
-              Barkley: [{ id: "1", createdAt: now, coordinates: { x: 0, y: 0 } }],
+              Barkley: [
+                { id: "1", createdAt: now, coordinates: { x: 0, y: 0 } },
+              ],
             },
           },
         },
@@ -200,11 +204,11 @@ describe("helpAllPetsInHouse", () => {
       },
     };
 
-    // Default help limit is 10; setting totalHelpedToday to 9 means only 1 more pet can be helped
+    // Default help limit is 5; setting totalHelpedToday to 4 means only 1 more pet can be helped
     const [state] = helpAllPetsInHouse({
       state: stateWithManyPets,
       visitorState: baseVisitor,
-      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 9 },
+      action: { type: "pet.helpAllPetsInHouse", totalHelpedToday: 4 },
       createdAt: now,
     });
 

--- a/src/features/game/events/visiting/helpAllPetsInHouse.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.ts
@@ -1,0 +1,90 @@
+import type { GameState } from "features/game/types/game";
+import { getHelpLimit, hasHitHelpLimit } from "features/game/types/monuments";
+import {
+  hasHitSocialPetLimit,
+  type PetName,
+  SOCIAL_PET_XP_PER_HELP,
+} from "features/game/types/pets";
+import { getKeys } from "lib/object";
+import { produce } from "immer";
+
+export type HelpAllPetsInHouseAction = {
+  type: "pet.helpAllPetsInHouse";
+  totalHelpedToday: number;
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: HelpAllPetsInHouseAction;
+  createdAt?: number;
+  visitorState?: GameState;
+};
+
+export function helpAllPetsInHouse({
+  state,
+  action,
+  visitorState,
+  createdAt = Date.now(),
+}: Options): [GameState, GameState] {
+  return produce([state, visitorState!], ([game, visitorGame]) => {
+    if (
+      hasHitHelpLimit({
+        game: visitorGame,
+        totalHelpedToday: action.totalHelpedToday,
+      })
+    ) {
+      throw new Error("Help limit reached");
+    }
+
+    const isPetHousePlaced = !!game.buildings["Pet House"]?.some(
+      (b) => !!b.coordinates,
+    );
+
+    if (!isPetHousePlaced) {
+      throw new Error("Pet House is not placed");
+    }
+
+    const day = new Date(createdAt).toISOString().slice(0, 10);
+    const helpLimit = getHelpLimit({ game: visitorGame });
+    let helpCount = action.totalHelpedToday;
+
+    const petHousePets = game.petHouse?.pets ?? {};
+
+    for (const name of getKeys(petHousePets)) {
+      if (helpCount >= helpLimit) break;
+
+      const isPlaced = petHousePets[name]?.some((item) => !!item.coordinates);
+      if (!isPlaced) continue;
+
+      const pet = game.pets?.common?.[name as PetName];
+      if (!pet || pet.visitedAt) continue;
+
+      if (!hasHitSocialPetLimit(pet)) {
+        const dailySocialXP = pet.dailySocialXP?.[day] ?? 0;
+        pet.dailySocialXP = pet.dailySocialXP ?? {};
+        pet.dailySocialXP[day] = dailySocialXP + SOCIAL_PET_XP_PER_HELP;
+        pet.experience = (pet.experience ?? 0) + SOCIAL_PET_XP_PER_HELP;
+      }
+
+      pet.visitedAt = createdAt;
+      helpCount++;
+    }
+
+    for (const id of getKeys(game.pets?.nfts ?? {})) {
+      if (helpCount >= helpLimit) break;
+
+      const pet = game.pets?.nfts?.[id];
+      if (!pet || pet.visitedAt || pet.location !== "petHouse") continue;
+
+      if (!hasHitSocialPetLimit(pet)) {
+        const dailySocialXP = pet.dailySocialXP?.[day] ?? 0;
+        pet.dailySocialXP = pet.dailySocialXP ?? {};
+        pet.dailySocialXP[day] = dailySocialXP + SOCIAL_PET_XP_PER_HELP;
+        pet.experience = (pet.experience ?? 0) + SOCIAL_PET_XP_PER_HELP;
+      }
+
+      pet.visitedAt = createdAt;
+      helpCount++;
+    }
+  });
+}

--- a/src/features/island/buildings/components/building/petHouse/PetHouse.tsx
+++ b/src/features/island/buildings/components/building/petHouse/PetHouse.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { BuildingImageWrapper } from "../BuildingImageWrapper";
 import { useNavigate } from "react-router";
@@ -8,17 +8,22 @@ import { useSelector } from "@xstate/react";
 import type { MachineState } from "features/game/lib/gameMachine";
 import { PET_HOUSE_VARIANTS } from "features/island/lib/alternateArt";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { getHelpRequired } from "features/game/types/monuments";
+import { getHelpRequired, isHelpComplete } from "features/game/types/monuments";
 import { isPetNapping, type PetName } from "features/game/types/pets";
 import { useNow } from "lib/utils/hooks/useNow";
 import type { GameState } from "features/game/types/game";
 import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
+import { Modal } from "components/ui/Modal";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { FarmHelped } from "features/island/hud/components/FarmHelped";
 
 const _farmId = (state: MachineState) => state.context.farmId;
 const _petHouseLevel = (state: MachineState) =>
   state.context.state.petHouse.level ?? 1;
-
 const _game = (state: MachineState) => state.context.state;
+const _totalHelpedToday = (state: MachineState) =>
+  state.context.totalHelpedToday ?? 0;
+const _bumpkin = (state: MachineState) => state.context.state.bumpkin;
 
 function useNappingPetInPetHouse(game: GameState): boolean {
   const now = useNow({ live: true });
@@ -50,22 +55,33 @@ export const PetHouse: React.FC = () => {
   const farmId = useSelector(gameService, _farmId);
   const { isVisiting: visiting } = useVisiting();
   const level = useSelector(gameService, _petHouseLevel);
+  const totalHelpedToday = useSelector(gameService, _totalHelpedToday);
+  const bumpkin = useSelector(gameService, _bumpkin);
 
   const hasNappingPet = useNappingPetInPetHouse(game);
+  const [showHelped, setShowHelped] = useState(false);
+
+  const helpRequired = getHelpRequired({ game });
+  const petHouseHelpRequired = helpRequired.tasks.petHouse.count;
 
   const handlePetHouseClick = () => {
+    if (visiting && petHouseHelpRequired > 0) {
+      gameService.send("pet.helpAllPetsInHouse", { totalHelpedToday });
+
+      if (isHelpComplete({ game: gameService.getSnapshot().context.state })) {
+        setShowHelped(true);
+      }
+      return;
+    }
+
     saveIslandScrollPosition();
 
     if (visiting) {
-      const targetPath = `/visit/${farmId}/pet-house`;
-      navigate(targetPath);
+      navigate(`/visit/${farmId}/pet-house`);
     } else {
       navigate("/pet-house");
     }
   };
-
-  const helpRequired = getHelpRequired({ game });
-  const petHouseHelpRequired = helpRequired.tasks.petHouse.count;
 
   return (
     <div className="absolute h-full w-full">
@@ -119,6 +135,11 @@ export const PetHouse: React.FC = () => {
           </div>
         )}
       </BuildingImageWrapper>
+      <Modal show={showHelped}>
+        <CloseButtonPanel bumpkinParts={bumpkin.equipped}>
+          <FarmHelped onClose={() => setShowHelped(false)} />
+        </CloseButtonPanel>
+      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Visitors can now click the **Pet House building exterior** to help all pets inside at once, instead of entering the house and clicking each pet individually
- New event `pet.helpAllPetsInHouse` processes all common pets and NFT pets in the house in a single action
- Respects the visitor's daily help limit — helps as many pets as the remaining quota allows
- Shows `FarmHelped` modal when all farm tasks are complete after the action

## Changes

- `src/features/game/events/visiting/helpAllPetsInHouse.ts` — new event handler
- `src/features/game/events/index.ts` — event registered in `LocalVisitingEvent`
- `src/features/island/buildings/components/building/petHouse/PetHouse.tsx` — click on building triggers help-all when visiting and pets need help; falls back to navigating inside if all pets already helped

## Video 

https://github.com/user-attachments/assets/0050087f-5274-4d92-96bb-1544416ca3bc


## Test plan

**Automated — 7/7 passing**

- [ ] Help limit reached → throws error
- [ ] Pet House building not placed → throws error
- [ ] All common pets in house receive XP + `visitedAt`
- [ ] Already-visited pets are skipped
- [ ] NFT pets in house receive XP + `visitedAt`
- [ ] NFT pets outside house are skipped
- [ ] Help limit is not exceeded when multiple pets present

**Manual (please verify)**

- [ ] Visit a farm that has pets placed inside a Pet House
- [ ] Confirm the help icon (disc + drag icon) appears on the Pet House building
- [ ] Click the Pet House — all pets inside should receive the interaction without entering the house
- [ ] Confirm the help icon disappears after clicking
- [ ] If all farm tasks are done, confirm `FarmHelped` modal appears
- [ ] If pets are already helped, confirm clicking the building navigates inside as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visiting the Pet House now supports helping all eligible pets in one action.
  * Players earn XP for assisted common and NFT pets located in the Pet House.

* **Bug Fixes**
  * Help now enforces daily help limits and stops when you’ve reached the allowance.
  * Actions won’t run if the Pet House building isn’t placed.
  * Pets already helped for the day are skipped correctly.

* **UI Improvements**
  * Added a “help completed” popup/confirmation once Pet House helping is finished.

* **Tests**
  * Added coverage for limits, Pet House availability, common vs NFT pets, and visited/XP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->