### PR TITLE
[FEAT] Ascension Age auction item registration

### DIFF
--- a/src/features/game/types/collections.ts
+++ b/src/features/game/types/collections.ts
@@ -427,6 +427,30 @@ export const CHAPTER_COLLECTIONS: Partial<
       },
     },
   }),
+  "Ascension Age": buildChapterCollection({
+    chapter: "Ascension Age",
+    overrides: {
+      auctioneer: {
+        collectibles: [
+          "Salt Rug",
+          "Coat Rack",
+          "Vibraphone",
+          "Winged Vase",
+          "Ascended Idol",
+          "Salt Worker Gnome",
+        ],
+        wearables: ["Surfer Hair"],
+      },
+      other: {
+        collectibles: [
+          "Ascension Age Banner",
+          ...getObjectEntries(CHAPTER_CRAFTING_ITEMS)
+            .filter((item) => item[1] === "Ascension Age")
+            .map((item) => item[0]),
+        ],
+      },
+    },
+  }),
 };
 
 /** Flattens source-keyed collection into collectibles and wearables arrays for the grid. */

--- a/src/features/game/types/petRevealConfig.ts
+++ b/src/features/game/types/petRevealConfig.ts
@@ -39,6 +39,14 @@ export const PET_NFT_REVEAL_CONFIG: PetNFTRevealConfig[] = [
     withdrawAt: new Date("2026-08-31T00:00:00.000Z"),
   },
 
+  {
+    revealAt: new Date("2026-10-13T00:00:00.000Z"),
+    startId: 1751,
+    endId: 2000,
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00.000Z"),
+  },
+
   // Reserved Eggs - Crabs and Traps
   {
     revealAt: new Date("2025-11-12T00:00:00.000Z"),

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1714,6 +1714,30 @@ export const INVENTORY_RELEASES: InventoryReleases = {
     tradeAt: CHAPTERS["Ascension Age"].endDate,
     withdrawAt: new Date("2026-11-30T00:00:00Z"),
   },
+  "Salt Rug": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  "Coat Rack": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  Vibraphone: {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  "Winged Vase": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  "Ascended Idol": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  "Salt Worker Gnome": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
   CluckCoin: {
     tradeAt: new Date("2025-01-01T00:00:00.000Z"),
   },

--- a/src/features/marketplace/lib/getTradeType.ts
+++ b/src/features/marketplace/lib/getTradeType.ts
@@ -1455,18 +1455,18 @@ export const ITEM_TRADE_TYPES: {
     "Ascension Monument": "instant",
 
     // Ascension Age decorations
-    "Salt Rug": "instant",
-    "Ascended Idol": "instant",
+    "Salt Rug": "onchain",
+    "Ascended Idol": "onchain",
     "Ascended Wheel": "instant",
     Astrolabe: "instant",
-    "Coat Rack": "instant",
+    "Coat Rack": "onchain",
     Lampshade: "instant",
     "Marble Head": "instant",
     "Otty the Otter": "instant",
-    "Salt Worker Gnome": "instant",
+    "Salt Worker Gnome": "onchain",
     "Shards Turtle": "instant",
-    Vibraphone: "instant",
-    "Winged Vase": "instant",
+    Vibraphone: "onchain",
+    "Winged Vase": "onchain",
     "Big Table": "instant",
     Crate: "instant",
     "Empty Pot": "instant",
@@ -2118,7 +2118,7 @@ export const ITEM_TRADE_TYPES: {
     "Crystal Shoes": "instant",
     "Marble Pants": "instant",
     "Spooky Coat": "instant",
-    "Surfer Hair": "instant",
+    "Surfer Hair": "onchain",
   },
 };
 


### PR DESCRIPTION
## Summary

FE-side registration for the Ascension Age (chapter 15) auction items. The auction schedule itself lives in the API (companion PR: sunflower-land-api#3517) — the FE fetches it from `/auctions`, so this PR only covers the item registration the auction/marketplace/withdraw flows need.

- **`petRevealConfig.ts`**: next Pet NFT Egg tranche, ids **1751–2000** (reveal Oct 13, tradeAt = chapter end, withdrawAt Nov 30) — mirrors the API config
- **`getTradeType.ts`**: the 7 auctioned items flipped `instant` → `onchain` (fixed-supply auction items): Salt Rug, Coat Rack, Vibraphone, Winged Vase, Ascended Idol, Salt Worker Gnome, Surfer Hair
- **`withdrawables.ts`**: `COLLECTIBLE_RELEASES` entries for the 6 new collectibles (tradeAt = chapter end, withdrawAt 2026-11-30, matching the existing Ascension block); Surfer Hair already had its wearable entry
- **`collections.ts`**: new `CHAPTER_COLLECTIONS["Ascension Age"]` entry (auctioneer collectibles/wearables + banner), following the Salt Awakening shape

Item buffs (labels + gameplay) are intentionally not included — separate follow-up slices per mechanic.

## Verification
- `tsc --noEmit` clean; related suites pass
- Codex auction schedule view and dashboard derive from the API + chapter window, so no further FE wiring is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Ascension Age chapter, including its collectibles, wearable, banner, and crafting items.
  * Added a new pet NFT reveal window for token IDs 1751–2000.
  * Added trading and withdrawal scheduling for new Ascension Age inventory items.

* **Marketplace**
  * Updated selected Ascension Age items to use on-chain trading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->