### PR TITLE
[FIX] Dedicated feed-all button instead of feeder machine hijack

### DIFF
--- a/src/features/barn/BarnInside.tsx
+++ b/src/features/barn/BarnInside.tsx
@@ -20,6 +20,7 @@ import {
   hasReadGuide,
 } from "features/game/expansion/components/animals/AnimalBuildingModal";
 import { FeederMachine } from "features/feederMachine/FeederMachine";
+import { FeedAllButton } from "features/game/expansion/components/animals/FeedAllButton";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { UpgradeBuildingModal } from "features/game/expansion/components/UpgradeBuildingModal";
 import { ANIMAL_HOUSE_IMAGES } from "features/henHouse/HenHouseInside";
@@ -235,6 +236,10 @@ export const BarnInside: React.FC = () => {
                 }}
               >
                 <FeederMachine building="Barn" />
+              </div>
+
+              <div className="absolute -top-[11px] right-[29%]">
+                <FeedAllButton building="Barn" />
               </div>
 
               <MapPlacement

--- a/src/features/feederMachine/FeederMachine.tsx
+++ b/src/features/feederMachine/FeederMachine.tsx
@@ -1,108 +1,21 @@
 import { SUNNYSIDE } from "assets/sunnyside";
 import { PIXEL_SCALE } from "features/game/lib/constants";
-import { useAppTranslation } from "lib/i18n/useAppTranslations";
-import React, { useContext, useEffect, useMemo, useState } from "react";
-import { useSelector } from "@xstate/react";
-import { Context } from "features/game/GameProvider";
-import type { MachineState } from "features/game/lib/gameMachine";
-import { makeAnimalBuildingKey } from "features/game/lib/animals";
-import type { AnimalBuildingType } from "features/game/types/animals";
-import {
-  getCoveredAnimalTypes,
-  getFeedAllTargets,
-} from "features/game/events/landExpansion/feedAllAnimals";
-import { useSound } from "lib/utils/hooks/useSound";
-import { getValues } from "lib/object";
-import classNames from "classnames";
+import React, { useState } from "react";
 import { FeederMachineModal } from "./FeederMachineModal";
 
-const _state = (state: MachineState) => state.context.state;
-
 interface Props {
-  // A golden asset covering this building turns the machine into a
-  // one-click feed-all trigger (shown with a lightning bolt). The crafting
-  // modal stays reachable whenever medicine or feed is still needed.
-  building: AnimalBuildingType;
+  building: "Hen House" | "Barn";
 }
 
 export const FeederMachine: React.FC<Props> = ({ building }) => {
-  const { t } = useAppTranslation();
   const [showFeederMachineModal, setFeederMachineModal] = useState(false);
   const feederMachineImage = SUNNYSIDE.building.feederMachine;
-
-  const { gameService } = useContext(Context);
-  const game = useSelector(gameService, _state);
-  const { play: playFeedAnimal } = useSound("feed_animal");
-
-  // Bumped when the soonest sleeping animal wakes so eligibility re-evaluates
-  const [, setWakeTick] = useState(0);
-
-  const covered = useMemo(
-    () => getCoveredAnimalTypes({ state: game, building }),
-    [building, game],
-  );
-
-  const targets = getFeedAllTargets({ state: game, building });
-  const eligibleCount =
-    covered.length > 0
-      ? targets.toClaim.length + targets.toCure.length + targets.toFeed.length
-      : 0;
-
-  const allWakeTimes = useMemo(
-    () =>
-      getValues(game[makeAnimalBuildingKey(building)].animals)
-        .filter((animal) => covered.includes(animal.type))
-        .map((animal) => animal.awakeAt),
-    [building, game, covered],
-  );
-  const nextWakeAt = Math.min(
-    ...allWakeTimes.filter(
-      // eslint-disable-next-line react-hooks/purity
-      (awakeAt) => awakeAt > Date.now(),
-    ),
-  );
-
-  useEffect(() => {
-    if (!isFinite(nextWakeAt)) return;
-
-    const timeout = setTimeout(
-      () => setWakeTick((tick) => tick + 1),
-      nextWakeAt - Date.now() + 100,
-    );
-
-    return () => clearTimeout(timeout);
-  }, [nextWakeAt]);
-
-  const hasGoldenAsset = covered.length > 0;
-  // Sick animals the action cannot cure are simply skipped (manual care);
-  // they do not block feeding the rest of the building.
-  const canFeedAll = hasGoldenAsset && eligibleCount > 0;
-
-  const handleClick = () => {
-    if (covered.length > 0) {
-      // Re-derive eligibility from the live machine snapshot rather than
-      // the render-scoped state, which can go stale (e.g. a double-tap
-      // before React re-renders after the first click consumed every
-      // target).
-      const { toClaim, toCure, toFeed } = getFeedAllTargets({
-        state: gameService.getSnapshot().context.state,
-        building,
-      });
-      if (toClaim.length + toCure.length + toFeed.length > 0) {
-        gameService.send({ type: "animals.fedAll", building });
-        playFeedAnimal();
-        return;
-      }
-    }
-
-    setFeederMachineModal(true);
-  };
 
   return (
     <>
       <div
         className="relative cursor-pointer hover:img-highlight"
-        onClick={handleClick}
+        onClick={() => setFeederMachineModal(true)}
       >
         <img
           src={SUNNYSIDE.animalFoods.grinder}
@@ -112,19 +25,6 @@ export const FeederMachine: React.FC<Props> = ({ building }) => {
           // Hover parent
           className="absolute top-0 -right-4 z-20"
         />
-        {hasGoldenAsset && (
-          <img
-            src={SUNNYSIDE.icons.lightning}
-            alt={t("animals.feedAll")}
-            className={classNames(
-              "absolute z-30 top-0 -right-4 pointer-events-none img-highlight",
-              canFeedAll ? "animate-pulsate" : "grayscale opacity-50",
-            )}
-            style={{
-              width: `${PIXEL_SCALE * 9}px`,
-            }}
-          />
-        )}
         <img
           src={feederMachineImage}
           className="relative z-0"

--- a/src/features/game/expansion/components/animals/FeedAllButton.tsx
+++ b/src/features/game/expansion/components/animals/FeedAllButton.tsx
@@ -1,0 +1,112 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { useSelector } from "@xstate/react";
+import classNames from "classnames";
+import { SUNNYSIDE } from "assets/sunnyside";
+import { PIXEL_SCALE } from "features/game/lib/constants";
+import { Context } from "features/game/GameProvider";
+import type { MachineState } from "features/game/lib/gameMachine";
+import { makeAnimalBuildingKey } from "features/game/lib/animals";
+import type { AnimalBuildingType } from "features/game/types/animals";
+import {
+  getCoveredAnimalTypes,
+  getFeedAllTargets,
+} from "features/game/events/landExpansion/feedAllAnimals";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { useSound } from "lib/utils/hooks/useSound";
+import { getValues } from "lib/object";
+
+const _state = (state: MachineState) => state.context.state;
+
+export const FeedAllButton: React.FC<{ building: AnimalBuildingType }> = ({
+  building,
+}) => {
+  const { gameService } = useContext(Context);
+  const { t } = useAppTranslation();
+  const game = useSelector(gameService, _state);
+  const { play: playFeedAnimal } = useSound("feed_animal");
+
+  // Bumped when the soonest sleeping animal wakes so eligibility re-evaluates
+  const [, setWakeTick] = useState(0);
+
+  const covered = getCoveredAnimalTypes({ state: game, building });
+  const { toClaim, toCure, toFeed } = getFeedAllTargets({
+    state: game,
+    building,
+  });
+  const eligibleCount = toClaim.length + toCure.length + toFeed.length;
+
+  const buildingKey = makeAnimalBuildingKey(building);
+  const allWakeTimes = useMemo(
+    () =>
+      getValues(game[buildingKey].animals)
+        .filter((animal) => covered.includes(animal.type))
+        .map((animal) => animal.awakeAt),
+    [buildingKey, game, covered],
+  );
+  const nextWakeAt = Math.min(
+    ...allWakeTimes.filter(
+      // eslint-disable-next-line react-hooks/purity
+      (awakeAt) => awakeAt > Date.now(),
+    ),
+  );
+
+  useEffect(() => {
+    if (!isFinite(nextWakeAt)) return;
+
+    const timeout = setTimeout(
+      () => setWakeTick((tick) => tick + 1),
+      nextWakeAt - Date.now() + 100,
+    );
+
+    return () => clearTimeout(timeout);
+  }, [nextWakeAt]);
+
+  if (covered.length === 0) return null;
+
+  const disabled = eligibleCount === 0;
+
+  const handleClick = () => {
+    // Re-derive eligibility from the live machine snapshot rather than
+    // the render-scoped state, which can go stale (e.g. a double-tap
+    // before React re-renders after the first click consumed every
+    // target).
+    const targets = getFeedAllTargets({
+      state: gameService.getSnapshot().context.state,
+      building,
+    });
+    const hasEligible =
+      targets.toClaim.length + targets.toCure.length + targets.toFeed.length >
+      0;
+    if (!hasEligible) return;
+
+    gameService.send({ type: "animals.fedAll", building });
+    playFeedAnimal();
+  };
+
+  return (
+    <div
+      className={classNames("z-10", {
+        "cursor-pointer": !disabled,
+        "opacity-60": disabled,
+      })}
+      onClick={handleClick}
+    >
+      <img
+        src={SUNNYSIDE.animalFoods.grinder}
+        alt={t("animals.feedAll")}
+        style={{ width: `${PIXEL_SCALE * 18}px` }}
+      />
+      <img
+        src={SUNNYSIDE.icons.lightning}
+        alt=""
+        className={classNames(
+          "absolute -top-0.5 -right-0.5 pointer-events-none",
+          {
+            "animate-pulsate img-highlight": !disabled,
+          },
+        )}
+        style={{ width: `${PIXEL_SCALE * 8}px` }}
+      />
+    </div>
+  );
+};

--- a/src/features/game/expansion/components/animals/FeedAllButton.tsx
+++ b/src/features/game/expansion/components/animals/FeedAllButton.tsx
@@ -25,13 +25,19 @@ export const FeedAllButton: React.FC<{ building: AnimalBuildingType }> = ({
   const game = useSelector(gameService, _state);
   const { play: playFeedAnimal } = useSound("feed_animal");
 
-  // Bumped when the soonest sleeping animal wakes so eligibility re-evaluates
-  const [, setWakeTick] = useState(0);
+  // The clock eligibility is judged against. Advanced by the effect below
+  // whenever the soonest sleeping animal wakes, so the button re-evaluates
+  // without reading Date.now() during render (the compiler memoises on it).
+  const [now, setNow] = useState(Date.now);
 
-  const covered = getCoveredAnimalTypes({ state: game, building });
+  const covered = useMemo(
+    () => getCoveredAnimalTypes({ state: game, building }),
+    [building, game],
+  );
   const { toClaim, toCure, toFeed } = getFeedAllTargets({
     state: game,
     building,
+    createdAt: now,
   });
   const eligibleCount = toClaim.length + toCure.length + toFeed.length;
 
@@ -43,23 +49,24 @@ export const FeedAllButton: React.FC<{ building: AnimalBuildingType }> = ({
         .map((animal) => animal.awakeAt),
     [buildingKey, game, covered],
   );
-  const nextWakeAt = Math.min(
-    ...allWakeTimes.filter(
-      // eslint-disable-next-line react-hooks/purity
-      (awakeAt) => awakeAt > Date.now(),
-    ),
-  );
 
   useEffect(() => {
-    if (!isFinite(nextWakeAt)) return;
+    const nextWakeAt = Math.min(
+      ...allWakeTimes.filter((awakeAt) => awakeAt > now),
+    );
 
+    if (!Number.isFinite(nextWakeAt)) return;
+
+    // `now` re-arms the chain: each firing schedules the following wake.
+    // A stale `now` (e.g. throttled timers) clamps to 0, fires immediately
+    // and self-corrects.
     const timeout = setTimeout(
-      () => setWakeTick((tick) => tick + 1),
-      nextWakeAt - Date.now() + 100,
+      () => setNow(Date.now()),
+      Math.max(0, nextWakeAt - now + 100),
     );
 
     return () => clearTimeout(timeout);
-  }, [nextWakeAt]);
+  }, [allWakeTimes, now]);
 
   if (covered.length === 0) return null;
 

--- a/src/features/henHouse/HenHouseInside.tsx
+++ b/src/features/henHouse/HenHouseInside.tsx
@@ -16,6 +16,7 @@ import { Chicken } from "./Chicken";
 import shopDisc from "assets/icons/shop_disc.png";
 import { AnimalBuildingModal } from "features/game/expansion/components/animals/AnimalBuildingModal";
 import { FeederMachine } from "features/feederMachine/FeederMachine";
+import { FeedAllButton } from "features/game/expansion/components/animals/FeedAllButton";
 import { UpgradeBuildingModal } from "features/game/expansion/components/UpgradeBuildingModal";
 import { Modal } from "components/ui/Modal";
 import {
@@ -229,6 +230,10 @@ export const HenHouseInside: React.FC = () => {
                 }}
               >
                 <FeederMachine building="Hen House" />
+              </div>
+
+              <div className="absolute -top-[11px] right-[29%]">
+                <FeedAllButton building="Hen House" />
               </div>
 
               <MapPlacement


### PR DESCRIPTION
## Description

Follow-up to #7469 based on player feedback: the golden-asset feed-all action no longer hijacks the feeder machine click, so players keep full control over opening the crafting modal.

- **FeederMachine** reverted to its original behavior — clicking always opens the crafting modal. Lightning bolt overlay and feed-all click handling removed.
- **New `FeedAllButton`** mounted beside the feeder machine in the Barn and Hen House interiors: the grinder icon with a lightning bolt overlay. The bolt pulses when feed-all is actionable and the button dims when nothing is eligible (all covered animals asleep / only sick animals). Hidden entirely without a covering golden asset.
- Behavior is unchanged under the hood: same `animals.fedAll` event, same eligibility rules, same live-snapshot double-tap guard, and the button still re-evaluates when the next sleeping animal wakes.

No game event or server changes — only the UI trigger moved.

## Testing

- `yarn tsc --noEmit` clean
- `yarn eslint` on touched files clean
- `feedAllAnimals.test.ts` — 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01771BZsLYsYunD33Mao8Mey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Feed All” button to the Barn and Hen House interiors.
  * The button only shows when there are covered, relevant animals and is disabled when nothing is eligible to feed.
  * Feeding all eligible animals updates their status and plays the feeding sound.
* **UI/UX Updates**
  * The “Feeder Machine” control now opens its modal directly on click.
  * Removed the previous one-click “feed all” capability and related visual indicator from the feeder machine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->