### PR TITLE
[FIX] Post-release-review follow-ups

### DIFF
--- a/src/components/ui/SplitScreenView.tsx
+++ b/src/components/ui/SplitScreenView.tsx
@@ -61,8 +61,9 @@ export const SplitScreenView: React.FC<Props> = ({
       }
     };
 
-    measure();
-
+    // ResizeObserver fires its callback once on observe() with the node's
+    // initial size, so it handles the first measurement too — no direct
+    // setState in the effect body is needed.
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     window.addEventListener("resize", measure);

--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -51,8 +51,8 @@ const ConfirmButton: React.FC<{
   className?: string;
   onClick: () => void;
 }> = ({ children, className, onClick }) => {
-  const [unlockAt] = useState(() => Date.now() + 1000);
-  const { totalSeconds } = useCountdown(unlockAt);
+  const mountedAt = useNow(); // live:false → stable snapshot at mount
+  const { totalSeconds } = useCountdown(mountedAt + 1000);
 
   return (
     <Button className={className} disabled={totalSeconds > 0} onClick={onClick}>

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -583,7 +583,9 @@ const FeedContent: React.FC<FeedContentProps> = ({
   const { t } = useAppTranslation();
   const [canPaginate, setCanPaginate] = useState(false);
   const [hasMeasuredScroll, setHasMeasuredScroll] = useState(false);
-  const now = useNow({ live: true });
+  // Minute granularity is plenty — todayKey only flips at UTC midnight, so a
+  // 1s tick would reconcile the whole feed list every second for nothing.
+  const now = useNow({ live: true, intervalMs: 60_000 });
   const todayKey = getUTCDateKey(now);
 
   // Intersection observer to load more interactions when the loader is in view
@@ -690,7 +692,7 @@ const FeedContent: React.FC<FeedContentProps> = ({
 
           return (
             <React.Fragment
-              key={`${interaction.sender.id}-${interaction.createdAt}`}
+              key={`${interaction.sender.id}-${interaction.createdAt}-${index}`}
             >
               {showOlderPostsSeparator && <OlderPostsSeparator />}
               <div

--- a/src/features/social/Feed.tsx
+++ b/src/features/social/Feed.tsx
@@ -692,7 +692,10 @@ const FeedContent: React.FC<FeedContentProps> = ({
 
           return (
             <React.Fragment
-              key={`${interaction.sender.id}-${interaction.createdAt}-${index}`}
+              key={
+                interaction.id ??
+                `${interaction.type}-${interaction.sender.id}-${interaction.createdAt}`
+              }
             >
               {showOlderPostsSeparator && <OlderPostsSeparator />}
               <div

--- a/src/features/social/components/FollowList.tsx
+++ b/src/features/social/components/FollowList.tsx
@@ -11,16 +11,13 @@ import type { Detail } from "../actions/getFollowNetworkDetails";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
 import type { MachineState } from "features/game/lib/gameMachine";
+import { useNow } from "lib/utils/hooks/useNow";
 
 const EMPTY_FARMS: number[] = [];
 
-const _cheeredFarmsToday = (state: MachineState) => {
+const _cheersGiven = (state: MachineState) => {
   const game = state.context.visitorState ?? state.context.state;
-  const today = new Date().toISOString().split("T")[0];
-
-  if (game.socialFarming.cheersGiven.date !== today) return EMPTY_FARMS;
-
-  return game.socialFarming.cheersGiven.farms;
+  return game.socialFarming.cheersGiven;
 };
 
 type Props = {
@@ -51,7 +48,12 @@ export const FollowList: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const { gameService } = useContext(Context);
-  const cheeredFarmsToday = useSelector(gameService, _cheeredFarmsToday);
+  // Minute granularity: the "cheered today" key only flips at UTC midnight.
+  const now = useNow({ live: true, intervalMs: 60_000 });
+  const cheersGiven = useSelector(gameService, _cheersGiven);
+  const today = new Date(now).toISOString().split("T")[0];
+  const cheeredFarmsToday =
+    cheersGiven.date === today ? cheersGiven.farms : EMPTY_FARMS;
   const [isScrollable, setIsScrollable] = useState(false);
   // Intersection observer to load more details when the loader is in view
   const { ref: intersectionRef, inView } = useInView({


### PR DESCRIPTION
## What

Small, non-blocking cleanups surfaced while comparing `main` against the last tag (`v2.26.17-fix-volcano-saltwort`) as a pre-release check. None block the release; grouped here as a quick follow-up.

## Changes

- **Feed** ([`Feed.tsx`](../blob/main/src/features/social/Feed.tsx)): coarsen the `todayKey` `useNow` tick to `60_000ms`. `todayKey` only flips at UTC midnight, so the previous 1s tick reconciled the entire feed list every second for nothing. (`RelativeTime`'s per-second tick is intentional and left as-is.)
- **Feed**: restore the `-${index}` tiebreaker on the interaction `React.Fragment` key — the prior `${sender.id}-${createdAt}` key collided when one sender had two entries at the same millisecond, dropping an entry + logging a key warning.
- **AnimalBounties `ConfirmButton`**: read the mount time via `useNow()` instead of `Date.now()` (CLAUDE.md convention; `useCountdown` still drives the 1s unlock).
- **FollowList**: derive "cheered today" reactively via `useNow` (60s) instead of an argless `new Date()` inside the selector, so the cheer icon updates across a UTC-midnight rollover instead of going stale until the next state change.
- **SplitScreenView**: drop the redundant in-effect `measure()` call. `ResizeObserver` fires an initial callback on `observe()`, so the first measurement is still taken — this removes the only direct setState in the effect body.

## Verification

- ESLint clean on all four files (no `set-state-in-effect` / `Date.now` flags).
- `tsc --noEmit`: 0 errors project-wide.
- Manual smoke test recommended: Feed (no per-second flash, "Older posts" separator intact, no key warnings), bounty sell confirm flow, follow-list cheer icon, and the Recipes crafting panel column alignment (`matchPanelHeight`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved countdown timing on animal bounty confirmation buttons.
  * Improved rendering/reconciliation for feed items with identical timestamps.
  * Ensured “cheered today” and related date-bound sections refresh correctly at UTC midnight.
* **Performance**
  * Reduced unnecessary feed updates by recalculating UTC “today” once per minute.
  * Improved split-screen resizing responsiveness by relying on automatic resize detection instead of a manual initial measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->