### PR TITLE
[FIX] Interior farm-hand row covering half the screen on mobile

### DIFF
--- a/src/features/home/components/InteriorBumpkins.tsx
+++ b/src/features/home/components/InteriorBumpkins.tsx
@@ -64,17 +64,31 @@ export const InteriorBumpkins: React.FC<Props> = ({ location = "home" }) => {
 
   return (
     <>
-      <div className="flex flex-wrap items-end gap-2 max-w-[70vw]">
+      <div className="flex flex-col sm:flex-row sm:flex-wrap items-center sm:items-end gap-2 max-w-[90vw] sm:max-w-[70vw]">
         <div
-          className="flex flex-wrap"
-          style={{ rowGap: `${32 * PIXEL_SCALE}px` }}
+          className="flex flex-nowrap sm:flex-wrap overflow-x-auto overflow-y-hidden sm:overflow-visible max-w-full"
+          style={{
+            rowGap: `${32 * PIXEL_SCALE}px`,
+            // NPCPlaceable renders above its own top (see `top: -12 * PIXEL_SCALE`
+            // below) at up to 2x its width in height - the scroll container needs
+            // headroom or a horizontal scrollbar clips the sprite's top on mobile,
+            // where `overflow-x-auto` forces `overflow-y` to also clip instead of
+            // staying visible (a CSS rule, not a Tailwind quirk) - explicitly
+            // pinning overflow-y-hidden keeps this scrolling horizontal-only.
+            paddingTop: `${44 * PIXEL_SCALE}px`,
+            marginTop: `${-44 * PIXEL_SCALE}px`,
+            // NPCPlaceable is 1.25x its own width, overhanging its right edge -
+            // without this the last sprite's overhang gets clipped by the
+            // scroll container's edge, showing as a sliced-off sliver.
+            paddingRight: `${8 * PIXEL_SCALE}px`,
+          }}
         >
           {(!isLandscaping ||
             !bumpkin.coordinates ||
             bumpkin.location !== location) && (
             <div
               className={classNames(
-                "mr-2",
+                "mr-2 shrink-0 relative",
                 isLandscaping && bumpkin.coordinates
                   ? "cursor-not-allowed opacity-75"
                   : "cursor-pointer",
@@ -123,7 +137,7 @@ export const InteriorBumpkins: React.FC<Props> = ({ location = "home" }) => {
           {unplacedFarmHandIds.map((id) => (
             <div
               key={id}
-              className="mr-2 cursor-pointer relative"
+              className="mr-2 shrink-0 cursor-pointer relative"
               onClick={() => {
                 if (isLandscaping) {
                   handlePlaceFarmHand(id);


### PR DESCRIPTION
## Summary

Follow-up to #7457, which moved the interior farm-hand/bumpkin avatar row (`InteriorBumpkins`) into the HUD on `/interior` and `/level_one`, fixed to the viewport. That fixed the row overlapping the in-world Upgrade button, but on a mobile viewport the row itself became a new problem.

`InteriorBumpkins` caps the row at `max-w-[70vw]` and wraps (`flex-wrap`) onto as many lines as needed to fit within that width. On desktop, 70vw is wide enough for a full farm-hand roster to fit in 1-2 rows. On a narrow phone viewport, 70vw is only wide enough for about 3 avatars per row — with a roster of 12+ farm hands, the row wrapped onto 4-5 lines and visually covered roughly half the screen, stacked directly under the top HUD (coins/gems).

## Fix

Switched the row to scroll horizontally as a single line on mobile instead of wrapping onto multiple rows (`flex-nowrap overflow-x-auto`), restoring the existing multi-row desktop behavior above the `sm` (640px) breakpoint (`sm:flex-wrap sm:overflow-visible`).

Two more issues surfaced while verifying this fix in the running app:

1. **Avatar cards were shrinking instead of scrolling.** Flex items shrink to fit their container by default; with `overflow-x-auto` this squeezed every avatar into the visible width instead of keeping them full-size and letting the row scroll. Added `shrink-0` to each avatar card.
2. **Sprites got clipped top and right.** `NPCPlaceable` renders well outside its own layout box — it's offset `top: -12 * PIXEL_SCALE` above its container, and internally 1.25x its own width (overhanging both the left and right edges — see `NPC.tsx`). `overflow-visible` on desktop always had room for this; `overflow-x-auto` on mobile clipped the tops and right edges of the sprites. Fixed by:
   - Adding headroom via a compensating `padding-top` / `margin-top` pair (equal magnitude, opposite sign) so the row gets vertical room for the sprite without visually shifting position.
   - Adding `padding-right` sized to the sprite's known right overhang, so the last visible sprite in the row isn't sliced off by the scroll container's edge.
   - Explicitly pinning `overflow-y-hidden` — setting `overflow-x` to anything other than `visible` forces the browser to also stop treating `overflow-y: visible` as visible (a CSS spec rule, not a Tailwind quirk); without this the row scrolled vertically as well as horizontally, which wasn't intended.

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors.
- [x] Manually verified in the running app at a mobile viewport width, using a mock roster of 15 farm hands:
  - The row is now a single horizontal-scrolling line instead of wrapping onto multiple rows, no longer covering a large portion of the screen.
  - Sprites are not clipped at the top or right edge.
  - Scrolling the row is horizontal-only (no accidental vertical scroll).
  - Desktop (`sm:` and above) layout is unchanged — still wraps onto multiple rows with `overflow-visible`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated bumpkin and farm-hand selection tiles to scroll horizontally on smaller screens.
  * Improved tile sizing and spacing to prevent character sprites from being clipped.
  * Preserved consistent tile placement while browsing available selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->