### PR TITLE
[FIX] Kitchen recipe panel height mismatch

### DIFF
--- a/src/components/ui/SplitScreenView.tsx
+++ b/src/components/ui/SplitScreenView.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX } from "react";
+import React, { type JSX, useEffect, useRef, useState } from "react";
 import { InnerPanel } from "components/ui/Panel";
 import classNames from "classnames";
 
@@ -12,6 +12,7 @@ import classNames from "classnames";
  * @param panel The top or right panel view.
  * @param content The bottom or left content view.
  * @param mobileReversePanelOrder Whether to show the panel below the content on mobile.
+ * @param matchPanelHeight On desktop, caps the content column's height to the panel column's actual rendered height (measured live), instead of a fixed max-height, so the two columns' borders line up regardless of how much either side renders.
  */
 interface Props {
   divRef?: React.RefObject<HTMLDivElement | null>;
@@ -23,6 +24,7 @@ interface Props {
   panel: JSX.Element;
   content: JSX.Element;
   mobileReversePanelOrder?: boolean;
+  matchPanelHeight?: boolean;
 }
 
 /**
@@ -39,7 +41,38 @@ export const SplitScreenView: React.FC<Props> = ({
   panel: header,
   content,
   tallDesktopContent = false,
+  matchPanelHeight = false,
 }) => {
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const [panelHeight, setPanelHeight] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!matchPanelHeight || !headerRef.current) return;
+
+    const node = headerRef.current;
+
+    const measure = () => {
+      // Only constrain on desktop (sm+); mobile stacks the panels, where the
+      // fixed tallMobileContent/max-h caps below already apply.
+      if (window.innerWidth >= 640) {
+        setPanelHeight(node.offsetHeight);
+      } else {
+        setPanelHeight(undefined);
+      }
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    window.addEventListener("resize", measure);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [matchPanelHeight]);
+
   return (
     <div
       className={classNames("flex sm:flex-row", {
@@ -49,8 +82,8 @@ export const SplitScreenView: React.FC<Props> = ({
     >
       <InnerPanel
         className={classNames("w-full sm:w-3/5 h-fit p-1 flex", {
-          "sm:max-h-96": !tallDesktopContent,
-          "sm:max-h-[30rem]": tallDesktopContent,
+          "sm:max-h-96": !tallDesktopContent && !matchPanelHeight,
+          "sm:max-h-[30rem]": tallDesktopContent && !matchPanelHeight,
           "max-h-80": tallMobileContent,
           "max-h-56": !tallMobileContent,
           "lg:w-3/4": wideModal,
@@ -59,6 +92,11 @@ export const SplitScreenView: React.FC<Props> = ({
           "flex-col": !contentScrollable,
           "mt-1 sm:mt-0": !mobileReversePanelOrder,
         })}
+        style={
+          matchPanelHeight && panelHeight
+            ? { maxHeight: `${panelHeight}px` }
+            : undefined
+        }
         divRef={divRef}
       >
         {content}
@@ -69,6 +107,7 @@ export const SplitScreenView: React.FC<Props> = ({
             "lg:w-1/4": wideModal,
             "mt-1 sm:mt-0": mobileReversePanelOrder,
           })}
+          divRef={headerRef}
         >
           {header}
         </InnerPanel>

--- a/src/components/ui/SplitScreenView.tsx
+++ b/src/components/ui/SplitScreenView.tsx
@@ -47,7 +47,7 @@ export const SplitScreenView: React.FC<Props> = ({
   const [panelHeight, setPanelHeight] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (!matchPanelHeight || !headerRef.current) return;
+    if (!matchPanelHeight || !showHeader || !headerRef.current) return;
 
     const node = headerRef.current;
 
@@ -71,7 +71,7 @@ export const SplitScreenView: React.FC<Props> = ({
       observer.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [matchPanelHeight]);
+  }, [matchPanelHeight, showHeader]);
 
   return (
     <div
@@ -82,8 +82,8 @@ export const SplitScreenView: React.FC<Props> = ({
     >
       <InnerPanel
         className={classNames("w-full sm:w-3/5 h-fit p-1 flex", {
-          "sm:max-h-96": !tallDesktopContent && !matchPanelHeight,
-          "sm:max-h-[30rem]": tallDesktopContent && !matchPanelHeight,
+          "sm:max-h-96": !tallDesktopContent,
+          "sm:max-h-[30rem]": tallDesktopContent,
           "max-h-80": tallMobileContent,
           "max-h-56": !tallMobileContent,
           "lg:w-3/4": wideModal,
@@ -93,7 +93,7 @@ export const SplitScreenView: React.FC<Props> = ({
           "mt-1 sm:mt-0": !mobileReversePanelOrder,
         })}
         style={
-          matchPanelHeight && panelHeight
+          matchPanelHeight && showHeader && panelHeight
             ? { maxHeight: `${panelHeight}px` }
             : undefined
         }

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -191,6 +191,7 @@ export const Recipes: React.FC<Props> = ({
   return (
     <>
       <SplitScreenView
+        matchPanelHeight
         panel={
           <>
             <CraftingRequirements


### PR DESCRIPTION
## Summary
- Cooking building modals (Fire Pit, Kitchen, Bakery, Deli, Smoothie Shack) show a recipe list panel (left) and a recipe details panel (right) side by side. The two panels sized independently, so whichever side had less content (e.g. left panel with few unlocked recipes vs. a right panel stretched by VIP/boost text) left visible empty space instead of the two columns lining up.
- Added an opt-in `matchPanelHeight` prop to `SplitScreenView` that measures the panel (right) column's live rendered height via `ResizeObserver` and caps the content (left) column to match it on desktop, so both columns' borders always align regardless of how much content renders on either side.
- Wired it up only in `Recipes.tsx` (the shared component behind all cooking building modals) — the other 30+ consumers of `SplitScreenView` are unaffected since the prop defaults to off.
<img width="771" height="722" alt="image" src="https://github.com/user-attachments/assets/6ecf3f58-6a63-487b-8ccd-0523303fcaac" />


## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] Manually verified in-browser (ART_MODE) across Fire Pit, Kitchen, Bakery, Deli, Smoothie Shack at various content lengths (many recipes / few recipes, with and without boosts/VIP) — panels consistently line up on desktop
- [x] Verified no regression on mobile (panels stack, unaffected by the desktop-only height matching)
- [x] Verified no regression in the Crafting Box "Craft" tab (also uses `SplitScreenView`, without the new prop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to match split-screen header and content panel heights on desktop.
  - The height matching updates automatically when the header size changes.
  - Enabled this improved alignment in the Recipes view for a more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->