### PR TITLE
[FEAT] Separate tab for temporary boosts in chests

### DIFF
--- a/src/features/island/hud/components/inventory/utils/chestCategories.test.ts
+++ b/src/features/island/hud/components/inventory/utils/chestCategories.test.ts
@@ -1,0 +1,47 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import type { GameState } from "features/game/types/game";
+import { getChestCategories } from "./chestCategories";
+
+describe("getChestCategories", () => {
+  const state: GameState = { ...TEST_FARM };
+
+  it("splits temporary boosts (totems, hourglasses, shrines) from permanent boosts", () => {
+    const categories = getChestCategories(state, [
+      "Basic Scarecrow",
+      "Time Warp Totem",
+      "Gourmet Hourglass",
+      "Fox Shrine",
+    ]);
+
+    const boosts = categories.find((c) => c.id === "boosts");
+    const temporaryBoosts = categories.find((c) => c.id === "temporaryBoosts");
+
+    expect(boosts?.items).toEqual(["Basic Scarecrow"]);
+    expect(temporaryBoosts?.items).toEqual(
+      expect.arrayContaining([
+        "Time Warp Totem",
+        "Gourmet Hourglass",
+        "Fox Shrine",
+      ]),
+    );
+    expect(temporaryBoosts?.items).toHaveLength(3);
+  });
+
+  it("does not double-count temporary boosts under decorations or permanent boosts", () => {
+    const categories = getChestCategories(state, ["Time Warp Totem"]);
+
+    const boosts = categories.find((c) => c.id === "boosts");
+    const decorations = categories.find((c) => c.id === "decorations");
+
+    expect(boosts?.items).not.toContain("Time Warp Totem");
+    expect(decorations?.items).not.toContain("Time Warp Totem");
+  });
+
+  it("returns an empty temporaryBoosts category when there are none", () => {
+    const categories = getChestCategories(state, ["Basic Scarecrow"]);
+
+    const temporaryBoosts = categories.find((c) => c.id === "temporaryBoosts");
+
+    expect(temporaryBoosts?.items).toEqual([]);
+  });
+});

--- a/src/features/island/hud/components/inventory/utils/chestCategories.ts
+++ b/src/features/island/hud/components/inventory/utils/chestCategories.ts
@@ -14,6 +14,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import lightning from "assets/icons/lightning.png";
 import { getChestFlowers } from "./inventory";
 import { hasBoost } from "./boosts";
+import { EXPIRY_COOLDOWNS } from "features/game/lib/collectibleBuilt";
 
 /**
  * The collectible chest categories (id + icon) in display order.
@@ -27,6 +28,7 @@ const CHEST_CATEGORIES_META = [
   { id: "resource.nodes", icon: SUNNYSIDE.resource.tree },
   { id: "buildings", icon: SUNNYSIDE.icons.hammer },
   { id: "boosts", icon: lightning },
+  { id: "temporaryBoosts", icon: SUNNYSIDE.icons.stopwatch },
   { id: "banners", icon: ITEM_DETAILS["Lifetime Farmer Banner"].image },
   { id: "beds", icon: ITEM_DETAILS["Basic Bed"].image },
   { id: "weatherItems", icon: ITEM_DETAILS["Tornado Pinwheel"].image },
@@ -102,8 +104,11 @@ export const getChestCategories = (
   const dollsSet = new Set(dolls);
   const petsSet = new Set(pets);
 
-  const boosts = collectibleNames
-    .filter((name) => hasBoost(name, state))
+  // Totems, hourglasses and shrines expire and need re-triggering - split
+  // them out from the "always on" boosts (EXPIRY_COOLDOWNS is the ground
+  // truth for what's temporary, shared with the renewal/expiry logic).
+  const temporaryBoosts = collectibleNames
+    .filter((name) => name in EXPIRY_COOLDOWNS)
     .filter(
       (name) =>
         !resourcesSet.has(name) &&
@@ -114,6 +119,21 @@ export const getChestCategories = (
         !flowersSet.has(name),
     );
 
+  const temporaryBoostsSet = new Set(temporaryBoosts);
+
+  const boosts = collectibleNames
+    .filter((name) => hasBoost(name, state))
+    .filter(
+      (name) =>
+        !resourcesSet.has(name) &&
+        !buildingsSet.has(name) &&
+        !monumentsSet.has(name) &&
+        !villageProjectsSet.has(name) &&
+        !bedsSet.has(name) &&
+        !flowersSet.has(name) &&
+        !temporaryBoostsSet.has(name),
+    );
+
   const boostsSet = new Set(boosts);
 
   const decorations = collectibleNames.filter(
@@ -121,6 +141,7 @@ export const getChestCategories = (
       !resourcesSet.has(name) &&
       !buildingsSet.has(name) &&
       !boostsSet.has(name) &&
+      !temporaryBoostsSet.has(name) &&
       !bannersSet.has(name) &&
       !bedsSet.has(name) &&
       !weatherItemsSet.has(name) &&
@@ -136,6 +157,7 @@ export const getChestCategories = (
     "resource.nodes": resources,
     buildings,
     boosts,
+    temporaryBoosts,
     banners,
     beds,
     weatherItems,

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2574,6 +2574,7 @@
   "new.species": "New Species",
   "buildings": "Buildings",
   "boosts": "Boosts",
+  "temporaryBoosts": "Temporary Boosts",
   "decorations": "Decorations",
   "decoration": "Decoration",
   "sfl/coins": "FLOWER/Coins",


### PR DESCRIPTION
Closes #7389

## Summary
- Splits the Chest/Basket "Boosts" category into two: **Boosts** (always-on collectibles) and **Temporary Boosts** (totems, hourglasses, shrines that expire and need re-triggering).
- Classification uses `EXPIRY_COOLDOWNS` from `src/features/game/lib/collectibleBuilt.ts` — the existing ground truth for what counts as a temporary collectible (already used by the renewal/expiry logic), so no new concept was invented.
- Both the Chest modal and the landscaping quick panel consume the shared `getChestCategories` helper (`chestCategories.ts`), so the new category shows up on both surfaces automatically with zero changes to either component.

<img width="929" height="533" alt="image" src="https://github.com/user-attachments/assets/632d003e-1e1d-4a28-b2c8-fba3dfe151e4" />

## Test plan
- [x] New `chestCategories.test.ts`: permanent vs temporary split, no double-counting under decorations/boosts, empty category when none owned
- [x] Full suite: 305/305 test suites, 4467 tests passing
- [x] `tsc --noEmit` and `eslint` clean
- [x] Manually verified in art/offline mode: Chest now shows separate "Boosts" (Basic Scarecrow) and "Temporary Boosts" (Time Warp Totem, Super Totem, Gourmet/Harvest Hourglass, Fox Shrine, Obsidian Shrine) sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Temporary Boosts** category in chest inventories.
  * Temporary boosts are separated from permanent boosts and decorations.
  * Added localized labeling and category ordering for the new section.

* **Tests**
  * Added coverage verifying categorization, duplicate prevention, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->