### PR TITLE
[FEAT] Speed-rate model for Rapid Root & Sproutroot Surprise fertilisers (behind SPEED_BOOSTS)

### DIFF
--- a/src/features/game/events/landExpansion/fertilisePlot.test.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.test.ts
@@ -4,6 +4,7 @@ import { INITIAL_FARM } from "features/game/lib/constants";
 import { CROPS } from "features/game/types/crops";
 import type { GameState, CropPlot } from "features/game/types/game";
 import { fertilisePlot, FERTILISE_CROP_ERRORS } from "./fertilisePlot";
+import { getCropReadyAt } from "./harvest";
 
 const GAME_STATE: GameState = {
   ...INITIAL_FARM,
@@ -307,5 +308,97 @@ describe("fertiliseCrop", () => {
       createdAt: dateNow,
     });
     expect(gameState.crops[0].crop?.boostedTime).toEqual(10 * 1000);
+  });
+
+  // Speed-rate model: a windowed crop (has `baseDurationMs`) is boosted by a live
+  // 2× window from `fertilisedAt` (see getCropFertiliserWindows), so fertilising
+  // it must NOT mutate the crop — only record the fertiliser. Keyed off
+  // `baseDurationMs`, not the flag.
+  describe("Rapid Root / Sproutroot Surprise — SPEED_BOOSTS (windowed)", () => {
+    const sunflowerMs = CROPS.Sunflower.harvestSeconds * 1000;
+
+    const fertiliseWindowedCrop = (
+      fertiliser: "Rapid Root" | "Sproutroot Surprise",
+    ) =>
+      fertilisePlot({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            ...inventory,
+            "Rapid Root": new Decimal(5),
+            "Sproutroot Surprise": new Decimal(5),
+          },
+          crops: {
+            0: {
+              ...plot,
+              crop: {
+                name: "Sunflower",
+                plantedAt: dateNow - sunflowerMs / 2,
+                baseDurationMs: sunflowerMs,
+              },
+            },
+          },
+        },
+        action: { type: "plot.fertilised", plotID: "0", fertiliser },
+        createdAt: dateNow,
+      });
+
+    it("does NOT mutate a windowed crop — just records the fertiliser at fertilisedAt", () => {
+      const plantedAt = dateNow - sunflowerMs / 2;
+      const state = fertiliseWindowedCrop("Rapid Root");
+      const crop = state.crops["0"].crop;
+      // No deduction: plantedAt / baseDurationMs untouched, no boostedTime banked.
+      expect(crop?.plantedAt).toEqual(plantedAt);
+      expect(crop?.baseDurationMs).toEqual(sunflowerMs);
+      expect(crop?.boostedTime).toBeUndefined();
+      expect(state.crops["0"].fertiliser).toEqual({
+        name: "Rapid Root",
+        fertilisedAt: dateNow,
+      });
+    });
+
+    it("brings the ready time forward by speeding the work accrued AFTER it was applied", () => {
+      const state = fertiliseWindowedCrop("Rapid Root");
+      const crop = state.crops["0"].crop!;
+      const fertiliser = state.crops["0"].fertiliser;
+
+      const readyWith = getCropReadyAt(
+        crop,
+        CROPS.Sunflower,
+        state,
+        fertiliser,
+      );
+      const readyWithout = getCropReadyAt(
+        crop,
+        CROPS.Sunflower,
+        state,
+        undefined,
+      );
+
+      // Half the work was done at 1×; the remaining half accrues at 2× from
+      // fertilisedAt (dateNow): readyAt = dateNow + (sunflowerMs / 2) / 2.
+      expect(readyWith).toBe(dateNow + sunflowerMs / 2 / 2);
+      expect(readyWith).toBeLessThan(readyWithout);
+    });
+
+    it("windows a Sproutroot Surprise crop the same way (time half) without mutation", () => {
+      const plantedAt = dateNow - sunflowerMs / 2;
+      const state = fertiliseWindowedCrop("Sproutroot Surprise");
+      const crop = state.crops["0"].crop!;
+      expect(crop.plantedAt).toEqual(plantedAt);
+      expect(crop.baseDurationMs).toEqual(sunflowerMs);
+      expect(state.crops["0"].fertiliser).toEqual({
+        name: "Sproutroot Surprise",
+        fertilisedAt: dateNow,
+      });
+      expect(
+        getCropReadyAt(
+          crop,
+          CROPS.Sunflower,
+          state,
+          state.crops["0"].fertiliser,
+        ),
+      ).toBe(dateNow + sunflowerMs / 2 / 2);
+    });
   });
 });

--- a/src/features/game/events/landExpansion/fertilisePlot.ts
+++ b/src/features/game/events/landExpansion/fertilisePlot.ts
@@ -3,10 +3,6 @@ import type { GameState } from "../../types/game";
 import type { CropCompostName } from "features/game/types/composters";
 import { CROPS, type Crop, isBasicCrop } from "features/game/types/crops";
 import { getCropReadyAt, isReadyToHarvest } from "./harvest";
-import {
-  getCropPlotBoostWindows,
-  workAccruedAt,
-} from "features/game/lib/boostWindows";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { produce } from "immer";
 import {
@@ -86,16 +82,11 @@ export function applyFertiliserToPlot({
     (fertiliser === "Rapid Root" || fertiliser === "Sproutroot Surprise") &&
     cropDetails
   ) {
-    if (crop.baseDurationMs !== undefined) {
-      // Speed-rate model: halve the remaining work (in base-duration ms).
-      const accrued = workAccruedAt({
-        startedAt: crop.plantedAt,
-        at: createdAt,
-        windows: getCropPlotBoostWindows(game),
-      });
-      const remainingWork = Math.max(crop.baseDurationMs - accrued, 0);
-      crop.baseDurationMs = crop.baseDurationMs - remainingWork / 2;
-    } else {
+    // Speed-rate model: the fertiliser is a live 2× window from `fertilisedAt`
+    // (recorded on `plot.fertiliser` above), so a windowed crop needs no mutation
+    // — its readyAt is derived live via getCropFertiliserWindows. Only legacy
+    // crops back-date plantedAt.
+    if (crop.baseDurationMs === undefined) {
       const { newPlantedAt, timeReduction } = getPlantedAt(
         fertiliser,
         crop.plantedAt,
@@ -150,7 +141,7 @@ export function applyFertiliserToPlot({
           "Basic Scarecrow",
           { dx, dy },
           createdAt,
-          getCropReadyAt(crop, cropDetails, game) - createdAt,
+          getCropReadyAt(crop, cropDetails, game, plot.fertiliser) - createdAt,
         );
       }
     }

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -80,6 +80,52 @@ describe("harvest", () => {
     ).toThrow(`Not ready`);
   });
 
+  it("harvests a windowed crop early thanks to a Rapid Root fertiliser window", () => {
+    const plot = GAME_STATE.crops[0];
+    const carrotMs = CROPS.Carrot.harvestSeconds * 1000;
+    // 35 min into a 60 min Carrot: not ready at 1×, but the Rapid Root 2× window
+    // (active from plant) readies it at plantedAt + 30 min = 5 min ago.
+    const plantedAt = dateNow - 35 * 60 * 1000;
+    const windowedCarrot = {
+      name: "Carrot" as const,
+      plantedAt,
+      baseDurationMs: carrotMs,
+    };
+
+    const state = harvest({
+      state: {
+        ...GAME_STATE,
+        inventory: {},
+        crops: {
+          0: {
+            ...plot,
+            crop: windowedCarrot,
+            fertiliser: { name: "Rapid Root", fertilisedAt: plantedAt },
+          },
+        },
+      },
+      action: { type: "crop.harvested", index: "0" },
+      createdAt: dateNow,
+    });
+
+    // The fertiliser window made it ready early → harvested.
+    expect(state.crops?.[0].crop).toBeUndefined();
+    expect(state.inventory.Carrot).toBeDefined();
+
+    // Without the fertiliser the same crop is still growing at 1×.
+    expect(() =>
+      harvest({
+        state: {
+          ...GAME_STATE,
+          inventory: {},
+          crops: { 0: { ...plot, crop: windowedCarrot } },
+        },
+        action: { type: "crop.harvested", index: "0" },
+        createdAt: dateNow,
+      }),
+    ).toThrow("Not ready");
+  });
+
   it("harvests a crop", () => {
     const plot = GAME_STATE.crops[0];
 

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -112,13 +112,16 @@ describe("harvest", () => {
     expect(state.crops?.[0].crop).toBeUndefined();
     expect(state.inventory.Carrot).toBeDefined();
 
-    // Without the fertiliser the same crop is still growing at 1×.
+    // Without the fertiliser window (explicitly cleared so the case can't
+    // silently inherit one) the same crop is still growing at 1× → not ready.
     expect(() =>
       harvest({
         state: {
           ...GAME_STATE,
           inventory: {},
-          crops: { 0: { ...plot, crop: windowedCarrot } },
+          crops: {
+            0: { ...plot, crop: windowedCarrot, fertiliser: undefined },
+          },
         },
         action: { type: "crop.harvested", index: "0" },
         createdAt: dateNow,

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -2,6 +2,7 @@ import type {
   AOE,
   BoostName,
   CriticalHitName,
+  CropFertiliser,
   GameState,
   PlantedCrop,
   Reward,
@@ -32,6 +33,7 @@ import {
 } from "features/game/lib/collectibleBuilt";
 import {
   computeReadyAt,
+  getCropFertiliserWindows,
   getCropPlotBoostWindows,
 } from "features/game/lib/boostWindows";
 import { FACTION_ITEMS } from "features/game/lib/factions";
@@ -115,12 +117,16 @@ export const getCropReadyAt = (
   plantedCrop: PlantedCrop,
   cropDetails: Crop,
   game: GameState,
+  fertiliser?: CropFertiliser,
 ): number => {
   if (plantedCrop.baseDurationMs !== undefined) {
     return computeReadyAt({
       startedAt: plantedCrop.plantedAt,
       baseDurationMs: plantedCrop.baseDurationMs,
-      windows: getCropPlotBoostWindows(game),
+      windows: [
+        ...getCropPlotBoostWindows(game),
+        ...getCropFertiliserWindows(fertiliser),
+      ],
     });
   }
 
@@ -132,8 +138,9 @@ export const isReadyToHarvest = (
   plantedCrop: PlantedCrop,
   cropDetails: Crop,
   game: GameState,
+  fertiliser?: CropFertiliser,
 ) => {
-  return now >= getCropReadyAt(plantedCrop, cropDetails, game);
+  return now >= getCropReadyAt(plantedCrop, cropDetails, game, fertiliser);
 };
 
 export function isCropGrowing(plot: CropPlot, game: GameState) {
@@ -141,7 +148,13 @@ export function isCropGrowing(plot: CropPlot, game: GameState) {
   if (!crop) return false;
 
   const cropDetails = CROPS[crop.name];
-  return !isReadyToHarvest(Date.now(), crop, cropDetails, game);
+  return !isReadyToHarvest(
+    Date.now(),
+    crop,
+    cropDetails,
+    game,
+    plot.fertiliser,
+  );
 }
 
 /**
@@ -155,10 +168,12 @@ const getCropGrowDurationMs = (
   cropName: CropName | GreenHouseCropName,
   plantedCrop: PlantedCrop | undefined,
   game: GameState,
+  fertiliser?: CropFertiliser,
 ): number => {
   const cropDetails = CROPS[cropName as CropName];
   return plantedCrop?.baseDurationMs !== undefined
-    ? getCropReadyAt(plantedCrop, cropDetails, game) - plantedCrop.plantedAt
+    ? getCropReadyAt(plantedCrop, cropDetails, game, fertiliser) -
+        plantedCrop.plantedAt
     : cropDetails.harvestSeconds * 1000 - (plantedCrop?.boostedTime ?? 0);
 };
 
@@ -541,7 +556,7 @@ export function getCropYieldAmount({
         updatedAoe,
         "Scary Mike",
         { dx, dy },
-        getCropGrowDurationMs(crop, plot?.crop, game),
+        getCropGrowDurationMs(crop, plot?.crop, game, plot?.fertiliser),
         createdAt,
       );
 
@@ -590,7 +605,7 @@ export function getCropYieldAmount({
         updatedAoe,
         "Sir Goldensnout",
         { dx, dy },
-        getCropGrowDurationMs(crop, plot?.crop, game),
+        getCropGrowDurationMs(crop, plot?.crop, game, plot?.fertiliser),
         createdAt,
       );
 
@@ -639,7 +654,7 @@ export function getCropYieldAmount({
         updatedAoe,
         "Laurie the Chuckle Crow",
         { dx, dy },
-        getCropGrowDurationMs(crop, plot.crop, game),
+        getCropGrowDurationMs(crop, plot.crop, game, plot.fertiliser),
         createdAt,
       );
 
@@ -690,7 +705,7 @@ export function getCropYieldAmount({
         updatedAoe,
         "Queen Cornelia",
         { dx, dy },
-        getCropGrowDurationMs(crop, plot?.crop, game),
+        getCropGrowDurationMs(crop, plot?.crop, game, plot?.fertiliser),
         createdAt,
       );
 
@@ -748,7 +763,7 @@ export function getCropYieldAmount({
         updatedAoe,
         "Gnome",
         { dx, dy },
-        getCropGrowDurationMs(crop, plot?.crop, game),
+        getCropGrowDurationMs(crop, plot?.crop, game, plot?.fertiliser),
         createdAt,
       );
       if (canUseAoe) {
@@ -1016,7 +1031,15 @@ export function harvestCropFromPlot({
         prngArgs: { farmId, counter },
       });
 
-  if (!isReadyToHarvest(createdAt, plot.crop, CROPS[cropName], game)) {
+  if (
+    !isReadyToHarvest(
+      createdAt,
+      plot.crop,
+      CROPS[cropName],
+      game,
+      plot.fertiliser,
+    )
+  ) {
     throw new Error("Not ready");
   }
 

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -110,8 +110,16 @@ export const isWinterCrop = (
 
 /**
  * When a planted crop is ready, across both boost models. New crops (with
- * `baseDurationMs`) derive their ready time live from the Sparrow Shrine speed
- * windows; legacy crops use their back-dated `plantedAt` + base grow time.
+ * `baseDurationMs`) derive their ready time live from the crop-plot speed windows
+ * plus any per-plot fertiliser (Rapid Root / Sproutroot Surprise) window; legacy
+ * crops use their back-dated `plantedAt` + base grow time.
+ *
+ * Branching on `baseDurationMs` — NOT the `SPEED_BOOSTS` flag — is intentional:
+ * the marker makes a crop permanently speed-rate, so it keeps windowed timing
+ * (and its baked permanent boosts) even if the flag is rolled back, matching every
+ * other windowed activity. The fertiliser windows are merged unconditionally here
+ * for the same reason as the collectible windows; only the plant / fertilise WRITE
+ * paths gate on the flag.
  */
 export const getCropReadyAt = (
   plantedCrop: PlantedCrop,

--- a/src/features/game/events/landExpansion/placePlot.ts
+++ b/src/features/game/events/landExpansion/placePlot.ts
@@ -4,6 +4,7 @@ import Decimal from "decimal.js-light";
 import { produce } from "immer";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 import {
+  getCropFertiliserWindows,
   getCropPlotBoostWindows,
   workAccruedAt,
 } from "features/game/lib/boostWindows";
@@ -61,7 +62,10 @@ export function placePlot({
           const banked = workAccruedAt({
             startedAt: crop.plantedAt,
             at: updatedPlot.removedAt,
-            windows: getCropPlotBoostWindows(game),
+            windows: [
+              ...getCropPlotBoostWindows(game),
+              ...getCropFertiliserWindows(updatedPlot.fertiliser),
+            ],
           });
           crop.baseDurationMs = Math.max(crop.baseDurationMs - banked, 0);
           crop.boostedTime = (crop.boostedTime ?? 0) + banked;

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -860,7 +860,7 @@ describe("plant", () => {
       expect(time).toEqual(60 * 60);
     });
 
-    it("plants a fertilised carrot", () => {
+    it("does not bake Rapid Root into the plot time under SPEED_BOOSTS", () => {
       const { time } = getCropPlotTime({
         crop: "Carrot",
         game: FARM_WITH_PLOTS,
@@ -872,10 +872,11 @@ describe("plant", () => {
         createdAt: dateNow,
       });
 
-      expect(time).toEqual(30 * 60);
+      // Windowed (2×) via getCropFertiliserWindows, so the base time is unchanged.
+      expect(time).toEqual(60 * 60);
     });
 
-    it("plants a carrot fertilised with Sproutroot Surprise", () => {
+    it("does not bake Sproutroot Surprise into the plot time under SPEED_BOOSTS", () => {
       const { time } = getCropPlotTime({
         crop: "Carrot",
         game: FARM_WITH_PLOTS,
@@ -887,7 +888,8 @@ describe("plant", () => {
         createdAt: dateNow,
       });
 
-      expect(time).toEqual(30 * 60);
+      // Only its grow-TIME half is windowed (2×); the +0.2 yield is separate.
+      expect(time).toEqual(60 * 60);
     });
 
     it("when Bumpkin has Carrot Amulet equipped it reduces 20% the harvest time", () => {

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -416,9 +416,13 @@ export const getCropPlotTime = ({
     boostsUsed.push({ name: "Broccoli Hat", value: "x0.5" });
   }
 
+  // Rapid Root / Sproutroot Surprise: under SPEED_BOOSTS these are a windowed 2×
+  // speed boost for the crop (see getCropFertiliserWindows); legacy / flag-off
+  // bakes the discount-at-start here. (Sproutroot's +0.2 yield is separate.)
   if (
-    plot?.fertiliser?.name === "Rapid Root" ||
-    plot?.fertiliser?.name === "Sproutroot Surprise"
+    !hasFeatureAccess(game, "SPEED_BOOSTS") &&
+    (plot?.fertiliser?.name === "Rapid Root" ||
+      plot?.fertiliser?.name === "Sproutroot Surprise")
   ) {
     seconds = seconds * 0.5;
   }

--- a/src/features/game/events/landExpansion/removeCrop.ts
+++ b/src/features/game/events/landExpansion/removeCrop.ts
@@ -61,7 +61,9 @@ export function removeCrop({ state, action, createdAt = Date.now() }: Options) {
     }
 
     const cropDetails = CROPS[crop.name];
-    if (isReadyToHarvest(createdAt, crop, cropDetails, stateCopy)) {
+    if (
+      isReadyToHarvest(createdAt, crop, cropDetails, stateCopy, plot.fertiliser)
+    ) {
       throw new Error(REMOVE_CROP_ERRORS.READY_TO_HARVEST);
     }
 

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -357,6 +357,7 @@ export function powerSkillDisabledConditions({
           plot.crop,
           CROPS[plot.crop.name],
           state,
+          plot.fertiliser,
         )
           ? "ready"
           : "growing";

--- a/src/features/game/lib/aoe.ts
+++ b/src/features/game/lib/aoe.ts
@@ -1,7 +1,11 @@
 import type { AOEItemName } from "../expansion/placeable/lib/collisionDetection";
 import type { CollectibleName } from "../types/craftables";
 import type { AOE, GameState } from "../types/game";
-import { computeReadyAt, getCropPlotBoostWindows } from "./boostWindows";
+import {
+  computeReadyAt,
+  getCropFertiliserWindows,
+  getCropPlotBoostWindows,
+} from "./boostWindows";
 
 /**
  * Important: for yield boosts, the gameState.aoe object contains when the boost was last used.
@@ -88,7 +92,7 @@ export function refreshBasicScarecrowTimeAOE(game: GameState): void {
     game.aoe["Basic Scarecrow"]![dx]![dy] = computeReadyAt({
       startedAt: crop.plantedAt,
       baseDurationMs: crop.baseDurationMs,
-      windows,
+      windows: [...windows, ...getCropFertiliserWindows(plot.fertiliser)],
     });
   });
 }

--- a/src/features/game/lib/boostWindows.test.ts
+++ b/src/features/game/lib/boostWindows.test.ts
@@ -12,6 +12,7 @@ import {
   getMineBoostWindows,
   getFruitBoostWindows,
   getTurbofruitMixWindows,
+  getCropFertiliserWindows,
   getFlowerBoostWindows,
   appendBoostHistory,
   type BoostWindow,
@@ -786,6 +787,112 @@ describe("getTurbofruitMixWindows", () => {
         baseDurationMs /
           (FRUIT_BOOST_SPEED["Orchard Hourglass"] *
             FRUIT_BOOST_SPEED["Turbofruit Mix"]),
+    );
+  });
+});
+
+describe("getCropFertiliserWindows", () => {
+  const fertilisedAt = 1_000_000;
+
+  it("returns no window when the plot has no fertiliser", () => {
+    expect(getCropFertiliserWindows(undefined)).toEqual([]);
+  });
+
+  it("returns no window for a non-speed fertiliser (Sprout Mix)", () => {
+    expect(
+      getCropFertiliserWindows({ name: "Sprout Mix", fertilisedAt }),
+    ).toEqual([]);
+  });
+
+  it("builds an open-ended 2× window from fertilisedAt for Rapid Root", () => {
+    expect(
+      getCropFertiliserWindows({ name: "Rapid Root", fertilisedAt }),
+    ).toEqual([
+      {
+        from: fertilisedAt,
+        to: Number.MAX_SAFE_INTEGER,
+        speed: CROP_PLOT_BOOST_SPEED["Rapid Root"],
+      },
+    ]);
+  });
+
+  it("builds an open-ended 2× window from fertilisedAt for Sproutroot Surprise", () => {
+    expect(
+      getCropFertiliserWindows({ name: "Sproutroot Surprise", fertilisedAt }),
+    ).toEqual([
+      {
+        from: fertilisedAt,
+        to: Number.MAX_SAFE_INTEGER,
+        speed: CROP_PLOT_BOOST_SPEED["Sproutroot Surprise"],
+      },
+    ]);
+  });
+
+  it("keeps the segment maths finite over the far-future bound", () => {
+    // Edge case for the MAX_SAFE_INTEGER bound: a crop under a fertiliser window
+    // is ready long before the bound and computeReadyAt stays finite.
+    const startedAt = fertilisedAt;
+    const baseDurationMs = 10 * HOUR;
+    const readyAt = computeReadyAt({
+      startedAt,
+      baseDurationMs,
+      windows: getCropFertiliserWindows({ name: "Rapid Root", fertilisedAt }),
+    });
+
+    // Whole grow is at 2× → wall-clock = base / 2.
+    expect(readyAt).toBe(
+      startedAt + baseDurationMs / CROP_PLOT_BOOST_SPEED["Rapid Root"],
+    );
+    expect(Number.isFinite(readyAt)).toBe(true);
+  });
+
+  it("only speeds work accrued AFTER it was applied mid-grow", () => {
+    const startedAt = 0;
+    const baseDurationMs = 10 * HOUR;
+    const midFertilisedAt = 2 * HOUR;
+    const readyAt = computeReadyAt({
+      startedAt,
+      baseDurationMs,
+      windows: getCropFertiliserWindows({
+        name: "Rapid Root",
+        fertilisedAt: midFertilisedAt,
+      }),
+    });
+
+    // First 2h at 1× (2h work), remaining 8h work at 2× → 8h / 2 = 4h.
+    expect(readyAt).toBe(
+      midFertilisedAt +
+        (baseDurationMs - 2 * HOUR) / CROP_PLOT_BOOST_SPEED["Rapid Root"],
+    );
+  });
+
+  it("stacks MULTIPLICATIVELY with the collectible crop windows", () => {
+    const startedAt = 0;
+    const baseDurationMs = 10 * HOUR;
+    const sparrow: BoostWindow[] = [
+      {
+        from: 0,
+        to: Number.MAX_SAFE_INTEGER,
+        speed: CROP_PLOT_BOOST_SPEED["Sparrow Shrine"],
+      },
+    ];
+    const rapidRoot = getCropFertiliserWindows({
+      name: "Rapid Root",
+      fertilisedAt: 0,
+    });
+
+    const readyAt = computeReadyAt({
+      startedAt,
+      baseDurationMs,
+      windows: [...sparrow, ...rapidRoot],
+    });
+
+    // Both cover the whole grow → 1.35 × 2 effective speed.
+    expect(readyAt).toBe(
+      startedAt +
+        baseDurationMs /
+          (CROP_PLOT_BOOST_SPEED["Sparrow Shrine"] *
+            CROP_PLOT_BOOST_SPEED["Rapid Root"]),
     );
   });
 });

--- a/src/features/game/lib/boostWindows.test.ts
+++ b/src/features/game/lib/boostWindows.test.ts
@@ -19,7 +19,7 @@ import {
 } from "./boostWindows";
 import { EXPIRY_COOLDOWNS } from "./collectibleBuilt";
 import { TEST_FARM } from "./constants";
-import type { GameState } from "../types/game";
+import type { CropFertiliser, GameState } from "../types/game";
 import type { RockName } from "../types/resources";
 
 const HOUR = 60 * 60 * 1000;
@@ -801,6 +801,12 @@ describe("getCropFertiliserWindows", () => {
   it("returns no window for a non-speed fertiliser (Sprout Mix)", () => {
     expect(
       getCropFertiliserWindows({ name: "Sprout Mix", fertilisedAt }),
+    ).toEqual([]);
+  });
+
+  it("returns no window when the name is valid but fertilisedAt is missing (malformed state)", () => {
+    expect(
+      getCropFertiliserWindows({ name: "Rapid Root" } as CropFertiliser),
     ).toEqual([]);
   });
 

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -1,6 +1,7 @@
 import { getActiveGuardian } from "./getActiveGuardian";
 import type {
   BoostHistoryWindow,
+  CropFertiliser,
   FruitFertiliser,
   GameState,
   PlacedItem,
@@ -40,6 +41,10 @@ export const CROP_PLOT_BOOST_SPEED = {
   "Super Totem": 2,
   "Time Warp Totem": 2,
   "Power hour": 2,
+  // Per-crop fertilisers (not collectibles); windowed via getCropFertiliserWindows.
+  // Sproutroot Surprise's +0.2 yield is separate — only its grow-time half is here.
+  "Rapid Root": 2,
+  "Sproutroot Surprise": 2,
   sunshower: 2,
   sunshowerGuardian: 4,
 } as const;
@@ -268,6 +273,40 @@ export const getTurbofruitMixWindows = (
       // always ready long before this.
       to: Number.MAX_SAFE_INTEGER,
       speed: FRUIT_BOOST_SPEED["Turbofruit Mix"],
+    },
+  ];
+};
+
+/**
+ * The crop-plot fertiliser speed windows (Rapid Root, Sproutroot Surprise). Like
+ * Turbofruit Mix for fruit, these are per-CROP and never expire on a timer: a 2×
+ * speed active from when the fertiliser was applied (`fertilisedAt`) until the
+ * crop is harvested, so the window is open-ended. Returns [] when the plot has no
+ * speed fertiliser. Sproutroot Surprise's +0.2 yield is separate (baked in
+ * getCropYieldAmount) — only its grow-TIME half is windowed here. Assembled
+ * separately from `getCropPlotBoostWindows` (game-global) and unioned in by
+ * `getCropReadyAt` and the plot UI.
+ */
+export const getCropFertiliserWindows = (
+  fertiliser?: CropFertiliser,
+): BoostWindow[] => {
+  // Guard fertilisedAt too: the type requires it, but defend against malformed
+  // persisted state producing a `from: undefined` window.
+  if (
+    (fertiliser?.name !== "Rapid Root" &&
+      fertiliser?.name !== "Sproutroot Surprise") ||
+    fertiliser.fertilisedAt === undefined
+  ) {
+    return [];
+  }
+  return [
+    {
+      from: fertiliser.fertilisedAt,
+      // Open-ended: active for the crop's whole remaining grow. A far-future
+      // bound (not Infinity, to keep the segment maths finite) — the crop is
+      // always ready long before this.
+      to: Number.MAX_SAFE_INTEGER,
+      speed: CROP_PLOT_BOOST_SPEED[fertiliser.name],
     },
   ];
 };

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -85,7 +85,9 @@ export function getFertiliserBuffLabels({
         game,
       }),
       {
-        shortDescription: translate("description.rapid.root.boost"),
+        shortDescription: hasFeatureAccess(game, "SPEED_BOOSTS")
+          ? translate("description.rapid.root.boost.speed")
+          : translate("description.rapid.root.boost"),
         labelType: "info",
         boostTypeIcon: SUNNYSIDE.icons.stopwatch,
         boostedItemIcon: ITEM_DETAILS["Crop Plot"].image,
@@ -413,9 +415,11 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
       fertiliser: "Fruitful Blend",
       game,
     }),
-  "Rapid Root": () => [
+  "Rapid Root": (game) => [
     {
-      shortDescription: translate("description.rapid.root.boost"),
+      shortDescription: hasFeatureAccess(game, "SPEED_BOOSTS")
+        ? translate("description.rapid.root.boost.speed")
+        : translate("description.rapid.root.boost"),
       labelType: "info",
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: ITEM_DETAILS["Crop Plot"].image,

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useState, type JSX } from "react";
+import React, { useContext, useMemo, useRef, useState, type JSX } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import type { Reward, CropPlot } from "features/game/types/game";
@@ -132,11 +132,16 @@ export const Plot: React.FC<Props> = ({ id }) => {
 
   // Union the plot's own Rapid Root / Sproutroot Surprise fertiliser window
   // (per-plot, keyed off fertilisedAt) with the game-global crop boost windows,
-  // so the countdown ticks at the fertiliser's boosted rate too.
-  const cropBoostWindows = [
-    ...getCropPlotBoostWindows(state),
-    ...getCropFertiliserWindows(fertiliser),
-  ];
+  // so the countdown ticks at the fertiliser's boosted rate too. Memoised so the
+  // per-tick `useNow` re-renders don't reallocate the array (it only depends on
+  // `state` and `fertiliser`, not `now`).
+  const cropBoostWindows = useMemo(
+    () => [
+      ...getCropPlotBoostWindows(state),
+      ...getCropFertiliserWindows(fertiliser),
+    ],
+    [state, fertiliser],
+  );
 
   // Calculate expected reward for UI preview (captcha gate for non-seasoned players)
   const expectedReward =

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -26,7 +26,10 @@ import {
   selectVerified,
 } from "features/game/lib/gameMachine";
 import { isSeasonedPlayer } from "features/game/lib/seasonedPlayer";
-import { getCropPlotBoostWindows } from "features/game/lib/boostWindows";
+import {
+  getCropFertiliserWindows,
+  getCropPlotBoostWindows,
+} from "features/game/lib/boostWindows";
 import { ZoomContext } from "components/ZoomProvider";
 import { CROP_COMPOST } from "features/game/types/composters";
 import { gameAnalytics } from "lib/gameAnalytics";
@@ -127,12 +130,18 @@ export const Plot: React.FC<Props> = ({ id }) => {
   const now = useNow({ live: true });
   const isSeasoned = isSeasonedPlayer({ game: state, verified, now });
 
-  const cropBoostWindows = getCropPlotBoostWindows(state);
+  // Union the plot's own Rapid Root / Sproutroot Surprise fertiliser window
+  // (per-plot, keyed off fertilisedAt) with the game-global crop boost windows,
+  // so the countdown ticks at the fertiliser's boosted rate too.
+  const cropBoostWindows = [
+    ...getCropPlotBoostWindows(state),
+    ...getCropFertiliserWindows(fertiliser),
+  ];
 
   // Calculate expected reward for UI preview (captcha gate for non-seasoned players)
   const expectedReward =
     crop?.reward ??
-    (crop && isReadyToHarvest(now, crop, CROPS[crop.name], state)
+    (crop && isReadyToHarvest(now, crop, CROPS[crop.name], state, fertiliser)
       ? getReward({
           crop: crop.name,
           skills: state.bumpkin?.skills ?? {},
@@ -214,7 +223,8 @@ export const Plot: React.FC<Props> = ({ id }) => {
 
   const onClick = (seed: SeedName = selectedItem as SeedName) => {
     const readyToHarvest =
-      !!crop && isReadyToHarvest(now, crop, CROPS[crop.name], state);
+      !!crop &&
+      isReadyToHarvest(now, crop, CROPS[crop.name], state, fertiliser);
     const wantsToPlant = !crop && seed && isCropSeed(seed);
 
     // small buffer to prevent accidental double clicks

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -9074,6 +9074,7 @@
   "description.fruitful.blend.boost": "+0.1 Fruit Patch Yield",
   "description.fruitful.bounty.skill.boost": "+0.1 Fruit Patch Yield from Fruitful Bounty Skill",
   "description.rapid.root.boost": "x0.5 Crop Plot Growth Time",
+  "description.rapid.root.boost.speed": "2x Crop Plot Growth Speed",
   "description.sproutroot.surprise.boost": "+0.2 Crop Plot Yield",
   "description.sproutroot.surprise.boost.2": "x0.5 Crop Plot Growth Time",
   "description.turbofruit.mix.boost": "x0.8 Fruit Patch Growth Time",


### PR DESCRIPTION
## What

Migrates the two −50%-time plot-crop fertilisers — **Rapid Root** and **Sproutroot Surprise** — from a one-shot baked discount into a **per-crop live 2× speed window**, mirroring how Turbofruit Mix was done for fruit patches. Behind the `SPEED_BOOSTS` flag. (−50% ⇒ 2×, per the agreed 1-for-1 conversion.)

## How

- **Engine** — new `getCropFertiliserWindows(fertiliser?)` in `boostWindows.ts`: an open-ended `[fertilisedAt, MAX_SAFE_INTEGER)` window at `CROP_PLOT_BOOST_SPEED["Rapid Root" | "Sproutroot Surprise"] = 2` (covers both names; guards `fertilisedAt` undefined).
- **Read path** — threaded `fertiliser?: CropFertiliser` through `getCropReadyAt` / `isReadyToHarvest` / `getCropGrowDurationMs` and every call site (harvest, removeCrop, skillUsed Instant-Growth, `Plot.tsx`), plus the two secondary consumers: `aoe.ts` (Basic Scarecrow AOE refresh) and `placePlot.ts` (landscaping lift-banking).
- **Write path** — `applyFertiliserToPlot` no longer mutates `baseDurationMs` for windowed crops (the window drives readyAt); legacy crops still back-date. `getCropPlotTime` bakes the `0.5×` only when the flag is off.
- **Sproutroot Surprise** stays a mixed boost — only its grow-**time** half is windowed; its **+0.2 yield** remains baked (`getCropYieldAmount`).
- **Display** — `Plot.tsx` unions the per-plot fertiliser window into `cropBoostWindows` → boosted countdown + lightning.
- **Description** — flag-gated `.speed` buff label (`"2x Crop Plot Growth Speed"`) in `collectibleItemBuffs.ts` + `dictionary.json`.

Crops are one-shot (fertiliser deleted on harvest), so no `forceWindowed`/stickiness is needed.

## Tests

- `getCropFertiliserWindows` unit block (both fertiliser names, 2×, mid-grow retroactivity, multiplicative stacking with Sparrow Shrine).
- `fertilisePlot` event tests: windowed crop is not mutated + fertiliser recorded; ready time brought forward by remaining/2.
- Updated 2 `getCropPlotTime` tests to expect the un-baked base time under the flag.

`tsc` + eslint clean; jest green across boostWindows/fertilisePlot/harvest/plant/placePlot/removeCrop/skillUsed/aoe.

Backend counterpart: sunflower-land-api#3461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crop fertilisers now drive windowed growth timing more precisely, affecting harvest readiness and boost countdowns.
  * Added fertiliser-specific “Rapid Root” speed description when **SPEED_BOOSTS** is enabled.
* **Bug Fixes**
  * Improved consistency across planting/resuming, harvest eligibility, plot reward/reward-flow checks, crop removal, and **Instant Growth** readiness—now taking plot fertiliser into account.
  * Corrected fertiliser handling for windowed crops and timing calculations.
* **Tests**
  * Expanded coverage for fertiliser windows, stacking behavior, and readiness/duration expectations (including early harvest with **Rapid Root**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->