### PR TITLE
[FIX] Correct shrine expiry progress bars

### DIFF
--- a/src/features/island/collectibles/components/ObsidianShrine.tsx
+++ b/src/features/island/collectibles/components/ObsidianShrine.tsx
@@ -79,8 +79,8 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
 
   const expiresAt = createdAt + (EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0);
   const { totalSeconds: secondsToExpire } = useCountdown(expiresAt);
-  const durationSeconds = EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0;
-  const percentage = 100 - (secondsToExpire / durationSeconds) * 100;
+  const durationSeconds = (EXPIRY_COOLDOWNS["Obsidian Shrine"] ?? 0) / 1000;
+  const percentage = (secondsToExpire / durationSeconds) * 100;
   const hasExpired = secondsToExpire <= 0;
 
   const now = useNow({ live: !hasExpired, autoEndAt: expiresAt });
@@ -194,7 +194,7 @@ export const ObsidianShrine: React.FC<CollectibleProps> = ({
               seconds={secondsToExpire}
               formatLength="medium"
               type="error"
-              percentage={percentage}
+              percentage={100}
             />
           </div>
         )}

--- a/src/features/island/collectibles/components/PetShrine.tsx
+++ b/src/features/island/collectibles/components/PetShrine.tsx
@@ -81,8 +81,8 @@ export const PetShrine: React.FC<
   const expiresAt = createdAt + (EXPIRY_COOLDOWNS[name] ?? 0);
 
   const { totalSeconds: secondsToExpire } = useCountdown(expiresAt);
-  const durationSeconds = EXPIRY_COOLDOWNS[name] ?? 0;
-  const percentage = 100 - (secondsToExpire / durationSeconds) * 100;
+  const durationSeconds = (EXPIRY_COOLDOWNS[name] ?? 0) / 1000;
+  const percentage = (secondsToExpire / durationSeconds) * 100;
   const hasExpired = secondsToExpire <= 0;
 
   const handleRenewClick = () => {
@@ -121,7 +121,7 @@ export const PetShrine: React.FC<
               seconds={secondsToExpire}
               formatLength="medium"
               type="error"
-              percentage={percentage}
+              percentage={100}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary

  Fixes shrine expiry progress bars so they correctly show the remaining duration.

  ## Context / motivation

  Shrine progress bars were using milliseconds where seconds were expected, causing them to appear nearly full or empty incorrectly.

  ## How to test

  1. Run the app on the Amoy network with `yarn dev`.
  2. Place or renew a shrine.
  3. Wait for the progress bar to decrease, or use the temporary developer testing tools to advance time.
  4. Confirm the bar decreases as the remaining time decreases.
  5. Confirm the bar is fully red after the shrine expires.

  ## Screenshots or screen recording

### Issue
 
https://github.com/user-attachments/assets/7f75cefe-5eb4-46ef-8482-2803697629f0

### Fix

https://github.com/user-attachments/assets/9510b96b-9981-4428-a169-2e4bb20b81ae

 ## Related issues

  Fixes #7447

  ## Checklist

  ### PR and scope

  - [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
  - [x] I have read the contributing guidelines and agree to the T&Cs

  ### UI (if applicable)

  - [ ] Screenshots or recording are attached above
  - [x] Copy and layout match existing patterns where relevant

  ### Code quality

  - [x] I have performed a self-review of my own code
  - [x] I have commented code only where it helps future readers
  - [ ] I have updated documentation if behaviour or public APIs changed
  - [x] My changes do not introduce new warnings

  ### Tests

  - [ ] I have added or updated tests that cover this change
  - [ ] New and existing unit tests pass locally

  ### Dependencies and coordination

  - [x] Any required changes in other repos are merged or linked in the description
  - [x] Any dependent packages or downstream modules are already published / coordinated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected countdown progress calculations for Obsidian Shrine and Pet Shrine timers.
  * Updated progress bars to display accurately as shrine cooldowns expire.
  * Ensured expired shrines consistently show a full progress indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->