### PR TITLE
[FEAT] Temporarily lock swamp→spooky (A2) ascension until 7 Sep

### DIFF
--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -5,7 +5,16 @@ import {
   ASCENSION_BUMPKIN_LEVEL,
 } from "./upgradeFarm";
 import Decimal from "decimal.js-light";
-import { LEVEL_EXPERIENCE } from "features/game/lib/level";
+import {
+  LEVEL_EXPERIENCE,
+  ascensionBaseline,
+  bandXp,
+} from "features/game/lib/level";
+import { CONFIG } from "lib/config";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+
+const SPOOKY_ASCENSION_START =
+  TIME_BASED_FEATURE_FLAG_WINDOWS.SPOOKY_ASCENSION.start.getTime();
 import { getLand, TOTAL_EXPANSION_NODES } from "features/game/types/expansions";
 import { getIslandSpawnPositions } from "features/game/expansion/lib/island";
 
@@ -1184,6 +1193,80 @@ describe("upgradeFarm", () => {
         createdAt: Date.now(),
       }),
     ).toThrow("Player has not met the level requirements");
+  });
+
+  describe("swamp->spooky (A2) temporary lock", () => {
+    // Readies the bumpkin for the swamp band so the temporary gate — not the level
+    // gate — is what's under test.
+    const readyXp = ascensionBaseline(1) + bandXp(1);
+    const swampState = {
+      ...INITIAL_FARM,
+      // Team username so the SWAMP_ASCENSION gate passes on mainnet and the
+      // temporary A2 lock is the check under test.
+      username: "elias",
+      coins: 10000,
+      bumpkin: {
+        ...INITIAL_FARM.bumpkin,
+        experience: readyXp,
+      },
+      island: {
+        type: "swamp" as const,
+        ascensionLevel: 1,
+      },
+      inventory: {
+        ...INITIAL_FARM.inventory,
+        // Meets the expansion requirement but holds no ascension-cost items, so a
+        // player past the temporary gate lands on the cost check.
+        "Basic Land": new Decimal(42),
+      },
+    };
+
+    let previousNetwork: (typeof CONFIG)["NETWORK"];
+    beforeEach(() => {
+      previousNetwork = CONFIG.NETWORK;
+    });
+    afterEach(() => {
+      CONFIG.NETWORK = previousNetwork;
+    });
+
+    it("blocks swamp->spooky before the unlock date on mainnet", () => {
+      CONFIG.NETWORK = "mainnet";
+
+      expect(() =>
+        upgrade({
+          farmId,
+          action: { type: "farm.upgraded" },
+          state: swampState,
+          createdAt: SPOOKY_ASCENSION_START - 1,
+        }),
+      ).toThrow("Ascension to the next island is not yet available");
+    });
+
+    it("allows swamp->spooky once the unlock date passes on mainnet", () => {
+      CONFIG.NETWORK = "mainnet";
+
+      expect(() =>
+        upgrade({
+          farmId,
+          action: { type: "farm.upgraded" },
+          state: swampState,
+          createdAt: SPOOKY_ASCENSION_START,
+        }),
+      ).toThrow("Insufficient Crimstone");
+    });
+
+    it("lets testnet bypass the lock before the unlock date", () => {
+      CONFIG.NETWORK = "amoy";
+
+      expect(() =>
+        upgrade({
+          farmId,
+          action: { type: "farm.upgraded" },
+          state: swampState,
+          createdAt: SPOOKY_ASCENSION_START - 1,
+        }),
+      ).toThrow("Insufficient Crimstone");
+    });
   });
 
   it("scales the ascension upgrade cost with level", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -13,7 +13,7 @@ import type {
   TemperateSeasonName,
 } from "features/game/types/game";
 import { ASCENSION_ISLANDS } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasFeatureAccess, hasTimeBasedFeatureAccess } from "lib/flags";
 import { getAscensionLevel, getMaxBumpkinLevel } from "features/game/lib/level";
 import {
   getTotalBaseResourceEquivalents,
@@ -1255,6 +1255,20 @@ export function upgrade({ state, createdAt = Date.now(), farmId }: Options) {
 
   if (targetIsAscension && !hasFeatureAccess(game, "SWAMP_ASCENSION")) {
     throw new Error("Swamp ascension is not yet available");
+  }
+
+  // Temporary: ascending from Swamp (A1) into the next island (A2) is gated behind
+  // the SPOOKY_ASCENSION window (testnet bypasses). The first ascension (A0 → A1)
+  // is unaffected.
+  if (
+    (game.island.ascensionLevel ?? 0) + 1 === 2 &&
+    !hasTimeBasedFeatureAccess({
+      featureName: "SPOOKY_ASCENSION",
+      now: createdAt,
+      game,
+    })
+  ) {
+    throw new Error("Ascension to the next island is not yet available");
   }
 
   // Ascension islands require the player to have maxed their current ascension band

--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -21,6 +21,7 @@ import {
   getAscensionUpgradeCost,
   ASCENSION_BUMPKIN_LEVEL,
 } from "features/game/events/landExpansion/upgradeFarm";
+import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 import {
   getAscensionLevel,
   getMaxBumpkinLevel,
@@ -32,7 +33,7 @@ import { createPortal } from "react-dom";
 import confetti from "canvas-confetti";
 import type { IslandType } from "features/game/types/game";
 import { ASCENSION_ISLANDS } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasFeatureAccess, TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Transition } from "@headlessui/react";
@@ -117,6 +118,21 @@ const IslandUpgraderModal: React.FC<{
 
   const { island, inventory, collectibles, home, coins, bumpkin } =
     gameState.context.state;
+
+  // Temporary: ascending from Swamp (A1) to the next island (A2) is gated behind
+  // the SPOOKY_ASCENSION window (testnet bypasses). Mirror the server gate so the
+  // button reflects it.
+  const hasSpookyAscensionAccess = useTimeBasedFeatureAccess({
+    featureName: "SPOOKY_ASCENSION",
+    game: gameState.context.state,
+  });
+  const isNextAscensionLocked =
+    island.type === "swamp" && !hasSpookyAscensionAccess;
+  const nextAscensionUnlockDate =
+    TIME_BASED_FEATURE_FLAG_WINDOWS.SPOOKY_ASCENSION.start.toLocaleDateString(
+      navigator.language,
+      { day: "numeric", month: "long", year: "numeric", timeZone: "UTC" },
+    );
   const upgrade = isLandUpgradable(island.type)
     ? ISLAND_UPGRADE[island.type]
     : NO_ISLAND_UPGRADE;
@@ -259,6 +275,16 @@ const IslandUpgraderModal: React.FC<{
           </Label>
         )}
 
+        {hasUpgrade && isNextAscensionLocked && (
+          <Label
+            icon={SUNNYSIDE.icons.lock}
+            type="danger"
+            className="mr-3 my-2"
+          >
+            {t("islandupgrade.comingSoon", { date: nextAscensionUnlockDate })}
+          </Label>
+        )}
+
         {hasUpgrade && (
           <>
             <div className="flex items-center mt-2 mb-1 flex-wrap gap-x-2 gap-y-1">
@@ -325,7 +351,8 @@ const IslandUpgraderModal: React.FC<{
           !hasUpgrade ||
           !hasResources ||
           !hasRequiredLevel ||
-          remainingExpansions > 0
+          remainingExpansions > 0 ||
+          isNextAscensionLocked
         }
         onClick={() => setShowConfirmation(true)}
       >

--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -126,17 +126,19 @@ const IslandUpgraderModal: React.FC<{
     featureName: "SPOOKY_ASCENSION",
     game: gameState.context.state,
   });
+  // Match the reducer's authoritative A1→A2 condition (ascensionLevel === 1) so
+  // the button can't enable an upgrade the server rejects, or vice versa.
   const isNextAscensionLocked =
-    island.type === "swamp" && !hasSpookyAscensionAccess;
-  const nextAscensionUnlockDate =
-    TIME_BASED_FEATURE_FLAG_WINDOWS.SPOOKY_ASCENSION.start.toLocaleDateString(
-      navigator.language,
-      { day: "numeric", month: "long", year: "numeric", timeZone: "UTC" },
-    );
+    (island.ascensionLevel ?? 0) === 1 && !hasSpookyAscensionAccess;
   const upgrade = isLandUpgradable(island.type)
     ? ISLAND_UPGRADE[island.type]
     : NO_ISLAND_UPGRADE;
-  const { t } = useAppTranslation();
+  const { t, i18n } = useAppTranslation();
+  const nextAscensionUnlockDate =
+    TIME_BASED_FEATURE_FLAG_WINDOWS.SPOOKY_ASCENSION.start.toLocaleDateString(
+      i18n.resolvedLanguage,
+      { day: "numeric", month: "long", year: "numeric", timeZone: "UTC" },
+    );
 
   const remainingExpansions =
     upgrade.expansions - (inventory["Basic Land"]?.toNumber() ?? 0);

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -88,6 +88,13 @@ export const TIME_BASED_FEATURE_FLAG_WINDOWS = {
     start: WAYPOINT_WALLET_ENDDATE,
     end: null,
   },
+  // Ascending from Swamp (A1) into the next island (Spooky, A2) unlocks on this
+  // date. Testnet bypasses; the first ascension (Volcano → Swamp / A0 → A1) is
+  // gated separately by SWAMP_ASCENSION and is unaffected.
+  SPOOKY_ASCENSION: {
+    start: new Date("2026-09-07T00:00:00Z"),
+    end: null,
+  },
 } satisfies Record<string, TimeBasedFeatureWindow>;
 
 /** All time-based flags receive the full window; start-only helpers ignore `end`. */
@@ -106,6 +113,8 @@ export const TIME_BASED_FEATURE_FLAGS: Record<
   APRIL_FOOLS_EVENT_FLAG: betaTimePeriodFeatureFlag,
   RONIN_WAYPOINT_DEPRECATION: timePeriodFeatureFlag,
   COLORS_2026_EVENT_FLAG: betaTimePeriodFeatureFlag,
+  // Testnet-only bypass before the date (not beta), so live testers can reach A2.
+  SPOOKY_ASCENSION: timePeriodFeatureFlag,
 };
 
 /**


### PR DESCRIPTION
## What

Temporarily blocks ascending from **Swamp (A1)** into the next island **Spooky (A2)** until **7 September 2026**. The first ascension (Volcano → Swamp / A0 → A1) is **unaffected**, and re-ascensions beyond A2 are unaffected.

Implemented as a new `SPOOKY_ASCENSION` entry in the existing `TIME_BASED_FEATURE_FLAG_WINDOWS` using `timePeriodFeatureFlag`, so **testnet bypasses the lock** (live testers can still reach A2) and mainnet unlocks automatically on the date.

## Changes

- **`lib/flags.ts`** — add the `SPOOKY_ASCENSION` window (`start: 2026-09-07T00:00:00Z, end: null`) + `timePeriodFeatureFlag` mapping.
- **`upgradeFarm.ts`** — gate the A1→A2 upgrade: throw unless `hasTimeBasedFeatureAccess("SPOOKY_ASCENSION")` (keyed off the action `createdAt`).
- **`IslandUpgrader.tsx`** — disable the upgrade button and show a "Coming soon - 7 September 2026" label when locked, via the `useTimeBasedFeatureAccess` hook.
- **tests** — mainnet block-before-date / allow-after-date + a testnet-bypass case.

## Retiring the lock

When A2 is ready to launch: delete the `SPOOKY_ASCENSION` window + flag-map entry, the reducer gate, the UI additions, and the three lock tests.

## Note

Paired with the backend change in sunflower-land-api (same gate in the BE `upgradeFarm` reducer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled, time-based “coming soon” gate for ascending from Swamp (A1) to the next island (A2), unlocking on September 7, 2026.
  * The upgrade modal now shows the unlock date (UTC) and disables the Continue button until the window is active.
  * Test environments bypass the temporary lock.

* **Bug Fixes**
  * Prevents premature Swamp → Spooky ascension by enforcing the same availability check in both the server upgrade flow and the UI.

* **Tests**
  * Added coverage for both locked and unlocked scenarios, including the expected upgrade error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->