### PR TITLE
[FIX] Correct shrine progress bars

### DIFF
--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -79,7 +79,7 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
 
   const expiresAt = createdAt + (EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0);
   const { totalSeconds: secondsToExpire } = useCountdown(expiresAt);
-  const durationSeconds = EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0;
+  const durationSeconds = (EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0) / 1000;
   const percentage = 100 - (secondsToExpire / durationSeconds) * 100;
   const hasExpired = secondsToExpire <= 0;
 

--- a/src/features/island/collectibles/components/PetShrine.tsx
+++ b/src/features/island/collectibles/components/PetShrine.tsx
@@ -81,7 +81,7 @@ export const PetShrine: React.FC<
   const expiresAt = createdAt + (EXPIRY_COOLDOWNS[name] ?? 0);
 
   const { totalSeconds: secondsToExpire } = useCountdown(expiresAt);
-  const durationSeconds = EXPIRY_COOLDOWNS[name] ?? 0;
+  const durationSeconds = (EXPIRY_COOLDOWNS[name] ?? 0) / 1000;
   const percentage = 100 - (secondsToExpire / durationSeconds) * 100;
   const hasExpired = secondsToExpire <= 0;
 


### PR DESCRIPTION
# Pull request description

## Summary

Fix shrine progress bars so their fill accurately reflects elapsed lifetime and increases as a shrine approaches expiry.

<img width="303" height="123" alt="image" src="https://github.com/user-attachments/assets/870d61c2-aba9-42dc-a2f5-b8aaf1c4c1ec" />


## Context / motivation
**Root cause:** `useCountdown` returns the remaining duration in seconds, while `EXPIRY_COOLDOWNS` stores shrine durations in milliseconds. Dividing seconds by milliseconds kept the calculated elapsed percentage close to 100% for nearly the shrine's entire lifetime.

**Solution:** Convert the configured shrine duration from milliseconds to seconds before calculating the elapsed percentage. This matches the existing behavior of Super Totem, Time Warp Totem, and Hourglass progress bars: the bar fills as the temporary collectible approaches expiry.

## How to test

1. Load a farm with active Pet Shrines and/or an Obsidian Shrine at different points in their active lifetime, with timers enabled.
2. Compare a shrine with several days remaining against one with only a few hours remaining.
3. Verify the bar is mostly empty early in the shrine lifetime and fills progressively as expiry approaches.
4. Confirm the timer text continues to show the correct remaining duration.

## Screenshots or screen recording
<img width="524" height="164" alt="image" src="https://github.com/user-attachments/assets/9d717717-c9db-4b39-9f06-246c7510f115" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cooldown progress calculations for the Obsidian Shrine and Pet Shrine.
  * Progress bars now accurately reflect remaining time, preventing misleading or incorrectly scaled cooldown indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->