### PR TITLE
[FEAT] Bulk fetch: spread energy use evenly across pets

### DIFF
--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
@@ -186,4 +186,40 @@ describe("planBulkFetch", () => {
     });
     expect(plan.shortfall).toEqual({});
   });
+
+  it("still drains a pet heavily when it is the only source of a resource", () => {
+    // Barkley (Dog) is the only pet that can make chewed bone. Even with
+    // even-spread on, it takes the full chewed-bone load (using far more
+    // energy than Meowchi), and the shared acorn goes to the pet with energy
+    // to spare. That lopsided drain is acceptable when there is no alternative.
+    const activePets: ActivePets = [
+      ["Barkley", makePet("Barkley", { experience: LEVEL_3_XP, energy: 1000 })],
+      ["Meowchi", makePet("Meowchi", { energy: 1000 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { "Chewed Bone": 4, Acorn: 4 },
+      now,
+    });
+
+    // Barkley alone can make chewed bone, so it takes all 4 (800 energy)...
+    expect(plan.fetches).toContainEqual({
+      petId: "Barkley",
+      fetch: "Chewed Bone",
+      amount: 4,
+    });
+    // ...and none of the acorn, which flows to the pet with energy to spare.
+    expect(
+      plan.fetches.find((f) => f.petId === "Barkley" && f.fetch === "Acorn"),
+    ).toBeUndefined();
+    expect(plan.fetches).toContainEqual({
+      petId: "Meowchi",
+      fetch: "Acorn",
+      amount: 4,
+    });
+    expect(plan.energyAfter.Barkley).toEqual(200);
+    expect(plan.energyAfter.Meowchi).toEqual(600);
+    expect(plan.shortfall).toEqual({});
+  });
 });

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
@@ -158,4 +158,32 @@ describe("planBulkFetch", () => {
     expect(plan.fulfilled.Acorn?.toNumber()).toEqual(4.2);
     expect(plan.shortfall).toEqual({});
   });
+
+  it("spreads the load across pets by energy, not onto the highest-yield pet", () => {
+    // Barkley (lvl 18) yields 2.1 acorn per fetch; Meowchi (lvl 1) yields 1.
+    // A yield-first pick would take all 3 fetches from Barkley and leave
+    // Meowchi idle. Balancing by remaining energy instead uses both.
+    const activePets: ActivePets = [
+      ["Barkley", makePet("Barkley", { experience: LEVEL_18_XP, energy: 300 })],
+      ["Meowchi", makePet("Meowchi", { energy: 300 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { Acorn: 5 },
+      now,
+    });
+
+    expect(plan.fetches).toContainEqual({
+      petId: "Barkley",
+      fetch: "Acorn",
+      amount: 2,
+    });
+    expect(plan.fetches).toContainEqual({
+      petId: "Meowchi",
+      fetch: "Acorn",
+      amount: 1,
+    });
+    expect(plan.shortfall).toEqual({});
+  });
 });

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
@@ -60,8 +60,10 @@ type PetWork = {
  *     so a versatile pet's energy is not spent on a resource many pets share.
  *  3. For each resource, each single fetch is assigned to the pet that is the
  *     least useful elsewhere (can serve the fewest OTHER still-needed
- *     resources), preserving specialists; ties break on higher yield, then
- *     more remaining energy, then a stable id.
+ *     resources), preserving specialists; among those it goes to the pet with
+ *     the MOST energy left, so the load spreads evenly across pets rather than
+ *     draining the highest-yield ones first. Ties then break on higher yield,
+ *     then a stable id.
  *
  * Yields are deterministic (`getFetchYield`) and energy is the only limiter, so
  * the projection is exact. Anything that cannot be met is reported as
@@ -155,11 +157,15 @@ export function planBulkFetch({
         const usesB = otherNeededUses(b, resource);
         if (usesA !== usesB) return usesA - usesB; // preserve specialists
 
+        // Spread the load: send each fetch to the pet with the most energy
+        // left, so all pets drain down together instead of emptying the
+        // highest-yield ones first.
+        if (a.energy !== b.energy) return b.energy - a.energy;
+
         const yieldA = a.yields[resource] as Decimal;
         const yieldB = b.yields[resource] as Decimal;
         if (!yieldA.eq(yieldB)) return yieldB.minus(yieldA).toNumber();
 
-        if (a.energy !== b.energy) return b.energy - a.energy;
         return a.key.localeCompare(b.key);
       });
 


### PR DESCRIPTION
## What

Bulk fetch now **spreads energy use evenly across pets** instead of concentrating on the highest-yield ones.

Before, the per-fetch pet pick preferred higher yield, so an order drained the two highest-yield pets while lower-level pets sat idle. Now, among equally-specialist pets, each fetch goes to the pet with the **most energy remaining**, so all pets drain down together and the idle ones get used.

## Change

One tie-break flip in `planBulkFetch.ts` — "most energy left" is now ranked above "higher yield". Everything else is unchanged:
- **Scarcity ordering** (rarest resource first) — unchanged.
- **Specialist preservation** (rare resources still go to the pets that can make them) — unchanged.
- Yield is now only a tie-break; a stable id breaks the final tie.

## Trade-off

Spreading onto lower-yield pets means slightly **more total fetches/energy**, scaling with the yield gap between pets — negligible on a balanced roster, noticeable only when mixing e.g. a lvl-1 and a lvl-100 pet.

## Testing

- `planBulkFetch.test.ts` — 8/8, including a new "spreads the load across pets by energy" case (both pets used instead of one); the scarcity/specialist and boosted-yield tests still hold.
- tsc clean, ESLint + Prettier clean.

FE-only — `pets.bulkFetch` just applies whichever list the planner produces, so no BE change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-fetch planning when multiple pets can contribute, distributing work more fairly based on remaining energy.
  * Refined the selection order for eligible pets to better balance assignments and outcomes in shared scenarios.
* **Tests**
  * Added new coverage for bulk-fetch allocation, including mixed-resource and single-source edge cases, to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->