### PR TITLE
[FIX] Speed-boost timer regressions (node pause, honey, bulk harvest, crimstone art)

### DIFF
--- a/src/features/game/events/landExpansion/bulkHarvest.test.ts
+++ b/src/features/game/events/landExpansion/bulkHarvest.test.ts
@@ -342,6 +342,29 @@ describe("getPlotsToHarvest", () => {
     expect(readyPlots).not.toHaveProperty("4");
   });
 
+  it("includes a windowed crop fertilised with Rapid Root at its boosted ready time", () => {
+    const baseDurationMs = 2000;
+    const plantedAt = dateNow - 1002; // > half of baseDuration ago
+    const state: GameState = {
+      ...GAME_STATE,
+      crops: {
+        "1": {
+          x: 1,
+          y: 1,
+          createdAt: 0,
+          crop: { name: "Sunflower" as CropName, plantedAt, baseDurationMs },
+          fertiliser: { name: "Rapid Root", fertilisedAt: plantedAt },
+        },
+      },
+    };
+
+    // Rapid Root is a 2x speed window, so the crop is ready at half its
+    // baseDuration. The bulk detector must forward plot.fertiliser to see this;
+    // without it the crop looks unready until its un-boosted (2x longer) time.
+    const { readyPlots } = getCropsToHarvest(state, dateNow);
+    expect(readyPlots).toHaveProperty("1");
+  });
+
   it("returns empty object when no crops are ready", () => {
     const state = {
       ...GAME_STATE,

--- a/src/features/game/events/landExpansion/bulkHarvest.ts
+++ b/src/features/game/events/landExpansion/bulkHarvest.ts
@@ -29,7 +29,15 @@ export const getCropsToHarvest = (state: GameState, now = Date.now()) => {
     // Exclude plots destroyed by tornado, tsunami, greatFreeze
     if (getAffectedWeather({ id: plotId, game: state })) return;
 
-    if (isReadyToHarvest(now, plot.crop, CROPS[plot.crop.name], state)) {
+    if (
+      isReadyToHarvest(
+        now,
+        plot.crop,
+        CROPS[plot.crop.name],
+        state,
+        plot.fertiliser,
+      )
+    ) {
       readyPlots[plotId] = plot;
       readyCrops[plot.crop.name] = (readyCrops[plot.crop.name] || 0) + 1;
     }

--- a/src/features/game/events/landExpansion/fruitHarvested.ts
+++ b/src/features/game/events/landExpansion/fruitHarvested.ts
@@ -345,6 +345,8 @@ export function harvestFruit({
       forceWindowed,
     );
     delete patch.fruit.amount;
+    // New replenish phase starts with a fresh progress bar (no banked work yet).
+    delete patch.fruit.boostedTime;
     patch.fruit.harvestedAt = newPlantedAt;
     // Windowed replenish stores the real harvestedAt + a permanent-boost-only
     // base recovery; a legacy (never-windowed) fruit under flag-off back-dates

--- a/src/features/game/events/landExpansion/instaGrowFlower.test.ts
+++ b/src/features/game/events/landExpansion/instaGrowFlower.test.ts
@@ -265,12 +265,66 @@ describe("instaGrowFlower — SPEED_BOOSTS speed windows", () => {
 
     const flower = result.flowers.flowerBeds[flowerBedId].flower!;
 
-    // Windowed insta-grow zeroes remaining work rather than back-dating plantedAt.
+    // Windowed insta-grow zeroes remaining work and anchors the start to now.
     expect(flower.baseDurationMs).toEqual(0);
-    expect(flower.plantedAt).toEqual(plantedAt);
-    // Ready now: readyAt resolves to startedAt, which is <= createdAt.
-    expect(getFlowerReadyAt(flower, result)).toBeLessThanOrEqual(createdAt);
+    expect(flower.plantedAt).toEqual(createdAt);
+    // Ready now: readyAt resolves to the (now) start === createdAt.
+    expect(getFlowerReadyAt(flower, result)).toEqual(createdAt);
     // Some Obsidian was spent.
     expect(result.inventory.Obsidian!.lt(new Decimal(100))).toBe(true);
+  });
+
+  it("credits beehive honey accrued before insta-growing an attached windowed flower", () => {
+    const createdAt = 2_000_000_000;
+    const plantedAt = createdAt - 12 * 60 * 60 * 1000; // planted 12h ago
+    const flowerBedId = "1";
+
+    const result = instaGrowFlower({
+      state: {
+        ...INITIAL_FARM,
+        inventory: { Obsidian: new Decimal(100) },
+        beehives: {
+          hive: {
+            swarm: false,
+            honey: { updatedAt: plantedAt, produced: 0 },
+            x: 0,
+            y: 0,
+            flowers: [
+              {
+                id: flowerBedId,
+                attachedAt: plantedAt,
+                attachedUntil: plantedAt + baseMs,
+              },
+            ],
+          },
+        },
+        flowers: {
+          discovered: {},
+          flowerBeds: {
+            [flowerBedId]: {
+              createdAt: 0,
+              x: 0,
+              y: 0,
+              // Windowed flower with a 24h base still 12h from ready.
+              flower: {
+                name: flowerName,
+                plantedAt,
+                baseDurationMs: 24 * 60 * 60 * 1000,
+              },
+            },
+          },
+        },
+      } as GameState,
+      action: { type: "flower.instaGrown", id: flowerBedId },
+      createdAt,
+    });
+
+    const flower = result.flowers.flowerBeds[flowerBedId].flower!;
+    // readyAt anchored to now, NOT collapsed back to the (past) plantedAt.
+    expect(flower.plantedAt).toEqual(createdAt);
+    expect(getFlowerReadyAt(flower, result)).toEqual(createdAt);
+    // Honey produced over [attachedAt, insta-grow] is credited, not clamped to 0
+    // by a past readyAt.
+    expect(result.beehives.hive.honey.produced).toBeGreaterThan(0);
   });
 });

--- a/src/features/game/events/landExpansion/instaGrowFlower.ts
+++ b/src/features/game/events/landExpansion/instaGrowFlower.ts
@@ -61,9 +61,13 @@ export function instaGrowFlower({
     stateCopy.inventory.Obsidian = playerObsidian.sub(obsidianCost);
 
     if (flower.baseDurationMs !== undefined) {
-      // Speed-rate model: zero the remaining work so computeReadyAt resolves to
-      // startedAt (ready now) regardless of any active boost windows.
+      // Speed-rate model: zero the remaining work AND re-anchor the start to now
+      // so computeReadyAt resolves to `createdAt` (ready now), not the original
+      // (past) plantedAt. Anchoring to now matches the legacy branch's
+      // `readyAt === createdAt`, so updateBeehives credits honey accrued up to
+      // the insta-grow instead of clamping it to a past readyAt.
       flower.baseDurationMs = 0;
+      flower.plantedAt = createdAt;
     } else {
       // Legacy: back-date plantedAt so plantedAt + base grow time === createdAt.
       flower.plantedAt =

--- a/src/features/game/events/landExpansion/placeBuilding.ts
+++ b/src/features/game/events/landExpansion/placeBuilding.ts
@@ -13,7 +13,7 @@ import { createInitialAgingShed } from "features/game/lib/agingShed";
 import {
   getGreenhouseBoostWindows,
   getGreenhouseGlowWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import { getReadyAt } from "./startComposter";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
@@ -128,32 +128,20 @@ export function placeBuilding({
         Object.values(greenhouse.pots).forEach((pot) => {
           if (pot.plant && existingBuilding.removedAt) {
             const { plant } = pot;
-            if (plant.baseDurationMs !== undefined) {
-              // Windowed plant: "pause" growth across the move. Bank the work
-              // accrued before removal (already done, so it isn't redone), then
-              // resume the remaining work from now against the current windows.
-              // `boostedTime` keeps the pre-move progress for the growth bar;
-              // `baseDurationMs` holds the remaining work still to accrue.
-              // (Mirrors placePlot's lift-banking for windowed crops.)
-              const accured = workAccruedAt({
-                startedAt: plant.plantedAt,
-                at: existingBuilding.removedAt,
-                windows: [
-                  ...getGreenhouseBoostWindows(stateCopy, plant.name),
-                  ...getGreenhouseGlowWindows(pot.fertiliser),
-                ],
-              });
-              const banked = Math.min(accured, plant.baseDurationMs);
-              plant.baseDurationMs -= banked;
-              plant.boostedTime = (plant.boostedTime ?? 0) + banked;
-              plant.plantedAt = createdAt;
-            } else {
-              // Legacy plant: back-date plantedAt so the moved interval
-              // doesn't count.
-              const existingProgress =
-                existingBuilding.removedAt - plant.plantedAt;
-              plant.plantedAt = createdAt - existingProgress;
-            }
+            // Pause growth across the move (windowed banking or legacy back-date).
+            // trackProgress banks the pre-move work into boostedTime for the
+            // growth bar. (Mirrors placePlot's lift-banking for windowed crops.)
+            plant.plantedAt = pauseWindowedTimer({
+              timer: plant,
+              startedAt: plant.plantedAt,
+              removedAt: existingBuilding.removedAt,
+              createdAt,
+              windows: [
+                ...getGreenhouseBoostWindows(stateCopy, plant.name),
+                ...getGreenhouseGlowWindows(pot.fertiliser),
+              ],
+              trackProgress: true,
+            });
           }
         });
       }

--- a/src/features/game/events/landExpansion/placeCrimstone.test.ts
+++ b/src/features/game/events/landExpansion/placeCrimstone.test.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { MINE_BOOST_SPEED } from "features/game/lib/boostWindows";
 import { placeCrimstone } from "./placeCrimstone";
 
 describe("placeRuby", () => {
@@ -152,5 +153,51 @@ describe("placeRuby", () => {
         minesLeft: 5,
       },
     });
+  });
+
+  it("banks boosted work when a Mole Shrine window covered the pre-lift period", () => {
+    const dateNow = Date.now();
+    const minedAt = dateNow - 180000;
+    const removedAt = dateNow - 120000; // 60s of real recovery before the lift
+    const baseDurationMs = 200000;
+    const speed = MINE_BOOST_SPEED["Mole Shrine"]; // 1.35x
+
+    const state = placeCrimstone({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Crimstone Rock",
+        type: "crimstone.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Crimstone Rock": new Decimal(2) },
+        collectibles: {
+          "Mole Shrine": [
+            {
+              id: "ms",
+              coordinates: { x: 5, y: 5 },
+              createdAt: dateNow - 200000,
+              readyAt: dateNow - 200000,
+            },
+          ],
+        },
+        crimstones: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt, baseDurationMs },
+            removedAt,
+            minesLeft: 5,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.crimstones["123"].stone;
+    const banked = 60000 * speed;
+    expect(stone.minedAt).toBe(dateNow);
+    expect(stone.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeCrimstone.ts
+++ b/src/features/game/events/landExpansion/placeCrimstone.ts
@@ -4,7 +4,7 @@ import Decimal from "decimal.js-light";
 import { produce } from "immer";
 import {
   getMineBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -53,23 +53,14 @@ export function placeCrimstone({
       };
 
       if (updatedCrimstone.stone && updatedCrimstone.removedAt) {
-        const stone = updatedCrimstone.stone;
-        if (stone.baseDurationMs !== undefined) {
-          // Windowed rock: "pause" recovery across the lift. Bank the work
-          // accrued before removal, then resume the remaining work from now
-          // against the current mine boost windows (mirrors placePlot).
-          const banked = workAccruedAt({
-            startedAt: stone.minedAt,
-            at: updatedCrimstone.removedAt,
-            windows: getMineBoostWindows(game, "Crimstone Rock"),
-          });
-          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
-          stone.minedAt = createdAt;
-        } else {
-          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
-          const existingProgress = updatedCrimstone.removedAt - stone.minedAt;
-          stone.minedAt = createdAt - existingProgress;
-        }
+        // Pause recovery across the lift (windowed banking or legacy back-date).
+        updatedCrimstone.stone.minedAt = pauseWindowedTimer({
+          timer: updatedCrimstone.stone,
+          startedAt: updatedCrimstone.stone.minedAt,
+          removedAt: updatedCrimstone.removedAt,
+          createdAt,
+          windows: getMineBoostWindows(game, "Crimstone Rock"),
+        });
       }
       delete updatedCrimstone.removedAt;
 

--- a/src/features/game/events/landExpansion/placeCrimstone.ts
+++ b/src/features/game/events/landExpansion/placeCrimstone.ts
@@ -2,6 +2,10 @@ import type { FiniteResource, GameState } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import {
+  getMineBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceCrimstoneAction = {
@@ -49,9 +53,23 @@ export function placeCrimstone({
       };
 
       if (updatedCrimstone.stone && updatedCrimstone.removedAt) {
-        const existingProgress =
-          updatedCrimstone.removedAt - updatedCrimstone.stone.minedAt;
-        updatedCrimstone.stone.minedAt = createdAt - existingProgress;
+        const stone = updatedCrimstone.stone;
+        if (stone.baseDurationMs !== undefined) {
+          // Windowed rock: "pause" recovery across the lift. Bank the work
+          // accrued before removal, then resume the remaining work from now
+          // against the current mine boost windows (mirrors placePlot).
+          const banked = workAccruedAt({
+            startedAt: stone.minedAt,
+            at: updatedCrimstone.removedAt,
+            windows: getMineBoostWindows(game, "Crimstone Rock"),
+          });
+          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
+          stone.minedAt = createdAt;
+        } else {
+          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
+          const existingProgress = updatedCrimstone.removedAt - stone.minedAt;
+          stone.minedAt = createdAt - existingProgress;
+        }
       }
       delete updatedCrimstone.removedAt;
 

--- a/src/features/game/events/landExpansion/placeFlowerBed.test.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.test.ts
@@ -223,5 +223,7 @@ describe("placeFlowerBed", () => {
     const banked = 60000 * speed;
     expect(flower?.plantedAt).toBe(now);
     expect(flower?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
+    // Banked work is retained as boostedTime for the progress bar.
+    expect(flower?.boostedTime).toBeCloseTo(banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeFlowerBed.test.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.test.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { placeFlowerBed } from "./placeFlowerBed";
 import { TEST_FARM } from "features/game/lib/constants";
+import { FLOWER_BOOST_SPEED } from "features/game/lib/boostWindows";
 
 describe("placeFlowerBed", () => {
   const dateNow = Date.now();
@@ -175,5 +176,52 @@ describe("placeFlowerBed", () => {
     expect(state.flowers.flowerBeds["123"].flower?.plantedAt).toBe(
       dateNow - 60000,
     );
+  });
+
+  it("banks boosted work when a flower speed window covered the pre-lift period", () => {
+    const now = Date.now();
+    const plantedAt = now - 180000;
+    const removedAt = now - 120000; // 60s of real growth before the lift
+    const baseDurationMs = 200000;
+    const speed = FLOWER_BOOST_SPEED["Blossom Hourglass"]; // 1.35x
+
+    const state = placeFlowerBed({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "156",
+        type: "flowerBed.placed",
+      },
+      state: {
+        ...TEST_FARM,
+        buildings: {},
+        inventory: { "Flower Bed": new Decimal(3) },
+        collectibles: {
+          "Blossom Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: now - 200000,
+              readyAt: now - 200000,
+            },
+          ],
+        },
+        flowers: {
+          flowerBeds: {
+            "123": {
+              createdAt: now,
+              flower: { name: "Red Pansy", plantedAt, baseDurationMs },
+              removedAt,
+            },
+          },
+          discovered: {},
+        },
+      },
+      createdAt: now,
+    });
+
+    const flower = state.flowers.flowerBeds["123"].flower;
+    const banked = 60000 * speed;
+    expect(flower?.plantedAt).toBe(now);
+    expect(flower?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeFlowerBed.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.ts
@@ -2,6 +2,10 @@ import Decimal from "decimal.js-light";
 import { updateBeehives } from "features/game/lib/updateBeehives";
 import type { FlowerBed, GameState } from "features/game/types/game";
 import { produce } from "immer";
+import {
+  getFlowerBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceFlowerBedAction = {
@@ -50,9 +54,25 @@ export function placeFlowerBed({
       };
 
       if (updatedFlowerBed.flower && updatedFlowerBed.removedAt) {
-        const existingProgress =
-          updatedFlowerBed.removedAt - updatedFlowerBed.flower.plantedAt;
-        updatedFlowerBed.flower.plantedAt = createdAt - existingProgress;
+        const flower = updatedFlowerBed.flower;
+        if (flower.baseDurationMs !== undefined) {
+          // Windowed flower: "pause" growth across the lift. Bank the work
+          // accrued before removal against the current flower boost windows,
+          // then resume the remainder from now (mirrors placePlot). Runs before
+          // updateBeehives below so hive pollination sees the corrected timing.
+          const banked = workAccruedAt({
+            startedAt: flower.plantedAt,
+            at: updatedFlowerBed.removedAt,
+            windows: getFlowerBoostWindows(game),
+          });
+          flower.baseDurationMs = Math.max(flower.baseDurationMs - banked, 0);
+          flower.plantedAt = createdAt;
+        } else {
+          // Legacy flower: back-date plantedAt so the lifted interval doesn't count.
+          const existingProgress =
+            updatedFlowerBed.removedAt - flower.plantedAt;
+          flower.plantedAt = createdAt - existingProgress;
+        }
       }
       delete updatedFlowerBed.removedAt;
 

--- a/src/features/game/events/landExpansion/placeFlowerBed.ts
+++ b/src/features/game/events/landExpansion/placeFlowerBed.ts
@@ -4,7 +4,7 @@ import type { FlowerBed, GameState } from "features/game/types/game";
 import { produce } from "immer";
 import {
   getFlowerBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -54,25 +54,17 @@ export function placeFlowerBed({
       };
 
       if (updatedFlowerBed.flower && updatedFlowerBed.removedAt) {
-        const flower = updatedFlowerBed.flower;
-        if (flower.baseDurationMs !== undefined) {
-          // Windowed flower: "pause" growth across the lift. Bank the work
-          // accrued before removal against the current flower boost windows,
-          // then resume the remainder from now (mirrors placePlot). Runs before
-          // updateBeehives below so hive pollination sees the corrected timing.
-          const banked = workAccruedAt({
-            startedAt: flower.plantedAt,
-            at: updatedFlowerBed.removedAt,
-            windows: getFlowerBoostWindows(game),
-          });
-          flower.baseDurationMs = Math.max(flower.baseDurationMs - banked, 0);
-          flower.plantedAt = createdAt;
-        } else {
-          // Legacy flower: back-date plantedAt so the lifted interval doesn't count.
-          const existingProgress =
-            updatedFlowerBed.removedAt - flower.plantedAt;
-          flower.plantedAt = createdAt - existingProgress;
-        }
+        // Pause growth across the lift (windowed banking or legacy back-date).
+        // Runs before updateBeehives below so hive pollination sees the
+        // corrected timing.
+        updatedFlowerBed.flower.plantedAt = pauseWindowedTimer({
+          timer: updatedFlowerBed.flower,
+          startedAt: updatedFlowerBed.flower.plantedAt,
+          removedAt: updatedFlowerBed.removedAt,
+          createdAt,
+          windows: getFlowerBoostWindows(game),
+          trackProgress: true,
+        });
       }
       delete updatedFlowerBed.removedAt;
 

--- a/src/features/game/events/landExpansion/placeFruitPatch.test.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.test.ts
@@ -219,4 +219,109 @@ describe("placeFruitPatch", () => {
     expect(fruit?.plantedAt).toBe(now);
     expect(fruit?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
+
+  it("banks replenishing-phase boosted work (harvestedAt) for a windowed fruit on lift", () => {
+    const now = Date.now();
+    const plantedAt = now - 600000; // first planted long ago
+    const harvestedAt = now - 180000; // last harvested → replenishing phase active
+    const removedAt = now - 120000; // 60s of replenish before the lift
+    const baseDurationMs = 200000;
+    const speed = FRUIT_BOOST_SPEED["Orchard Hourglass"]; // 1.35x
+
+    const state = placeFruitPatch({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Fruit Patch",
+        type: "fruitPatch.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Fruit Patch": new Decimal(2) },
+        collectibles: {
+          "Orchard Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: now - 200000,
+              readyAt: now - 200000,
+            },
+          ],
+        },
+        fruitPatches: {
+          "123": {
+            createdAt: now,
+            fruit: {
+              name: "Apple",
+              plantedAt,
+              harvestsLeft: 2,
+              harvestedAt,
+              baseDurationMs,
+            },
+            removedAt,
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const fruit = state.fruitPatches["123"].fruit;
+    const banked = 60000 * speed;
+    // Replenishing (harvestedAt > plantedAt): the active phase timestamp is
+    // harvestedAt, so it — not plantedAt — is reset to now.
+    expect(fruit?.harvestedAt).toBe(now);
+    expect(fruit?.plantedAt).toBe(plantedAt);
+    expect(fruit?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
+  });
+
+  it("only banks unboosted work when a fruit boost starts during the lift", () => {
+    const now = Date.now();
+    const plantedAt = now - 180000;
+    const removedAt = now - 120000; // 60s of UNBOOSTED growth before the lift
+    const baseDurationMs = 200000;
+
+    const state = placeFruitPatch({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Fruit Patch",
+        type: "fruitPatch.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Fruit Patch": new Decimal(2) },
+        collectibles: {
+          // Placed AFTER the patch was lifted — must not retro-credit pre-lift growth.
+          "Orchard Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: now - 60000,
+              readyAt: now - 60000,
+            },
+          ],
+        },
+        fruitPatches: {
+          "123": {
+            createdAt: now,
+            fruit: {
+              name: "Apple",
+              plantedAt,
+              harvestsLeft: 3,
+              harvestedAt: 0,
+              baseDurationMs,
+            },
+            removedAt,
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const fruit = state.fruitPatches["123"].fruit;
+    expect(fruit?.plantedAt).toBe(now);
+    expect(fruit?.baseDurationMs).toBe(baseDurationMs - 60000);
+  });
 });

--- a/src/features/game/events/landExpansion/placeFruitPatch.test.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.test.ts
@@ -218,6 +218,8 @@ describe("placeFruitPatch", () => {
     const banked = 60000 * speed;
     expect(fruit?.plantedAt).toBe(now);
     expect(fruit?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
+    // Banked work is retained as boostedTime for the progress bar.
+    expect(fruit?.boostedTime).toBeCloseTo(banked, 5);
   });
 
   it("banks replenishing-phase boosted work (harvestedAt) for a windowed fruit on lift", () => {
@@ -273,6 +275,7 @@ describe("placeFruitPatch", () => {
     expect(fruit?.harvestedAt).toBe(now);
     expect(fruit?.plantedAt).toBe(plantedAt);
     expect(fruit?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
+    expect(fruit?.boostedTime).toBeCloseTo(banked, 5);
   });
 
   it("only banks unboosted work when a fruit boost starts during the lift", () => {

--- a/src/features/game/events/landExpansion/placeFruitPatch.test.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.test.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js-light";
 import { placeFruitPatch } from "./placeFruitPatch";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { FRUIT_BOOST_SPEED } from "features/game/lib/boostWindows";
 
 describe("placeFruitPatch", () => {
   const dateNow = Date.now();
@@ -166,5 +167,56 @@ describe("placeFruitPatch", () => {
       createdAt: dateNow,
     });
     expect(state.fruitPatches["123"].fruit?.harvestedAt).toBe(dateNow - 60000);
+  });
+
+  it("banks boosted work when a fruit speed window covered the pre-lift period", () => {
+    const now = Date.now();
+    const plantedAt = now - 180000;
+    const removedAt = now - 120000; // 60s of real growth before the lift
+    const baseDurationMs = 200000;
+    const speed = FRUIT_BOOST_SPEED["Orchard Hourglass"]; // 1.35x
+
+    const state = placeFruitPatch({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Fruit Patch",
+        type: "fruitPatch.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Fruit Patch": new Decimal(2) },
+        collectibles: {
+          "Orchard Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: now - 200000,
+              readyAt: now - 200000,
+            },
+          ],
+        },
+        fruitPatches: {
+          "123": {
+            createdAt: now,
+            fruit: {
+              name: "Apple",
+              plantedAt,
+              harvestsLeft: 3,
+              harvestedAt: 0,
+              baseDurationMs,
+            },
+            removedAt,
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const fruit = state.fruitPatches["123"].fruit;
+    const banked = 60000 * speed;
+    expect(fruit?.plantedAt).toBe(now);
+    expect(fruit?.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeFruitPatch.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.ts
@@ -5,7 +5,7 @@ import { produce } from "immer";
 import {
   getFruitBoostWindows,
   getTurbofruitMixWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -53,35 +53,25 @@ export function placeFruitPatch({
       };
       if (existingPatch.fruit && existingPatch.removedAt) {
         const fruit = existingPatch.fruit;
-        // HarvestedAt will be greater than plantedAt if the fruit was harvested
+        // HarvestedAt will be greater than plantedAt if the fruit was harvested;
+        // pause the active phase (windowed banking or legacy back-date) and write
+        // the resumed start back to that same phase field.
         const isReplenishing = fruit.harvestedAt > fruit.plantedAt;
-
-        if (fruit.baseDurationMs !== undefined) {
-          // Windowed fruit: "pause" growth/replenish across the lift. Bank the
-          // work accrued before removal against the current fruit boost windows
-          // (+ the patch's Turbofruit Mix), then resume the remainder from now
-          // (mirrors placePlot). The active phase is harvestedAt || plantedAt.
-          const banked = workAccruedAt({
-            startedAt: isReplenishing ? fruit.harvestedAt : fruit.plantedAt,
-            at: existingPatch.removedAt,
-            windows: [
-              ...getFruitBoostWindows(game),
-              ...getTurbofruitMixWindows(existingPatch.fertiliser),
-            ],
-          });
-          fruit.baseDurationMs = Math.max(fruit.baseDurationMs - banked, 0);
-          if (isReplenishing) {
-            fruit.harvestedAt = createdAt;
-          } else {
-            fruit.plantedAt = createdAt;
-          }
-        } else if (isReplenishing) {
-          // Legacy fruit: back-date so the lifted interval doesn't count.
-          const existingProgress = existingPatch.removedAt - fruit.harvestedAt;
-          fruit.harvestedAt = createdAt - existingProgress;
+        const newStart = pauseWindowedTimer({
+          timer: fruit,
+          startedAt: isReplenishing ? fruit.harvestedAt : fruit.plantedAt,
+          removedAt: existingPatch.removedAt,
+          createdAt,
+          windows: [
+            ...getFruitBoostWindows(game),
+            ...getTurbofruitMixWindows(existingPatch.fertiliser),
+          ],
+          trackProgress: true,
+        });
+        if (isReplenishing) {
+          fruit.harvestedAt = newStart;
         } else {
-          const existingProgress = existingPatch.removedAt - fruit.plantedAt;
-          fruit.plantedAt = createdAt - existingProgress;
+          fruit.plantedAt = newStart;
         }
       }
       delete existingPatch.removedAt;

--- a/src/features/game/events/landExpansion/placeFruitPatch.ts
+++ b/src/features/game/events/landExpansion/placeFruitPatch.ts
@@ -2,6 +2,11 @@ import type { FruitPatch, GameState } from "features/game/types/game";
 import type { ResourceName } from "features/game/types/resources";
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
+import {
+  getFruitBoostWindows,
+  getTurbofruitMixWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceFruitPatchAction = {
@@ -47,15 +52,36 @@ export function placeFruitPatch({
         y: action.coordinates.y,
       };
       if (existingPatch.fruit && existingPatch.removedAt) {
+        const fruit = existingPatch.fruit;
         // HarvestedAt will be greater than plantedAt if the fruit was harvested
-        if (existingPatch.fruit.harvestedAt > existingPatch.fruit.plantedAt) {
-          const existingProgress =
-            existingPatch.removedAt - existingPatch.fruit.harvestedAt;
-          existingPatch.fruit.harvestedAt = createdAt - existingProgress;
+        const isReplenishing = fruit.harvestedAt > fruit.plantedAt;
+
+        if (fruit.baseDurationMs !== undefined) {
+          // Windowed fruit: "pause" growth/replenish across the lift. Bank the
+          // work accrued before removal against the current fruit boost windows
+          // (+ the patch's Turbofruit Mix), then resume the remainder from now
+          // (mirrors placePlot). The active phase is harvestedAt || plantedAt.
+          const banked = workAccruedAt({
+            startedAt: isReplenishing ? fruit.harvestedAt : fruit.plantedAt,
+            at: existingPatch.removedAt,
+            windows: [
+              ...getFruitBoostWindows(game),
+              ...getTurbofruitMixWindows(existingPatch.fertiliser),
+            ],
+          });
+          fruit.baseDurationMs = Math.max(fruit.baseDurationMs - banked, 0);
+          if (isReplenishing) {
+            fruit.harvestedAt = createdAt;
+          } else {
+            fruit.plantedAt = createdAt;
+          }
+        } else if (isReplenishing) {
+          // Legacy fruit: back-date so the lifted interval doesn't count.
+          const existingProgress = existingPatch.removedAt - fruit.harvestedAt;
+          fruit.harvestedAt = createdAt - existingProgress;
         } else {
-          const existingProgress =
-            existingPatch.removedAt - existingPatch.fruit.plantedAt;
-          existingPatch.fruit.plantedAt = createdAt - existingProgress;
+          const existingProgress = existingPatch.removedAt - fruit.plantedAt;
+          fruit.plantedAt = createdAt - existingProgress;
         }
       }
       delete existingPatch.removedAt;

--- a/src/features/game/events/landExpansion/placeGold.test.ts
+++ b/src/features/game/events/landExpansion/placeGold.test.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { MINE_BOOST_SPEED } from "features/game/lib/boostWindows";
 import { placeGold } from "./placeGold";
 
 describe("placeGold", () => {
@@ -148,5 +149,50 @@ describe("placeGold", () => {
         y: 2,
       },
     });
+  });
+
+  it("banks boosted work when a mine speed window covered the pre-lift period", () => {
+    const dateNow = Date.now();
+    const minedAt = dateNow - 180000;
+    const removedAt = dateNow - 120000; // 60s of real recovery before the lift
+    const baseDurationMs = 200000;
+    const speed = MINE_BOOST_SPEED["Ore Hourglass"]; // 2x
+
+    const state = placeGold({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Gold Rock",
+        type: "gold.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Gold Rock": new Decimal(2) },
+        collectibles: {
+          "Ore Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: dateNow - 200000,
+              readyAt: dateNow - 200000,
+            },
+          ],
+        },
+        gold: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt, baseDurationMs },
+            removedAt,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.gold["123"].stone;
+    const banked = 60000 * speed;
+    expect(stone.minedAt).toBe(dateNow);
+    expect(stone.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeGold.ts
+++ b/src/features/game/events/landExpansion/placeGold.ts
@@ -12,7 +12,7 @@ import {
 } from "features/game/lib/resourceNodes";
 import {
   getMineBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -57,23 +57,14 @@ export function placeGold({
       };
 
       if (updatedGold.stone && updatedGold.removedAt) {
-        const stone = updatedGold.stone;
-        if (stone.baseDurationMs !== undefined) {
-          // Windowed rock: "pause" recovery across the lift. Bank the work
-          // accrued before removal, then resume the remaining work from now
-          // against the current mine boost windows (mirrors placePlot).
-          const banked = workAccruedAt({
-            startedAt: stone.minedAt,
-            at: updatedGold.removedAt,
-            windows: getMineBoostWindows(game, action.name),
-          });
-          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
-          stone.minedAt = createdAt;
-        } else {
-          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
-          const existingProgress = updatedGold.removedAt - stone.minedAt;
-          stone.minedAt = createdAt - existingProgress;
-        }
+        // Pause recovery across the lift (windowed banking or legacy back-date).
+        updatedGold.stone.minedAt = pauseWindowedTimer({
+          timer: updatedGold.stone,
+          startedAt: updatedGold.stone.minedAt,
+          removedAt: updatedGold.removedAt,
+          createdAt,
+          windows: getMineBoostWindows(game, action.name),
+        });
       }
       delete updatedGold.removedAt;
 

--- a/src/features/game/events/landExpansion/placeGold.ts
+++ b/src/features/game/events/landExpansion/placeGold.ts
@@ -10,6 +10,10 @@ import {
   findExistingUnplacedNode,
   getAvailableNodes,
 } from "features/game/lib/resourceNodes";
+import {
+  getMineBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceGoldAction = {
@@ -53,9 +57,23 @@ export function placeGold({
       };
 
       if (updatedGold.stone && updatedGold.removedAt) {
-        const existingProgress =
-          updatedGold.removedAt - updatedGold.stone.minedAt;
-        updatedGold.stone.minedAt = createdAt - existingProgress;
+        const stone = updatedGold.stone;
+        if (stone.baseDurationMs !== undefined) {
+          // Windowed rock: "pause" recovery across the lift. Bank the work
+          // accrued before removal, then resume the remaining work from now
+          // against the current mine boost windows (mirrors placePlot).
+          const banked = workAccruedAt({
+            startedAt: stone.minedAt,
+            at: updatedGold.removedAt,
+            windows: getMineBoostWindows(game, action.name),
+          });
+          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
+          stone.minedAt = createdAt;
+        } else {
+          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
+          const existingProgress = updatedGold.removedAt - stone.minedAt;
+          stone.minedAt = createdAt - existingProgress;
+        }
       }
       delete updatedGold.removedAt;
 

--- a/src/features/game/events/landExpansion/placeIron.test.ts
+++ b/src/features/game/events/landExpansion/placeIron.test.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { MINE_BOOST_SPEED } from "features/game/lib/boostWindows";
 import { placeIron } from "./placeIron";
 
 describe("placeIron", () => {
@@ -148,5 +149,50 @@ describe("placeIron", () => {
         y: 2,
       },
     });
+  });
+
+  it("banks boosted work when a mine speed window covered the pre-lift period", () => {
+    const dateNow = Date.now();
+    const minedAt = dateNow - 180000;
+    const removedAt = dateNow - 120000; // 60s of real recovery before the lift
+    const baseDurationMs = 200000;
+    const speed = MINE_BOOST_SPEED["Ore Hourglass"]; // 2x
+
+    const state = placeIron({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Iron Rock",
+        type: "iron.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Iron Rock": new Decimal(2) },
+        collectibles: {
+          "Ore Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: dateNow - 200000,
+              readyAt: dateNow - 200000,
+            },
+          ],
+        },
+        iron: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt, baseDurationMs },
+            removedAt,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.iron["123"].stone;
+    const banked = 60000 * speed;
+    expect(stone.minedAt).toBe(dateNow);
+    expect(stone.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeIron.ts
+++ b/src/features/game/events/landExpansion/placeIron.ts
@@ -12,7 +12,7 @@ import {
 } from "features/game/lib/resourceNodes";
 import {
   getMineBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -57,23 +57,14 @@ export function placeIron({
       };
 
       if (updatedIron.stone && updatedIron.removedAt) {
-        const stone = updatedIron.stone;
-        if (stone.baseDurationMs !== undefined) {
-          // Windowed rock: "pause" recovery across the lift. Bank the work
-          // accrued before removal, then resume the remaining work from now
-          // against the current mine boost windows (mirrors placePlot).
-          const banked = workAccruedAt({
-            startedAt: stone.minedAt,
-            at: updatedIron.removedAt,
-            windows: getMineBoostWindows(game, action.name),
-          });
-          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
-          stone.minedAt = createdAt;
-        } else {
-          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
-          const existingProgress = updatedIron.removedAt - stone.minedAt;
-          stone.minedAt = createdAt - existingProgress;
-        }
+        // Pause recovery across the lift (windowed banking or legacy back-date).
+        updatedIron.stone.minedAt = pauseWindowedTimer({
+          timer: updatedIron.stone,
+          startedAt: updatedIron.stone.minedAt,
+          removedAt: updatedIron.removedAt,
+          createdAt,
+          windows: getMineBoostWindows(game, action.name),
+        });
       }
       delete updatedIron.removedAt;
 

--- a/src/features/game/events/landExpansion/placeIron.ts
+++ b/src/features/game/events/landExpansion/placeIron.ts
@@ -10,6 +10,10 @@ import {
   findExistingUnplacedNode,
   getAvailableNodes,
 } from "features/game/lib/resourceNodes";
+import {
+  getMineBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceIronAction = {
@@ -53,9 +57,23 @@ export function placeIron({
       };
 
       if (updatedIron.stone && updatedIron.removedAt) {
-        const existingProgress =
-          updatedIron.removedAt - updatedIron.stone.minedAt;
-        updatedIron.stone.minedAt = createdAt - existingProgress;
+        const stone = updatedIron.stone;
+        if (stone.baseDurationMs !== undefined) {
+          // Windowed rock: "pause" recovery across the lift. Bank the work
+          // accrued before removal, then resume the remaining work from now
+          // against the current mine boost windows (mirrors placePlot).
+          const banked = workAccruedAt({
+            startedAt: stone.minedAt,
+            at: updatedIron.removedAt,
+            windows: getMineBoostWindows(game, action.name),
+          });
+          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
+          stone.minedAt = createdAt;
+        } else {
+          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
+          const existingProgress = updatedIron.removedAt - stone.minedAt;
+          stone.minedAt = createdAt - existingProgress;
+        }
       }
       delete updatedIron.removedAt;
 

--- a/src/features/game/events/landExpansion/placePlot.ts
+++ b/src/features/game/events/landExpansion/placePlot.ts
@@ -6,7 +6,7 @@ import type { Coordinates } from "features/game/expansion/components/MapPlacemen
 import {
   getCropFertiliserWindows,
   getCropPlotBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 
 export type PlacePlotAction = {
@@ -51,30 +51,19 @@ export function placePlot({
       };
 
       if (updatedPlot.crop && updatedPlot.removedAt) {
-        const crop = updatedPlot.crop;
-
-        if (crop.baseDurationMs !== undefined) {
-          // Windowed crop: "pause" growth across the lift. Bank the work accrued
-          // before removal (already done, so it isn't redone), then resume the
-          // remaining work from now against the current windows. `boostedTime`
-          // keeps the pre-lift progress for the growth bar; `baseDurationMs`
-          // holds the remaining work that still has to accrue.
-          const banked = workAccruedAt({
-            startedAt: crop.plantedAt,
-            at: updatedPlot.removedAt,
-            windows: [
-              ...getCropPlotBoostWindows(game),
-              ...getCropFertiliserWindows(updatedPlot.fertiliser),
-            ],
-          });
-          crop.baseDurationMs = Math.max(crop.baseDurationMs - banked, 0);
-          crop.boostedTime = (crop.boostedTime ?? 0) + banked;
-          crop.plantedAt = createdAt;
-        } else {
-          // Legacy crop: back-date plantedAt so the lifted interval doesn't count.
-          const existingProgress = updatedPlot.removedAt - crop.plantedAt;
-          crop.plantedAt = createdAt - existingProgress;
-        }
+        // Pause growth across the lift (windowed banking or legacy back-date).
+        // trackProgress banks the pre-lift work into boostedTime for the growth bar.
+        updatedPlot.crop.plantedAt = pauseWindowedTimer({
+          timer: updatedPlot.crop,
+          startedAt: updatedPlot.crop.plantedAt,
+          removedAt: updatedPlot.removedAt,
+          createdAt,
+          windows: [
+            ...getCropPlotBoostWindows(game),
+            ...getCropFertiliserWindows(updatedPlot.fertiliser),
+          ],
+          trackProgress: true,
+        });
       }
       delete updatedPlot.removedAt;
 

--- a/src/features/game/events/landExpansion/placeStone.test.ts
+++ b/src/features/game/events/landExpansion/placeStone.test.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { MINE_BOOST_SPEED } from "features/game/lib/boostWindows";
 import { placeStone } from "./placeStone";
 
 describe("placeStone", () => {
@@ -149,5 +150,98 @@ describe("placeStone", () => {
         y: 2,
       },
     });
+  });
+
+  it("banks boosted work when a mine speed window covered the pre-lift period", () => {
+    const dateNow = Date.now();
+    const minedAt = dateNow - 180000;
+    const removedAt = dateNow - 120000; // 60s of real recovery before the lift
+    const baseDurationMs = 200000;
+    const speed = MINE_BOOST_SPEED["Ore Hourglass"]; // 2x
+
+    const state = placeStone({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Stone Rock",
+        type: "stone.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Stone Rock": new Decimal(2) },
+        collectibles: {
+          // Placed before the rock was mined, so its window covers the whole pre-lift period.
+          "Ore Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: dateNow - 200000,
+              readyAt: dateNow - 200000,
+            },
+          ],
+        },
+        stones: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt, baseDurationMs },
+            removedAt,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.stones["123"].stone;
+    const banked = 60000 * speed; // 60s of real time at 2x = 120000ms of work
+    // Recovery resumes from the replace time; the boost credit earned before the
+    // lift is banked, so far more than the 60s wall-clock is subtracted.
+    expect(stone.minedAt).toBe(dateNow);
+    expect(stone.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
+  });
+
+  it("does not credit a mine boost that was only added during the lift", () => {
+    const dateNow = Date.now();
+    const minedAt = dateNow - 180000;
+    const removedAt = dateNow - 120000; // 60s of UNBOOSTED recovery before the lift
+    const baseDurationMs = 200000;
+
+    const state = placeStone({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        name: "Stone Rock",
+        type: "stone.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Stone Rock": new Decimal(2) },
+        collectibles: {
+          // Placed AFTER the rock was lifted — must not retro-credit pre-lift recovery.
+          "Ore Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: dateNow - 60000,
+              readyAt: dateNow - 60000,
+            },
+          ],
+        },
+        stones: {
+          "123": {
+            createdAt: dateNow,
+            stone: { minedAt, baseDurationMs },
+            removedAt,
+          },
+        },
+      },
+      createdAt: dateNow,
+    });
+
+    const stone = state.stones["123"].stone;
+    // 60s of pre-lift recovery accrued at 1x (no boost then): exactly 60000 banked.
+    expect(stone.minedAt).toBe(dateNow);
+    expect(stone.baseDurationMs).toBe(baseDurationMs - 60000);
   });
 });

--- a/src/features/game/events/landExpansion/placeStone.ts
+++ b/src/features/game/events/landExpansion/placeStone.ts
@@ -12,7 +12,7 @@ import {
 } from "features/game/lib/resourceNodes";
 import {
   getMineBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -57,23 +57,14 @@ export function placeStone({
       };
 
       if (updatedStone.stone && updatedStone.removedAt) {
-        const stone = updatedStone.stone;
-        if (stone.baseDurationMs !== undefined) {
-          // Windowed rock: "pause" recovery across the lift. Bank the work
-          // accrued before removal, then resume the remaining work from now
-          // against the current mine boost windows (mirrors placePlot).
-          const banked = workAccruedAt({
-            startedAt: stone.minedAt,
-            at: updatedStone.removedAt,
-            windows: getMineBoostWindows(game, action.name),
-          });
-          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
-          stone.minedAt = createdAt;
-        } else {
-          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
-          const existingProgress = updatedStone.removedAt - stone.minedAt;
-          stone.minedAt = createdAt - existingProgress;
-        }
+        // Pause recovery across the lift (windowed banking or legacy back-date).
+        updatedStone.stone.minedAt = pauseWindowedTimer({
+          timer: updatedStone.stone,
+          startedAt: updatedStone.stone.minedAt,
+          removedAt: updatedStone.removedAt,
+          createdAt,
+          windows: getMineBoostWindows(game, action.name),
+        });
       }
       delete updatedStone.removedAt;
 

--- a/src/features/game/events/landExpansion/placeStone.ts
+++ b/src/features/game/events/landExpansion/placeStone.ts
@@ -10,6 +10,10 @@ import {
   findExistingUnplacedNode,
   getAvailableNodes,
 } from "features/game/lib/resourceNodes";
+import {
+  getMineBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceStoneAction = {
@@ -53,9 +57,23 @@ export function placeStone({
       };
 
       if (updatedStone.stone && updatedStone.removedAt) {
-        const existingProgress =
-          updatedStone.removedAt - updatedStone.stone.minedAt;
-        updatedStone.stone.minedAt = createdAt - existingProgress;
+        const stone = updatedStone.stone;
+        if (stone.baseDurationMs !== undefined) {
+          // Windowed rock: "pause" recovery across the lift. Bank the work
+          // accrued before removal, then resume the remaining work from now
+          // against the current mine boost windows (mirrors placePlot).
+          const banked = workAccruedAt({
+            startedAt: stone.minedAt,
+            at: updatedStone.removedAt,
+            windows: getMineBoostWindows(game, action.name),
+          });
+          stone.baseDurationMs = Math.max(stone.baseDurationMs - banked, 0);
+          stone.minedAt = createdAt;
+        } else {
+          // Legacy rock: back-date minedAt so the lifted interval doesn't count.
+          const existingProgress = updatedStone.removedAt - stone.minedAt;
+          stone.minedAt = createdAt - existingProgress;
+        }
       }
       delete updatedStone.removedAt;
 

--- a/src/features/game/events/landExpansion/placeTree.test.ts
+++ b/src/features/game/events/landExpansion/placeTree.test.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js-light";
 import { INITIAL_FARM } from "features/game/lib/constants";
+import { TREE_BOOST_SPEED } from "features/game/lib/boostWindows";
 import { placeTree } from "./placeTree";
 
 describe("placeTree", () => {
@@ -154,5 +155,50 @@ describe("placeTree", () => {
         y: 2,
       },
     });
+  });
+
+  it("banks boosted work when a tree speed window covered the pre-lift period", () => {
+    const now = Date.now();
+    const choppedAt = now - 180000;
+    const removedAt = now - 120000; // 60s of real recovery before the lift
+    const baseDurationMs = 200000;
+    const speed = TREE_BOOST_SPEED["Timber Hourglass"]; // 1.35x
+
+    const state = placeTree({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "156",
+        name: "Tree",
+        type: "tree.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { Tree: new Decimal(2) },
+        collectibles: {
+          "Timber Hourglass": [
+            {
+              id: "hg",
+              coordinates: { x: 5, y: 5 },
+              createdAt: now - 200000,
+              readyAt: now - 200000,
+            },
+          ],
+        },
+        trees: {
+          "123": {
+            createdAt: now,
+            wood: { choppedAt, baseDurationMs },
+            removedAt,
+          },
+        },
+      },
+      createdAt: now,
+    });
+
+    const wood = state.trees["123"].wood;
+    const banked = 60000 * speed;
+    expect(wood.choppedAt).toBe(now);
+    expect(wood.baseDurationMs).toBeCloseTo(baseDurationMs - banked, 5);
   });
 });

--- a/src/features/game/events/landExpansion/placeTree.ts
+++ b/src/features/game/events/landExpansion/placeTree.ts
@@ -10,6 +10,10 @@ import {
   findExistingUnplacedNode,
   getAvailableNodes,
 } from "features/game/lib/resourceNodes";
+import {
+  getTreeBoostWindows,
+  workAccruedAt,
+} from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
 export type PlaceTreeAction = {
@@ -53,9 +57,23 @@ export function placeTree({
       };
 
       if (updatedTree.wood && updatedTree.removedAt) {
-        const existingProgress =
-          updatedTree.removedAt - updatedTree.wood.choppedAt;
-        updatedTree.wood.choppedAt = createdAt - existingProgress;
+        const wood = updatedTree.wood;
+        if (wood.baseDurationMs !== undefined) {
+          // Windowed tree: "pause" recovery across the lift. Bank the work
+          // accrued before removal, then resume the remaining work from now
+          // against the current tree boost windows (mirrors placePlot).
+          const banked = workAccruedAt({
+            startedAt: wood.choppedAt,
+            at: updatedTree.removedAt,
+            windows: getTreeBoostWindows(game),
+          });
+          wood.baseDurationMs = Math.max(wood.baseDurationMs - banked, 0);
+          wood.choppedAt = createdAt;
+        } else {
+          // Legacy tree: back-date choppedAt so the lifted interval doesn't count.
+          const existingProgress = updatedTree.removedAt - wood.choppedAt;
+          wood.choppedAt = createdAt - existingProgress;
+        }
       }
       delete updatedTree.removedAt;
 

--- a/src/features/game/events/landExpansion/placeTree.ts
+++ b/src/features/game/events/landExpansion/placeTree.ts
@@ -12,7 +12,7 @@ import {
 } from "features/game/lib/resourceNodes";
 import {
   getTreeBoostWindows,
-  workAccruedAt,
+  pauseWindowedTimer,
 } from "features/game/lib/boostWindows";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
 
@@ -57,23 +57,14 @@ export function placeTree({
       };
 
       if (updatedTree.wood && updatedTree.removedAt) {
-        const wood = updatedTree.wood;
-        if (wood.baseDurationMs !== undefined) {
-          // Windowed tree: "pause" recovery across the lift. Bank the work
-          // accrued before removal, then resume the remaining work from now
-          // against the current tree boost windows (mirrors placePlot).
-          const banked = workAccruedAt({
-            startedAt: wood.choppedAt,
-            at: updatedTree.removedAt,
-            windows: getTreeBoostWindows(game),
-          });
-          wood.baseDurationMs = Math.max(wood.baseDurationMs - banked, 0);
-          wood.choppedAt = createdAt;
-        } else {
-          // Legacy tree: back-date choppedAt so the lifted interval doesn't count.
-          const existingProgress = updatedTree.removedAt - wood.choppedAt;
-          wood.choppedAt = createdAt - existingProgress;
-        }
+        // Pause recovery across the lift (windowed banking or legacy back-date).
+        updatedTree.wood.choppedAt = pauseWindowedTimer({
+          timer: updatedTree.wood,
+          startedAt: updatedTree.wood.choppedAt,
+          removedAt: updatedTree.removedAt,
+          createdAt,
+          windows: getTreeBoostWindows(game),
+        });
       }
       delete updatedTree.removedAt;
 

--- a/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
@@ -153,6 +153,7 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
     resource.minesLeft,
     resource.stone.minedAt,
     now,
+    readyAt,
   );
 
   // For windowed rocks the remaining time is remaining *work* (in base
@@ -271,6 +272,7 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
             minesLeft={resource.minesLeft}
             minedAt={resource.stone.minedAt}
             now={now}
+            readyAt={readyAt}
           />
         </div>
       )}
@@ -282,6 +284,7 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
           minesLeft={resource.minesLeft}
           now={now}
           minedAt={resource.stone.minedAt}
+          readyAt={readyAt}
         />
       )}
 
@@ -292,6 +295,7 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
           minesLeft={resource.minesLeft}
           now={now}
           minedAt={resource.stone.minedAt}
+          readyAt={readyAt}
           speed={speed}
         />
       )}

--- a/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
@@ -149,12 +149,7 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
   const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
   const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
 
-  const crimstoneStage = getCrimstoneStage(
-    resource.minesLeft,
-    resource.stone.minedAt,
-    now,
-    readyAt,
-  );
+  const crimstoneStage = getCrimstoneStage(resource.minesLeft, now, readyAt);
 
   // For windowed rocks the remaining time is remaining *work* (in base
   // duration), so it visibly ticks down faster while a boost window is active.
@@ -270,7 +265,6 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
             hasTool={hasTool}
             touchCount={touchCount}
             minesLeft={resource.minesLeft}
-            minedAt={resource.stone.minedAt}
             now={now}
             readyAt={readyAt}
           />
@@ -283,7 +277,6 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
           resourceAmount={harvested.current}
           minesLeft={resource.minesLeft}
           now={now}
-          minedAt={resource.stone.minedAt}
           readyAt={readyAt}
         />
       )}
@@ -294,7 +287,6 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
           timeLeft={timeLeft}
           minesLeft={resource.minesLeft}
           now={now}
-          minedAt={resource.stone.minedAt}
           readyAt={readyAt}
           speed={speed}
         />

--- a/src/features/game/expansion/components/resources/crimstone/components/DepletedCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/DepletedCrimstone.tsx
@@ -16,6 +16,7 @@ interface Props {
   minesLeft: number;
   minedAt: number;
   now: number;
+  readyAt: number;
   /**
    * Current effective recovery speed from windowed boosts (e.g. Mole Shrine).
    * > 1 shows a lightning marker + the multiplier in the popover.
@@ -29,6 +30,7 @@ const DepletedCrimstoneComponent: React.FC<Props> = ({
   minedAt,
   speed,
   now,
+  readyAt,
 }) => {
   const { t } = useAppTranslation();
   const [showTimeLeft, setShowTimeLeft] = useState(false);
@@ -41,7 +43,7 @@ const DepletedCrimstoneComponent: React.FC<Props> = ({
     crimstone_4,
     crimstone_5,
     crimstone_6,
-  ][getCrimstoneStage(minesLeft, minedAt, now) - 1];
+  ][getCrimstoneStage(minesLeft, minedAt, now, readyAt) - 1];
 
   return (
     <div

--- a/src/features/game/expansion/components/resources/crimstone/components/DepletedCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/DepletedCrimstone.tsx
@@ -14,7 +14,6 @@ import { SUNNYSIDE } from "assets/sunnyside";
 interface Props {
   timeLeft: number;
   minesLeft: number;
-  minedAt: number;
   now: number;
   readyAt: number;
   /**
@@ -27,7 +26,6 @@ interface Props {
 const DepletedCrimstoneComponent: React.FC<Props> = ({
   timeLeft,
   minesLeft,
-  minedAt,
   speed,
   now,
   readyAt,
@@ -43,7 +41,7 @@ const DepletedCrimstoneComponent: React.FC<Props> = ({
     crimstone_4,
     crimstone_5,
     crimstone_6,
-  ][getCrimstoneStage(minesLeft, minedAt, now, readyAt) - 1];
+  ][getCrimstoneStage(minesLeft, now, readyAt) - 1];
 
   return (
     <div

--- a/src/features/game/expansion/components/resources/crimstone/components/DepletingCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/DepletingCrimstone.tsx
@@ -17,6 +17,7 @@ interface Props {
   minesLeft: number;
   minedAt: number;
   now: number;
+  readyAt: number;
 }
 
 const DepletingCrimstoneComponent: React.FC<Props> = ({
@@ -24,13 +25,14 @@ const DepletingCrimstoneComponent: React.FC<Props> = ({
   minesLeft,
   minedAt,
   now,
+  readyAt,
 }) => {
   const { scale } = useContext(ZoomContext);
   const [playing, setPlaying] = useState(false);
   const sparkGif = useRef<SpriteSheetInstance>(undefined);
 
   const getDropSheet = () => {
-    if (getCrimstoneStage(minesLeft, minedAt, now) === 6) {
+    if (getCrimstoneStage(minesLeft, minedAt, now, readyAt) === 6) {
       return dropSheet2;
     }
     return dropSheet1;

--- a/src/features/game/expansion/components/resources/crimstone/components/DepletingCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/DepletingCrimstone.tsx
@@ -15,7 +15,6 @@ const DROP_SHEET_FRAME_HEIGHT = 48;
 interface Props {
   resourceAmount?: number;
   minesLeft: number;
-  minedAt: number;
   now: number;
   readyAt: number;
 }
@@ -23,7 +22,6 @@ interface Props {
 const DepletingCrimstoneComponent: React.FC<Props> = ({
   resourceAmount,
   minesLeft,
-  minedAt,
   now,
   readyAt,
 }) => {
@@ -32,7 +30,7 @@ const DepletingCrimstoneComponent: React.FC<Props> = ({
   const sparkGif = useRef<SpriteSheetInstance>(undefined);
 
   const getDropSheet = () => {
-    if (getCrimstoneStage(minesLeft, minedAt, now, readyAt) === 6) {
+    if (getCrimstoneStage(minesLeft, now, readyAt) === 6) {
       return dropSheet2;
     }
     return dropSheet1;

--- a/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
@@ -31,7 +31,6 @@ interface Props {
   hasTool: boolean;
   touchCount: number;
   minesLeft: number;
-  minedAt: number;
   now: number;
   readyAt: number;
 }
@@ -40,7 +39,6 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
   hasTool,
   touchCount,
   minesLeft,
-  minedAt,
   now,
   readyAt,
 }) => {
@@ -65,7 +63,7 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
     crimstone_3,
     crimstone_4,
     crimstone_5,
-  ][getCrimstoneStage(minesLeft, minedAt, now, readyAt) - 1];
+  ][getCrimstoneStage(minesLeft, now, readyAt) - 1];
 
   useEffect(() => {
     if (touchCount > 0) {

--- a/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/components/RecoveredCrimstone.tsx
@@ -33,6 +33,7 @@ interface Props {
   minesLeft: number;
   minedAt: number;
   now: number;
+  readyAt: number;
 }
 
 const RecoveredCrimstoneComponent: React.FC<Props> = ({
@@ -41,6 +42,7 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
   minesLeft,
   minedAt,
   now,
+  readyAt,
 }) => {
   const { scale } = useContext(ZoomContext);
   const [showEquipTool, setShowEquipTool] = useState(false);
@@ -63,7 +65,7 @@ const RecoveredCrimstoneComponent: React.FC<Props> = ({
     crimstone_3,
     crimstone_4,
     crimstone_5,
-  ][getCrimstoneStage(minesLeft, minedAt, now) - 1];
+  ][getCrimstoneStage(minesLeft, minedAt, now, readyAt) - 1];
 
   useEffect(() => {
     if (touchCount > 0) {

--- a/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.test.ts
+++ b/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.test.ts
@@ -1,0 +1,42 @@
+import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
+import { getCrimstoneStage } from "./getCrimstoneStage";
+
+describe("getCrimstoneStage", () => {
+  const recovery = CRIMSTONE_RECOVERY_TIME * 1000;
+  const minedAt = 1_000_000;
+
+  it("returns a valid recovered stage (not 6) for a boosted rock that recovered early", () => {
+    // A Mole Shrine pulled readyAt earlier than the base recovery.
+    const readyAt = minedAt + recovery / 2;
+    const now = readyAt + 1; // recovered, but still within the base recovery window
+
+    // now - minedAt < base recovery, so the old constant-based check returned 6
+    // and over-indexed the Recovered view's 5-frame sprite array.
+    expect(now - minedAt).toBeLessThan(recovery);
+    expect(getCrimstoneStage(5, minedAt, now, readyAt)).toBe(1);
+  });
+
+  it("returns stage 6 while a fresh rock is still recovering", () => {
+    const readyAt = minedAt + recovery;
+    const now = minedAt + 1; // not ready yet
+
+    expect(getCrimstoneStage(5, minedAt, now, readyAt)).toBe(6);
+  });
+
+  it("matches legacy behaviour when readyAt === minedAt + base recovery", () => {
+    const readyAt = minedAt + recovery;
+
+    expect(getCrimstoneStage(5, minedAt, readyAt - 1, readyAt)).toBe(6); // recovering
+    expect(getCrimstoneStage(5, minedAt, readyAt + 1, readyAt)).toBe(1); // recovered
+  });
+
+  it("maps intermediate minesLeft to stages 2-5", () => {
+    const readyAt = minedAt + recovery;
+    const now = minedAt + 1;
+
+    expect(getCrimstoneStage(4, minedAt, now, readyAt)).toBe(2);
+    expect(getCrimstoneStage(3, minedAt, now, readyAt)).toBe(3);
+    expect(getCrimstoneStage(2, minedAt, now, readyAt)).toBe(4);
+    expect(getCrimstoneStage(1, minedAt, now, readyAt)).toBe(5);
+  });
+});

--- a/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.test.ts
+++ b/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.test.ts
@@ -13,30 +13,41 @@ describe("getCrimstoneStage", () => {
     // now - minedAt < base recovery, so the old constant-based check returned 6
     // and over-indexed the Recovered view's 5-frame sprite array.
     expect(now - minedAt).toBeLessThan(recovery);
-    expect(getCrimstoneStage(5, minedAt, now, readyAt)).toBe(1);
+    expect(getCrimstoneStage(5, now, readyAt)).toBe(1);
   });
 
   it("returns stage 6 while a fresh rock is still recovering", () => {
     const readyAt = minedAt + recovery;
     const now = minedAt + 1; // not ready yet
 
-    expect(getCrimstoneStage(5, minedAt, now, readyAt)).toBe(6);
+    expect(getCrimstoneStage(5, now, readyAt)).toBe(6);
   });
 
   it("matches legacy behaviour when readyAt === minedAt + base recovery", () => {
     const readyAt = minedAt + recovery;
 
-    expect(getCrimstoneStage(5, minedAt, readyAt - 1, readyAt)).toBe(6); // recovering
-    expect(getCrimstoneStage(5, minedAt, readyAt + 1, readyAt)).toBe(1); // recovered
+    expect(getCrimstoneStage(5, readyAt - 1, readyAt)).toBe(6); // recovering
+    expect(getCrimstoneStage(5, readyAt + 1, readyAt)).toBe(1); // recovered
   });
 
   it("maps intermediate minesLeft to stages 2-5", () => {
     const readyAt = minedAt + recovery;
     const now = minedAt + 1;
 
-    expect(getCrimstoneStage(4, minedAt, now, readyAt)).toBe(2);
-    expect(getCrimstoneStage(3, minedAt, now, readyAt)).toBe(3);
-    expect(getCrimstoneStage(2, minedAt, now, readyAt)).toBe(4);
-    expect(getCrimstoneStage(1, minedAt, now, readyAt)).toBe(5);
+    expect(getCrimstoneStage(4, now, readyAt)).toBe(2);
+    expect(getCrimstoneStage(3, now, readyAt)).toBe(3);
+    expect(getCrimstoneStage(2, now, readyAt)).toBe(4);
+    expect(getCrimstoneStage(1, now, readyAt)).toBe(5);
+  });
+
+  it("resets to stage 1 24h after the actual (windowed) ready time", () => {
+    const dayMs = 24 * 60 * 60 * 1000;
+    // Boosted rock: recovered early (readyAt well before minedAt + base recovery).
+    const readyAt = minedAt + recovery / 2;
+
+    // Just before 24h after the actual readyAt: not reset yet (normal stage).
+    expect(getCrimstoneStage(4, readyAt + dayMs - 1, readyAt)).toBe(2);
+    // Past 24h after the actual readyAt: fully reset to stage 1.
+    expect(getCrimstoneStage(4, readyAt + dayMs + 1, readyAt)).toBe(1);
   });
 });

--- a/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.ts
+++ b/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.ts
@@ -1,5 +1,3 @@
-import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
-
 /**
  * Visual depletion stage (1-6) for a crimstone, derived from minesLeft + whether
  * it is still recovering. `now` and `readyAt` are passed in (from the component
@@ -18,12 +16,15 @@ import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
  */
 export const getCrimstoneStage = (
   minesLeft: number,
-  minedAt: number,
   now: number,
   readyAt: number,
 ) => {
-  const timeToReset = (CRIMSTONE_RECOVERY_TIME + 24 * 60 * 60) * 1000;
-  if (now - minedAt > timeToReset) {
+  // Long after it became ready the rock fully resets to a fresh stage 1. Anchor
+  // this off the actual (windowed) readyAt rather than `minedAt + base recovery`,
+  // so a boosted rock resets 24h after it truly recovered (legacy:
+  // readyAt === minedAt + base recovery, so behaviour is unchanged).
+  const timeToReset = readyAt + 24 * 60 * 60 * 1000;
+  if (now > timeToReset) {
     return 1;
   }
 

--- a/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.ts
+++ b/src/features/game/expansion/components/resources/crimstone/getCrimstoneStage.ts
@@ -1,9 +1,16 @@
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 
 /**
- * Visual depletion stage (1-6) for a crimstone, derived from minesLeft + how long
- * it has been recovering. `now` is passed in (from the component clock) so this
- * stays a pure helper — no `Date.now()` in the render path.
+ * Visual depletion stage (1-6) for a crimstone, derived from minesLeft + whether
+ * it is still recovering. `now` and `readyAt` are passed in (from the component
+ * clock / live windowed ready time) so this stays a pure helper — no `Date.now()`
+ * in the render path.
+ *
+ * `readyAt` is the ACTUAL (windowed) ready time, not `minedAt + base recovery`: a
+ * boosted rock (e.g. Mole Shrine) recovers early, so keying the freshly-mined
+ * stage 6 off `now < readyAt` keeps the Recovered view from ever requesting stage
+ * 6 and over-indexing its 5-frame sprite array. For legacy rocks
+ * `readyAt === minedAt + base recovery`, so behaviour is unchanged.
  *
  * Kept in its own leaf module (rather than in Crimstone.tsx) to avoid an import
  * cycle: Crimstone.tsx imports its Recovered/Depleting/Depleted children, and each
@@ -13,14 +20,14 @@ export const getCrimstoneStage = (
   minesLeft: number,
   minedAt: number,
   now: number,
+  readyAt: number,
 ) => {
   const timeToReset = (CRIMSTONE_RECOVERY_TIME + 24 * 60 * 60) * 1000;
   if (now - minedAt > timeToReset) {
     return 1;
   }
 
-  if (minesLeft === 5 && now - minedAt < CRIMSTONE_RECOVERY_TIME * 1000)
-    return 6;
+  if (minesLeft === 5 && now < readyAt) return 6;
   if (minesLeft === 5) return 1;
   if (minesLeft === 4) return 2;
   if (minesLeft === 3) return 3;

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -708,3 +708,53 @@ export function workAccruedAt({
 
   return work;
 }
+
+/**
+ * "Pause" a resource-node timer across a landscaping lift and return the new
+ * start timestamp the caller should write back to the node's phase field
+ * (minedAt / choppedAt / plantedAt / harvestedAt).
+ *
+ * - Windowed node (`timer.baseDurationMs` set): bank the work accrued before
+ *   removal against `windows` and shrink `baseDurationMs` in place (mutates
+ *   `timer`), then resume from `createdAt` — so the lifted interval is excluded
+ *   and boost credit earned before the lift is neither lost nor re-applied over
+ *   a different part of the windows.
+ * - Legacy node (no `baseDurationMs`): back-date the start so the lifted
+ *   interval doesn't count (wall-clock elapsed === work when unboosted).
+ *
+ * The caller owns which field is the start timestamp (and, for multi-phase fruit,
+ * which phase is active), so it passes `startedAt` and writes the returned value
+ * back to that same field. `trackProgress` additionally banks the accrued work
+ * into `timer.boostedTime` for the growth bar — used by the crop / greenhouse
+ * plant handlers, which carry that field; resource nodes omit it. Shared by every
+ * resource place handler to keep the bank/shrink/back-date logic in one place.
+ */
+export function pauseWindowedTimer({
+  timer,
+  startedAt,
+  removedAt,
+  createdAt,
+  windows,
+  trackProgress = false,
+}: {
+  timer: { baseDurationMs?: number; boostedTime?: number };
+  startedAt: number;
+  removedAt: number;
+  createdAt: number;
+  windows: BoostWindow[];
+  trackProgress?: boolean;
+}): number {
+  if (timer.baseDurationMs === undefined) {
+    return createdAt - (removedAt - startedAt);
+  }
+
+  const banked = Math.min(
+    workAccruedAt({ startedAt, at: removedAt, windows }),
+    timer.baseDurationMs,
+  );
+  timer.baseDurationMs -= banked;
+  if (trackProgress) {
+    timer.boostedTime = (timer.boostedTime ?? 0) + banked;
+  }
+  return createdAt;
+}

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -800,6 +800,14 @@ export type PlantedFruit = {
   criticalHit?: CriticalHit;
   amount?: number;
   /**
+   * Work (ms) banked when the patch was lifted mid-grow/replenish (windowed
+   * fruit freeze accrued WORK, not wall-clock progress, while the patch sits in
+   * inventory). Display-only: the patch UI folds it into the progress bar;
+   * readiness ignores it — the banked work is already subtracted from
+   * `baseDurationMs`. Reset when a new phase begins (harvest → replenish).
+   */
+  boostedTime?: number;
+  /**
    * Unboosted-by-windowed-collectibles grow/replenish duration (ms), with all
    * permanent (discount-at-start) boosts already folded in. Present only on
    * fruit planted/harvested under the speed-rate model; its presence — NOT the
@@ -1755,6 +1763,14 @@ export type PlantedFlower = {
   reward?: Reward;
   criticalHit?: CriticalHit;
   amount?: number;
+  /**
+   * Work (ms) banked when the flower bed was lifted mid-grow (windowed flowers
+   * freeze accrued WORK, not wall-clock progress, while the bed sits in
+   * inventory). Display-only: the bed UI folds it into the progress bar;
+   * readiness ignores it — the banked work is already subtracted from
+   * `baseDurationMs`. Flowers are one-shot, so it never needs resetting.
+   */
+  boostedTime?: number;
   /**
    * Unboosted-by-windowed-collectibles grow duration (ms), with all permanent
    * (discount-at-start) boosts already folded in. Present only on flowers planted

--- a/src/features/island/flowers/FlowerBed.tsx
+++ b/src/features/island/flowers/FlowerBed.tsx
@@ -231,8 +231,12 @@ const Flower: React.FC<{ flower: PlantedFlower; id: string }> = ({
           0,
         )
       : Math.max((readyAt - now) / 1000, 0);
+  // Fold pre-lift banked work into the denominator so the progress bar retains
+  // its fill across a landscaping lift instead of snapping backward.
   const totalSeconds =
-    baseDurationMs !== undefined ? baseDurationMs / 1000 : growSeconds;
+    baseDurationMs !== undefined
+      ? (baseDurationMs + (flower.boostedTime ?? 0)) / 1000
+      : growSeconds;
   // Guard the zero-duration case (an insta-grown windowed flower has
   // baseDurationMs === 0): 0 / 0 would be NaN, which makes getGrowthStage fall
   // through to "sprout" for a flower that is actually ready.

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -42,8 +42,14 @@ const getFruitTreeStatus = (
   // No fruits planted
   if (!plantedFruit) return { stage: "Empty" };
 
-  const { name, harvestsLeft, harvestedAt, plantedAt, baseDurationMs } =
-    plantedFruit;
+  const {
+    name,
+    harvestsLeft,
+    harvestedAt,
+    plantedAt,
+    baseDurationMs,
+    boostedTime,
+  } = plantedFruit;
 
   // Dead tree/bush
   if (!harvestsLeft) return { stage: "Dead" };
@@ -64,7 +70,9 @@ const getFruitTreeStatus = (
     // so it ticks down faster while a boost window is active.
     const workDoneMs = workAccruedAt({ startedAt, at: now, windows });
     timeLeft = Math.max((baseDurationMs - workDoneMs) / 1000, 0);
-    totalSeconds = baseDurationMs / 1000;
+    // Fold pre-lift banked work into the denominator so the progress bar retains
+    // its fill across a landscaping lift instead of snapping backward.
+    totalSeconds = (baseDurationMs + (boostedTime ?? 0)) / 1000;
   } else {
     timeLeft = Math.max((startedAt + plantSeconds * 1000 - now) / 1000, 0);
     totalSeconds = plantSeconds;


### PR DESCRIPTION
## Summary

Fixes a set of regressions found in a full audit of the merged `SPEED_BOOSTS` windowed-timer change set, plus a follow-up refactor and a progress-bar fix. All windowed behaviour is gated by the `baseDurationMs` marker (windowed nodes only); legacy nodes are unaffected. Mirrored on the backend (sunflower-land-api#3464).

### Correctness fixes
1. **Node remove/replace pause (the systemic one).** Only `placePlot` banked accrued work when a growing node was lifted to inventory and re-placed during landscaping. The stone/iron/gold/crimstone/tree/fruit-patch/flower-bed handlers still used the legacy wall-clock back-date and then replayed the full `baseDurationMs` against the *current* boost windows — so a boosted node finished **too late** (lost boost credit, up to ~6h on a 24h Crimstone) or **too early** (boost credited over growth that predated the boost). Now they mirror `placePlot` (bank `workAccruedAt`, shrink `baseDurationMs`, reset the start timestamp). Sunstone/Ascension Crystal have no boost windows and are left on the exact back-date.
2. **insta-grow flower honey loss.** The windowed branch zeroed `baseDurationMs` but left `plantedAt` in the past, so `readyAt` collapsed to the past and `updateBeehives` clamped all honey accrued since attachment to zero. Now also anchors `plantedAt = createdAt`.
3. **"Harvest All" ignored crop fertiliser.** `getCropsToHarvest` didn't forward `plot.fertiliser`, so Rapid Root / Sproutroot crops weren't bulk-harvestable until their un-boosted (up to 2× longer) time.
4. **Recovered Crimstone sprite.** `getCrimstoneStage` gated the freshly-mined stage 6 (and the 24h full-reset) on the base recovery constant, so a rock recovered early by a Mole Shrine over-indexed `RecoveredCrimstone`'s 5-frame array (broken sprite). Now keyed off the live windowed `readyAt` (identical for legacy rocks).

### Refactor
5. **Extract `pauseWindowedTimer`.** The bank/shrink/reset (or legacy back-date) sequence was duplicated across all nine place handlers. Centralised into one helper in `boostWindows`; `placePlot` and `placeBuilding` (greenhouse move) use its `trackProgress` flag to also bank into `boostedTime` for the growth bar. Behaviour-preserving.

### Progress-bar fix
6. **Retain the fruit/flower progress bar across a lift.** Patch fruit and flowers render a continuous fill bar but had no banked-progress field, so fix #1 (which resets the start timestamp) made their bar snap backward. Added `boostedTime` to `PlantedFruit`/`PlantedFlower`, banked via `trackProgress`, reset on a fruit's replenish phase, and folded into the `FruitTree`/`FlowerBed` bar denominator. Rocks/wood trees are unaffected — they render a countdown, not a fill bar.

## Notes
- The pause error is bounded (`readyAt ∈ [startedAt, startedAt + baseDurationMs]`, start never moves to the future) — not a runaway timer. `moveX` (direct landscaping move) doesn't pause, so it's unaffected.
- `boostedTime` is display-only for windowed nodes; timing + AOE gating key off `baseDurationMs`.

## Testing
- `tsc` clean, eslint clean on touched files. New/updated tests for every fix (windowed-pause banking + no-early-ready exploit, honey preservation, fertilised bulk-harvest, `getCrimstoneStage` early-recovery/reset, fruit replenish-phase + boost-during-lift banking, boostedTime retention). All touched suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timing behavior for re-placed crops, trees, rocks, and flowers so boosted progress is preserved when a window overlaps the pre-lift period.
  * Crimstone recovery now reflects the actual ready time, improving stage and image updates during boosted recovery.

* **Bug Fixes**
  * Fixed boosted harvest and grow timing so ready/ready-at states are anchored correctly.
  * Added coverage for boost-window edge cases, including honey accrual and mine-speed credit during relift/recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->