### PR TITLE
[BALANCE] Ascension Crystal yields 3 shards instead of 10

### DIFF
--- a/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
+++ b/src/features/game/events/landExpansion/ascensionCrystalGrants.test.ts
@@ -137,11 +137,11 @@ describe("Ascension Crystal upgrade-node grant (upgradeFarm)", () => {
     ],
   ];
 
-  // Each transition grants exactly 1 Ascension Crystal. Basic-island upgrades add
-  // it straight to inventory; ascension upgrades (swamp onward) deliver it via the
-  // side-island reward chest (a `missing-resources` airdrop) instead. Seeding the
-  // player with the crystals they should already own means the net grant is 1
-  // wherever it lands.
+  // Each transition grants exactly 1 Ascension Crystal. Every upgrade — basic and
+  // ascension alike — delivers it via the side-island reward chest (a
+  // `missing-resources` airdrop); nothing tops crystals up into inventory
+  // directly. Seeding the player with the crystals they should already own means
+  // the chest's net grant is exactly 1.
   it.each(cases)(
     "grants exactly 1 crystal on %s",
     (_label, { from, ascensionLevel, basicLand, experience }) => {

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.test.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js-light";
 import { TEST_FARM, INITIAL_BUMPKIN } from "../../lib/constants";
 import type { GameState } from "../../types/game";
 import {
-  ASCENSION_SHARDS_PER_MINE,
   EVENT_ERRORS,
   type MineAscensionCrystalAction,
   mineAscensionCrystal,
@@ -141,10 +140,9 @@ describe("mineAscensionCrystal", () => {
 
     const game = mineAscensionCrystal(payload);
 
+    // Burns 1 Gold Pickaxe and yields the agreed 3 shards.
     expect(game.inventory["Gold Pickaxe"]).toEqual(new Decimal(0));
-    expect(game.inventory["Ascension Shard"]).toEqual(
-      new Decimal(ASCENSION_SHARDS_PER_MINE),
-    );
+    expect(game.inventory["Ascension Shard"]).toEqual(new Decimal(3));
     // Single-use: the node is removed and the rock count decremented.
     expect(game.ascensionCrystals["0"]).toBeUndefined();
     expect(game.inventory["Ascension Crystal"]).toEqual(new Decimal(1));
@@ -170,9 +168,37 @@ describe("mineAscensionCrystal", () => {
 
     const game = mineAscensionCrystal(payload);
 
-    expect(game.inventory["Ascension Shard"]).toEqual(
-      new Decimal(5 + ASCENSION_SHARDS_PER_MINE),
-    );
+    expect(game.inventory["Ascension Shard"]).toEqual(new Decimal(8));
+  });
+
+  it("yields 3 shards per crystal across repeated mines", () => {
+    const mine = (state: GameState, index: string) =>
+      mineAscensionCrystal({
+        state,
+        createdAt: Date.now(),
+        action: {
+          type: "ascensionCrystal.mined",
+          index,
+        } as MineAscensionCrystalAction,
+      });
+
+    const start: GameState = {
+      ...GAME_STATE,
+      bumpkin: INITIAL_BUMPKIN,
+      inventory: {
+        "Gold Pickaxe": new Decimal(2),
+        "Ascension Crystal": new Decimal(2),
+      },
+    };
+
+    const game = mine(mine(start, "0"), "1");
+
+    // Two crystals mined at 3 shards each, both nodes consumed.
+    expect(game.inventory["Ascension Shard"]).toEqual(new Decimal(6));
+    expect(game.inventory["Ascension Crystal"]).toEqual(new Decimal(0));
+    expect(game.inventory["Gold Pickaxe"]).toEqual(new Decimal(0));
+    expect(game.ascensionCrystals["0"]).toBeUndefined();
+    expect(game.ascensionCrystals["1"]).toBeUndefined();
   });
 
   describe("BumpkinActivity", () => {

--- a/src/features/game/events/landExpansion/mineAscensionCrystal.ts
+++ b/src/features/game/events/landExpansion/mineAscensionCrystal.ts
@@ -4,7 +4,7 @@ import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 
 /** Shards yielded by mining a single-use Ascension Crystal. */
-export const ASCENSION_SHARDS_PER_MINE = 10;
+export const ASCENSION_SHARDS_PER_MINE = 3;
 
 export type MineAscensionCrystalAction = {
   type: "ascensionCrystal.mined";

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -959,8 +959,9 @@ const isTargetAscension = (
 
 /**
  * Prepares the game state for an ascension island (swamp onward) by clearing
- * previous home structures, adding a mansion, and ensuring minimum starting
- * resources.
+ * previous home structures and adding a mansion. Unlike the basic-island
+ * upgrades, this does NOT top the starting-node floor up into inventory — see
+ * the note in the body.
  *
  * @returns The updated game state for the ascension island.
  */
@@ -982,8 +983,9 @@ function ascensionUpgrade(state: GameState, target: UpgradeTarget) {
 
   // The starting-node floor is NOT topped up into inventory here — any shortfall
   // vs the swamp floor is delivered to the player through the ascension reward
-  // chest instead (see `buildAscensionRewardBundle`). A maxed volcano already
-  // exceeds the floor, so this only matters for under-provisioned/legacy farms.
+  // chest instead (the shared `getMissingResources` back-pay in
+  // `transitionToIsland`). A maxed volcano already exceeds the floor, so this
+  // only matters for under-provisioned/legacy farms.
 
   return game;
 }


### PR DESCRIPTION
## What

Mining a single-use Ascension Crystal paid out **10** Ascension Shards. The agreed value is **3**. Drops `ASCENSION_SHARDS_PER_MINE` to 3.

Paired with sunflower-land-api (BE), which holds the same constant plus a clawback report for players who already mined at 10.

## Why the tests changed

The existing mine tests asserted against the constant itself:

```ts
expect(game.inventory["Ascension Shard"]).toEqual(
  new Decimal(ASCENSION_SHARDS_PER_MINE),
);
```

That passes at 10, at 3, or at any other value — it never pinned the balance number, which is likely how the code drifted from the balance decision in the first place. The assertions are now literals (`new Decimal(3)`, `new Decimal(8)`), plus a repeated-mine test that runs two crystals through the real event and checks shard accrual, node consumption, crystal decrement and pickaxe burn.

Verified by mutation: reverting the constant to 10 fails **3** of these tests (the old suite failed none on value alone).

## Also included

Two stale comments found while tracing the crystal grant paths — no behaviour change:

- `ascensionCrystalGrants.test.ts` claimed basic-island upgrades add crystals *straight to inventory*. They don't — every upgrade, basic and ascension alike, delivers via the `missing-resources` reward chest.
- `upgradeFarm.ts` `ascensionUpgrade` referenced `buildAscensionRewardBundle`, which no longer exists (it's now the inline `getMissingResources` back-pay in `transitionToIsland`). Its docblock also claimed it ensures "minimum starting resources" — the body comment directly below says it deliberately does *not*.

## Note for reviewers

This is a ~70% cut to shard supply per crystal, but it does not disturb skill costs: `ASCENSION_SKILLS` is `testnetFeatureFlag` (amoy only), so buying ranks — the only shard sink — is closed on mainnet. No live rank-up curve to rebalance.

## Testing

- `mineAscensionCrystal.test.ts` + `ascensionCrystalGrants.test.ts`: 23 passing
- Related suites (`upgradeFarm`, `resetSkills`, `placeAscensionCrystal`): 82 passing
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Mining an Ascension Crystal now awards 3 Ascension Shards instead of 10.
  * Updated reward handling documentation to clarify how Ascension Crystal grants are delivered through reward chests during land upgrades.
* **Tests**
  * Updated coverage to verify the revised shard rewards for single and repeated mining actions.
  * Added clearer validation of Ascension Crystal grants during upgrade transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
