### PR TITLE
[FIX] Bulk fetch: pick the most energy-efficient pet (yield over specialist)

### DIFF
--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
@@ -9,6 +9,7 @@ const state: GameState = { ...INITIAL_FARM };
 // XP thresholds: level n requires 50 * (n-1) * n XP.
 const LEVEL_3_XP = 300;
 const LEVEL_18_XP = 15300;
+const LEVEL_100_XP = 495000;
 
 const makePet = (name: PetName, overrides: Partial<Pet> = {}): Pet => ({
   name,
@@ -156,6 +157,46 @@ describe("planBulkFetch", () => {
       { petId: "Barkley", fetch: "Acorn", amount: 2 },
     ]);
     expect(plan.fulfilled.Acorn?.toNumber()).toEqual(4.2);
+    expect(plan.shortfall).toEqual({});
+  });
+
+  it("prefers the higher-yield pet even when it is more useful elsewhere", () => {
+    // Meowchi (Cat, lvl 100) yields 1.25 heart leaf and can also make ribbon;
+    // Twizzle (Owl, lvl 3) yields only 1.0 and cannot make ribbon. With ribbon
+    // also requested, the old "least useful elsewhere" pick saved Meowchi and
+    // handed heart leaf to Twizzle. Ranking yield first uses the efficient pet.
+    // (Barkley is only here so ribbon has two sources and stays pending while
+    // heart leaf is allocated.)
+    const activePets: ActivePets = [
+      [
+        "Meowchi",
+        makePet("Meowchi", { experience: LEVEL_100_XP, energy: 5000 }),
+      ],
+      ["Twizzle", makePet("Twizzle", { experience: LEVEL_3_XP, energy: 5000 })],
+      [
+        "Barkley",
+        makePet("Barkley", { experience: LEVEL_18_XP, energy: 5000 }),
+      ],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { "Heart leaf": 6, Ribbon: 4 },
+      now,
+    });
+
+    // The higher-yield pet (Meowchi, 1.25) takes the heart leaf...
+    expect(
+      plan.fetches.find(
+        (f) => f.petId === "Meowchi" && f.fetch === "Heart leaf",
+      ),
+    ).toBeDefined();
+    // ...not the lower-yield Twizzle (1.0), which the old logic would have used.
+    expect(
+      plan.fetches.find(
+        (f) => f.petId === "Twizzle" && f.fetch === "Heart leaf",
+      ),
+    ).toBeUndefined();
     expect(plan.shortfall).toEqual({});
   });
 });

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
@@ -197,6 +197,14 @@ describe("planBulkFetch", () => {
         (f) => f.petId === "Twizzle" && f.fetch === "Heart leaf",
       ),
     ).toBeUndefined();
+    // Ribbon likewise goes to the higher-yield Meowchi (1.25 vs Barkley's 1.1),
+    // which still has energy to spare — the efficient pet takes both.
+    expect(
+      plan.fetches.find((f) => f.petId === "Meowchi" && f.fetch === "Ribbon"),
+    ).toBeDefined();
+    expect(
+      plan.fetches.find((f) => f.petId === "Barkley" && f.fetch === "Ribbon"),
+    ).toBeUndefined();
     expect(plan.shortfall).toEqual({});
   });
 });

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
@@ -58,10 +58,12 @@ type PetWork = {
  *  1. Only awake, non-neglected pets with unlocked fetches are eligible.
  *  2. Requested resources are allocated scarcest-first (fewest capable pets),
  *     so a versatile pet's energy is not spent on a resource many pets share.
- *  3. For each resource, each single fetch is assigned to the pet that is the
- *     least useful elsewhere (can serve the fewest OTHER still-needed
- *     resources), preserving specialists; ties break on higher yield, then
- *     more remaining energy, then a stable id.
+ *  3. For each resource, each single fetch goes to the pet with the highest
+ *     yield (fewest fetches → least energy for that resource). Because
+ *     scarcest resources are allocated first, the pets that rarer resources
+ *     depend on are already reserved, so favouring yield here does not starve
+ *     them. Ties break toward the pet least useful elsewhere (fewest OTHER
+ *     still-needed resources), then more remaining energy, then a stable id.
  *
  * Yields are deterministic (`getFetchYield`) and energy is the only limiter, so
  * the projection is exact. Anything that cannot be met is reported as
@@ -151,13 +153,19 @@ export function planBulkFetch({
       if (candidates.length === 0) break;
 
       candidates.sort((a, b) => {
-        const usesA = otherNeededUses(a, resource);
-        const usesB = otherNeededUses(b, resource);
-        if (usesA !== usesB) return usesA - usesB; // preserve specialists
-
+        // Energy-efficient: the highest-yield pet needs the fewest fetches, so
+        // the least energy, for this resource. Scarcest-first ordering has
+        // already reserved the pets that rarer resources depend on, so a
+        // versatile high-yield pet (e.g. an NFT) is used here, not saved.
         const yieldA = a.yields[resource] as Decimal;
         const yieldB = b.yields[resource] as Decimal;
         if (!yieldA.eq(yieldB)) return yieldB.minus(yieldA).toNumber();
+
+        // Among equal-yield pets, prefer the one least useful elsewhere, then
+        // the one with more energy, then a stable id.
+        const usesA = otherNeededUses(a, resource);
+        const usesB = otherNeededUses(b, resource);
+        if (usesA !== usesB) return usesA - usesB;
 
         if (a.energy !== b.energy) return b.energy - a.energy;
         return a.key.localeCompare(b.key);

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
@@ -69,6 +69,11 @@ type PetWork = {
  * the projection is exact. Anything that cannot be met is reported as
  * `shortfall` rather than throwing — the executing `pets.bulkFetch` event
  * re-validates every fetch anyway.
+ *
+ * Being a greedy per-resource pick, this is not a global optimum: a versatile
+ * pet with limited energy can be spent on a shared resource a specialist could
+ * have covered, occasionally leaving another request short (an exact optimum is
+ * an assignment problem).
  */
 export function planBulkFetch({
   activePets,


### PR DESCRIPTION
## What

Fixes a real inefficiency spotted on a live farm: bulk fetch picked a **lower-yield** pet for a resource when a **higher-yield** pet was available with plenty of energy — the opposite of the energy-efficient goal.

## Why

The per-fetch pet pick ranked **specialist-preservation** ("least useful elsewhere") *above* yield. A versatile high-yield pet (e.g. an NFT that's Moonkin + Beast + Guardian) scores as "needed elsewhere" for the other requested resources, so it got **saved** and a less-versatile, lower-yield pet did the fetch — even with ~90k energy to spare on the versatile pet.

Reported example: heart leaf went to a lvl-59 Cat (yield **1.15**) instead of a lvl-75 NFT Phoenix (yield **2.15**) — ~2× more fetches/energy.

## Fix

Rank **yield first** in the per-fetch pick. Scarcest-first *ordering* already gives rarer resources (moonfur, chewed bone) first dibs on the versatile pet's energy, so favouring yield for the shared load can't starve them. Specialist-preservation stays as a yield tie-break.

## Testing

- `planBulkFetch.test.ts` — 8/8, including a new "prefers the higher-yield pet even when it is more useful elsewhere" case (fails on the old logic, passes now); the scarce-first/specialist and boosted-yield tests still hold.
- tsc / ESLint / Prettier clean.

FE-only — the `pets.bulkFetch` event just applies whatever list the planner produces.

_Side effect: this concentrates the shared load even more onto your strongest pets, which is the energy-efficient behaviour._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pet resource allocation so single fetches are assigned to the pet with the highest yield first.
  * Updated tie-breaking to prefer pets that are less useful for other requested items, improving overall allocation quality and reducing shortfalls.
* **Tests**
  * Added coverage to verify higher-yield pet selection behavior across multiple simultaneous requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->