### PR TITLE
[FIX] Restore search results when navigating back from marketplace item

### DIFF
--- a/src/features/marketplace/components/MarketplaceSearch.tsx
+++ b/src/features/marketplace/components/MarketplaceSearch.tsx
@@ -14,6 +14,7 @@ export const MarketplaceSearch: React.FC<{
           icon={SUNNYSIDE.icons.search}
           value={search}
           onValueChange={setSearch}
+          onCancel={() => setSearch("")}
         />
       </div>
     </div>

--- a/src/features/marketplace/components/home/MarketplaceHome.tsx
+++ b/src/features/marketplace/components/home/MarketplaceHome.tsx
@@ -3,7 +3,7 @@ import { InnerPanel } from "components/ui/Panel";
 import filterIcon from "assets/icons/filter_icon.webp";
 import flowerIcon from "assets/icons/flower_token.webp";
 import crownIcon from "assets/icons/vip.webp";
-import { Route, Routes, useNavigate } from "react-router";
+import { Route, Routes, useNavigate, useSearchParams } from "react-router";
 import { Collection, preloadCollections } from "../Collection";
 import { Favourites } from "../Favourites";
 import { Modal } from "components/ui/Modal";
@@ -45,7 +45,22 @@ export const MarketplaceNavigation: React.FC = () => {
   const navigate = useNavigate();
   const crabChapterStartMs = CHAPTERS["Crabs and Traps"].startDate.getTime();
 
-  const [search, setSearch] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get("q") ?? "";
+  const setSearch = (value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set("q", value);
+        } else {
+          next.delete("q");
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
   const [showFilters, setShowFilters] = useState(false);
   const [showQuickswap, setShowQuickswap] = useState(false);
   const [hideLimited, setHideLimited] = useState<boolean>(() => {
@@ -210,13 +225,7 @@ export const MarketplaceNavigation: React.FC = () => {
 
         <div className="flex-1 flex flex-col w-full">
           {search ? (
-            <Collection
-              search={search}
-              hideLimited={hideLimited}
-              onNavigated={() => {
-                setSearch("");
-              }}
-            />
+            <Collection search={search} hideLimited={hideLimited} />
           ) : (
             <Routes>
               <Route path="/profile" element={<MarketplaceProfile />} />


### PR DESCRIPTION
## Summary

- **Bug**: After searching for an item in the marketplace, opening it, and pressing Back — the player was returned to the main marketplace screen instead of search results.
- **Root cause**: Search state was stored in React `useState`. The `onNavigated` callback cleared the search immediately on item click, so by the time `Tradeable` navigated back, the search was gone.
- **Fix**: Moved search state into the URL param `?q=`, so the `backRoute` captured by `Collection` naturally includes the query string. Navigating back restores the search automatically.
- **Bonus**: Added a clear (✕) button to the search field by wiring up the existing `onCancel` prop on `TextInput`.




## Changes

- `MarketplaceHome.tsx` — replaced `useState` for search with `useSearchParams` (`?q=` param); removed the now-unnecessary `onNavigated` callback.
- `MarketplaceSearch.tsx` — pass `onCancel` to `TextInput` to show the clear button when input is non-empty.

https://github.com/user-attachments/assets/c3980668-60c0-4da9-b578-211f538f20ff
## Test plan

- [ ] Search for an item in the marketplace
- [ ] Open an item from search results
- [ ] Press Back — verify search results are restored with the original query
- [ ] Verify the ✕ button appears while typing and clears the field on click
- [ ] Verify normal marketplace navigation (tabs, filters) is unaffected