### PR TITLE
[FIX] Show XP to next cycle instead of static Max Level text for sleeping animals

### DIFF
--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -97,10 +97,17 @@ export const SleepingAnimalModal = ({
   const level = getAnimalLevel(animal.experience, animal.type);
   const isMaxLevel = isMaxAnimalLevel(animal.type, level);
 
-  const nextLevelXP = isMaxLevel
-    ? null
-    : ANIMAL_LEVELS[animal.type][(level + 1) as AnimalLevel];
-  const xpToNext = nextLevelXP != null ? nextLevelXP - animal.experience : null;
+  const xpToNext = isMaxLevel
+    ? (() => {
+        const levelBeforeMaxXP =
+          ANIMAL_LEVELS[animal.type][(level - 1) as AnimalLevel];
+        const maxLevelXP = ANIMAL_LEVELS[animal.type][level as AnimalLevel];
+        const cycleXP = maxLevelXP - levelBeforeMaxXP;
+        const excessXP = animal.experience - maxLevelXP;
+        return cycleXP - (excessXP % cycleXP);
+      })()
+    : ANIMAL_LEVELS[animal.type][(level + 1) as AnimalLevel] -
+      animal.experience;
 
   const { name: mutantName } = animal.reward?.items?.[0] ?? {};
 
@@ -133,11 +140,11 @@ export const SleepingAnimalModal = ({
               {t("sleepingAnimal.xp", { experience: animal.experience })}
             </span>
             {isMaxLevel ? (
-              <span className="text-yellow-400">{t("levelUpMax")}</span>
+              <span>{t("sleepingAnimal.xpToNextCycle", { xpToNext })}</span>
             ) : (
               <span>
                 {t("sleepingAnimal.xpToNextLevel", {
-                  xpToNext: xpToNext!,
+                  xpToNext,
                   level: level + 1,
                 })}
               </span>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -7404,6 +7404,7 @@
   "sleepingAnimal.harvestsLeft": "{{count}} harvests remaining",
   "sleepingAnimal.xp": "XP: {{experience}}",
   "sleepingAnimal.xpToNextLevel": "+{{xpToNext}} to Lvl {{level}}",
+  "sleepingAnimal.xpToNextCycle": "+{{xpToNext}} XP to next cycle",
   "description.bonusBracelet.boost": "+1 Bracelet",
   "description.architectRuler.boost": "x0.75 Crafting Box Time",
   "description.reelmastersChair.boost": "+5 daily fishing reels",


### PR DESCRIPTION
## Summary
- Max-level animals (Chicken/Sheep/Cow) keep accumulating XP toward repeating feed cycles after hitting level 15, but the sleeping-animal modal showed a static "Max Level!" label instead of any progress.
- `SleepingAnimalModal` now computes and shows the remaining XP for the current cycle (same cycle math already used in `feedAnimal.ts` / `LevelProgress.tsx`), using a new `sleepingAnimal.xpToNextCycle` translation key.

## Screenshots
<img width="565" height="323" alt="image" src="https://github.com/user-attachments/assets/95b528d4-d6dd-45ee-a998-84714f87912e" />
<img width="585" height="403" alt="image" src="https://github.com/user-attachments/assets/f917d257-e0e1-4921-8bef-d9ea08214c37" />
<img width="571" height="331" alt="image" src="https://github.com/user-attachments/assets/ee657d2b-d43d-4e8a-a95c-c631eae9a74d" />


## Test plan
- [x] `yarn tsc --noEmit`
- [x] `feedAnimal.test.ts` / `animals.test.ts` pass
- [x] Manually verified in a running local game (Hen House + Barn populated with low/mid/max-level Chickens, Sheep, and Cows) that the max-level modal shows "+XP to next cycle" instead of "Max Level!", while non-max levels are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the sleeping animal XP display to show progress toward the next cycle when an animal is at max level.
  * Added a new in-app label for this max-level XP progress state.

* **Bug Fixes**
  * Improved XP progress handling so max-level animals now display a clear remaining XP value instead of an empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->