### PR TITLE
[FIX] marketplace profile section layout

### DIFF
--- a/src/features/marketplace/components/home/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/home/MarketplaceHome.tsx
@@ -245,7 +245,7 @@ export const MarketplaceNavigation: React.FC = () => {
               />
               <Route
                 path="/profile/:id/collection"
-                element={<MyCollection />}
+                element={<MyCollection fullHeight />}
               />
               <Route path="/profile/rewards" element={<MarketplaceRewards />} />
               {/* default to hot */}

--- a/src/features/marketplace/components/profile/MyCollection.tsx
+++ b/src/features/marketplace/components/profile/MyCollection.tsx
@@ -41,6 +41,10 @@ type EnrichedCollectionItem = CollectionItem & {
   category: CollectionCategory;
 };
 
+type Props = {
+  fullHeight?: boolean;
+};
+
 const _state = (state: MachineState) => state.context.state;
 const BUILDING_NAMES = new Set(Object.keys(BUILDINGS));
 
@@ -59,7 +63,7 @@ const getBaseCategory = (
   return details.buffs.length > 0 ? "collectibles" : "cosmetic";
 };
 
-export const MyCollection: React.FC = () => {
+export const MyCollection: React.FC<Props> = ({ fullHeight = false }) => {
   const { t } = useAppTranslation();
 
   const { gameService } = useContext(Context);
@@ -175,11 +179,19 @@ export const MyCollection: React.FC = () => {
   return (
     <>
       <InnerPanel
-        className="w-full mb-1"
-        style={{
-          height: "auto",
-          minHeight: "200px",
-        }}
+        className={
+          fullHeight
+            ? "w-full h-full min-h-0 flex flex-col mb-1"
+            : "w-full mb-1"
+        }
+        style={
+          fullHeight
+            ? undefined
+            : {
+                height: "auto",
+                minHeight: "200px",
+              }
+        }
       >
         <Label className="mb-2 ml-2" type="default" icon={chest}>
           {t("marketplace.myCollection")}
@@ -192,7 +204,13 @@ export const MyCollection: React.FC = () => {
           onToggleCategory={toggleCategory}
           onClearCategories={() => setActiveCategories([])}
         />
-        <div className="p-2 h-full w-full">
+        <div
+          className={
+            fullHeight
+              ? "min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden scrollable p-2"
+              : "p-2 h-full w-full"
+          }
+        >
           {enrichedItems.length === 0 ? (
             <p className="text-sm">{t("marketplace.noCollection")}</p>
           ) : (

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -34,7 +34,11 @@ const _authToken = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
 const _state = (state: MachineState) => state.context.state;
 
-export const MyListings: React.FC = () => {
+type Props = {
+  fullHeight?: boolean;
+};
+
+export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
   const { t } = useAppTranslation();
   const params = useParams<{
     collection?: CollectionName;
@@ -148,8 +152,12 @@ export const MyListings: React.FC = () => {
         )}
       </Modal>
 
-      <InnerPanel className="mb-1">
-        <div className="p-2">
+      <InnerPanel
+        className={fullHeight ? "flex h-full min-h-0 flex-col" : "mb-1"}
+      >
+        <div
+          className={fullHeight ? "flex h-full min-h-0 flex-col p-2" : "p-2"}
+        >
           <div className="flex items-center justify-between mb-2">
             <Label type="default" icon={trade}>
               {t("marketplace.myListings")}
@@ -163,11 +171,17 @@ export const MyListings: React.FC = () => {
               </p>
             </Button>
           </div>
-          <div className="flex flex-wrap">
+          <div
+            className={fullHeight ? "flex min-h-0 flex-1" : "flex flex-wrap"}
+          >
             {getKeys(filteredListings).length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyListings")}</p>
             ) : (
-              <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
+              <div
+                className={`w-full relative border-collapse mb-2 scrollable overflow-y-auto overflow-x-hidden ${
+                  fullHeight ? "h-full min-h-0" : "max-h-[200px]"
+                }`}
+              >
                 {getKeys(filteredListings).map((id, index) => {
                   const listing = listings[id];
                   const itemName = getKeys(

--- a/src/features/marketplace/components/profile/MyOffers.tsx
+++ b/src/features/marketplace/components/profile/MyOffers.tsx
@@ -28,7 +28,11 @@ import { Button } from "components/ui/Button";
 const _authToken = (state: AuthMachineState) =>
   state.context.user.rawToken as string;
 
-export const MyOffers: React.FC = () => {
+type Props = {
+  fullHeight?: boolean;
+};
+
+export const MyOffers: React.FC<Props> = ({ fullHeight = false }) => {
   const { t } = useAppTranslation();
   const params = useParams<{
     collection?: CollectionName;
@@ -152,8 +156,12 @@ export const MyOffers: React.FC = () => {
         />
       </Modal>
 
-      <InnerPanel className="mb-1">
-        <div className="p-2">
+      <InnerPanel
+        className={fullHeight ? "flex h-full min-h-0 flex-col" : "mb-1"}
+      >
+        <div
+          className={fullHeight ? "flex h-full min-h-0 flex-col p-2" : "p-2"}
+        >
           <div className="flex justify-between flex-col mb-2">
             <div className="flex items-center justify-between mb-1">
               <Label type="default" icon={trade}>
@@ -174,11 +182,17 @@ export const MyOffers: React.FC = () => {
               })}
             </Label>
           </div>
-          <div className="flex flex-wrap">
+          <div
+            className={fullHeight ? "flex min-h-0 flex-1" : "flex flex-wrap"}
+          >
             {getKeys(filteredOffers).length === 0 ? (
               <p className="text-sm">{t("marketplace.noMyOffers")}</p>
             ) : (
-              <div className="w-full relative border-collapse mb-2 max-h-[200px] scrollable overflow-y-auto overflow-x-hidden">
+              <div
+                className={`w-full relative border-collapse mb-2 scrollable overflow-y-auto overflow-x-hidden ${
+                  fullHeight ? "h-full min-h-0" : "max-h-[200px]"
+                }`}
+              >
                 {getKeys(filteredOffers).map((id, index) => {
                   const offer = filteredOffers[id];
                   const itemName = getKeys(

--- a/src/features/marketplace/components/profile/MyTrades.tsx
+++ b/src/features/marketplace/components/profile/MyTrades.tsx
@@ -16,9 +16,9 @@ export const MyTrades: React.FC = () => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const trades = useSelector(gameService, _trades);
-  const hasActiveTrades =
-    getKeys(trades.offers ?? {}).length > 0 ||
-    getKeys(trades.listings ?? {}).length > 0;
+  const hasOffers = getKeys(trades.offers ?? {}).length > 0;
+  const hasListings = getKeys(trades.listings ?? {}).length > 0;
+  const hasActiveTrades = hasOffers || hasListings;
 
   if (!hasActiveTrades) {
     return (
@@ -35,9 +35,17 @@ export const MyTrades: React.FC = () => {
   }
 
   return (
-    <div className="overflow-y-scroll scrollable pr-1 h-full">
-      <MyOffers />
-      <MyListings />
+    <div className="flex h-full min-h-0 flex-col gap-1 pr-1">
+      {hasOffers && (
+        <div className="min-h-0 flex-1">
+          <MyOffers fullHeight />
+        </div>
+      )}
+      {hasListings && (
+        <div className="min-h-0 flex-1">
+          <MyListings fullHeight />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Let Active Trades offers and listings fill the available marketplace profile space and split it evenly when both sections are present.
<img width="1280" height="596" alt="telegram-cloud-photo-size-2-5325749672154439030-y" src="https://github.com/user-attachments/assets/a88c5984-1197-4dee-8931-307879072d06" />

- Keep existing offer/listing layouts unchanged outside the full-height marketplace route.
- Make the profile Collection route use an internal scroll container so collection cards stay inside the marketplace window.
<img width="1280" height="585" alt="telegram-cloud-photo-size-2-5325749672154439033-y" src="https://github.com/user-attachments/assets/3548a486-56be-494c-a750-90184b86a442" />


## Problem
After the profile marketplace cleanup, the Active Trades tab still used the previous capped offer/listing panel heights. This left unused vertical space even though other profile content had been removed. The Collection tab also rendered long content beyond the marketplace bounds without a working internal scroll area.

## Solution
- Add an optional full-height mode to MyOffers, MyListings, and MyCollection.
- Use that mode from the marketplace profile routes only.
- Rework MyTrades into a flex column so offers/listings can share the available height instead of relying on fixed max heights.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the profile collection, listings, and offers views with a full-height layout option for a better fit on larger screens.
  * Updated the trades page to display offers and listings only when they’re available, creating a cleaner, more relevant view.

* **Bug Fixes**
  * Refined scrolling and spacing in marketplace profile panels for a more consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->