### PR TITLE
[FEAT] Cheer reciprocity icon driven by per-notification flag

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -91,8 +91,6 @@ const _farmId = (state: MachineState) =>
 const _cheersAvailable = (state: MachineState) =>
   (state.context.visitorState ?? state.context.state).inventory["Cheer"] ??
   new Decimal(0);
-const _cheersGiven = (state: MachineState) =>
-  (state.context.visitorState ?? state.context.state).socialFarming.cheersGiven;
 const _totalHelpedToday = (state: MachineState) =>
   state.context.totalHelpedToday;
 const _game = (state: MachineState) =>
@@ -162,7 +160,6 @@ export const Feed: React.FC<Props> = ({
   const token = useSelector(authService, _token);
   const farmId = useSelector(gameService, _farmId);
   const cheersAvailable = useSelector(gameService, _cheersAvailable);
-  const cheersGiven = useSelector(gameService, _cheersGiven);
   const totalHelpedToday = useSelector(gameService, _totalHelpedToday);
   const game = useSelector(gameService, _game);
   const helpLimit = getHelpLimit({ game });
@@ -496,7 +493,6 @@ export const Feed: React.FC<Props> = ({
             loadMore={loadMore}
             onInteractionClick={handleInteractionClick}
             filter={selectedFilter}
-            cheersGiven={cheersGiven}
           />
         )}
       </div>
@@ -576,10 +572,6 @@ type FeedContentProps = {
   onInteractionClick: (interaction: Interaction) => void;
   onFollowClick: (id: number) => void;
   loadMore: () => void;
-  cheersGiven: {
-    date: string;
-    farms: number[];
-  };
 };
 
 const FeedContent: React.FC<FeedContentProps> = ({
@@ -593,7 +585,6 @@ const FeedContent: React.FC<FeedContentProps> = ({
   hasMore,
   loadMore,
   filter,
-  cheersGiven,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
@@ -727,10 +718,6 @@ const FeedContent: React.FC<FeedContentProps> = ({
               : () => onInteractionClick(interaction);
           const isFollowing = following.includes(interaction.sender.id);
           const isAtMaxFollowing = !isFollowing && following.length >= 5000;
-          const hasCheeredThemToday =
-            interaction.type === "cheer" &&
-            cheersGiven.date === todayKey &&
-            cheersGiven.farms.includes(interaction.sender.id);
 
           return (
             <div
@@ -784,7 +771,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
                           helpedThemToday={interaction.helpedThemToday}
                         />
                       )}
-                      {hasCheeredThemToday && <CheerGivenIcon />}
+                      {!!interaction.cheeredThemToday && <CheerGivenIcon />}
                     </div>
                   </div>
                   {!isAtMaxFollowing && (

--- a/src/features/social/types/types.ts
+++ b/src/features/social/types/types.ts
@@ -25,6 +25,7 @@ export type Interaction = {
   readAt?: number; // Timestamp when the message was read by the recipient
   id?: string; // Unique identifier for the message
   helpedThemToday?: boolean;
+  cheeredThemToday?: boolean;
 };
 
 export type Milestone = Interaction & {


### PR DESCRIPTION
## What

Makes the cheer icon in the social feed behave exactly like the help icon: it shows on a "Cheered your farm!" notification **only when you cheered that sender back the same day**, and only on that day's notification.

## Why

The previous implementation derived the icon from the client's local `socialFarming.cheersGiven` state (`cheersGiven.farms.includes(sender.id)`), so it fired on *every* visible cheer row from a farm you'd cheered that day — not tied to the specific notification. This mirrors the help logic, which is computed server-side per interaction.

## Changes

- **`types.ts`** — added `cheeredThemToday?: boolean` to `Interaction`.
- **`Feed.tsx`** — the cheer icon now renders off `{!!interaction.cheeredThemToday && <CheerGivenIcon />}`; removed the now-dead `_cheersGiven` selector and its prop plumbing through `FeedContent`.

## Paired with

Backend: sunflower-land/sunflower-land-api#3454 (computes `cheeredThemToday`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the social feed so cheer status is shown directly from each interaction, making the cheer icon display more consistent.
  * Improved how the feed tracks whether someone has already been cheered today, reducing mismatches in the UI.

* **New Features**
  * Added support for a new cheer-status flag on feed interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->