### PR TITLE
[FIX] Finn and Timmy delivery icon layering

### DIFF
--- a/src/features/world/containers/BumpkinContainer.ts
+++ b/src/features/world/containers/BumpkinContainer.ts
@@ -26,6 +26,7 @@ const NAME_ALIASES: Partial<Record<NPCName, string>> = {
   "pumpkin' pete": "pete",
   "hammerin harry": "auctions",
 };
+const DELIVERY_ICON_DEPTH = 1000001;
 export const NPCS_WITH_ALERTS: Partial<Record<NPCName, boolean>> = {};
 
 export class BumpkinContainer extends Phaser.GameObjects.Container {
@@ -160,6 +161,7 @@ export class BumpkinContainer extends Phaser.GameObjects.Container {
         text.toUpperCase(),
         labelType,
         labelIconKey,
+        labelIconKey ? DELIVERY_ICON_DEPTH : undefined,
       );
       this.add(label);
 

--- a/src/features/world/containers/Label.ts
+++ b/src/features/world/containers/Label.ts
@@ -1,14 +1,18 @@
 const ICON_WIDTH = 11;
 const ICON_GAP = -1;
+const ICON_CENTER_Y = 3.5;
 
 export class Label extends Phaser.GameObjects.Container {
   private iconSprite: Phaser.GameObjects.Sprite | undefined;
+  private iconVisible = true;
+  private syncFloatingIcon: (() => void) | undefined;
 
   constructor(
     scene: Phaser.Scene,
     text: string,
     type: "brown" | "grey" | "gold" | "vibrant" = "grey",
     iconKey?: string,
+    iconDepth?: number,
   ) {
     super(scene, 0, 0);
     this.scene = scene;
@@ -51,19 +55,52 @@ export class Label extends Phaser.GameObjects.Container {
     if (hasIcon) {
       const iconX = -patchWidth / 2 - ICON_GAP - ICON_WIDTH / 2;
       const icon = scene.add
-        .sprite(iconX, 3.5, iconKey!)
+        .sprite(iconX, ICON_CENTER_Y, iconKey!)
         .setSize(ICON_WIDTH, ICON_WIDTH)
         .setOrigin(0.5, 0.5);
       this.iconSprite = icon;
-      this.add(icon);
+
+      if (iconDepth) {
+        icon.setDepth(iconDepth);
+        this.syncFloatingIcon = () => {
+          if (!icon.active) return;
+
+          const point = this.getWorldTransformMatrix().transformPoint(
+            iconX,
+            ICON_CENTER_Y,
+          );
+
+          icon.setPosition(point.x, point.y);
+          icon.setVisible(
+            this.iconVisible &&
+              this.visible &&
+              (this.parentContainer?.visible ?? true),
+          );
+        };
+
+        this.syncFloatingIcon();
+        scene.events.on("update", this.syncFloatingIcon);
+        this.once("destroy", () => {
+          if (this.syncFloatingIcon) {
+            scene.events.off("update", this.syncFloatingIcon);
+          }
+
+          icon.destroy();
+        });
+      } else {
+        this.add(icon);
+      }
     }
 
     this.setDepth(1);
   }
 
   setIconVisible(visible: boolean) {
+    this.iconVisible = visible;
+
     if (this.iconSprite) {
       this.iconSprite.setVisible(visible);
+      this.syncFloatingIcon?.();
     }
   }
 }

--- a/src/features/world/containers/Label.ts
+++ b/src/features/world/containers/Label.ts
@@ -60,7 +60,7 @@ export class Label extends Phaser.GameObjects.Container {
         .setOrigin(0.5, 0.5);
       this.iconSprite = icon;
 
-      if (iconDepth) {
+      if (iconDepth !== undefined) {
         icon.setDepth(iconDepth);
         this.syncFloatingIcon = () => {
           if (!icon.active) return;


### PR DESCRIPTION
Problem: Delivery-ready box icons for Finn and Timmy were rendered inside the NPC label/container, so top map layers and nearby buildings could draw over the icon.

<img width="506" height="378" alt="telegram-cloud-photo-size-2-5355282863714146749-x" src="https://github.com/user-attachments/assets/54f503fb-993b-4caa-a2f4-b1a52f419d3c" />
<img height="378" alt="telegram-cloud-photo-size-2-5364059556369079286-x" src="https://github.com/user-attachments/assets/a13e5db0-d6e7-4336-bdef-71e01f8afc71" />


Solution: Allow labels to render an optional floating icon at an explicit scene depth, and use it for delivery icons so the box stays above building layers without lifting the whole NPC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery icon rendering on NPC labels so the icon appears on the correct layer and remains properly aligned as the scene updates.
  * Fixed floating icon visibility and positioning behavior, ensuring icons stay in sync when labels or their parent containers are shown, hidden, or moved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->