### PR TITLE
[FEAT] Show required feed quantity for chickens

### DIFF
--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -575,6 +575,9 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
               top={PIXEL_SCALE * -3.5}
               left={PIXEL_SCALE * 20}
               request={requestBubbleRequest()}
+              quantity={
+                idle && !hasGoldEgg ? requiredFoodQty.toNumber() : undefined
+              }
             />
           )}
           {/* Over-capacity lock */}


### PR DESCRIPTION
## Summary

- Add `quantity` prop to `RequestBubble` in `Chicken.tsx` so chickens display the required feed amount (e.g. `x1`) above their head when idle, matching the existing behaviour for cows and sheep.
<img width="606" height="418" alt="image" src="https://github.com/user-attachments/assets/5a0e5392-3a07-4678-bca7-60a075b29242" />

Closes #7357



## Test plan

- [ ] Open Hen House in Art Mode — each idle chicken shows the feed quantity on the request bubble
- [ ] Chickens with Golden Egg do not show the quantity (consistent with cow/sheep Golden variants)
- [ ] Quantity reflects any active boosts (Fat Chicken, Cluckulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the amount shown in request bubbles for chickens so it only appears when a chicken is idle and doesn’t have a Gold Egg.
  * For all other chicken states, the requested quantity is now hidden, improving the consistency of the on-screen display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->