### PR TITLE
[FIX] Improve sick animal sell confirmation

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -23,7 +23,7 @@ import { FeederMachine } from "features/feederMachine/FeederMachine";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { UpgradeBuildingModal } from "features/game/expansion/components/UpgradeBuildingModal";
 import { ANIMAL_HOUSE_IMAGES } from "features/henHouse/HenHouseInside";
-import type { Animal, AnimalBounty } from "features/game/types/game";
+import type { AnimalBounty } from "features/game/types/game";
 import { AnimalDeal, ExchangeHud } from "./components/AnimalBounties";
 import { Modal } from "components/ui/Modal";
 import classNames from "classnames";
@@ -69,7 +69,7 @@ export const BarnInside: React.FC = () => {
   const { gameService } = useContext(Context);
   const [showModal, setShowModal] = useState(!hasReadGuide());
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-  const [selected, setSelected] = useState<Animal>();
+  const [selectedAnimalId, setSelectedAnimalId] = useState<string>();
   const [deal, setDeal] = useState<AnimalBounty>();
   const { authService } = useContext(AuthContext);
   const context = gameService.getSnapshot().context;
@@ -183,17 +183,20 @@ export const BarnInside: React.FC = () => {
         onClose={() => setShowUpgradeModal(false)}
       />
 
-      <Modal show={!!selected && !!deal} onHide={() => setSelected(undefined)}>
+      <Modal
+        show={!!selectedAnimalId && !!deal}
+        onHide={() => setSelectedAnimalId(undefined)}
+      >
         <AnimalDeal
           onClose={() => {
-            setSelected(undefined);
+            setSelectedAnimalId(undefined);
           }}
           onSold={() => {
             setDeal(undefined);
-            setSelected(undefined);
+            setSelectedAnimalId(undefined);
           }}
           deal={deal}
-          animal={selected}
+          animalId={selectedAnimalId}
         />
       </Modal>
       <>
@@ -268,7 +271,7 @@ export const BarnInside: React.FC = () => {
                             e.stopPropagation();
                             e.preventDefault();
                             if (!isValid) return;
-                            setSelected(animal);
+                            setSelectedAnimalId(animal.id.toString());
                           }
                         }}
                       >

--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -20,6 +20,7 @@ import type {
   Animal,
   AnimalBounty,
   BountyRequest,
+  GameState,
   InventoryItemName,
 } from "features/game/types/game";
 import { ITEM_DETAILS } from "features/game/types/images";
@@ -32,7 +33,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { NPC_WEARABLES } from "lib/npcs";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { useNow } from "lib/utils/hooks/useNow";
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import chapterPoints from "assets/icons/red_medal_short.webp";
 
 import { getChapterTaskPoints } from "features/game/types/tracks";
@@ -44,6 +45,21 @@ interface Props {
   reward?: "coins" | "tickets";
   readonly?: boolean;
 }
+
+const ConfirmButton: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+  onClick: () => void;
+}> = ({ children, className, onClick }) => {
+  const [unlockAt] = useState(() => Date.now() + 1000);
+  const { totalSeconds } = useCountdown(unlockAt);
+
+  return (
+    <Button className={className} disabled={totalSeconds > 0} onClick={onClick}>
+      {children}
+    </Button>
+  );
+};
 
 export const AnimalBounties: React.FC<Props> = ({
   type,
@@ -172,25 +188,70 @@ export const AnimalBounties: React.FC<Props> = ({
 
 export const AnimalDeal: React.FC<{
   deal?: BountyRequest;
-  animal?: Animal;
+  animalId?: string;
   onClose: () => void;
   onSold: () => void;
-}> = ({ deal, animal, onClose, onSold }) => {
+}> = ({ deal, animalId, onClose, onSold }) => {
   const { gameService, gameState } = useGame();
   const state = gameState.context.state;
+  const [animalOverride, setAnimalOverride] = useState<{
+    animalId: string;
+    animal: Animal;
+    showStateChangeWarning: boolean;
+  }>();
+  const renderedAnimalState = useRef<Animal["state"] | undefined>(undefined);
   const now = useNow({ live: true, intervalMs: 60_000 });
   const { t } = useAppTranslation();
   const chapterTicket = getChapterTicket(now);
 
+  const getAnimal = (state: GameState) => {
+    if (!deal || !animalId) return undefined;
+
+    return deal.name === "Chicken"
+      ? state.henHouse.animals[animalId]
+      : state.barn.animals[animalId];
+  };
+
+  const activeAnimalOverride =
+    animalOverride?.animalId === animalId ? animalOverride : undefined;
+  const animal = activeAnimalOverride?.animal ?? getAnimal(state);
+  const showStateChangeWarning =
+    activeAnimalOverride?.showStateChangeWarning ?? false;
+
+  const confirmationKey = `${animalId ?? ""}-${animal?.state ?? ""}-${
+    showStateChangeWarning ? "changed" : "current"
+  }`;
+
+  useEffect(() => {
+    if (animal) {
+      renderedAnimalState.current = animal.state;
+    }
+  }, [animal, animal?.state]);
+
   // Guard against transient undefined props
-  if (!deal || !animal) {
+  if (!deal || !animalId || !animal) {
     return null;
   }
 
   const sell = () => {
+    const currentAnimal = getAnimal(gameService.getSnapshot().context.state);
+
+    if (!currentAnimal) {
+      return;
+    }
+
+    if (renderedAnimalState.current !== currentAnimal.state) {
+      setAnimalOverride({
+        animalId,
+        animal: currentAnimal,
+        showStateChangeWarning: true,
+      });
+      return;
+    }
+
     gameService.send("animal.sold", {
       requestId: deal.id,
-      animalId: animal.id.toString(),
+      animalId,
     });
 
     onSold();
@@ -222,22 +283,47 @@ export const AnimalDeal: React.FC<{
     pointsAwarded = getChapterTaskPoints({ task: "bounty", points });
   }
 
+  const renderSickReward = (amount: number, label: string, icon: string) => {
+    const sickAmount = getSickAnimalRewardAmount(amount);
+
+    if (amount === sickAmount) {
+      return (
+        <Label type="warning" icon={icon} className="text-sm">
+          {`x ${sickAmount} ${label}`}
+        </Label>
+      );
+    }
+
+    return (
+      <>
+        <Label type="warning" icon={icon} className="text-sm">
+          <span className="line-through">{`x ${amount} ${label}`}</span>
+        </Label>
+        <Label type="warning" icon={icon} className="text-sm">
+          {`x ${sickAmount} ${label}`}
+        </Label>
+      </>
+    );
+  };
+
   return (
     <>
       {animal.state === "sick" ? (
         <Panel bumpkinParts={NPC_WEARABLES.grabnab}>
           <div className="p-2">
+            {showStateChangeWarning && (
+              <Label type="danger" className="mb-2">
+                {t("bounties.sell.animal.stateChanged")}
+              </Label>
+            )}
             <p className="mb-1">{t("bounties.sell.animal.sick")}</p>
+            <Label type="danger" className="my-2">
+              {t("bounties.sell.animal.sickReducedBounty")}
+            </Label>
             <div className="flex flex-col space-y-1 my-3">
               {deal.coins && (
                 <div className="flex items-center space-x-1">
-                  <Label
-                    type="warning"
-                    icon={SUNNYSIDE.ui.coinsImg}
-                    className="text-sm"
-                  >
-                    {`x ${getSickAnimalRewardAmount(coins)} coins`}
-                  </Label>
+                  {renderSickReward(coins, "coins", SUNNYSIDE.ui.coinsImg)}
                 </div>
               )}
               {getKeys(deal.items ?? {}).map((name) => {
@@ -253,13 +339,7 @@ export const AnimalDeal: React.FC<{
 
                 return (
                   <div className="flex items-center space-x-1" key={name}>
-                    <Label
-                      type="warning"
-                      icon={ITEM_DETAILS[name].image}
-                      className="text-sm"
-                    >
-                      {`x ${getSickAnimalRewardAmount(amount)} ${name}`}
-                    </Label>
+                    {renderSickReward(amount, name, ITEM_DETAILS[name].image)}
                   </div>
                 );
               })}
@@ -273,12 +353,19 @@ export const AnimalDeal: React.FC<{
           </div>
           <div className="flex space-x-1">
             <Button onClick={onClose}>{t("cancel")}</Button>
-            <Button onClick={sell}>{t("confirm")}</Button>
+            <ConfirmButton key={confirmationKey} onClick={sell}>
+              {t("confirm")}
+            </ConfirmButton>
           </div>
         </Panel>
       ) : (
         <Panel>
           <div className="p-2">
+            {showStateChangeWarning && (
+              <Label type="danger" className="mb-2">
+                {t("bounties.sell.animal.stateChanged")}
+              </Label>
+            )}
             <div className="mb-2 flex flex-wrap">
               <Label
                 type="default"
@@ -340,7 +427,9 @@ export const AnimalDeal: React.FC<{
             <Button className="mr-1" onClick={onClose}>
               {t("cancel")}
             </Button>
-            <Button onClick={sell}>{t("confirm")}</Button>
+            <ConfirmButton key={confirmationKey} onClick={sell}>
+              {t("confirm")}
+            </ConfirmButton>
           </div>
         </Panel>
       )}

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -22,7 +22,7 @@ import {
   AnimalDeal,
   ExchangeHud,
 } from "features/barn/components/AnimalBounties";
-import type { Animal, AnimalBounty } from "features/game/types/game";
+import type { AnimalBounty } from "features/game/types/game";
 import { isValidDeal } from "features/game/events/landExpansion/sellAnimal";
 import classNames from "classnames";
 import { EXTERIOR_ISLAND_BG } from "features/barn/BarnInside";
@@ -53,7 +53,7 @@ export const HenHouseInside: React.FC = () => {
   const [showModal, setShowModal] = useState(!hasReadGuide());
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [deal, setDeal] = useState<AnimalBounty>();
-  const [selected, setSelected] = useState<Animal>();
+  const [selectedAnimalId, setSelectedAnimalId] = useState<string>();
 
   const henHouse = useSelector(gameService, _henHouse);
   const token = useSelector(authService, _token);
@@ -147,17 +147,20 @@ export const HenHouseInside: React.FC = () => {
         onClose={() => setShowUpgradeModal(false)}
       />
 
-      <Modal show={!!selected && !!deal} onHide={() => setSelected(undefined)}>
+      <Modal
+        show={!!selectedAnimalId && !!deal}
+        onHide={() => setSelectedAnimalId(undefined)}
+      >
         <AnimalDeal
           onClose={() => {
-            setSelected(undefined);
+            setSelectedAnimalId(undefined);
           }}
           onSold={() => {
             setDeal(undefined);
-            setSelected(undefined);
+            setSelectedAnimalId(undefined);
           }}
           deal={deal}
-          animal={selected}
+          animalId={selectedAnimalId}
         />
       </Modal>
       <div
@@ -263,7 +266,7 @@ export const HenHouseInside: React.FC = () => {
 
                             if (!isValid) return;
 
-                            setSelected(animal);
+                            setSelectedAnimalId(animal.id.toString());
                           }
                         }}
                       >

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4915,6 +4915,8 @@
   "bounties.sell.items": "Are you sure you want to sell this for {{amount}}?",
   "bounties.sell.sfl": "Are you sure you want to sell this for {{amount}} FLOWER?",
   "bounties.sell.animal.sick": "Hmm, I see this poor animal is sick. I'll still take them off your hands, but I will have to offer you a reduced bounty. Deal?",
+  "bounties.sell.animal.sickReducedBounty": "Sick animals only earn 75% of this bounty.",
+  "bounties.sell.animal.stateChanged": "This animal's health changed. Please review the updated bounty and confirm again.",
   "bounties.animal.select": "Select a {{name}} to sell.",
   "bounties.animal.noAnimalToSell": "{{name}} must be awake & leveled to sell.",
   "bounties.bonus.allCompleted": "All Bounties Completed!",


### PR DESCRIPTION
## Summary
Improves the sick animal bounty confirmation flow so reduced rewards are harder to miss and accidental confirmation clicks are blocked briefly.

## Context / motivation

<img width="1034" height="558" alt="telegram-cloud-photo-size-2-5348113949116803048-y" src="https://github.com/user-attachments/assets/06e84c4a-5d6d-40d3-884d-ef1fd4d368c6" />

Sick animals only pay 75% of the normal bounty, but the previous confirmation UI made that discount easy to miss. Players could confirm the sale while focusing on the reward badge and miss that the payout had been reduced. There is also a stale-state corner case: if an animal becomes sick after the modal opens, the player can be looking at old expectations unless the UI re-checks the live animal state before selling.

## What changed
- Adds a danger warning inside the sick animal sell confirmation modal.
- Splits the reward display into two labels: the full bounty is shown struck through, and the actual reduced bounty is shown separately.
- Disables the Confirm button for one second when the confirmation modal opens to reduce accidental taps/clicks.

!!!
- Re-checks the selected animal against the live game state before sending `animal.sold`.
- If animal health changes after the modal opens, the sale is blocked, the displayed bounty is refreshed, and the player must confirm again after the short delay.
- Applies the same confirmation flow to Barn and Hen House by passing the selected animal id into the shared confirmation modal.

<img width="529" height="302" alt="image" src="https://github.com/user-attachments/assets/f8f604fe-4dd8-4a66-a16d-bb7b08b0ff48" />


## How to test
1. Open Barn or Hen House with an animal bounty available.
2. Select a sick animal for sale.
3. Confirm the modal shows the sick-animal warning, the full reward struck through, and the reduced reward separately.
4. Click Confirm immediately after opening the modal and verify the sale does not go through.
5. Wait one second, click Confirm again, and verify the animal is sold for the reduced bounty.
6. For the state-change guard, simulate the selected animal becoming sick after the modal opens and confirm the first click refreshes the modal instead of selling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved animal sale flow with a brief confirmation step before finalizing deals.
  * Added clearer bounty displays for sick animals, including reduced rewards and original-vs-updated amount comparisons.

* **Bug Fixes**
  * Animal selection now stays tied to the chosen animal’s ID, making sale dialogs more reliable.
  * If an animal’s state changes before selling, the sale view now warns you and recalculates the reward using the latest state.

* **Documentation**
  * Added new on-screen messages for reduced bounty amounts and state-change warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->