### PR TITLE
[CHORE] Highlight selected Pet House bulk feed items

### DIFF
--- a/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
+++ b/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
@@ -72,7 +72,7 @@ export const FoodButtonPanel: React.FC<FoodButtonPanelProps> = ({
           <img
             src={SUNNYSIDE.icons.confirm}
             alt={foodFed ? "Fed" : "Selected"}
-            className="absolute top-0 left-0 w-4 h-4 object-contain z-10"
+            className="absolute top-0 left-0 w-5 h-5 object-contain z-10"
           />
         )}
 

--- a/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
+++ b/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
@@ -7,6 +7,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import classNames from "classnames";
 import type Decimal from "decimal.js-light";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 const INNER_CANVAS_WIDTH = 12;
 
@@ -35,6 +36,7 @@ export const FoodButtonPanel: React.FC<FoodButtonPanelProps> = ({
   locked,
   className,
 }) => {
+  const { t } = useAppTranslation();
   const foodImage = ITEM_DETAILS[food]?.image;
 
   return (
@@ -71,7 +73,7 @@ export const FoodButtonPanel: React.FC<FoodButtonPanelProps> = ({
         {(foodFed || selected) && (
           <img
             src={SUNNYSIDE.icons.confirm}
-            alt={foodFed ? "Fed" : "Selected"}
+            alt={foodFed ? t("pets.foodFedToday") : t("selected")}
             className="absolute top-0 left-0 w-5 h-5 object-contain z-10"
           />
         )}

--- a/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
+++ b/src/features/island/buildings/components/building/petHouse/FoodButtonPanel.tsx
@@ -68,10 +68,10 @@ export const FoodButtonPanel: React.FC<FoodButtonPanelProps> = ({
           />
         )}
 
-        {foodFed && (
+        {(foodFed || selected) && (
           <img
             src={SUNNYSIDE.icons.confirm}
-            alt="Locked"
+            alt={foodFed ? "Fed" : "Selected"}
             className="absolute top-0 left-0 w-4 h-4 object-contain z-10"
           />
         )}


### PR DESCRIPTION
## Summary

Just increase contrast between Selected and Unselected food for bulk feeding. 

Adds a clear green confirmation icon to food cards selected in Pet House Bulk Feed mode. Selected cards remain at full opacity so they are visually distinct from both already-fed and unselected food.

## Context / motivation

Bulk Feed currently presents three food-card states: already fed, selected for the pending bulk feed, and not selected. The selected and unselected states rely mainly on the panel border treatment, which makes them easy to confuse when scanning several pets and requests.

The existing green confirmation icon already communicates a completed feed clearly. Reusing that familiar visual for the pending selection creates a stronger selection signal without introducing a new asset or interaction pattern.

This UI-only chore is intentionally separate from the Bulk Feed deselection fix in #7463. It does not change selection logic, inventory allocation, feeding behavior, rewards, or game state.

## Solution

The existing confirmation icon is now rendered when a food card is either already fed or selected for Bulk Feed. Selected cards remain enabled and at full opacity, while already-fed cards keep their existing disabled opacity. The icon also receives an accurate `Fed` or `Selected` accessible label for the displayed state.

## How to test

1. Open a Pet House containing multiple pets with outstanding food requests.
2. Enter Bulk Feed mode.
3. Confirm every automatically selected food card displays the green confirmation icon at full opacity.
4. Deselect a food card and confirm the icon disappears immediately.
5. Select it again and confirm the icon returns.
6. Confirm already-fed cards still show the same icon with their existing reduced opacity.
7. Confirm unselected cards show no confirmation icon.

## Screenshots or screen recording
<img width="896" height="653" alt="image" src="https://github.com/user-attachments/assets/b12ef97b-207f-4da9-ae18-564ae0057820" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the food selection indicator in the pet house.
  * The indicator now appears immediately when food is selected (not just after feeding), clearly distinguishing selected vs. fed states.
  * Updated the indicator icon to be larger and to use translated alt text for improved accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->