### PR TITLE
[FEAT] Double Bounty Board bonus to 100 tickets from Ascension Age

### DIFF
--- a/src/features/game/events/landExpansion/claimBountyBonus.test.ts
+++ b/src/features/game/events/landExpansion/claimBountyBonus.test.ts
@@ -103,6 +103,23 @@ describe("claimBountyBonus", () => {
     expect(result.bounties.bonusClaimedAt).toBe(createdAt);
   });
 
+  it("claims a boosted bonus of 100 tickets from Ascension Age onwards", () => {
+    const ascensionCreatedAt = new Date("2026-08-11").getTime();
+
+    const result = claimBountyBonus({
+      state: GAME_STATE,
+      action: {
+        type: "claim.bountyBoardBonus",
+      },
+      createdAt: ascensionCreatedAt,
+    });
+
+    expect(result.inventory[getChapterTicket(ascensionCreatedAt)]).toEqual(
+      new Decimal(100),
+    );
+    expect(result.bounties.bonusClaimedAt).toBe(ascensionCreatedAt);
+  });
+
   it("adds to existing seasonal tickets if player has some", () => {
     const result = claimBountyBonus({
       state: {

--- a/src/features/game/events/landExpansion/claimBountyBonus.ts
+++ b/src/features/game/events/landExpansion/claimBountyBonus.ts
@@ -37,6 +37,8 @@ export const NO_BONUS_BOUNTIES_WEEK = [
   "2026-04-06", // Crabs and Traps Auction Week
   "2026-05-04", // Salt Awakening Rest Week
   "2026-07-06", // Salt Awakening Auction Week
+  "2026-08-03", // Ascension Age Rest Week
+  "2026-10-05", // Ascension Age Auction Week
 ];
 
 const TICKET_BONUS_AMOUNT = 50;

--- a/src/features/game/events/landExpansion/claimBountyBonus.ts
+++ b/src/features/game/events/landExpansion/claimBountyBonus.ts
@@ -2,7 +2,11 @@ import Decimal from "decimal.js-light";
 import { getWeekKey, weekResetsAt } from "features/game/lib/factions";
 import { ANIMALS } from "features/game/types/animals";
 import type { GameState } from "features/game/types/game";
-import { getChapterTicket } from "features/game/types/chapters";
+import {
+  CHAPTER_ORDER,
+  getChapterTicket,
+  getCurrentChapter,
+} from "features/game/types/chapters";
 import { produce } from "immer";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 
@@ -36,6 +40,15 @@ export const NO_BONUS_BOUNTIES_WEEK = [
 ];
 
 const TICKET_BONUS_AMOUNT = 50;
+const ASCENSION_TICKET_BONUS_AMOUNT = 100;
+
+export function getBountyBonusAmount(now: number): number {
+  const chapter = getCurrentChapter(now);
+
+  return CHAPTER_ORDER[chapter] >= CHAPTER_ORDER["Ascension Age"]
+    ? ASCENSION_TICKET_BONUS_AMOUNT
+    : TICKET_BONUS_AMOUNT;
+}
 
 export function claimBountyBonus({
   state,
@@ -86,15 +99,14 @@ export function claimBountyBonus({
 
     // Claim bonus
     const ticket = getChapterTicket(createdAt);
-    inventory[ticket] = (inventory[ticket] ?? new Decimal(0)).add(
-      TICKET_BONUS_AMOUNT,
-    );
+    const bonusAmount = getBountyBonusAmount(createdAt);
+    inventory[ticket] = (inventory[ticket] ?? new Decimal(0)).add(bonusAmount);
     bounties.bonusClaimedAt = createdAt;
 
     draft.farmActivity = trackFarmActivity(
       `${ticket} Collected`,
       draft.farmActivity,
-      new Decimal(TICKET_BONUS_AMOUNT),
+      new Decimal(bonusAmount),
     );
 
     return draft;

--- a/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
+++ b/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
@@ -37,7 +37,10 @@ import { Button } from "components/ui/Button";
 import confetti from "canvas-confetti";
 import flowerIcon from "assets/icons/flower_token.webp";
 import chapterPoints from "assets/icons/red_medal_short.webp";
-import { NO_BONUS_BOUNTIES_WEEK } from "features/game/events/landExpansion/claimBountyBonus";
+import {
+  getBountyBonusAmount,
+  NO_BONUS_BOUNTIES_WEEK,
+} from "features/game/events/landExpansion/claimBountyBonus";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { useNow } from "lib/utils/hooks/useNow";
@@ -522,7 +525,10 @@ export const MegaBountyBoardContent: React.FC<{ readonly?: boolean }> = ({
             )}
           </div>
           <p className="text-xs ml-1">
-            {t("bounties.bonus.getBonus", { chapterTicket })}
+            {t("bounties.bonus.getBonus", {
+              amount: getBountyBonusAmount(now),
+              chapterTicket,
+            })}
           </p>
           {!readonly && (
             <Button

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4981,7 +4981,7 @@
   "bounties.sellSelected": "Sell Selected: {{count}}",
   "bounties.bonus.headToPoppy": "Head to Poppy to claim your bonus!",
   "bounties.bonus.clickToClaim": "Claim bonus",
-  "bounties.bonus.getBonus": "Get Bonus 50 {{chapterTicket}}s for completing all bounties!",
+  "bounties.bonus.getBonus": "Get Bonus {{amount}} {{chapterTicket}}s for completing all bounties!",
   "bountyType.label": "{{type}} Bounties",
   "npcDialogues.chase.intro1": "Howdy Bumpkin! Animals are coming to Sunflower Land on November 1st.",
   "npcDialogues.chase.intro2": "However I'm in a bit of a pickle. My herd has mysteriously gone missing - it's like they disappeared out of thin air!",


### PR DESCRIPTION
Mirrors API commit c8bc1d215 (feat/bounty-board-ascension-boosts). The completion bonus rises from 50 to 100 chapter tickets once the current chapter reaches Ascension Age (2026-08-03); earlier chapters keep 50.

getBountyBonusAmount resolves the amount from CHAPTER_ORDER so the claim handler and the MegaBountyBoard copy stay in sync, and the bounties.bonus.getBonus string takes the amount as a parameter.

en.json deliberately untouched per LANGUAGES.md (bot-managed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the Bounty Bonus seasonal ticket reward from 50 to 100 starting with the Ascension Age.
  * Bounty Board messaging now displays the correct, dynamically calculated reward amount.

* **Bug Fixes**
  * Bonus claim rewards and related activity tracking now consistently use the current chapter’s reward value.

* **Tests**
  * Added coverage for the Ascension Age bonus-claim behavior to confirm the boosted reward and timestamp tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->