### PR TITLE
[FIX] Preserve historical cheer feed entries

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -9,7 +9,6 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -118,23 +117,6 @@ const mergeUpdates = (
 
 const getUTCDateKey = (timestamp: number) =>
   new Date(timestamp).toISOString().split("T")[0];
-
-const getNextUTCDateKeyRefreshAt = (timestamp: number) => {
-  const date = new Date(timestamp);
-
-  return (
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1) +
-    1000
-  );
-};
-
-const shouldShowInteraction = (interaction: Interaction, todayKey: string) => {
-  if (interaction.type !== "cheer") {
-    return true;
-  }
-
-  return getUTCDateKey(interaction.createdAt) === todayKey;
-};
 
 export type FeedFilter = "all" | "help" | "chat" | "cheer" | "follow";
 export type FeedFilterOption = {
@@ -599,16 +581,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const loaderRef = useRef<HTMLDivElement>(null);
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
-  const [hasMeasuredScroll, setHasMeasuredScroll] = useState(false);
-  const [todayKey, setTodayKey] = useState(() => getUTCDateKey(Date.now()));
-  const refreshTimeoutRef = useRef<number | null>(null);
-  const visibleFeed = useMemo(
-    () =>
-      feed.filter((interaction) =>
-        shouldShowInteraction(interaction, todayKey),
-      ),
-    [feed, todayKey],
-  );
+  const today = getUTCDateKey(Date.now());
 
   // Intersection observer to load more interactions when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -622,28 +595,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     if (!el) return;
     // tiny buffer so off-by-1 doesn’t trigger
     setCanPaginate(el.scrollHeight > el.clientHeight + 2);
-    setHasMeasuredScroll(true);
-  }, [visibleFeed.length, filter]);
-
-  useEffect(() => {
-    const refreshTodayKey = () => {
-      const now = Date.now();
-      const refreshIn = getNextUTCDateKeyRefreshAt(now) - now;
-
-      refreshTimeoutRef.current = window.setTimeout(() => {
-        setTodayKey(getUTCDateKey(Date.now()));
-        refreshTodayKey();
-      }, refreshIn);
-    };
-
-    refreshTodayKey();
-
-    return () => {
-      if (refreshTimeoutRef.current) {
-        window.clearTimeout(refreshTimeoutRef.current);
-      }
-    };
-  }, []);
+  }, [feed.length, filter]);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -654,25 +606,10 @@ const FeedContent: React.FC<FeedContentProps> = ({
   }, [filter]);
 
   useEffect(() => {
-    const shouldLoadMore =
-      hasMore &&
-      !isLoadingMore &&
-      (inView ||
-        visibleFeed.length === 0 ||
-        (hasMeasuredScroll && !canPaginate));
-
-    if (shouldLoadMore) {
+    if (inView && hasMore && !isLoadingMore && canPaginate) {
       loadMore();
     }
-  }, [
-    canPaginate,
-    hasMeasuredScroll,
-    hasMore,
-    inView,
-    isLoadingMore,
-    loadMore,
-    visibleFeed.length,
-  ]);
+  }, [inView, hasMore, isLoadingMore, loadMore, scrollContainerRef]);
 
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {
@@ -696,14 +633,10 @@ const FeedContent: React.FC<FeedContentProps> = ({
     return <FeedSkeleton />;
   }
 
-  if (visibleFeed.length === 0) {
+  if (feed.length === 0) {
     return (
       <div className="flex justify-center items-center h-full">
-        {hasMore ? (
-          <Loading dotsOnly />
-        ) : (
-          <Label type="default">{t("noActivity")}</Label>
-        )}
+        <Label type="default">{t("noActivity")}</Label>
       </div>
     );
   }
@@ -714,7 +647,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
       className="scrollable overflow-hidden overflow-y-auto"
     >
       <div className="flex flex-col gap-1 pr-1">
-        {visibleFeed.map((interaction, index) => {
+        {feed.map((interaction, index) => {
           const direction =
             interaction?.sender.username === username ? "right" : "left";
           const sender =
@@ -729,7 +662,8 @@ const FeedContent: React.FC<FeedContentProps> = ({
           const isAtMaxFollowing = !isFollowing && following.length >= 5000;
           const hasCheeredThemToday =
             interaction.type === "cheer" &&
-            cheersGiven.date === todayKey &&
+            getUTCDateKey(interaction.createdAt) === today &&
+            cheersGiven.date === today &&
             cheersGiven.farms.includes(interaction.sender.id);
 
           return (

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -609,7 +609,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     if (inView && hasMore && !isLoadingMore && canPaginate) {
       loadMore();
     }
-  }, [inView, hasMore, isLoadingMore, loadMore, scrollContainerRef]);
+  }, [inView, hasMore, isLoadingMore, loadMore, canPaginate]);
 
   const setRefs = useCallback(
     (node: HTMLDivElement | null) => {


### PR DESCRIPTION
## Summary
Fix for report https://discord.com/channels/880987707214544966/1347190192745742336/1520008977453158561

Preserves historical cheer feed messages while keeping the reciprocal cheer icon limited to today cheer interactions only.

## Context / motivation
PR #7369 fixed duplicated cheer icons by filtering cheer interactions to today date, but that also hid older "Cheered your farm!" feed messages. The message history should remain intact; only the small icon that indicates the player has cheered that farm today should be date-limited.

## How to test
1. Open the Social Feed and switch to the Cheered filter.
2. Confirm older "Cheered your farm!" entries are still visible.
3. Confirm the cheer icon only appears on rows created today when that sender is present in today cheersGiven list.
4. Run yarn jest src/features/game/events/landExpansion/deliver.test.ts --runInBand.
5. Run yarn tsc --noEmit.

## Screenshots or screen recording
N/A

## Related issues
Follow-up to #7369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed loading and infinite scroll pagination conditions for smoother loading.
  * Adjusted “today” activity highlighting to be consistent with UTC date handling (including cheer “today” badges).
  * Updated empty-state logic to reflect actual feed availability.
* **Refactor**
  * Simplified feed rendering so interactions appear immediately without extra client-side filtering, improving responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->