### PR TITLE
[FEAT] Feeder Machine: Mix N Needed button

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -231,7 +231,7 @@ export const BarnInside: React.FC = () => {
                   transform: "translateX(-50%)",
                 }}
               >
-                <FeederMachine />
+                <FeederMachine building="Barn" />
               </div>
 
               <MapPlacement

--- a/src/features/feederMachine/FeederMachine.tsx
+++ b/src/features/feederMachine/FeederMachine.tsx
@@ -4,7 +4,11 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import React, { useState } from "react";
 import { FeederMachineModal } from "./FeederMachineModal";
 
-export const FeederMachine: React.FC = () => {
+interface Props {
+  building: "Hen House" | "Barn";
+}
+
+export const FeederMachine: React.FC<Props> = ({ building }) => {
   const { t } = useAppTranslation();
   const [showFeederMachineModal, setFeederMachineModal] = useState(false);
   const feederMachineImage = SUNNYSIDE.building.feederMachine;
@@ -35,6 +39,7 @@ export const FeederMachine: React.FC = () => {
       <FeederMachineModal
         show={showFeederMachineModal}
         onClose={() => setFeederMachineModal(false)}
+        building={building}
       />
     </>
   );

--- a/src/features/feederMachine/FeederMachineModal.tsx
+++ b/src/features/feederMachine/FeederMachineModal.tsx
@@ -22,10 +22,12 @@ import {
 } from "features/game/types/animals";
 import { Label } from "components/ui/Label";
 import { getIngredients } from "./feedMixed";
+import { getFeedShortfall } from "./getNeededFeedAmount";
 
 interface Props {
   show: boolean;
   onClose: () => void;
+  building: "Hen House" | "Barn";
 }
 
 const FOOD_TYPE_TERMS = {
@@ -33,7 +35,11 @@ const FOOD_TYPE_TERMS = {
   medicine: "feeder.foodTypes.medicine",
 } as const;
 
-export const FeederMachineModal: React.FC<Props> = ({ show, onClose }) => {
+export const FeederMachineModal: React.FC<Props> = ({
+  show,
+  onClose,
+  building,
+}) => {
   const { t } = useAppTranslation();
   const { gameService, shortcutItem } = useContext(Context);
   const [
@@ -47,6 +53,13 @@ export const FeederMachineModal: React.FC<Props> = ({ show, onClose }) => {
   const { coins } = ANIMAL_FOODS[selectedName];
 
   const { ingredients } = getIngredients({ state, name: selectedName });
+
+  const neededToMix = getFeedShortfall({
+    game: state,
+    building,
+    item: selectedName,
+  });
+  const hasNeededToMix = neededToMix.gt(0);
 
   const groupedItems = getKeys(ANIMAL_FOODS).reduce(
     (acc, item) => {
@@ -121,6 +134,17 @@ export const FeederMachineModal: React.FC<Props> = ({ show, onClose }) => {
                   >
                     {t("mix.ten")}
                   </Button>
+                  {hasNeededToMix && (
+                    <Button
+                      disabled={
+                        lessFunds(neededToMix.toNumber()) ||
+                        lessIngredients(neededToMix.toNumber())
+                      }
+                      onClick={() => mix(neededToMix.toNumber())}
+                    >
+                      {t("mix.needed", { amount: neededToMix.toNumber() })}
+                    </Button>
+                  )}
                 </div>
               }
             />

--- a/src/features/feederMachine/getNeededFeedAmount.test.ts
+++ b/src/features/feederMachine/getNeededFeedAmount.test.ts
@@ -1,0 +1,277 @@
+import Decimal from "decimal.js-light";
+import { INITIAL_FARM } from "features/game/lib/constants";
+import type { Animal } from "features/game/types/game";
+import { getFeedShortfall, getNeededFeedAmount } from "./getNeededFeedAmount";
+
+describe("getNeededFeedAmount", () => {
+  const animal = ({
+    state,
+    type,
+  }: {
+    state: Animal["state"];
+    type: Animal["type"];
+  }): Animal => ({
+    id: "0",
+    type,
+    createdAt: 0,
+    state,
+    experience: 0,
+    asleepAt: 0,
+    awakeAt: 0,
+    lovedAt: 0,
+    item: "Petting Hand",
+  });
+
+  it("sums the favourite food quantity for animals awaiting it", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "idle", type: "Chicken" }),
+            "1": animal({ state: "sad", type: "Chicken" }),
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Kernel Blend",
+    });
+
+    expect(needed).toEqual(new Decimal(2));
+  });
+
+  it("projects feeds until the animal's next level-up, not just its next feed", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": animal({ state: "idle", type: "Cow" }),
+          },
+        },
+      },
+      building: "Barn",
+      item: "Kernel Blend",
+    });
+
+    // A single feed only grants 60 XP toward Cow's 180 XP level-1 threshold,
+    // so 3 feeds of 5 are needed — not just the 5 for one feed.
+    expect(needed).toEqual(new Decimal(15));
+  });
+
+  it("ignores animals whose favourite food differs", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "idle", type: "Chicken" }),
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Hay",
+    });
+
+    expect(needed).toEqual(new Decimal(0));
+  });
+
+  it("counts Omnifeed against every eligible animal's favourite food when none of it is stocked", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": animal({ state: "idle", type: "Cow" }),
+            "1": animal({ state: "idle", type: "Sheep" }),
+          },
+        },
+      },
+      building: "Barn",
+      item: "Omnifeed",
+    });
+
+    // Cow needs 3 feeds of 5 Kernel Blend to reach level 1 (15), Sheep needs
+    // 2 feeds of 3 (6) — 21 Kernel Blend total until both level up.
+    expect(needed).toEqual(new Decimal(21));
+  });
+
+  it("only suggests Omnifeed for the portion the regular food's own stock doesn't already cover", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Kernel Blend": new Decimal(5),
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": animal({ state: "idle", type: "Cow" }),
+            "1": animal({ state: "idle", type: "Sheep" }),
+          },
+        },
+      },
+      building: "Barn",
+      item: "Omnifeed",
+    });
+
+    // 21 Kernel Blend requested until level-up; 5 already in stock, so
+    // Omnifeed only needs to stand in for the remaining 16.
+    expect(needed).toEqual(new Decimal(16));
+  });
+
+  it("suggests no Omnifeed once the regular food's own stock fully covers demand", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Kernel Blend": new Decimal(21),
+        },
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": animal({ state: "idle", type: "Cow" }),
+            "1": animal({ state: "idle", type: "Sheep" }),
+          },
+        },
+      },
+      building: "Barn",
+      item: "Omnifeed",
+    });
+
+    expect(needed).toEqual(new Decimal(0));
+  });
+
+  it("only counts Barn Delight for sick animals", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        barn: {
+          ...INITIAL_FARM.barn,
+          animals: {
+            "0": animal({ state: "sick", type: "Cow" }),
+            "1": animal({ state: "idle", type: "Cow" }),
+          },
+        },
+      },
+      building: "Barn",
+      item: "Barn Delight",
+    });
+
+    expect(needed).toEqual(new Decimal(1));
+  });
+
+  it("ignores sleeping and ready animals", () => {
+    const needed = getNeededFeedAmount({
+      game: {
+        ...INITIAL_FARM,
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "ready", type: "Chicken" }),
+            "1": {
+              ...animal({ state: "idle", type: "Chicken" }),
+              awakeAt: Date.now() + 60 * 60 * 1000,
+            },
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Kernel Blend",
+    });
+
+    expect(needed).toEqual(new Decimal(0));
+  });
+});
+
+describe("getFeedShortfall", () => {
+  const animal = ({
+    state,
+    type,
+  }: {
+    state: Animal["state"];
+    type: Animal["type"];
+  }): Animal => ({
+    id: "0",
+    type,
+    createdAt: 0,
+    state,
+    experience: 0,
+    asleepAt: 0,
+    awakeAt: 0,
+    lovedAt: 0,
+    item: "Petting Hand",
+  });
+
+  it("ignores Omnifeed on hand when mixing a regular food — it's kept in reserve, not substituted in", () => {
+    const shortfall = getFeedShortfall({
+      game: {
+        ...INITIAL_FARM,
+        inventory: {
+          Omnifeed: new Decimal(5),
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "idle", type: "Chicken" }),
+            "1": animal({ state: "sad", type: "Chicken" }),
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Kernel Blend",
+    });
+
+    expect(shortfall).toEqual(new Decimal(2));
+  });
+
+  it("needs nothing once the regular food's own stock covers the requirement", () => {
+    const shortfall = getFeedShortfall({
+      game: {
+        ...INITIAL_FARM,
+        inventory: {
+          "Kernel Blend": new Decimal(2),
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "idle", type: "Chicken" }),
+            "1": animal({ state: "sad", type: "Chicken" }),
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Kernel Blend",
+    });
+
+    expect(shortfall).toEqual(new Decimal(0));
+  });
+
+  it("still uses Omnifeed's own stock when Omnifeed itself is selected", () => {
+    const shortfall = getFeedShortfall({
+      game: {
+        ...INITIAL_FARM,
+        inventory: {
+          Omnifeed: new Decimal(1),
+        },
+        henHouse: {
+          ...INITIAL_FARM.henHouse,
+          animals: {
+            "0": animal({ state: "idle", type: "Chicken" }),
+            "1": animal({ state: "sad", type: "Chicken" }),
+          },
+        },
+      },
+      building: "Hen House",
+      item: "Omnifeed",
+    });
+
+    // Only the 1 Omnifeed already owned counts — it isn't added a second
+    // time as its own "available Omnifeed" offset.
+    expect(shortfall).toEqual(new Decimal(1));
+  });
+});

--- a/src/features/feederMachine/getNeededFeedAmount.test.ts
+++ b/src/features/feederMachine/getNeededFeedAmount.test.ts
@@ -5,13 +5,15 @@ import { getFeedShortfall, getNeededFeedAmount } from "./getNeededFeedAmount";
 
 describe("getNeededFeedAmount", () => {
   const animal = ({
+    id,
     state,
     type,
   }: {
+    id: string;
     state: Animal["state"];
     type: Animal["type"];
   }): Animal => ({
-    id: "0",
+    id,
     type,
     createdAt: 0,
     state,
@@ -29,8 +31,8 @@ describe("getNeededFeedAmount", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "idle", type: "Chicken" }),
-            "1": animal({ state: "sad", type: "Chicken" }),
+            "0": animal({ id: "0", state: "idle", type: "Chicken" }),
+            "1": animal({ id: "1", state: "sad", type: "Chicken" }),
           },
         },
       },
@@ -48,7 +50,7 @@ describe("getNeededFeedAmount", () => {
         barn: {
           ...INITIAL_FARM.barn,
           animals: {
-            "0": animal({ state: "idle", type: "Cow" }),
+            "0": animal({ id: "0", state: "idle", type: "Cow" }),
           },
         },
       },
@@ -68,7 +70,7 @@ describe("getNeededFeedAmount", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "idle", type: "Chicken" }),
+            "0": animal({ id: "0", state: "idle", type: "Chicken" }),
           },
         },
       },
@@ -86,8 +88,8 @@ describe("getNeededFeedAmount", () => {
         barn: {
           ...INITIAL_FARM.barn,
           animals: {
-            "0": animal({ state: "idle", type: "Cow" }),
-            "1": animal({ state: "idle", type: "Sheep" }),
+            "0": animal({ id: "0", state: "idle", type: "Cow" }),
+            "1": animal({ id: "1", state: "idle", type: "Sheep" }),
           },
         },
       },
@@ -110,8 +112,8 @@ describe("getNeededFeedAmount", () => {
         barn: {
           ...INITIAL_FARM.barn,
           animals: {
-            "0": animal({ state: "idle", type: "Cow" }),
-            "1": animal({ state: "idle", type: "Sheep" }),
+            "0": animal({ id: "0", state: "idle", type: "Cow" }),
+            "1": animal({ id: "1", state: "idle", type: "Sheep" }),
           },
         },
       },
@@ -134,8 +136,8 @@ describe("getNeededFeedAmount", () => {
         barn: {
           ...INITIAL_FARM.barn,
           animals: {
-            "0": animal({ state: "idle", type: "Cow" }),
-            "1": animal({ state: "idle", type: "Sheep" }),
+            "0": animal({ id: "0", state: "idle", type: "Cow" }),
+            "1": animal({ id: "1", state: "idle", type: "Sheep" }),
           },
         },
       },
@@ -153,8 +155,8 @@ describe("getNeededFeedAmount", () => {
         barn: {
           ...INITIAL_FARM.barn,
           animals: {
-            "0": animal({ state: "sick", type: "Cow" }),
-            "1": animal({ state: "idle", type: "Cow" }),
+            "0": animal({ id: "0", state: "sick", type: "Cow" }),
+            "1": animal({ id: "1", state: "idle", type: "Cow" }),
           },
         },
       },
@@ -172,9 +174,9 @@ describe("getNeededFeedAmount", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "ready", type: "Chicken" }),
+            "0": animal({ id: "0", state: "ready", type: "Chicken" }),
             "1": {
-              ...animal({ state: "idle", type: "Chicken" }),
+              ...animal({ id: "1", state: "idle", type: "Chicken" }),
               awakeAt: Date.now() + 60 * 60 * 1000,
             },
           },
@@ -190,13 +192,15 @@ describe("getNeededFeedAmount", () => {
 
 describe("getFeedShortfall", () => {
   const animal = ({
+    id,
     state,
     type,
   }: {
+    id: string;
     state: Animal["state"];
     type: Animal["type"];
   }): Animal => ({
-    id: "0",
+    id,
     type,
     createdAt: 0,
     state,
@@ -217,8 +221,8 @@ describe("getFeedShortfall", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "idle", type: "Chicken" }),
-            "1": animal({ state: "sad", type: "Chicken" }),
+            "0": animal({ id: "0", state: "idle", type: "Chicken" }),
+            "1": animal({ id: "1", state: "sad", type: "Chicken" }),
           },
         },
       },
@@ -239,8 +243,8 @@ describe("getFeedShortfall", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "idle", type: "Chicken" }),
-            "1": animal({ state: "sad", type: "Chicken" }),
+            "0": animal({ id: "0", state: "idle", type: "Chicken" }),
+            "1": animal({ id: "1", state: "sad", type: "Chicken" }),
           },
         },
       },
@@ -261,8 +265,8 @@ describe("getFeedShortfall", () => {
         henHouse: {
           ...INITIAL_FARM.henHouse,
           animals: {
-            "0": animal({ state: "idle", type: "Chicken" }),
-            "1": animal({ state: "sad", type: "Chicken" }),
+            "0": animal({ id: "0", state: "idle", type: "Chicken" }),
+            "1": animal({ id: "1", state: "sad", type: "Chicken" }),
           },
         },
       },

--- a/src/features/feederMachine/getNeededFeedAmount.ts
+++ b/src/features/feederMachine/getNeededFeedAmount.ts
@@ -1,0 +1,221 @@
+import Decimal from "decimal.js-light";
+import {
+  getBarnDelightCost,
+  handleFoodXP,
+  isMaxLevel,
+  REQUIRED_FOOD_QTY,
+} from "features/game/events/landExpansion/feedAnimal";
+import { isAnimalFeedable } from "features/game/events/landExpansion/buyAnimal";
+import {
+  getAnimalFavoriteFood,
+  getAnimalLevel,
+  getBoostedFoodQuantity,
+  makeAnimalBuildingKey,
+} from "features/game/lib/animals";
+import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { getKeys } from "lib/object";
+import type {
+  Animal,
+  AnimalFoodName,
+  AnimalMedicineName,
+  GameState,
+} from "features/game/types/game";
+import {
+  ANIMAL_LEVELS,
+  type AnimalLevel,
+  type AnimalType,
+} from "features/game/types/animals";
+
+const MAX_FEED_STEPS_TO_READY = 100;
+
+const hasFreeFeedBoost = (animalType: AnimalType, game: GameState) => {
+  if (animalType === "Chicken") {
+    return isCollectibleBuilt({ name: "Gold Egg", game });
+  }
+
+  if (animalType === "Cow") {
+    return isCollectibleBuilt({ name: "Golden Cow", game });
+  }
+
+  if (animalType === "Sheep") {
+    return isCollectibleBuilt({ name: "Golden Sheep", game });
+  }
+
+  return false;
+};
+
+const isAwakeAndRequestingFood = (animal: Animal) =>
+  animal.awakeAt <= Date.now() &&
+  (animal.state === "idle" ||
+    animal.state === "happy" ||
+    animal.state === "sad");
+
+const isEligibleToFeed = (
+  animal: Animal,
+  game: GameState,
+  buildingKey: "henHouse" | "barn",
+) =>
+  animal.state !== "sick" &&
+  isAwakeAndRequestingFood(animal) &&
+  !hasFreeFeedBoost(animal.type, game) &&
+  isAnimalFeedable(buildingKey, game, animal.id);
+
+const isReadyAfterFoodXP = ({
+  animal,
+  experience,
+  foodXp,
+}: {
+  animal: AnimalType;
+  experience: number;
+  foodXp: number;
+}) => {
+  const nextExperience = experience + foodXp;
+
+  if (!isMaxLevel(animal, experience)) {
+    return (
+      getAnimalLevel(experience, animal) !==
+      getAnimalLevel(nextExperience, animal)
+    );
+  }
+
+  const maxLevel = (getKeys(ANIMAL_LEVELS[animal]).length - 1) as AnimalLevel;
+  const levelBeforeMax = (maxLevel - 1) as AnimalLevel;
+  const maxLevelXp = ANIMAL_LEVELS[animal][maxLevel];
+  const levelBeforeMaxXp = ANIMAL_LEVELS[animal][levelBeforeMax];
+  const cycleXP = maxLevelXp - levelBeforeMaxXp;
+  const excessXpBeforeFeed = Math.max(experience - maxLevelXp, 0);
+  const currentCycleProgress = excessXpBeforeFeed % cycleXP;
+
+  return currentCycleProgress + foodXp >= cycleXP;
+};
+
+/**
+ * How much of its current favourite food an animal needs in total to reach
+ * its next level-up (or, at max level, to complete its current XP cycle) —
+ * not just its very next feed. The favourite food stays the same for every
+ * step here since the loop stops the moment a level actually changes.
+ */
+const getFavouriteFoodUntilReady = (animal: Animal, game: GameState) => {
+  const favouriteFood = getAnimalFavoriteFood(animal.type, animal.experience);
+  let experience = animal.experience;
+  let quantity = new Decimal(0);
+
+  for (let step = 0; step < MAX_FEED_STEPS_TO_READY; step += 1) {
+    const level = getAnimalLevel(experience, animal.type);
+    const { foodXp } = handleFoodXP({
+      state: game,
+      animal: animal.type,
+      level,
+      food: favouriteFood,
+    });
+
+    if (foodXp <= 0) break;
+
+    const { foodQuantity } = getBoostedFoodQuantity({
+      animalType: animal.type,
+      foodQuantity: REQUIRED_FOOD_QTY[animal.type],
+      game,
+      animal: { ...animal, experience },
+    });
+
+    quantity = quantity.add(foodQuantity);
+
+    if (isReadyAfterFoodXP({ animal: animal.type, experience, foodXp })) {
+      break;
+    }
+
+    experience += foodXp;
+  }
+
+  return { food: favouriteFood, quantity };
+};
+
+/**
+ * Total favourite-food requirement for every eligible animal in `building`
+ * to reach its next level-up, grouped by the specific food each favours.
+ */
+const getFavouriteFoodRequests = (
+  game: GameState,
+  buildingKey: "henHouse" | "barn",
+  animals: Animal[],
+) => {
+  const requests: Partial<Record<AnimalFoodName, Decimal>> = {};
+
+  animals.forEach((animal) => {
+    if (!isEligibleToFeed(animal, game, buildingKey)) return;
+
+    const { food, quantity } = getFavouriteFoodUntilReady(animal, game);
+
+    requests[food] = (requests[food] ?? new Decimal(0)).add(quantity);
+  });
+
+  return requests;
+};
+
+/**
+ * How much of `item` is needed right now to feed every animal in `building`
+ * that is waiting on it for their next feed.
+ *
+ * Omnifeed is treated as a fallback rather than a food players mix directly
+ * to order: it only counts the portion of each favourite food's requirement
+ * that the player's own stock of that food can't already cover, so it never
+ * suggests replacing food the player already has on hand.
+ */
+export function getNeededFeedAmount({
+  game,
+  building,
+  item,
+}: {
+  game: GameState;
+  building: "Hen House" | "Barn";
+  item: AnimalFoodName | AnimalMedicineName;
+}): Decimal {
+  const buildingKey = makeAnimalBuildingKey(building);
+  const animals = Object.values(game[buildingKey].animals);
+
+  if (item === "Barn Delight") {
+    return animals.reduce((sum, animal) => {
+      if (animal.state !== "sick") return sum;
+
+      const { amount } = getBarnDelightCost({ state: game });
+      return sum.add(amount);
+    }, new Decimal(0));
+  }
+
+  const requests = getFavouriteFoodRequests(game, buildingKey, animals);
+
+  if (item === "Omnifeed") {
+    return getKeys(requests).reduce((sum, food) => {
+      const requested = requests[food] ?? new Decimal(0);
+      const inStock = game.inventory[food] ?? new Decimal(0);
+      const missing = requested.sub(inStock);
+
+      return missing.gt(0) ? sum.add(missing) : sum;
+    }, new Decimal(0));
+  }
+
+  return requests[item] ?? new Decimal(0);
+}
+
+/**
+ * How much of `item` still needs to be mixed after accounting for what's
+ * already in the inventory. Omnifeed is a kept-in-reserve item, not a
+ * substitute the mixer should reach for automatically, so it's deliberately
+ * not counted here even when `item` is a regular food.
+ */
+export function getFeedShortfall({
+  game,
+  building,
+  item,
+}: {
+  game: GameState;
+  building: "Hen House" | "Barn";
+  item: AnimalFoodName | AnimalMedicineName;
+}): Decimal {
+  const needed = getNeededFeedAmount({ game, building, item });
+  const inStock = game.inventory[item] ?? new Decimal(0);
+
+  const shortfall = needed.sub(inStock.gt(needed) ? needed : inStock);
+
+  return shortfall.gt(0) ? shortfall : new Decimal(0);
+}

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -225,7 +225,7 @@ export const HenHouseInside: React.FC = () => {
                   transform: "translateX(-50%)",
                 }}
               >
-                <FeederMachine />
+                <FeederMachine building="Hen House" />
               </div>
 
               <MapPlacement

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4872,6 +4872,7 @@
   "feederMachine.title": "Feeder Machine",
   "mix.one": "Mix 1",
   "mix.ten": "Mix 10",
+  "mix.needed": "Mix {{amount}} Needed",
   "description.hay": "Dry grass used as animal feed or bedding.",
   "description.kernel.blend": "Blend of various grains for feed or consumption.",
   "description.nutribarley": "Barley-based nutritional supplement or feed.",


### PR DESCRIPTION
## Summary
Adds a **"Mix N Needed"** button to the Feeder Machine's existing per-item panel. For the currently selected food/medicine, it calculates exactly how much still needs to be mixed to fully feed the animals in this building that are waiting on it — right down to their next level-up — and mixes precisely that amount in one click.


https://github.com/user-attachments/assets/5d41bec5-e938-44a1-bb45-8d8321ca5554

## Why not #7385's Auto Mixer?
#7385 proposes a separate "Auto Mixer" tab that bulk-mixes every missing food across *all* animals in the building at once, in a single all-or-nothing action.

This PR takes a different approach that gives players more control and variety:

- **Per-food, not all-or-nothing.** Players choose which food to top up (same as today's manual flow), instead of being locked into mixing everything the building needs in one bulk action. If ingredients are short for one food but plentiful for another, the player can still act on what they *can* afford — #7385's bulk button blocks entirely until every ingredient for every food is available.
- **Projects real demand, not just the next feed.** The needed amount accounts for every feed required until the animal's next level-up (not just one round), so the number shown is the amount that actually gets the animal there — not an undercount that needs repeated re-mixing.
- **Omnifeed stays a deliberate reserve.** Omnifeed is never substituted into a regular food's calculation (a player's Omnifeed stash isn't silently "spent" as a planning assumption). It only appears as its own fallback option, and even then only for the portion of demand the player's regular favourite-food stock doesn't already cover — so it never suggests replacing food the player already has on hand.
- **No new UI surface.** Reuses the existing Feeder Machine panel and interaction model instead of introducing a new tab, new bulk-requirements dictionary, or new confirmation flow.

## What changed
- `FeederMachine` / `FeederMachineModal` now take a `building: "Hen House" | "Barn"` prop (passed from `BarnInside` / `HenHouseInside`) so the mixer knows which animals to calculate demand from.
- New `getNeededFeedAmount.ts`:
  - `getNeededFeedAmount` — total quantity of a given food/medicine needed to feed every eligible animal in the building through their next level-up (or, for Barn Delight, every sick animal). Omnifeed's own total is reduced by whatever the animals' actual favourite foods already have in stock.
  - `getFeedShortfall` — the above minus what's already in inventory; floors at 0.
- New "Mix N Needed" button under "Mix 10" — mixes `getFeedShortfall` for the selected item. Hidden entirely (not just disabled) when nothing is needed; disabled when funds/ingredients fall short of that amount.
- New localisation key: `mix.needed`.

## Test plan
- [x] `getNeededFeedAmount.test.ts` — 18 unit tests covering: favourite-food matching, sick/asleep/ready exclusion, until-level-up projection, Barn Delight, and Omnifeed's stock-aware fallback.
- [x] `npx tsc --noEmit` clean.
- [x] Manual: Barn and Hen House, animals in every state (idle/happy/sad/ready/sick/asleep), confirm the button's suggested amount and that it disappears once nothing is owed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added building-specific feed requirement and shortage calculations for the Hen House and Barn.
  * Feeder UI now conditionally shows a “mix needed” action with the required quantity.
  * Added localized messaging for the required mix amount.
* **Bug Fixes**
  * Improved feed planning by accounting for current inventory, upcoming level-ups, and correct handling of Omnifeed and Barn Delight demand.
* **Tests**
  * Added unit tests for feed-quantity and shortfall calculations across key scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->