### PR TITLE
[FIX] Pet House quick-placement panel offers items it can't place there

### DIFF
--- a/src/features/island/hud/components/LandscapingQuickPanel.tsx
+++ b/src/features/island/hud/components/LandscapingQuickPanel.tsx
@@ -35,7 +35,7 @@ import {
   BUILDINGS_DIMENSIONS,
   type BuildingName,
 } from "features/game/types/buildings";
-import { isPetNFTRevealed } from "features/game/types/pets";
+import { isPetNFTRevealed, PET_TYPES } from "features/game/types/pets";
 import { Box, type BoxProps } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -337,16 +337,23 @@ export const LandscapingQuickPanel: React.FC<Props> = ({
   );
 
   // ── Chest inventory ────────────────────────────────────────────────────
-  const buds = getChestBuds(state);
+  // The Pet House only accepts pets - mirror Chest.tsx's petHouse gating so
+  // this panel doesn't offer decorations/boosts/buildings/etc that can't
+  // actually be placed there.
+  const buds = location === "petHouse" ? {} : getChestBuds(state);
   const petsNFTs = getChestPets(state.pets?.nfts ?? {});
-  const farmHands = getChestFarmHands(state.farmHands);
+  const farmHands =
+    location === "petHouse" ? {} : getChestFarmHands(state.farmHands);
   const chestMap = getChestItems(state);
   const biome = useMemo(() => getCurrentBiome(state.island), [state.island]);
 
   const collectibleNames = useMemo(
-    () => getKeys(chestMap).filter((item) => chestMap[item]?.gt(0)),
+    () =>
+      getKeys(chestMap)
+        .filter((item) => chestMap[item]?.gt(0))
+        .filter((item) => (location === "petHouse" ? item in PET_TYPES : true)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [chestMap],
+    [chestMap, location],
   );
 
   // ── Group items (shared with the chest) ────────────────────────────────


### PR DESCRIPTION
## Summary
- Bug: opening the landscaping quick-drag panel while inside the Pet House showed every collectible category (decorations, boosts, buildings, banners, etc.), but the Pet House only accepts pets - attempting to place anything else there doesn't work.
- Root cause: `Chest.tsx` already restricts its item list to pet collectibles (and hides buds/farm hands) when `location === "petHouse"`, but that same gating was never ported to `LandscapingQuickPanel.tsx` when it was added - the two components independently build their item lists from the same `getChestCategories` helper, and only one of them filtered its input.
- Fix: `LandscapingQuickPanel.tsx` now applies the identical `location === "petHouse"` gating as `Chest.tsx` before computing categories, so only the "Pets" tab (plus Pet NFTs) shows up, and empty tabs are hidden automatically by the panel's existing `hasItems` filter - no new UI/tab logic needed.

<img width="1900" height="936" alt="image" src="https://github.com/user-attachments/assets/1fccc5f3-37ac-4577-95c9-9a78463a1e95" />


## Test plan
- [x] Full suite: 304/304 test suites, 4464 tests passing
- [x] `tsc --noEmit` and `eslint` clean (only pre-existing, unrelated `any` warnings)
- [x] Verified with a targeted data-level check against the real `getChestCategories` categorizer: on the farm, a mixed inventory (a pet, a boost, a building, a decoration) produces 6 non-empty tabs; applying the same `petHouse` filter this PR adds narrows it to exactly `["pets"]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pet house panel to display only relevant pet items.
  * Prevented non-pet collectibles from appearing when viewing the pet house.
  * Updated item filtering when switching between panel locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->