### PR TITLE
[FEAT] Speed boosts: oil reserves

### DIFF
--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -879,11 +879,11 @@ describe("drillOilReserve", () => {
     });
   });
 
-  // Regression: a reserve already carrying the baseDurationMs marker must stay
-  // windowed and REFRESH baseDurationMs on every re-drill, even flag-off (sticky).
-  // Otherwise a stale marker (e.g. Grease Lightning's 0) would persist beside a new
-  // drilledAt and mis-time recovery (permanently instantly-ready in the 0 case).
-  describe("sticky-windowed re-drill (mainnet, flag off)", () => {
+  // Regression: a fresh drill rebuilds the timer, so a flag-off re-drill CLEARS any
+  // prior windowed marker and reverts the reserve to legacy — mirrors stone/tree
+  // re-mine/re-chop, and prevents a stale marker (e.g. Grease Lightning's 0) from
+  // mis-timing the next recovery.
+  describe("flag-off re-drill reverts a windowed reserve to legacy", () => {
     const originalNetwork = CONFIG.NETWORK;
     beforeAll(() => {
       (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
@@ -894,7 +894,7 @@ describe("drillOilReserve", () => {
 
     const BASE_MS = OIL_RESERVE_RECOVERY_TIME * 1000;
 
-    it("refreshes a Grease-Lightning'd (baseDurationMs 0) reserve to the full duration", () => {
+    it("clears a Grease-Lightning'd (baseDurationMs 0) marker instead of leaving it stale", () => {
       const now = Date.now();
       const game = drillOilReserve({
         action: { id: "1", type: "oilReserve.drilled" },
@@ -914,15 +914,15 @@ describe("drillOilReserve", () => {
         createdAt: now,
       });
       const reserve = game.oilReserves["1"];
-      // Refreshed, NOT left at the stale 0 — and never deleted.
-      expect(reserve.oil.baseDurationMs).toBe(BASE_MS);
+      // Marker cleared → legacy. No boosts → drilledAt == now (buffMs 0).
+      expect(reserve.oil.baseDurationMs).toBeUndefined();
       expect(reserve.oil.drilledAt).toBe(now);
       // No longer instantly ready.
       expect(canDrillOilReserve(reserve, game, now)).toBe(false);
       expect(getOilReserveReadyAt(reserve, game)).toBe(now + BASE_MS);
     });
 
-    it("refreshes a marked reserve to the new permanent-only cycle (Dev Wrench x0.5)", () => {
+    it("clears a stale marker and back-dates with permanent boosts (Dev Wrench x0.5)", () => {
       const now = Date.now();
       const game = drillOilReserve({
         action: { id: "1", type: "oilReserve.drilled" },
@@ -947,9 +947,9 @@ describe("drillOilReserve", () => {
         createdAt: now,
       });
       const reserve = game.oilReserves["1"];
-      // Refreshed to the new cycle's permanent-only duration, NOT the stale 999.
-      expect(reserve.oil.baseDurationMs).toBe(BASE_MS * 0.5);
-      expect(reserve.oil.drilledAt).toBe(now);
+      // Marker cleared; legacy back-date folds in the permanent Dev Wrench (x0.5).
+      expect(reserve.oil.baseDurationMs).toBeUndefined();
+      expect(reserve.oil.drilledAt).toBe(now - BASE_MS * 0.5);
     });
   });
 });

--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -878,4 +878,78 @@ describe("drillOilReserve", () => {
       ).toBeCloseTo(base / 1.35, 0);
     });
   });
+
+  // Regression: a reserve already carrying the baseDurationMs marker must stay
+  // windowed and REFRESH baseDurationMs on every re-drill, even flag-off (sticky).
+  // Otherwise a stale marker (e.g. Grease Lightning's 0) would persist beside a new
+  // drilledAt and mis-time recovery (permanently instantly-ready in the 0 case).
+  describe("sticky-windowed re-drill (mainnet, flag off)", () => {
+    const originalNetwork = CONFIG.NETWORK;
+    beforeAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+    });
+    afterAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+    });
+
+    const BASE_MS = OIL_RESERVE_RECOVERY_TIME * 1000;
+
+    it("refreshes a Grease-Lightning'd (baseDurationMs 0) reserve to the full duration", () => {
+      const now = Date.now();
+      const game = drillOilReserve({
+        action: { id: "1", type: "oilReserve.drilled" },
+        state: {
+          ...TEST_FARM,
+          inventory: { "Oil Drill": new Decimal(2) },
+          oilReserves: {
+            "1": {
+              x: 1,
+              y: 1,
+              createdAt: 0,
+              drilled: 1,
+              oil: { drilledAt: 1, baseDurationMs: 0 },
+            },
+          },
+        },
+        createdAt: now,
+      });
+      const reserve = game.oilReserves["1"];
+      // Refreshed, NOT left at the stale 0 — and never deleted.
+      expect(reserve.oil.baseDurationMs).toBe(BASE_MS);
+      expect(reserve.oil.drilledAt).toBe(now);
+      // No longer instantly ready.
+      expect(canDrillOilReserve(reserve, game, now)).toBe(false);
+      expect(getOilReserveReadyAt(reserve, game)).toBe(now + BASE_MS);
+    });
+
+    it("refreshes a marked reserve to the new permanent-only cycle (Dev Wrench x0.5)", () => {
+      const now = Date.now();
+      const game = drillOilReserve({
+        action: { id: "1", type: "oilReserve.drilled" },
+        state: {
+          ...TEST_FARM,
+          inventory: { "Oil Drill": new Decimal(2) },
+          bumpkin: {
+            ...TEST_BUMPKIN,
+            equipped: { ...TEST_BUMPKIN.equipped, tool: "Dev Wrench" },
+          },
+          oilReserves: {
+            "1": {
+              x: 1,
+              y: 1,
+              createdAt: 0,
+              drilled: 1,
+              // A stale marker from a prior windowed cycle.
+              oil: { drilledAt: 1, baseDurationMs: 999 },
+            },
+          },
+        },
+        createdAt: now,
+      });
+      const reserve = game.oilReserves["1"];
+      // Refreshed to the new cycle's permanent-only duration, NOT the stale 999.
+      expect(reserve.oil.baseDurationMs).toBe(BASE_MS * 0.5);
+      expect(reserve.oil.drilledAt).toBe(now);
+    });
+  });
 });

--- a/src/features/game/events/landExpansion/drillOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.test.ts
@@ -5,9 +5,13 @@ import {
   OIL_RESERVE_RECOVERY_TIME,
   drillOilReserve,
   getDrilledAt,
+  canDrillOilReserve,
+  getOilReserveReadyAt,
 } from "./drillOilReserve";
 import { TEST_FARM } from "features/game/lib/constants";
 import { TEST_BUMPKIN } from "features/game/lib/bumpkinData";
+import { CONFIG } from "lib/config";
+import type { GameState } from "features/game/types/game";
 
 describe("drillOilReserve", () => {
   it("throws an error if the oil reserve does not exist", () => {
@@ -581,7 +585,18 @@ describe("drillOilReserve", () => {
     );
   });
 
-  describe("getDrilledAt", () => {
+  // Legacy (flag-off) back-date model: getDrilledAt returns a past timestamp. Under
+  // SPEED_BOOSTS these permanent boosts are baked into baseDurationMs instead (see
+  // the windowed describe below), so pin these to mainnet.
+  describe("getDrilledAt (legacy back-date, mainnet)", () => {
+    const originalNetwork = CONFIG.NETWORK;
+    beforeAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+    });
+    afterAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+    });
+
     it("replenishes oil twice as fast with Dev Wrench", () => {
       const now = Date.now();
 
@@ -617,6 +632,250 @@ describe("drillOilReserve", () => {
       });
 
       expect(time).toEqual(now - OIL_RESERVE_RECOVERY_TIME * 0.2 * 1000);
+    });
+  });
+
+  // FE + BE jest run amoy, so SPEED_BOOSTS is ON by default here.
+  describe("SPEED_BOOSTS (windowed)", () => {
+    const HOUR = 60 * 60 * 1000;
+    const BASE_MS = OIL_RESERVE_RECOVERY_TIME * 1000;
+
+    it("stores the real drill time + a permanent-only baseDurationMs", () => {
+      const now = Date.now();
+      const game = drillOilReserve({
+        action: { id: "1", type: "oilReserve.drilled" },
+        state: {
+          ...TEST_FARM,
+          inventory: { "Oil Drill": new Decimal(2) },
+          oilReserves: {
+            "1": {
+              x: 1,
+              y: 1,
+              createdAt: 0,
+              drilled: 0,
+              oil: { drilledAt: 0 },
+            },
+          },
+        },
+        createdAt: now,
+      });
+      const reserve = game.oilReserves["1"];
+      expect(reserve.oil.drilledAt).toBe(now);
+      expect(reserve.oil.baseDurationMs).toBe(BASE_MS);
+    });
+
+    it("bakes permanent boosts (Dev Wrench x0.5) into baseDurationMs, not a back-date", () => {
+      const now = Date.now();
+      const game = drillOilReserve({
+        action: { id: "1", type: "oilReserve.drilled" },
+        state: {
+          ...TEST_FARM,
+          inventory: { "Oil Drill": new Decimal(2) },
+          bumpkin: {
+            ...TEST_BUMPKIN,
+            equipped: { ...TEST_BUMPKIN.equipped, tool: "Dev Wrench" },
+          },
+          oilReserves: {
+            "1": {
+              x: 1,
+              y: 1,
+              createdAt: 0,
+              drilled: 0,
+              oil: { drilledAt: 0 },
+            },
+          },
+        },
+        createdAt: now,
+      });
+      const reserve = game.oilReserves["1"];
+      expect(reserve.oil.drilledAt).toBe(now);
+      expect(reserve.oil.baseDurationMs).toBe(BASE_MS * 0.5);
+    });
+
+    it("excludes the Stag Shrine time half from baseDurationMs and boostsUsed", () => {
+      const now = Date.now();
+      const game: GameState = {
+        ...TEST_FARM,
+        collectibles: {
+          "Stag Shrine": [
+            {
+              id: "1",
+              coordinates: { x: 3, y: 3 },
+              createdAt: now,
+              readyAt: now,
+            },
+          ],
+        },
+      };
+      const { time, baseDurationMs, boostsUsed } = getDrilledAt({
+        game,
+        createdAt: now,
+      });
+      expect(time).toBe(now);
+      // Stag Shrine's time half is a window, NOT baked into baseDurationMs.
+      expect(baseDurationMs).toBe(BASE_MS);
+      expect(boostsUsed.map((b) => b.name)).not.toContain("Stag Shrine");
+    });
+
+    it("keeps the +15 Stag Shrine yield on the 3rd drill (yield half stays baked)", () => {
+      const now = Date.now();
+      const game = drillOilReserve({
+        action: { id: "1", type: "oilReserve.drilled" },
+        state: {
+          ...TEST_FARM,
+          inventory: { "Oil Drill": new Decimal(2) },
+          collectibles: {
+            "Stag Shrine": [
+              {
+                id: "1",
+                coordinates: { x: 3, y: 3 },
+                createdAt: now,
+                readyAt: now,
+              },
+            ],
+          },
+          oilReserves: {
+            "1": {
+              x: 1,
+              y: 1,
+              createdAt: 0,
+              drilled: 2,
+              oil: { drilledAt: 0 },
+            },
+          },
+        },
+        createdAt: now,
+      });
+      expect(game.inventory.Oil?.toNumber()).toBe(
+        BASE_OIL_DROP_AMOUNT + OIL_BONUS_DROP_AMOUNT + 15,
+      );
+    });
+
+    it("readies a reserve 1.35x sooner under an active Stag Shrine", () => {
+      const now = Date.now();
+      const game: GameState = {
+        ...TEST_FARM,
+        collectibles: {
+          "Stag Shrine": [
+            {
+              id: "1",
+              coordinates: { x: 3, y: 3 },
+              createdAt: now,
+              readyAt: now,
+            },
+          ],
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            createdAt: now,
+            drilled: 1,
+            oil: { drilledAt: now, baseDurationMs: BASE_MS },
+          },
+        },
+      };
+      const reserve = game.oilReserves["1"];
+      const readyAt = getOilReserveReadyAt(reserve, game);
+      // The whole recovery falls inside the 7-day Stag window → base / 1.35.
+      expect(readyAt - now).toBeCloseTo(BASE_MS / 1.35, 0);
+      expect(canDrillOilReserve(reserve, game, readyAt + 1)).toBe(true);
+      expect(canDrillOilReserve(reserve, game, readyAt - 1)).toBe(false);
+    });
+
+    it("credits an expired/partial Stag Shrine window to an in-progress reserve", () => {
+      const T0 = Date.now();
+      const base = 20 * HOUR;
+      const game: GameState = {
+        ...TEST_FARM,
+        collectibles: {
+          "Stag Shrine": [
+            {
+              id: "1",
+              coordinates: { x: 3, y: 3 },
+              createdAt: T0,
+              removedAt: T0 + 10 * HOUR, // active only the first 10h
+              readyAt: T0,
+            },
+          ],
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            createdAt: T0,
+            drilled: 1,
+            oil: { drilledAt: T0, baseDurationMs: base },
+          },
+        },
+      };
+      // 10h @1.35 = 13.5h of work, leaving 6.5h @1x → readyAt = T0 + 16.5h.
+      expect(getOilReserveReadyAt(game.oilReserves["1"], game)).toBe(
+        T0 + 16.5 * HOUR,
+      );
+    });
+
+    it("is not drillable exactly at readyAt (strict >)", () => {
+      const now = Date.now();
+      const game: GameState = {
+        ...TEST_FARM,
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            createdAt: now,
+            drilled: 1,
+            oil: { drilledAt: now, baseDurationMs: BASE_MS },
+          },
+        },
+      };
+      const reserve = game.oilReserves["1"];
+      const readyAt = getOilReserveReadyAt(reserve, game); // no window → now + base
+      expect(readyAt).toBe(now + BASE_MS);
+      expect(canDrillOilReserve(reserve, game, readyAt)).toBe(false);
+      expect(canDrillOilReserve(reserve, game, readyAt + 1)).toBe(true);
+    });
+  });
+
+  // getOilReserveReadyAt keys off the baseDurationMs marker, NOT the flag, so a
+  // reserve drilled while the flag was on keeps windowed timing on rollback.
+  describe("getOilReserveReadyAt keeps windowed timing on mainnet", () => {
+    const originalNetwork = CONFIG.NETWORK;
+    beforeAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = "mainnet";
+    });
+    afterAll(() => {
+      (CONFIG as { NETWORK: "mainnet" | "amoy" }).NETWORK = originalNetwork;
+    });
+
+    it("uses computeReadyAt for a baseDurationMs reserve even flag-off", () => {
+      const now = Date.now();
+      const base = OIL_RESERVE_RECOVERY_TIME * 1000;
+      const game: GameState = {
+        ...TEST_FARM,
+        collectibles: {
+          "Stag Shrine": [
+            {
+              id: "1",
+              coordinates: { x: 3, y: 3 },
+              createdAt: now,
+              readyAt: now,
+            },
+          ],
+        },
+        oilReserves: {
+          "1": {
+            x: 1,
+            y: 1,
+            createdAt: now,
+            drilled: 1,
+            oil: { drilledAt: now, baseDurationMs: base },
+          },
+        },
+      };
+      expect(
+        getOilReserveReadyAt(game.oilReserves["1"], game) - now,
+      ).toBeCloseTo(base / 1.35, 0);
     });
   });
 });

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -142,12 +142,25 @@ export function getRequiredOilDrillAmount(gameState: GameState): {
 type getDrilledAtArgs = {
   createdAt: number;
   game: GameState;
+  windowed?: boolean;
 };
 
 /**
  * Single source of truth for oil recovery boosts. Used by both getDrilledAt (game) and UI.
+ *
+ * `windowed` (default = the flag) selects the speed-rate model: when true the
+ * temporary Stag Shrine boost is a retroactive window and is excluded from the
+ * baked recovery here (permanent boosts only). The drill path passes
+ * `windowed = flag || reserve is already marked` so a windowed reserve stays
+ * windowed across re-drills even flag-off (sticky).
  */
-export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
+export function getOilRecoveryTimeForDisplay({
+  game,
+  windowed = hasFeatureAccess(game, "SPEED_BOOSTS"),
+}: {
+  game: GameState;
+  windowed?: boolean;
+}): {
   baseTimeMs: number;
   recoveryTimeMs: number;
   boostsUsed: { name: BoostName; value: string }[];
@@ -156,11 +169,11 @@ export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
   let totalSeconds = OIL_RESERVE_RECOVERY_TIME;
   const boostsUsed: { name: BoostName; value: string }[] = [];
 
-  // Under SPEED_BOOSTS the temporary Stag Shrine recovery boost is a retroactive
-  // speed-rate window (see boostWindows), so it's excluded from the baked recovery
-  // here — what remains is the permanent-boost-only base duration. Flag-off keeps
-  // the legacy discount-at-start.
-  const boostsWindowed = hasFeatureAccess(game, "SPEED_BOOSTS");
+  // Under the windowed model the temporary Stag Shrine recovery boost is a
+  // retroactive speed-rate window (see boostWindows), so it's excluded from the
+  // baked recovery here — what remains is the permanent-boost-only base duration.
+  // Legacy (unmarked, flag-off) keeps the legacy discount-at-start.
+  const boostsWindowed = windowed;
 
   if (isWearableActive({ game, name: "Dev Wrench" })) {
     totalSeconds = totalSeconds * 0.5;
@@ -187,24 +200,30 @@ export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
 }
 
 /**
- * The drilled-at time to persist, plus (under SPEED_BOOSTS) the base recovery
- * duration.
+ * The drilled-at time to persist, plus (under the windowed model) the base
+ * recovery duration.
  *
  * Legacy model: back-date `drilledAt` into the past so the reserve replenishes
- * faster. Speed-rate model (SPEED_BOOSTS): store the REAL drill time and a
+ * faster. Speed-rate model (`windowed`): store the REAL drill time and a
  * `baseDurationMs` carrying only the permanent boosts; the temporary Stag Shrine
- * boost is derived live from windows. Uses getOilRecoveryTimeForDisplay for boost
- * logic. Mirrors `getMinedAt`.
+ * boost is derived live from windows. `windowed` defaults to the flag; the drill
+ * path passes `flag || reserve already marked` so a marked reserve is refreshed
+ * (never left with a stale `baseDurationMs`) even flag-off. Uses
+ * getOilRecoveryTimeForDisplay for boost logic. Mirrors `getMinedAt`.
  */
-export function getDrilledAt({ createdAt, game }: getDrilledAtArgs): {
+export function getDrilledAt({
+  createdAt,
+  game,
+  windowed = hasFeatureAccess(game, "SPEED_BOOSTS"),
+}: getDrilledAtArgs): {
   time: number;
   baseDurationMs?: number;
   boostsUsed: { name: BoostName; value: string }[];
 } {
   const { baseTimeMs, recoveryTimeMs, boostsUsed } =
-    getOilRecoveryTimeForDisplay({ game });
+    getOilRecoveryTimeForDisplay({ game, windowed });
 
-  if (hasFeatureAccess(game, "SPEED_BOOSTS")) {
+  if (windowed) {
     return { time: createdAt, baseDurationMs: recoveryTimeMs, boostsUsed };
   }
 
@@ -249,14 +268,21 @@ export function drillOilReserve({
     );
     // Take away one drill
     game.inventory["Oil Drill"] = drillAmount.sub(requiredDrills);
-    // Update drilled at time
+    // Update drilled at time. Sticky-windowed: a reserve that already carries the
+    // baseDurationMs marker stays windowed across re-drills even flag-off, so we
+    // refresh a fresh permanent-only baseDurationMs rather than leaving a stale one
+    // (mirrors the fruit forceWindowed re-action pattern).
+    const windowed =
+      hasFeatureAccess(game, "SPEED_BOOSTS") ||
+      oilReserve.oil.baseDurationMs !== undefined;
     const {
       time,
       baseDurationMs,
       boostsUsed: drilledAtBoostsUsed,
     } = getDrilledAt({
       createdAt,
-      game: game,
+      game,
+      windowed,
     });
     oilReserve.oil.drilledAt = time;
     if (baseDurationMs !== undefined) {

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -12,6 +12,11 @@ import type {
 } from "features/game/types/game";
 import { produce } from "immer";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
+import { hasFeatureAccess } from "lib/flags";
+import {
+  computeReadyAt,
+  getOilBoostWindows,
+} from "features/game/lib/boostWindows";
 
 export type DrillOilReserveAction = {
   type: "oilReserve.drilled";
@@ -78,11 +83,44 @@ export function isNextDrillHasBonus(reserve: OilReserve): boolean {
   return (reserve.drilled + 1) % 3 === 0;
 }
 
+/**
+ * When a drilled reserve is ready to drill again, across both boost models.
+ * Reserves drilled under the speed-rate model (with `oil.baseDurationMs`) derive
+ * their ready time live from the oil boost windows; legacy reserves use their
+ * back-dated `drilledAt` + base recovery time.
+ *
+ * `baseDurationMs` is a PERMANENT per-reserve migration marker: the read path keys
+ * off its presence, NOT the `SPEED_BOOSTS` flag (matching `getTreeReadyAt`). A
+ * reserve drilled while the flag was on therefore keeps windowed timing even if the
+ * flag is later disabled — windowed reserves store the real `drilledAt` + a
+ * permanent-boost-only `baseDurationMs`, so falling back to `drilledAt + base
+ * recovery` would drop their baked permanent-boost credit and wrongly lengthen
+ * recovery on rollback.
+ */
+export function getOilReserveReadyAt(
+  reserve: OilReserve,
+  game: GameState,
+): number {
+  const { baseDurationMs, drilledAt } = reserve.oil;
+
+  if (baseDurationMs !== undefined) {
+    return computeReadyAt({
+      startedAt: drilledAt,
+      baseDurationMs,
+      windows: getOilBoostWindows(game),
+    });
+  }
+
+  return drilledAt + OIL_RESERVE_RECOVERY_TIME * 1000;
+}
+
 export function canDrillOilReserve(
   reserve: OilReserve,
+  game: GameState,
   now: number = Date.now(),
 ) {
-  return now - reserve.oil.drilledAt > OIL_RESERVE_RECOVERY_TIME * 1000;
+  // Strict `>` preserves the legacy `now - drilledAt > RECOVERY * 1000` boundary.
+  return now > getOilReserveReadyAt(reserve, game);
 }
 
 export function getRequiredOilDrillAmount(gameState: GameState): {
@@ -118,6 +156,12 @@ export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
   let totalSeconds = OIL_RESERVE_RECOVERY_TIME;
   const boostsUsed: { name: BoostName; value: string }[] = [];
 
+  // Under SPEED_BOOSTS the temporary Stag Shrine recovery boost is a retroactive
+  // speed-rate window (see boostWindows), so it's excluded from the baked recovery
+  // here — what remains is the permanent-boost-only base duration. Flag-off keeps
+  // the legacy discount-at-start.
+  const boostsWindowed = hasFeatureAccess(game, "SPEED_BOOSTS");
+
   if (isWearableActive({ game, name: "Dev Wrench" })) {
     totalSeconds = totalSeconds * 0.5;
     boostsUsed.push({ name: "Dev Wrench", value: "x0.5" });
@@ -127,7 +171,10 @@ export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
     boostsUsed.push({ name: "Oil Be Back", value: "x0.8" });
   }
 
-  if (isTemporaryCollectibleActive({ name: "Stag Shrine", game })) {
+  if (
+    !boostsWindowed &&
+    isTemporaryCollectibleActive({ name: "Stag Shrine", game })
+  ) {
     totalSeconds = totalSeconds * 0.75;
     boostsUsed.push({ name: "Stag Shrine", value: "x0.75" });
   }
@@ -140,14 +187,27 @@ export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
 }
 
 /**
- * Set a drilled in the past to make it replenish faster. Uses getOilRecoveryTimeForDisplay for boost logic.
+ * The drilled-at time to persist, plus (under SPEED_BOOSTS) the base recovery
+ * duration.
+ *
+ * Legacy model: back-date `drilledAt` into the past so the reserve replenishes
+ * faster. Speed-rate model (SPEED_BOOSTS): store the REAL drill time and a
+ * `baseDurationMs` carrying only the permanent boosts; the temporary Stag Shrine
+ * boost is derived live from windows. Uses getOilRecoveryTimeForDisplay for boost
+ * logic. Mirrors `getMinedAt`.
  */
 export function getDrilledAt({ createdAt, game }: getDrilledAtArgs): {
   time: number;
+  baseDurationMs?: number;
   boostsUsed: { name: BoostName; value: string }[];
 } {
   const { baseTimeMs, recoveryTimeMs, boostsUsed } =
     getOilRecoveryTimeForDisplay({ game });
+
+  if (hasFeatureAccess(game, "SPEED_BOOSTS")) {
+    return { time: createdAt, baseDurationMs: recoveryTimeMs, boostsUsed };
+  }
+
   const buffMs = baseTimeMs - recoveryTimeMs;
   return { time: createdAt - buffMs, boostsUsed };
 }
@@ -175,7 +235,7 @@ export function drillOilReserve({
       throw new Error("No oil drills available");
     }
 
-    if (!canDrillOilReserve(oilReserve, createdAt)) {
+    if (!canDrillOilReserve(oilReserve, game, createdAt)) {
       throw new Error("Oil reserve is still recovering");
     }
 
@@ -190,11 +250,18 @@ export function drillOilReserve({
     // Take away one drill
     game.inventory["Oil Drill"] = drillAmount.sub(requiredDrills);
     // Update drilled at time
-    const { time, boostsUsed: drilledAtBoostsUsed } = getDrilledAt({
+    const {
+      time,
+      baseDurationMs,
+      boostsUsed: drilledAtBoostsUsed,
+    } = getDrilledAt({
       createdAt,
       game: game,
     });
     oilReserve.oil.drilledAt = time;
+    if (baseDurationMs !== undefined) {
+      oilReserve.oil.baseDurationMs = baseDurationMs;
+    }
     // Increment drilled count
     oilReserve.drilled += 1;
 

--- a/src/features/game/events/landExpansion/drillOilReserve.ts
+++ b/src/features/game/events/landExpansion/drillOilReserve.ts
@@ -142,25 +142,12 @@ export function getRequiredOilDrillAmount(gameState: GameState): {
 type getDrilledAtArgs = {
   createdAt: number;
   game: GameState;
-  windowed?: boolean;
 };
 
 /**
  * Single source of truth for oil recovery boosts. Used by both getDrilledAt (game) and UI.
- *
- * `windowed` (default = the flag) selects the speed-rate model: when true the
- * temporary Stag Shrine boost is a retroactive window and is excluded from the
- * baked recovery here (permanent boosts only). The drill path passes
- * `windowed = flag || reserve is already marked` so a windowed reserve stays
- * windowed across re-drills even flag-off (sticky).
  */
-export function getOilRecoveryTimeForDisplay({
-  game,
-  windowed = hasFeatureAccess(game, "SPEED_BOOSTS"),
-}: {
-  game: GameState;
-  windowed?: boolean;
-}): {
+export function getOilRecoveryTimeForDisplay({ game }: { game: GameState }): {
   baseTimeMs: number;
   recoveryTimeMs: number;
   boostsUsed: { name: BoostName; value: string }[];
@@ -169,11 +156,11 @@ export function getOilRecoveryTimeForDisplay({
   let totalSeconds = OIL_RESERVE_RECOVERY_TIME;
   const boostsUsed: { name: BoostName; value: string }[] = [];
 
-  // Under the windowed model the temporary Stag Shrine recovery boost is a
-  // retroactive speed-rate window (see boostWindows), so it's excluded from the
-  // baked recovery here — what remains is the permanent-boost-only base duration.
-  // Legacy (unmarked, flag-off) keeps the legacy discount-at-start.
-  const boostsWindowed = windowed;
+  // Under SPEED_BOOSTS the temporary Stag Shrine recovery boost is a retroactive
+  // speed-rate window (see boostWindows), so it's excluded from the baked recovery
+  // here — what remains is the permanent-boost-only base duration. Flag-off keeps
+  // the legacy discount-at-start.
+  const boostsWindowed = hasFeatureAccess(game, "SPEED_BOOSTS");
 
   if (isWearableActive({ game, name: "Dev Wrench" })) {
     totalSeconds = totalSeconds * 0.5;
@@ -200,30 +187,25 @@ export function getOilRecoveryTimeForDisplay({
 }
 
 /**
- * The drilled-at time to persist, plus (under the windowed model) the base
- * recovery duration.
+ * The drilled-at time to persist, plus (under SPEED_BOOSTS) the base recovery
+ * duration.
  *
  * Legacy model: back-date `drilledAt` into the past so the reserve replenishes
- * faster. Speed-rate model (`windowed`): store the REAL drill time and a
+ * faster. Speed-rate model (SPEED_BOOSTS): store the REAL drill time and a
  * `baseDurationMs` carrying only the permanent boosts; the temporary Stag Shrine
- * boost is derived live from windows. `windowed` defaults to the flag; the drill
- * path passes `flag || reserve already marked` so a marked reserve is refreshed
- * (never left with a stale `baseDurationMs`) even flag-off. Uses
- * getOilRecoveryTimeForDisplay for boost logic. Mirrors `getMinedAt`.
+ * boost is derived live from windows. Uses getOilRecoveryTimeForDisplay for boost
+ * logic. Mirrors `getMinedAt`. Returns no `baseDurationMs` flag-off, so a
+ * flag-off re-drill reverts the reserve to legacy (see the reducer).
  */
-export function getDrilledAt({
-  createdAt,
-  game,
-  windowed = hasFeatureAccess(game, "SPEED_BOOSTS"),
-}: getDrilledAtArgs): {
+export function getDrilledAt({ createdAt, game }: getDrilledAtArgs): {
   time: number;
   baseDurationMs?: number;
   boostsUsed: { name: BoostName; value: string }[];
 } {
   const { baseTimeMs, recoveryTimeMs, boostsUsed } =
-    getOilRecoveryTimeForDisplay({ game, windowed });
+    getOilRecoveryTimeForDisplay({ game });
 
-  if (windowed) {
+  if (hasFeatureAccess(game, "SPEED_BOOSTS")) {
     return { time: createdAt, baseDurationMs: recoveryTimeMs, boostsUsed };
   }
 
@@ -268,13 +250,11 @@ export function drillOilReserve({
     );
     // Take away one drill
     game.inventory["Oil Drill"] = drillAmount.sub(requiredDrills);
-    // Update drilled at time. Sticky-windowed: a reserve that already carries the
-    // baseDurationMs marker stays windowed across re-drills even flag-off, so we
-    // refresh a fresh permanent-only baseDurationMs rather than leaving a stale one
-    // (mirrors the fruit forceWindowed re-action pattern).
-    const windowed =
-      hasFeatureAccess(game, "SPEED_BOOSTS") ||
-      oilReserve.oil.baseDurationMs !== undefined;
+    // Update drilled at time. A fresh drill rebuilds the timer from scratch, so a
+    // flag-off re-drill clears any prior windowed marker and reverts to legacy —
+    // mirrors stoneMine (`rock.stone = { minedAt }`) / chop (`delete baseDurationMs`),
+    // the resource-node family oil belongs to. (Without the clear, a stale marker —
+    // e.g. Grease Lightning's 0 — would mis-time the next recovery.)
     const {
       time,
       baseDurationMs,
@@ -282,11 +262,12 @@ export function drillOilReserve({
     } = getDrilledAt({
       createdAt,
       game,
-      windowed,
     });
     oilReserve.oil.drilledAt = time;
     if (baseDurationMs !== undefined) {
       oilReserve.oil.baseDurationMs = baseDurationMs;
+    } else {
+      delete oilReserve.oil.baseDurationMs;
     }
     // Increment drilled count
     oilReserve.drilled += 1;

--- a/src/features/game/events/landExpansion/placeOilReserve.test.ts
+++ b/src/features/game/events/landExpansion/placeOilReserve.test.ts
@@ -151,4 +151,38 @@ describe("placeOil", () => {
       },
     });
   });
+
+  it("banks accrued work for a windowed reserve on lift/replace", () => {
+    const T0 = Date.now();
+    const HOUR = 60 * 60 * 1000;
+    const state = placeOilReserve({
+      action: {
+        coordinates: { x: 2, y: 2 },
+        id: "1",
+        type: "oilReserve.placed",
+      },
+      state: {
+        ...INITIAL_FARM,
+        buildings: {},
+        inventory: { "Oil Reserve": new Decimal(2) },
+        oilReserves: {
+          "123": {
+            createdAt: T0,
+            // 5h of the 20h recovery elapsed before the lift (no boost → 1x).
+            oil: { drilledAt: T0, baseDurationMs: 20 * HOUR },
+            drilled: 5,
+            removedAt: T0 + 5 * HOUR,
+          },
+        },
+      },
+      createdAt: T0 + 8 * HOUR,
+    });
+
+    // Work resumes from the placement time; the 5h banked shrinks baseDurationMs.
+    expect(state.oilReserves["123"].oil).toEqual({
+      drilledAt: T0 + 8 * HOUR,
+      baseDurationMs: 15 * HOUR,
+    });
+    expect(state.oilReserves["123"].removedAt).toBeUndefined();
+  });
 });

--- a/src/features/game/events/landExpansion/placeOilReserve.ts
+++ b/src/features/game/events/landExpansion/placeOilReserve.ts
@@ -2,6 +2,10 @@ import type { GameState, OilReserve } from "features/game/types/game";
 import Decimal from "decimal.js-light";
 import { produce } from "immer";
 import type { Coordinates } from "features/game/expansion/components/MapPlacement";
+import {
+  getOilBoostWindows,
+  pauseWindowedTimer,
+} from "features/game/lib/boostWindows";
 
 export type PlaceOilReserveAction = {
   type: "oilReserve.placed";
@@ -46,9 +50,16 @@ export function placeOilReserve({
       };
 
       if (updatedOilReserve.oil && updatedOilReserve.removedAt) {
-        const existingProgress =
-          updatedOilReserve.removedAt - updatedOilReserve.oil.drilledAt;
-        updatedOilReserve.oil.drilledAt = createdAt - existingProgress;
+        // Pause recovery across the lift: bank work for a windowed reserve
+        // (shrinks baseDurationMs), else legacy back-date. Behaviour-identical to
+        // the old back-date for legacy reserves.
+        updatedOilReserve.oil.drilledAt = pauseWindowedTimer({
+          timer: updatedOilReserve.oil,
+          startedAt: updatedOilReserve.oil.drilledAt,
+          removedAt: updatedOilReserve.removedAt,
+          createdAt,
+          windows: getOilBoostWindows(game),
+        });
       }
       delete updatedOilReserve.removedAt;
 

--- a/src/features/game/events/landExpansion/skillUsed.test.ts
+++ b/src/features/game/events/landExpansion/skillUsed.test.ts
@@ -894,6 +894,35 @@ describe("skillUse", () => {
       expect(state.oilReserves["456"].oil.drilledAt).toEqual(1);
       expect(state.oilReserves["789"].oil.drilledAt).toEqual(1);
     });
+
+    it("zeroes baseDurationMs for a windowed reserve (instant recovery)", () => {
+      const state = skillUse({
+        state: {
+          ...INITIAL_FARM,
+          bumpkin: {
+            ...INITIAL_FARM.bumpkin,
+            skills: { "Grease Lightning": 1 },
+          },
+          oilReserves: {
+            "123": {
+              createdAt: dateNow,
+              oil: {
+                drilledAt: dateNow - 1000 * 60,
+                baseDurationMs: 20 * 60 * 60 * 1000,
+              },
+              x: 10,
+              y: -1,
+              drilled: 5,
+            },
+          },
+        },
+        action: { type: "skill.used", skill: "Grease Lightning" },
+        createdAt: dateNow,
+      });
+
+      expect(state.oilReserves["123"].oil.drilledAt).toEqual(1);
+      expect(state.oilReserves["123"].oil.baseDurationMs).toEqual(0);
+    });
   });
 
   describe("useInstantGratification", () => {

--- a/src/features/game/events/landExpansion/skillUsed.ts
+++ b/src/features/game/events/landExpansion/skillUsed.ts
@@ -158,7 +158,14 @@ function useGreaseLightning({
   getKeys(oilReserves).forEach((reserve) => {
     const { oil } = oilReserves[reserve];
     if (oil) {
+      // Instant recovery. Legacy: a far-past `drilledAt` makes the fixed recovery
+      // window already elapsed. Windowed (`baseDurationMs` set): also zero the
+      // remaining work so `computeReadyAt` collapses `readyAt` to `drilledAt`
+      // (mirrors instaGrowFlower / Greenhouse Guru).
       oil.drilledAt = 1;
+      if (oil.baseDurationMs !== undefined) {
+        oil.baseDurationMs = 0;
+      }
     }
   });
   return oilReserves;
@@ -428,7 +435,7 @@ export function powerSkillDisabledConditions({
     case "Grease Lightning": {
       if (
         Object.values(oilReserves).every((reserve) =>
-          canDrillOilReserve(reserve),
+          canDrillOilReserve(reserve, state, createdAt),
         )
       ) {
         return {

--- a/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
@@ -2,7 +2,10 @@ import React, { useContext, useState } from "react";
 import { RecoveredOilReserve } from "./components/RecoveredOilReserve";
 import { Context } from "features/game/GameProvider";
 import type { MachineState } from "features/game/lib/gameMachine";
-import type { OilReserve as IOilReserve } from "features/game/types/game";
+import type {
+  GameState,
+  OilReserve as IOilReserve,
+} from "features/game/types/game";
 import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import {
@@ -13,7 +16,15 @@ import {
 } from "features/game/events/landExpansion/drillOilReserve";
 import { RecoveringOilReserve } from "./components/RecoveringOilReserve";
 import { DepletedOilReserve } from "./components/DepletedOilReserve";
-import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { getTimeLeft } from "lib/utils/time";
+import { useNow } from "lib/utils/hooks/useNow";
+import {
+  computeReadyAt,
+  getEffectiveSpeedAt,
+  getOilBoostWindows,
+  workAccruedAt,
+  type BoostWindow,
+} from "features/game/lib/boostWindows";
 
 interface Props {
   id: string;
@@ -23,29 +34,106 @@ const _reserve = (id: string) => (state: MachineState) =>
   state.context.state.oilReserves[id];
 const _drills = (state: MachineState) =>
   state.context.state.inventory["Oil Drill"] ?? new Decimal(0);
-const selectGame = (state: MachineState) => state.context.state;
+const _state = (state: MachineState) => state.context.state;
+
+// Only re-render the game selector when the drill requirement changes (Infernal
+// Drill). The recovery windows have their own field-compared selector below, so
+// the component no longer subscribes to the whole game state every tick.
+const _compareOilDrill = (prev: GameState, next: GameState) =>
+  getRequiredOilDrillAmount(prev).amount.equals(
+    getRequiredOilDrillAmount(next).amount,
+  );
 
 const compareResource = (prev: IOilReserve, next: IOilReserve) => {
   return JSON.stringify(prev) === JSON.stringify(next);
 };
+
+// Field comparator for the oil boost windows so the selector skips re-renders
+// without allocating JSON strings on every service update.
+const areBoostWindowsEqual = (a: BoostWindow[], b: BoostWindow[]) =>
+  a.length === b.length &&
+  a.every((window, index) => {
+    const other = b[index];
+    return (
+      other !== undefined &&
+      window.from === other.from &&
+      window.to === other.to &&
+      window.speed === other.speed
+    );
+  });
 
 export const OilReserve: React.FC<Props> = ({ id }) => {
   const { gameService } = useContext(Context);
   const [drilling, setDrilling] = useState(false);
   const [oilHarvested, setOilHarvested] = useState(0);
 
-  const state = useSelector(gameService, selectGame);
+  const game = useSelector(gameService, _state, _compareOilDrill);
   const reserve = useSelector(gameService, _reserve(id), compareResource);
   const drills = useSelector(gameService, _drills);
-  const readyAt = reserve.oil.drilledAt + OIL_RESERVE_RECOVERY_TIME * 1000;
-  const { totalSeconds: timeLeft } = useCountdown(readyAt);
+  // Live windowed oil-recovery speed boost (Stag Shrine). Recomputed from full
+  // state but only re-renders when the windows actually change, so the countdown
+  // reacts to a Stag Shrine placed/expired mid-recovery.
+  const oilBoostWindows = useSelector(
+    gameService,
+    (state) => getOilBoostWindows(state.context.state),
+    areBoostWindowsEqual,
+  );
+
+  const { drilledAt, baseDurationMs } = reserve.oil;
+  // Speed-rate model (baseDurationMs set): derive the ready time live from the
+  // boost windows. Legacy reserves use the back-dated drilledAt + base recovery.
+  const readyAt =
+    baseDurationMs !== undefined
+      ? computeReadyAt({
+          startedAt: drilledAt,
+          baseDurationMs,
+          windows: oilBoostWindows,
+        })
+      : drilledAt + OIL_RESERVE_RECOVERY_TIME * 1000;
+
+  // Coarse 1s clock to pick the current boost speed; only windowed reserves are
+  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
+  // tick rather than jumping by `speed` each second.
+  const tickNow = useNow({
+    live: baseDurationMs !== undefined,
+    autoEndAt: readyAt,
+  });
+  const speed =
+    baseDurationMs !== undefined
+      ? getEffectiveSpeedAt({ at: tickNow, windows: oilBoostWindows })
+      : 1;
+  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
+  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
+
+  // For windowed reserves the remaining time is remaining *work* (in base
+  // duration), so it visibly ticks down faster while a boost window is active.
+  const timeLeft =
+    baseDurationMs !== undefined
+      ? Math.max(
+          (baseDurationMs -
+            workAccruedAt({
+              startedAt: drilledAt,
+              at: now,
+              windows: oilBoostWindows,
+            })) /
+            1000,
+          0,
+        )
+      : getTimeLeft(drilledAt, OIL_RESERVE_RECOVERY_TIME, now);
+
   const ready = timeLeft <= 0;
-  const halfReady = !ready && timeLeft <= OIL_RESERVE_RECOVERY_TIME / 2;
+  // Half-recovery art switches at the midpoint of remaining WORK, so it lands at
+  // the right point when a boost has shrunk the remaining duration.
+  const halfThreshold =
+    baseDurationMs !== undefined
+      ? baseDurationMs / 2000
+      : OIL_RESERVE_RECOVERY_TIME / 2;
+  const halfReady = !ready && timeLeft <= halfThreshold;
 
   const handleDrill = async () => {
-    const requiredDrillAmount = getRequiredOilDrillAmount(state).amount;
+    const requiredDrillAmount = getRequiredOilDrillAmount(game).amount;
     if (!ready || drills.lessThan(requiredDrillAmount)) return;
-    const { amount: oilDropAmount } = getOilDropAmount(state, reserve);
+    const { amount: oilDropAmount } = getOilDropAmount(game, reserve);
 
     gameService.send({ type: "oilReserve.drilled", id });
 
@@ -55,7 +143,7 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
     await new Promise((res) => setTimeout(res, 2000));
     setDrilling(false);
   };
-  const hasDrill = drills.gte(getRequiredOilDrillAmount(state).amount);
+  const hasDrill = drills.gte(getRequiredOilDrillAmount(game).amount);
 
   return (
     <div className="relative w-full h-full flex justify-center items-center">
@@ -66,12 +154,13 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
           onDrill={handleDrill}
         />
       )}
-      {halfReady && <RecoveringOilReserve timeLeft={timeLeft} />}
+      {halfReady && <RecoveringOilReserve timeLeft={timeLeft} speed={speed} />}
       {!ready && !halfReady && (
         <DepletedOilReserve
           drilling={drilling}
           oilAmount={oilHarvested}
           timeLeft={timeLeft}
+          speed={speed}
           onOilTransitionEnd={() => setOilHarvested(0)}
         />
       )}

--- a/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
@@ -2,10 +2,7 @@ import React, { useContext, useState } from "react";
 import { RecoveredOilReserve } from "./components/RecoveredOilReserve";
 import { Context } from "features/game/GameProvider";
 import type { MachineState } from "features/game/lib/gameMachine";
-import type {
-  GameState,
-  OilReserve as IOilReserve,
-} from "features/game/types/game";
+import type { OilReserve as IOilReserve } from "features/game/types/game";
 import { useSelector } from "@xstate/react";
 import Decimal from "decimal.js-light";
 import {
@@ -34,15 +31,6 @@ const _reserve = (id: string) => (state: MachineState) =>
   state.context.state.oilReserves[id];
 const _drills = (state: MachineState) =>
   state.context.state.inventory["Oil Drill"] ?? new Decimal(0);
-const _state = (state: MachineState) => state.context.state;
-
-// Only re-render the game selector when the drill requirement changes (Infernal
-// Drill). The recovery windows have their own field-compared selector below, so
-// the component no longer subscribes to the whole game state every tick.
-const _compareOilDrill = (prev: GameState, next: GameState) =>
-  getRequiredOilDrillAmount(prev).amount.equals(
-    getRequiredOilDrillAmount(next).amount,
-  );
 
 const compareResource = (prev: IOilReserve, next: IOilReserve) => {
   return JSON.stringify(prev) === JSON.stringify(next);
@@ -67,9 +55,27 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
   const [drilling, setDrilling] = useState(false);
   const [oilHarvested, setOilHarvested] = useState(0);
 
-  const game = useSelector(gameService, _state, _compareOilDrill);
   const reserve = useSelector(gameService, _reserve(id), compareResource);
   const drills = useSelector(gameService, _drills);
+  // Derive just the values this component needs from game state, each with its own
+  // comparator, instead of holding a whole-game snapshot (which would either
+  // re-render every tick or — if narrowly compared — go stale for the oil-yield
+  // animation when e.g. a Stag Shrine is placed).
+  const requiredDrillAmount = useSelector(
+    gameService,
+    (state) => getRequiredOilDrillAmount(state.context.state).amount,
+    (a, b) => a.equals(b),
+  );
+  const oilDropAmount = useSelector(
+    gameService,
+    (state) => {
+      const oilReserve = state.context.state.oilReserves[id];
+      return oilReserve
+        ? getOilDropAmount(state.context.state, oilReserve).amount
+        : 0;
+    },
+    (a, b) => a === b,
+  );
   // Live windowed oil-recovery speed boost (Stag Shrine). Recomputed from full
   // state but only re-renders when the windows actually change, so the countdown
   // reacts to a Stag Shrine placed/expired mid-recovery.
@@ -131,9 +137,7 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
   const halfReady = !ready && timeLeft <= halfThreshold;
 
   const handleDrill = async () => {
-    const requiredDrillAmount = getRequiredOilDrillAmount(game).amount;
     if (!ready || drills.lessThan(requiredDrillAmount)) return;
-    const { amount: oilDropAmount } = getOilDropAmount(game, reserve);
 
     gameService.send({ type: "oilReserve.drilled", id });
 
@@ -143,7 +147,7 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
     await new Promise((res) => setTimeout(res, 2000));
     setDrilling(false);
   };
-  const hasDrill = drills.gte(getRequiredOilDrillAmount(game).amount);
+  const hasDrill = drills.gte(requiredDrillAmount);
 
   return (
     <div className="relative w-full h-full flex justify-center items-center">

--- a/src/features/game/expansion/components/resources/oilReserve/components/DepletedOilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/components/DepletedOilReserve.tsx
@@ -7,11 +7,17 @@ import { Transition } from "@headlessui/react";
 import oil from "assets/resources/oil.webp";
 import emptyOilReserve from "assets/resources/oil/oil_reserve_empty.webp";
 import classNames from "classnames";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 interface Props {
   timeLeft: number;
   oilAmount?: number;
   drilling: boolean;
+  /**
+   * Current effective recovery speed from the windowed Stag Shrine boost.
+   * > 1 shows a lightning marker + the multiplier in the popover.
+   */
+  speed?: number;
   onOilTransitionEnd?: () => void;
 }
 
@@ -19,10 +25,12 @@ export const DepletedOilReserve: React.FC<Props> = ({
   timeLeft,
   oilAmount,
   drilling,
+  speed,
   onOilTransitionEnd,
 }) => {
   const { t } = useAppTranslation();
   const [showTimeLeft, setShowTimeLeft] = useState(false);
+  const boosted = speed !== undefined && speed > 1;
 
   return (
     <div
@@ -45,6 +53,19 @@ export const DepletedOilReserve: React.FC<Props> = ({
           }}
           alt="Empty oil reserve"
         />
+        {boosted && (
+          <img
+            src={SUNNYSIDE.icons.lightning}
+            alt=""
+            aria-hidden
+            className="absolute animate-pulse"
+            style={{
+              width: `${PIXEL_SCALE * 7}px`,
+              top: `${PIXEL_SCALE * 2}px`,
+              right: `${PIXEL_SCALE * 2}px`,
+            }}
+          />
+        )}
         <div
           className="flex justify-center absolute w-full"
           style={{
@@ -55,6 +76,7 @@ export const DepletedOilReserve: React.FC<Props> = ({
             text={t("resources.recoversIn")}
             timeLeft={timeLeft}
             showTimeLeft={showTimeLeft}
+            speed={speed}
           />
         </div>
       </div>

--- a/src/features/game/expansion/components/resources/oilReserve/components/RecoveringOilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/components/RecoveringOilReserve.tsx
@@ -4,14 +4,21 @@ import halfFullOilReserve from "assets/resources/oil/oil_reserve_half.webp";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { TimeLeftPanel } from "components/ui/TimeLeftPanel";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { SUNNYSIDE } from "assets/sunnyside";
 
 interface Props {
   timeLeft: number;
+  /**
+   * Current effective recovery speed from the windowed Stag Shrine boost.
+   * > 1 shows a lightning marker + the multiplier in the popover.
+   */
+  speed?: number;
 }
 
-export const RecoveringOilReserve: React.FC<Props> = ({ timeLeft }) => {
+export const RecoveringOilReserve: React.FC<Props> = ({ timeLeft, speed }) => {
   const { t } = useAppTranslation();
   const [showTimeLeft, setShowTimeLeft] = useState(false);
+  const boosted = speed !== undefined && speed > 1;
 
   return (
     <div
@@ -26,6 +33,19 @@ export const RecoveringOilReserve: React.FC<Props> = ({ timeLeft }) => {
         }}
         alt="Full oil reserve"
       />
+      {boosted && (
+        <img
+          src={SUNNYSIDE.icons.lightning}
+          alt=""
+          aria-hidden
+          className="absolute animate-pulse"
+          style={{
+            width: `${PIXEL_SCALE * 7}px`,
+            top: `${PIXEL_SCALE * 2}px`,
+            right: `${PIXEL_SCALE * 2}px`,
+          }}
+        />
+      )}
       <div
         className="flex justify-center absolute w-full"
         style={{
@@ -36,6 +56,7 @@ export const RecoveringOilReserve: React.FC<Props> = ({ timeLeft }) => {
           text={t("resources.recoversIn")}
           timeLeft={timeLeft}
           showTimeLeft={showTimeLeft}
+          speed={speed}
         />
       </div>
     </div>

--- a/src/features/game/lib/boostWindows.test.ts
+++ b/src/features/game/lib/boostWindows.test.ts
@@ -17,6 +17,8 @@ import {
   getFlowerBoostWindows,
   getGreenhouseBoostWindows,
   getGreenhouseGlowWindows,
+  getOilBoostWindows,
+  OIL_BOOST_SPEED,
   appendBoostHistory,
   type BoostWindow,
 } from "./boostWindows";
@@ -698,6 +700,61 @@ describe("getFlowerBoostWindows", () => {
 
   it("returns no windows when none are placed", () => {
     expect(getFlowerBoostWindows(TEST_FARM)).toEqual([]);
+  });
+});
+
+describe("getOilBoostWindows", () => {
+  const createdAt = 1_000_000;
+
+  it("builds a window for an active Stag Shrine at the oil speed", () => {
+    const windows = getOilBoostWindows({
+      ...TEST_FARM,
+      collectibles: {
+        ...TEST_FARM.collectibles,
+        "Stag Shrine": [{ id: "1", coordinates: { x: 0, y: 0 }, createdAt }],
+      },
+    });
+
+    expect(windows).toContainEqual({
+      from: createdAt,
+      to: createdAt + getExpiryCooldown("Stag Shrine", TEST_FARM),
+      speed: OIL_BOOST_SPEED["Stag Shrine"],
+    });
+  });
+
+  it("does NOT include totems (oil gets no totem boost)", () => {
+    const windows = getOilBoostWindows({
+      ...TEST_FARM,
+      collectibles: {
+        ...TEST_FARM.collectibles,
+        "Super Totem": [{ id: "1", coordinates: { x: 0, y: 0 }, createdAt }],
+        "Time Warp Totem": [
+          { id: "2", coordinates: { x: 1, y: 1 }, createdAt },
+        ],
+      },
+    });
+
+    expect(windows).toEqual([]);
+  });
+
+  it("includes a removed/burned Stag Shrine via boostHistory", () => {
+    const from = 1_000_000;
+    const to = from + getExpiryCooldown("Stag Shrine", TEST_FARM);
+    const windows = getOilBoostWindows({
+      ...TEST_FARM,
+      collectibles: {},
+      boostHistory: { "Stag Shrine": [{ from, to }] },
+    });
+
+    expect(windows).toContainEqual({
+      from,
+      to,
+      speed: OIL_BOOST_SPEED["Stag Shrine"],
+    });
+  });
+
+  it("returns no windows when none are placed", () => {
+    expect(getOilBoostWindows(TEST_FARM)).toEqual([]);
   });
 });
 

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -105,6 +105,16 @@ export const FLOWER_BOOST_SPEED = {
 } as const;
 
 /**
+ * Speed multiplier for the windowed oil-reserve recovery boost. Oil's only
+ * temporary boost is the Stag Shrine (no totems apply to oil, mirroring flowers).
+ * Stag Shrine is a MIXED boost: only its recovery-TIME half is windowed here; its
+ * +15 bonus-oil yield (every 3rd drill) stays baked in getOilDropAmount.
+ */
+export const OIL_BOOST_SPEED = {
+  "Stag Shrine": 1.35,
+} as const;
+
+/**
  * Speed multipliers for the windowed greenhouse growth boosts — the single place
  * to tune them. Stacking is multiplicative; Super & Time Warp Totem share the
  * same 2× and merge so they don't stack with each other. Coverage differs by
@@ -270,6 +280,20 @@ export const getFlowerBoostWindows = (game: GameState): BoostWindow[] => [
     speed: FLOWER_BOOST_SPEED["Moth Shrine"],
   }),
 ];
+
+/**
+ * The windowed speed boosts that apply to an oil reserve's recovery. Oil's only
+ * temporary boost is the Stag Shrine (no totems — mirrors flowers). Only its
+ * recovery-TIME half is windowed; the +15 bonus-oil yield stays baked in
+ * getOilDropAmount. Empty set (no Stag Shrine) makes `computeReadyAt` reduce to
+ * `drilledAt + baseDurationMs`.
+ */
+export const getOilBoostWindows = (game: GameState): BoostWindow[] =>
+  getBoostWindows({
+    game,
+    name: "Stag Shrine",
+    speed: OIL_BOOST_SPEED["Stag Shrine"],
+  });
 
 /**
  * The Turbofruit Mix fertiliser's speed window for a fruit patch. Unlike the

--- a/src/features/game/types/collectibleItemBuffs.ts
+++ b/src/features/game/types/collectibleItemBuffs.ts
@@ -1854,9 +1854,11 @@ export const COLLECTIBLE_BUFF_LABELS: Partial<
       boostTypeIcon: powerup,
     },
   ],
-  "Stag Shrine": () => [
+  "Stag Shrine": (game) => [
     {
-      shortDescription: translate("description.stagShrine.buff"),
+      shortDescription: hasFeatureAccess(game, "SPEED_BOOSTS")
+        ? translate("description.stagShrine.buff.speed")
+        : translate("description.stagShrine.buff"),
       labelType: "info",
       boostTypeIcon: SUNNYSIDE.icons.stopwatch,
       boostedItemIcon: ITEM_DETAILS.Oil.image,

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -870,6 +870,15 @@ export type Rock = {
 
 export type Oil = {
   drilledAt: number;
+  /**
+   * Unboosted-by-windowed-collectibles recovery duration (ms), with all
+   * permanent (discount-at-start) boosts already folded in. Present only on
+   * reserves drilled under the speed-rate model; its presence selects
+   * `computeReadyAt` over the legacy back-dated `drilledAt` readiness check.
+   * Oil has no progress-fill bar (countdown only), so — like `Wood` — it
+   * carries no `boostedTime`.
+   */
+  baseDurationMs?: number;
 };
 
 export type OilReserve = {

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -878,11 +878,10 @@ export type Oil = {
    * Oil has no progress-fill bar (countdown only), so — like `Wood` — it
    * carries no `boostedTime`.
    *
-   * Lifecycle: PERMANENT per-reserve. Once drilled windowed the reserve stays
-   * windowed, and every subsequent drill REFRESHES this to that cycle's
-   * permanent-only duration (sticky), regardless of the `SPEED_BOOSTS` flag — it
-   * is never left stale beside a fresh `drilledAt`, nor does it silently revert to
-   * the legacy back-date.
+   * Lifecycle: each drill rebuilds the timer, so a flag-off re-drill CLEARS this
+   * and reverts the reserve to legacy — mirrors the stone/tree resource nodes
+   * (`rock.stone` rebuild / `delete tree.wood.baseDurationMs`). The read path stays
+   * windowed on the marker's presence until that next drill.
    */
   baseDurationMs?: number;
 };

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -877,6 +877,12 @@ export type Oil = {
    * `computeReadyAt` over the legacy back-dated `drilledAt` readiness check.
    * Oil has no progress-fill bar (countdown only), so — like `Wood` — it
    * carries no `boostedTime`.
+   *
+   * Lifecycle: PERMANENT per-reserve. Once drilled windowed the reserve stays
+   * windowed, and every subsequent drill REFRESHES this to that cycle's
+   * permanent-only duration (sticky), regardless of the `SPEED_BOOSTS` flag — it
+   * is never left stale beside a fresh `drilledAt`, nor does it silently revert to
+   * the legacy back-date.
    */
   baseDurationMs?: number;
 };

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -7599,6 +7599,7 @@
   "description.badgerShrine.buff.2": "x0.75 Stone Recovery Time",
   "description.badgerShrine.buff.2.speed": "1.35x Stone Recovery Speed",
   "description.stagShrine.buff": "x0.75 Oil Recovery Time",
+  "description.stagShrine.buff.speed": "1.35x Oil Recovery Speed",
   "description.stagShrine.buff.2": "+15 Oil every 3rd drill",
   "description.moleShrine.buff": "x0.75 Iron Recovery Time",
   "description.moleShrine.buff.speed": "1.35x Iron Recovery Speed",


### PR DESCRIPTION
## Oil reserves → speed-boost window migration (behind `SPEED_BOOSTS`)

Next slice in the temp-boost → live speed-rate migration (after crops / trees / mines / fruit / flowers / greenhouse). Oil's only temporary boost is the **Stag Shrine** (legacy ×0.75 oil recovery time), which becomes a **1.35× recovery-speed window**. It's a mixed boost — only the **time half** is windowed; the **+15 bonus-oil yield** (every 3rd drill) stays baked. Permanent boosts (Dev Wrench ×0.5, Oil Be Back ×0.8) bake into a new `Oil.baseDurationMs` marker. No totems apply to oil (mirrors flowers). Oil has no progress-fill bar, so — like trees — it carries `baseDurationMs` but no `boostedTime`.

### Changes
- **Engine** (`boostWindows.ts`): `OIL_BOOST_SPEED` + `getOilBoostWindows` (Stag only).
- **Drill** (`drillOilReserve.ts`): `getOilReserveReadyAt` + `canDrillOilReserve(reserve, game, now)` key off the `baseDurationMs` marker (not the flag, rollback-safe); `getOilRecoveryTimeForDisplay` excludes Stag under the flag; `getDrilledAt` stores the real drill time + permanent-only `baseDurationMs`.
- **Lift/replace** (`placeOilReserve.ts`): shared `pauseWindowedTimer` (behaviour-identical for legacy reserves).
- **Grease Lightning** (`skillUsed.ts`): zeroes `baseDurationMs` for a windowed reserve (instant recovery).
- **UI** (`OilReserve.tsx` + Recovering/Depleted children): scoped windows selector (replaces the full-state subscription), `computeReadyAt`, `useNow` speed-tick, lightning indicator; the half-recovery art threshold is made windowed-aware so it flips at the right point under a boost.
- **Label**: `description.stagShrine.buff.speed` = "1.35x Oil Recovery Speed" (flag-gated; +15 yield label untouched).

### Notes
- `getOilRecoveryTimeForDisplay` (ToolsGuide recovery display) shows base/permanent-only recovery time under the flag — the temp boost is shown live on the node, consistent with how stone/tree were done.
- Fully gated: on mainnet `baseDurationMs` is never written and all read paths fall back to legacy.

### Tests
tsc + eslint clean; new engine / drill (windowed shape, Stag excluded from `boostsUsed` but +15 yield preserved, readies-1.35×-sooner, expired-window credit, strict-`>` boundary, mainnet permanent-marker pin) / place-banking / Grease-Lightning tests. Oil-adjacent (reveal/move/remove) suites green.

Pairs with the backend oil migration + `migrateSpeedBoosts` in **sunflower-land-api** (`sunflower-land-api#3471`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oil reserves now use boost-window-aware recovery timing, so the “ready” moments are correct during speed boost windows.
  * Stag Shrine’s oil recovery speed bonus is now shown as a localized buff label.
  * Boosted oil reserves display a lightning indicator and reflect faster recovery in the UI.
* **Bug Fixes**
  * Fixed oil drilling/ready eligibility to prevent drilling exactly at the ready time.
  * Improved recovery pausing/resuming and time banking when replacing an oil reserve mid-recovery.
  * Grease Lightning now immediately completes affected oil recovery, including windowed reserves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->