### PR TITLE
[FEAT] Gate Saltwort marketplace trading behind Chapter Crop Week access

### DIFF
--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -222,7 +222,8 @@ export const Tradeable: React.FC<{ hideLimited?: boolean }> = ({
 
   // Chapter Crop Week crop (Saltwort) trading is gated to players with event
   // access (beta testers early; everyone during the event window). Everyone else
-  // sees a "coming soon" panel instead of the buy / list / offer / accept UI.
+  // can still view the item, but the buy / list / offer / accept actions are
+  // disabled.
   const isChapterCropWeekLocked =
     display.name === CHAPTER_CROP_WEEK_CROP && !hasChapterCropWeekAccess(state);
 

--- a/src/features/marketplace/components/Tradeable.tsx
+++ b/src/features/marketplace/components/Tradeable.tsx
@@ -26,6 +26,8 @@ import { MyOffers } from "./profile/MyOffers";
 import { TradeableListings } from "./TradeableListings";
 import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
+import { hasChapterCropWeekAccess } from "lib/flags";
+import { CHAPTER_CROP_WEEK_CROP } from "features/game/types/chapterCropWeek";
 import { TradeableStats } from "./TradeableStats";
 import { getKeys } from "lib/object";
 import { tradeToId } from "../lib/offers";
@@ -217,6 +219,13 @@ export const Tradeable: React.FC<{ hideLimited?: boolean }> = ({
   const marketPrice = getMarketPrice({ tradeable });
 
   const isStoneBeetle = collection === "collectibles" && Number(id) === 2129;
+
+  // Chapter Crop Week crop (Saltwort) trading is gated to players with event
+  // access (beta testers early; everyone during the event window). Everyone else
+  // sees a "coming soon" panel instead of the buy / list / offer / accept UI.
+  const isChapterCropWeekLocked =
+    display.name === CHAPTER_CROP_WEEK_CROP && !hasChapterCropWeekAccess(state);
+
   const favoriteItem =
     collection === "economies"
       ? undefined
@@ -276,6 +285,7 @@ export const Tradeable: React.FC<{ hideLimited?: boolean }> = ({
           onBack={onBack}
           reload={reload}
           onListClick={() => setShowListItem(true)}
+          disabled={isChapterCropWeekLocked}
         />
 
         {!isMobile && (
@@ -304,6 +314,7 @@ export const Tradeable: React.FC<{ hideLimited?: boolean }> = ({
             setShowListItem(false);
           }}
           reload={reload}
+          disabled={isChapterCropWeekLocked}
         />
 
         {!isStoneBeetle && (
@@ -316,6 +327,7 @@ export const Tradeable: React.FC<{ hideLimited?: boolean }> = ({
             display={display}
             farmId={farmId}
             reload={reload}
+            disabled={isChapterCropWeekLocked}
           />
         )}
 

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -50,6 +50,8 @@ type TradeableHeaderProps = {
   reload: () => void;
   limitedPurchasesLeft: number;
   display: TradeableDisplay;
+  /** When true, buying & listing are blocked (e.g. Saltwort without event access). */
+  disabled?: boolean;
 };
 
 const _balance = (state: MachineState) => state.context.state.balance;
@@ -64,6 +66,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
   onListClick,
   reload,
   display,
+  disabled,
 }) => {
   const { gameService } = useContext(Context);
   const balance = useSelector(gameService, _balance);
@@ -312,7 +315,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
             {showBuyNow && (
               <Button
                 onClick={() => setShowPurchaseModal(true)}
-                disabled={!canBuy}
+                disabled={!canBuy || disabled}
                 className={classNames("mr-1 w-full sm:w-auto", {
                   "animate-pulsate": isTutorialBuy,
                 })}
@@ -324,6 +327,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
               <Button
                 onClick={onListClick}
                 disabled={
+                  disabled ||
                   !availableCount ||
                   (!hasTradeReputation &&
                     getRemainingTrades({

--- a/src/features/marketplace/components/TradeableHeader.tsx
+++ b/src/features/marketplace/components/TradeableHeader.tsx
@@ -275,7 +275,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 {showBuyNow && (
                   <Button
                     onClick={() => setShowPurchaseModal(true)}
-                    disabled={!canBuy}
+                    disabled={!canBuy || disabled}
                     className={classNames("mr-1 w-full sm:w-auto", {
                       "animate-pulsate": isTutorialBuy,
                     })}
@@ -286,6 +286,7 @@ export const TradeableHeader: React.FC<TradeableHeaderProps> = ({
                 {tradeable?.isActive && !vipIsRequired && !isTutorialItem && (
                   <Button
                     disabled={
+                      disabled ||
                       !availableCount ||
                       // Already has one listed?
 

--- a/src/features/marketplace/components/TradeableListings.tsx
+++ b/src/features/marketplace/components/TradeableListings.tsx
@@ -52,6 +52,8 @@ type TradeableListingsProps = {
   onListClick: () => void;
   onListClose: () => void;
   reload: KeyedMutator<TradeableDetails>;
+  /** When true, buying is blocked (e.g. Saltwort without event access). */
+  disabled?: boolean;
 };
 
 type BulkOrder = {
@@ -74,6 +76,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
   showListItem,
   reload,
   onListClose,
+  disabled,
 }) => {
   const { gameService, showAnimations } = useContext(Context);
   const { t } = useAppTranslation();
@@ -339,6 +342,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
                   </Button>
                   <Button
                     disabled={
+                      disabled ||
                       bulkOrder === undefined ||
                       bulkOrder?.ids.length === 0 ||
                       new Decimal(bulkOrder?.price ?? 0).gt(balance)
@@ -353,6 +357,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
               {!!availableListings.length &&
                 isResource &&
                 !showBulkBuy &&
+                !disabled &&
                 tradeable?.isActive &&
                 limitedTradesLeft === Infinity && (
                   <Button
@@ -402,7 +407,7 @@ export const TradeableListings: React.FC<TradeableListingsProps> = ({
                   id={farmId}
                   tableType="listings"
                   onClick={
-                    tradeable.isActive
+                    tradeable.isActive && !disabled
                       ? (listingId) => {
                           handleSelectListing(listingId);
                           setShowPurchaseModal(true);

--- a/src/features/marketplace/components/TradeableOffers.tsx
+++ b/src/features/marketplace/components/TradeableOffers.tsx
@@ -57,6 +57,8 @@ export const TradeableOffers: React.FC<{
   display: TradeableDisplay;
   itemId: number;
   reload: KeyedMutator<TradeableDetails>;
+  /** When true, making & accepting offers is blocked (e.g. Saltwort without event access). */
+  disabled?: boolean;
 }> = ({
   hideLimited,
   tradeable,
@@ -66,6 +68,7 @@ export const TradeableOffers: React.FC<{
   itemId,
   reload,
   limitedPurchasesLeft,
+  disabled,
 }) => {
   const { authService } = useContext(Auth.Context);
   const { gameService, showAnimations } = useContext(Context);
@@ -237,6 +240,7 @@ export const TradeableOffers: React.FC<{
                     <Button
                       className="w-full sm:w-fit mr-1"
                       disabled={
+                        disabled ||
                         !tradeable ||
                         !tradeable?.isActive ||
                         limitedPurchasesLeft <= 0
@@ -252,6 +256,7 @@ export const TradeableOffers: React.FC<{
                   {topOffer && tradeable?.isActive && !vipIsRequired && (
                     <Button
                       disabled={
+                        disabled ||
                         topOffer.offeredBy.id === farmId ||
                         limitedTradesLeft <= 0
                       }
@@ -318,7 +323,7 @@ export const TradeableOffers: React.FC<{
                   id={farmId}
                   tableType="offers"
                   onClick={
-                    tradeable.isActive && !vipIsRequired
+                    tradeable.isActive && !vipIsRequired && !disabled
                       ? (offerId) => {
                           handleSelectOffer(offerId);
                           setShowAcceptOffer(true);
@@ -332,6 +337,7 @@ export const TradeableOffers: React.FC<{
           <div className="w-full justify-end flex sm:pb-2 sm:pr-2">
             <Button
               className="w-full sm:w-fit"
+              disabled={disabled}
               onClick={() => setShowMakeOffer(true)}
             >
               {t("marketplace.makeOffer")}


### PR DESCRIPTION
## What

Disables the four Saltwort marketplace actions — **buy**, **list**, **make offer**, **accept offer** — for players without Chapter Crop Week access, across **both desktop and mobile** views.

The Saltwort info panel already carries the "Temporarily tradeable during Chapter Crop Week" notice, so this PR only greys out the action buttons rather than adding a separate "coming soon" panel.

## How

- Compute `isChapterCropWeekLocked` in `Tradeable.tsx` (`display.name === CHAPTER_CROP_WEEK_CROP && !hasChapterCropWeekAccess(state)`) and thread a `disabled` prop into:
  - **TradeableHeader** — Buy Now + List for Sale (desktop & mobile)
  - **TradeableListings** — resource buy (ResourceTable), Bulk Buy toggle + Buy
  - **TradeableOffers** — Make Offer + Accept Offer (collectible and resource paths)
- Uses the same `hasChapterCropWeekAccess(state)` helper as the seed shop, fire pit and cook gates, so flipping that one helper to the event window at public launch flows through automatically.

Backend enforcement is in the companion sunflower-land-api PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trading interactions are now properly disabled for restricted marketplace items, preventing “Buy Now,” “List for Sale,” and offer-related actions when player access is limited.
  * Marketplace listings now consistently respect the locked state by disabling bulk purchase actions and preventing row selection/click handling for unavailable trades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->