### PR TITLE
[FIX] "View trades" from a player's profile now opens their sale history

### DIFF
--- a/src/features/social/PlayerModal.tsx
+++ b/src/features/social/PlayerModal.tsx
@@ -294,7 +294,9 @@ export const PlayerModal: React.FC<Props> = ({
                 className="text-xxs underline cursor-pointer"
                 onClick={() => {
                   closeModal();
-                  navigate(`${marketplaceBase}/profile/${currentPlayerId}`);
+                  navigate(
+                    `${marketplaceBase}/profile/${currentPlayerId}/history`,
+                  );
                 }}
               >
                 {t("playerModal.viewTrades")}


### PR DESCRIPTION
## Summary
PR #7191 split the marketplace profile into separate routes: the bare `/profile/:id` now defaults to the `stats` view, and `/profile/:id/history` shows sale history.

`PlayerModal`'s "View trades" link was never updated and still navigates to the bare `/profile/:id` route. Clicking it from another player's profile now opens their stats screen instead of their trade/sale history, and there's no way to reach history from there since `MarketplaceUser` only switches view based on the route, not from any in-page control.

## Fix
Point the link at `/profile/:id/history` instead.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Click "View trades" on another player's profile modal and confirm it opens their Sale History (not Stats)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “View Trades” link to open the player’s trade history instead of their profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->