### PR TITLE
[CHORE] Fix stale comment on retroactive re-timing test

### DIFF
--- a/src/features/game/lib/collectibleBuilt.test.ts
+++ b/src/features/game/lib/collectibleBuilt.test.ts
@@ -324,15 +324,11 @@ describe("getExpiryCooldown", () => {
     );
   });
 
-  // The cooldown is derived from CURRENT feature access rather than persisted at
-  // placement time, so flipping SPEED_BOOSTS retroactively re-times already-placed
-  // boosters. This is INTENTIONAL and safe under this rollout: the flag is
-  // `testnetFeatureFlag` (network-static — always on for amoy, off for mainnet), so
-  // no player experiences a mid-life flip. Locked in here so the eventual
-  // username/mainnet rollout doesn't surprise anyone.
+  // The cooldown is derived from CURRENT feature access, not persisted at placement
+  // time, so an account with SPEED_BOOSTS access reads its already-placed boosters at
+  // the rebalanced durations (a benign one-time extension — intended).
   it("retroactively re-times already-placed boosters when the flag flips", () => {
     // A Time Warp Totem placed 3h ago: past the legacy 2h lifetime, inside the 4h one.
-    // The flag is network-static (testnetFeatureFlag), so only the network decides.
     const totemGame: GameState = {
       ...TEST_FARM,
       collectibles: {


### PR DESCRIPTION
Comment-only. Now that `SPEED_BOOSTS` is `usernameFeatureFlag` (merged), the retroactive re-timing test's "network-static (testnetFeatureFlag)" note is outdated. Reframes it as: an account with SPEED_BOOSTS access reads its already-placed boosters at the rebalanced durations (a benign one-time extension — intended). No test-behaviour change.

BE mirror: sunflower-land-api companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test comments to better reflect how cooldown timing is determined.
  * No behavior, features, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->