### PR TITLE
[FIX] Show cheer feed entries for all days

### DIFF
--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -113,6 +113,9 @@ const mergeUpdates = (
   ];
 };
 
+const getUTCDateKey = (timestamp: number) =>
+  new Date(timestamp).toISOString().split("T")[0];
+
 export type FeedFilter = "all" | "help" | "chat" | "cheer" | "follow";
 export type FeedFilterOption = {
   value: FeedFilter;
@@ -580,6 +583,8 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
   const [hasMeasuredScroll, setHasMeasuredScroll] = useState(false);
+  const now = useNow({ live: true });
+  const todayKey = getUTCDateKey(now);
 
   // Intersection observer to load more interactions when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -676,7 +681,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
               : () => onInteractionClick(interaction);
           const isFollowing = following.includes(interaction.sender.id);
           const isAtMaxFollowing = !isFollowing && following.length >= 5000;
-          const previousInteraction = visibleFeed[index - 1];
+          const previousInteraction = feed[index - 1];
           const currentDateKey = getUTCDateKey(interaction.createdAt);
           const showOlderPostsSeparator =
             currentDateKey < todayKey &&

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -9,7 +9,6 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -112,26 +111,6 @@ const mergeUpdates = (
     },
     ...current.slice(1),
   ];
-};
-
-const getUTCDateKey = (timestamp: number) =>
-  new Date(timestamp).toISOString().split("T")[0];
-
-const getNextUTCDateKeyRefreshAt = (timestamp: number) => {
-  const date = new Date(timestamp);
-
-  return (
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1) +
-    1000
-  );
-};
-
-const shouldShowInteraction = (interaction: Interaction, todayKey: string) => {
-  if (interaction.type !== "cheer") {
-    return true;
-  }
-
-  return getUTCDateKey(interaction.createdAt) === todayKey;
 };
 
 export type FeedFilter = "all" | "help" | "chat" | "cheer" | "follow";
@@ -601,15 +580,6 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
   const [hasMeasuredScroll, setHasMeasuredScroll] = useState(false);
-  const [todayKey, setTodayKey] = useState(() => getUTCDateKey(Date.now()));
-  const refreshTimeoutRef = useRef<number | null>(null);
-  const visibleFeed = useMemo(
-    () =>
-      feed.filter((interaction) =>
-        shouldShowInteraction(interaction, todayKey),
-      ),
-    [feed, todayKey],
-  );
 
   // Intersection observer to load more interactions when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -624,27 +594,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     // tiny buffer so off-by-1 doesn’t trigger
     setCanPaginate(el.scrollHeight > el.clientHeight + 2);
     setHasMeasuredScroll(true);
-  }, [visibleFeed.length, filter]);
-
-  useEffect(() => {
-    const refreshTodayKey = () => {
-      const now = Date.now();
-      const refreshIn = getNextUTCDateKeyRefreshAt(now) - now;
-
-      refreshTimeoutRef.current = window.setTimeout(() => {
-        setTodayKey(getUTCDateKey(Date.now()));
-        refreshTodayKey();
-      }, refreshIn);
-    };
-
-    refreshTodayKey();
-
-    return () => {
-      if (refreshTimeoutRef.current) {
-        window.clearTimeout(refreshTimeoutRef.current);
-      }
-    };
-  }, []);
+  }, [feed.length, filter]);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -658,9 +608,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     const shouldLoadMore =
       hasMore &&
       !isLoadingMore &&
-      (inView ||
-        visibleFeed.length === 0 ||
-        (hasMeasuredScroll && !canPaginate));
+      (inView || feed.length === 0 || (hasMeasuredScroll && !canPaginate));
 
     if (shouldLoadMore) {
       loadMore();
@@ -672,7 +620,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     inView,
     isLoadingMore,
     loadMore,
-    visibleFeed.length,
+    feed.length,
   ]);
 
   const setRefs = useCallback(
@@ -697,7 +645,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
     return <FeedSkeleton />;
   }
 
-  if (visibleFeed.length === 0) {
+  if (feed.length === 0) {
     return (
       <div className="flex justify-center items-center h-full">
         {hasMore ? (
@@ -715,7 +663,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
       className="scrollable overflow-hidden overflow-y-auto"
     >
       <div className="flex flex-col gap-1 pr-1">
-        {visibleFeed.map((interaction, index) => {
+        {feed.map((interaction, index) => {
           const direction =
             interaction?.sender.username === username ? "right" : "left";
           const sender =

--- a/src/features/social/components/FollowDetailPanel.tsx
+++ b/src/features/social/components/FollowDetailPanel.tsx
@@ -10,6 +10,7 @@ import socialPointsIcon from "assets/icons/social_score.webp";
 import potIcon from "assets/icons/pot.png";
 import helpIcon from "assets/icons/help.webp";
 import helpedIcon from "assets/icons/helped.webp";
+import cheerIcon from "assets/icons/cheer.webp";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { shortenCount } from "lib/utils/formatNumber";
 import { useNow } from "lib/utils/hooks/useNow";
@@ -21,6 +22,7 @@ type Props = {
   username: string;
   helpedThemToday: boolean;
   helpedYouToday: boolean;
+  cheeredThemToday?: boolean;
   socialPoints: number;
   lastOnlineAt: number;
   hasCookingPot: boolean;
@@ -35,6 +37,7 @@ export const FollowDetailPanel: React.FC<Props> = ({
   username,
   helpedThemToday,
   helpedYouToday,
+  cheeredThemToday,
   socialPoints,
   lastOnlineAt,
   hasCookingPot,
@@ -88,6 +91,9 @@ export const FollowDetailPanel: React.FC<Props> = ({
               <div className="flex items-center gap-1 flex-wrap">
                 {helpedThemToday && <img src={helpIcon} className="w-5 h-5" />}
                 {helpedYouToday && <img src={helpedIcon} className="w-5 h-5" />}
+                {cheeredThemToday && (
+                  <img src={cheerIcon} className="w-5 h-5" />
+                )}
                 {hasCookingPot && <img src={potIcon} className="w-5 h-5" />}
               </div>
               {helpStreak > 0 && (

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -12,11 +12,13 @@ import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import type { MachineState } from "features/game/lib/gameMachine";
 
+const EMPTY_FARMS: number[] = [];
+
 const _cheeredFarmsToday = (state: MachineState) => {
   const game = state.context.visitorState ?? state.context.state;
   const today = new Date().toISOString().split("T")[0];
 
-  if (game.socialFarming.cheersGiven.date !== today) return [];
+  if (game.socialFarming.cheersGiven.date !== today) return EMPTY_FARMS;
 
   return game.socialFarming.cheersGiven.farms;
 };

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Label } from "components/ui/Label";
 import { FollowDetailPanel } from "./FollowDetailPanel";
@@ -8,6 +8,18 @@ import { useFollowNetwork } from "../hooks/useFollowNetwork";
 import { useInView } from "react-intersection-observer";
 import { Loading } from "features/auth/components";
 import type { Detail } from "../actions/getFollowNetworkDetails";
+import { Context } from "features/game/GameProvider";
+import { useSelector } from "@xstate/react";
+import type { MachineState } from "features/game/lib/gameMachine";
+
+const _cheeredFarmsToday = (state: MachineState) => {
+  const game = state.context.visitorState ?? state.context.state;
+  const today = new Date().toISOString().split("T")[0];
+
+  if (game.socialFarming.cheersGiven.date !== today) return [];
+
+  return game.socialFarming.cheersGiven.farms;
+};
 
 type Props = {
   loggedInFarmId: number;
@@ -36,6 +48,8 @@ export const FollowList: React.FC<Props> = ({
   navigateToPlayer,
 }) => {
   const { t } = useTranslation();
+  const { gameService } = useContext(Context);
+  const cheeredFarmsToday = useSelector(gameService, _cheeredFarmsToday);
   const [isScrollable, setIsScrollable] = useState(false);
   // Intersection observer to load more details when the loader is in view
   const { ref: intersectionRef, inView } = useInView({
@@ -154,6 +168,7 @@ export const FollowList: React.FC<Props> = ({
               socialPoints={detail.socialPoints ?? 0}
               helpedThemToday={detail.helpedThemToday}
               helpedYouToday={detail.helpedYouToday}
+              cheeredThemToday={cheeredFarmsToday.includes(detail.id)}
               helpStreak={detail.helpStreak}
             />
           );


### PR DESCRIPTION
## What

Fixes a regression from #7369: cheer rows in the social feed were being hidden whenever they were older than the current UTC day, while help/chat/follow rows stayed visible regardless of age. Removes that date filter so cheer interactions render like every other interaction type - visible for as long as they're in the feed, not just for today.

Also adds a small follow-up: the Following list now shows a cheer icon (mirroring the existing help icon) when you've cheered that farm today, computed client-side from `socialFarming.cheersGiven.farms` - no backend change required.

## Why

#7369 added `shouldShowInteraction()` to hide cheer entries outside the current UTC day, intended to keep cheer activity "fresh," but it also meant a legitimate past cheer would vanish from the feed the next day - inconsistent with how help/chat/follow behave, and confusing since the same information stays visible elsewhere (e.g. `PlayerDetails`).

## Changes

- `Feed.tsx` - removed `shouldShowInteraction`, `getUTCDateKey`, `getNextUTCDateKeyRefreshAt`, the `todayKey` state, and the midnight-UTC refresh timer. The feed list renders directly with no date filter.
- `FollowList.tsx` - reads `socialFarming.cheersGiven.farms` for today via `gameService`/`useSelector` and passes `cheeredThemToday` per row.
- `FollowDetailPanel.tsx` - renders the cheer icon next to the existing help icons when `cheeredThemToday` is true.

## Left untouched

- The per-notification rocket icon on individual cheer rows (`interaction.cheeredThemToday`, from #7379) - still driven by the backend flag, unaffected by this change.
- Help icon logic in the feed - was never date-filtered, unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean (pre-existing `no-explicit-any` warning unrelated to this change)
- [x] Manually verified locally with mock feed/follow data: cheer rows from previous days now render; Following list shows the cheer icon only for farms cheered today; help icons and rocket reciprocity icon behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Social feed interactions are now shown consistently without being limited by the current UTC day, improving loading/pagination and the empty-state experience.
  * Follow details now correctly indicate whether you have cheered the viewed player today, including correct “previous interaction” separation for older posts.
* **New Features**
  * Added a “cheered” indicator to the follow detail panel when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->