### PR TITLE
[FIX] Hide stale animal care status icons

### DIFF
--- a/src/features/game/events/landExpansion/loveAnimal.test.ts
+++ b/src/features/game/events/landExpansion/loveAnimal.test.ts
@@ -2,6 +2,7 @@ import { INITIAL_FARM } from "features/game/lib/constants";
 import {
   getNextLoveAvailableAt,
   isAnimalNeedingLove,
+  isAnimalReadyForLove,
   loveAnimal,
 } from "./loveAnimal";
 import Decimal from "decimal.js-light";
@@ -477,6 +478,15 @@ describe("getNextLoveAvailableAt", () => {
     // Gate opens at the boundary — false strictly before, true at and after.
     expect(isAnimalNeedingLove(animal, openAt - 1)).toBe(false);
     expect(isAnimalNeedingLove(animal, openAt)).toBe(true);
+  });
+
+  it("only marks love ready while the animal is still asleep", () => {
+    const animal = { ...baseAnimal, lovedAt: 0 };
+    const openAt = getNextLoveAvailableAt(animal);
+
+    expect(isAnimalReadyForLove(animal, openAt)).toBe(true);
+    expect(isAnimalReadyForLove(animal, awakeAt)).toBe(false);
+    expect(isAnimalReadyForLove(animal, awakeAt + 1)).toBe(false);
   });
 
   it("returns a value >= awakeAt when no slot remains this cycle", () => {

--- a/src/features/game/events/landExpansion/loveAnimal.ts
+++ b/src/features/game/events/landExpansion/loveAnimal.ts
@@ -42,6 +42,14 @@ export function isAnimalNeedingLove(animal: Animal, now: number): boolean {
   return getNextLoveAvailableAt(animal) <= now;
 }
 
+/**
+ * UI/action affordance form: the love window has opened and the animal is
+ * still asleep. Once the animal wakes, feeding becomes the next required action.
+ */
+export function isAnimalReadyForLove(animal: Animal, now: number): boolean {
+  return now < animal.awakeAt && isAnimalNeedingLove(animal, now);
+}
+
 export type LoveAnimalAction = {
   type: "animal.loved";
   animal: AnimalType;

--- a/src/features/island/buildings/components/building/barn/Barn.tsx
+++ b/src/features/island/buildings/components/building/barn/Barn.tsx
@@ -13,7 +13,7 @@ import { useNow } from "lib/utils/hooks/useNow";
 import type { TemperateSeasonName } from "features/game/types/game";
 import { getCurrentBiome } from "features/island/biomes/biomes";
 import type { LandBiomeName } from "features/island/biomes/biomes";
-import { isAnimalNeedingLove } from "features/game/events/landExpansion/loveAnimal";
+import { isAnimalReadyForLove } from "features/game/events/landExpansion/loveAnimal";
 import classNames from "classnames";
 import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
@@ -257,7 +257,7 @@ export const Barn: React.FC<BuildingProps> = ({ isBuilt, island, season }) => {
   // game-state events, which wouldn't fire when crossing the time gate.
   const now = useNow({ live: true });
   const animalsNeedLove = Object.values(barnAnimals).some((animal) =>
-    isAnimalNeedingLove(animal, now),
+    isAnimalReadyForLove(animal, now),
   );
   const handleClick = () => {
     if (isBuilt) {

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from "react-router";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useSound } from "lib/utils/hooks/useSound";
 import { useNow } from "lib/utils/hooks/useNow";
-import { isAnimalNeedingLove } from "features/game/events/landExpansion/loveAnimal";
+import { isAnimalReadyForLove } from "features/game/events/landExpansion/loveAnimal";
 import classNames from "classnames";
 import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
@@ -47,7 +47,7 @@ export const ChickenHouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
   // game-state events, which wouldn't fire when crossing the time gate.
   const now = useNow({ live: true });
   const chickensNeedLove = Object.values(henHouseAnimals).some((animal) =>
-    isAnimalNeedingLove(animal, now),
+    isAnimalReadyForLove(animal, now),
   );
 
   const { play: barnAudio } = useSound("barn");


### PR DESCRIPTION
[Pull request description
](https://github.com/sunflower-land/sunflower-land/issues/7387)


## Summary
Fixes stale Barn and Hen House exterior care indicators by only showing the care icon while an animal is still asleep and actually eligible for love.

## Context / motivation
After the animal status icons were added, the exterior care icon could appear after animals woke up and started asking for food. The root cause was that isAnimalNeedingLove only checks whether the love cooldown gate has opened; it does not mean the animal is still asleep. Once awakeAt has passed, feeding is the next required action, so the outside building indicator should not advertise care.

## How to test
1. Put Barn or Hen House animals into a state where the love window has opened but awakeAt has passed.
2. Confirm the exterior building shows the feeding indicator, not the care indicator.
3. Put animals into a sleeping state where the love window is open before awakeAt.
4. Confirm the exterior care indicator still appears.
5. Run `yarn test src/features/game/events/landExpansion/loveAnimal.test.ts --runInBand`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Love alert indicators for animals now show only after the love window opens and while the animal is still asleep.
  * Barn and hen house love icons now follow this updated timing.

* **Bug Fixes**
  * Corrected the love status timing so the alert no longer stays visible after an animal wakes up.
  * Added test coverage to ensure the alert appears at the correct moment and disappears immediately after waking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->