### PR TITLE
[FEAT] Neutralise ascension skill boosts on Chapter Crop Week items

### DIFF
--- a/src/features/game/events/landExpansion/collectRecipe.ts
+++ b/src/features/game/events/landExpansion/collectRecipe.ts
@@ -15,7 +15,12 @@ import { isCookingBuilding } from "./isCookingBuilding";
 import { isWearableActive } from "features/game/lib/wearables";
 import { assertCookableName } from "features/game/types/consumables";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+} from "features/game/types/bumpkinSkills";
+import { CHAPTER_CROP_WEEK_RECIPE } from "features/game/types/chapterCropWeek";
 
 /**
  * The Double Nom rank a recipe was cooked at, so its +food collects at the rank
@@ -66,8 +71,15 @@ export const getCookingAmount = ({
     boostsUsed.push({ name: "Double Nom", value: `+${bonus}` });
   }
 
-  // Fiery Jackpot - 20%/25%/30% chance of +1 food from Fire Pit (scales w/ rank)
-  const fieryJackpotLevel = getSkillLevel(game.bumpkin.skills, "Fiery Jackpot");
+  // Fiery Jackpot - 20%/25%/30% chance of +1 food from Fire Pit (scales w/ rank).
+  // Saltbite (the CHAPTER_CROP_WEEK event recipe) ignores upgraded ranks — the
+  // live read caps at rank 1 (Double Nom above reads the recipe snapshot instead,
+  // so it already reflects the rank paid at cook time).
+  const fieryJackpotSkills =
+    recipeName === CHAPTER_CROP_WEEK_RECIPE
+      ? downgradeChapterCropWeekSkills(game.bumpkin.skills)
+      : game.bumpkin.skills;
+  const fieryJackpotLevel = getSkillLevel(fieryJackpotSkills, "Fiery Jackpot");
   if (
     building === "Fire Pit" &&
     fieryJackpotLevel &&

--- a/src/features/game/events/landExpansion/cook.test.ts
+++ b/src/features/game/events/landExpansion/cook.test.ts
@@ -17,6 +17,7 @@ import {
   getExpiryCooldown,
 } from "features/game/lib/collectibleBuilt";
 import { getCookingTime } from "features/game/expansion/lib/boosts";
+import { CHAPTER_CROP_WEEK } from "features/game/types/chapterCropWeek";
 
 const GAME_STATE: GameState = {
   ...TEST_FARM,
@@ -410,6 +411,49 @@ describe("cook", () => {
     expect(
       state.buildings["Fire Pit"]?.[0].crafting?.[0].skills?.["Double Nom"],
     ).toEqual(2);
+  });
+
+  it("neutralises a rank 3 Double Nom on the Saltbite event recipe (2x cost, stamps rank 1)", () => {
+    const state = cook({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          Saltwort: new Decimal(30),
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          skills: { "Double Nom": 3 },
+        },
+        buildings: {
+          "Fire Pit": [
+            {
+              coordinates: { x: 2, y: 3 },
+              readyAt: 1000,
+              createdAt: 1000,
+              id: "64eca77c-10fb-4088-a71f-3743b2ef6b16",
+              oil: 0,
+            },
+          ],
+        },
+      },
+      action: {
+        type: "recipe.cooked",
+        item: "Saltbite",
+        buildingId: "64eca77c-10fb-4088-a71f-3743b2ef6b16",
+      },
+      farmId: 1,
+      // Saltbite is only cookable during CHAPTER_CROP_WEEK.
+      createdAt: CHAPTER_CROP_WEEK.startDate.getTime(),
+    });
+
+    // Saltbite (event recipe) ignores the upgraded rank: 10 Saltwort base x2
+    // (rank 1) = 20 consumed, not rank 3's x4 = 40. Boiled Eggs above (a non-event
+    // recipe) still pays the full upgraded cost, proving the scoping.
+    expect(state.inventory["Saltwort"]).toEqual(new Decimal(10));
+    // Recipe is stamped rank 1 so the later collect also honors rank 1.
+    expect(
+      state.buildings["Fire Pit"]?.[0].crafting?.[0].skills?.["Double Nom"],
+    ).toEqual(1);
   });
 
   it("adds another recipe to the building if there is a slot available", () => {

--- a/src/features/game/events/landExpansion/cook.ts
+++ b/src/features/game/events/landExpansion/cook.ts
@@ -20,7 +20,11 @@ import { hasVipAccess } from "features/game/lib/vipAccess";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import { getCookingAmount } from "./collectRecipe";
 import { isCookingBuilding } from "./isCookingBuilding";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+} from "features/game/types/bumpkinSkills";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import {
   CHAPTER_CROP_WEEK_RECIPE,
@@ -92,7 +96,13 @@ export function getCookingOilBoost(
   const itemOilConsumption = getOilConsumption(buildingName, item);
   const oilRemaining = building?.oil || 0;
 
-  const boostValue = BUILDING_OIL_BOOSTS(game.bumpkin.skills)[buildingName];
+  // Saltbite (the CHAPTER_CROP_WEEK event recipe) ignores upgraded Cooking-skill
+  // ranks (base skill still applies), so its oil boost caps at rank 1.
+  const oilSkills =
+    item === CHAPTER_CROP_WEEK_RECIPE
+      ? downgradeChapterCropWeekSkills(game.bumpkin.skills)
+      : game.bumpkin.skills;
+  const boostValue = BUILDING_OIL_BOOSTS(oilSkills)[buildingName];
   const boostedCookingTime = itemCookingTime * (1 - boostValue);
 
   if (oilRemaining >= itemOilConsumption) {
@@ -182,7 +192,15 @@ export function getCookingRequirements({
   let { ingredients } = COOKABLES[item];
   const { bumpkin } = state;
 
-  const level = doubleNomLevel ?? getSkillLevel(bumpkin.skills, "Double Nom");
+  // Saltbite (the CHAPTER_CROP_WEEK event recipe) ignores upgraded Double Nom
+  // ranks — the ingredient cost (and the +food payout, snapshotted at cook time)
+  // both fall back to rank 1. `doubleNomLevel`, when passed (cancel/refund), keeps
+  // honoring the rank actually paid on the recipe.
+  const skills =
+    item === CHAPTER_CROP_WEEK_RECIPE
+      ? downgradeChapterCropWeekSkills(bumpkin.skills)
+      : bumpkin.skills;
+  const level = doubleNomLevel ?? getSkillLevel(skills, "Double Nom");
   // Double Nom - 2x/3x/4x ingredients (scales with rank)
   const multiplier = level
     ? SKILL_RANKS["Double Nom"].ingredients[level - 1]
@@ -240,6 +258,14 @@ export function cook({
       throw new Error("You do not have a Bumpkin!");
     }
 
+    // Saltbite (the CHAPTER_CROP_WEEK event recipe) ignores upgraded Double Nom
+    // ranks — snapshot rank 1 on the recipe so cancel/collect stay consistent with
+    // the (rank-1) ingredient cost charged above.
+    const cookSkills =
+      item === CHAPTER_CROP_WEEK_RECIPE
+        ? downgradeChapterCropWeekSkills(bumpkin.skills)
+        : bumpkin.skills;
+
     if (!building) {
       throw new Error(translate("error.requiredBuildingNotExist"));
     }
@@ -280,7 +306,7 @@ export function cook({
         recipe: {
           name: item,
           boost: {},
-          skills: { "Double Nom": getSkillLevel(bumpkin.skills, "Double Nom") },
+          skills: { "Double Nom": getSkillLevel(cookSkills, "Double Nom") },
           readyAt: createdAt,
         },
         farmId,
@@ -327,7 +353,7 @@ export function cook({
         name: item,
         boost: { Oil: oilConsumed },
         // Marks whether the Double Nom skill was applied at the time of cooking
-        skills: { "Double Nom": getSkillLevel(bumpkin.skills, "Double Nom") },
+        skills: { "Double Nom": getSkillLevel(cookSkills, "Double Nom") },
         readyAt,
       },
     ];

--- a/src/features/game/events/landExpansion/harvest.test.ts
+++ b/src/features/game/events/landExpansion/harvest.test.ts
@@ -2737,6 +2737,35 @@ describe("harvest", () => {
       expect(state.inventory.Cabbage).toEqual(new Decimal(1.15));
     });
 
+    it("neutralises a rank 3 Experienced Farmer on the Saltwort event crop (+0.1, not +0.15)", () => {
+      const state = harvest({
+        state: {
+          ...GAME_STATE,
+          bumpkin: {
+            ...TEST_BUMPKIN,
+            skills: { ...TEST_BUMPKIN.skills, "Experienced Farmer": 3 },
+          },
+          crops: {
+            [firstId]: {
+              ...GAME_STATE.crops[firstId],
+              crop: {
+                name: "Saltwort",
+                plantedAt:
+                  dateNow - (CROPS["Saltwort"].harvestSeconds ?? 0) * 1000,
+              },
+            },
+          },
+        },
+        createdAt: dateNow,
+        action: { type: "crop.harvested", index: firstId },
+      });
+      expect(state.crops[firstId].crop).toBeUndefined();
+      // Saltwort (event crop) ignores the upgraded rank: rank-1 bonus (+0.1),
+      // not the owned rank 3 (+0.15). Cabbage above (a non-event medium crop)
+      // still gets the full +0.15, proving the scoping.
+      expect(state.inventory.Saltwort).toEqual(new Decimal(1.1));
+    });
+
     it("gives +0.125 to advanced crop when Old Farmer skill is rank 2", () => {
       const state = harvest({
         state: {

--- a/src/features/game/events/landExpansion/harvest.ts
+++ b/src/features/game/events/landExpansion/harvest.ts
@@ -61,7 +61,12 @@ import {
   type FarmActivityName,
 } from "features/game/types/farmActivity";
 import { isBuffActive } from "features/game/types/buffs";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+} from "features/game/types/bumpkinSkills";
+import { CHAPTER_CROP_WEEK_CROP } from "features/game/types/chapterCropWeek";
 import { prngChance } from "lib/prng";
 import { KNOWN_IDS } from "features/game/types";
 import { mfTrack } from "lib/moonforgeAnalytics";
@@ -321,7 +326,13 @@ export function getCropYieldAmount({
 
   const { bumpkin, buds, aoe } = game;
   const updatedAoe = cloneDeep(aoe);
-  const skills = bumpkin?.skills ?? {};
+  // Saltwort (the CHAPTER_CROP_WEEK event crop) ignores upgraded Crops-skill ranks
+  // (base skill still applies) — cap here so every downstream yield/AOE read uses
+  // the neutralised ranks without touching the player's stored skills.
+  const skills =
+    crop === CHAPTER_CROP_WEEK_CROP
+      ? downgradeChapterCropWeekSkills(bumpkin?.skills ?? {})
+      : (bumpkin?.skills ?? {});
   const itemId = KNOWN_IDS[crop];
   const criticalDrop = (
     criticalHitName: CriticalHitName,

--- a/src/features/game/events/landExpansion/plant.test.ts
+++ b/src/features/game/events/landExpansion/plant.test.ts
@@ -1497,6 +1497,29 @@ describe("plant", () => {
       expect(time).toEqual(baseHarvestSeconds * 0.925);
     });
 
+    it("neutralises a rank 3 Green Thumb on the Saltwort event crop (x0.95, not x0.925)", () => {
+      const baseHarvestSeconds = CROPS["Saltwort"].harvestSeconds;
+      const { time } = getCropPlotTime({
+        crop: "Saltwort",
+        game: {
+          ...FARM_WITH_PLOTS,
+          collectibles: {},
+          bumpkin: {
+            ...TEST_BUMPKIN,
+            skills: {
+              "Green Thumb": 3,
+            },
+          },
+        },
+        plot: { ...plot, x: 0, y: -3 },
+        createdAt: dateNow,
+      });
+
+      // Saltwort (event crop) uses the rank-1 multiplier (x0.95); Corn above
+      // (a non-event crop) still gets the full rank-3 x0.925.
+      expect(time).toEqual(baseHarvestSeconds * 0.95);
+    });
+
     it("applies a +12.5% speed boost on advanced crops with rank 2 Strong Roots skill", () => {
       const baseHarvestSeconds = CROPS["Radish"].harvestSeconds;
       const { time } = getCropPlotTime({

--- a/src/features/game/events/landExpansion/plant.ts
+++ b/src/features/game/events/landExpansion/plant.ts
@@ -34,7 +34,10 @@ import {
   type SeedName,
   SEEDS,
 } from "features/game/types/seeds";
-import { CHAPTER_CROP_WEEK_SEED } from "features/game/types/chapterCropWeek";
+import {
+  CHAPTER_CROP_WEEK_CROP,
+  CHAPTER_CROP_WEEK_SEED,
+} from "features/game/types/chapterCropWeek";
 import {
   isWithinAOE,
   type Position,
@@ -62,7 +65,11 @@ import {
   trackFarmActivity,
 } from "features/game/types/farmActivity";
 import { isBuffActive } from "features/game/types/buffs";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+} from "features/game/types/bumpkinSkills";
 import { isAutumnCrop, isSummerCrop } from "./harvest";
 import { getKeys } from "lib/object";
 import { mfTrack } from "lib/moonforgeAnalytics";
@@ -211,7 +218,12 @@ export function getCropTime({
   let multiplier = 1;
   const boostsUsed: { name: BoostName; value: string }[] = [];
   const { inventory, buds = {}, bumpkin } = game;
-  const skills = bumpkin?.skills ?? {};
+  // Saltwort is the CHAPTER_CROP_WEEK event crop: neutralise upgraded Crops skills
+  // (they still apply at rank 1) so the event crop isn't boosted by ascension ranks.
+  const skills =
+    crop === CHAPTER_CROP_WEEK_CROP
+      ? downgradeChapterCropWeekSkills(bumpkin?.skills ?? {})
+      : (bumpkin?.skills ?? {});
 
   if (inventory["Seed Specialist"]?.gte(1)) {
     multiplier = multiplier * 0.9;
@@ -305,10 +317,12 @@ export const getCropPlotTime = ({
   aoe: AOE;
   boostsUsed: { name: BoostName; value: string }[];
 } => {
-  const {
-    aoe,
-    bumpkin: { skills },
-  } = game;
+  const { aoe } = game;
+  // Saltwort (the CHAPTER_CROP_WEEK event crop) ignores upgraded Crops-skill ranks.
+  const skills =
+    crop === CHAPTER_CROP_WEEK_CROP
+      ? downgradeChapterCropWeekSkills(game.bumpkin.skills)
+      : game.bumpkin.skills;
   const updatedAoe = cloneDeep(aoe);
 
   let seconds = CROPS[crop].harvestSeconds;

--- a/src/features/game/expansion/lib/boosts.ts
+++ b/src/features/game/expansion/lib/boosts.ts
@@ -23,7 +23,12 @@ import {
   meetsLevelRequirement,
 } from "features/game/lib/level";
 import { isWearableActive } from "features/game/lib/wearables";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+} from "features/game/types/bumpkinSkills";
+import { CHAPTER_CROP_WEEK_RECIPE } from "features/game/types/chapterCropWeek";
 import type { SellableItem } from "features/game/events/landExpansion/sellCrop";
 import {
   FACTION_ITEMS,
@@ -276,8 +281,15 @@ export const getCookingTime = ({
     boostsUsed.push({ name: "Desert Gnome", value: "x0.9" });
   }
 
+  // Saltbite (the CHAPTER_CROP_WEEK event recipe) ignores upgraded Cooking-skill
+  // ranks — its cook-time reductions cap at rank 1 (base skill still applies).
+  const cookSkills =
+    item === CHAPTER_CROP_WEEK_RECIPE
+      ? downgradeChapterCropWeekSkills(bumpkin?.skills ?? {})
+      : (bumpkin?.skills ?? {});
+
   // -10%/-20%/-30% on Fire Pit + Kitchen with Fast Feasts skill (scales w/ rank)
-  const fastFeastsLevel = getSkillLevel(bumpkin?.skills ?? {}, "Fast Feasts");
+  const fastFeastsLevel = getSkillLevel(cookSkills, "Fast Feasts");
   if (
     (buildingName === "Fire Pit" || buildingName === "Kitchen") &&
     fastFeastsLevel
@@ -289,10 +301,7 @@ export const getCookingTime = ({
   }
 
   // -10%/-20%/-30% on Cakes with Frosted Cakes skill (scales with rank)
-  const frostedCakesLevel = getSkillLevel(
-    bumpkin?.skills ?? {},
-    "Frosted Cakes",
-  );
+  const frostedCakesLevel = getSkillLevel(cookSkills, "Frosted Cakes");
   if (item in COOKABLE_CAKES && frostedCakesLevel) {
     const multiplier =
       1 - SKILL_RANKS["Frosted Cakes"].ranks[frostedCakesLevel - 1];

--- a/src/features/game/types/bumpkinSkills.test.ts
+++ b/src/features/game/types/bumpkinSkills.test.ts
@@ -1,0 +1,103 @@
+import {
+  downgradeChapterCropWeekSkills,
+  hasUpgradedChapterCropWeekSkill,
+} from "./bumpkinSkills";
+import type { Skills } from "./game";
+import { COOKABLES, COOKABLE_CAKES } from "./consumables";
+import { isMediumCrop } from "./crops";
+import {
+  CHAPTER_CROP_WEEK_CROP,
+  CHAPTER_CROP_WEEK_RECIPE,
+} from "./chapterCropWeek";
+
+describe("downgradeChapterCropWeekSkills", () => {
+  it("caps upgraded Crops and Cooking ranks at 1", () => {
+    const result = downgradeChapterCropWeekSkills({
+      "Green Thumb": 3, // Crops
+      "Double Nom": 2, // Cooking
+    });
+    expect(result["Green Thumb"]).toBe(1);
+    expect(result["Double Nom"]).toBe(1);
+  });
+
+  it("leaves rank 1 and unrelated skill trees unchanged", () => {
+    const result = downgradeChapterCropWeekSkills({
+      "Green Thumb": 1, // Crops, already base rank
+      "Iron Bumpkin": 3, // Mining, out of scope
+    });
+    expect(result["Green Thumb"]).toBe(1);
+    expect(result["Iron Bumpkin"]).toBe(3);
+  });
+
+  it("does not mutate the input object", () => {
+    const skills: Skills = { "Green Thumb": 3 };
+    downgradeChapterCropWeekSkills(skills);
+    expect(skills["Green Thumb"]).toBe(3);
+  });
+
+  it("returns the same reference when nothing needs capping", () => {
+    const skills: Skills = { "Iron Bumpkin": 3, "Green Thumb": 1 };
+    expect(downgradeChapterCropWeekSkills(skills)).toBe(skills);
+  });
+});
+
+describe("hasUpgradedChapterCropWeekSkill", () => {
+  it("is true when a skill in the tree is rank 2+", () => {
+    expect(hasUpgradedChapterCropWeekSkill({ "Green Thumb": 2 }, "Crops")).toBe(
+      true,
+    );
+    expect(
+      hasUpgradedChapterCropWeekSkill({ "Double Nom": 3 }, "Cooking"),
+    ).toBe(true);
+  });
+
+  it("is false at rank 1 (base effect still applies)", () => {
+    expect(hasUpgradedChapterCropWeekSkill({ "Green Thumb": 1 }, "Crops")).toBe(
+      false,
+    );
+  });
+
+  it("respects the tree argument", () => {
+    // A rank-2 Cooking skill does not trigger the Crops notice, and vice versa.
+    expect(hasUpgradedChapterCropWeekSkill({ "Double Nom": 2 }, "Crops")).toBe(
+      false,
+    );
+    expect(
+      hasUpgradedChapterCropWeekSkill({ "Green Thumb": 2 }, "Cooking"),
+    ).toBe(false);
+  });
+
+  it("ignores upgraded skills from unrelated trees", () => {
+    expect(
+      hasUpgradedChapterCropWeekSkill({ "Iron Bumpkin": 3 }, "Crops"),
+    ).toBe(false);
+  });
+
+  it("ignores in-tree skills that can't affect the event item", () => {
+    // Frosted Cakes only affects cakes, and Saltbite is not a cake.
+    expect(
+      hasUpgradedChapterCropWeekSkill({ "Frosted Cakes": 3 }, "Cooking"),
+    ).toBe(false);
+    // Young Farmer (basic) / Old Farmer (advanced) don't affect medium Saltwort.
+    expect(
+      hasUpgradedChapterCropWeekSkill({ "Young Farmer": 3 }, "Crops"),
+    ).toBe(false);
+    expect(hasUpgradedChapterCropWeekSkill({ "Old Farmer": 3 }, "Crops")).toBe(
+      false,
+    );
+  });
+});
+
+describe("CHAPTER_CROP_WEEK notice-skill assumptions", () => {
+  // The notice skill sets are hand-picked from the event items' properties; guard
+  // those assumptions so a future crop/recipe tweak fails loudly here instead of
+  // silently mis-showing (or hiding) the "boosts paused" notice.
+  it("Saltwort is a medium plot crop", () => {
+    expect(isMediumCrop(CHAPTER_CROP_WEEK_CROP)).toBe(true);
+  });
+
+  it("Saltbite is a non-cake Fire Pit recipe", () => {
+    expect(COOKABLES[CHAPTER_CROP_WEEK_RECIPE].building).toBe("Fire Pit");
+    expect(CHAPTER_CROP_WEEK_RECIPE in COOKABLE_CAKES).toBe(false);
+  });
+});

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -4662,6 +4662,56 @@ export const isUpgradeableSkillName = (
   name: BumpkinRevampSkillName,
 ): name is UpgradeableSkillName => name in SKILL_RANKS;
 
+// Upgradeable Cooking/Crops skills whose upgraded rank is neutralised on the
+// CHAPTER_CROP_WEEK event items (the Saltwort crop and the Saltbite recipe).
+// Derived from the tree (tree === Cooking/Crops + an `upgrade` block) so it can
+// never drift from which skills are actually upgradeable.
+export const CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS: Set<UpgradeableSkillName> =
+  new Set(
+    getKeys(BUMPKIN_REVAMP_SKILL_TREE).filter(
+      (name): name is UpgradeableSkillName => {
+        const { tree } = BUMPKIN_REVAMP_SKILL_TREE[name];
+        return (tree === "Cooking" || tree === "Crops") && name in SKILL_RANKS;
+      },
+    ),
+  );
+
+// Returns `skills` with every upgradeable Cooking/Crops skill capped at rank 1
+// (the base skill still applies, but the upgraded rank grants no extra bonus).
+// Used to neutralise upgraded skill effects on the CHAPTER_CROP_WEEK event items
+// WITHOUT mutating the player's real ranks — callers pass the result only into the
+// Saltwort/Saltbite boost math and keep the original ranks everywhere else. Returns
+// the original object untouched when nothing needs capping (the common case).
+export const downgradeChapterCropWeekSkills = (skills: Skills): Skills => {
+  let result: Skills | undefined;
+  for (const name of CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS) {
+    if ((skills[name] ?? 0) > 1) {
+      result = result ?? { ...skills };
+      result[name] = 1;
+    }
+  }
+  return result ?? skills;
+};
+
+// Whether the player owns an UPGRADED (rank 2+) skill in the given tree that the
+// CHAPTER_CROP_WEEK event neutralises. Drives the "ascension boosts paused" notice
+// in the Market (Crops) and Fire Pit (Cooking) — a rank-1 skill still applies its
+// base effect on the event items, so it does not count.
+export const hasUpgradedChapterCropWeekSkill = (
+  skills: Skills,
+  tree: "Crops" | "Cooking",
+): boolean => {
+  for (const name of CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS) {
+    if (
+      BUMPKIN_REVAMP_SKILL_TREE[name].tree === tree &&
+      (skills[name] ?? 0) >= 2
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 // Effective "1 in N" gold chance shown to players for Golden Sunflower per rank.
 // Derived from the mechanical dropChance so the display can't drift: prngChance
 // fires when prngValue*100 < chance, so the player-facing odds are 100 / chance

--- a/src/features/game/types/bumpkinSkills.ts
+++ b/src/features/game/types/bumpkinSkills.ts
@@ -4666,15 +4666,16 @@ export const isUpgradeableSkillName = (
 // CHAPTER_CROP_WEEK event items (the Saltwort crop and the Saltbite recipe).
 // Derived from the tree (tree === Cooking/Crops + an `upgrade` block) so it can
 // never drift from which skills are actually upgradeable.
-export const CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS: Set<UpgradeableSkillName> =
-  new Set(
-    getKeys(BUMPKIN_REVAMP_SKILL_TREE).filter(
-      (name): name is UpgradeableSkillName => {
-        const { tree } = BUMPKIN_REVAMP_SKILL_TREE[name];
-        return (tree === "Cooking" || tree === "Crops") && name in SKILL_RANKS;
-      },
-    ),
-  );
+// Module-private so no other module can mutate this shared set (it drives the
+// event-item downgrade + the "boosts paused" notice); callers use the helpers below.
+const CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS: Set<UpgradeableSkillName> = new Set(
+  getKeys(BUMPKIN_REVAMP_SKILL_TREE).filter(
+    (name): name is UpgradeableSkillName => {
+      const { tree } = BUMPKIN_REVAMP_SKILL_TREE[name];
+      return (tree === "Cooking" || tree === "Crops") && name in SKILL_RANKS;
+    },
+  ),
+);
 
 // Returns `skills` with every upgradeable Cooking/Crops skill capped at rank 1
 // (the base skill still applies, but the upgraded rank grants no extra bonus).
@@ -4693,24 +4694,47 @@ export const downgradeChapterCropWeekSkills = (skills: Skills): Skills => {
   return result ?? skills;
 };
 
-// Whether the player owns an UPGRADED (rank 2+) skill in the given tree that the
-// CHAPTER_CROP_WEEK event neutralises. Drives the "ascension boosts paused" notice
-// in the Market (Crops) and Fire Pit (Cooking) — a rank-1 skill still applies its
-// base effect on the event items, so it does not count.
+// The upgradeable skills whose downgrade actually changes a CHAPTER_CROP_WEEK
+// event item's result: Saltwort is a MEDIUM plot crop and Saltbite is a Fire-Pit
+// (non-cake) recipe, so only the skills that mechanically apply to those are
+// listed — e.g. Frosted Cakes (cakes only) and basic/advanced farmer skills are
+// excluded because they can never affect Saltbite / medium Saltwort.
+//
+// `downgradeChapterCropWeekSkills` intentionally caps the WHOLE Crops/Cooking tree
+// (a correct superset — capping an inapplicable skill is a no-op for the event
+// item), so mechanics stay robust to crop/recipe tweaks; this list is a subset of
+// it, so the notice can never claim a suppression the mechanics don't make.
+const CHAPTER_CROP_WEEK_NOTICE_SKILLS: Record<
+  "Crops" | "Cooking",
+  readonly UpgradeableSkillName[]
+> = {
+  // Green Thumb (growth, all crops), Experienced Farmer (medium yield), Acre Farm
+  // (debuffs medium), Hectare Farm (buffs medium), Horror Mike (Scary Mike AOE,
+  // medium). See getCropYieldAmount / getCropPlotTime for the class gates.
+  Crops: [
+    "Green Thumb",
+    "Experienced Farmer",
+    "Acre Farm",
+    "Hectare Farm",
+    "Horror Mike",
+  ],
+  // Double Nom (cost + food, all recipes), Fast Feasts (Fire Pit time), Swift
+  // Sizzle (Fire Pit oil), Fiery Jackpot (Fire Pit crit). See cook / collectRecipe.
+  Cooking: ["Double Nom", "Fast Feasts", "Swift Sizzle", "Fiery Jackpot"],
+};
+
+// Whether the player owns an UPGRADED (rank 2+) skill that the CHAPTER_CROP_WEEK
+// event actually neutralises for its item. Drives the "ascension boosts paused"
+// notice in the Market (Crops → Saltwort) and Fire Pit (Cooking → Saltbite) — a
+// rank-1 skill still applies its base effect, and a skill that can't affect the
+// event item never counts, so the notice only shows a real, suppressed boost.
 export const hasUpgradedChapterCropWeekSkill = (
   skills: Skills,
   tree: "Crops" | "Cooking",
-): boolean => {
-  for (const name of CHAPTER_CROP_WEEK_DOWNGRADED_SKILLS) {
-    if (
-      BUMPKIN_REVAMP_SKILL_TREE[name].tree === tree &&
-      (skills[name] ?? 0) >= 2
-    ) {
-      return true;
-    }
-  }
-  return false;
-};
+): boolean =>
+  CHAPTER_CROP_WEEK_NOTICE_SKILLS[tree].some(
+    (name) => (skills[name] ?? 0) >= 2,
+  );
 
 // Effective "1 in N" gold chance shown to players for Golden Sunflower per rank.
 // Derived from the mechanical dropChance so the display can't drift: prngChance

--- a/src/features/island/buildings/components/building/Recipes.tsx
+++ b/src/features/island/buildings/components/building/Recipes.tsx
@@ -28,7 +28,12 @@ import {
   MAX_COOKING_SLOTS,
 } from "features/game/events/landExpansion/cook";
 import type { CookingBuildingName } from "features/game/types/buildings";
-import { SKILL_RANKS, getSkillLevel } from "features/game/types/bumpkinSkills";
+import {
+  SKILL_RANKS,
+  getSkillLevel,
+  downgradeChapterCropWeekSkills,
+  hasUpgradedChapterCropWeekSkill,
+} from "features/game/types/bumpkinSkills";
 import { BuildingOilTank } from "./BuildingOilTank";
 import pumpkinSoup from "assets/food/pumpkin_soup.png";
 import powerup from "assets/icons/level_up.png";
@@ -183,7 +188,18 @@ export const Recipes: React.FC<Props> = ({
   const isOilBoosted = buildingCrafting.find(
     (recipe) => recipe.name === selected.name && recipe.boost?.["Oil"],
   );
-  const doubleNomLevel = getSkillLevel(bumpkin.skills, "Double Nom");
+  // Saltbite (the CHAPTER_CROP_WEEK event recipe) neutralises upgraded Cooking
+  // ranks, so preview the Double Nom label at its downgraded (applied) rank and
+  // surface a notice when a real upgraded rank is being suppressed.
+  const isEventRecipe = selected.name === CHAPTER_CROP_WEEK_RECIPE;
+  const doubleNomLevel = getSkillLevel(
+    isEventRecipe
+      ? downgradeChapterCropWeekSkills(bumpkin.skills)
+      : bumpkin.skills,
+    "Double Nom",
+  );
+  const showAscensionPausedNotice =
+    isEventRecipe && hasUpgradedChapterCropWeekSkill(bumpkin.skills, "Cooking");
   const isVIP = useVipAccess({ game: state });
   const isQueueFull =
     [...readyRecipes, ...queue].length + (cooking ? 1 : 0) >= availableSlots;
@@ -214,6 +230,11 @@ export const Recipes: React.FC<Props> = ({
               setShowTimeBoosts={setShowTimeBoosts}
               actionView={
                 <>
+                  {showAscensionPausedNotice && (
+                    <Label type="warning">
+                      {t("chapterCropWeek.ascensionBoostsPaused")}
+                    </Label>
+                  )}
                   {doubleNomLevel > 0 && (
                     <Label type="success" icon={powerup}>
                       {`Double Nom Boost: +${

--- a/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalCrops.tsx
@@ -37,6 +37,7 @@ import {
   CHAPTER_CROP_WEEK_CROP,
   isChapterCropWeekActive,
 } from "features/game/types/chapterCropWeek";
+import { hasUpgradedChapterCropWeekSkill } from "features/game/types/bumpkinSkills";
 import { useNow } from "lib/utils/hooks/useNow";
 import { SpecialEventPanel } from "../SpecialEventPanel";
 
@@ -157,6 +158,15 @@ export const SeasonalCrops: React.FC = () => {
               }}
               actionView={
                 <>
+                  {selected.name === CHAPTER_CROP_WEEK_CROP &&
+                    hasUpgradedChapterCropWeekSkill(
+                      state.bumpkin.skills,
+                      "Crops",
+                    ) && (
+                      <Label type="warning" className="mb-1">
+                        {t("chapterCropWeek.ascensionBoostsPaused")}
+                      </Label>
+                    )}
                   <div className="flex flex-col h-full justify-between">
                     <div className="flex space-x-1 mb-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
                       {cropAmount.greaterThan(1) && (

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -81,6 +81,7 @@ import {
   CHAPTER_CROP_WEEK_SEED,
   isChapterCropWeekActive,
 } from "features/game/types/chapterCropWeek";
+import { hasUpgradedChapterCropWeekSkill } from "features/game/types/bumpkinSkills";
 
 export const SEASON_ICONS: Record<TemperateSeasonName, string> = {
   spring: springIcon,
@@ -191,6 +192,12 @@ export const SeasonalSeeds: React.FC = () => {
     // return buy buttons otherwise
     return (
       <>
+        {selectedName === CHAPTER_CROP_WEEK_SEED &&
+          hasUpgradedChapterCropWeekSkill(bumpkin.skills, "Crops") && (
+            <Label type="warning" className="mb-1">
+              {t("chapterCropWeek.ascensionBoostsPaused")}
+            </Label>
+          )}
         <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
           <Button
             disabled={lessFunds() || stock.lessThan(1)}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4832,6 +4832,7 @@
   "chapterCropWeek.specialEventRecipe": "Special Event Recipe",
   "chapterCropWeek.daysRemaining": "{{days}} days remaining",
   "chapterCropWeek.comingSoon": "This item will be tradeable during Chapter Crop Week. Check back soon!",
+  "chapterCropWeek.ascensionBoostsPaused": "Ascension skill boosts don't apply during Chapter Crop Week",
   "gems.speedUp": "Speed up",
   "crafting.readySoon": "{{name}} will be ready soon...",
   "crafting.expansionSoon": "Your land will be ready soon...",


### PR DESCRIPTION
## What

During **Chapter Crop Week**, upgraded (rank 2+) Crops and Cooking skills are treated as **rank 1 on the event items only** — the **Saltwort** crop and the **Saltbite** recipe. The base skill still applies; the ascension rank grants no extra bonus. Every other crop and recipe is completely unaffected.

Scope was deliberately narrowed to the event items (not a global week-long downgrade), so normal gameplay — and every existing test — is untouched.

## How

- New shared helper `downgradeChapterCropWeekSkills(skills)` in `bumpkinSkills.ts` caps the upgradeable Crops/Cooking ranks at 1, derived from the skill tree so it can't drift. Player ranks are never mutated.
- Each boost function swaps in the capped skills when its item is Saltwort/Saltbite:
  - **Saltwort** → crop yield + AOE (`getCropYieldAmount`), growth time (`getCropTime` / `getCropPlotTime`)
  - **Saltbite** → ingredient cost + Double Nom snapshot (`getCookingRequirements`, `cook`), oil boost + cook time (`getCookingOilBoost`, `getCookingTime`), live Fiery Jackpot (`getCookingAmount`)
- Double Nom's `+food` payout reads the per-recipe snapshot, so a recipe cooked at rank 1 collects at rank 1.

## UI

Shows an **"Ascension skill boosts don't apply during Chapter Crop Week"** notice — only when the player owns a suppressed rank-2+ skill — in the Market (Saltwort seed/crop panels) and the Fire Pit (Saltbite). The Fire Pit Double Nom label now previews the applied (downgraded) rank so the panel isn't self-contradictory. New key added to `dictionary.json` only.

## Tests

Paired tests prove the scoping: rank-3 Experienced Farmer / Green Thumb / Double Nom give the **rank-1** result on Saltwort/Saltbite, while the same rank-3 skill on Cabbage / Corn / Boiled Eggs keeps the **full** bonus. All pre-existing suites pass unchanged; `tsc` + ESLint clean.

Backend companion PR mirrors the reducer logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chapter Crop Week warnings in seasonal seed/crop sell flows and recipe UI when ascension skill boosts are paused.
  * Updated Double Nom handling to support legacy and ranked values.

* **Bug Fixes**
  * Made Chapter Crop Week cooking, crop yield, planting timing, and harvesting bonuses consistently use event-appropriate (rank-1) effects, preventing upgraded ranks from applying.
  * Fixed Double Nom cost/collection behavior for Saltbite to match the intended rank context.

* **Tests**
  * Added/expanded automated coverage for Chapter Crop Week harvest, planting timing, and Saltbite cooking scenarios (including skill neutralization helpers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->