### PR TITLE
[FIX] Interior fixes

### DIFF
--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -193,6 +193,73 @@ describe("Place Collectible", () => {
     expect(state.collectibles["Big Orange"]).toHaveLength(1);
   });
 
+  it("does not restart a village project when re-placing a monument", () => {
+    const dateNow = Date.now();
+    const state = placeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Basic Cooking Pot": new Decimal(1),
+        },
+        collectibles: {
+          // Previously placed, then removed - its project has already been
+          // consumed, so restarting it must go through `project.started`
+          "Basic Cooking Pot": [{ id: "123", removedAt: dateNow }],
+        },
+      },
+      action: {
+        id: "123",
+        type: "collectible.placed",
+        name: "Basic Cooking Pot",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+        location: "farm",
+      },
+      createdAt: dateNow,
+    });
+
+    expect(
+      state.socialFarming.villageProjects["Basic Cooking Pot"],
+    ).toBeUndefined();
+  });
+
+  it("does not restart a village project when moving a monument out of the home", () => {
+    const dateNow = Date.now();
+    const state = placeCollectible({
+      state: {
+        ...GAME_STATE,
+        inventory: {
+          "Basic Cooking Pot": new Decimal(1),
+        },
+        collectibles: {},
+        home: {
+          ...GAME_STATE.home,
+          collectibles: {
+            "Basic Cooking Pot": [{ id: "123", removedAt: dateNow }],
+          },
+        },
+      },
+      action: {
+        id: "456",
+        type: "collectible.placed",
+        name: "Basic Cooking Pot",
+        coordinates: {
+          x: 0,
+          y: 0,
+        },
+        location: "farm",
+      },
+      createdAt: dateNow,
+    });
+
+    expect(
+      state.socialFarming.villageProjects["Basic Cooking Pot"],
+    ).toBeUndefined();
+    expect(state.collectibles["Basic Cooking Pot"]).toHaveLength(1);
+  });
+
   it("Cannot place a building", () => {
     expect(() =>
       placeCollectible({
@@ -600,6 +667,77 @@ describe("Place Collectible", () => {
           coordinates: { x: 0, y: 0 },
         },
       ]);
+    });
+
+    it("moves an unplaced interior collectible to the farm rather than creating a duplicate", () => {
+      const state = placeCollectible({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            "Tornado Pinwheel": new Decimal(1),
+          },
+          collectibles: {},
+          interior: {
+            ground: {
+              collectibles: {
+                // Removed from the interior, so it has no coordinates
+                "Tornado Pinwheel": [{ id: "interior-1", used: true }],
+              },
+            },
+          },
+        },
+        action: {
+          id: "new-id",
+          type: "collectible.placed",
+          name: "Tornado Pinwheel",
+          coordinates: { x: 1, y: 1 },
+          location: "farm",
+        },
+      });
+
+      // The same instance is moved across — a weather item's `used` flag must
+      // survive the move, otherwise it is renewed for free.
+      expect(state.collectibles["Tornado Pinwheel"]).toEqual([
+        { id: "interior-1", used: true, coordinates: { x: 1, y: 1 } },
+      ]);
+      expect(state.interior.ground.collectibles["Tornado Pinwheel"]).toEqual(
+        [],
+      );
+    });
+
+    it("moves an unplaced level_one collectible to the home rather than creating a duplicate", () => {
+      const state = placeCollectible({
+        state: {
+          ...GAME_STATE,
+          inventory: {
+            "Tornado Pinwheel": new Decimal(1),
+          },
+          collectibles: {},
+          interior: {
+            ground: { collectibles: {} },
+            expansion: "level-one-start",
+            level_one: {
+              collectibles: {
+                "Tornado Pinwheel": [{ id: "lo-1", used: true }],
+              },
+            },
+          },
+        },
+        action: {
+          id: "new-id",
+          type: "collectible.placed",
+          name: "Tornado Pinwheel",
+          coordinates: { x: 1, y: 1 },
+          location: "home",
+        },
+      });
+
+      expect(state.home.collectibles["Tornado Pinwheel"]).toEqual([
+        { id: "lo-1", used: true, coordinates: { x: 1, y: 1 } },
+      ]);
+      expect(
+        state.interior.level_one!.collectibles["Tornado Pinwheel"],
+      ).toEqual([]);
     });
 
     it("rejects placing on level_one before the upgrade has been bought", () => {

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -4,7 +4,10 @@ import {
 } from "../../types/craftables";
 import type { GameState, PlacedItem } from "features/game/types/game";
 import { trackFarmActivity } from "features/game/types/farmActivity";
-import type { PlaceableLocation } from "features/game/types/collectibles";
+import {
+  PLACEABLE_LOCATIONS,
+  type PlaceableLocation,
+} from "features/game/types/collectibles";
 import { produce } from "immer";
 import { getCountAndType } from "features/island/hud/components/inventory/utils/inventory";
 import {
@@ -23,6 +26,7 @@ import type { Coordinates } from "features/game/expansion/components/MapPlacemen
 import { COMPETITION_POINTS } from "features/game/types/competitions";
 import { populateSaltFarm } from "features/game/types/salt";
 import { refreshBasicScarecrowTimeAOE } from "features/game/lib/aoe";
+import { getCollectiblesAcrossLocations } from "features/game/lib/getCollectiblesAcrossLocations";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -90,8 +94,17 @@ export function placeCollectible({
         action.name as MonumentName,
       ) ?? false;
 
+    // Monuments obtained outside of `buyMonument` (rewards, trades) have no
+    // village project, so seed one the first time they are placed. Only ever on
+    // a first placement — otherwise removing and re-placing a monument whose
+    // project has already been consumed would restart it for free, skipping the
+    // `project.started` cost.
+    const hasBeenPlacedBefore =
+      getCollectiblesAcrossLocations(stateCopy, action.name).length > 0;
+
     if (
       isMonument &&
+      !hasBeenPlacedBefore &&
       !stateCopy.socialFarming.villageProjects[action.name as MonumentName] &&
       !isInCompletedProjects
     ) {
@@ -167,18 +180,14 @@ export function placeCollectible({
       return stateCopy;
     }
 
-    // If no existing collectible is found, search for it in other locations, and move it to the new location
-    // Define which locations to search based on target location
-    const otherLocations: PlaceableLocation[] =
-      action.location === "home"
-        ? ["farm", "petHouse"]
-        : action.location === "petHouse"
-          ? ["farm", "home"]
-          : action.location === "interior"
-            ? ["farm", "home", "level_one"]
-            : action.location === "level_one"
-              ? ["farm", "home", "interior"]
-              : ["home", "petHouse"]; // farm
+    // If no existing collectible is found, search for it in other locations, and move it to the new location.
+    // Every other location must be searched: missing one creates a duplicate
+    // placement instead of moving the existing one, which silently drops the
+    // instance's state (e.g. a weather item's `used` flag would be lost, renewing
+    // it for free).
+    const otherLocations: PlaceableLocation[] = PLACEABLE_LOCATIONS.filter(
+      (location) => location !== action.location,
+    );
 
     const getCollectiblesForLocation = (
       loc: PlaceableLocation,
@@ -188,12 +197,12 @@ export function placeCollectible({
           return stateCopy.home.collectibles[action.name] ?? [];
         case "petHouse":
           return isPetCollectible(action.name)
-            ? (stateCopy.petHouse.pets[action.name] ?? [])
+            ? (stateCopy.petHouse?.pets[action.name] ?? [])
             : [];
         case "interior":
-          return stateCopy.interior.ground.collectibles[action.name] ?? [];
+          return stateCopy.interior?.ground.collectibles[action.name] ?? [];
         case "level_one":
-          return stateCopy.interior.level_one?.collectibles[action.name] ?? [];
+          return stateCopy.interior?.level_one?.collectibles[action.name] ?? [];
         case "farm":
         default:
           return stateCopy.collectibles[action.name] ?? [];
@@ -214,10 +223,12 @@ export function placeCollectible({
           }
           break;
         case "interior":
-          stateCopy.interior.ground.collectibles[action.name] = items;
+          if (stateCopy.interior) {
+            stateCopy.interior.ground.collectibles[action.name] = items;
+          }
           break;
         case "level_one":
-          if (stateCopy.interior.level_one) {
+          if (stateCopy.interior?.level_one) {
             stateCopy.interior.level_one.collectibles[action.name] = items;
           }
           break;


### PR DESCRIPTION
# Pull request description

**Bug 1: weather item renewed for free**

When you place an item, the reducer looks for an existing (coordinate-less) placement to move, but the list of locations it searched was hardcoded and incomplete: placing on farm only searched ["home", "petHouse"], and placing in home only searched ["farm", "petHouse"] — neither searched interior / level_one.

So moving an item out of the mansion interior fell through to "create a new placement", producing a fresh PlacedItem with a new id and no used flag, while the real used instance stayed parked (unplaced) in the interior., etc.

Fix: derive the search list from PLACEABLE_LOCATIONS minus the target, so every other location is always searched.

**Bug 2: Cooking Pots**
Different mechanism, same "free renewal on re-place" symptom.

Fix: only seed on a first-ever placement (no existing instance in any location).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monument relocation so previously used monuments do not restart their associated village projects.
  * Improved collectible movement between interior areas, the home, and the farm without creating duplicates.
  * Preserved collectible usage status and identity when moving items.
  * Improved placement reliability when optional interior or pet-house areas are not initialized.

* **Tests**
  * Added coverage for monument relocation and collectible movement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->