### PR TITLE
[FEAT] Show active grow-time boosts in inventory Basket

### DIFF
--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -48,6 +48,8 @@ interface HarvestsRequirementProps {
 /**
  * The props for the inventory properties.
  * @param timeSeconds The wait time in seconds for using the item.
+ * @param baseTimeSeconds The base wait time before boosts (for strikethrough display).
+ * @param timeBoostsUsed The boosts applied to the grow time (for clickable boost display).
  * @param harvests The min/max harvests for the item.
  * @param xp The XP gained for consuming the item.
  * @param xpBoostsUsed The boosts applied to food XP (for clickable boost display).
@@ -58,6 +60,8 @@ interface HarvestsRequirementProps {
  */
 interface PropertiesProps {
   timeSeconds?: number;
+  baseTimeSeconds?: number;
+  timeBoostsUsed?: { name: BoostName; value: string }[];
   harvests?: HarvestsRequirementProps;
   xp?: Decimal;
   xpBoostsUsed?: { name: BoostName; value: string }[];
@@ -170,6 +174,51 @@ export const InventoryItemDetails: React.FC<Props> = ({
   const getProperties = () => {
     if (!properties) return <></>;
 
+    const getTimeDisplay = () => {
+      if (!properties.timeSeconds) return <></>;
+
+      const isTimeBoosted =
+        properties.timeBoostsUsed &&
+        properties.timeBoostsUsed.length > 0 &&
+        properties.baseTimeSeconds !== undefined &&
+        properties.timeSeconds !== properties.baseTimeSeconds;
+
+      if (
+        isTimeBoosted &&
+        properties.timeBoostsUsed &&
+        properties.setShowBoosts &&
+        properties.showBoosts !== undefined
+      ) {
+        return (
+          <div
+            className="flex flex-col items-center cursor-pointer"
+            onClick={() => properties.setShowBoosts?.(!properties.showBoosts)}
+          >
+            <RequirementLabel
+              type="time"
+              waitSeconds={properties.timeSeconds}
+              boosted
+            />
+            <RequirementLabel
+              type="time"
+              waitSeconds={properties.baseTimeSeconds ?? 0}
+              strikethrough
+            />
+            <BoostsDisplay
+              boosts={properties.timeBoostsUsed}
+              show={properties.showBoosts}
+              state={game}
+              onClick={() => properties.setShowBoosts?.(!properties.showBoosts)}
+            />
+          </div>
+        );
+      }
+
+      return (
+        <RequirementLabel type="time" waitSeconds={properties.timeSeconds} />
+      );
+    };
+
     const getXPDisplay = () => {
       if (!properties.xp) return <></>;
 
@@ -217,9 +266,7 @@ export const InventoryItemDetails: React.FC<Props> = ({
         )}
       >
         {/* Time requirement display */}
-        {!!properties.timeSeconds && (
-          <RequirementLabel type="time" waitSeconds={properties.timeSeconds} />
-        )}
+        {getTimeDisplay()}
 
         {/* Harvests display */}
         {!!properties.harvests && (

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -154,30 +154,54 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
 
   const getHarvestTime = (seedName: SeedName) => {
     if (isFlowerSeed(seedName)) {
-      return getFlowerTime(seedName, gameState).seconds;
+      return getFlowerTime(seedName, gameState);
     }
 
     if (isPatchFruitSeed(seedName)) {
-      return getFruitPatchTime(seedName, gameState).seconds;
+      return getFruitPatchTime(seedName, gameState);
     }
     if (seedName in GREENHOUSE_SEEDS || seedName in GREENHOUSE_FRUIT_SEEDS) {
       const plant = SEED_TO_PLANT[seedName as GreenHouseCropSeedName];
-      const { seconds } = getGreenhouseCropTime({
+      return getGreenhouseCropTime({
         crop: plant,
         game: gameState,
       });
-      return seconds;
     }
 
     const crop = SEEDS[seedName].yield as CropName;
-    return getCropPlotTime({
+    const { time: seconds, boostsUsed } = getCropPlotTime({
       crop,
       game: gameState,
       createdAt: now,
-    }).time;
+    });
+    return { seconds, boostsUsed };
+  };
+
+  const getBaseHarvestTime = (seedName: SeedName): number => {
+    if (seedName in FLOWER_SEEDS) {
+      return FLOWER_SEEDS[seedName as keyof typeof FLOWER_SEEDS].plantSeconds;
+    }
+    if (seedName in PATCH_FRUIT_SEEDS) {
+      return PATCH_FRUIT_SEEDS[seedName as keyof typeof PATCH_FRUIT_SEEDS]
+        .plantSeconds;
+    }
+    if (seedName in GREENHOUSE_SEEDS) {
+      return GREENHOUSE_SEEDS[seedName as keyof typeof GREENHOUSE_SEEDS]
+        .plantSeconds;
+    }
+    if (seedName in GREENHOUSE_FRUIT_SEEDS) {
+      return GREENHOUSE_FRUIT_SEEDS[
+        seedName as keyof typeof GREENHOUSE_FRUIT_SEEDS
+      ].plantSeconds;
+    }
+    return CROP_SEEDS[seedName as keyof typeof CROP_SEEDS].plantSeconds;
   };
 
   const harvestCounts = getFruitHarvests(gameState, selectedItem as SeedName);
+
+  const seedHarvestTime = isSeed(selectedItem)
+    ? getHarvestTime(selectedItem)
+    : undefined;
 
   const foodExpBoost = isFood(selectedItem)
     ? getFoodExpBoost({
@@ -541,13 +565,15 @@ export const Basket: React.FC<Prop> = ({ gameState, selected, onSelect }) => {
                 baseXp: foodExpBoost
                   ? CONSUMABLES[selectedItem as ConsumableName].experience
                   : undefined,
-                ...(foodExpBoost && {
+                ...((foodExpBoost || isSeed(selectedItem)) && {
                   showBoosts,
                   setShowBoosts,
                 }),
-                timeSeconds: isSeed(selectedItem)
-                  ? getHarvestTime(selectedItem)
+                timeSeconds: seedHarvestTime?.seconds,
+                baseTimeSeconds: isSeed(selectedItem)
+                  ? getBaseHarvestTime(selectedItem)
                   : undefined,
+                timeBoostsUsed: seedHarvestTime?.boostsUsed,
                 showOpenSeaLink: true,
               }}
             />


### PR DESCRIPTION
## What

Mirrors the Market **Buy** panel's **"⚡ Boosts applied"** display into the inventory **Basket**.

Previously, selecting a seed in the Basket showed only a single, un-annotated grow time (e.g. `32mins 24secs`) — even though the boosted time was already being computed, the boost list and base time were discarded. The Market Buy panel, meanwhile, shows the boosted time (green) + struck-through base time and a click-to-reveal list of every active boost.

Now the Basket matches: selecting a boosted seed shows the boosted grow time + struck-through base time, and clicking it toggles the same **"Boosts applied"** panel (e.g. `x0.8 Fruit Tune Box`, `x0.5 Tomato Clown`).

## How

Reuses the existing pattern already present in the shared `InventoryItemDetails` component for **food XP** boosts — no new component.

- **`InventoryItemDetails.tsx`** — added `baseTimeSeconds` + `timeBoostsUsed` to `PropertiesProps`, and a `getTimeDisplay()` helper that's the time twin of the existing `getXPDisplay()`. When the grow time is boosted it renders boosted + strikethrough + the reusable `BoostsDisplay` panel (sharing the existing `showBoosts` toggle); otherwise it falls back to the plain single time label.
- **`Basket.tsx`** — `getHarvestTime` now returns the full `{ seconds, boostsUsed }` for every seed type (crop/fruit/flower/greenhouse) instead of dropping the boost list, mirroring the Market's `getPlantSeconds`. Added `getBaseHarvestTime` (mirror of `getBasePlantSeconds`) for the strikethrough base time, and wired the boosts + toggle through to the panel.

Seeds and consumables are mutually exclusive, so time-boosts and food-XP-boosts never render for the same item and safely share the one `showBoosts` state. FE-only — the Market boosts display has no backend equivalent.

## Testing

- `tsc --noEmit` clean (only pre-existing unrelated `virtual:pwa-register/react` errors) and both files lint clean.
- Manual: Basket → boosted seed shows green boosted time + struck-through base time; clicking toggles the "Boosts applied" list matching the Market Buy panel. Verified across crop / fruit / flower / greenhouse seeds. Seeds with no active boosts keep the plain single time label; food XP boosts unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory item details now show boosted time requirements when applicable, including a comparison to the base time and an option to view boost details.
  * Seed items in the inventory now display harvest timing with boost-aware information and can show boost controls.
* **Bug Fixes**
  * Time display handling has been unified so inventory details consistently show either boosted or standard timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->