### PR TITLE
[FIX] Handle purchase.claimed/airdrop.claimed while in each other's state

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -1702,6 +1702,12 @@ export function startGame(authContext: AuthContext) {
         airdrop: {
           on: {
             "airdrop.claimed": (GAME_EVENT_HANDLERS as any)["airdrop.claimed"],
+            "purchase.claimed": (GAME_EVENT_HANDLERS as any)[
+              "purchase.claimed"
+            ],
+            RESET: {
+              target: "refreshing",
+            },
             CLOSE: {
               target: "playing",
             },
@@ -1731,6 +1737,7 @@ export function startGame(authContext: AuthContext) {
             "purchase.claimed": (GAME_EVENT_HANDLERS as any)[
               "purchase.claimed"
             ],
+            "airdrop.claimed": (GAME_EVENT_HANDLERS as any)["airdrop.claimed"],
             RESET: {
               target: "refreshing",
             },


### PR DESCRIPTION
## Summary
Split out from #7430 per @adamhannigan's review — just the game-machine bugfix, no UI changes.

The `airdrop` and `marketplaceSale` states in the game machine only handled their own claim event:
- `airdrop` handled `airdrop.claimed` but not `purchase.claimed`
- `marketplaceSale` handled `purchase.claimed` but not `airdrop.claimed`

If a player had both an airdrop and a marketplace sale pending, claiming one while the other's popup was open would silently drop the event (it doesn't match any transition on the current state), instead of applying it.

Also added `RESET` to the `airdrop` state to match `marketplaceSale`/`offers`, so a stale signed listing there refreshes consistently instead of being the odd one out.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Confirm claiming an airdrop while a marketplace sale popup is open (and vice versa) applies correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game event handling so purchase claims and airdrop claims are processed correctly across the relevant game states.
  * Preserved existing reset and close behavior while ensuring claim events trigger the appropriate actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->