### PR TITLE
[FEAT] Preserve farm layout across island ascension

### DIFF
--- a/src/features/game/events/landExpansion/applyLayout.test.ts
+++ b/src/features/game/events/landExpansion/applyLayout.test.ts
@@ -240,7 +240,7 @@ describe("applyLayout", () => {
     expect(coords).toContainEqual({ x: 1, y: 0 });
   });
 
-  it("leaves a blocked position unplaced and places the rest", () => {
+  it("clears items absent from the layout and places the full layout (exact restore)", () => {
     const saved = withSavedLayout({
       ...withInventory({ "Wicker Man": 2, "Golden Bonsai": 1 }),
       collectibles: {
@@ -252,7 +252,8 @@ describe("applyLayout", () => {
     });
 
     const moved = cloneDeep(saved);
-    // A non-layout item blocks the (0,0) position.
+    // A non-layout item sits on a layout target. Applying is an exact restore:
+    // it is lifted back to inventory, so it neither survives nor blocks.
     moved.collectibles["Golden Bonsai"] = [
       { id: "c", coordinates: { x: 0, y: 0 }, createdAt },
     ];
@@ -262,15 +263,15 @@ describe("applyLayout", () => {
       action: { type: "layout.applied", layoutId: 0 },
     });
 
-    const placed = result.collectibles["Wicker Man"]!.filter(
-      (c) => !!c.coordinates,
+    const byId = Object.fromEntries(
+      result.collectibles["Wicker Man"]!.map((c) => [c.id, c.coordinates]),
     );
-    expect(placed).toHaveLength(1);
-    expect(placed[0].coordinates).toEqual({ x: 1, y: 0 });
-    expect(result.collectibles["Golden Bonsai"]![0].coordinates).toEqual({
-      x: 0,
-      y: 0,
-    });
+    expect(byId["a"]).toEqual({ x: 0, y: 0 });
+    expect(byId["b"]).toEqual({ x: 1, y: 0 });
+    // The non-layout Golden Bonsai is lifted (returned to inventory).
+    expect(
+      result.collectibles["Golden Bonsai"]![0].coordinates,
+    ).toBeUndefined();
   });
 
   it("reports applied / skipped / noInventory counts", () => {
@@ -565,17 +566,15 @@ describe("applyLayout", () => {
     });
 
     const moved = cloneDeep(saved);
-    // Layout wants Wicker Man at (1, 0); it currently sits at (0, 0); a
-    // non-layout item blocks (1, 0).
+    // Layout wants Wicker Man off-land at (50, 0) (blocked by the land bounds — a
+    // block exact restore can't clear); it currently sits at (0, 0), which stays
+    // free, so the best-effort restore leaves it there.
     moved.layouts![0].collectibles["Wicker Man"]![0].coordinates = {
-      x: 1,
+      x: 50,
       y: 0,
     };
     moved.collectibles["Wicker Man"] = [
       { id: "w", coordinates: { x: 0, y: 0 }, createdAt },
-    ];
-    moved.collectibles["Golden Bonsai"] = [
-      { id: "g", coordinates: { x: 1, y: 0 }, createdAt },
     ];
 
     const result = applyLayout({
@@ -601,17 +600,15 @@ describe("applyLayout", () => {
     });
 
     const moved = cloneDeep(saved);
-    // Layout: a -> (1, 0) [will be blocked], b -> (0, 0) [a's original tile].
+    // Layout: a -> (50, 0) [off-land, blocked by bounds], b -> (0, 0) [a's
+    // original tile]. b claims a's original, so a has nowhere to fall back to.
     moved.layouts![0].collectibles["Wicker Man"] = [
-      { id: "a", coordinates: { x: 1, y: 0 } },
+      { id: "a", coordinates: { x: 50, y: 0 } },
       { id: "b", coordinates: { x: 0, y: 0 } },
     ];
     moved.collectibles["Wicker Man"] = [
       { id: "a", coordinates: { x: 0, y: 0 }, createdAt },
       { id: "b", coordinates: { x: 2, y: 0 }, createdAt },
-    ];
-    moved.collectibles["Golden Bonsai"] = [
-      { id: "g", coordinates: { x: 1, y: 0 }, createdAt },
     ];
 
     const result = applyLayout({

--- a/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
+++ b/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
@@ -8,6 +8,7 @@ import {
   ascensionBaseline,
   bandXp,
 } from "features/game/lib/level";
+import { getExpectedAscensionCrystals } from "features/game/expansion/lib/ascension";
 
 /** Total Ascension Crystals offered by the missing-resources back-pay chest. */
 const backPaidCrystals = (game: GameState): number => {
@@ -136,9 +137,20 @@ describe("Ascension Crystal upgrade-node grant (upgradeFarm)", () => {
     ],
   ];
 
+  // Each transition grants exactly 1 Ascension Crystal. Basic-island upgrades add
+  // it straight to inventory; ascension upgrades (swamp onward) deliver it via the
+  // side-island reward chest (a `missing-resources` airdrop) instead. Seeding the
+  // player with the crystals they should already own means the net grant is 1
+  // wherever it lands.
   it.each(cases)(
     "grants exactly 1 crystal on %s",
     (_label, { from, ascensionLevel, basicLand, experience }) => {
+      const ownedBefore = getExpectedAscensionCrystals({
+        islandType: from,
+        ascensionLevel: ascensionLevel ?? 0,
+        basicLand,
+      });
+
       const state = upgrade({
         farmId: 1,
         action: { type: "farm.upgraded" },
@@ -154,15 +166,23 @@ describe("Ascension Crystal upgrade-node grant (upgradeFarm)", () => {
             ...INITIAL_FARM.inventory,
             ...RESOURCES_FOR_ANY_COST,
             "Basic Land": new Decimal(basicLand),
-            "Ascension Crystal": new Decimal(0),
+            "Ascension Crystal": new Decimal(ownedBefore),
           },
         },
         createdAt: Date.now(),
       });
 
-      expect(
-        (state.inventory["Ascension Crystal"] ?? new Decimal(0)).toNumber(),
-      ).toBe(1);
+      const inventoryAfter = (
+        state.inventory["Ascension Crystal"] ?? new Decimal(0)
+      ).toNumber();
+      const chestCrystals = (state.airdrops ?? [])
+        .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
+        .reduce(
+          (sum, airdrop) => sum + (airdrop.items["Ascension Crystal"] ?? 0),
+          0,
+        );
+
+      expect(inventoryAfter + chestCrystals - ownedBefore).toBe(1);
     },
   );
 });

--- a/src/features/game/events/landExpansion/deleteLayout.test.ts
+++ b/src/features/game/events/landExpansion/deleteLayout.test.ts
@@ -49,4 +49,20 @@ describe("deleteLayout", () => {
       }),
     ).toThrow("Layout does not exist");
   });
+
+  it("throws when deleting the protected Ascension Layout", () => {
+    const built = withTwoLayouts();
+    const state: GameState = {
+      ...built,
+      layouts: built.layouts!.map((layout, i) =>
+        i === 0 ? { ...layout, auto: true } : layout,
+      ),
+    };
+    expect(() =>
+      deleteLayout({
+        state,
+        action: { type: "layout.deleted", layoutId: 0 },
+      }),
+    ).toThrow("The Ascension Layout cannot be deleted");
+  });
 });

--- a/src/features/game/events/landExpansion/deleteLayout.ts
+++ b/src/features/game/events/landExpansion/deleteLayout.ts
@@ -23,6 +23,9 @@ export function deleteLayout({ state, action }: Options): GameState {
     if (!layouts[action.layoutId]) {
       throw new Error("Layout does not exist");
     }
+    if (layouts[action.layoutId].auto) {
+      throw new Error("The Ascension Layout cannot be deleted");
+    }
 
     layouts.splice(action.layoutId, 1);
     stateCopy.layouts = layouts;

--- a/src/features/game/events/landExpansion/lib/layouts.ts
+++ b/src/features/game/events/landExpansion/lib/layouts.ts
@@ -857,6 +857,33 @@ export function applyFarmLayout(
     });
   }
 
+  // Exact restore: applying a layout yields exactly the saved snapshot, so lift
+  // every placed item the layout does NOT represent too — its instance (with any
+  // timers) is kept; it simply returns to inventory. Resources are lifted in full
+  // above; mirror that for the name/id-keyed categories. The player's own Bumpkin
+  // is intentionally left alone — it is the avatar and is always captured on-farm.
+  getObjectEntries(state.collectibles).forEach(([name, items]) => {
+    if (layout.collectibles[name]) return;
+    items?.forEach((item) => {
+      item.coordinates = undefined;
+    });
+  });
+  getObjectEntries(state.buildings).forEach(([name, items]) => {
+    if (layout.buildings[name]) return;
+    items?.forEach((item) => {
+      item.coordinates = undefined;
+    });
+  });
+  Object.entries(state.buds ?? {}).forEach(([id, bud]) => {
+    if (!layout.buds?.[id]) bud.coordinates = undefined;
+  });
+  Object.entries(state.pets?.nfts ?? {}).forEach(([id, pet]) => {
+    if (!layout.petNFTs?.[id]) pet.coordinates = undefined;
+  });
+  Object.entries(state.farmHands?.bumpkins ?? {}).forEach(([id, fh]) => {
+    if (!layout.farmHands?.[id]) fh.coordinates = undefined;
+  });
+
   // Everything is now lifted. Place each slot in turn against the live draft
   // (non-layout items + already-placed slots). A blocked slot stays unplaced
   // for now; reused instances get a best-effort restore pass below.

--- a/src/features/game/events/landExpansion/renameLayout.test.ts
+++ b/src/features/game/events/landExpansion/renameLayout.test.ts
@@ -47,6 +47,21 @@ describe("renameLayout", () => {
     ).toThrow("Layout does not exist");
   });
 
+  it("throws when renaming the protected Ascension Layout", () => {
+    const built = withLayout();
+    const state: GameState = {
+      ...built,
+      layouts: built.layouts!.map((layout) => ({ ...layout, auto: true })),
+    };
+    expect(() =>
+      renameLayout({
+        state,
+        action: { type: "layout.renamed", layoutId: 0, name: "New Name" },
+        createdAt,
+      }),
+    ).toThrow("The Ascension Layout cannot be renamed");
+  });
+
   it("rejects empty / too-long names", () => {
     expect(() =>
       renameLayout({

--- a/src/features/game/events/landExpansion/renameLayout.ts
+++ b/src/features/game/events/landExpansion/renameLayout.ts
@@ -39,6 +39,9 @@ export function renameLayout({
     if (!layout) {
       throw new Error("Layout does not exist");
     }
+    if (layout.auto) {
+      throw new Error("The Ascension Layout cannot be renamed");
+    }
 
     layout.name = name;
     layout.updatedAt = createdAt;

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -6,11 +6,11 @@ import {
 } from "features/game/expansion/lib/constants";
 import {
   EXPANSION_REQUIREMENTS,
-  getExpectedResources,
   getLand,
+  getMissingResources,
+  SUNSTONE_MINES,
 } from "features/game/types/expansions";
 import type { Airdrop, GameState } from "features/game/types/game";
-import type { ResourceName } from "features/game/types/resources";
 import { hasFeatureAccess } from "lib/flags";
 
 import { getKeys } from "lib/object";
@@ -26,11 +26,6 @@ import {
   TREE_RECOVERY_TIME,
 } from "features/game/lib/constants";
 import { OIL_RESERVE_RECOVERY_TIME } from "./drillOilReserve";
-
-// Each sunstone rock can be mined this many times before it is depleted and
-// removed from the farm (see mineSunstone). Used both when placing new rocks
-// and when reconciling how many the player has mined to depletion.
-const SUNSTONE_MINES = 10;
 
 // Preloaded crops that will appear on plots when they reveal
 const EXPANSION_CROPS: Record<number, CropName> = {
@@ -582,91 +577,17 @@ export function getRewards({
     }
   }
 
-  const missingNodes: Record<ResourceName, number> = {
-    "Crimstone Rock": 0,
-    "Crop Plot": 0,
-    "Flower Bed": 0,
-    "Fruit Patch": 0,
-    "Gold Rock": 0,
-    "Iron Rock": 0,
-    "Stone Rock": 0,
-    "Sunstone Rock": 0,
-    Beehive: 0,
-    Tree: 0,
-    "Oil Reserve": 0,
-    "Lava Pit": 0,
-    "Fused Stone Rock": 0,
-    "Reinforced Stone Rock": 0,
-    Boulder: 0,
-    "Ancient Tree": 0,
-    "Sacred Tree": 0,
-    "Refined Iron Rock": 0,
-    "Tempered Iron Rock": 0,
-    "Pure Gold Rock": 0,
-    "Prime Gold Rock": 0,
-    "Ascension Crystal": 0,
-  };
-
-  const expected = getExpectedResources({
+  // Shared back-pay reconciliation (also used by the ascension reward chest):
+  // expected-vs-owned per-tier, minus what an un-collected missing-resources
+  // airdrop already promises, crediting depleted sunstones / mined crystals.
+  const missingNodes = getMissingResources({
     game,
     expansion: expansions.toNumber(),
   });
 
-  // Items already promised by an unclaimed missing-resources airdrop are not
-  // yet in the inventory. Counting them as still-missing would duplicate the
-  // grant if the player expands again before collecting the previous airdrop.
-  const pendingMissing: Partial<Record<ResourceName, number>> = {};
-  (game.airdrops ?? [])
-    .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
-    .forEach((airdrop) => {
-      getKeys(missingNodes).forEach((key) => {
-        pendingMissing[key] =
-          (pendingMissing[key] ?? 0) + (airdrop.items[key] ?? 0);
-      });
-    });
-
-  getKeys(missingNodes).forEach((key) => {
-    let missing =
-      (expected[key] ?? 0) -
-      (game.inventory[key]?.toNumber() ?? 0) -
-      (pendingMissing[key] ?? 0);
-
-    // Sunstone rocks are finite: once a rock is mined to depletion it is
-    // removed from the inventory (see mineSunstone). To avoid re-granting rocks
-    // the player legitimately consumed, subtract the rocks already mined to
-    // depletion. Each rock holds 10 mines, but mines spent on rocks the player
-    // still owns are not depletions, so they are excluded before dividing. A
-    // player who has never mined a sunstone receives the full missing amount.
-    if (key === "Sunstone Rock") {
-      const lifetimeMines = game.farmActivity?.["Sunstone Mined"] ?? 0;
-      const minesOnLiveRocks = Object.values(game.sunstones ?? {}).reduce(
-        (total, rock) => total + (SUNSTONE_MINES - rock.minesLeft),
-        0,
-      );
-      const depleted = Math.floor(
-        Math.max(0, lifetimeMines - minesOnLiveRocks) / SUNSTONE_MINES,
-      );
-      missing -= depleted;
-    }
-
-    // Ascension Crystals are single-use: each mine destroys exactly one crystal
-    // (and decrements the inventory, see mineAscensionCrystal). Subtract the
-    // crystals already mined so this back-pay airdrop never resurrects ones the
-    // player legitimately consumed. A legacy player (0 owned, 0 mined) receives
-    // the full expected amount.
-    if (key === "Ascension Crystal") {
-      missing -= game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
-    }
-
-    // They have the expected amount of resources
-    if (missing <= 0) {
-      return;
-    }
-
-    missingNodes[key] = missing;
-  });
-
-  const hasMissing = getKeys(missingNodes).some((key) => missingNodes[key] > 0);
+  const hasMissing = getKeys(missingNodes).some(
+    (key) => (missingNodes[key] ?? 0) > 0,
+  );
   if (hasMissing) {
     const expansionBoundaries = {
       x: EXPANSION_ORIGINS[expansions.toNumber() - 1].x - LAND_SIZE / 2,
@@ -685,17 +606,8 @@ export function getRewards({
       {
         createdAt,
         id: `missing-resources-${expansions.toNumber()}`,
-        // Only include items greater than 0
-        items: getKeys(missingNodes).reduce(
-          (acc, key) =>
-            missingNodes[key] > 0
-              ? {
-                  ...acc,
-                  [key]: missingNodes[key],
-                }
-              : acc,
-          {},
-        ),
+        // getMissingResources already returns only positive shortfalls.
+        items: { ...missingNodes },
         sfl: 0,
         coins: 0,
         wearables: {},

--- a/src/features/game/events/landExpansion/saveLayout.test.ts
+++ b/src/features/game/events/landExpansion/saveLayout.test.ts
@@ -313,6 +313,55 @@ describe("saveLayout", () => {
     ).toThrow("Maximum number of layouts reached");
   });
 
+  it("does not count the protected Ascension Layout against the limit", () => {
+    let state = saveLayout({
+      state: baseFarm,
+      action: { type: "layout.saved", name: "a" },
+      createdAt,
+    });
+    state = saveLayout({
+      state,
+      action: { type: "layout.saved", name: "b" },
+      createdAt,
+    });
+    // Mark one of the two as the auto Ascension Layout — it should be exempt, so a
+    // third manual layout still fits (2 manual < MAX_SAVED_LAYOUTS).
+    const withAuto: GameState = {
+      ...state,
+      layouts: state.layouts!.map((layout, i) =>
+        i === 0 ? { ...layout, auto: true } : layout,
+      ),
+    };
+
+    const result = saveLayout({
+      state: withAuto,
+      action: { type: "layout.saved", name: "c" },
+      createdAt,
+    });
+
+    expect(result.layouts).toHaveLength(3);
+  });
+
+  it("throws when overwriting the protected Ascension Layout", () => {
+    const saved = saveLayout({
+      state: baseFarm,
+      action: { type: "layout.saved", name: "a" },
+      createdAt,
+    });
+    const state: GameState = {
+      ...saved,
+      layouts: saved.layouts!.map((layout) => ({ ...layout, auto: true })),
+    };
+
+    expect(() =>
+      saveLayout({
+        state,
+        action: { type: "layout.saved", name: "x", layoutId: 0 },
+        createdAt,
+      }),
+    ).toThrow("The Ascension Layout cannot be overwritten");
+  });
+
   it("trims a provided name and rejects too-long names", () => {
     const trimmed = saveLayout({
       state: baseFarm,

--- a/src/features/game/events/landExpansion/saveLayout.ts
+++ b/src/features/game/events/landExpansion/saveLayout.ts
@@ -44,6 +44,9 @@ export function saveLayout({
       if (!existing) {
         throw new Error("Layout does not exist");
       }
+      if (existing.auto) {
+        throw new Error("The Ascension Layout cannot be overwritten");
+      }
       layouts[action.layoutId] = {
         ...existing,
         ...snapshot,
@@ -52,7 +55,10 @@ export function saveLayout({
         updatedAt: createdAt,
       };
     } else {
-      if (layouts.length >= MAX_SAVED_LAYOUTS) {
+      // The auto-managed Ascension Layout is exempt from the manual limit.
+      if (
+        layouts.filter((layout) => !layout.auto).length >= MAX_SAVED_LAYOUTS
+      ) {
         throw new Error("Maximum number of layouts reached");
       }
       layouts.push({

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1350,6 +1350,44 @@ describe("upgradeFarm", () => {
     expect(chest?.items["Sunstone Rock"]).toBeUndefined();
   });
 
+  it("delivers the basic-upgrade back-pay via a chest while still laying out the new island", () => {
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        island: { type: "desert" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(25),
+          Oil: new Decimal(200),
+          "Crop Plot": new Decimal(65),
+          "Fruit Patch": new Decimal(15),
+          Tree: new Decimal(23),
+          "Stone Rock": new Decimal(20),
+          "Iron Rock": new Decimal(12),
+          "Gold Rock": new Decimal(7),
+          "Crimstone Rock": new Decimal(4),
+          "Sunstone Rock": new Decimal(6),
+          Beehive: new Decimal(3),
+          "Flower Bed": new Decimal(3),
+        },
+      },
+    });
+
+    // The starting island is still laid out from inventory (placeInitialLand runs
+    // before the back-pay) — the volcano floor's Oil Reserve is placed.
+    expect(Object.keys(state.oilReserves)).toHaveLength(1);
+
+    // The upgrade's Ascension Crystals are folded into the reward chest keyed on
+    // the target island, not granted straight to inventory.
+    const chest = state.airdrops?.find(
+      (airdrop) => airdrop.id === "missing-resources-upgrade-volcano",
+    );
+    expect(chest?.items["Ascension Crystal"]).toBeGreaterThan(0);
+    expect(state.inventory["Ascension Crystal"]).toBeUndefined();
+  });
+
   it("does not re-grant crystals already pending in an un-collected chest", () => {
     const createdAt = SPOOKY_ASCENSION_START;
     const readyXp = ascensionBaseline(1) + bandXp(1);

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1,4 +1,5 @@
 import { INITIAL_FARM, TEST_FARM } from "features/game/lib/constants";
+import type { GameState, SavedLayout } from "features/game/types/game";
 import {
   upgrade,
   getAscensionUpgradeCost,
@@ -16,7 +17,10 @@ import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 const SPOOKY_ASCENSION_START =
   TIME_BASED_FEATURE_FLAG_WINDOWS.SPOOKY_ASCENSION.start.getTime();
 import { getLand, TOTAL_EXPANSION_NODES } from "features/game/types/expansions";
-import { getIslandSpawnPositions } from "features/game/expansion/lib/island";
+import {
+  getIslandAnchorX,
+  getIslandSpawnPositions,
+} from "features/game/expansion/lib/island";
 
 describe("upgradeFarm", () => {
   const farmId = 1;
@@ -1105,8 +1109,22 @@ describe("upgradeFarm", () => {
     });
   });
 
-  it("upgrades to swamp island", () => {
+  it("upgrades to swamp island preserving the player's arrangement", () => {
     const createdAt = Date.now();
+    // A realistic maxed volcano farm: Mansion already placed, plus a collectible
+    // and a tree at custom positions the player chose.
+    const mansion = {
+      id: "1",
+      coordinates: { x: 0, y: 0 },
+      createdAt,
+      readyAt: createdAt,
+    };
+    const statue = {
+      id: "1",
+      coordinates: { x: 3, y: 3 },
+      createdAt,
+      readyAt: createdAt,
+    };
     const state = upgrade({
       farmId,
       action: {
@@ -1129,9 +1147,14 @@ describe("upgradeFarm", () => {
           Crimstone: new Decimal(100),
           Oil: new Decimal(100),
           Obsidian: new Decimal(10),
-          // No node pre-seed: swampUpgrade's arrival floor must cover the
-          // INITIAL_SWAMP_LAND_COORDINATES placements for a realistic account.
+          Mansion: new Decimal(1),
+          "Sunflower Statue": new Decimal(1),
         },
+        buildings: { Mansion: [mansion] },
+        collectibles: { "Sunflower Statue": [statue] },
+        trees: {
+          "1": { createdAt, wood: {}, x: 5, y: 5 },
+        } as unknown as GameState["trees"],
       },
       createdAt,
     });
@@ -1149,19 +1172,96 @@ describe("upgradeFarm", () => {
     expect(state.inventory.Obsidian).toEqual(new Decimal(7));
     expect(state.coins).toEqual(5000);
 
-    // Keeps the Mansion as the home, laid out per the swamp layout
-    expect(state.buildings.Manor).toBeUndefined();
-    expect(state.inventory.Mansion).toEqual(new Decimal(1));
-    expect(state.buildings.Mansion?.[0].coordinates).toEqual({ x: -3, y: 15 });
+    // Keeps the player's arrangement in place — nothing is wiped or re-laid out
+    expect(state.buildings.Mansion?.[0].coordinates).toEqual({ x: 0, y: 0 });
+    expect(state.collectibles["Sunflower Statue"]?.[0].coordinates).toEqual({
+      x: 3,
+      y: 3,
+    });
+    expect(state.trees["1"]).toMatchObject({ x: 5, y: 5 });
 
-    // Lays out the swamp starting nodes, incl. the swamp-specific types
-    expect(Object.keys(state.crops)).toHaveLength(65);
-    expect(Object.keys(state.fruitPatches)).toHaveLength(15);
-    expect(Object.keys(state.gold)).toHaveLength(8);
-    expect(Object.keys(state.crimstones)).toHaveLength(5);
-    expect(Object.keys(state.beehives)).toHaveLength(3);
-    expect(Object.keys(state.flowers.flowerBeds)).toHaveLength(3);
-    expect(Object.keys(state.lavaPits)).toHaveLength(3);
+    // Saves the arrangement as the protected, auto-managed Ascension Layout
+    const ascensionLayout = state.layouts?.find((layout) => layout.auto);
+    expect(ascensionLayout?.name).toEqual("Ascension Layout");
+    expect(ascensionLayout?.resources.ascensionCrystals).toEqual({});
+    expect(ascensionLayout?.buildings.Mansion?.[0].coordinates).toEqual({
+      x: 0,
+      y: 0,
+    });
+
+    // Drops the ascension reward chest (Ascension Crystals) on the side island,
+    // rather than granting the crystal straight to inventory.
+    expect(state.inventory["Ascension Crystal"]).toBeUndefined();
+    const chest = state.airdrops?.find(
+      (airdrop) => airdrop.id === "missing-resources-ascension-1",
+    );
+    // Expected crystals at swamp a1 (basicLand 30): 3 (A0) + 1 (upgrade node) = 4
+    expect(chest?.items["Ascension Crystal"]).toEqual(4);
+    expect(chest?.coordinates).toBeDefined();
+  });
+
+  it("delivers node shortfall to the reward chest and avoids stacking chests", () => {
+    const createdAt = Date.now();
+    const anchorX = getIslandAnchorX(30);
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+        },
+        // Under-provisioned: nothing placed, so the swamp floor is all shortfall.
+        collectibles: {},
+        buildings: {},
+        trees: {},
+        stones: {},
+        gold: {},
+        iron: {},
+        crimstones: {},
+        sunstones: {},
+        oilReserves: {},
+        crops: {},
+        fruitPatches: {},
+        beehives: {},
+        lavaPits: {},
+        ascensionCrystals: {},
+        flowers: { ...INITIAL_FARM.flowers, flowerBeds: {} },
+        // An un-collected chest already sits on the first candidate side-island tile.
+        airdrops: [
+          {
+            id: "prior",
+            createdAt,
+            coordinates: { x: anchorX + 1, y: 7 },
+            items: {},
+            wearables: {},
+            sfl: 0,
+            coins: 0,
+          },
+        ],
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (airdrop) => airdrop.id === "missing-resources-ascension-1",
+    );
+    // Swamp floor has 3 Lava Pits; the player owns none, so they arrive via the chest.
+    expect(chest?.items["Lava Pit"]).toEqual(3);
+    // The floor is NOT topped up into inventory anymore.
+    expect(state.inventory["Lava Pit"]).toBeUndefined();
+    // The chest avoids the tile already occupied by the prior airdrop.
+    expect(chest?.coordinates).not.toEqual({ x: anchorX + 1, y: 7 });
   });
 
   it("requires the minimum Bumpkin level to ascend to swamp island", () => {
@@ -1267,6 +1367,124 @@ describe("upgradeFarm", () => {
         }),
       ).toThrow("Insufficient Crimstone");
     });
+  });
+
+  it("preserves crop growth timers across the first ascension (no instant growth)", () => {
+    const createdAt = Date.now();
+    const plantedAt = createdAt - 60 * 1000;
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+        },
+        crops: {
+          "99": {
+            createdAt,
+            x: 4,
+            y: 4,
+            crop: { id: "99", name: "Sunflower", plantedAt },
+          },
+        } as GameState["crops"],
+      },
+      createdAt,
+    });
+
+    // The same plot instance survives untouched — its planted crop keeps its timer.
+    expect(state.crops["99"]).toMatchObject({ x: 4, y: 4 });
+    expect(state.crops["99"]?.crop?.plantedAt).toEqual(plantedAt);
+  });
+
+  it("reuses the saved Ascension Layout on later ascensions", () => {
+    const createdAt = SPOOKY_ASCENSION_START;
+    const readyXp = ascensionBaseline(1) + bandXp(1);
+    const emptyLayoutResources: SavedLayout["resources"] = {
+      trees: {},
+      stones: {},
+      gold: {},
+      iron: {},
+      crimstones: {},
+      sunstones: {},
+      ascensionCrystals: {},
+      oilReserves: {},
+      crops: {},
+      fruitPatches: {},
+      beehives: {},
+      flowerBeds: {},
+      lavaPits: {},
+    };
+    // The layout captured at volcano->swamp places the statue at { x: 7, y: 7 }.
+    const autoLayout: SavedLayout = {
+      name: "Ascension Layout",
+      auto: true,
+      createdAt,
+      updatedAt: createdAt,
+      collectibles: {
+        "Sunflower Statue": [{ id: "1", coordinates: { x: 7, y: 7 } }],
+      },
+      buildings: {},
+      resources: emptyLayoutResources,
+    };
+
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        // Team username so SWAMP_ASCENSION passes on mainnet.
+        username: "elias",
+        coins: 100000,
+        bumpkin: { ...INITIAL_FARM.bumpkin, experience: readyXp },
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(42),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+          "Sunflower Statue": new Decimal(1),
+        },
+        // Current arrangement differs from the saved layout — the statue is elsewhere.
+        collectibles: {
+          "Sunflower Statue": [
+            {
+              id: "1",
+              coordinates: { x: 1, y: 1 },
+              createdAt,
+              readyAt: createdAt,
+            },
+          ],
+        },
+        layouts: [autoLayout],
+      },
+      createdAt,
+    });
+
+    expect(state.island.type).toEqual("spooky");
+    expect(state.island.ascensionLevel).toEqual(2);
+    // Reset to the saved layout: the statue moved back to { x: 7, y: 7 }.
+    expect(state.collectibles["Sunflower Statue"]?.[0].coordinates).toEqual({
+      x: 7,
+      y: 7,
+    });
+    // A reward chest is dropped for this ascension too.
+    expect(
+      state.airdrops?.some(
+        (airdrop) => airdrop.id === "missing-resources-ascension-2",
+      ),
+    ).toBe(true);
   });
 
   it("scales the ascension upgrade cost with level", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1,5 +1,9 @@
 import { INITIAL_FARM, TEST_FARM } from "features/game/lib/constants";
-import type { GameState, SavedLayout } from "features/game/types/game";
+import type {
+  GameState,
+  InventoryItemName,
+  SavedLayout,
+} from "features/game/types/game";
 import {
   upgrade,
   getAscensionUpgradeCost,
@@ -1367,6 +1371,108 @@ describe("upgradeFarm", () => {
     // Expected at swamp a1 (Basic Land 30) = 4; owned = 3 (inventory already
     // includes the 3 placed) → chest tops up exactly 1, not 0.
     expect(chest?.items["Ascension Crystal"]).toEqual(1);
+  });
+
+  it("does not duplicate owned nodes into the reward chest (no over-grant)", () => {
+    const createdAt = Date.now();
+    const floor = {
+      "Crop Plot": 65,
+      Tree: 23,
+      "Stone Rock": 20,
+      "Iron Rock": 13,
+      "Gold Rock": 8,
+      "Fruit Patch": 15,
+      "Crimstone Rock": 5,
+      "Sunstone Rock": 13,
+      "Oil Reserve": 4,
+      "Lava Pit": 3,
+      Beehive: 3,
+      "Flower Bed": 3,
+    };
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+          ...Object.fromEntries(
+            Object.entries(floor).map(([k, v]) => [k, new Decimal(v)]),
+          ),
+        },
+        // Lava Pits actually PLACED (the reviewer's example) while inventory
+        // counts them — proves placement does not make them "uncounted".
+        lavaPits: {
+          l1: { createdAt, x: -1, y: 1, stone: { minedAt: 0 }, minesLeft: 3 },
+          l2: { createdAt, x: 1, y: 1, stone: { minedAt: 0 }, minesLeft: 3 },
+          l3: { createdAt, x: 3, y: 1, stone: { minedAt: 0 }, minesLeft: 3 },
+        } as GameState["lavaPits"],
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (a) => a.id === "missing-resources-ascension-1",
+    );
+    // Every floor node is already owned (inventory includes placed) → none are
+    // re-granted in the chest.
+    Object.keys(floor).forEach((node) =>
+      expect(chest?.items[node as InventoryItemName]).toBeUndefined(),
+    );
+  });
+
+  it("ignores non-reward airdrops when sizing the crystal chest", () => {
+    const createdAt = Date.now();
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+        },
+        // A promo/event airdrop that happens to contain crystals — NOT a reward
+        // chest, so it must not count toward what the player is owed here.
+        airdrops: [
+          {
+            id: "promo-gift",
+            createdAt,
+            coordinates: { x: -30, y: 7 },
+            items: { "Ascension Crystal": 10 },
+            wearables: {},
+            sfl: 0,
+            coins: 0,
+          },
+        ],
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (a) => a.id === "missing-resources-ascension-1",
+    );
+    // Full expected (4) is still delivered — the promo's crystals don't count.
+    expect(chest?.items["Ascension Crystal"]).toEqual(4);
   });
 
   it("requires the minimum Bumpkin level to ascend to swamp island", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1276,6 +1276,80 @@ describe("upgradeFarm", () => {
     ).toBe(false);
   });
 
+  it("delivers the sunstone shortfall via the chest", () => {
+    const createdAt = Date.now();
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+          // Maxed volcano owns the volcano floor of 6 sunstone rocks.
+          "Sunstone Rock": new Decimal(6),
+        },
+        sunstones: {},
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (airdrop) => airdrop.id === "missing-resources-ascension-1",
+    );
+    // Swamp floor wants 13 sunstone rocks; a maxed volcano owns 6, so the chest
+    // tops up the remaining 7 (no longer hard-excluded).
+    expect(chest?.items["Sunstone Rock"]).toEqual(7);
+  });
+
+  it("does not re-grant sunstone rocks the player mined to depletion", () => {
+    const createdAt = Date.now();
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+          // Was granted the full 13, but mined 3 rocks to depletion (each rock
+          // holds 10 mines) — depletion removes them from inventory, leaving 10.
+          "Sunstone Rock": new Decimal(10),
+        },
+        sunstones: {},
+        farmActivity: {
+          ...INITIAL_FARM.farmActivity,
+          "Sunstone Mined": 30,
+        },
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (airdrop) => airdrop.id === "missing-resources-ascension-1",
+    );
+    // owned = 10 inventory + 3 depleted = 13 = floor, so no sunstone shortfall.
+    expect(chest?.items["Sunstone Rock"]).toBeUndefined();
+  });
+
   it("does not re-grant crystals already pending in an un-collected chest", () => {
     const createdAt = SPOOKY_ASCENSION_START;
     const readyXp = ascensionBaseline(1) + bandXp(1);

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -21,6 +21,7 @@ import {
   getIslandAnchorX,
   getIslandSpawnPositions,
 } from "features/game/expansion/lib/island";
+import { getExpectedAscensionCrystals } from "features/game/expansion/lib/ascension";
 
 describe("upgradeFarm", () => {
   const farmId = 1;
@@ -1200,9 +1201,21 @@ describe("upgradeFarm", () => {
     expect(chest?.coordinates).toBeDefined();
   });
 
-  it("delivers node shortfall to the reward chest and avoids stacking chests", () => {
+  it("delivers node shortfall to the chest and finds a free tile even when the initial rows are full", () => {
     const createdAt = Date.now();
     const anchorX = getIslandAnchorX(30);
+    // Occupy every tile in the first two side-island rows (the old fixed set).
+    const priorAirdrops = [7, 8].flatMap((y) =>
+      [1, 0, 2].map((dx) => ({
+        id: `prior-${dx}-${y}`,
+        createdAt,
+        coordinates: { x: anchorX + dx, y },
+        items: {},
+        wearables: {},
+        sfl: 0,
+        coins: 0,
+      })),
+    );
     const state = upgrade({
       farmId,
       action: { type: "farm.upgraded" },
@@ -1237,18 +1250,7 @@ describe("upgradeFarm", () => {
         lavaPits: {},
         ascensionCrystals: {},
         flowers: { ...INITIAL_FARM.flowers, flowerBeds: {} },
-        // An un-collected chest already sits on the first candidate side-island tile.
-        airdrops: [
-          {
-            id: "prior",
-            createdAt,
-            coordinates: { x: anchorX + 1, y: 7 },
-            items: {},
-            wearables: {},
-            sfl: 0,
-            coins: 0,
-          },
-        ],
+        airdrops: priorAirdrops,
       },
       createdAt,
     });
@@ -1260,8 +1262,70 @@ describe("upgradeFarm", () => {
     expect(chest?.items["Lava Pit"]).toEqual(3);
     // The floor is NOT topped up into inventory anymore.
     expect(state.inventory["Lava Pit"]).toBeUndefined();
-    // The chest avoids the tile already occupied by the prior airdrop.
-    expect(chest?.coordinates).not.toEqual({ x: anchorX + 1, y: 7 });
+    // The chest lands on a genuinely free tile beyond the (full) initial rows.
+    const occupied = new Set(
+      priorAirdrops.map((a) => `${a.coordinates.x},${a.coordinates.y}`),
+    );
+    expect(chest?.coordinates).toBeDefined();
+    expect(
+      occupied.has(`${chest!.coordinates!.x},${chest!.coordinates!.y}`),
+    ).toBe(false);
+  });
+
+  it("does not re-grant crystals already pending in an un-collected chest", () => {
+    const createdAt = SPOOKY_ASCENSION_START;
+    const readyXp = ascensionBaseline(1) + bandXp(1);
+    // On swamp (A1) with an un-collected volcano→swamp chest holding the 4
+    // crystals the player was already owed.
+    const priorChest = {
+      id: "missing-resources-ascension-1",
+      createdAt,
+      coordinates: { x: -30, y: 7 },
+      items: { "Ascension Crystal": 4 },
+      wearables: {},
+      sfl: 0,
+      coins: 0,
+    };
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        username: "elias",
+        coins: 100000,
+        bumpkin: { ...INITIAL_FARM.bumpkin, experience: readyXp },
+        island: { type: "swamp", ascensionLevel: 1 },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(42),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+        },
+        airdrops: [priorChest],
+      },
+      createdAt,
+    });
+
+    const chests = (state.airdrops ?? []).filter((a) =>
+      a.id.startsWith("missing-resources"),
+    );
+    const totalCrystals = chests.reduce(
+      (sum, a) => sum + (a.items["Ascension Crystal"] ?? 0),
+      0,
+    );
+    // Cumulative entitlement at spooky (a2, Basic Land reset to 30) — NOT doubled.
+    const expected = getExpectedAscensionCrystals({
+      islandType: "spooky",
+      ascensionLevel: 2,
+      basicLand: 30,
+    });
+    expect(totalCrystals).toEqual(expected);
+    // The new chest only tops up the difference beyond the pending 4.
+    const newChest = chests.find(
+      (a) => a.id === "missing-resources-ascension-2",
+    );
+    expect(newChest?.items["Ascension Crystal"]).toEqual(expected - 4);
   });
 
   it("requires the minimum Bumpkin level to ascend to swamp island", () => {

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -1328,6 +1328,47 @@ describe("upgradeFarm", () => {
     expect(newChest?.items["Ascension Crystal"]).toEqual(expected - 4);
   });
 
+  it("counts placed crystals once when sizing the reward chest", () => {
+    const createdAt = Date.now();
+    // Earned 3 A0 crystals, all placed on volcano. Inventory is the total owned
+    // (placing does not decrement it); the 3 nodes are a subset of that total,
+    // so they must not be counted a second time.
+    const state = upgrade({
+      farmId,
+      action: { type: "farm.upgraded" },
+      state: {
+        ...INITIAL_FARM,
+        coins: 10000,
+        bumpkin: {
+          ...INITIAL_FARM.bumpkin,
+          experience: LEVEL_EXPERIENCE[ASCENSION_BUMPKIN_LEVEL],
+        },
+        island: { type: "volcano" },
+        inventory: {
+          ...INITIAL_FARM.inventory,
+          "Basic Land": new Decimal(30),
+          Crimstone: new Decimal(100),
+          Oil: new Decimal(100),
+          Obsidian: new Decimal(10),
+          "Ascension Crystal": new Decimal(3),
+        },
+        ascensionCrystals: {
+          c1: { createdAt, x: 1, y: 1, stone: { minedAt: 0 }, minesLeft: 1 },
+          c2: { createdAt, x: 3, y: 1, stone: { minedAt: 0 }, minesLeft: 1 },
+          c3: { createdAt, x: 5, y: 1, stone: { minedAt: 0 }, minesLeft: 1 },
+        } as GameState["ascensionCrystals"],
+      },
+      createdAt,
+    });
+
+    const chest = state.airdrops?.find(
+      (a) => a.id === "missing-resources-ascension-1",
+    );
+    // Expected at swamp a1 (Basic Land 30) = 4; owned = 3 (inventory already
+    // includes the 3 placed) → chest tops up exactly 1, not 0.
+    expect(chest?.items["Ascension Crystal"]).toEqual(1);
+  });
+
   it("requires the minimum Bumpkin level to ascend to swamp island", () => {
     expect(() =>
       upgrade({

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -1086,6 +1086,15 @@ function buildAscensionRewardBundle(
 ): Partial<Record<InventoryItemName, number>> {
   const bundle: Partial<Record<InventoryItemName, number>> = {};
 
+  // Items already promised by an un-collected reward chest count as owned — the
+  // player will receive them on claim. Ignoring them would re-issue the same
+  // crystals/nodes on the next ascension (both chests stay claimable).
+  const pending = (item: InventoryItemName): number =>
+    (game.airdrops ?? []).reduce(
+      (total, airdrop) => total + (airdrop.items[item] ?? 0),
+      0,
+    );
+
   // Node floor for the starting island (base row), excluding the sunstone bonus —
   // matching `ascensionUpgrade`'s minimum. After `applySetup` this is already met,
   // so the shortfall is only positive for legacy / under-provisioned accounts.
@@ -1098,16 +1107,18 @@ function buildAscensionRewardBundle(
     "Sunstone Rock": 0,
   };
   getObjectEntries(floor).forEach(([resource, amount]) => {
-    const shortfall =
-      (amount ?? 0) - getTotalBaseResourceEquivalents(game, resource);
+    const owned =
+      getTotalBaseResourceEquivalents(game, resource) + pending(resource);
+    const shortfall = (amount ?? 0) - owned;
     if (shortfall > 0) {
       bundle[resource] = (bundle[resource] ?? 0) + shortfall;
     }
   });
 
   // Ascension Crystals owed for this ascension: the expected cumulative count
-  // minus what the player already owns (inventory + placed) and has mined
-  // (single-use). This replaces the +1 inventory grant on the ascension path.
+  // minus what the player already owns (inventory + placed), has mined
+  // (single-use), or has pending in an un-collected chest. This replaces the +1
+  // inventory grant on the ascension path.
   const expectedCrystals = getExpectedAscensionCrystals({
     islandType: target,
     ascensionLevel: game.island.ascensionLevel ?? 0,
@@ -1117,7 +1128,11 @@ function buildAscensionRewardBundle(
     (game.inventory["Ascension Crystal"]?.toNumber() ?? 0) +
     Object.keys(game.ascensionCrystals ?? {}).length;
   const minedCrystals = game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
-  const crystalShortfall = expectedCrystals - ownedCrystals - minedCrystals;
+  const crystalShortfall =
+    expectedCrystals -
+    ownedCrystals -
+    minedCrystals -
+    pending("Ascension Crystal");
   if (crystalShortfall > 0) {
     bundle["Ascension Crystal"] =
       (bundle["Ascension Crystal"] ?? 0) + crystalShortfall;
@@ -1129,26 +1144,27 @@ function buildAscensionRewardBundle(
 /**
  * A free side-island tile for the ascension reward chest. The side island sits
  * off the main land, so `pickEmptyPosition`/`detectCollision` (which treats
- * off-land tiles as water) can't be used — instead scan a few tiles just below
- * the mushroom spawn rows and pick the first not already holding an airdrop, so
- * successive un-collected ascension chests don't stack on the same tile.
+ * off-land tiles as water) can't be used — instead scan tiles just below the
+ * mushroom spawn rows and return the first not already holding an airdrop. The
+ * scan walks down unbounded rows so a genuinely free tile is always found, no
+ * matter how many un-collected chests have piled up (e.g. marble→marble).
  */
 function pickAscensionChestPosition(
   game: GameState,
   setup: IslandSetup,
 ): Coordinates {
   const anchorX = getIslandAnchorX(setup.startingExpansions);
-  const candidates: Coordinates[] = [7, 8].flatMap((y) =>
-    [1, 0, 2].map((dx) => ({ x: anchorX + dx, y })),
-  );
   const taken = new Set(
     (game.airdrops ?? [])
       .filter((airdrop) => airdrop.coordinates)
       .map((airdrop) => `${airdrop.coordinates!.x},${airdrop.coordinates!.y}`),
   );
-  return (
-    candidates.find(({ x, y }) => !taken.has(`${x},${y}`)) ?? candidates[0]
-  );
+  for (let y = 7; ; y++) {
+    for (const dx of [1, 0, 2]) {
+      const position = { x: anchorX + dx, y };
+      if (!taken.has(`${position.x},${position.y}`)) return position;
+    }
+  }
 }
 
 /**

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -38,11 +38,8 @@ import { applyFarmLayout, snapshotFarm } from "./lib/layouts";
 import {
   TOTAL_EXPANSION_NODES,
   getExpansionNodes,
+  getMissingResources,
 } from "features/game/types/expansions";
-import {
-  SWAMP_BASE_EXPANSION,
-  getExpectedAscensionCrystals,
-} from "features/game/expansion/lib/ascension";
 import { ISLAND_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequirements";
 import {
   getIslandAnchorX,
@@ -1070,79 +1067,6 @@ const ISLAND_SETUP: Record<UpgradeTarget, IslandSetup> = {
 };
 
 /**
- * Contents of the ascension reward chest (a side-island airdrop). Delivers the
- * Ascension Crystals the player is owed for this ascension — routed through the
- * chest instead of straight to inventory — plus a node-shortfall safety net for
- * under-provisioned/legacy farms (0 for a normal farm, which already meets the
- * floor after `applySetup`).
- *
- * Uses the same expected-vs-owned accounting as `revealLand`'s missing-resources
- * back-pay, and the chest is emitted with a `missing-resources` id prefix so
- * `revealLand`'s dedup never grants the same crystals twice.
- */
-function buildAscensionRewardBundle(
-  game: GameState,
-  target: AscensionIslandType,
-): Partial<Record<InventoryItemName, number>> {
-  const bundle: Partial<Record<InventoryItemName, number>> = {};
-
-  // Items already promised by an un-collected reward chest count as owned — the
-  // player will receive them on claim. Ignoring them would re-issue the same
-  // crystals/nodes on the next ascension (both chests stay claimable). Scoped to
-  // `missing-resources` chests (our ascension chests + revealLand's back-pay), so
-  // an unrelated promo/event airdrop can't shrink what this ascension owes —
-  // mirrors revealLand's pendingMissing filter.
-  const pending = (item: InventoryItemName): number =>
-    (game.airdrops ?? [])
-      .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
-      .reduce((total, airdrop) => total + (airdrop.items[item] ?? 0), 0);
-
-  // Node floor for the starting island (base row), excluding the sunstone bonus —
-  // matching `ascensionUpgrade`'s minimum. After `applySetup` this is already met,
-  // so the shortfall is only positive for legacy / under-provisioned accounts.
-  const floor = {
-    ...getExpansionNodes({
-      island: target,
-      expansion: SWAMP_BASE_EXPANSION,
-      ascensionLevel: game.island.ascensionLevel,
-    }),
-    "Sunstone Rock": 0,
-  };
-  getObjectEntries(floor).forEach(([resource, amount]) => {
-    const owned =
-      getTotalBaseResourceEquivalents(game, resource) + pending(resource);
-    const shortfall = (amount ?? 0) - owned;
-    if (shortfall > 0) {
-      bundle[resource] = (bundle[resource] ?? 0) + shortfall;
-    }
-  });
-
-  // Ascension Crystals owed for this ascension: the expected cumulative count
-  // minus what the player already owns (inventory, which already includes any
-  // placed crystals — placing never decrements it), has mined (single-use), or
-  // has pending in an un-collected chest. Mirrors revealLand's back-pay formula.
-  // This replaces the +1 inventory grant on the ascension path.
-  const expectedCrystals = getExpectedAscensionCrystals({
-    islandType: target,
-    ascensionLevel: game.island.ascensionLevel ?? 0,
-    basicLand: game.inventory["Basic Land"]?.toNumber() ?? 0,
-  });
-  const ownedCrystals = game.inventory["Ascension Crystal"]?.toNumber() ?? 0;
-  const minedCrystals = game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
-  const crystalShortfall =
-    expectedCrystals -
-    ownedCrystals -
-    minedCrystals -
-    pending("Ascension Crystal");
-  if (crystalShortfall > 0) {
-    bundle["Ascension Crystal"] =
-      (bundle["Ascension Crystal"] ?? 0) + crystalShortfall;
-  }
-
-  return bundle;
-}
-
-/**
  * A free side-island tile for the ascension reward chest. The side island sits
  * off the main land, so `pickEmptyPosition`/`detectCollision` (which treats
  * off-land tiles as water) can't be used — instead scan tiles just below the
@@ -1344,13 +1268,15 @@ function transitionToIsland({
     if (isAscensionTarget) {
       // Ascension rewards — the Ascension Crystals the player is owed (most
       // players won't have any yet) plus any node shortfall — are delivered via
-      // a chest on the side island rather than straight to inventory. The
-      // `missing-resources` id prefix lets revealLand's back-pay dedup so the
-      // same crystals are never granted twice.
-      const bundle = buildAscensionRewardBundle(
+      // a chest on the side island rather than straight to inventory. Reuses the
+      // shared `getMissingResources` reconciliation (same as revealLand's
+      // back-pay: per-tier/forging-safe, depletion-aware), keyed on the current
+      // Basic Land count. The `missing-resources` id prefix lets revealLand's
+      // dedup so the same items are never granted twice.
+      const bundle = getMissingResources({
         game,
-        target as AscensionIslandType,
-      );
+        expansion: game.inventory["Basic Land"]?.toNumber() ?? 0,
+      });
       if (getObjectEntries(bundle).length > 0) {
         game.airdrops = [
           ...(game.airdrops ?? []),

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -9,6 +9,7 @@ import type {
   IslandType,
   Inventory,
   InventoryItemName,
+  SavedLayout,
   Season,
   TemperateSeasonName,
 } from "features/game/types/game";
@@ -33,13 +34,20 @@ import { placeBeehive } from "./placeBeehive";
 import { placeFlowerBed } from "./placeFlowerBed";
 import { placeLavaPit } from "./placeLavaPit";
 import { removeAll } from "./removeAll";
+import { applyFarmLayout, snapshotFarm } from "./lib/layouts";
 import {
   TOTAL_EXPANSION_NODES,
   getExpansionNodes,
 } from "features/game/types/expansions";
-import { SWAMP_BASE_EXPANSION } from "features/game/expansion/lib/ascension";
+import {
+  SWAMP_BASE_EXPANSION,
+  getExpectedAscensionCrystals,
+} from "features/game/expansion/lib/ascension";
 import { ISLAND_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequirements";
-import { reAnchorToIsland } from "features/game/expansion/lib/island";
+import {
+  getIslandAnchorX,
+  reAnchorToIsland,
+} from "features/game/expansion/lib/island";
 
 export type UpgradeFarmAction = {
   type: "farm.upgraded";
@@ -972,35 +980,10 @@ function ascensionUpgrade(state: GameState, target: UpgradeTarget) {
   // Add new resources
   game.inventory.Mansion = new Decimal(1);
 
-  // Ensure they have the minimum resources to start the island with
-  // Do not give bonus sunstones
-  // Account for upgraded resources when checking minimums
-  // Carry-forward floor: base + every prior ascension's grants (ascensionLevel
-  // is already bumped to the level being entered by the time this runs).
-  const minimum = {
-    ...getExpansionNodes({
-      island: target,
-      expansion: SWAMP_BASE_EXPANSION,
-      ascensionLevel: game.island.ascensionLevel,
-    }),
-    "Sunstone Rock": 0,
-  };
-
-  getObjectEntries(minimum).forEach(([resource, amount]) => {
-    const totalEquivalents = getTotalBaseResourceEquivalents(game, resource);
-
-    // Only set minimum if total equivalents are less than required
-    if (totalEquivalents < amount) {
-      topUpResourceToMinimum({
-        game,
-        name: resource,
-        amount,
-        totalEquivalents,
-      });
-    }
-  });
-
-  // No welcome airdrop for now
+  // The starting-node floor is NOT topped up into inventory here — any shortfall
+  // vs the swamp floor is delivered to the player through the ascension reward
+  // chest instead (see `buildAscensionRewardBundle`). A maxed volcano already
+  // exceeds the floor, so this only matters for under-provisioned/legacy farms.
 
   return game;
 }
@@ -1087,9 +1070,95 @@ const ISLAND_SETUP: Record<UpgradeTarget, IslandSetup> = {
 };
 
 /**
+ * Contents of the ascension reward chest (a side-island airdrop). Delivers the
+ * Ascension Crystals the player is owed for this ascension — routed through the
+ * chest instead of straight to inventory — plus a node-shortfall safety net for
+ * under-provisioned/legacy farms (0 for a normal farm, which already meets the
+ * floor after `applySetup`).
+ *
+ * Uses the same expected-vs-owned accounting as `revealLand`'s missing-resources
+ * back-pay, and the chest is emitted with a `missing-resources` id prefix so
+ * `revealLand`'s dedup never grants the same crystals twice.
+ */
+function buildAscensionRewardBundle(
+  game: GameState,
+  target: AscensionIslandType,
+): Partial<Record<InventoryItemName, number>> {
+  const bundle: Partial<Record<InventoryItemName, number>> = {};
+
+  // Node floor for the starting island (base row), excluding the sunstone bonus —
+  // matching `ascensionUpgrade`'s minimum. After `applySetup` this is already met,
+  // so the shortfall is only positive for legacy / under-provisioned accounts.
+  const floor = {
+    ...getExpansionNodes({
+      island: target,
+      expansion: SWAMP_BASE_EXPANSION,
+      ascensionLevel: game.island.ascensionLevel,
+    }),
+    "Sunstone Rock": 0,
+  };
+  getObjectEntries(floor).forEach(([resource, amount]) => {
+    const shortfall =
+      (amount ?? 0) - getTotalBaseResourceEquivalents(game, resource);
+    if (shortfall > 0) {
+      bundle[resource] = (bundle[resource] ?? 0) + shortfall;
+    }
+  });
+
+  // Ascension Crystals owed for this ascension: the expected cumulative count
+  // minus what the player already owns (inventory + placed) and has mined
+  // (single-use). This replaces the +1 inventory grant on the ascension path.
+  const expectedCrystals = getExpectedAscensionCrystals({
+    islandType: target,
+    ascensionLevel: game.island.ascensionLevel ?? 0,
+    basicLand: game.inventory["Basic Land"]?.toNumber() ?? 0,
+  });
+  const ownedCrystals =
+    (game.inventory["Ascension Crystal"]?.toNumber() ?? 0) +
+    Object.keys(game.ascensionCrystals ?? {}).length;
+  const minedCrystals = game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
+  const crystalShortfall = expectedCrystals - ownedCrystals - minedCrystals;
+  if (crystalShortfall > 0) {
+    bundle["Ascension Crystal"] =
+      (bundle["Ascension Crystal"] ?? 0) + crystalShortfall;
+  }
+
+  return bundle;
+}
+
+/**
+ * A free side-island tile for the ascension reward chest. The side island sits
+ * off the main land, so `pickEmptyPosition`/`detectCollision` (which treats
+ * off-land tiles as water) can't be used — instead scan a few tiles just below
+ * the mushroom spawn rows and pick the first not already holding an airdrop, so
+ * successive un-collected ascension chests don't stack on the same tile.
+ */
+function pickAscensionChestPosition(
+  game: GameState,
+  setup: IslandSetup,
+): Coordinates {
+  const anchorX = getIslandAnchorX(setup.startingExpansions);
+  const candidates: Coordinates[] = [7, 8].flatMap((y) =>
+    [1, 0, 2].map((dx) => ({ x: anchorX + dx, y })),
+  );
+  const taken = new Set(
+    (game.airdrops ?? [])
+      .filter((airdrop) => airdrop.coordinates)
+      .map((airdrop) => `${airdrop.coordinates!.x},${airdrop.coordinates!.y}`),
+  );
+  return (
+    candidates.find(({ x, y }) => !taken.has(`${x},${y}`)) ?? candidates[0]
+  );
+}
+
+/**
  * Transitions a farm to a new island, establishing a fresh starting configuration.
  *
  * Clears the previous farm state, carries forward expansion history and sunstone counts, relocates mushrooms and social farming clutter to the new island's side island, applies target-island-specific setup (home adjustments, resource flooring, airdrops), and initializes all starting land, buildings, and resources. Per-island configurations are determined by `ISLAND_SETUP[target]`.
+ *
+ * On ascension (swamp onward) the wipe is skipped: the first ascension
+ * (volcano→swamp) keeps the player's arrangement in place and saves it as the
+ * protected "Ascension Layout"; later ascensions re-apply that saved layout.
  *
  * @returns The transitioned game state with the new island fully initialized
  */
@@ -1106,20 +1175,36 @@ function transitionToIsland({
 }): GameState {
   let game = cloneDeep(state);
 
-  // Return every placed item to the inventory
-  try {
-    game = removeAll({
-      state: game,
-      action: {
-        type: "items.removed",
-        location: "farm",
-      },
-      createdAt,
-    });
-  } catch (error) {
-    // Ignore errors
+  // Ascension (swamp onward) preserves the player's arrangement instead of wiping:
+  // - the first ascension (volcano→swamp) keeps every item exactly where it is
+  //   (identical 30-expansion land; a maxed volcano already meets the swamp floor);
+  // - later ascensions re-apply the layout saved at that first ascension.
+  const isAscensionTarget = (ASCENSION_ISLANDS as readonly string[]).includes(
+    target,
+  );
+  const isFirstAscension = isAscensionTarget && game.island.type === "volcano";
+  const storedAscensionLayout = game.layouts?.find((layout) => layout.auto);
+  const keepArrangement = isFirstAscension;
+  const reuseSavedLayout =
+    isAscensionTarget && !isFirstAscension && !!storedAscensionLayout;
+
+  // Return every placed item to the inventory (skipped when we preserve the
+  // arrangement — `applyFarmLayout` does its own lifting on the reuse path).
+  if (!keepArrangement && !reuseSavedLayout) {
+    try {
+      game = removeAll({
+        state: game,
+        action: {
+          type: "items.removed",
+          location: "farm",
+        },
+        createdAt,
+      });
+    } catch (error) {
+      // Ignore errors
+    }
+    game = cloneDeep(game);
   }
-  game = cloneDeep(game);
 
   // Reset transient systems that do not carry across islands
   game.fishing.wharf = {};
@@ -1181,9 +1266,7 @@ function transitionToIsland({
 
   // Every upgrade into an ascension island (swamp onward) bumps the ascension
   // counter by one — continuous from swamp. Basic islands leave it unset.
-  const isAscensionTarget = (ASCENSION_ISLANDS as readonly string[]).includes(
-    target,
-  );
+  // (`isAscensionTarget` is computed at the top of the transition.)
 
   // Set the new island
   game.island = {
@@ -1202,26 +1285,85 @@ function transitionToIsland({
   // Remove any previous in progress expansions (LEGACY)
   delete game.expansionConstruction;
 
-  // Island-specific setup, then lay out the starting island
+  // Island-specific setup (home swap + resource floor), then lay out the island.
   const setup = ISLAND_SETUP[target];
   game = setup.applySetup(game, target);
   game.inventory["Basic Land"] = new Decimal(setup.startingExpansions);
-  game = placeInitialLand({
-    state: game,
-    farmId,
-    createdAt,
-    initialLandCoordinates: setup.initialCoordinates,
-  });
 
-  // Grant the Ascension Crystal "upgrade node": 1 per island upgrade (the A0
-  // spring/desert/volcano grants and each ascension's upgrade node). Granted to
-  // inventory for the player to place; the per-expansion crystals auto-place via
-  // the ascension layout. Kept additive (never reset) so it stays in lockstep
-  // with getExpectedAscensionCrystals for the revealLand back-pay reconciliation.
+  if (keepArrangement) {
+    // Volcano→Swamp: leave every placed item exactly where it is (no wipe, no
+    // re-place) — the land is identical and the arrangement is already correct.
+  } else if (reuseSavedLayout && storedAscensionLayout) {
+    // Later ascensions reset the farm to the layout saved at volcano→swamp
+    // (best-effort; items that no longer fit the land drop back to the chest).
+    applyFarmLayout(game, storedAscensionLayout, createdAt);
+  } else {
+    game = placeInitialLand({
+      state: game,
+      farmId,
+      createdAt,
+      initialLandCoordinates: setup.initialCoordinates,
+    });
+  }
+
+  // Capture the arrangement as the protected, auto-managed "Ascension Layout" the
+  // first time the player ascends (volcano→swamp); it is reused on every later
+  // ascension. Appended once (idempotent guard) and exempt from the manual cap.
+  if (isFirstAscension && !game.layouts?.some((layout) => layout.auto)) {
+    const ascensionLayout: SavedLayout = {
+      ...snapshotFarm(game),
+      name: "Ascension Layout",
+      auto: true,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    // Crystals are single-use and delivered per-upgrade via the reward chest, so
+    // they are never part of the reusable layout.
+    ascensionLayout.resources.ascensionCrystals = {};
+    game.layouts = [...(game.layouts ?? []), ascensionLayout];
+  }
+
   if (hasFeatureAccess(game, "SWAMP_ASCENSION")) {
-    game.inventory["Ascension Crystal"] = (
-      game.inventory["Ascension Crystal"] ?? new Decimal(0)
-    ).add(1);
+    if (isAscensionTarget) {
+      // Ascension rewards — the Ascension Crystals the player is owed (most
+      // players won't have any yet) plus any node shortfall — are delivered via
+      // a chest on the side island rather than straight to inventory. The
+      // `missing-resources` id prefix lets revealLand's back-pay dedup so the
+      // same crystals are never granted twice.
+      const bundle = buildAscensionRewardBundle(
+        game,
+        target as AscensionIslandType,
+      );
+      if (getObjectEntries(bundle).length > 0) {
+        game.airdrops = [
+          ...(game.airdrops ?? []),
+          {
+            // Keyed on the (strictly increasing) ascension level so every
+            // ascension — including the infinite marble→marble loop — gets a
+            // unique id. `claimAirdrop` removes every airdrop matching the
+            // claimed id, so a reused id would drop an un-collected chest's
+            // rewards. The `missing-resources` prefix keeps revealLand's back-pay
+            // dedup working.
+            id: `missing-resources-ascension-${game.island.ascensionLevel}`,
+            createdAt,
+            coordinates: pickAscensionChestPosition(game, setup),
+            items: bundle,
+            wearables: {},
+            sfl: 0,
+            coins: 0,
+            message:
+              "Ascension rewards! Collect them and place them on your island.",
+          },
+        ];
+      }
+    } else {
+      // Basic-island upgrades (spring/desert/volcano) keep granting the upgrade
+      // crystal straight to inventory — cumulative A0 grants that keep the player
+      // in lockstep with getExpectedAscensionCrystals for the revealLand back-pay.
+      game.inventory["Ascension Crystal"] = (
+        game.inventory["Ascension Crystal"] ?? new Decimal(0)
+      ).add(1);
+    }
   }
 
   game = cloneDeep(game);

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -1088,12 +1088,14 @@ function buildAscensionRewardBundle(
 
   // Items already promised by an un-collected reward chest count as owned — the
   // player will receive them on claim. Ignoring them would re-issue the same
-  // crystals/nodes on the next ascension (both chests stay claimable).
+  // crystals/nodes on the next ascension (both chests stay claimable). Scoped to
+  // `missing-resources` chests (our ascension chests + revealLand's back-pay), so
+  // an unrelated promo/event airdrop can't shrink what this ascension owes —
+  // mirrors revealLand's pendingMissing filter.
   const pending = (item: InventoryItemName): number =>
-    (game.airdrops ?? []).reduce(
-      (total, airdrop) => total + (airdrop.items[item] ?? 0),
-      0,
-    );
+    (game.airdrops ?? [])
+      .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
+      .reduce((total, airdrop) => total + (airdrop.items[item] ?? 0), 0);
 
   // Node floor for the starting island (base row), excluding the sunstone bonus —
   // matching `ascensionUpgrade`'s minimum. After `applySetup` this is already met,

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -1116,17 +1116,16 @@ function buildAscensionRewardBundle(
   });
 
   // Ascension Crystals owed for this ascension: the expected cumulative count
-  // minus what the player already owns (inventory + placed), has mined
-  // (single-use), or has pending in an un-collected chest. This replaces the +1
-  // inventory grant on the ascension path.
+  // minus what the player already owns (inventory, which already includes any
+  // placed crystals — placing never decrements it), has mined (single-use), or
+  // has pending in an un-collected chest. Mirrors revealLand's back-pay formula.
+  // This replaces the +1 inventory grant on the ascension path.
   const expectedCrystals = getExpectedAscensionCrystals({
     islandType: target,
     ascensionLevel: game.island.ascensionLevel ?? 0,
     basicLand: game.inventory["Basic Land"]?.toNumber() ?? 0,
   });
-  const ownedCrystals =
-    (game.inventory["Ascension Crystal"]?.toNumber() ?? 0) +
-    Object.keys(game.ascensionCrystals ?? {}).length;
+  const ownedCrystals = game.inventory["Ascension Crystal"]?.toNumber() ?? 0;
   const minedCrystals = game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
   const crystalShortfall =
     expectedCrystals -

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -853,8 +853,10 @@ function desertUpgrade(state: GameState) {
   // Add new resources
   game.inventory.Manor = new Decimal(1);
 
-  // Ensure they have the minimum resources to start the island with
-  // Do not give bonus sunstones
+  // Ensure they have the minimum resources to place the starting island layout
+  // (excluding bonus sunstones). Any shortfall beyond this — sunstones, per-tier
+  // gaps, and the upgrade's Ascension Crystals — is reconciled after the layout
+  // by the shared missing-resources chest in transitionToIsland.
   const minimum = { ...TOTAL_EXPANSION_NODES.desert[4], "Sunstone Rock": 0 };
 
   Object.entries(minimum).forEach(([name, amount]) => {
@@ -908,14 +910,15 @@ function volcanoUpgrade(state: GameState) {
   // Add new resources
   game.inventory.Mansion = new Decimal(1);
 
-  // Ensure they have the minimum resources to start the island with
-  // Do not give bonus sunstones
-  // Account for upgraded resources when checking minimums
+  // Ensure they have the minimum resources to place the starting island layout
+  // (excluding bonus sunstones, accounting for upgraded resources). Any shortfall
+  // beyond this — sunstones, per-tier gaps, and the upgrade's Ascension Crystals —
+  // is reconciled after the layout by the shared missing-resources chest in
+  // transitionToIsland.
   const minimum = { ...TOTAL_EXPANSION_NODES.volcano[5], "Sunstone Rock": 0 };
 
   getObjectEntries(minimum).forEach(([resource, amount]) => {
     const totalEquivalents = getTotalBaseResourceEquivalents(game, resource);
-
     // Only set minimum if total equivalents are less than required
     if (totalEquivalents < amount) {
       topUpResourceToMinimum({
@@ -1265,47 +1268,40 @@ function transitionToIsland({
   }
 
   if (hasFeatureAccess(game, "SWAMP_ASCENSION")) {
-    if (isAscensionTarget) {
-      // Ascension rewards — the Ascension Crystals the player is owed (most
-      // players won't have any yet) plus any node shortfall — are delivered via
-      // a chest on the side island rather than straight to inventory. Reuses the
-      // shared `getMissingResources` reconciliation (same as revealLand's
-      // back-pay: per-tier/forging-safe, depletion-aware), keyed on the current
-      // Basic Land count. The `missing-resources` id prefix lets revealLand's
-      // dedup so the same items are never granted twice.
-      const bundle = getMissingResources({
-        game,
-        expansion: game.inventory["Basic Land"]?.toNumber() ?? 0,
-      });
-      if (getObjectEntries(bundle).length > 0) {
-        game.airdrops = [
-          ...(game.airdrops ?? []),
-          {
-            // Keyed on the (strictly increasing) ascension level so every
-            // ascension — including the infinite marble→marble loop — gets a
-            // unique id. `claimAirdrop` removes every airdrop matching the
-            // claimed id, so a reused id would drop an un-collected chest's
-            // rewards. The `missing-resources` prefix keeps revealLand's back-pay
-            // dedup working.
-            id: `missing-resources-ascension-${game.island.ascensionLevel}`,
-            createdAt,
-            coordinates: pickAscensionChestPosition(game, setup),
-            items: bundle,
-            wearables: {},
-            sfl: 0,
-            coins: 0,
-            message:
-              "Ascension rewards! Collect them and place them on your island.",
-          },
-        ];
-      }
-    } else {
-      // Basic-island upgrades (spring/desert/volcano) keep granting the upgrade
-      // crystal straight to inventory — cumulative A0 grants that keep the player
-      // in lockstep with getExpectedAscensionCrystals for the revealLand back-pay.
-      game.inventory["Ascension Crystal"] = (
-        game.inventory["Ascension Crystal"] ?? new Decimal(0)
-      ).add(1);
+    // Every island upgrade (basic + ascension) reconciles the player's resources
+    // against the new island's floor via the shared `getMissingResources`
+    // back-pay (same as revealLand's: per-tier/forging-safe, depletion-aware) and
+    // delivers any shortfall — nodes, sunstones, and the upgrade's Ascension
+    // Crystals — through a side-island reward chest rather than topping up
+    // inventory. The `missing-resources` id prefix lets revealLand's back-pay
+    // dedup so the same items are never granted twice.
+    const bundle = getMissingResources({
+      game,
+      expansion: game.inventory["Basic Land"]?.toNumber() ?? 0,
+    });
+    if (getObjectEntries(bundle).length > 0) {
+      game.airdrops = [
+        ...(game.airdrops ?? []),
+        {
+          // Unique per upgrade so `claimAirdrop` (which removes every airdrop
+          // matching the claimed id) never drops a pending chest: ascension
+          // islands key on the strictly-increasing ascension level (incl. the
+          // infinite marble→marble loop); basic islands key on the target island
+          // (each is reached once in the linear progression).
+          id: isAscensionTarget
+            ? `missing-resources-ascension-${game.island.ascensionLevel}`
+            : `missing-resources-upgrade-${target}`,
+          createdAt,
+          coordinates: pickAscensionChestPosition(game, setup),
+          items: bundle,
+          wearables: {},
+          sfl: 0,
+          coins: 0,
+          message: isAscensionTarget
+            ? "Ascension rewards! Collect them and place them on your island."
+            : "Upgrade rewards! Collect them and place them on your island.",
+        },
+      ];
     }
   }
 

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -141,6 +141,86 @@ export function getExpectedResources({
 }
 
 /**
+ * Mines a full sunstone rock holds before it depletes and is removed from the
+ * farm (see mineSunstone). Used when reconciling how many rocks a player has
+ * mined to depletion so they are not re-granted.
+ */
+export const SUNSTONE_MINES = 10;
+
+/**
+ * Resource/node counts the player is owed but does not yet have — the shared
+ * back-pay reconciliation used by BOTH `revealLand`'s missing-resources airdrop
+ * and the ascension reward chest. For each node type it is the expected amount
+ * (per-tier, from `getExpectedResources`, which subtracts forged/burned nodes)
+ * minus what the player owns in inventory, minus what an un-collected
+ * `missing-resources` airdrop already promises. Finite resources are credited
+ * for legitimate consumption so they are never resurrected: Sunstone Rocks for
+ * rocks mined to depletion, Ascension Crystals for crystals mined (single-use).
+ *
+ * Counting per-tier (not base-equivalents) is what makes this forging-safe: a
+ * player who forges 4 Trees → 1 Ancient Tree has `expected.Tree` reduced by the
+ * burn, so the base Trees are not re-granted.
+ *
+ * @returns Only positive shortfalls, keyed by resource name.
+ */
+export function getMissingResources({
+  game,
+  expansion,
+}: {
+  game: GameState;
+  expansion: number;
+}): Partial<Record<ResourceName, number>> {
+  const expected = getExpectedResources({ game, expansion });
+
+  // Items already promised by an un-collected missing-resources airdrop are not
+  // yet in inventory; counting them as still-missing would duplicate the grant
+  // if the player reveals/ascends again before collecting the previous airdrop.
+  const pendingMissing: Partial<Record<ResourceName, number>> = {};
+  (game.airdrops ?? [])
+    .filter((airdrop) => airdrop.id.startsWith("missing-resources"))
+    .forEach((airdrop) => {
+      getKeys(expected).forEach((key) => {
+        pendingMissing[key] =
+          (pendingMissing[key] ?? 0) + (airdrop.items[key] ?? 0);
+      });
+    });
+
+  const missing: Partial<Record<ResourceName, number>> = {};
+  getKeys(expected).forEach((key) => {
+    let shortfall =
+      (expected[key] ?? 0) -
+      (game.inventory[key]?.toNumber() ?? 0) -
+      (pendingMissing[key] ?? 0);
+
+    // Sunstone rocks are finite: once mined to depletion a rock is removed from
+    // inventory. Subtract the depletions so they are not re-granted. Each rock
+    // holds SUNSTONE_MINES mines; mines spent on rocks the player still owns are
+    // not depletions, so exclude them before dividing.
+    if (key === "Sunstone Rock") {
+      const lifetimeMines = game.farmActivity?.["Sunstone Mined"] ?? 0;
+      const minesOnLiveRocks = Object.values(game.sunstones ?? {}).reduce(
+        (total, rock) => total + (SUNSTONE_MINES - rock.minesLeft),
+        0,
+      );
+      const depleted = Math.floor(
+        Math.max(0, lifetimeMines - minesOnLiveRocks) / SUNSTONE_MINES,
+      );
+      shortfall -= depleted;
+    }
+
+    // Ascension Crystals are single-use: each mine destroys one crystal and
+    // decrements inventory. Subtract mined crystals so they are not resurrected.
+    if (key === "Ascension Crystal") {
+      shortfall -= game.farmActivity?.["Ascension Crystal Mined"] ?? 0;
+    }
+
+    if (shortfall > 0) missing[key] = shortfall;
+  });
+
+  return missing;
+}
+
+/**
  * Computes the layout for the player's next land expansion with resource availability constraints applied.
  *
  * @param game - The current game state

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1102,6 +1102,13 @@ export type SavedLayout = {
   name: string;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Marks the auto-managed "Ascension Layout" captured when the player first
+   * ascends (volcano→swamp) and re-applied on later ascensions. It is protected:
+   * the player cannot delete, rename, or overwrite it, and it does not count
+   * against the manual `MAX_SAVED_LAYOUTS` limit.
+   */
+  auto?: boolean;
   collectibles: Partial<Record<CollectibleName, LayoutPlacement[]>>;
   buildings: Partial<Record<BuildingName, LayoutPlacement[]>>;
   resources: {


### PR DESCRIPTION
## What

Reworks island **ascension** (behind `SWAMP_ASCENSION`) so it no longer wipes the farm.

- **Volcano → Swamp (first ascension):** keeps the player's arrangement exactly in place — skips `removeAll` + `placeInitialLand` — since the land is identical (both 30 expansions) and a maxed volcano already meets the swamp node floor. The arrangement is saved as a **protected "Ascension Layout"** (`SavedLayout.auto`): it can't be deleted, renamed or overwritten, and doesn't count against the manual `MAX_SAVED_LAYOUTS` cap.
- **Swamp → future ascensions:** re-applies that saved Ascension Layout via `applyFarmLayout` (reset to the canonical arrangement). Legacy farms with no saved layout fall back to the old `placeInitialLand` behaviour.
- **Ascension rewards → side-island chest:** the Ascension Crystals a player is owed (most players won't have any yet) plus any node shortfall are delivered via a reward chest (airdrop) on the side island instead of straight to inventory. The chest reuses `revealLand`'s `missing-resources` back-pay accounting + dedup (so crystals are never double-granted), is keyed on `ascensionLevel` for a unique id (incl. the infinite `marble→marble` loop), and picks a free side-island tile so un-collected chests don't stack.

## Why

Players lost their carefully-built farm arrangement on every ascension. Now the arrangement is preserved and the ascension rewards are surfaced as a collectable chest.

## Notes

- Gated behind `SWAMP_ASCENSION` (testnet + team usernames); the saved-layout UI is behind `SAVED_LAYOUTS`.
- `ascensionUpgrade` no longer tops resource inventory up to the floor — any shortfall flows to the reward chest instead.
- Mirrors the backend change 1:1: sunflower-land/sunflower-land-api#3486.

## Test plan

- `yarn jest src/features/game/events/landExpansion/upgradeFarm.test.ts src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts src/features/game/events/landExpansion/saveLayout.test.ts src/features/game/events/landExpansion/renameLayout.test.ts src/features/game/events/landExpansion/deleteLayout.test.ts src/features/game/events/landExpansion/applyLayout.test.ts` — all green.
- New coverage: arrangement preserved across ascension, growth timers untouched (no instant growth), reward chest holds owed crystals + node shortfall (not inventory), Ascension Layout saved once and protected (cap-exempt / un-deletable), future-ascension layout reuse, unique chest ids + no stacking.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserved island farm arrangements across ascensions using an auto-managed “Ascension Layout.”
  - Ascension rewards now deliver via side-island reward chests, including missing-resources handling.
- **Bug Fixes**
  - Protected “Ascension Layout” can’t be deleted, renamed, or overwritten; auto layouts don’t count toward the saved-layout limit.
  - Improved layout restoration by unplacing conflicting instances and restoring intended placements precisely.
  - Updated reward/back-pay reconciliation to use shared missing-resource calculations and place safe, non-colliding chests.
- **Tests**
  - Expanded unit coverage for protected layouts, ascension transitions, reward chest delivery, and restoration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->