### PR TITLE
[FIX] Seed purchases permanently blocked by fractional inventory remainder

### DIFF
--- a/src/features/game/events/landExpansion/seedBought.test.ts
+++ b/src/features/game/events/landExpansion/seedBought.test.ts
@@ -141,6 +141,37 @@ describe("seedBought", () => {
     ).toThrow("Can't buy more seeds than the inventory limit");
   });
 
+  it("allows buying up to the limit even if inventory has a stray fractional remainder below it", () => {
+    const sunflowerLimit =
+      INVENTORY_LIMIT(GAME_STATE)["Sunflower Seed"] ?? new Decimal(0);
+
+    // Simulates a historical bug that left a fractional amount in the
+    // inventory (seeds are always meant to be whole units). The player is
+    // still one whole seed under the limit and should be able to buy.
+    const state = seedBought({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          ...GAME_STATE.inventory,
+          "Sunflower Seed": sunflowerLimit.minus(1).plus(0.5),
+        },
+        stock: {
+          "Sunflower Seed": new Decimal(1),
+        },
+        coins: 100,
+      },
+      action: {
+        type: "seed.bought",
+        item: "Sunflower Seed",
+        amount: 1,
+      },
+    });
+
+    expect(state.inventory["Sunflower Seed"]).toEqual(
+      sunflowerLimit.minus(1).plus(0.5).plus(1),
+    );
+  });
+
   it("subtracts the coins on purchase", () => {
     const coins = 1;
     const balance = new Decimal(1);

--- a/src/features/game/events/landExpansion/seedBought.ts
+++ b/src/features/game/events/landExpansion/seedBought.ts
@@ -203,7 +203,12 @@ export function seedBought({ state, action, createdAt = Date.now() }: Options) {
     const oldAmount = stateCopy.inventory[item] ?? new Decimal(0);
 
     const inventoryLimit = INVENTORY_LIMIT(state)[item] ?? new Decimal(0);
-    if (oldAmount.add(amount).gt(inventoryLimit)) {
+    // Rounded down to a whole seed before comparing: seeds are discrete
+    // units, and a stray fractional remainder in oldAmount (e.g. from a
+    // historical bug) should not permanently block purchases when the
+    // player has less than one whole seed of headroom left.
+    const wholeOldAmount = oldAmount.toDecimalPlaces(0, Decimal.ROUND_DOWN);
+    if (wholeOldAmount.add(amount).gt(inventoryLimit)) {
       throw new Error("Can't buy more seeds than the inventory limit");
     }
 

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -153,9 +153,13 @@ export const SeasonalSeeds: React.FC = () => {
 
   const stock = state.stock[selectedName] || new Decimal(0);
   const inventoryLimit = INVENTORY_LIMIT(state)[selectedName] ?? new Decimal(0);
+  // Rounded down to a whole seed: seeds are discrete units, and comparing
+  // against inventoryLimit at 2 decimal places lets a stray fractional
+  // remainder (e.g. from a historical bug) permanently block purchases
+  // even though the player has less than one whole seed of headroom left.
   const inventoryAmount = setPrecision(
     inventory[selectedName] ?? new Decimal(0),
-    2,
+    0,
   );
   const bulkBuyLimit = inventoryLimit.minus(inventoryAmount);
   // Calculates the difference between amount in inventory and the inventory limit

--- a/src/features/island/buildings/components/building/market/lib/planSeedPurchases.test.ts
+++ b/src/features/island/buildings/components/building/market/lib/planSeedPurchases.test.ts
@@ -172,7 +172,7 @@ describe("planSeedPurchases", () => {
     const plan = planSeedPurchases(state, ["Sunflower Seed"]);
 
     expect(plan.purchases).toHaveLength(1);
-    expect(plan.purchases[0].amount).toBeGreaterThanOrEqual(1);
+    expect(plan.purchases[0].amount).toBe(1);
   });
 
   it("skips full moon seeds outside of a full moon", () => {

--- a/src/features/island/buildings/components/building/market/lib/planSeedPurchases.test.ts
+++ b/src/features/island/buildings/components/building/market/lib/planSeedPurchases.test.ts
@@ -1,6 +1,10 @@
 import Decimal from "decimal.js-light";
 
-import { INITIAL_BUMPKIN, TEST_FARM } from "features/game/lib/constants";
+import {
+  INITIAL_BUMPKIN,
+  INVENTORY_LIMIT,
+  TEST_FARM,
+} from "features/game/lib/constants";
 import type { GameState } from "features/game/types/game";
 import {
   CHAPTER_CROP_WEEK,
@@ -149,6 +153,26 @@ describe("planSeedPurchases", () => {
     const plan = planSeedPurchases(state, ["Sunflower Seed"]);
 
     expect(plan.purchases).toHaveLength(0);
+  });
+
+  it("still plans a purchase when inventory has a stray fractional remainder below the limit", () => {
+    // Simulates a historical bug that left a fractional amount in the
+    // inventory (seeds are always meant to be whole units). The player is
+    // still one whole seed under the limit and should get a plan.
+    const sunflowerLimit =
+      INVENTORY_LIMIT(GAME_STATE)["Sunflower Seed"] ?? new Decimal(0);
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: {
+        ...GAME_STATE.inventory,
+        "Sunflower Seed": sunflowerLimit.minus(1).plus(0.5),
+      },
+    };
+
+    const plan = planSeedPurchases(state, ["Sunflower Seed"]);
+
+    expect(plan.purchases).toHaveLength(1);
+    expect(plan.purchases[0].amount).toBeGreaterThanOrEqual(1);
   });
 
   it("skips full moon seeds outside of a full moon", () => {

--- a/src/features/island/buildings/components/building/market/lib/planSeedPurchases.ts
+++ b/src/features/island/buildings/components/building/market/lib/planSeedPurchases.ts
@@ -93,9 +93,11 @@ export function planSeedPurchases(
 
     const stock = state.stock[seedName] ?? new Decimal(0);
     const inventoryLimit = inventoryLimits[seedName] ?? new Decimal(0);
+    // Rounded down to a whole seed: see the matching comment in
+    // SeasonalSeeds.tsx for why this must be 0 decimal places, not 2.
     const inventoryAmount = setPrecision(
       state.inventory[seedName] ?? new Decimal(0),
-      2,
+      0,
     );
     const bulkBuyLimit = inventoryLimit.minus(inventoryAmount);
 


### PR DESCRIPTION
## Summary

A player reported that a historical bug had left their "Apple Seed" inventory count non-integer, and as a result they could no longer buy that seed at all — they noted it was "the same bug as normal buy" (i.e. the same underlying issue also affects the new bulk-buy-seeds feature from #7432).

## Root cause

Three places compare the player's current seed inventory count against the whole-number inventory limit, but only round to 2 decimal places (or don't round at all) before doing so — so a stray fractional remainder in the inventory (seeds are always meant to be whole units) can permanently look like "no headroom left" even though the player is under one whole seed away from the real limit:

- `SeasonalSeeds.tsx` — `setPrecision(inventory[seed], 2)` leaves a fractional remainder that can still be `>= inventoryLimit`, permanently showing `restock.tooManySeeds` and hiding the buy buttons for that seed.
- `planSeedPurchases.ts` (the new bulk-buy planner from #7432) — the exact same pattern, inherited from the single-seed buy flow.
- `seedBought.ts` — the purchase event itself compares `oldAmount.add(amount)` against `inventoryLimit` with no rounding at all, so even if the UI allowed the attempt, the event would still throw `"Can't buy more seeds than the inventory limit"`.

I wasn't able to find a currently-live code path that produces a fractional seed amount in the first place — all quantity-affecting operations on seed inventory I found (`plant.ts`, `bulkPlant.ts`, `fruitPlanted.ts`, `plantGreenhouse.ts`, `supplyCropMachine.ts`, `seedBought.ts`) use whole-number amounts. This strongly suggests whatever historical bug originally wrote a fractional value is long gone from the codebase, but nothing in the current pipeline (there's no generic inventory sanitization on load — checked `processEvent.ts` and `gameMachine.ts`) ever cleans up a stray fractional value once it exists, so it just sits there and permanently blocks purchases via the three comparisons above.

## Fix

Round the inventory amount down to a whole number (0 decimal places, not 2) immediately before each of these three comparisons. Seeds are discrete units, so a fractional remainder below one full seed shouldn't count as "no headroom left" — the fix only changes the comparison, it does not modify or "clean up" the underlying persisted inventory value.

## Test plan

- [x] Added a regression test to `seedBought.test.ts`: buying 1 seed succeeds when inventory is `limit - 1 + 0.5` (a fractional remainder just under the limit), and the resulting inventory is `limit - 1 + 0.5 + 1` as expected.
- [x] Added a regression test to `planSeedPurchases.test.ts`: the bulk-buy planner still produces a purchase plan under the same fractional-remainder scenario.
- [x] Confirmed the existing test asserting a genuine over-limit purchase still throws `"Can't buy more seeds than the inventory limit"` continues to pass — the fix doesn't weaken the real limit check, only its tolerance for sub-1 fractional noise.
- [x] `npx tsc --noEmit` passes with 0 errors.
- [x] `yarn test` on both affected test files: 48/48 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Seed purchases and purchasing plans now correctly handle fractional seed remnants, allowing players to buy available whole seeds up to the inventory limit.
  * Market headroom, “inventory full” behavior, and bulk-buy capacity calculations now consistently use whole-unit seed amounts.

* **Tests**
  * Added regression coverage for seed purchase execution and purchase planning when fractional inventory remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->