### PR TITLE
[FIX] Show cheer feed icon for today only

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -9,6 +9,7 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -117,6 +118,15 @@ const mergeUpdates = (
 
 const getUTCDateKey = (timestamp: number) =>
   new Date(timestamp).toISOString().split("T")[0];
+
+const getNextUTCDateKeyRefreshAt = (timestamp: number) => {
+  const date = new Date(timestamp);
+
+  return (
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1) +
+    1000
+  );
+};
 
 const shouldShowInteraction = (interaction: Interaction, todayKey: string) => {
   if (interaction.type !== "cheer") {
@@ -589,10 +599,15 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const loaderRef = useRef<HTMLDivElement>(null);
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
-  const now = useNow({ live: true });
-  const todayKey = getUTCDateKey(now);
-  const visibleFeed = feed.filter((interaction) =>
-    shouldShowInteraction(interaction, todayKey),
+  const [hasMeasuredScroll, setHasMeasuredScroll] = useState(false);
+  const [todayKey, setTodayKey] = useState(() => getUTCDateKey(Date.now()));
+  const refreshTimeoutRef = useRef<number | null>(null);
+  const visibleFeed = useMemo(
+    () =>
+      feed.filter((interaction) =>
+        shouldShowInteraction(interaction, todayKey),
+      ),
+    [feed, todayKey],
   );
 
   // Intersection observer to load more interactions when the loader is in view
@@ -607,7 +622,28 @@ const FeedContent: React.FC<FeedContentProps> = ({
     if (!el) return;
     // tiny buffer so off-by-1 doesn’t trigger
     setCanPaginate(el.scrollHeight > el.clientHeight + 2);
+    setHasMeasuredScroll(true);
   }, [visibleFeed.length, filter]);
+
+  useEffect(() => {
+    const refreshTodayKey = () => {
+      const now = Date.now();
+      const refreshIn = getNextUTCDateKeyRefreshAt(now) - now;
+
+      refreshTimeoutRef.current = window.setTimeout(() => {
+        setTodayKey(getUTCDateKey(Date.now()));
+        refreshTodayKey();
+      }, refreshIn);
+    };
+
+    refreshTodayKey();
+
+    return () => {
+      if (refreshTimeoutRef.current) {
+        window.clearTimeout(refreshTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -618,10 +654,25 @@ const FeedContent: React.FC<FeedContentProps> = ({
   }, [filter]);
 
   useEffect(() => {
-    if (inView && hasMore && !isLoadingMore && canPaginate) {
+    const shouldLoadMore =
+      hasMore &&
+      !isLoadingMore &&
+      (inView ||
+        visibleFeed.length === 0 ||
+        (hasMeasuredScroll && !canPaginate));
+
+    if (shouldLoadMore) {
       loadMore();
     }
-  }, [inView, hasMore, isLoadingMore, loadMore, scrollContainerRef]);
+  }, [
+    canPaginate,
+    hasMeasuredScroll,
+    hasMore,
+    inView,
+    isLoadingMore,
+    loadMore,
+    visibleFeed.length,
+  ]);
 
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {
@@ -641,8 +692,6 @@ const FeedContent: React.FC<FeedContentProps> = ({
     e.stopPropagation();
     onFollowClick(id);
   };
-  const today = new Date().toISOString().split("T")[0];
-
   if (isLoadingInitialData) {
     return <FeedSkeleton />;
   }
@@ -650,7 +699,11 @@ const FeedContent: React.FC<FeedContentProps> = ({
   if (visibleFeed.length === 0) {
     return (
       <div className="flex justify-center items-center h-full">
-        <Label type="default">{t("noActivity")}</Label>
+        {hasMore ? (
+          <Loading dotsOnly />
+        ) : (
+          <Label type="default">{t("noActivity")}</Label>
+        )}
       </div>
     );
   }
@@ -676,7 +729,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
           const isAtMaxFollowing = !isFollowing && following.length >= 5000;
           const hasCheeredThemToday =
             interaction.type === "cheer" &&
-            cheersGiven.date === today &&
+            cheersGiven.date === todayKey &&
             cheersGiven.farms.includes(interaction.sender.id);
 
           return (

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -115,6 +115,17 @@ const mergeUpdates = (
   ];
 };
 
+const getUTCDateKey = (timestamp: number) =>
+  new Date(timestamp).toISOString().split("T")[0];
+
+const shouldShowInteraction = (interaction: Interaction, todayKey: string) => {
+  if (interaction.type !== "cheer") {
+    return true;
+  }
+
+  return getUTCDateKey(interaction.createdAt) === todayKey;
+};
+
 export type FeedFilter = "all" | "help" | "chat" | "cheer" | "follow";
 export type FeedFilterOption = {
   value: FeedFilter;
@@ -578,6 +589,11 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const loaderRef = useRef<HTMLDivElement>(null);
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
+  const now = useNow({ live: true });
+  const todayKey = getUTCDateKey(now);
+  const visibleFeed = feed.filter((interaction) =>
+    shouldShowInteraction(interaction, todayKey),
+  );
 
   // Intersection observer to load more interactions when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -591,7 +607,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     if (!el) return;
     // tiny buffer so off-by-1 doesn’t trigger
     setCanPaginate(el.scrollHeight > el.clientHeight + 2);
-  }, [feed.length, filter]);
+  }, [visibleFeed.length, filter]);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -631,7 +647,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     return <FeedSkeleton />;
   }
 
-  if (feed.length === 0) {
+  if (visibleFeed.length === 0) {
     return (
       <div className="flex justify-center items-center h-full">
         <Label type="default">{t("noActivity")}</Label>
@@ -645,7 +661,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
       className="scrollable overflow-hidden overflow-y-auto"
     >
       <div className="flex flex-col gap-1 pr-1">
-        {feed.map((interaction, index) => {
+        {visibleFeed.map((interaction, index) => {
           const direction =
             interaction?.sender.username === username ? "right" : "left";
           const sender =


### PR DESCRIPTION
Just my bad 

after this pr https://github.com/sunflower-land/sunflower-land/pull/7320
<img width="295" height="772" alt="image" src="https://github.com/user-attachments/assets/8b8b7afe-52a3-4c79-9d47-47f9f8956b24" />

## Problem
Cheer activity in the Social Feed was shown on older feed entries for the same player, even when the cheer happened today. This made historical feed rows look like they also had a recent cheer event, which was misleading.

## Why this differs from Help
Help currently uses helpedThemToday as a “today relationship status” badge. That logic was left unchanged.
Cheer is different because the feed already has a real interaction type: type: "cheer". A cheer should be treated as an activity event with its own timestamp, not as a reusable player status across older rows.

## Fix
The feed **now filters cheer interactions by the current UTC date before rendering**. This keeps today’s cheers visible, but prevents cheer activity from appearing on previous days’ feed entries. Other interaction types, including Help, are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feed items now show more accurately based on the current UTC day for “cheer” activity.
  * The empty-state message now appears only when there are no visible items, not just no raw feed items.
  * Pagination now updates correctly when filtered feed items change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->