### PR TITLE
[FIX] Scope sick animal confirm lock

### DIFF
--- a/src/features/barn/components/AnimalBounties.tsx
+++ b/src/features/barn/components/AnimalBounties.tsx
@@ -427,9 +427,7 @@ export const AnimalDeal: React.FC<{
             <Button className="mr-1" onClick={onClose}>
               {t("cancel")}
             </Button>
-            <ConfirmButton key={confirmationKey} onClick={sell}>
-              {t("confirm")}
-            </ConfirmButton>
+            <Button onClick={sell}>{t("confirm")}</Button>
           </div>
         </Panel>
       )}


### PR DESCRIPTION
## Summary

My bad — fix for https://github.com/sunflower-land/sunflower-land/pull/7412

Fixes the sell confirmation regression where the one-second Confirm lock applied to every animal sale instead of only sick animal confirmations.

## Context / motivation
The misclick protection was added for the sick animal reduced-bounty flow, where the player needs a moment to notice the warning and reduced payout. Healthy animal confirmations should keep the original immediate Confirm behavior.

## What changed
- Keeps the one-second Confirm delay only in the sick animal confirmation branch.
- Restores the normal immediate Confirm button for healthy animal sales.
- Leaves the stale-state protection intact: if an animal becomes sick after the modal opens, the UI switches into the sick confirmation flow and the delay applies there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the animal sale confirmation flow so the confirm button can be selected immediately without being blocked by a countdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->