### PR TITLE
[FIX] Allow home-expansion upgrades on ascension islands past volcano

### DIFF
--- a/src/features/game/events/landExpansion/upgradeInterior.test.ts
+++ b/src/features/game/events/landExpansion/upgradeInterior.test.ts
@@ -83,13 +83,21 @@ describe("upgradeInterior (interior.upgrade)", () => {
     ).toHaveLength(1);
   });
 
-  it("rejects upgrade when not on volcano island", () => {
+  it("rejects upgrade when not yet on volcano island", () => {
     expect(() =>
       upgradeInterior({
         state: { ...richVolcanoState(), island: { type: "spring" } },
         action: { type: "interior.upgrade" },
       }),
     ).toThrow(UPGRADE_INTERIOR_ERRORS.NOT_ON_VOLCANO);
+  });
+
+  it("allows upgrade on ascension islands past volcano", () => {
+    const next = upgradeInterior({
+      state: { ...richVolcanoState(), island: { type: "swamp" } },
+      action: { type: "interior.upgrade" },
+    });
+    expect(next.interior.expansion).toBe("level-one-start");
   });
 
   it("rejects upgrade once expansion is level-one-full", () => {

--- a/src/features/game/events/landExpansion/upgradeInterior.ts
+++ b/src/features/game/events/landExpansion/upgradeInterior.ts
@@ -6,6 +6,7 @@ import type {
   InventoryItemName,
 } from "features/game/types/game";
 import { nextHomeExpansionTier } from "features/game/expansion/placeable/lib/interiorLayouts";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import {
   HOME_EXPANSION_UPGRADE_REQUIREMENTS,
   type UpgradeCost,
@@ -14,7 +15,7 @@ import { getKeys } from "lib/object";
 
 export enum UPGRADE_INTERIOR_ERRORS {
   NO_ACCESS = "Home expansions are not available for this player",
-  NOT_ON_VOLCANO = "Interior upgrades are only available on volcano island",
+  NOT_ON_VOLCANO = "Interior upgrades are only available from volcano island onwards",
   ALREADY_MAXED = "Interior is already at maximum tier (level-one-full)",
   INSUFFICIENT_COINS = "Not enough coins to perform this upgrade",
   INSUFFICIENT_INVENTORY = "Not enough inventory items to perform this upgrade",
@@ -73,7 +74,7 @@ export function upgradeInterior({
     if (!game.settings.interiorsEnabled) {
       throw new Error(UPGRADE_INTERIOR_ERRORS.NO_ACCESS);
     }
-    if (game.island.type !== "volcano") {
+    if (!hasRequiredIslandExpansion(game.island.type, "volcano")) {
       throw new Error(UPGRADE_INTERIOR_ERRORS.NOT_ON_VOLCANO);
     }
 

--- a/src/features/interior/components/UpgradeButton.tsx
+++ b/src/features/interior/components/UpgradeButton.tsx
@@ -12,6 +12,7 @@ import type {
   HomeExpansionTier,
   InventoryItemName,
 } from "features/game/types/game";
+import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import { nextHomeExpansionTier } from "features/game/expansion/placeable/lib/interiorLayouts";
 import { HOME_EXPANSION_UPGRADE_REQUIREMENTS } from "../lib/upgradeRequirements";
 import { getKeys } from "lib/object";
@@ -32,8 +33,10 @@ const _hasInteriorAccess = (state: MachineState) =>
  * a MapPlacement by the caller so it sits on the gameboard at a chosen tile
  * (see UPGRADE_BUTTON_TILE in Interior.tsx / LevelOne.tsx).
  *
- * Self-hides when the `interiors` experiment is off, when the player isn't on volcano island,
- * and when the expansion is already maxed at level-one-full.
+ * Self-hides when the `interiors` experiment is off, when the player hasn't
+ * reached volcano yet (home expansions unlock at volcano and carry forward
+ * through every later ascension island), and when the expansion is already
+ * maxed at level-one-full.
  *
  * Clicking opens a small panel showing the next tier's coin + inventory cost
  * and a confirm button. Confirm dispatches the `interior.upgrade` event; on
@@ -54,8 +57,9 @@ export const UpgradeButton: React.FC = () => {
 
   // Hide for non-beta players.
   if (!hasAccess) return null;
-  // Only show on volcano.
-  if (island.type !== "volcano") return null;
+  // Home expansions unlock at volcano and stay available on every island
+  // reached after it (swamp, spooky, etc. — see ISLAND_EXPANSIONS ordering).
+  if (!hasRequiredIslandExpansion(island.type, "volcano")) return null;
 
   const targetTier: HomeExpansionTier | null = expansion
     ? nextHomeExpansionTier(expansion)


### PR DESCRIPTION
## Summary
The Upgrade button and the `interior.upgrade` event handler both hard-gated on `island.type === "volcano"`, so ascending to swamp/spooky/etc. after volcano silently took away the ability to unlock further home-expansion tiers. Home expansions unlock at volcano and should carry forward through every later ascension island, matching the existing floor-navigation gate (`hasRequiredIslandExpansion(island.type, "volcano")`) — applied the same check here instead of an exact island match.

## Context
Split out from #7457 — that commit landed in main before this follow-up commit was pushed, so it never made it into the merge. Cherry-picked from the same branch.

## Test plan
- [x] Added a unit test asserting `interior.upgrade` succeeds on `swamp`; existing pre-volcano rejection test (`spring`) still passes.
- [ ] Confirm the in-world Upgrade button appears and works on swamp (and later ascension islands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interior upgrades are now available starting from volcano island and remain available on later ascension islands.
* **Bug Fixes**
  * Fixed upgrade eligibility so valid later-stage islands are no longer incorrectly blocked.
* **UI Updates**
  * The interior upgrade button now unlocks based on expansion progression (volcano onward), matching the updated availability messaging.
* **Tests**
  * Added coverage for interior upgrades on eligible ascension island types after volcano.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->