### PR TITLE
[FEAT] Saved Layouts: capture buds/pets/farmhands/bumpkin + faithful preview

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   codex:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,7 +1,7 @@
 name: Perform a code review when a pull request is created
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   codex:

--- a/src/features/game/events/landExpansion/applyLayout.test.ts
+++ b/src/features/game/events/landExpansion/applyLayout.test.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js-light";
 import cloneDeep from "lodash.clonedeep";
 import { produce } from "immer";
 import { TEST_FARM } from "features/game/lib/constants";
-import type { GameState } from "features/game/types/game";
+import type { GameState, InventoryItemName } from "features/game/types/game";
 import { saveLayout } from "./saveLayout";
 import { applyLayout } from "./applyLayout";
 import { applyFarmLayout } from "./lib/layouts";
@@ -34,14 +34,25 @@ const baseFarm: GameState = {
   layouts: [],
 };
 
+/** baseFarm with the given items owned (inventory). */
+const withInventory = (owned: Partial<Record<InventoryItemName, number>>) => ({
+  ...baseFarm,
+  inventory: {
+    ...baseFarm.inventory,
+    ...Object.fromEntries(
+      Object.entries(owned).map(([k, v]) => [k, new Decimal(v as number)]),
+    ),
+  },
+});
+
 /** Save a layout snapshot of `state` and return the state with the layout. */
 const withSavedLayout = (state: GameState): GameState =>
   saveLayout({ state, action: { type: "layout.saved", name: "L" }, createdAt });
 
 describe("applyLayout", () => {
-  it("restores a collectible to its saved position and flip", () => {
+  it("places an owned collectible at its saved position and flip", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Wicker Man": 1 }),
       collectibles: {
         "Wicker Man": [
           { id: "a", coordinates: { x: 0, y: 0 }, flipped: true, createdAt },
@@ -65,9 +76,148 @@ describe("applyLayout", () => {
     expect(result.collectibles["Wicker Man"]![0].flipped).toEqual(true);
   });
 
-  it("swaps two items without a false self-collision (lift then place)", () => {
+  it("places a removed-but-owned collectible (the core fix)", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Wicker Man": 1 }),
+      collectibles: {
+        "Wicker Man": [{ id: "a", coordinates: { x: 0, y: 0 }, createdAt }],
+      },
+    });
+
+    // Removed during landscaping: still owned (in the bucket) but unplaced.
+    const moved = cloneDeep(saved);
+    delete moved.collectibles["Wicker Man"]![0].coordinates;
+    moved.collectibles["Wicker Man"]![0].removedAt = createdAt;
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.collectibles["Wicker Man"]![0].coordinates).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(result.collectibles["Wicker Man"]![0].removedAt).toBeUndefined();
+  });
+
+  it("creates new instances from inventory when none are placed yet", () => {
+    // Owns 2 Wicker Man but has never placed one (no bucket instances).
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 2 }),
+      collectibles: {
+        "Wicker Man": [
+          { id: "x", coordinates: { x: 0, y: 0 }, createdAt },
+          { id: "y", coordinates: { x: 1, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.collectibles["Wicker Man"] = []; // owned in inventory, no instances
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const placed = result.collectibles["Wicker Man"]!.filter(
+      (c) => !!c.coordinates,
+    );
+    expect(placed).toHaveLength(2);
+    // New instances get deterministic, non-uuid ids.
+    placed.forEach((c) => expect(c.id.startsWith("L")).toBe(true));
+    expect(placed.map((c) => c.coordinates)).toContainEqual({ x: 0, y: 0 });
+    expect(placed.map((c) => c.coordinates)).toContainEqual({ x: 1, y: 0 });
+  });
+
+  it("caps placement at inventory availability (noInventory)", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 1 }),
+      collectibles: {
+        "Wicker Man": [
+          { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
+          { id: "b", coordinates: { x: 1, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    // Owns only one Wicker Man.
+    const moved = cloneDeep(saved);
+    moved.collectibles["Wicker Man"] = [
+      { id: "a", coordinates: { x: 2, y: 0 }, createdAt },
+    ];
+
+    let counts:
+      | { applied: number; skipped: number; noInventory: number }
+      | undefined;
+    produce(moved, (draft) => {
+      counts = applyFarmLayout(draft, draft.layouts![0], createdAt);
+    });
+
+    expect(counts).toEqual({ applied: 1, skipped: 0, noInventory: 1 });
+  });
+
+  it("matches by name, not by saved id (shared layouts)", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 1 }),
+      collectibles: {
+        "Wicker Man": [
+          { id: "from-another-player", coordinates: { x: 0, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    // The player owns a Wicker Man, but under a different id.
+    const moved = cloneDeep(saved);
+    moved.collectibles["Wicker Man"] = [
+      { id: "mine", coordinates: { x: 2, y: 0 }, createdAt },
+    ];
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.collectibles["Wicker Man"]).toHaveLength(1);
+    expect(result.collectibles["Wicker Man"]![0].id).toEqual("mine");
+    expect(result.collectibles["Wicker Man"]![0].coordinates).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("fills positions in order and unplaces extras", () => {
+    // Layout has 1 Wicker Man position; the player owns 3.
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 3 }),
+      collectibles: {
+        "Wicker Man": [{ id: "a", coordinates: { x: -1, y: 0 }, createdAt }],
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.collectibles["Wicker Man"] = [
+      { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
+      { id: "b", coordinates: { x: 1, y: 0 }, createdAt },
+      { id: "c", coordinates: { x: 2, y: 0 }, createdAt },
+    ];
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const placed = result.collectibles["Wicker Man"]!.filter(
+      (c) => !!c.coordinates,
+    );
+    expect(placed).toHaveLength(1);
+    expect(placed[0].coordinates).toEqual({ x: -1, y: 0 });
+  });
+
+  it("swaps two items without a false self-collision", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 2 }),
       collectibles: {
         "Wicker Man": [
           { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
@@ -85,20 +235,14 @@ describe("applyLayout", () => {
       action: { type: "layout.applied", layoutId: 0 },
     });
 
-    const group = result.collectibles["Wicker Man"]!;
-    expect(group.find((c) => c.id === "a")!.coordinates).toEqual({
-      x: 0,
-      y: 0,
-    });
-    expect(group.find((c) => c.id === "b")!.coordinates).toEqual({
-      x: 1,
-      y: 0,
-    });
+    const coords = result.collectibles["Wicker Man"]!.map((c) => c.coordinates);
+    expect(coords).toContainEqual({ x: 0, y: 0 });
+    expect(coords).toContainEqual({ x: 1, y: 0 });
   });
 
-  it("skips an item whose target is blocked but applies the others", () => {
+  it("leaves a blocked position unplaced and places the rest", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Wicker Man": 2, "Golden Bonsai": 1 }),
       collectibles: {
         "Wicker Man": [
           { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
@@ -108,9 +252,7 @@ describe("applyLayout", () => {
     });
 
     const moved = cloneDeep(saved);
-    // Displace both, and drop a non-layout item onto a's saved spot.
-    moved.collectibles["Wicker Man"]![0].coordinates = { x: 2, y: 0 };
-    moved.collectibles["Wicker Man"]![1].coordinates = { x: -1, y: 0 };
+    // A non-layout item blocks the (0,0) position.
     moved.collectibles["Golden Bonsai"] = [
       { id: "c", coordinates: { x: 0, y: 0 }, createdAt },
     ];
@@ -120,54 +262,20 @@ describe("applyLayout", () => {
       action: { type: "layout.applied", layoutId: 0 },
     });
 
-    const group = result.collectibles["Wicker Man"]!;
-    // a's target (0,0) is blocked → a stays where it was.
-    expect(group.find((c) => c.id === "a")!.coordinates).toEqual({
-      x: 2,
-      y: 0,
-    });
-    // b's target (1,0) is free → b is placed.
-    expect(group.find((c) => c.id === "b")!.coordinates).toEqual({
-      x: 1,
-      y: 0,
-    });
+    const placed = result.collectibles["Wicker Man"]!.filter(
+      (c) => !!c.coordinates,
+    );
+    expect(placed).toHaveLength(1);
+    expect(placed[0].coordinates).toEqual({ x: 1, y: 0 });
     expect(result.collectibles["Golden Bonsai"]![0].coordinates).toEqual({
       x: 0,
       y: 0,
     });
   });
 
-  it("skips an item whose saved position is now off the land", () => {
+  it("reports applied / skipped / noInventory counts", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
-      collectibles: {
-        "Wicker Man": [{ id: "a", coordinates: { x: 0, y: 0 }, createdAt }],
-      },
-    });
-
-    const moved = cloneDeep(saved);
-    // Pretend the farm shrank (e.g. ascension): the saved spot is now water.
-    moved.layouts![0].collectibles["Wicker Man"]![0].coordinates = {
-      x: 50,
-      y: 50,
-    };
-    // a currently sits on valid land.
-    moved.collectibles["Wicker Man"]![0].coordinates = { x: 1, y: 0 };
-
-    const result = applyLayout({
-      state: moved,
-      action: { type: "layout.applied", layoutId: 0 },
-    });
-
-    expect(result.collectibles["Wicker Man"]![0].coordinates).toEqual({
-      x: 1,
-      y: 0,
-    });
-  });
-
-  it("reports applied and skipped counts", () => {
-    const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Wicker Man": 2 }),
       collectibles: {
         "Wicker Man": [
           { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
@@ -177,58 +285,33 @@ describe("applyLayout", () => {
     });
 
     const moved = cloneDeep(saved);
+    // b's saved position is now off-land.
     moved.layouts![0].collectibles["Wicker Man"]![1].coordinates = {
       x: 50,
       y: 50,
-    }; // b's target is now off-land
-    moved.collectibles["Wicker Man"]![0].coordinates = { x: 2, y: 0 };
-    moved.collectibles["Wicker Man"]![1].coordinates = { x: -1, y: 0 };
+    };
 
-    let counts: { applied: number; skipped: number } | undefined;
+    let counts:
+      | { applied: number; skipped: number; noInventory: number }
+      | undefined;
     produce(moved, (draft) => {
-      counts = applyFarmLayout(draft, draft.layouts![0]);
+      counts = applyFarmLayout(draft, draft.layouts![0], createdAt);
     });
 
-    expect(counts).toEqual({ applied: 1, skipped: 1 });
+    // (0,0) placed; (50,50) off-land → skipped (owns enough, just can't fit).
+    expect(counts).toEqual({ applied: 1, skipped: 1, noInventory: 0 });
   });
 
-  it("skips snapshot members that no longer exist and applies the rest", () => {
+  it("places a removed-but-owned resource", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
-      collectibles: {
-        "Wicker Man": [
-          { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
-          { id: "b", coordinates: { x: 1, y: 0 }, createdAt },
-        ],
-      },
-    });
-
-    const moved = cloneDeep(saved);
-    moved.collectibles["Wicker Man"] = [
-      { id: "a", coordinates: { x: 2, y: 0 }, createdAt },
-    ];
-
-    const result = applyLayout({
-      state: moved,
-      action: { type: "layout.applied", layoutId: 0 },
-    });
-
-    expect(result.collectibles["Wicker Man"]).toHaveLength(1);
-    expect(result.collectibles["Wicker Man"]![0].coordinates).toEqual({
-      x: 0,
-      y: 0,
-    });
-  });
-
-  it("restores resource coordinates as top-level x/y", () => {
-    const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Crop Plot": 1 }),
       crops: { c1: { x: 2, y: 0, createdAt } },
     });
 
     const moved = cloneDeep(saved);
-    moved.crops.c1.x = -3;
-    moved.crops.c1.y = 0;
+    delete moved.crops.c1.x;
+    delete moved.crops.c1.y;
+    moved.crops.c1.removedAt = createdAt;
 
     const result = applyLayout({
       state: moved,
@@ -237,12 +320,58 @@ describe("applyLayout", () => {
 
     expect(result.crops.c1.x).toEqual(2);
     expect(result.crops.c1.y).toEqual(0);
-    expect("coordinates" in result.crops.c1).toBe(false);
+    expect(result.crops.c1.removedAt).toBeUndefined();
   });
 
-  it("carries oX/oY render offsets through to the restored position", () => {
+  it("creates new crop plots from inventory", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Crop Plot": 2 }),
+      crops: {
+        c1: { x: 0, y: 0, createdAt },
+        c2: { x: 1, y: 0, createdAt },
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.crops = {}; // owned in inventory, no instances yet
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const placed = Object.values(result.crops).filter((c) => c.x !== undefined);
+    expect(placed).toHaveLength(2);
+  });
+
+  it("creates new tree nodes from inventory (tiered family)", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ Tree: 2 }),
+      trees: {
+        t1: { x: -3, y: 0, wood: { choppedAt: 0 }, createdAt },
+        t2: { x: -1, y: 0, wood: { choppedAt: 0 }, createdAt },
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.trees = {};
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const placed = Object.values(result.trees).filter((t) => t.x !== undefined);
+    expect(placed).toHaveLength(2);
+    placed.forEach((t) => {
+      expect(t.name).toEqual("Tree");
+      expect(t.wood).toBeDefined();
+    });
+  });
+
+  it("carries oX/oY render offsets through to the placed position", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 1 }),
       collectibles: {
         "Wicker Man": [
           { id: "a", coordinates: { x: 0, y: 0, oX: 4, oY: -4 }, createdAt },
@@ -266,9 +395,9 @@ describe("applyLayout", () => {
     });
   });
 
-  it("repositions buildings", () => {
+  it("places buildings", () => {
     const saved = withSavedLayout({
-      ...baseFarm,
+      ...withInventory({ "Fire Pit": 1 }),
       buildings: {
         "Fire Pit": [
           {
@@ -293,60 +422,6 @@ describe("applyLayout", () => {
       x: -3,
       y: 0,
     });
-  });
-
-  it("never restores a skipped item onto another layout item's tile", () => {
-    // Saved: a -> (0,0), b -> (2,0). Now: a sits at (2,0) (b's target), b is
-    // elsewhere, and a non-layout item blocks a's target (0,0). a can't move, so
-    // b must NOT be placed onto (2,0) and overlap a.
-    const saved = withSavedLayout({
-      ...baseFarm,
-      collectibles: {
-        "Wicker Man": [
-          { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
-          { id: "b", coordinates: { x: 2, y: 0 }, createdAt },
-        ],
-      },
-    });
-
-    const moved = cloneDeep(saved);
-    moved.collectibles["Wicker Man"]![0].coordinates = { x: 2, y: 0 };
-    moved.collectibles["Wicker Man"]![1].coordinates = { x: -1, y: 0 };
-    moved.collectibles["Golden Bonsai"] = [
-      { id: "c", coordinates: { x: 0, y: 0 }, createdAt },
-    ];
-
-    const result = applyLayout({
-      state: moved,
-      action: { type: "layout.applied", layoutId: 0 },
-    });
-
-    const group = result.collectibles["Wicker Man"]!;
-    const a = group.find((c) => c.id === "a")!.coordinates!;
-    const b = group.find((c) => c.id === "b")!.coordinates!;
-    expect(a).toEqual({ x: 2, y: 0 });
-    expect(`${a.x},${a.y}`).not.toEqual(`${b.x},${b.y}`);
-  });
-
-  it("does not re-place a withdrawn (coordinate-less) collectible", () => {
-    const saved = withSavedLayout({
-      ...baseFarm,
-      collectibles: {
-        "Wicker Man": [{ id: "a", coordinates: { x: 0, y: 0 }, createdAt }],
-      },
-    });
-
-    const moved = cloneDeep(saved);
-    // Removed during landscaping: still owned (in the bucket) but unplaced.
-    delete moved.collectibles["Wicker Man"]![0].coordinates;
-    moved.collectibles["Wicker Man"]![0].removedAt = createdAt;
-
-    const result = applyLayout({
-      state: moved,
-      action: { type: "layout.applied", layoutId: 0 },
-    });
-
-    expect(result.collectibles["Wicker Man"]![0].coordinates).toBeUndefined();
   });
 
   const EQUIPPED = {
@@ -376,7 +451,7 @@ describe("applyLayout", () => {
     location: "farm" as const,
   });
 
-  it("restores buds, pet NFTs, farmhands and the bumpkin (with flip)", () => {
+  it("places owned buds, pet NFTs, farmhands and the bumpkin (with flip)", () => {
     const saved = withSavedLayout({
       ...baseFarm,
       buds: { 1: { ...BUD, coordinates: { x: 2, y: 2 }, location: "farm" } },
@@ -399,7 +474,6 @@ describe("applyLayout", () => {
       },
     });
 
-    // Displace everything (and clear the flips) before applying.
     const moved = cloneDeep(saved);
     moved.buds![1].coordinates = { x: -3, y: 0 };
     moved.pets!.nfts![1].coordinates = { x: 1, y: 2 };
@@ -424,24 +498,62 @@ describe("applyLayout", () => {
     expect(result.bumpkin.flipped).toEqual(true);
   });
 
-  it("does not pull a bud back onto the farm if it is now in the house", () => {
+  it("places farmhands by count, ignoring the saved id", () => {
     const saved = withSavedLayout({
       ...baseFarm,
-      buds: { 1: { ...BUD, coordinates: { x: 2, y: 2 }, location: "farm" } },
+      farmHands: {
+        bumpkins: {
+          a: {
+            equipped: EQUIPPED,
+            coordinates: { x: 0, y: 0 },
+            location: "farm",
+          },
+          b: {
+            equipped: EQUIPPED,
+            coordinates: { x: 1, y: 0 },
+            location: "farm",
+          },
+        },
+      },
     });
 
     const moved = cloneDeep(saved);
-    // The bud was moved into the house since the layout was saved.
-    moved.buds![1].coordinates = { x: 0, y: 0 };
-    moved.buds![1].location = "home";
+    moved.farmHands = {
+      bumpkins: {
+        mine: {
+          equipped: EQUIPPED,
+          coordinates: { x: 2, y: 0 },
+          location: "farm",
+        },
+      },
+    };
 
     const result = applyLayout({
       state: moved,
       action: { type: "layout.applied", layoutId: 0 },
     });
 
-    expect(result.buds![1].location).toEqual("home");
-    expect(result.buds![1].coordinates).toEqual({ x: 0, y: 0 });
+    expect(result.farmHands.bumpkins["mine"].coordinates).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("skips buds/pets the player does not own (shared layouts)", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      buds: { 1: { ...BUD, coordinates: { x: 2, y: 2 }, location: "farm" } },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.buds = {};
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.buds).toEqual({});
   });
 
   it("throws when the layout does not exist", () => {

--- a/src/features/game/events/landExpansion/applyLayout.test.ts
+++ b/src/features/game/events/landExpansion/applyLayout.test.ts
@@ -349,6 +349,101 @@ describe("applyLayout", () => {
     expect(result.collectibles["Wicker Man"]![0].coordinates).toBeUndefined();
   });
 
+  const EQUIPPED = {
+    background: "Farm Background" as const,
+    body: "Beige Farmer Potion" as const,
+    hair: "Basic Hair" as const,
+    shoes: "Black Farmer Boots" as const,
+    pants: "Farmer Pants" as const,
+    shirt: "Yellow Farmer Shirt" as const,
+    tool: "Farmer Pitchfork" as const,
+  };
+  const BUD = {
+    aura: "Basic" as const,
+    colour: "Beige" as const,
+    ears: "Ears" as const,
+    stem: "3 Leaf Clover" as const,
+    type: "Beach" as const,
+  };
+  const petNFT = (coordinates: { x: number; y: number }) => ({
+    id: 1,
+    name: "Pet #1" as const,
+    requests: { food: [], fedAt: createdAt },
+    energy: 100,
+    experience: 0,
+    pettedAt: createdAt,
+    coordinates,
+    location: "farm" as const,
+  });
+
+  it("restores buds, pet NFTs, farmhands and the bumpkin (with flip)", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      buds: { 1: { ...BUD, coordinates: { x: 2, y: 2 }, location: "farm" } },
+      pets: { nfts: { 1: petNFT({ x: -1, y: 1 }) } },
+      farmHands: {
+        bumpkins: {
+          "fh-1": {
+            equipped: EQUIPPED,
+            coordinates: { x: 1, y: 0 },
+            flipped: true,
+            location: "farm",
+          },
+        },
+      },
+      bumpkin: {
+        ...baseFarm.bumpkin,
+        coordinates: { x: 2, y: 0 },
+        location: "farm",
+        flipped: true,
+      },
+    });
+
+    // Displace everything (and clear the flips) before applying.
+    const moved = cloneDeep(saved);
+    moved.buds![1].coordinates = { x: -3, y: 0 };
+    moved.pets!.nfts![1].coordinates = { x: 1, y: 2 };
+    moved.farmHands.bumpkins["fh-1"].coordinates = { x: -2, y: 0 };
+    moved.farmHands.bumpkins["fh-1"].flipped = false;
+    moved.bumpkin.coordinates = { x: -1, y: 2 };
+    moved.bumpkin.flipped = false;
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.buds![1].coordinates).toEqual({ x: 2, y: 2 });
+    expect(result.pets!.nfts![1].coordinates).toEqual({ x: -1, y: 1 });
+    expect(result.farmHands.bumpkins["fh-1"].coordinates).toEqual({
+      x: 1,
+      y: 0,
+    });
+    expect(result.farmHands.bumpkins["fh-1"].flipped).toEqual(true);
+    expect(result.bumpkin.coordinates).toEqual({ x: 2, y: 0 });
+    expect(result.bumpkin.flipped).toEqual(true);
+  });
+
+  it("does not pull a bud back onto the farm if it is now in the house", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      buds: { 1: { ...BUD, coordinates: { x: 2, y: 2 }, location: "farm" } },
+    });
+
+    const moved = cloneDeep(saved);
+    // The bud was moved into the house since the layout was saved.
+    moved.buds![1].coordinates = { x: 0, y: 0 };
+    moved.buds![1].location = "home";
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.buds![1].location).toEqual("home");
+    expect(result.buds![1].coordinates).toEqual({ x: 0, y: 0 });
+  });
+
   it("throws when the layout does not exist", () => {
     expect(() =>
       applyLayout({

--- a/src/features/game/events/landExpansion/applyLayout.test.ts
+++ b/src/features/game/events/landExpansion/applyLayout.test.ts
@@ -556,6 +556,158 @@ describe("applyLayout", () => {
     expect(result.buds).toEqual({});
   });
 
+  it("leaves a blocked item at its original spot (best-effort restore)", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 1 }),
+      collectibles: {
+        "Wicker Man": [{ id: "w", coordinates: { x: 0, y: 0 }, createdAt }],
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    // Layout wants Wicker Man at (1, 0); it currently sits at (0, 0); a
+    // non-layout item blocks (1, 0).
+    moved.layouts![0].collectibles["Wicker Man"]![0].coordinates = {
+      x: 1,
+      y: 0,
+    };
+    moved.collectibles["Wicker Man"] = [
+      { id: "w", coordinates: { x: 0, y: 0 }, createdAt },
+    ];
+    moved.collectibles["Golden Bonsai"] = [
+      { id: "g", coordinates: { x: 1, y: 0 }, createdAt },
+    ];
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.collectibles["Wicker Man"]![0].coordinates).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("unplaces a blocked item when its original tile is taken by the layout", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 2 }),
+      collectibles: {
+        "Wicker Man": [
+          { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
+          { id: "b", coordinates: { x: 2, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    // Layout: a -> (1, 0) [will be blocked], b -> (0, 0) [a's original tile].
+    moved.layouts![0].collectibles["Wicker Man"] = [
+      { id: "a", coordinates: { x: 1, y: 0 } },
+      { id: "b", coordinates: { x: 0, y: 0 } },
+    ];
+    moved.collectibles["Wicker Man"] = [
+      { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
+      { id: "b", coordinates: { x: 2, y: 0 }, createdAt },
+    ];
+    moved.collectibles["Golden Bonsai"] = [
+      { id: "g", coordinates: { x: 1, y: 0 }, createdAt },
+    ];
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const byId = Object.fromEntries(
+      result.collectibles["Wicker Man"]!.map((c) => [c.id, c.coordinates]),
+    );
+    expect(byId["b"]).toEqual({ x: 0, y: 0 });
+    expect(byId["a"]).toBeUndefined();
+  });
+
+  it("restores each owned collectible to its own saved spot (hybrid by id)", () => {
+    // ids sort opposite to positions, so pure-availability would swap them.
+    const saved = withSavedLayout({
+      ...withInventory({ "Wicker Man": 2 }),
+      collectibles: {
+        "Wicker Man": [
+          { id: "z", coordinates: { x: 0, y: 0 }, createdAt },
+          { id: "a", coordinates: { x: 1, y: 0 }, createdAt },
+        ],
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.collectibles["Wicker Man"]![0].coordinates = { x: 2, y: 0 }; // z
+    moved.collectibles["Wicker Man"]![1].coordinates = { x: -1, y: 0 }; // a
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    const byId = Object.fromEntries(
+      result.collectibles["Wicker Man"]!.map((c) => [c.id, c.coordinates]),
+    );
+    expect(byId["z"]).toEqual({ x: 0, y: 0 });
+    expect(byId["a"]).toEqual({ x: 1, y: 0 });
+  });
+
+  it("restores each owned resource node to its own saved spot (hybrid by id)", () => {
+    const saved = withSavedLayout({
+      ...withInventory({ "Crop Plot": 2 }),
+      crops: {
+        z: { x: 0, y: 0, createdAt },
+        a: { x: 1, y: 0, createdAt },
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.crops.z = { x: 2, y: 0, createdAt };
+    moved.crops.a = { x: -1, y: 0, createdAt };
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.crops.z).toMatchObject({ x: 0, y: 0 });
+    expect(result.crops.a).toMatchObject({ x: 1, y: 0 });
+  });
+
+  it("restores each owned farmhand to its own saved spot (hybrid by id)", () => {
+    const saved = withSavedLayout({
+      ...baseFarm,
+      farmHands: {
+        bumpkins: {
+          z: {
+            equipped: EQUIPPED,
+            coordinates: { x: 0, y: 0 },
+            location: "farm",
+          },
+          a: {
+            equipped: EQUIPPED,
+            coordinates: { x: 1, y: 0 },
+            location: "farm",
+          },
+        },
+      },
+    });
+
+    const moved = cloneDeep(saved);
+    moved.farmHands.bumpkins.z.coordinates = { x: 2, y: 0 };
+    moved.farmHands.bumpkins.a.coordinates = { x: -1, y: 0 };
+
+    const result = applyLayout({
+      state: moved,
+      action: { type: "layout.applied", layoutId: 0 },
+    });
+
+    expect(result.farmHands.bumpkins.z.coordinates).toEqual({ x: 0, y: 0 });
+    expect(result.farmHands.bumpkins.a.coordinates).toEqual({ x: 1, y: 0 });
+  });
+
   it("throws when the layout does not exist", () => {
     expect(() =>
       applyLayout({

--- a/src/features/game/events/landExpansion/applyLayout.ts
+++ b/src/features/game/events/landExpansion/applyLayout.ts
@@ -21,7 +21,11 @@ type Options = {
  * they are. Saved layouts are immutable — editing the farm never changes them;
  * use `saveLayout` with a `layoutId` to overwrite one.
  */
-export function applyLayout({ state, action }: Options): GameState {
+export function applyLayout({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
   return produce(state, (stateCopy) => {
     if (!hasFeatureAccess(stateCopy, "SAVED_LAYOUTS")) {
       throw new Error("Saved layouts are not available");
@@ -32,7 +36,7 @@ export function applyLayout({ state, action }: Options): GameState {
       throw new Error("Layout does not exist");
     }
 
-    applyFarmLayout(stateCopy, layout);
+    applyFarmLayout(stateCopy, layout, createdAt);
 
     return stateCopy;
   });

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -9,12 +9,27 @@ import {
   RESOURCE_DIMENSIONS,
   type ResourceName,
 } from "features/game/types/resources";
+import { PET_NFT_DIMENSIONS } from "features/game/types/pets";
 import {
   detectCollision,
   type Position,
 } from "features/game/expansion/placeable/lib/collisionDetection";
 import type { LandscapingPlaceable } from "features/game/expansion/placeable/landscapingMachine";
 import { getObjectEntries } from "lib/object";
+
+/**
+ * Collision dimensions for the placeables that aren't in
+ * {@link PLACEABLE_DIMENSIONS} (Buds/Pet NFTs/FarmHands/Bumpkin). Mirrors the
+ * hardcoded boxes used by `detectCollision` and the placement UI: 1x1 for
+ * everything except the 2x2 Pet NFT.
+ */
+const BUD_DIMENSIONS = { width: 1, height: 1 };
+const FARM_HAND_DIMENSIONS = { width: 1, height: 1 };
+const BUMPKIN_DIMENSIONS = { width: 1, height: 1 };
+
+/** True when a placeable's `location` marks it as on the farm (legacy = farm). */
+const isOnFarm = (placed: { location?: string; coordinates?: unknown }) =>
+  !!placed.coordinates && (!placed.location || placed.location === "farm");
 
 const PLACEABLE_DIMENSIONS: Record<string, { width: number; height: number }> =
   {
@@ -109,7 +124,17 @@ const copyCoordinates = (item: PlacedResource): LayoutCoordinates => {
  */
 export function snapshotFarm(
   state: GameState,
-): Pick<SavedLayout, "collectibles" | "buildings" | "resources"> {
+): Pick<
+  SavedLayout,
+  | "collectibles"
+  | "buildings"
+  | "resources"
+  | "buds"
+  | "petNFTs"
+  | "farmHands"
+  | "bumpkin"
+  | "land"
+> {
   const collectibles: SavedLayout["collectibles"] = {};
   getObjectEntries(state.collectibles).forEach(([name, group]) => {
     if (!group) return;
@@ -145,7 +170,54 @@ export function snapshotFarm(
     });
   });
 
-  return { collectibles, buildings, resources };
+  // Buds and Pet NFTs: single bucket each, distinguished from home/interior
+  // copies by `location`. Neither is flippable, so store bare coordinates.
+  const buds: NonNullable<SavedLayout["buds"]> = {};
+  Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
+    if (!isOnFarm(bud)) return;
+    buds[id] = { ...(bud.coordinates as LayoutCoordinates) };
+  });
+
+  const petNFTs: NonNullable<SavedLayout["petNFTs"]> = {};
+  Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
+    if (!isOnFarm(pet)) return;
+    petNFTs[id] = { ...(pet.coordinates as LayoutCoordinates) };
+  });
+
+  // FarmHands (extra bumpkins) carry a `flipped` flag like the main Bumpkin.
+  const farmHands: NonNullable<SavedLayout["farmHands"]> = {};
+  Object.entries(state.farmHands?.bumpkins ?? {}).forEach(([id, farmHand]) => {
+    if (!isOnFarm(farmHand)) return;
+    farmHands[id] = {
+      ...(farmHand.coordinates as LayoutCoordinates),
+      ...(farmHand.flipped !== undefined ? { flipped: farmHand.flipped } : {}),
+    };
+  });
+
+  const bumpkin = isOnFarm(state.bumpkin)
+    ? {
+        ...(state.bumpkin.coordinates as LayoutCoordinates),
+        ...(state.bumpkin.flipped !== undefined
+          ? { flipped: state.bumpkin.flipped }
+          : {}),
+      }
+    : undefined;
+
+  const land = {
+    expansions: state.inventory["Basic Land"]?.toNumber() ?? 3,
+    island: { ...state.island },
+  };
+
+  return {
+    collectibles,
+    buildings,
+    resources,
+    land,
+    ...(Object.keys(buds).length > 0 ? { buds } : {}),
+    ...(Object.keys(petNFTs).length > 0 ? { petNFTs } : {}),
+    ...(Object.keys(farmHands).length > 0 ? { farmHands } : {}),
+    ...(bumpkin ? { bumpkin } : {}),
+  };
 }
 
 /**
@@ -159,7 +231,14 @@ export function defaultLayoutName(layouts: SavedLayout[]): string {
   return `Layout ${n}`;
 }
 
-export type LayoutRectCategory = "collectible" | "building" | "resource";
+export type LayoutRectCategory =
+  | "collectible"
+  | "building"
+  | "resource"
+  // Buds & Pet NFTs — sprite resolved from `id` (getBudImage/getPetImage…).
+  | "nft"
+  // The player's Bumpkin & FarmHands — sprite composed from equipped parts.
+  | "avatar";
 
 export type LayoutRect = {
   x: number;
@@ -169,6 +248,11 @@ export type LayoutRect = {
   category: LayoutRectCategory;
   /** Item name (for sprite lookup); resources use their representative name. */
   name: string;
+  /**
+   * Entity id for `nft`/`avatar` rects, used by the preview to resolve the
+   * live sprite (bud/pet by id; farmhand by id → equipped). Bumpkin omits it.
+   */
+  id?: string;
 };
 
 /**
@@ -178,7 +262,16 @@ export type LayoutRect = {
  * the top edge y). `name` is the item name so a renderer can resolve a sprite.
  */
 export function layoutItemRects(
-  layout: Pick<SavedLayout, "collectibles" | "buildings" | "resources">,
+  layout: Pick<
+    SavedLayout,
+    | "collectibles"
+    | "buildings"
+    | "resources"
+    | "buds"
+    | "petNFTs"
+    | "farmHands"
+    | "bumpkin"
+  >,
 ): LayoutRect[] {
   const rects: LayoutRect[] = [];
 
@@ -226,6 +319,53 @@ export function layoutItemRects(
       }),
     );
   });
+
+  // Buds & Pet NFTs — sprite resolved from the entity id in the preview.
+  Object.entries(layout.buds ?? {}).forEach(([id, coordinates]) =>
+    rects.push({
+      x: coordinates.x,
+      y: coordinates.y,
+      width: BUD_DIMENSIONS.width,
+      height: BUD_DIMENSIONS.height,
+      category: "nft",
+      name: "Bud",
+      id,
+    }),
+  );
+  Object.entries(layout.petNFTs ?? {}).forEach(([id, coordinates]) =>
+    rects.push({
+      x: coordinates.x,
+      y: coordinates.y,
+      width: PET_NFT_DIMENSIONS.width,
+      height: PET_NFT_DIMENSIONS.height,
+      category: "nft",
+      name: "Pet",
+      id,
+    }),
+  );
+
+  // FarmHands & the player's Bumpkin — sprite composed from equipped parts.
+  Object.entries(layout.farmHands ?? {}).forEach(([id, placement]) =>
+    rects.push({
+      x: placement.x,
+      y: placement.y,
+      width: FARM_HAND_DIMENSIONS.width,
+      height: FARM_HAND_DIMENSIONS.height,
+      category: "avatar",
+      name: "FarmHand",
+      id,
+    }),
+  );
+  if (layout.bumpkin) {
+    rects.push({
+      x: layout.bumpkin.x,
+      y: layout.bumpkin.y,
+      width: BUMPKIN_DIMENSIONS.width,
+      height: BUMPKIN_DIMENSIONS.height,
+      category: "avatar",
+      name: "Bumpkin",
+    });
+  }
 
   return rects;
 }
@@ -360,6 +500,110 @@ export function applyFarmLayout(
       item.y = undefined;
     });
   });
+
+  // Buds — single bucket, 1x1, not flippable. Only re-place ones currently on
+  // the farm (an item moved to the house keeps its house spot).
+  Object.entries(layout.buds ?? {}).forEach(([id, coordinates]) => {
+    const item = state.buds?.[Number(id)];
+    if (!item || !isOnFarm(item)) return;
+    const original = { ...item.coordinates! };
+    pending.push({
+      name: "Bud",
+      position: {
+        x: coordinates.x,
+        y: coordinates.y,
+        width: BUD_DIMENSIONS.width,
+        height: BUD_DIMENSIONS.height,
+      },
+      toTarget: () => {
+        item.coordinates = { x: coordinates.x, y: coordinates.y };
+      },
+      toOriginal: () => {
+        item.coordinates = original;
+      },
+    });
+    item.coordinates = undefined; // lift
+  });
+
+  // Pet NFTs — keyed under pets.nfts, 2x2, not flippable.
+  Object.entries(layout.petNFTs ?? {}).forEach(([id, coordinates]) => {
+    const item = state.pets?.nfts?.[Number(id)];
+    if (!item || !isOnFarm(item)) return;
+    const original = { ...item.coordinates! };
+    pending.push({
+      name: "Pet",
+      position: {
+        x: coordinates.x,
+        y: coordinates.y,
+        width: PET_NFT_DIMENSIONS.width,
+        height: PET_NFT_DIMENSIONS.height,
+      },
+      toTarget: () => {
+        item.coordinates = { x: coordinates.x, y: coordinates.y };
+      },
+      toOriginal: () => {
+        item.coordinates = original;
+      },
+    });
+    item.coordinates = undefined; // lift
+  });
+
+  // FarmHands — extra bumpkins, 1x1, flippable.
+  Object.entries(layout.farmHands ?? {}).forEach(([id, placement]) => {
+    const item = state.farmHands?.bumpkins?.[id];
+    if (!item || !isOnFarm(item)) return;
+    const original = {
+      coordinates: { ...item.coordinates! },
+      flipped: item.flipped,
+    };
+    pending.push({
+      name: "FarmHand",
+      position: {
+        x: placement.x,
+        y: placement.y,
+        width: FARM_HAND_DIMENSIONS.width,
+        height: FARM_HAND_DIMENSIONS.height,
+      },
+      toTarget: () => {
+        item.coordinates = { x: placement.x, y: placement.y };
+        item.flipped = placement.flipped;
+      },
+      toOriginal: () => {
+        item.coordinates = original.coordinates;
+        item.flipped = original.flipped;
+      },
+    });
+    item.coordinates = undefined; // lift
+  });
+
+  // The player's own Bumpkin — single, 1x1, flippable. Passing name "Bumpkin"
+  // makes detectCollision self-exclude it (it's lifted anyway).
+  if (layout.bumpkin && isOnFarm(state.bumpkin)) {
+    const placement = layout.bumpkin;
+    const bumpkin = state.bumpkin;
+    const original = {
+      coordinates: { ...bumpkin.coordinates! },
+      flipped: bumpkin.flipped,
+    };
+    pending.push({
+      name: "Bumpkin",
+      position: {
+        x: placement.x,
+        y: placement.y,
+        width: BUMPKIN_DIMENSIONS.width,
+        height: BUMPKIN_DIMENSIONS.height,
+      },
+      toTarget: () => {
+        bumpkin.coordinates = { x: placement.x, y: placement.y };
+        bumpkin.flipped = placement.flipped;
+      },
+      toOriginal: () => {
+        bumpkin.coordinates = original.coordinates;
+        bumpkin.flipped = original.flipped;
+      },
+    });
+    bumpkin.coordinates = undefined; // lift
+  }
 
   // Pass 1: with every applicable item lifted, anything still blocked can't be
   // placed at all (its target is off-land or taken by a non-layout item).

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -466,6 +466,13 @@ type LayoutSlot = {
   position: Position;
   /** Materialise the resolved instance at this slot. */
   place: () => void;
+  /**
+   * For a reused instance that was already on the farm: where it sat before the
+   * layout lifted it, so that if this slot is blocked we can leave the item
+   * there (when that tile is still free) instead of unplacing it. Newly-created
+   * instances have no `restore` — they simply aren't created.
+   */
+  restore?: { position: Position; apply: () => void };
 };
 
 /** Deterministic position order so FE and BE fill slots identically. */
@@ -477,20 +484,22 @@ const byPosition = (a: LayoutCoordinates, b: LayoutCoordinates) =>
  * inventory availability (not by saved id) so a layout can be shared between
  * players. Best-effort — mutates `state` in place (expects an Immer draft).
  *
- * Matching: collectibles/buildings/resources by name+availability; buds/pet
- * NFTs by id ownership; farmhands by however many are unlocked; the bumpkin
- * always. For each type the player's current farm placements are lifted, then
- * the type's saved positions are filled (in a deterministic order) from the
- * available instances — so owning fewer than the layout asks leaves the extra
- * positions empty (`noInventory`), and owning more leaves the extras unplaced.
+ * Matching: collectibles/buildings/resources prefer the player's own instance
+ * for each saved id (so applying your own layout restores each item to its exact
+ * spot, keeping its timers/state), then fall back to inventory availability for
+ * ids you don't own (e.g. a shared layout). Buds/pet NFTs match by id ownership;
+ * farmhands prefer the saved id then fill by count; the bumpkin is always placed.
+ * For each type the player's current farm placements are lifted, then the type's
+ * saved positions are filled (in a deterministic order) — owning fewer than the
+ * layout asks leaves the extra positions empty (`noInventory`), owning more
+ * leaves the extras unplaced.
  *
- * Collectibles & buildings are placed up to full inventory availability:
- * unplaced instances are reused first, then new instances are created (with
- * deterministic ids) from the remaining owned inventory. Resources/buds/pets/
- * farmhands reuse existing instances (resource nodes are pre-created by land
- * expansion, so reuse already covers what a player owns); positions with no
- * available instance count as `noInventory`. Positions blocked off-land or under
- * a non-layout item are `skipped`.
+ * Collectibles, buildings & resources are placed up to full inventory
+ * availability: existing instances are reused first, then new instances are
+ * created (with deterministic ids) from the remaining owned inventory. Buds/pets/
+ * farmhands reuse existing instances only; positions with no available instance
+ * count as `noInventory`. Positions blocked off-land or under a non-layout item
+ * are `skipped`.
  */
 export function applyFarmLayout(
   state: GameState,
@@ -518,42 +527,78 @@ export function applyFarmLayout(
       const dimensions = PLACEABLE_DIMENSIONS[name];
       if (!dimensions || !entries) return;
       const group = getBucket(name) ?? [];
+      const originalCoords = new Map(
+        group.map((item) => [item.id, item.coordinates]),
+      );
       group.forEach((item) => {
         if (item.coordinates) item.coordinates = undefined; // lift
       });
-      const available = group
-        .filter((item) => !item.coordinates)
-        .sort((a, b) => a.id.localeCompare(b.id));
+      const byId = new Map(group.map((item) => [item.id, item]));
       const owned = getChestItemCount(
         state,
         name as InventoryItemName,
       ).toNumber();
-      const capacity = Math.min(entries.length, owned);
-      [...entries]
-        .sort((a, b) => byPosition(a.coordinates, b.coordinates))
-        .forEach((entry, i) => {
-          if (i >= capacity) {
-            noInventory += 1;
-            return;
-          }
-          const reuse = available[i];
-          slots.push({
-            name: name as LandscapingPlaceable,
-            position: {
-              x: entry.coordinates.x,
-              y: entry.coordinates.y,
-              width: dimensions.width,
-              height: dimensions.height,
-            },
-            place: () => {
-              const item = reuse ?? newItem(name, newId(name, i));
-              if (!reuse) ensureBucket(name).push(item);
-              item.coordinates = { ...entry.coordinates };
-              item.flipped = entry.flipped;
-              delete item.removedAt;
-            },
-          });
+      const sortedEntries = [...entries].sort((a, b) =>
+        byPosition(a.coordinates, b.coordinates),
+      );
+      const capacity = Math.min(sortedEntries.length, owned);
+      // Prefer the player's own copy of each saved instance (exact restoration);
+      // reserve those ids, then fall back to any other unplaced instance
+      // (id-sorted) and finally to creating new ones from inventory.
+      const ownedSavedIds = new Set(
+        sortedEntries
+          .slice(0, capacity)
+          .map((entry) => entry.id)
+          .filter((id) => byId.has(id)),
+      );
+      const freePool = group
+        .map((item) => item.id)
+        .filter((id) => !ownedSavedIds.has(id))
+        .sort((a, b) => a.localeCompare(b));
+      let freeIdx = 0;
+      sortedEntries.forEach((entry, i) => {
+        if (i >= capacity) {
+          noInventory += 1;
+          return;
+        }
+        const reuseId = byId.has(entry.id) ? entry.id : freePool[freeIdx++];
+        const reuse = reuseId !== undefined ? byId.get(reuseId) : undefined;
+        const original =
+          reuse && reuseId !== undefined
+            ? originalCoords.get(reuseId)
+            : undefined;
+        slots.push({
+          name: name as LandscapingPlaceable,
+          position: {
+            x: entry.coordinates.x,
+            y: entry.coordinates.y,
+            width: dimensions.width,
+            height: dimensions.height,
+          },
+          place: () => {
+            const item = reuse ?? newItem(name, newId(name, i));
+            if (!reuse) ensureBucket(name).push(item);
+            item.coordinates = { ...entry.coordinates };
+            item.flipped = entry.flipped;
+            delete item.removedAt;
+          },
+          restore:
+            reuse && original
+              ? {
+                  position: {
+                    x: original.x,
+                    y: original.y,
+                    width: dimensions.width,
+                    height: dimensions.height,
+                  },
+                  apply: () => {
+                    reuse.coordinates = { ...original };
+                    delete reuse.removedAt;
+                  },
+                }
+              : undefined,
         });
+      });
     });
   };
   addNamedSlots(
@@ -573,32 +618,59 @@ export function applyFarmLayout(
   // Resources: keyed by bucket (tiers aggregated), placed up to availability.
   // Lift the bucket, reuse the (id-sorted) unplaced instances first, then create
   // new nodes from the remaining owned inventory.
-  let beehivePlaced = false;
+  let affectsBeehives = false;
   RESOURCE_BUCKETS.forEach(({ key, resourceName, get }) => {
     const dimensions = RESOURCE_DIMENSIONS[resourceName];
     const bucket = get(state);
+    const originalCoords = new Map(
+      Object.entries(bucket).map(([id, node]) => [
+        id,
+        node.x !== undefined && node.y !== undefined
+          ? { x: node.x, y: node.y, oX: node.oX, oY: node.oY }
+          : undefined,
+      ]),
+    );
     Object.values(bucket).forEach((node) => {
       if (node.x !== undefined) {
         node.x = undefined; // lift
         node.y = undefined;
       }
     });
-    const available = Object.keys(bucket)
-      .filter((id) => bucket[id].x === undefined)
-      .sort((a, b) => a.localeCompare(b));
     const owned = isTieredFamily(key)
       ? getAvailableNodes(state, key).toNumber()
       : getChestItemCount(state, resourceName as InventoryItemName).toNumber();
-    const positions = Object.values(layout.resources[key] ?? {}).sort(
-      byPosition,
+    const entries = Object.entries(layout.resources[key] ?? {}).sort(
+      ([, a], [, b]) => byPosition(a, b),
     );
-    const capacity = Math.min(positions.length, owned);
-    positions.forEach((coordinates, i) => {
+    const capacity = Math.min(entries.length, owned);
+    // Prefer the player's own node for each saved id (keeps its tier + timers at
+    // the saved spot); reserve those, then fall back to any other unplaced node
+    // (id-sorted) and finally to creating new ones from inventory.
+    const ownedSavedIds = new Set(
+      entries
+        .slice(0, capacity)
+        .map(([id]) => id)
+        .filter((id) => bucket[id] !== undefined),
+    );
+    const freePool = Object.keys(bucket)
+      .filter((id) => bucket[id].x === undefined && !ownedSavedIds.has(id))
+      .sort((a, b) => a.localeCompare(b));
+    let freeIdx = 0;
+    entries.forEach(([savedId, coordinates], i) => {
       if (i >= capacity) {
         noInventory += 1;
         return;
       }
-      const reuseId = available[i];
+      const reuseId =
+        bucket[savedId] !== undefined ? savedId : freePool[freeIdx++];
+      const original =
+        reuseId !== undefined ? originalCoords.get(reuseId) : undefined;
+      const markBeehives = () => {
+        // Moving a beehive OR a flower bed changes beehive flower adjacency.
+        if (key === "beehives" || key === "flowerBeds") {
+          affectsBeehives = true;
+        }
+      };
       slots.push({
         name: resourceName,
         position: {
@@ -623,8 +695,28 @@ export function applyFarmLayout(
               createdAt,
             );
           }
-          if (key === "beehives") beehivePlaced = true;
+          markBeehives();
         },
+        restore:
+          reuseId !== undefined && original
+            ? {
+                position: {
+                  x: original.x,
+                  y: original.y,
+                  width: dimensions.width,
+                  height: dimensions.height,
+                },
+                apply: () => {
+                  const node = bucket[reuseId];
+                  node.x = original.x;
+                  node.y = original.y;
+                  node.oX = original.oX;
+                  node.oY = original.oY;
+                  delete node.removedAt;
+                  markBeehives();
+                },
+              }
+            : undefined,
       });
     });
   });
@@ -634,6 +726,7 @@ export function applyFarmLayout(
   Object.entries(layout.buds ?? {}).forEach(([id, coordinates]) => {
     const bud = state.buds?.[Number(id)];
     if (!bud) return;
+    const original = bud.coordinates;
     bud.coordinates = undefined; // lift
     slots.push({
       name: "Bud",
@@ -642,12 +735,22 @@ export function applyFarmLayout(
         bud.coordinates = { x: coordinates.x, y: coordinates.y };
         bud.location = "farm";
       },
+      restore: original
+        ? {
+            position: { x: original.x, y: original.y, ...BUD_DIMENSIONS },
+            apply: () => {
+              bud.coordinates = { x: original.x, y: original.y };
+              bud.location = "farm";
+            },
+          }
+        : undefined,
     });
   });
   Object.entries(layout.petNFTs ?? {}).forEach(([id, coordinates]) => {
     // Owned by id (a pet in a layout was placed once, so it's already revealed).
     const pet = state.pets?.nfts?.[Number(id)];
     if (!pet) return;
+    const original = pet.coordinates;
     pet.coordinates = undefined; // lift
     slots.push({
       name: "Pet",
@@ -656,42 +759,83 @@ export function applyFarmLayout(
         pet.coordinates = { x: coordinates.x, y: coordinates.y };
         pet.location = "farm";
       },
+      restore: original
+        ? {
+            position: { x: original.x, y: original.y, ...PET_NFT_DIMENSIONS },
+            apply: () => {
+              pet.coordinates = { x: original.x, y: original.y };
+              pet.location = "farm";
+            },
+          }
+        : undefined,
     });
   });
 
-  // FarmHands: by count — bind the (id-sorted) unlocked farmhands to the
-  // (position-sorted) saved slots, ignoring the saved ids.
+  // FarmHands: prefer the saved farmhand id if the player owns it (keeps each
+  // bumpkin's equipment + flip at its saved spot), else bind any other unlocked
+  // farmhand by count. No creation — you can't mint farmhands.
   const farmHandIds = Object.keys(state.farmHands?.bumpkins ?? {}).sort(
     (a, b) => a.localeCompare(b),
+  );
+  const farmHandOriginals = new Map(
+    farmHandIds.map((id) => [id, state.farmHands.bumpkins[id].coordinates]),
   );
   farmHandIds.forEach((id) => {
     const fh = state.farmHands.bumpkins[id];
     if (fh.coordinates) fh.coordinates = undefined; // lift
   });
-  Object.values(layout.farmHands ?? {})
-    .sort(byPosition)
-    .forEach((placement, i) => {
-      const id = farmHandIds[i];
-      if (id === undefined) {
-        noInventory += 1;
-        return;
-      }
-      const fh = state.farmHands.bumpkins[id];
-      slots.push({
-        name: "FarmHand",
-        position: { ...placement, ...FARM_HAND_DIMENSIONS },
-        place: () => {
-          fh.coordinates = { x: placement.x, y: placement.y };
-          fh.flipped = placement.flipped;
-          fh.location = "farm";
-        },
-      });
+  const fhEntries = Object.entries(layout.farmHands ?? {}).sort(
+    ([, a], [, b]) => byPosition(a, b),
+  );
+  const fhCapacity = Math.min(fhEntries.length, farmHandIds.length);
+  const ownedFarmHandIds = new Set(
+    fhEntries
+      .slice(0, fhCapacity)
+      .map(([id]) => id)
+      .filter((id) => state.farmHands.bumpkins[id] !== undefined),
+  );
+  const farmHandPool = farmHandIds.filter((id) => !ownedFarmHandIds.has(id));
+  let fhPoolIdx = 0;
+  fhEntries.forEach(([savedId, placement], i) => {
+    if (i >= fhCapacity) {
+      noInventory += 1;
+      return;
+    }
+    const id =
+      state.farmHands.bumpkins[savedId] !== undefined
+        ? savedId
+        : farmHandPool[fhPoolIdx++];
+    if (id === undefined) {
+      noInventory += 1;
+      return;
+    }
+    const fh = state.farmHands.bumpkins[id];
+    const original = farmHandOriginals.get(id);
+    slots.push({
+      name: "FarmHand",
+      position: { ...placement, ...FARM_HAND_DIMENSIONS },
+      place: () => {
+        fh.coordinates = { x: placement.x, y: placement.y };
+        fh.flipped = placement.flipped;
+        fh.location = "farm";
+      },
+      restore: original
+        ? {
+            position: { x: original.x, y: original.y, ...FARM_HAND_DIMENSIONS },
+            apply: () => {
+              fh.coordinates = { x: original.x, y: original.y };
+              fh.location = "farm";
+            },
+          }
+        : undefined,
     });
+  });
 
   // The player's own Bumpkin — always placed at its saved position.
   if (layout.bumpkin && state.bumpkin) {
     const placement = layout.bumpkin;
     const bumpkin = state.bumpkin;
+    const original = bumpkin.coordinates;
     bumpkin.coordinates = undefined; // lift
     slots.push({
       name: "Bumpkin",
@@ -701,13 +845,24 @@ export function applyFarmLayout(
         bumpkin.flipped = placement.flipped;
         bumpkin.location = "farm";
       },
+      restore: original
+        ? {
+            position: { x: original.x, y: original.y, ...BUMPKIN_DIMENSIONS },
+            apply: () => {
+              bumpkin.coordinates = { x: original.x, y: original.y };
+              bumpkin.location = "farm";
+            },
+          }
+        : undefined,
     });
   }
 
   // Everything is now lifted. Place each slot in turn against the live draft
-  // (non-layout items + already-placed slots). A blocked slot stays unplaced.
+  // (non-layout items + already-placed slots). A blocked slot stays unplaced
+  // for now; reused instances get a best-effort restore pass below.
   let applied = 0;
   let skipped = 0;
+  const blockedSlots: LayoutSlot[] = [];
   for (const slot of slots) {
     const blocked = detectCollision({
       state,
@@ -717,15 +872,31 @@ export function applyFarmLayout(
     });
     if (blocked) {
       skipped += 1;
+      if (slot.restore) blockedSlots.push(slot);
     } else {
       slot.place();
       applied += 1;
     }
   }
 
+  // Best-effort: an item whose saved spot was blocked stays where it was before
+  // the layout lifted it, as long as that tile is still free (nothing in the new
+  // arrangement claimed it). Otherwise it remains unplaced.
+  for (const slot of blockedSlots) {
+    const restore = slot.restore;
+    if (!restore) continue;
+    const stillBlocked = detectCollision({
+      state,
+      position: restore.position,
+      location: "farm",
+      name: slot.name,
+    });
+    if (!stillBlocked) restore.apply();
+  }
+
   // Recompute honey now that beehives sit next to their flowers (mirrors the
   // place events, which call this whenever a beehive or flower bed is placed).
-  if (beehivePlaced) {
+  if (affectsBeehives) {
     state.beehives = updateBeehives({ game: state, createdAt });
   }
 

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -1,13 +1,22 @@
 import type {
   GameState,
+  InventoryItemName,
   LayoutCoordinates,
+  LayoutPlacement,
+  PlacedItem,
   SavedLayout,
 } from "features/game/types/game";
+import { getChestItemCount } from "features/island/hud/components/inventory/utils/inventory";
+import { isCollectibleWithTimestamps } from "features/game/events/landExpansion/placeCollectible";
+import { getAvailableNodes } from "features/game/lib/resourceNodes";
+import { updateBeehives } from "features/game/lib/updateBeehives";
 import { COLLECTIBLES_DIMENSIONS } from "features/game/types/craftables";
 import { BUILDINGS_DIMENSIONS } from "features/game/types/buildings";
 import {
   RESOURCE_DIMENSIONS,
+  RESOURCE_MULTIPLIER,
   type ResourceName,
+  type UpgradeableResource,
 } from "features/game/types/resources";
 import { PET_NFT_DIMENSIONS } from "features/game/types/pets";
 import {
@@ -39,7 +48,13 @@ const PLACEABLE_DIMENSIONS: Record<string, { width: number; height: number }> =
   };
 
 /** Minimal coordinate shape shared by every placed resource/plot. */
-type PlacedResource = { x?: number; y?: number; oX?: number; oY?: number };
+type PlacedResource = {
+  x?: number;
+  y?: number;
+  oX?: number;
+  oY?: number;
+  removedAt?: number;
+};
 
 type ResourceBucketKey = keyof SavedLayout["resources"];
 
@@ -89,6 +104,72 @@ export const RESOURCE_BUCKETS: {
   },
   { key: "lavaPits", resourceName: "Lava Pit", get: (s) => s.lavaPits },
 ];
+
+/** Resource buckets whose availability spans an upgradeable tier family. */
+const TIERED_FAMILIES = ["trees", "stones", "gold", "iron"] as const;
+type TieredFamily = (typeof TIERED_FAMILIES)[number];
+const isTieredFamily = (key: ResourceBucketKey): key is TieredFamily =>
+  (TIERED_FAMILIES as readonly string[]).includes(key);
+
+/**
+ * Build a fresh resource node for a bucket — mirrors the new-instance shape each
+ * `placeX` event creates. Tiered families default to the base tier (advanced
+ * tiers only ever exist as already-placed instances, so they're reused, not
+ * created).
+ */
+const createResourceNode = (
+  key: ResourceBucketKey,
+  resourceName: ResourceName,
+  c: LayoutCoordinates,
+  createdAt: number,
+): PlacedResource => {
+  const base = { createdAt, x: c.x, y: c.y, oX: c.oX, oY: c.oY };
+  switch (key) {
+    case "trees":
+      return {
+        ...base,
+        wood: { choppedAt: 0 },
+        name: resourceName,
+        multiplier: RESOURCE_MULTIPLIER[resourceName as UpgradeableResource],
+        tier: 1,
+      } as PlacedResource;
+    case "stones":
+    case "gold":
+    case "iron":
+      return {
+        ...base,
+        stone: { minedAt: 0 },
+        name: resourceName,
+        multiplier: RESOURCE_MULTIPLIER[resourceName as UpgradeableResource],
+        tier: 1,
+      } as PlacedResource;
+    case "crimstones":
+      return { ...base, stone: { minedAt: 0 }, minesLeft: 5 } as PlacedResource;
+    case "sunstones":
+      return {
+        ...base,
+        stone: { minedAt: 0 },
+        minesLeft: 10,
+      } as PlacedResource;
+    case "ascensionCrystals":
+      return { ...base, stone: { minedAt: 0 }, minesLeft: 1 } as PlacedResource;
+    case "oilReserves":
+      return { ...base, oil: { drilledAt: 0 }, drilled: 0 } as PlacedResource;
+    case "beehives":
+      return {
+        x: c.x,
+        y: c.y,
+        oX: c.oX,
+        oY: c.oY,
+        swarm: false,
+        honey: { updatedAt: createdAt, produced: 0 },
+        flowers: [],
+      } as PlacedResource;
+    default:
+      // crops, fruitPatches, flowerBeds, lavaPits — just coordinates + createdAt.
+      return base as PlacedResource;
+  }
+};
 
 const emptyResources = (): SavedLayout["resources"] => ({
   trees: {},
@@ -379,112 +460,146 @@ export function layoutItemRects(
   return rects;
 }
 
-type PendingPlacement = {
+/** A single position from the layout, with the resolved instance to place there. */
+type LayoutSlot = {
   name: LandscapingPlaceable;
   position: Position;
-  /** Move the item to its saved layout position. */
-  toTarget: () => void;
-  /** Leave the item exactly where it currently is (restore pre-lift coords). */
-  toOriginal: () => void;
+  /** Materialise the resolved instance at this slot. */
+  place: () => void;
 };
 
+/** Deterministic position order so FE and BE fill slots identically. */
+const byPosition = (a: LayoutCoordinates, b: LayoutCoordinates) =>
+  a.x - b.x || a.y - b.y;
+
 /**
- * Reposition the player's existing farm items to match a saved layout, on a
- * best-effort basis. Returns how many items were placed vs skipped.
+ * Arrange the player's OWNED items onto a saved layout's positions, driven by
+ * inventory availability (not by saved id) so a layout can be shared between
+ * players. Best-effort — mutates `state` in place (expects an Immer draft).
  *
- * Strategy ("lift then reserve then place"):
- *   1. Resolve which snapshot entries are applicable: the item must still exist
- *      AND be currently placed (an item withdrawn during landscaping stays in
- *      its bucket with no coordinates — those are ignored, not re-placed).
- *   2. Lift every applicable item (clear its coordinates), remembering where it
- *      was, so a layout item's target never falsely collides with another
- *      layout item's *current* spot (handles swaps).
- *   3. Pass 1 — with everything lifted, any target still blocked can't be placed
- *      (off-land, e.g. the farm shrank on ascension, or under a non-layout
- *      item). Restore those items to their current position immediately, as
- *      reservations, and count them skipped. The rest are candidates.
- *   4. Pass 2 — place each candidate at its target if it's still free against the
- *      reservations + already-placed candidates; otherwise it keeps its current
- *      position. Restoring skipped items *before* placing candidates is what
- *      prevents a restored item from landing on top of a placed one.
+ * Matching: collectibles/buildings/resources by name+availability; buds/pet
+ * NFTs by id ownership; farmhands by however many are unlocked; the bumpkin
+ * always. For each type the player's current farm placements are lifted, then
+ * the type's saved positions are filled (in a deterministic order) from the
+ * available instances — so owning fewer than the layout asks leaves the extra
+ * positions empty (`noInventory`), and owning more leaves the extras unplaced.
  *
- * Mutates `state` in place (expects an Immer draft).
+ * Collectibles & buildings are placed up to full inventory availability:
+ * unplaced instances are reused first, then new instances are created (with
+ * deterministic ids) from the remaining owned inventory. Resources/buds/pets/
+ * farmhands reuse existing instances (resource nodes are pre-created by land
+ * expansion, so reuse already covers what a player owns); positions with no
+ * available instance count as `noInventory`. Positions blocked off-land or under
+ * a non-layout item are `skipped`.
  */
 export function applyFarmLayout(
   state: GameState,
   layout: SavedLayout,
-): { applied: number; skipped: number } {
-  const pending: PendingPlacement[] = [];
+  createdAt: number,
+): { applied: number; skipped: number; noInventory: number } {
+  const slots: LayoutSlot[] = [];
+  let noInventory = 0;
 
-  getObjectEntries(layout.collectibles).forEach(([name, entries]) => {
-    if (!entries) return;
-    const dimensions = PLACEABLE_DIMENSIONS[name];
-    if (!dimensions) return;
-    const group = state.collectibles[name];
-    entries.forEach((entry) => {
-      const item = group?.find((collectible) => collectible.id === entry.id);
-      // Withdrawn items stay in the bucket with no coordinates — don't re-place.
-      if (!item?.coordinates) return;
-      const original = item.coordinates ? { ...item.coordinates } : undefined;
-      pending.push({
-        name,
-        position: {
-          x: entry.coordinates.x,
-          y: entry.coordinates.y,
-          width: dimensions.width,
-          height: dimensions.height,
-        },
-        toTarget: () => {
-          item.coordinates = { ...entry.coordinates };
-          item.flipped = entry.flipped;
-        },
-        toOriginal: () => {
-          item.coordinates = original;
-        },
+  // Deterministic id for a newly-created instance — identical on FE and BE
+  // (same `createdAt`), and never collides with the 8-hex uuid-slice ids.
+  const newId = (tag: string, i: number) =>
+    `L${createdAt.toString(36)}-${tag}-${i}`;
+
+  // Collectibles & buildings: keyed by name, placed up to inventory availability.
+  // Lift the farm instances, fill the (position-sorted) saved slots by reusing
+  // the (id-sorted) unplaced instances first, then creating new ones.
+  const addNamedSlots = <N extends string>(
+    layoutGroup: Partial<Record<N, LayoutPlacement[]>>,
+    getBucket: (name: N) => PlacedItem[] | undefined,
+    ensureBucket: (name: N) => PlacedItem[],
+    newItem: (name: N, id: string) => PlacedItem,
+  ) => {
+    getObjectEntries(layoutGroup).forEach(([name, entries]) => {
+      const dimensions = PLACEABLE_DIMENSIONS[name];
+      if (!dimensions || !entries) return;
+      const group = getBucket(name) ?? [];
+      group.forEach((item) => {
+        if (item.coordinates) item.coordinates = undefined; // lift
       });
-      item.coordinates = undefined; // lift
+      const available = group
+        .filter((item) => !item.coordinates)
+        .sort((a, b) => a.id.localeCompare(b.id));
+      const owned = getChestItemCount(
+        state,
+        name as InventoryItemName,
+      ).toNumber();
+      const capacity = Math.min(entries.length, owned);
+      [...entries]
+        .sort((a, b) => byPosition(a.coordinates, b.coordinates))
+        .forEach((entry, i) => {
+          if (i >= capacity) {
+            noInventory += 1;
+            return;
+          }
+          const reuse = available[i];
+          slots.push({
+            name: name as LandscapingPlaceable,
+            position: {
+              x: entry.coordinates.x,
+              y: entry.coordinates.y,
+              width: dimensions.width,
+              height: dimensions.height,
+            },
+            place: () => {
+              const item = reuse ?? newItem(name, newId(name, i));
+              if (!reuse) ensureBucket(name).push(item);
+              item.coordinates = { ...entry.coordinates };
+              item.flipped = entry.flipped;
+              delete item.removedAt;
+            },
+          });
+        });
     });
-  });
+  };
+  addNamedSlots(
+    layout.collectibles,
+    (name) => state.collectibles[name],
+    (name) => (state.collectibles[name] ??= []),
+    (name, id) =>
+      isCollectibleWithTimestamps(name) ? { id, createdAt } : { id },
+  );
+  addNamedSlots(
+    layout.buildings,
+    (name) => state.buildings[name],
+    (name) => (state.buildings[name] ??= []),
+    (_name, id) => ({ id, createdAt, readyAt: createdAt }),
+  );
 
-  getObjectEntries(layout.buildings).forEach(([name, entries]) => {
-    if (!entries) return;
-    const dimensions = PLACEABLE_DIMENSIONS[name];
-    if (!dimensions) return;
-    const group = state.buildings[name];
-    entries.forEach((entry) => {
-      const item = group?.find((building) => building.id === entry.id);
-      // Withdrawn items stay in the bucket with no coordinates — don't re-place.
-      if (!item?.coordinates) return;
-      const original = item.coordinates ? { ...item.coordinates } : undefined;
-      pending.push({
-        name,
-        position: {
-          x: entry.coordinates.x,
-          y: entry.coordinates.y,
-          width: dimensions.width,
-          height: dimensions.height,
-        },
-        toTarget: () => {
-          item.coordinates = { ...entry.coordinates };
-          item.flipped = entry.flipped;
-        },
-        toOriginal: () => {
-          item.coordinates = original;
-        },
-      });
-      item.coordinates = undefined; // lift
-    });
-  });
-
+  // Resources: keyed by bucket (tiers aggregated), placed up to availability.
+  // Lift the bucket, reuse the (id-sorted) unplaced instances first, then create
+  // new nodes from the remaining owned inventory.
+  let beehivePlaced = false;
   RESOURCE_BUCKETS.forEach(({ key, resourceName, get }) => {
     const dimensions = RESOURCE_DIMENSIONS[resourceName];
     const bucket = get(state);
-    Object.entries(layout.resources[key] ?? {}).forEach(([id, coordinates]) => {
-      const item = bucket[id];
-      // Withdrawn resources keep their object with x/y deleted — don't re-place.
-      if (!item || item.x === undefined || item.y === undefined) return;
-      const original = { x: item.x, y: item.y, oX: item.oX, oY: item.oY };
-      pending.push({
+    Object.values(bucket).forEach((node) => {
+      if (node.x !== undefined) {
+        node.x = undefined; // lift
+        node.y = undefined;
+      }
+    });
+    const available = Object.keys(bucket)
+      .filter((id) => bucket[id].x === undefined)
+      .sort((a, b) => a.localeCompare(b));
+    const owned = isTieredFamily(key)
+      ? getAvailableNodes(state, key).toNumber()
+      : getChestItemCount(state, resourceName as InventoryItemName).toNumber();
+    const positions = Object.values(layout.resources[key] ?? {}).sort(
+      byPosition,
+    );
+    const capacity = Math.min(positions.length, owned);
+    positions.forEach((coordinates, i) => {
+      if (i >= capacity) {
+        noInventory += 1;
+        return;
+      }
+      const reuseId = available[i];
+      slots.push({
         name: resourceName,
         position: {
           x: coordinates.x,
@@ -492,168 +607,127 @@ export function applyFarmLayout(
           width: dimensions.width,
           height: dimensions.height,
         },
-        toTarget: () => {
-          item.x = coordinates.x;
-          item.y = coordinates.y;
-          item.oX = coordinates.oX;
-          item.oY = coordinates.oY;
-        },
-        toOriginal: () => {
-          item.x = original.x;
-          item.y = original.y;
-          item.oX = original.oX;
-          item.oY = original.oY;
+        place: () => {
+          if (reuseId !== undefined) {
+            const node = bucket[reuseId];
+            node.x = coordinates.x;
+            node.y = coordinates.y;
+            node.oX = coordinates.oX;
+            node.oY = coordinates.oY;
+            delete node.removedAt;
+          } else {
+            bucket[newId(key, i)] = createResourceNode(
+              key,
+              resourceName,
+              coordinates,
+              createdAt,
+            );
+          }
+          if (key === "beehives") beehivePlaced = true;
         },
       });
-      item.x = undefined; // lift
-      item.y = undefined;
     });
   });
 
-  // Buds — single bucket, 1x1, not flippable. Only re-place ones currently on
-  // the farm (an item moved to the house keeps its house spot).
+  // Buds & Pet NFTs: by id ownership (shared-layout ids you don't own are
+  // skipped silently). Pets must be revealed to be placed.
   Object.entries(layout.buds ?? {}).forEach(([id, coordinates]) => {
-    const item = state.buds?.[Number(id)];
-    if (!item || !isOnFarm(item)) return;
-    const original = { ...item.coordinates! };
-    pending.push({
+    const bud = state.buds?.[Number(id)];
+    if (!bud) return;
+    bud.coordinates = undefined; // lift
+    slots.push({
       name: "Bud",
-      position: {
-        x: coordinates.x,
-        y: coordinates.y,
-        width: BUD_DIMENSIONS.width,
-        height: BUD_DIMENSIONS.height,
-      },
-      toTarget: () => {
-        item.coordinates = { x: coordinates.x, y: coordinates.y };
-      },
-      toOriginal: () => {
-        item.coordinates = original;
+      position: { ...coordinates, ...BUD_DIMENSIONS },
+      place: () => {
+        bud.coordinates = { x: coordinates.x, y: coordinates.y };
+        bud.location = "farm";
       },
     });
-    item.coordinates = undefined; // lift
   });
-
-  // Pet NFTs — keyed under pets.nfts, 2x2, not flippable.
   Object.entries(layout.petNFTs ?? {}).forEach(([id, coordinates]) => {
-    const item = state.pets?.nfts?.[Number(id)];
-    if (!item || !isOnFarm(item)) return;
-    const original = { ...item.coordinates! };
-    pending.push({
+    // Owned by id (a pet in a layout was placed once, so it's already revealed).
+    const pet = state.pets?.nfts?.[Number(id)];
+    if (!pet) return;
+    pet.coordinates = undefined; // lift
+    slots.push({
       name: "Pet",
-      position: {
-        x: coordinates.x,
-        y: coordinates.y,
-        width: PET_NFT_DIMENSIONS.width,
-        height: PET_NFT_DIMENSIONS.height,
-      },
-      toTarget: () => {
-        item.coordinates = { x: coordinates.x, y: coordinates.y };
-      },
-      toOriginal: () => {
-        item.coordinates = original;
+      position: { ...coordinates, ...PET_NFT_DIMENSIONS },
+      place: () => {
+        pet.coordinates = { x: coordinates.x, y: coordinates.y };
+        pet.location = "farm";
       },
     });
-    item.coordinates = undefined; // lift
   });
 
-  // FarmHands — extra bumpkins, 1x1, flippable.
-  Object.entries(layout.farmHands ?? {}).forEach(([id, placement]) => {
-    const item = state.farmHands?.bumpkins?.[id];
-    if (!item || !isOnFarm(item)) return;
-    const original = {
-      coordinates: { ...item.coordinates! },
-      flipped: item.flipped,
-    };
-    pending.push({
-      name: "FarmHand",
-      position: {
-        x: placement.x,
-        y: placement.y,
-        width: FARM_HAND_DIMENSIONS.width,
-        height: FARM_HAND_DIMENSIONS.height,
-      },
-      toTarget: () => {
-        item.coordinates = { x: placement.x, y: placement.y };
-        item.flipped = placement.flipped;
-      },
-      toOriginal: () => {
-        item.coordinates = original.coordinates;
-        item.flipped = original.flipped;
-      },
+  // FarmHands: by count — bind the (id-sorted) unlocked farmhands to the
+  // (position-sorted) saved slots, ignoring the saved ids.
+  const farmHandIds = Object.keys(state.farmHands?.bumpkins ?? {}).sort(
+    (a, b) => a.localeCompare(b),
+  );
+  farmHandIds.forEach((id) => {
+    const fh = state.farmHands.bumpkins[id];
+    if (fh.coordinates) fh.coordinates = undefined; // lift
+  });
+  Object.values(layout.farmHands ?? {})
+    .sort(byPosition)
+    .forEach((placement, i) => {
+      const id = farmHandIds[i];
+      if (id === undefined) {
+        noInventory += 1;
+        return;
+      }
+      const fh = state.farmHands.bumpkins[id];
+      slots.push({
+        name: "FarmHand",
+        position: { ...placement, ...FARM_HAND_DIMENSIONS },
+        place: () => {
+          fh.coordinates = { x: placement.x, y: placement.y };
+          fh.flipped = placement.flipped;
+          fh.location = "farm";
+        },
+      });
     });
-    item.coordinates = undefined; // lift
-  });
 
-  // The player's own Bumpkin — single, 1x1, flippable. Passing name "Bumpkin"
-  // makes detectCollision self-exclude it (it's lifted anyway).
-  if (layout.bumpkin && isOnFarm(state.bumpkin)) {
+  // The player's own Bumpkin — always placed at its saved position.
+  if (layout.bumpkin && state.bumpkin) {
     const placement = layout.bumpkin;
     const bumpkin = state.bumpkin;
-    const original = {
-      coordinates: { ...bumpkin.coordinates! },
-      flipped: bumpkin.flipped,
-    };
-    pending.push({
+    bumpkin.coordinates = undefined; // lift
+    slots.push({
       name: "Bumpkin",
-      position: {
-        x: placement.x,
-        y: placement.y,
-        width: BUMPKIN_DIMENSIONS.width,
-        height: BUMPKIN_DIMENSIONS.height,
-      },
-      toTarget: () => {
+      position: { ...placement, ...BUMPKIN_DIMENSIONS },
+      place: () => {
         bumpkin.coordinates = { x: placement.x, y: placement.y };
         bumpkin.flipped = placement.flipped;
-      },
-      toOriginal: () => {
-        bumpkin.coordinates = original.coordinates;
-        bumpkin.flipped = original.flipped;
+        bumpkin.location = "farm";
       },
     });
-    bumpkin.coordinates = undefined; // lift
   }
 
-  // Pass 1: with every applicable item lifted, anything still blocked can't be
-  // placed at all (its target is off-land or taken by a non-layout item).
-  // Restore those to their current position straight away so they act as
-  // reservations; the rest stay lifted as candidates.
-  const skipped: PendingPlacement[] = [];
-  const candidates: PendingPlacement[] = [];
-  for (const placement of pending) {
-    const blocked = detectCollision({
-      state,
-      position: placement.position,
-      location: "farm",
-      name: placement.name,
-    });
-    if (blocked) {
-      placement.toOriginal();
-      skipped.push(placement);
-    } else {
-      candidates.push(placement);
-    }
-  }
-
-  // Pass 2: place candidates against the reservations + already-placed items. A
-  // candidate now blocked (its target was taken by a restored skipped item)
-  // keeps its current position instead — never restored onto a placed item.
+  // Everything is now lifted. Place each slot in turn against the live draft
+  // (non-layout items + already-placed slots). A blocked slot stays unplaced.
   let applied = 0;
-  for (const placement of candidates) {
+  let skipped = 0;
+  for (const slot of slots) {
     const blocked = detectCollision({
       state,
-      position: placement.position,
+      position: slot.position,
       location: "farm",
-      name: placement.name,
+      name: slot.name,
     });
     if (blocked) {
-      placement.toOriginal();
-      skipped.push(placement);
+      skipped += 1;
     } else {
-      placement.toTarget();
+      slot.place();
       applied += 1;
     }
   }
 
-  return { applied, skipped: skipped.length };
+  // Recompute honey now that beehives sit next to their flowers (mirrors the
+  // place events, which call this whenever a beehive or flower bed is placed).
+  if (beehivePlaced) {
+    state.beehives = updateBeehives({ game: state, createdAt });
+  }
+
+  return { applied, skipped, noInventory };
 }

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -208,15 +208,18 @@ export function snapshotFarm(
     island: { ...state.island },
   };
 
+  // Every bucket is always present (empty when nothing is placed) so that
+  // overwriting a layout — `{ ...existing, ...snapshot }` — fully replaces the
+  // old arrangement instead of leaving stale buds/pets/farmhands/bumpkin behind.
   return {
     collectibles,
     buildings,
     resources,
     land,
-    ...(Object.keys(buds).length > 0 ? { buds } : {}),
-    ...(Object.keys(petNFTs).length > 0 ? { petNFTs } : {}),
-    ...(Object.keys(farmHands).length > 0 ? { farmHands } : {}),
-    ...(bumpkin ? { bumpkin } : {}),
+    buds,
+    petNFTs,
+    farmHands,
+    bumpkin,
   };
 }
 
@@ -253,6 +256,8 @@ export type LayoutRect = {
    * live sprite (bud/pet by id; farmhand by id → equipped). Bumpkin omits it.
    */
   id?: string;
+  /** Mirror the item horizontally, matching its on-farm orientation. */
+  flipped?: boolean;
 };
 
 /**
@@ -278,7 +283,7 @@ export function layoutItemRects(
   getObjectEntries(layout.collectibles).forEach(([name, entries]) => {
     const dimensions = PLACEABLE_DIMENSIONS[name];
     if (!dimensions || !entries) return;
-    entries.forEach(({ coordinates }) =>
+    entries.forEach(({ coordinates, flipped }) =>
       rects.push({
         x: coordinates.x,
         y: coordinates.y,
@@ -286,6 +291,7 @@ export function layoutItemRects(
         height: dimensions.height,
         category: "collectible",
         name,
+        flipped,
       }),
     );
   });
@@ -293,7 +299,7 @@ export function layoutItemRects(
   getObjectEntries(layout.buildings).forEach(([name, entries]) => {
     const dimensions = PLACEABLE_DIMENSIONS[name];
     if (!dimensions || !entries) return;
-    entries.forEach(({ coordinates }) =>
+    entries.forEach(({ coordinates, flipped }) =>
       rects.push({
         x: coordinates.x,
         y: coordinates.y,
@@ -301,6 +307,7 @@ export function layoutItemRects(
         height: dimensions.height,
         category: "building",
         name,
+        flipped,
       }),
     );
   });
@@ -354,6 +361,7 @@ export function layoutItemRects(
       category: "avatar",
       name: "FarmHand",
       id,
+      flipped: placement.flipped,
     }),
   );
   if (layout.bumpkin) {
@@ -364,6 +372,7 @@ export function layoutItemRects(
       height: BUMPKIN_DIMENSIONS.height,
       category: "avatar",
       name: "Bumpkin",
+      flipped: layout.bumpkin.flipped,
     });
   }
 

--- a/src/features/game/events/landExpansion/saveLayout.test.ts
+++ b/src/features/game/events/landExpansion/saveLayout.test.ts
@@ -114,6 +114,122 @@ describe("saveLayout", () => {
     ]);
   });
 
+  it("snapshots farm-placed buds, pet NFTs, farmhands and the bumpkin", () => {
+    const equipped = {
+      background: "Farm Background" as const,
+      body: "Beige Farmer Potion" as const,
+      hair: "Basic Hair" as const,
+      shoes: "Black Farmer Boots" as const,
+      pants: "Farmer Pants" as const,
+      shirt: "Yellow Farmer Shirt" as const,
+      tool: "Farmer Pitchfork" as const,
+    };
+    const bud = {
+      aura: "Basic" as const,
+      colour: "Beige" as const,
+      ears: "Ears" as const,
+      stem: "3 Leaf Clover" as const,
+      type: "Beach" as const,
+    };
+
+    const state: GameState = {
+      ...baseFarm,
+      buds: {
+        1: { ...bud, coordinates: { x: 1, y: 1 }, location: "farm" },
+        2: { ...bud }, // not placed → skipped
+        3: { ...bud, coordinates: { x: 5, y: 5 }, location: "home" }, // not farm
+      },
+      pets: {
+        nfts: {
+          1: {
+            id: 1,
+            name: "Pet #1",
+            requests: { food: [], fedAt: createdAt },
+            energy: 100,
+            experience: 0,
+            pettedAt: createdAt,
+            coordinates: { x: 2, y: 2 },
+            location: "farm",
+          },
+          2: {
+            id: 2,
+            name: "Pet #2",
+            requests: { food: [], fedAt: createdAt },
+            energy: 100,
+            experience: 0,
+            pettedAt: createdAt,
+            coordinates: { x: 0, y: 0 },
+            location: "petHouse", // not farm → excluded
+          },
+        },
+      },
+      farmHands: {
+        bumpkins: {
+          "fh-1": {
+            equipped,
+            coordinates: { x: 3, y: 3 },
+            flipped: true,
+            location: "farm",
+          },
+          "fh-2": {
+            equipped,
+            coordinates: { x: 6, y: 6 },
+            location: "home", // not farm → excluded
+          },
+        },
+      },
+      bumpkin: {
+        ...baseFarm.bumpkin,
+        coordinates: { x: -1, y: -1 },
+        location: "farm",
+        flipped: true,
+      },
+    };
+
+    const result = saveLayout({
+      state,
+      action: { type: "layout.saved", name: "Avatars" },
+      createdAt,
+    });
+    const layout = result.layouts![0];
+
+    expect(layout.buds).toEqual({ 1: { x: 1, y: 1 } });
+    expect(layout.petNFTs).toEqual({ 1: { x: 2, y: 2 } });
+    expect(layout.farmHands).toEqual({ "fh-1": { x: 3, y: 3, flipped: true } });
+    expect(layout.bumpkin).toEqual({ x: -1, y: -1, flipped: true });
+  });
+
+  it("omits the avatar keys when nothing of that kind is farm-placed", () => {
+    const state: GameState = {
+      ...baseFarm,
+      buds: {},
+      pets: { nfts: {} },
+      farmHands: { bumpkins: {} },
+      bumpkin: { ...baseFarm.bumpkin, coordinates: undefined },
+    };
+
+    const layout = saveLayout({
+      state,
+      action: { type: "layout.saved", name: "Empty" },
+      createdAt,
+    }).layouts![0];
+
+    expect(layout.buds).toBeUndefined();
+    expect(layout.petNFTs).toBeUndefined();
+    expect(layout.farmHands).toBeUndefined();
+    expect(layout.bumpkin).toBeUndefined();
+  });
+
+  it("captures the land extent (expansion count + island) at save time", () => {
+    const layout = saveLayout({
+      state: baseFarm,
+      action: { type: "layout.saved", name: "Land" },
+      createdAt,
+    }).layouts![0];
+
+    expect(layout.land).toEqual({ expansions: 1, island: TEST_FARM.island });
+  });
+
   it("overwrites an existing layout, preserving createdAt", () => {
     const first = saveLayout({
       state: baseFarm,

--- a/src/features/game/events/landExpansion/saveLayout.test.ts
+++ b/src/features/game/events/landExpansion/saveLayout.test.ts
@@ -199,7 +199,7 @@ describe("saveLayout", () => {
     expect(layout.bumpkin).toEqual({ x: -1, y: -1, flipped: true });
   });
 
-  it("omits the avatar keys when nothing of that kind is farm-placed", () => {
+  it("empties the avatar buckets when nothing of that kind is farm-placed", () => {
     const state: GameState = {
       ...baseFarm,
       buds: {},
@@ -214,10 +214,38 @@ describe("saveLayout", () => {
       createdAt,
     }).layouts![0];
 
-    expect(layout.buds).toBeUndefined();
-    expect(layout.petNFTs).toBeUndefined();
-    expect(layout.farmHands).toBeUndefined();
+    expect(layout.buds).toEqual({});
+    expect(layout.petNFTs).toEqual({});
+    expect(layout.farmHands).toEqual({});
     expect(layout.bumpkin).toBeUndefined();
+  });
+
+  it("clears stale avatar placements when overwriting a layout", () => {
+    const bud = {
+      aura: "Basic" as const,
+      colour: "Beige" as const,
+      ears: "Ears" as const,
+      stem: "3 Leaf Clover" as const,
+      type: "Beach" as const,
+    };
+    // First save captures a placed bud.
+    const withBud = saveLayout({
+      state: {
+        ...baseFarm,
+        buds: { 1: { ...bud, coordinates: { x: 1, y: 1 }, location: "farm" } },
+      },
+      action: { type: "layout.saved", name: "Farm" },
+      createdAt,
+    });
+
+    // Overwrite from a farm with no bud — the stale bud must not survive.
+    const overwritten = saveLayout({
+      state: { ...withBud, buds: {} },
+      action: { type: "layout.saved", layoutId: 0 },
+      createdAt: createdAt + 1000,
+    });
+
+    expect(overwritten.layouts![0].buds).toEqual({});
   });
 
   it("captures the land extent (expansion count + island) at save time", () => {

--- a/src/features/game/expansion/components/DirtRenderer.tsx
+++ b/src/features/game/expansion/components/DirtRenderer.tsx
@@ -247,6 +247,29 @@ type Edges = {
   left: boolean;
 };
 
+/**
+ * The dirt sprite for a `"Dirt Path"` tile (a crop plot or a Dirt Path
+ * decoration) given the surrounding grid — an edge is drawn on any side whose
+ * neighbour isn't also dirt, so runs of plots/paths join into one shape.
+ */
+export function getDirtImage(
+  grid: GameGrid,
+  x: number,
+  y: number,
+  biome: LandBiomeName,
+): string {
+  // It is an edge, if there is NOT a piece next to it
+  const edges: Edges = {
+    top: grid[x]?.[y + 1] !== "Dirt Path",
+    right: grid[x + 1]?.[y] !== "Dirt Path",
+    bottom: grid[x]?.[y - 1] !== "Dirt Path",
+    left: grid[x - 1]?.[y] !== "Dirt Path",
+  };
+
+  const edgeNames = getKeys(edges).filter((edge) => !!edges[edge]);
+  return IMAGE_PATHS[edgeNames.join("_")]?.[biome] ?? NO_EDGE[biome];
+}
+
 interface Props {
   grid: GameGrid;
   biome: LandBiomeName;
@@ -263,21 +286,7 @@ const Renderer: React.FC<Props> = ({ grid, biome }) => {
         return;
       }
 
-      // It is an edge, if there is NOT a piece next to it
-      const edges: Edges = {
-        top: grid[x][y + 1] !== "Dirt Path",
-        right: grid[x + 1]?.[y] !== "Dirt Path",
-        bottom: grid[x][y - 1] !== "Dirt Path",
-        left: grid[x - 1]?.[y] !== "Dirt Path",
-      };
-
-      let image = NO_EDGE[biome];
-      const edgeNames = getKeys(edges).filter((edge) => !!edges[edge]);
-      const name = edgeNames.join("_");
-      const path = IMAGE_PATHS[name]?.[biome];
-      if (path) {
-        image = path;
-      }
+      const image = getDirtImage(grid, x, y, biome);
 
       return (
         <img

--- a/src/features/game/expansion/components/LandBase.tsx
+++ b/src/features/game/expansion/components/LandBase.tsx
@@ -607,6 +607,24 @@ const LEVEL_IMAGES: Record<
   },
 };
 
+/** Highest land-image level shipped — counts above this reuse the level-42 art. */
+export const MAX_LAND_IMAGE_LEVEL = 42;
+
+/**
+ * The composite land sprite for an island at a given expansion count + season.
+ * Each image is 16px/tile with the world origin (0,0) at its exact centre, so a
+ * consumer can overlay world-coordinate items on it with an origin-centred map.
+ */
+export const getLandImage = (
+  island: GameState["island"],
+  expandedCount: number,
+  season: TemperateSeasonName,
+): string => {
+  const biome = getCurrentBiome(island);
+  const imageLevel = Math.min(expandedCount, MAX_LAND_IMAGE_LEVEL);
+  return LEVEL_IMAGES[biome][season][imageLevel];
+};
+
 interface Props {
   island: GameState["island"];
   expandedCount: number;
@@ -618,15 +636,9 @@ export const LandBase: React.FC<Props> = ({
   expandedCount,
   season,
 }) => {
-  const biome = getCurrentBiome(island);
-  // Each land image is generated at 16px/tile with the world origin (coordinate 0,0) at its exact
-  // centre, so it just needs to render at the game's natural scale (PIXEL_SCALE, via NaturalImage)
-  // and be centred by the wrapper in Land.tsx — no per-biome width, "extended" or translateX.
-
-  const MAX_LAND_IMAGE_LEVEL = 42;
-
-  const imageLevel = Math.min(expandedCount, MAX_LAND_IMAGE_LEVEL);
-  const src = LEVEL_IMAGES[biome][season][imageLevel];
+  // Centred by the wrapper in Land.tsx and rendered at the game's natural scale
+  // (PIXEL_SCALE, via NaturalImage) — see getLandImage for the 16px/tile origin.
+  const src = getLandImage(island, expandedCount, season);
 
   return (
     <NaturalImage

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1002,6 +1002,15 @@ export type LayoutPlacement = Pick<PlacedItem, "id" | "flipped"> & {
 };
 
 /**
+ * A restorable position for a placeable that can also be flipped (the player's
+ * Bumpkin and FarmHands). Buds/Pet NFTs aren't flippable so they store bare
+ * {@link LayoutCoordinates} instead.
+ */
+export type LayoutFlippablePlacement = LayoutCoordinates & {
+  flipped?: boolean;
+};
+
+/**
  * A named snapshot of the player's farm arrangement (`location: "farm"`).
  * Items are keyed by `id` so applying a layout repositions the player's
  * existing items. Collectibles/buildings mirror the live `name -> PlacedItem[]`
@@ -1028,6 +1037,24 @@ export type SavedLayout = {
     beehives: Record<string, LayoutCoordinates>;
     flowerBeds: Record<string, LayoutCoordinates>;
     lavaPits: Record<string, LayoutCoordinates>;
+  };
+  /** Placed Buds, keyed by bud id (not flippable). Farm-placed only. */
+  buds?: Record<string, LayoutCoordinates>;
+  /** Placed Pet NFTs, keyed by pet nft id (not flippable). Farm-placed only. */
+  petNFTs?: Record<string, LayoutCoordinates>;
+  /** Placed FarmHands (extra bumpkins), keyed by id. Farm-placed only. */
+  farmHands?: Record<string, LayoutFlippablePlacement>;
+  /** The player's own Bumpkin (single). Present only when placed on the farm. */
+  bumpkin?: LayoutFlippablePlacement;
+  /**
+   * Land extent at save time, so a preview can size itself to the land and draw
+   * the right biome art even after the farm later expands or ascends.
+   */
+  land?: {
+    /** Land expansion count (`inventory["Basic Land"]`) — picks the image level. */
+    expansions: number;
+    /** Island/biome — resolves the land sprite via `getCurrentBiome`. */
+    island: GameState["island"];
   };
 };
 

--- a/src/features/island/collectibles/components/Fence.tsx
+++ b/src/features/island/collectibles/components/Fence.tsx
@@ -38,7 +38,8 @@ interface Props {
   grid: GameGrid;
 }
 
-export const Fence: React.FC<Props> = ({ x, y, grid }) => {
+/** The connecting wood-fence sprite for tile (x,y), from its fence neighbours. */
+export function getFenceImage(grid: GameGrid, x: number, y: number): string {
   const edges: Edges = {
     top:
       grid[x]?.[y + 1] === "Fence" ||
@@ -62,13 +63,14 @@ export const Fence: React.FC<Props> = ({ x, y, grid }) => {
       grid[x - 1]?.[y] === "Golden Stone Fence",
   };
 
-  let image = SUNNYSIDE.decorations.woodFenceNoEdge;
   const edgeNames = getKeys(edges).filter((edge) => !!edges[edge]);
-  const name = edgeNames.join("_");
-  const path = IMAGE_PATHS[name];
-  if (path) {
-    image = path;
-  }
+  return (
+    IMAGE_PATHS[edgeNames.join("_")] ?? SUNNYSIDE.decorations.woodFenceNoEdge
+  );
+}
+
+export const Fence: React.FC<Props> = ({ x, y, grid }) => {
+  const image = getFenceImage(grid, x, y);
 
   return (
     <SFTDetailPopover name="Fence">

--- a/src/features/island/collectibles/components/GoldenFence.tsx
+++ b/src/features/island/collectibles/components/GoldenFence.tsx
@@ -38,7 +38,12 @@ interface Props {
   grid: GameGrid;
 }
 
-export const GoldenFence: React.FC<Props> = ({ x, y, grid }) => {
+/** The connecting golden-fence sprite for tile (x,y), from its fence neighbours. */
+export function getGoldenFenceImage(
+  grid: GameGrid,
+  x: number,
+  y: number,
+): string {
   const edges: Edges = {
     top:
       grid[x]?.[y + 1] === "Fence" ||
@@ -62,13 +67,14 @@ export const GoldenFence: React.FC<Props> = ({ x, y, grid }) => {
       grid[x - 1]?.[y] === "Golden Stone Fence",
   };
 
-  let image = SUNNYSIDE.decorations.goldenFenceNoEdge;
   const edgeNames = getKeys(edges).filter((edge) => !!edges[edge]);
-  const name = edgeNames.join("_");
-  const path = IMAGE_PATHS[name];
-  if (path) {
-    image = path;
-  }
+  return (
+    IMAGE_PATHS[edgeNames.join("_")] ?? SUNNYSIDE.decorations.goldenFenceNoEdge
+  );
+}
+
+export const GoldenFence: React.FC<Props> = ({ x, y, grid }) => {
+  const image = getGoldenFenceImage(grid, x, y);
 
   return (
     <SFTDetailPopover name="Golden Fence">

--- a/src/features/island/collectibles/components/GoldenStoneFence.tsx
+++ b/src/features/island/collectibles/components/GoldenStoneFence.tsx
@@ -32,7 +32,12 @@ const verticalImages = [
   SUNNYSIDE.decorations.goldenStoneVerticalFour,
 ];
 
-export const GoldenStoneFence: React.FC<Props> = ({ x, y, grid }) => {
+/** The connecting golden-stone-fence sprite for tile (x,y), from its neighbours. */
+export function getGoldenStoneFenceImage(
+  grid: GameGrid,
+  x: number,
+  y: number,
+): string {
   const edges: Edges = {
     top:
       grid[x]?.[y + 1] === "Stone Fence" ||
@@ -105,6 +110,12 @@ export const GoldenStoneFence: React.FC<Props> = ({ x, y, grid }) => {
     }
     image = verticalImages[(numberBelowMe - 1) % 4];
   }
+
+  return image;
+}
+
+export const GoldenStoneFence: React.FC<Props> = ({ x, y, grid }) => {
+  const image = getGoldenStoneFenceImage(grid, x, y);
 
   return (
     <SFTDetailPopover name="Golden Stone Fence">

--- a/src/features/island/collectibles/components/StoneFence.tsx
+++ b/src/features/island/collectibles/components/StoneFence.tsx
@@ -32,7 +32,12 @@ const verticalImages = [
   SUNNYSIDE.decorations.stoneVerticalFour,
 ];
 
-export const StoneFence: React.FC<Props> = ({ x, y, grid }) => {
+/** The connecting stone-fence sprite for tile (x,y), from its fence neighbours. */
+export function getStoneFenceImage(
+  grid: GameGrid,
+  x: number,
+  y: number,
+): string {
   const edges: Edges = {
     top:
       grid[x]?.[y + 1] === "Stone Fence" ||
@@ -105,6 +110,12 @@ export const StoneFence: React.FC<Props> = ({ x, y, grid }) => {
     }
     image = verticalImages[(numberBelowMe - 1) % 4];
   }
+
+  return image;
+}
+
+export const StoneFence: React.FC<Props> = ({ x, y, grid }) => {
+  const image = getStoneFenceImage(grid, x, y);
 
   return (
     <SFTDetailPopover name="Stone Fence">

--- a/src/features/island/collectibles/components/Tiles.tsx
+++ b/src/features/island/collectibles/components/Tiles.tsx
@@ -35,6 +35,9 @@ const CONNECTED_TILES: Record<TileName, string> = {
   "Red Tile": redTileConnected,
   "Yellow Tile": yellowTileConnected,
 };
+
+/** Every connecting colour-tile name, derived from {@link TILES}. */
+export const TILE_NAMES: Set<string> = new Set(Object.keys(TILES));
 type Edges = {
   connected: boolean;
 };

--- a/src/features/island/collectibles/components/Tiles.tsx
+++ b/src/features/island/collectibles/components/Tiles.tsx
@@ -46,16 +46,26 @@ interface Props {
   grid: GameGrid;
 }
 
-export const Tiles: React.FC<Props> = ({ name, x, y, grid }) => {
+/** The tile sprite for (x,y) — its connected variant when a tile sits below. */
+export function getTileImage(
+  name: TileName,
+  grid: GameGrid,
+  x: number,
+  y: number,
+): string {
   const edges: Edges = {
     connected: Object.keys(TILES).includes(grid[x]?.[y - 1]),
   };
 
-  let image = TILES[name];
-
   if (edges.connected && CONNECTED_TILES[name]) {
-    image = CONNECTED_TILES[name];
+    return CONNECTED_TILES[name];
   }
+  return TILES[name];
+}
+
+export const Tiles: React.FC<Props> = ({ name, x, y, grid }) => {
+  const image = getTileImage(name, grid, x, y);
+
   return (
     <SFTDetailPopover name={name}>
       <img

--- a/src/features/island/hud/components/LayoutPreview.tsx
+++ b/src/features/island/hud/components/LayoutPreview.tsx
@@ -1,49 +1,147 @@
-import React from "react";
-import type { SavedLayout } from "features/game/types/game";
+import React, { useState } from "react";
+import type { GameState, SavedLayout } from "features/game/types/game";
 import {
   layoutItemRects,
+  type LayoutRect,
   type LayoutRectCategory,
 } from "features/game/events/landExpansion/lib/layouts";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { getBudImage } from "lib/buds/types";
+import { getPetImage } from "features/island/pets/lib/petShared";
+import { getAnimatedWebpUrl } from "features/world/lib/animations";
+import { getLandImage } from "features/game/expansion/components/LandBase";
+import { getDirtImage } from "features/game/expansion/components/DirtRenderer";
+import { getCurrentBiome } from "features/island/biomes/biomes";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
+import { SUNNYSIDE } from "assets/sunnyside";
+import {
+  connectedCollectibleImage,
+  dirtTiles,
+  layoutGrid,
+} from "./connectedCollectibleSprite";
+import { SOIL_IMAGES } from "features/island/plots/lib/plant";
+import type { GameGrid } from "features/game/expansion/placeable/lib/makeGrid";
 
 const ITEM_IMAGE = ITEM_DETAILS as Record<string, { image: string }>;
+
+/** The land composite is generated at 16px/tile (origin 0,0 at its centre). */
+const LAND_IMAGE_TILE_PX = 16;
+
+/** The farm's ocean tile for this island/season — fills around the land. */
+const oceanTexture = (
+  island: GameState["island"] | undefined,
+  season: string,
+): string => {
+  if (season === "winter") return SUNNYSIDE.decorations.frozenOcean;
+  if (island && hasRequiredIslandExpansion(island.type, "volcano")) {
+    return SUNNYSIDE.decorations.darkOcean;
+  }
+  return SUNNYSIDE.decorations.ocean;
+};
+
+/** Tiled-ocean background, matching the farm's water behind the land. */
+const waterStyle = (
+  island: GameState["island"] | undefined,
+  season: string,
+): React.CSSProperties => ({
+  backgroundImage: `url(${oceanTexture(island, season)})`,
+  backgroundSize: "48px",
+  imageRendering: "pixelated",
+});
 
 /** Fallback block colour for the rare item with no resolvable sprite. */
 const FALLBACK_COLOR: Record<LayoutRectCategory, string> = {
   resource: "#63a74a",
   building: "#c98f4f",
   collectible: "#b35aa6",
-};
-
-/** Grass field styling with faint per-tile grid lines that scale with the box. */
-const grassStyle = (cols: number, rows: number): React.CSSProperties => ({
-  backgroundColor: "#8fbf57",
-  backgroundImage:
-    `repeating-linear-gradient(90deg, rgba(40,70,20,0.07) 0px, rgba(40,70,20,0.07) 1px, transparent 1px, transparent calc(100% / ${cols})),` +
-    `repeating-linear-gradient(0deg, rgba(40,70,20,0.07) 0px, rgba(40,70,20,0.07) 1px, transparent 1px, transparent calc(100% / ${rows})),` +
-    "linear-gradient(160deg, #97c75f 0%, #84b64d 100%)",
-  boxShadow: "inset 0 0 0 1px rgba(60,40,20,0.18)",
-  imageRendering: "pixelated",
-});
-
-type Props = {
-  layout: Pick<SavedLayout, "collectibles" | "buildings" | "resources">;
-  /** Applied to the outer box — set the width here; height follows the aspect. */
-  className?: string;
+  nft: "#e3b23c",
+  avatar: "#4a90d9",
 };
 
 /**
- * A miniature render of a layout using each item's real sprite on a grass
- * field — a live thumbnail of the farm. Fully responsive: the box fills its
- * container's width and derives height from the layout's aspect ratio, with
- * sprites positioned as percentages. World y increases upwards (so it is
- * flipped), sprites are bottom-anchored to overhang their tile, and painted
- * back-to-front.
+ * Resolve the sprite for a rect. Fences/paths pick a connecting sprite from the
+ * `grid` (so runs join up like on the farm); other collectibles/buildings/
+ * resources use their static `ITEM_DETAILS` image; Buds/Pet NFTs resolve from
+ * their id (the on-farm sprite, not the marketplace one); the Bumpkin/FarmHands
+ * compose an idle sprite from their live equipped parts (looked up on `game`).
+ * Returns undefined → the preview draws a colour block.
  */
-export const LayoutPreview: React.FC<Props> = ({ layout, className }) => {
-  const rects = layoutItemRects(layout);
+const resolveSprite = (
+  rect: LayoutRect,
+  grid: GameGrid,
+  game?: GameState,
+): string | undefined => {
+  if (rect.category === "nft") {
+    if (!rect.id) return undefined;
+    return rect.name === "Bud"
+      ? getBudImage(Number(rect.id))
+      : getPetImage("happy", Number(rect.id));
+  }
 
-  if (rects.length === 0) {
+  if (rect.category === "avatar") {
+    const parts =
+      rect.name === "Bumpkin"
+        ? game?.bumpkin.equipped
+        : rect.id
+          ? game?.farmHands.bumpkins[rect.id]?.equipped
+          : undefined;
+    return parts ? getAnimatedWebpUrl(parts, ["idle-small"]) : undefined;
+  }
+
+  if (rect.category === "collectible") {
+    const connected = connectedCollectibleImage(
+      rect.name,
+      grid,
+      rect.x,
+      rect.y,
+    );
+    if (connected) return connected;
+  }
+
+  return ITEM_IMAGE[rect.name]?.image;
+};
+
+type Props = {
+  layout: Pick<
+    SavedLayout,
+    | "collectibles"
+    | "buildings"
+    | "resources"
+    | "buds"
+    | "petNFTs"
+    | "farmHands"
+    | "bumpkin"
+    | "land"
+  >;
+  /** Applied to the outer box — set the width here; height follows the aspect. */
+  className?: string;
+  /**
+   * Live game state — supplies the current season for the land art and resolves
+   * Bumpkin/FarmHand equipped sprites by id. Falls back to the layout's stored
+   * land when absent.
+   */
+  game?: GameState;
+};
+
+/**
+ * A miniature render of a layout on the real, biome-correct land sprite — a live
+ * thumbnail of the farm sized to the land itself (not just the placed items).
+ * The land image is 16px/tile with world (0,0) at its centre, so items are laid
+ * out with an origin-centred map: world x grows right, world y grows up (so it
+ * is flipped on screen), sprites bottom-anchored to overhang their tile, painted
+ * back-to-front. The land's natural pixel size drives the box aspect ratio.
+ */
+export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
+  const [imgSize, setImgSize] = useState<{ w: number; h: number } | null>(null);
+
+  const island = layout.land?.island ?? game?.island;
+  const expansions =
+    layout.land?.expansions ?? game?.inventory["Basic Land"]?.toNumber() ?? 3;
+  const season = game?.season.season ?? "spring";
+  const landSrc = island ? getLandImage(island, expansions, season) : undefined;
+
+  // No resolvable land art (e.g. a legacy layout with no `land` and no game).
+  if (!landSrc) {
     return (
       <div
         className={className}
@@ -51,22 +149,35 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className }) => {
           width: "100%",
           aspectRatio: "16 / 11",
           borderRadius: 3,
-          ...grassStyle(16, 11),
+          ...waterStyle(island, season),
         }}
       />
     );
   }
 
-  const minX = Math.min(...rects.map((r) => r.x));
-  const maxX = Math.max(...rects.map((r) => r.x + r.width));
-  const minY = Math.min(...rects.map((r) => r.y - r.height));
-  const maxY = Math.max(...rects.map((r) => r.y));
+  const tilesWide = imgSize ? imgSize.w / LAND_IMAGE_TILE_PX : 0;
+  const tilesHigh = imgSize ? imgSize.h / LAND_IMAGE_TILE_PX : 0;
 
-  const worldWidth = Math.max(maxX - minX, 1);
-  const worldHeight = Math.max(maxY - minY, 1);
+  // Grid of placed items so fences/paths pick the connecting sprite.
+  const grid = layoutGrid(layout);
+  const biome = island ? getCurrentBiome(island) : undefined;
 
   // Paint back-to-front: higher world-y (further back) first.
-  const ordered = [...rects].sort((a, b) => b.y - a.y);
+  const ordered = [...layoutItemRects(layout)].sort((a, b) => b.y - a.y);
+
+  /** World tile (x,y) → CSS box on the origin-centred land image. */
+  const tileBox = (
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+  ): React.CSSProperties => ({
+    position: "absolute",
+    left: `${((x + tilesWide / 2) / tilesWide) * 100}%`,
+    top: `${((tilesHigh / 2 - y) / tilesHigh) * 100}%`,
+    width: `${(w / tilesWide) * 100}%`,
+    height: `${(h / tilesHigh) * 100}%`,
+  });
 
   return (
     <div
@@ -74,51 +185,94 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className }) => {
       style={{
         position: "relative",
         width: "100%",
-        aspectRatio: `${worldWidth} / ${worldHeight}`,
+        aspectRatio: imgSize ? `${imgSize.w} / ${imgSize.h}` : "1 / 1",
         overflow: "hidden",
         borderRadius: 3,
-        ...grassStyle(worldWidth, worldHeight),
+        ...waterStyle(island, season),
       }}
     >
-      {ordered.map((rect, i) => {
-        const image = ITEM_IMAGE[rect.name]?.image;
-        return (
-          <div
-            key={i}
-            style={{
-              position: "absolute",
-              left: `${((rect.x - minX) / worldWidth) * 100}%`,
-              top: `${((maxY - rect.y) / worldHeight) * 100}%`,
-              width: `${(rect.width / worldWidth) * 100}%`,
-              height: `${(rect.height / worldHeight) * 100}%`,
-            }}
-          >
-            {image ? (
-              <img
-                src={image}
-                alt=""
-                style={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  width: "100%",
-                  height: "auto",
-                  imageRendering: "pixelated",
-                }}
-              />
-            ) : (
-              <div
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  borderRadius: 1,
-                  backgroundColor: FALLBACK_COLOR[rect.category],
-                }}
-              />
-            )}
-          </div>
-        );
-      })}
+      <img
+        src={landSrc}
+        alt=""
+        onLoad={(e) =>
+          setImgSize({
+            w: e.currentTarget.naturalWidth,
+            h: e.currentTarget.naturalHeight,
+          })
+        }
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          imageRendering: "pixelated",
+        }}
+      />
+
+      {/* Dirt layer — crop plots + Dirt Path decorations, joined like the farm. */}
+      {imgSize &&
+        biome &&
+        dirtTiles(grid).map(({ x, y }) => (
+          <img
+            key={`dirt_${x}_${y}`}
+            src={getDirtImage(grid, x, y, biome)}
+            alt=""
+            style={{ ...tileBox(x, y, 1, 1), imageRendering: "pixelated" }}
+          />
+        ))}
+
+      {/* Empty plots — the dug soil sits on the connecting dirt. */}
+      {imgSize &&
+        biome &&
+        Object.values(layout.resources.crops ?? {}).map(({ x, y }, i) => (
+          <img
+            key={`plot_${i}`}
+            src={SOIL_IMAGES[biome].regular}
+            alt=""
+            style={{ ...tileBox(x, y, 1, 1), imageRendering: "pixelated" }}
+          />
+        ))}
+
+      {/* Items are placed only once the land's natural size is known. */}
+      {imgSize &&
+        ordered.map((rect, i) => {
+          // Crop plots and Dirt Path are drawn by the dirt layer above, so they
+          // share one connecting dirt shape exactly like the live game.
+          if (rect.name === "Dirt Path" || rect.name === "Crop Plot") {
+            return null;
+          }
+          const image = resolveSprite(rect, grid, game);
+          return (
+            <div
+              key={i}
+              style={tileBox(rect.x, rect.y, rect.width, rect.height)}
+            >
+              {image ? (
+                <img
+                  src={image}
+                  alt=""
+                  style={{
+                    position: "absolute",
+                    bottom: 0,
+                    left: 0,
+                    width: "100%",
+                    height: "auto",
+                    imageRendering: "pixelated",
+                  }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    borderRadius: 1,
+                    backgroundColor: FALLBACK_COLOR[rect.category],
+                  }}
+                />
+              )}
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/src/features/island/hud/components/LayoutPreview.tsx
+++ b/src/features/island/hud/components/LayoutPreview.tsx
@@ -268,6 +268,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
                     height: "auto",
                     imageRendering: "pixelated",
                     transform: rect.flipped ? "scaleX(-1)" : undefined,
+                    transformOrigin: "bottom center",
                   }}
                 />
               ) : (

--- a/src/features/island/hud/components/LayoutPreview.tsx
+++ b/src/features/island/hud/components/LayoutPreview.tsx
@@ -132,7 +132,13 @@ type Props = {
  * back-to-front. The land's natural pixel size drives the box aspect ratio.
  */
 export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
-  const [imgSize, setImgSize] = useState<{ w: number; h: number } | null>(null);
+  // The measured natural size is tagged with the land image it came from, so a
+  // newly-selected layout never paints a frame at the previous land's size.
+  const [measured, setMeasured] = useState<{
+    src: string;
+    w: number;
+    h: number;
+  } | null>(null);
 
   const island = layout.land?.island ?? game?.island;
   const expansions =
@@ -155,8 +161,10 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
     );
   }
 
-  const tilesWide = imgSize ? imgSize.w / LAND_IMAGE_TILE_PX : 0;
-  const tilesHigh = imgSize ? imgSize.h / LAND_IMAGE_TILE_PX : 0;
+  // Ignore a measurement left over from a previously-selected land image.
+  const size = measured?.src === landSrc ? measured : null;
+  const tilesWide = size ? size.w / LAND_IMAGE_TILE_PX : 0;
+  const tilesHigh = size ? size.h / LAND_IMAGE_TILE_PX : 0;
 
   // Grid of placed items so fences/paths pick the connecting sprite.
   const grid = layoutGrid(layout);
@@ -185,7 +193,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
       style={{
         position: "relative",
         width: "100%",
-        aspectRatio: imgSize ? `${imgSize.w} / ${imgSize.h}` : "1 / 1",
+        aspectRatio: size ? `${size.w} / ${size.h}` : "1 / 1",
         overflow: "hidden",
         borderRadius: 3,
         ...waterStyle(island, season),
@@ -195,7 +203,8 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
         src={landSrc}
         alt=""
         onLoad={(e) =>
-          setImgSize({
+          setMeasured({
+            src: landSrc,
             w: e.currentTarget.naturalWidth,
             h: e.currentTarget.naturalHeight,
           })
@@ -210,7 +219,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
       />
 
       {/* Dirt layer — crop plots + Dirt Path decorations, joined like the farm. */}
-      {imgSize &&
+      {size &&
         biome &&
         dirtTiles(grid).map(({ x, y }) => (
           <img
@@ -222,7 +231,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
         ))}
 
       {/* Empty plots — the dug soil sits on the connecting dirt. */}
-      {imgSize &&
+      {size &&
         biome &&
         Object.values(layout.resources.crops ?? {}).map(({ x, y }, i) => (
           <img
@@ -234,7 +243,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
         ))}
 
       {/* Items are placed only once the land's natural size is known. */}
-      {imgSize &&
+      {size &&
         ordered.map((rect, i) => {
           // Crop plots and Dirt Path are drawn by the dirt layer above, so they
           // share one connecting dirt shape exactly like the live game.
@@ -258,6 +267,7 @@ export const LayoutPreview: React.FC<Props> = ({ layout, className, game }) => {
                     width: "100%",
                     height: "auto",
                     imageRendering: "pixelated",
+                    transform: rect.flipped ? "scaleX(-1)" : undefined,
                   }}
                 />
               ) : (

--- a/src/features/island/hud/components/SavedLayoutsModal.tsx
+++ b/src/features/island/hud/components/SavedLayoutsModal.tsx
@@ -25,6 +25,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
 import chestIcon from "assets/icons/chest.png";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getCurrentBiome } from "features/island/biomes/biomes";
 import { LayoutPreview } from "./LayoutPreview";
 
@@ -46,6 +47,7 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
   const game = useSelector(gameService, _state);
+  const now = useNow();
   const layouts = game.layouts ?? [];
 
   // 0 = current farm; 1..n = saved layout at index (selected - 1).
@@ -128,17 +130,18 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
     const layoutId = selected - 1;
     if (mode === "confirmApply") {
       // Best-effort apply never throws — run it on a throwaway draft just to
-      // learn how many items won't fit (e.g. after the farm shrank), so the
-      // toast can say so.
-      let skipped = 0;
+      // learn how many layout positions won't be filled (blocked, or no item
+      // owned), so the toast can say so.
+      let notPlaced = 0;
       produce(game, (draft) => {
-        skipped = applyFarmLayout(draft, layouts[layoutId]).skipped;
+        const result = applyFarmLayout(draft, layouts[layoutId], now);
+        notPlaced = result.skipped + result.noInventory;
       });
       gameService.send({ type: "layout.applied", layoutId });
       setMode("idle");
       flash(
-        skipped > 0
-          ? t("savedLayouts.toastAppliedPartial", { skipped })
+        notPlaced > 0
+          ? t("savedLayouts.toastAppliedPartial", { skipped: notPlaced })
           : t("savedLayouts.toastApplied"),
       );
     } else if (mode === "confirmOverwrite") {

--- a/src/features/island/hud/components/SavedLayoutsModal.tsx
+++ b/src/features/island/hud/components/SavedLayoutsModal.tsx
@@ -22,10 +22,10 @@ import {
 } from "features/game/events/landExpansion/lib/layouts";
 import type { MachineState } from "features/game/lib/gameMachine";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { getObjectEntries } from "lib/object";
 import { SUNNYSIDE } from "assets/sunnyside";
 import chestIcon from "assets/icons/chest.png";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { getCurrentBiome } from "features/island/biomes/biomes";
 import { LayoutPreview } from "./LayoutPreview";
 
 interface Props {
@@ -41,67 +41,6 @@ type Mode =
   | "confirmDelete";
 
 const _state = (state: MachineState): GameState => state.context.state;
-
-const ITEM_IMAGE = ITEM_DETAILS as Record<string, { image: string }>;
-
-/** Resource bucket -> a representative item whose icon stands in for the chip. */
-const RESOURCE_CHIPS: { key: keyof SavedLayout["resources"]; item: string }[] =
-  [
-    { key: "crops", item: "Crop Plot" },
-    { key: "trees", item: "Tree" },
-    { key: "stones", item: "Stone Rock" },
-    { key: "iron", item: "Iron Rock" },
-    { key: "gold", item: "Gold Rock" },
-    { key: "crimstones", item: "Crimstone Rock" },
-    { key: "sunstones", item: "Sunstone Rock" },
-    { key: "ascensionCrystals", item: "Ascension Crystal" },
-    { key: "oilReserves", item: "Oil Reserve" },
-    { key: "fruitPatches", item: "Fruit Patch" },
-    { key: "flowerBeds", item: "Flower Bed" },
-    { key: "beehives", item: "Beehive" },
-    { key: "lavaPits", item: "Lava Pit" },
-  ];
-
-type Chip = { image?: string; count: number };
-
-/** Summarise a layout's contents into a few "icon × count" chips (top by count). */
-const summaryChips = (
-  layout: Pick<SavedLayout, "collectibles" | "buildings" | "resources">,
-): Chip[] => {
-  const chips: Chip[] = [];
-
-  RESOURCE_CHIPS.forEach(({ key, item }) => {
-    const count = Object.keys(layout.resources[key]).length;
-    if (count > 0) chips.push({ image: ITEM_IMAGE[item]?.image, count });
-  });
-
-  const mostCommon = (
-    group: Partial<Record<string, { id: string }[]>>,
-  ): { image?: string; count: number } => {
-    let total = 0;
-    let topName = "";
-    let topCount = 0;
-    getObjectEntries(group).forEach(([name, items]) => {
-      const n = items?.length ?? 0;
-      total += n;
-      if (n > topCount) {
-        topCount = n;
-        topName = name as string;
-      }
-    });
-    return {
-      image: topName ? ITEM_IMAGE[topName]?.image : undefined,
-      count: total,
-    };
-  };
-
-  const buildings = mostCommon(layout.buildings);
-  if (buildings.count > 0) chips.push(buildings);
-  const decorations = mostCommon(layout.collectibles);
-  if (decorations.count > 0) chips.push(decorations);
-
-  return chips.sort((a, b) => b.count - a.count).slice(0, 4);
-};
 
 export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
   const { t } = useAppTranslation();
@@ -136,6 +75,13 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
   const showCurrent = isCurrent || !layout;
   const previewLayout = showCurrent ? currentSnapshot : layout!;
   const atCap = layouts.length >= MAX_SAVED_LAYOUTS;
+
+  // Land the layout was saved on (biome + size) — a layout saved on a bigger
+  // farm than the player has now will skip the items that fall off the land.
+  const previewLand = previewLayout.land;
+  const currentExpansions = game.inventory["Basic Land"]?.toNumber() ?? 3;
+  const savedOnLargerFarm =
+    !showCurrent && !!previewLand && previewLand.expansions > currentExpansions;
 
   const close = () => {
     setSelected(0);
@@ -225,7 +171,7 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
       className="flex items-center gap-2 !p-1"
     >
       <div className="flex-none" style={{ width: 44 }}>
-        <LayoutPreview layout={preview} />
+        <LayoutPreview layout={preview} game={game} />
       </div>
       <div className="flex flex-col gap-0.5 min-w-0">
         <span className="text-xs truncate">{name}</span>
@@ -293,6 +239,25 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
           </span>
         </div>
 
+        {previewLand && (
+          <div className="flex flex-wrap items-center gap-1">
+            <Label
+              type="default"
+              icon={ITEM_DETAILS[getCurrentBiome(previewLand.island)].image}
+            >
+              {getCurrentBiome(previewLand.island)}
+            </Label>
+            <Label type="default" icon={ITEM_DETAILS["Basic Land"].image}>
+              {t("savedLayouts.expansions", { count: previewLand.expansions })}
+            </Label>
+            {savedOnLargerFarm && (
+              <Label type="warning">
+                {t("savedLayouts.savedOnLargerFarm")}
+              </Label>
+            )}
+          </div>
+        )}
+
         {showCurrent ? (
           <div className="flex flex-col gap-2">
             <Label type="info">{t("savedLayouts.current")}</Label>
@@ -324,16 +289,6 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
           </div>
         ) : mode === "idle" ? (
           <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap gap-1">
-              {summaryChips(layout!).map((chip, i) => (
-                <Label key={i} type="default">
-                  <div className="flex items-center gap-1">
-                    {chip.image && <img src={chip.image} className="h-3.5" />}
-                    <span>{`×${chip.count}`}</span>
-                  </div>
-                </Label>
-              ))}
-            </div>
             <Button onClick={() => setMode("confirmApply")}>
               <div className="flex items-center justify-center gap-1">
                 <img src={SUNNYSIDE.icons.confirm} className="w-4" />
@@ -416,7 +371,7 @@ export const SavedLayoutsModal: React.FC<Props> = ({ show, onHide }) => {
             )}
 
             <InnerPanel className="p-1">
-              <LayoutPreview layout={previewLayout} />
+              <LayoutPreview layout={previewLayout} game={game} />
             </InnerPanel>
 
             {error && (

--- a/src/features/island/hud/components/connectedCollectibleSprite.ts
+++ b/src/features/island/hud/components/connectedCollectibleSprite.ts
@@ -1,0 +1,93 @@
+import type { SavedLayout } from "features/game/types/game";
+import type { CollectibleName } from "features/game/types/craftables";
+import type { TileName } from "features/game/types/decorations";
+import {
+  getGameGrid,
+  type GameGrid,
+} from "features/game/expansion/placeable/lib/makeGrid";
+import { getObjectEntries } from "lib/object";
+import { getFenceImage } from "features/island/collectibles/components/Fence";
+import { getGoldenFenceImage } from "features/island/collectibles/components/GoldenFence";
+import { getStoneFenceImage } from "features/island/collectibles/components/StoneFence";
+import { getGoldenStoneFenceImage } from "features/island/collectibles/components/GoldenStoneFence";
+import { getTileImage } from "features/island/collectibles/components/Tiles";
+
+const TILE_NAMES = new Set<string>([
+  "Black Tile",
+  "Blue Tile",
+  "Green Tile",
+  "Purple Tile",
+  "Red Tile",
+  "Yellow Tile",
+] satisfies TileName[]);
+
+/**
+ * Build the {@link GameGrid} (id-by-tile map) a layout's fences/paths need to
+ * pick their connecting sprites. Crops are included so the dirt layer draws them
+ * as regular plots that join up with the Dirt Path decorations — just like the
+ * farm — instead of a separate (misaligned) Crop Plot sprite.
+ */
+export function layoutGrid(
+  layout: Pick<SavedLayout, "collectibles" | "resources">,
+): GameGrid {
+  const collectiblePositions: {
+    x: number;
+    y: number;
+    name: CollectibleName;
+  }[] = [];
+  getObjectEntries(layout.collectibles).forEach(([name, entries]) => {
+    entries?.forEach(({ coordinates }) =>
+      collectiblePositions.push({ name, x: coordinates.x, y: coordinates.y }),
+    );
+  });
+
+  const cropPositions = Object.values(layout.resources.crops ?? {}).map(
+    ({ x, y }) => ({ x, y }),
+  );
+
+  return getGameGrid({ cropPositions, collectiblePositions });
+}
+
+/**
+ * Tiles the {@link getDirtImage} layer should paint: every `"Dirt Path"` cell —
+ * crop plots and Dirt Path decorations alike — so the dirt joins them up.
+ */
+export function dirtTiles(grid: GameGrid): { x: number; y: number }[] {
+  const tiles: { x: number; y: number }[] = [];
+  Object.keys(grid).forEach((xKey) => {
+    Object.keys(grid[Number(xKey)]).forEach((yKey) => {
+      if (grid[Number(xKey)][Number(yKey)] === "Dirt Path") {
+        tiles.push({ x: Number(xKey), y: Number(yKey) });
+      }
+    });
+  });
+  return tiles;
+}
+
+/**
+ * The connecting sprite for a collectible that joins to its neighbours (fences,
+ * colour tiles). Returns undefined for everything else, so the caller falls back
+ * to the item's static sprite. Reuses the live components' selection logic.
+ * (`Dirt Path` is handled by the dirt layer, not here.)
+ */
+export function connectedCollectibleImage(
+  name: string,
+  grid: GameGrid,
+  x: number,
+  y: number,
+): string | undefined {
+  switch (name) {
+    case "Fence":
+      return getFenceImage(grid, x, y);
+    case "Golden Fence":
+      return getGoldenFenceImage(grid, x, y);
+    case "Stone Fence":
+      return getStoneFenceImage(grid, x, y);
+    case "Golden Stone Fence":
+      return getGoldenStoneFenceImage(grid, x, y);
+    default:
+      return TILE_NAMES.has(name)
+        ? getTileImage(name as TileName, grid, x, y)
+        : undefined;
+  }
+}

--- a/src/features/island/hud/components/connectedCollectibleSprite.ts
+++ b/src/features/island/hud/components/connectedCollectibleSprite.ts
@@ -10,16 +10,10 @@ import { getFenceImage } from "features/island/collectibles/components/Fence";
 import { getGoldenFenceImage } from "features/island/collectibles/components/GoldenFence";
 import { getStoneFenceImage } from "features/island/collectibles/components/StoneFence";
 import { getGoldenStoneFenceImage } from "features/island/collectibles/components/GoldenStoneFence";
-import { getTileImage } from "features/island/collectibles/components/Tiles";
-
-const TILE_NAMES = new Set<string>([
-  "Black Tile",
-  "Blue Tile",
-  "Green Tile",
-  "Purple Tile",
-  "Red Tile",
-  "Yellow Tile",
-] satisfies TileName[]);
+import {
+  getTileImage,
+  TILE_NAMES,
+} from "features/island/collectibles/components/Tiles";
 
 /**
  * Build the {@link GameGrid} (id-by-tile map) a layout's fences/paths need to

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -9141,7 +9141,7 @@
   "savedLayouts.delete": "Delete",
   "savedLayouts.saveName": "Save name",
   "savedLayouts.updated": "Updated {{date}}",
-  "savedLayouts.expansions": "{{count}} expansions",
+  "savedLayouts.expansions": "Expansions: {{count}}",
   "savedLayouts.savedOnLargerFarm": "Saved on a larger farm — some items may not fit",
   "savedLayouts.cap": "All {{max}} slots are full. Overwrite or delete a layout to save another.",
   "savedLayouts.nameRequired": "Please enter a layout name.",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -9141,6 +9141,8 @@
   "savedLayouts.delete": "Delete",
   "savedLayouts.saveName": "Save name",
   "savedLayouts.updated": "Updated {{date}}",
+  "savedLayouts.expansions": "{{count}} expansions",
+  "savedLayouts.savedOnLargerFarm": "Saved on a larger farm — some items may not fit",
   "savedLayouts.cap": "All {{max}} slots are full. Overwrite or delete a layout to save another.",
   "savedLayouts.nameRequired": "Please enter a layout name.",
   "savedLayouts.confirmApply": "Apply \"{{name}}\"? This will rearrange your farm to match this layout.",


### PR DESCRIPTION
## What

Two things, both behind the existing `SAVED_LAYOUTS` flag.

### 1. Capture the placeables that were missing
Saved layouts only snapshotted collectibles, buildings and resources. They now also capture the rest of what landscaping can place — **Buds, Pet NFTs, FarmHands and the player's Bumpkin** (farm-placed only) — plus the **land extent** (expansion count + island) so a layout remembers its size/biome. `applyFarmLayout` re-places the new placeables through the same lift → reserve → place passes.

### 2. Make the preview look like the live farm
- Canvas is sized to the **land** and draws the real **biome land image** on a tiled **ocean** background.
- Items use their **on-farm sprites** (buds/pets by id; bumpkin/farmhands from equipped parts), positioned with an origin-centred map that matches `MapPlacement`.
- **Fences & colour tiles** pick their connecting sprites; **Dirt Path + crop plots** share one connecting dirt shape, with empty-plot soil on top.
- Layout info shows the **biome + expansion count** as chips, with a warning when a layout was saved on a larger farm than the player currently has.

Fence/Tiles/DirtRenderer image-selection logic was extracted into pure exported functions reused by the preview — the live components render identically.

## Notes
- Persistence/Joi need no changes — a `SavedLayout` is stored wholesale and the actions are unchanged.
- Backend mirror: sunflower-land-api `feat/saved-layout-avatars-preview`.

## Testing
- `saveLayout` / `applyLayout` unit tests cover the new placeables (incl. farm-only filtering, flip restore) and the land extent. `tsc` clean.
- Preview verified visually in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved layouts now capture and restore buds, pet NFTs, farmhands, the player avatar (with flip state), and saved land extent (expansions/island).
  * Layout previews now render biome/season-aware land thumbnails and correctly display NFT/avatar placements.
* **Improvements**
  * Applying layouts now supports partial application when inventory is insufficient, with clearer skip/no-inventory handling.
  * Saved layouts UI shows saved expansion info with a warning for larger-farm layouts; simplified layout preview behavior.
  * Sprite selection for dirt/land/fences/tiles and connected collectibles is more consistent.
* **Tests**
  * Expanded save/preview/apply coverage across new entity types and restoration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->