### PR TITLE
[FEAT] Prioritise common pets over NFT pets for Acorn + release bulk fetch

### DIFF
--- a/src/features/island/buildings/components/building/petHouse/ManagePets.tsx
+++ b/src/features/island/buildings/components/building/petHouse/ManagePets.tsx
@@ -29,7 +29,6 @@ import { useNow } from "lib/utils/hooks/useNow";
 import { PetInfo } from "./PetInfo";
 import { BulkFetchInputs } from "./BulkFetchInputs";
 import { planBulkFetch, type BulkFetchPlan } from "./planBulkFetch";
-import { hasFeatureAccess } from "lib/flags";
 import { isWearableActive } from "features/game/lib/wearables";
 import * as Auth from "features/auth/lib/Provider";
 import type { AuthMachineState } from "features/auth/lib/authMachine";
@@ -81,7 +80,6 @@ export const ManagePets: React.FC<Props> = ({ activePets }) => {
     (state) => state.context.state.inventory,
   );
   const state = useSelector(gameService, (state) => state.context.state);
-  const hasBulkFetch = hasFeatureAccess(state, "BULK_PET_FETCH");
 
   // The planner turns the typed quantities into concrete per-pet fetches; the
   // pet cards then show those pre-selected, minus anything deselected. Only
@@ -446,7 +444,7 @@ export const ManagePets: React.FC<Props> = ({ activePets }) => {
               {t("cancel")}
             </Button>
           )}
-          {display === "fetching" && hasBulkFetch && !isBulkFetch && (
+          {display === "fetching" && !isBulkFetch && (
             <Button
               className="flex-1 min-w-0"
               disabled={activePets.length === 0}

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.test.ts
@@ -1,6 +1,11 @@
 import { INITIAL_FARM } from "features/game/lib/constants";
 import type { GameState } from "features/game/types/game";
-import type { Pet, PetName, PetNFT } from "features/game/types/pets";
+import type {
+  Pet,
+  PetName,
+  PetNFT,
+  PetNFTType,
+} from "features/game/types/pets";
 import { planBulkFetch } from "./planBulkFetch";
 
 const now = Date.now();
@@ -17,6 +22,30 @@ const makePet = (name: PetName, overrides: Partial<Pet> = {}): Pet => ({
   energy: 500,
   experience: 0,
   pettedAt: now,
+  ...overrides,
+});
+
+// An NFT pet needs `traits.type` — getPetType reads it for NFTs, and a pet with
+// no type is dropped from the plan entirely. Traits other than `type` do not
+// affect fetch yields.
+const makePetNFT = (
+  id: number,
+  type: PetNFTType,
+  overrides: Partial<Omit<PetNFT, "id" | "name" | "traits">> = {},
+): PetNFT => ({
+  id,
+  name: `Pet #${id}`,
+  requests: { food: [], fedAt: now },
+  energy: 500,
+  experience: 0,
+  pettedAt: now,
+  traits: {
+    type,
+    fur: "Green",
+    accessory: "Crown",
+    bib: "Gold Necklace",
+    aura: "No Aura",
+  },
   ...overrides,
 });
 
@@ -167,6 +196,8 @@ describe("planBulkFetch", () => {
     // handed heart leaf to Twizzle. Ranking yield first uses the efficient pet.
     // (Barkley is only here so ribbon has two sources and stays pending while
     // heart leaf is allocated.)
+    // Acorn is the one exception to yield-first — see the common-vs-NFT tests
+    // below — but these are all common pets and no Acorn is requested.
     const activePets: ActivePets = [
       [
         "Meowchi",
@@ -205,6 +236,102 @@ describe("planBulkFetch", () => {
     expect(
       plan.fetches.find((f) => f.petId === "Barkley" && f.fetch === "Ribbon"),
     ).toBeUndefined();
+    expect(plan.shortfall).toEqual({});
+  });
+
+  it("prefers a common pet over an NFT pet for Acorn, even at a lower yield", () => {
+    // The NFT (lvl 100) yields 2.25 Acorn to Meowchi's (lvl 1) 1.0, so ranking
+    // by yield alone would hand Acorn to the NFT. NFT pets gain nothing from
+    // Acorn (excluded from the level-60 NFT bonus) but +1 on every other
+    // resource, so their energy is saved and the common pet does the fetching.
+    const activePets: ActivePets = [
+      ["Meowchi", makePet("Meowchi", { energy: 200 })],
+      [1, makePetNFT(1, "Phoenix", { experience: LEVEL_100_XP, energy: 500 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { Acorn: 2 },
+      now,
+    });
+
+    expect(plan.fetches).toContainEqual({
+      petId: "Meowchi",
+      fetch: "Acorn",
+      amount: 2,
+    });
+    expect(plan.fetches.find((f) => f.petId === 1)).toBeUndefined();
+    expect(plan.shortfall).toEqual({});
+    // The NFT's energy is left untouched for fetches only it does well.
+    expect(plan.energyAfter["1"]).toEqual(500);
+  });
+
+  it("falls back to an NFT pet once common pets run out of energy", () => {
+    // Meowchi can only afford a single Acorn fetch (100 energy each). Commons
+    // that cannot afford a fetch drop out of the candidates, so the NFT covers
+    // the remainder rather than the request coming up short.
+    const activePets: ActivePets = [
+      ["Meowchi", makePet("Meowchi", { energy: 100 })],
+      [1, makePetNFT(1, "Phoenix", { energy: 500 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { Acorn: 3 },
+      now,
+    });
+
+    // The common pet is spent first...
+    expect(plan.fetches).toContainEqual({
+      petId: "Meowchi",
+      fetch: "Acorn",
+      amount: 1,
+    });
+    // ...and only the shortfall spills onto the NFT.
+    expect(plan.fetches).toContainEqual({
+      petId: 1,
+      fetch: "Acorn",
+      amount: 2,
+    });
+    expect(plan.shortfall).toEqual({});
+  });
+
+  it("uses NFT pets for Acorn when there are no common pets", () => {
+    const activePets: ActivePets = [
+      [1, makePetNFT(1, "Phoenix", { energy: 200 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { Acorn: 2 },
+      now,
+    });
+
+    expect(plan.fetches).toEqual([{ petId: 1, fetch: "Acorn", amount: 2 }]);
+    expect(plan.shortfall).toEqual({});
+  });
+
+  it("still prefers the higher-yield NFT pet for non-Acorn resources", () => {
+    // The common-first rule is scoped to Acorn. Both pets are Moonkin, so both
+    // fetch Heart leaf, but the NFT (lvl 100) yields 2.25 to Twizzle's 1.0 —
+    // including the level-60 NFT bonus that Acorn is excluded from.
+    const activePets: ActivePets = [
+      ["Twizzle", makePet("Twizzle", { experience: LEVEL_3_XP, energy: 200 })],
+      [1, makePetNFT(1, "Phoenix", { experience: LEVEL_100_XP, energy: 200 })],
+    ];
+    const plan = planBulkFetch({
+      activePets,
+      state,
+      desired: { "Heart leaf": 2 },
+      now,
+    });
+
+    expect(plan.fetches).toContainEqual({
+      petId: 1,
+      fetch: "Heart leaf",
+      amount: 1,
+    });
+    expect(plan.fetches.find((f) => f.petId === "Twizzle")).toBeUndefined();
     expect(plan.shortfall).toEqual({});
   });
 });

--- a/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
+++ b/src/features/island/buildings/components/building/petHouse/planBulkFetch.ts
@@ -47,6 +47,7 @@ type PetWork = {
   petId: PetName | number;
   key: string;
   energy: number;
+  isNFT: boolean;
   yields: Partial<Record<PetResourceName, Decimal>>;
 };
 
@@ -64,6 +65,10 @@ type PetWork = {
  *     depend on are already reserved, so favouring yield here does not starve
  *     them. Ties break toward the pet least useful elsewhere (fewest OTHER
  *     still-needed resources), then more remaining energy, then a stable id.
+ *  4. Acorn is the exception to (3): common pets are preferred over NFT pets
+ *     regardless of yield, falling back to NFT pets only once no common pet can
+ *     afford a fetch. NFT pets gain nothing from Acorn but +1 on every other
+ *     resource, so their energy is saved for fetches only they do well.
  *
  * Yields are deterministic (`getFetchYield`) and energy is the only limiter, so
  * the projection is exact. Anything that cannot be met is reported as
@@ -105,7 +110,7 @@ export function planBulkFetch({
       }).yieldAmount;
     });
 
-    pets.push({ petId, key: String(petId), energy: pet.energy, yields });
+    pets.push({ petId, key: String(petId), energy: pet.energy, isNFT, yields });
   });
 
   // 2. Outstanding demand (every positive request; unmet ones surface as shortfall).
@@ -158,6 +163,18 @@ export function planBulkFetch({
       if (candidates.length === 0) break;
 
       candidates.sort((a, b) => {
+        // Acorn is the exception to the yield-first rule below: an NFT pet gains
+        // nothing from it (getFetchYield excludes Acorn from the level-60 NFT
+        // bonus) while gaining +1 on every other resource, so NFT energy is
+        // worth more elsewhere. Prefer common pets even when an NFT out-yields
+        // them — Acorn yield only tracks level, so a high-level NFT would
+        // otherwise always win. Commons that run out of energy fail `canFetch`
+        // and leave `candidates`, so this falls back to NFT pets on its own, one
+        // fetch at a time.
+        if (resource === "Acorn" && a.isNFT !== b.isNFT) {
+          return a.isNFT ? 1 : -1;
+        }
+
         // Energy-efficient: the highest-yield pet needs the fewest fetches, so
         // the least energy, for this resource. Scarcest-first ordering has
         // already reserved the pets that rarer resources depend on, so a

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -178,11 +178,6 @@ const FEATURE_FLAGS = {
   // Saving & re-applying named farm layouts in landscaping mode.
   SAVED_LAYOUTS: betaFeatureFlag,
 
-  // Bulk-fetch resources from all pets at once: the player types how many of
-  // each resource they need, the FE plans the best allocation across all pets,
-  // and one `pets.bulkFetch` event executes it.
-  BULK_PET_FETCH: betaFeatureFlag,
-
   // Speed-rate (Clash-of-Clans potion) model for time-based boosts — starting
   // with the Sparrow Shrine on crops. When on, planting stores the new
   // baseDurationMs + true plantedAt model; when off, boosts stay discount-at-start.


### PR DESCRIPTION
## What

Two changes to bulk pet fetch, one commit each so either can be reverted alone:

1. **Acorn now prefers common pets over NFT pets**, falling back to NFT pets only when no common pet can afford a fetch.
2. **Removes the `BULK_PET_FETCH` beta gate**, releasing bulk fetch to all players.

## Why — Acorn priority

The planner picks pets by highest yield first, so Acorn goes to NFT pets whenever they out-level the commons. That's backwards: `getFetchYield` **excludes Acorn (and Moonfur) from the level-60 NFT bonus**, so NFT-ness adds *nothing* to Acorn yield while adding +1 to every other resource. NFT energy is strictly worth more elsewhere, and most players already avoid fetching Acorn with NFT pets by hand — this just codifies that.

### Implementation notes

- `PetWork` gained `isNFT` — already computed for the `getFetchYield` call, just not retained.
- The new tier sits **above the yield check** by necessity, not style: Acorn yield tracks *level* only, so a high-level NFT beats a low-level common on yield and the rule would never fire below it. This does mean a low-yield common can now beat a high-yield NFT on Acorn — that is the intent.
- **Fallback needed no extra code.** Energy-drained commons already fail the existing `canFetch` check and drop out of `candidates`, so NFT pets take over mid-loop, one fetch at a time.
- **Cannot starve other resources.** Acorn has the highest `capableCount` (level 1, every pet type) and the lowest energy cost (100 vs 200), so scarcest-first ordering allocates it **last**, after specialists are reserved.
- Scoped to Acorn only — every other resource still ranks yield first.

New sort: **Acorn:common-first → yield → specialist → energy → id**

## Why — flag removal

FE-only gate; `pets.bulkFetch` was never gated server-side (matching `pets.bulkFeed`), so **no BE change is needed**. `hasFeatureAccess` became a dead import and was dropped.

## Tests

Four new cases in `planBulkFetch.test.ts`. Two were **red before the fix** (the NFT took all the Acorn while the common pet sat idle); two are guardrails pinning the exception to Acorn:

- Common wins over a higher-yield NFT for Acorn *(was red)*
- Falls back to the NFT once commons run out of energy *(was red)*
- NFT-only pet house still fetches Acorn
- Non-Acorn resources still prefer the higher-yield NFT

Needed a new `makePetNFT` helper — the suite had no NFT fixtures at all before.

## Verification

- 94 tests pass across all 8 pet suites
- `tsc` clean (only the 3 pre-existing `virtual:pwa-register` errors, present on `main`)
- Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk pet-fetch controls are now available without feature-flag restrictions.
  * Added support for saved farm layouts in landscaping mode.

* **Improvements**
  * Bulk fetching now prioritizes common pets for Acorn resources, using NFT pets when needed.
  * For other resources, higher-yield NFT pets are selected more effectively.

* **Tests**
  * Expanded coverage for bulk-fetch behavior across common and NFT pets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->