### PR TITLE
[FIX] Help all pets in Pet House with a single click when visiting

### DIFF
--- a/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.test.ts
@@ -190,7 +190,7 @@ describe("helpAllPetsInHouse", () => {
     expect(state.pets?.nfts?.[1]?.visitedAt).toBeUndefined();
   });
 
-  it("does not exceed help limit when multiple pets are present", () => {
+  it("helps all pets in house even when totalHelpedToday is close to the limit", () => {
     const stateWithManyPets = {
       ...INITIAL_FARM,
       inventory: {
@@ -213,7 +213,8 @@ describe("helpAllPetsInHouse", () => {
       },
     };
 
-    // Default help limit is 5; setting totalHelpedToday to 4 means only 1 more pet can be helped
+    // totalHelpedToday is stale on the client (same as individual pet.visitingPets calls),
+    // so all pets in the house should be helped in a single click regardless of proximity to limit.
     const [state] = helpAllPetsInHouse({
       state: stateWithManyPets,
       visitorState: baseVisitor,
@@ -221,10 +222,7 @@ describe("helpAllPetsInHouse", () => {
       createdAt: now,
     });
 
-    const barkleyVisited = !!state.pets?.common?.Barkley?.visitedAt;
-    const meowchiVisited = !!state.pets?.common?.Meowchi?.visitedAt;
-
-    // Only one of the two pets should be helped (limit was 1 remaining)
-    expect(barkleyVisited !== meowchiVisited).toBe(true);
+    expect(state.pets?.common?.Barkley?.visitedAt).toEqual(now);
+    expect(state.pets?.common?.Meowchi?.visitedAt).toEqual(now);
   });
 });

--- a/src/features/game/events/visiting/helpAllPetsInHouse.ts
+++ b/src/features/game/events/visiting/helpAllPetsInHouse.ts
@@ -1,5 +1,5 @@
 import type { GameState } from "features/game/types/game";
-import { getHelpLimit, hasHitHelpLimit } from "features/game/types/monuments";
+import { hasHitHelpLimit } from "features/game/types/monuments";
 import {
   hasHitSocialPetLimit,
   type PetName,
@@ -45,14 +45,10 @@ export function helpAllPetsInHouse({
     }
 
     const day = new Date(createdAt).toISOString().slice(0, 10);
-    const helpLimit = getHelpLimit({ game: visitorGame });
-    let helpCount = action.totalHelpedToday;
 
     const petHousePets = game.petHouse?.pets ?? {};
 
     for (const name of getKeys(petHousePets)) {
-      if (helpCount >= helpLimit) break;
-
       const isPlaced = petHousePets[name]?.some((item) => !!item.coordinates);
       if (!isPlaced) continue;
 
@@ -67,12 +63,9 @@ export function helpAllPetsInHouse({
       }
 
       pet.visitedAt = createdAt;
-      helpCount++;
     }
 
     for (const id of getKeys(game.pets?.nfts ?? {})) {
-      if (helpCount >= helpLimit) break;
-
       const pet = game.pets?.nfts?.[id];
       if (!pet || pet.visitedAt || pet.location !== "petHouse") continue;
 
@@ -84,7 +77,6 @@ export function helpAllPetsInHouse({
       }
 
       pet.visitedAt = createdAt;
-      helpCount++;
     }
   });
 }


### PR DESCRIPTION
## Summary

- **Bug**: When visiting a farm, clicking the Pet House building required N separate clicks (one per pet) instead of helping all pets at once
- **Root cause**: `helpAllPetsInHouse` used a running `helpCount` counter starting at `action.totalHelpedToday` inside the pet loops. Since `totalHelpedToday` in XState context is a stale value loaded from the server at visit start and is never updated after local visiting events, if the visitor had already helped 4 things today (limit = 5), only 1 pet was helped per click
- **Fix**: Remove the per-pet `helpCount` tracking from the loops. Check `hasHitHelpLimit` once at the start (same as the individual `pet.visitingPets` event does), then help ALL pets in the house unconditionally

## Changes

- `helpAllPetsInHouse.ts` — removed `helpCount` counter and per-pet limit check from both common pet and NFT pet loops
- `helpAllPetsInHouse.test.ts` — updated test to assert both pets are helped when `totalHelpedToday` is close to the limit (was incorrectly asserting only 1 of 2 pets would be helped)
- `events/index.ts` — registers `pet.helpAllPetsInHouse` as a `LOCAL_VISITING_EVENT`
- `PetHouse.tsx` — UI: clicking the building exterior as a visitor sends `pet.helpAllPetsInHouse` once and shows the helped confirmation

## Test plan

- [ ] Visit a farm with pets in the Pet House
- [ ] Click the Pet House building once
- [ ] Verify all pets are marked as visited in a single click (not one per click)
- [ ] Verify that clicking when already at the help limit throws correctly
- [ ] Run `helpAllPetsInHouse.test.ts` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pets in the Pet House are now correctly all processed in a single action when eligible, even if the daily help total is near the limit.
  * Common and NFT pets placed in the Pet House can both gain the intended social XP and be marked as visited in the same run, as long as they haven’t been helped today.
  * Help-limit and Pet House placement validations remain enforced.

* **Tests**
  * Updated the multi-pet visiting test to reflect the new near-limit behavior and verify timestamps for all eligible pets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->