### PR TITLE
[FIX] Allow deselecting bulk pet food

### DIFF
--- a/src/features/island/buildings/components/building/petHouse/PetCard.tsx
+++ b/src/features/island/buildings/components/building/petHouse/PetCard.tsx
@@ -241,7 +241,8 @@ export const PetCard: React.FC<Props> = ({
                 (item) => item.petId === petName && item.food === food,
               );
 
-            const isDisabled = !canFeed || alreadyFed || isFoodLocked;
+            const isDisabled =
+              (!canFeed && !isSelected) || alreadyFed || isFoodLocked;
 
             const xp = getPetExperience({
               basePetXP: getPetRequestXP(food),


### PR DESCRIPTION
## Summary

Keeps selected Pet House Bulk Feed cards interactive when the selected requests consume the full inventory balance. Players can now deselect and reselect food consistently whether they own one unit or multiple units.


## Context / motivation

https://discord.com/channels/880987707214544966/1347190192745742336/1528927555099562066

Bulk Feed automatically selects feedable pet requests and subtracts those selections from the inventory count displayed on each food card. When the available quantity exactly matched the selected requests, the adjusted count became zero.

The card availability check treated that zero balance as unavailable even for a card that was already selected. The selected card was then rendered as disabled, which removed its click handler and prevented the player from deselecting the reserved food.

This change only adjusts the card interaction state. It does not change inventory consumption, automatic Bulk Feed allocation, pet requests, rewards, or the bulk feed game event.

## Solution

The card remains enabled when it is already selected, even if the remaining unallocated inventory is zero. Unselected cards with no available food remain disabled, while the existing already-fed and level-lock restrictions are unchanged.

## How to test

1. Place multiple pets with outstanding food requests in a Pet House.
2. Add exactly one unit of one requested food to the inventory.
3. Add multiple units of another requested food, matching the number of pets requesting it.
4. Open the Pet House management panel and enable Bulk Feed.
5. Confirm the fully allocated foods display a remaining count of zero but their selected cards can still be clicked to deselect them.
6. Confirm deselecting restores the displayed available count and allows the card to be selected again.
7. Confirm unselected requests remain disabled when all available units are allocated to other pets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pet feeding controls during bulk-feed mode.
  * Selected food items remain available for adjustment when feeding is otherwise unavailable.
  * Existing restrictions for already-fed pets and locked foods remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->