### PR TITLE
[FIX] Route delivery Old Salty and Pharaoh to Digging

### DIFF
--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -80,9 +80,9 @@ export const BEACH_BUMPKINS: NPCName[] = [
   "finn",
   "finley",
   "miranda",
-  "old salty",
-  "pharaoh",
 ];
+
+export const DIGGING_BUMPKINS: NPCName[] = ["old salty", "pharaoh"];
 
 export const KINGDOM_BUMPKINS: NPCName[] = ["victoria", "jester", "gambit"];
 
@@ -195,6 +195,7 @@ export const DeliveryOrders: React.FC<Props> = ({
 
   const getLocationName = (npcName: NPCName) => {
     if (RETREAT_BUMPKINS.includes(npcName)) return t("world.retreat");
+    if (DIGGING_BUMPKINS.includes(npcName)) return t("world.digging");
     if (BEACH_BUMPKINS.includes(npcName)) return t("world.beach");
     if (KINGDOM_BUMPKINS.includes(npcName)) return t("world.kingdom");
     return t("world.plaza");
@@ -205,6 +206,7 @@ export const DeliveryOrders: React.FC<Props> = ({
       const customPreposition: Record<string, string> = {
         [t("world.retreat")]: "в",
         [t("world.beach")]: "на",
+        [t("world.digging")]: "на",
         [t("world.kingdom")]: "в",
         [t("world.plaza")]: "на",
       };
@@ -741,6 +743,14 @@ export const DeliveryOrders: React.FC<Props> = ({
                               )
                             ) {
                               navigate("/world/retreat");
+                            } else if (
+                              DIGGING_BUMPKINS.includes(
+                                previewOrder?.from as NPCName,
+                              )
+                            ) {
+                              navigate("/world/beach", {
+                                state: { previousSceneId: "digging" },
+                              });
                             } else if (
                               BEACH_BUMPKINS.includes(
                                 previewOrder?.from as NPCName,


### PR DESCRIPTION
## Summary
Updates the delivery order location for Old Salty and Pharaoh from Beach to Digging. Their order cards now show Digging and the travel button opens the Digging entry point instead of the regular Beach spawn.

## Context / motivation
A new Digging transition point exists on the world map, but delivery orders for nearby NPCs still sent players to Beach. This made the CTA misleading for orders tied to digging-focused characters.

## How to test
1. Open the deliveries panel with an active Old Salty or Pharaoh order.
2. Confirm the location badge shows Digging.
3. Click the travel button.
4. Confirm the world opens through the Digging entry point rather than the default Beach spawn.

## Screenshots or screen recording
<img width="264" height="427" alt="image" src="https://github.com/user-attachments/assets/2f04d99f-fb32-4151-8340-a03e9f8c3e0d" />
<img width="254" height="432" alt="image" src="https://github.com/user-attachments/assets/d5434074-7a31-4202-abe3-e791c7d8d6ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Orders involving digging NPCs now show the correct location name and navigation behavior.
  * Russian text now uses the proper preposition for the digging location.
  * Completing these orders now routes users to the correct beach scene before continuing.

* **Style**
  * Minor formatting cleanup was applied to a location constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->