### PR TITLE
[FIX] Preserve active power-skill cooldown when upgrading a skill rank

### DIFF
--- a/src/features/game/events/landExpansion/upgradeSkill.test.ts
+++ b/src/features/game/events/landExpansion/upgradeSkill.test.ts
@@ -4,6 +4,9 @@ import { LEVEL_EXPERIENCE } from "features/game/lib/level";
 import { CONFIG } from "lib/config";
 import { upgradeSkill } from "./upgradeSkill";
 import { getAvailableBumpkinSkillPoints } from "./choseSkill";
+import { getSkillCooldown } from "./skillUsed";
+
+const HOUR = 60 * 60 * 1000;
 
 describe("upgradeSkill", () => {
   const dateNow = Date.now();
@@ -258,6 +261,112 @@ describe("upgradeSkill", () => {
         createdAt: dateNow,
       }),
     ).toThrow("This skill cannot be upgraded");
+  });
+
+  describe("power-skill cooldown re-anchoring on upgrade", () => {
+    // Instant Growth is a Tier 3 Crops power skill with a cooldown that shrinks
+    // per rank: rank 1 = 72h, rank 2 = 60h. Upgrading while it is on cooldown
+    // must NOT retroactively shorten the active cooldown — the current ready
+    // time (previousPowerUseAt + oldCooldown) has to stay put.
+    const cooldownState = (previousPowerUseAt?: number) => ({
+      ...TEST_FARM,
+      inventory: {
+        ...TEST_FARM.inventory,
+        "Ascension Shard": new Decimal(5),
+      },
+      bumpkin: {
+        ...INITIAL_BUMPKIN,
+        experience: LEVEL_EXPERIENCE[20],
+        skills: { ...CROPS_TIER_3, "Instant Growth": 1 },
+        ...(previousPowerUseAt !== undefined
+          ? { previousPowerUseAt: { "Instant Growth": previousPowerUseAt } }
+          : {}),
+      },
+    });
+
+    it("preserves the current ready time when upgrading mid-cooldown", () => {
+      const usedAt = dateNow - HOUR; // 1h into a 72h cooldown
+      const result = upgradeSkill({
+        state: cooldownState(usedAt),
+        action: { type: "skill.upgraded", skill: "Instant Growth" },
+        createdAt: dateNow,
+      });
+
+      expect(result.bumpkin?.skills["Instant Growth"]).toEqual(2);
+
+      // Stamp is pushed forward by (72h - 60h) so the ready time is unchanged.
+      const newStamp = result.bumpkin?.previousPowerUseAt?.["Instant Growth"];
+      expect(newStamp).toEqual(usedAt + (72 * HOUR - 60 * HOUR));
+
+      // Ready time (stamp + rank-2 cooldown) equals the pre-upgrade ready time.
+      const newCooldown = getSkillCooldown({
+        cooldown: 72 * HOUR,
+        state: result,
+        skillName: "Instant Growth",
+      });
+      expect((newStamp ?? 0) + newCooldown).toEqual(usedAt + 72 * HOUR);
+    });
+
+    it("does not touch the stamp when the skill is already off cooldown", () => {
+      const usedAt = dateNow - 100 * HOUR; // past the 72h cooldown
+      const result = upgradeSkill({
+        state: cooldownState(usedAt),
+        action: { type: "skill.upgraded", skill: "Instant Growth" },
+        createdAt: dateNow,
+      });
+
+      expect(result.bumpkin?.previousPowerUseAt?.["Instant Growth"]).toEqual(
+        usedAt,
+      );
+    });
+
+    it("does not create a stamp when the power was never used", () => {
+      const result = upgradeSkill({
+        state: cooldownState(),
+        action: { type: "skill.upgraded", skill: "Instant Growth" },
+        createdAt: dateNow,
+      });
+
+      expect(
+        result.bumpkin?.previousPowerUseAt?.["Instant Growth"],
+      ).toBeUndefined();
+    });
+
+    it("keeps the ready time invariant with Luna's Crescent equipped", () => {
+      const usedAt = dateNow - HOUR;
+      const state = {
+        ...cooldownState(usedAt),
+        bumpkin: {
+          ...cooldownState(usedAt).bumpkin,
+          equipped: {
+            ...INITIAL_BUMPKIN.equipped,
+            tool: "Luna's Crescent" as const,
+          },
+        },
+      };
+
+      const oldCooldown = getSkillCooldown({
+        cooldown: 72 * HOUR,
+        state,
+        skillName: "Instant Growth",
+      });
+      const oldReadyAt = usedAt + oldCooldown;
+
+      const result = upgradeSkill({
+        state,
+        action: { type: "skill.upgraded", skill: "Instant Growth" },
+        createdAt: dateNow,
+      });
+
+      const newStamp =
+        result.bumpkin?.previousPowerUseAt?.["Instant Growth"] ?? 0;
+      const newCooldown = getSkillCooldown({
+        cooldown: 72 * HOUR,
+        state: result,
+        skillName: "Instant Growth",
+      });
+      expect(newStamp + newCooldown).toEqual(oldReadyAt);
+    });
   });
 
   describe("when ASCENSION_SKILLS is off (mainnet)", () => {

--- a/src/features/game/events/landExpansion/upgradeSkill.ts
+++ b/src/features/game/events/landExpansion/upgradeSkill.ts
@@ -13,6 +13,7 @@ import {
   getAvailableBumpkinSkillPoints,
   getUnlockedTierForTree,
 } from "./choseSkill";
+import { getSkillCooldown } from "./skillUsed";
 
 export type UpgradeSkillAction = {
   type: "skill.upgraded";
@@ -25,7 +26,11 @@ type Options = {
   createdAt?: number;
 };
 
-export function upgradeSkill({ state, action }: Options): GameState {
+export function upgradeSkill({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
   return produce(state, (game) => {
     const { bumpkin } = game;
 
@@ -88,7 +93,31 @@ export function upgradeSkill({ state, action }: Options): GameState {
     }
 
     game.inventory["Ascension Shard"] = shards.sub(cost.shards);
+
+    // Power-skill cooldowns shrink with rank and are evaluated live against the
+    // current rank. If the skill is on cooldown when it is upgraded, recomputing
+    // the gate with the shorter cooldown would retroactively shorten — or clear —
+    // the active cooldown. Capture the effective cooldown at the old rank first,
+    // then re-anchor `previousPowerUseAt` so the current ready time is preserved;
+    // the shorter cooldown only applies to the next use.
+    const prevUse = bumpkin.previousPowerUseAt?.[action.skill];
+    const oldCooldown = getSkillCooldown({
+      cooldown: skillData.requirements.cooldown ?? 0,
+      state: game,
+      skillName: action.skill,
+    });
+
     bumpkin.skills[action.skill] = currentLevel + 1;
+
+    if (prevUse !== undefined && prevUse + oldCooldown > createdAt) {
+      const newCooldown = getSkillCooldown({
+        cooldown: skillData.requirements.cooldown ?? 0,
+        state: game,
+        skillName: action.skill,
+      });
+      bumpkin.previousPowerUseAt![action.skill] =
+        prevUse + (oldCooldown - newCooldown);
+    }
 
     return game;
   });


### PR DESCRIPTION
## Problem

Power-skill readiness is evaluated **live** as `previousPowerUseAt[skill] + getSkillCooldown(currentRank)`. Cooldown-kind skills shrink their cooldown per rank (e.g. Instant Growth `72h → 60h → 48h`), so upgrading a skill **while its power was on cooldown** recomputed the gate against the shorter value and retroactively shortened — or fully cleared — the active cooldown.

**Exploit:** use Instant Growth at rank 1 (ready in 72h), wait 50h, upgrade to rank 3 (48h cd) → immediately usable again. The rank-up buys the player out of an in-progress cooldown.

## Fix

In `upgradeSkill`, capture the effective cooldown at the *old* rank, bump the rank, and — only when the skill is still on cooldown — re-anchor `previousPowerUseAt` so the current ready time is preserved. The shorter cooldown now applies to the **next** use only.

- Uses `getSkillCooldown` (not the raw ranks array) so Luna's Crescent 0.5× is respected and the on-screen countdown is preserved exactly at the moment of upgrade.
- Non-cooldown-kind upgradeable power skills → `oldCooldown === newCooldown` → zero-delta no-op.

`resetSkills` not clearing `previousPowerUseAt` is left as-is (conservative; out of scope).

## Tests

New `describe("power-skill cooldown re-anchoring on upgrade")` block (confirmed red before the fix):
- mid-cooldown upgrade preserves the ready time
- off-cooldown upgrade is a no-op on the stamp
- never-used power creates no stamp
- ready time stays invariant with Luna's Crescent equipped

Paired with backend PR sunflower-land-api (same re-anchor logic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed power-skill cooldowns when upgrading skills mid-cooldown.
  - Upgrading a skill now preserves its current ready time instead of prematurely shortening or clearing the active cooldown.
  - Cooldown reductions apply correctly to the next available use.
  - Improved handling when a skill has no prior use, is already ready, or is used with Luna’s Crescent equipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->