### PR TITLE
[FIX] Track FLOWER Spent so High Roller & Big Spender progress again

### DIFF
--- a/src/features/game/events/landExpansion/buyChapterItem.test.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.test.ts
@@ -78,6 +78,20 @@ describe("buyChapterItem", () => {
     expect(result.balance).toEqual(new Decimal(990));
   });
 
+  it("tracks SFL Spent farm activity when buying an item", () => {
+    const result = buyChapterItem({
+      state: mockState,
+      action: {
+        type: "chapterItem.bought",
+        name: "Treasure Key",
+        tier: "basic",
+      },
+      createdAt: mockDate,
+    });
+
+    expect(result.farmActivity["SFL Spent"]).toEqual(10);
+  });
+
   it("subtracts items when buying an item", () => {
     const result = buyChapterItem({
       state: mockState,

--- a/src/features/game/events/landExpansion/buyChapterItem.test.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.test.ts
@@ -78,7 +78,7 @@ describe("buyChapterItem", () => {
     expect(result.balance).toEqual(new Decimal(990));
   });
 
-  it("tracks SFL Spent farm activity when buying an item", () => {
+  it("tracks FLOWER Spent farm activity when buying an item", () => {
     const result = buyChapterItem({
       state: mockState,
       action: {
@@ -89,7 +89,7 @@ describe("buyChapterItem", () => {
       createdAt: mockDate,
     });
 
-    expect(result.farmActivity["SFL Spent"]).toEqual(10);
+    expect(result.farmActivity["FLOWER Spent"]).toEqual(10);
   });
 
   it("subtracts items when buying an item", () => {

--- a/src/features/game/events/landExpansion/buyChapterItem.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.ts
@@ -254,6 +254,13 @@ export function buyChapterItem({
 
     // Deduct resources
     copy.balance = copy.balance.minus(_sfl);
+    if (_sfl.gt(0)) {
+      copy.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        copy.farmActivity,
+        _sfl,
+      );
+    }
     if (coins > 0) {
       copy.coins = currentCoins - coins;
     }

--- a/src/features/game/events/landExpansion/buyChapterItem.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.ts
@@ -256,7 +256,7 @@ export function buyChapterItem({
     copy.balance = copy.balance.minus(_sfl);
     if (_sfl.gt(0)) {
       copy.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         copy.farmActivity,
         _sfl,
       );

--- a/src/features/game/events/landExpansion/buyPortalItem.test.ts
+++ b/src/features/game/events/landExpansion/buyPortalItem.test.ts
@@ -209,7 +209,7 @@ describe("minigameItem.bought", () => {
     });
   });
 
-  it("tracks SFL Spent farm activity", () => {
+  it("tracks FLOWER Spent farm activity", () => {
     const state = buyEventShopItem({
       createdAt: now,
       action: {
@@ -233,7 +233,7 @@ describe("minigameItem.bought", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(20);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(20);
   });
 
   it("buys a collectible with VIP discount", () => {

--- a/src/features/game/events/landExpansion/buyPortalItem.test.ts
+++ b/src/features/game/events/landExpansion/buyPortalItem.test.ts
@@ -209,6 +209,33 @@ describe("minigameItem.bought", () => {
     });
   });
 
+  it("tracks SFL Spent farm activity", () => {
+    const state = buyEventShopItem({
+      createdAt: now,
+      action: {
+        id: "festival-of-colors-2025",
+        name: "Floating Toy",
+        type: "minigameItem.bought",
+      },
+      state: {
+        ...INITIAL_FARM,
+        balance: new Decimal(100),
+        inventory: { "Colors Token 2025": new Decimal(1000) },
+        minigames: {
+          prizes: {},
+          games: {
+            "festival-of-colors-2025": {
+              highscore: 0,
+              history: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(20);
+  });
+
   it("buys a collectible with VIP discount", () => {
     const state = buyEventShopItem({
       createdAt: now,

--- a/src/features/game/events/landExpansion/buyPortalItem.ts
+++ b/src/features/game/events/landExpansion/buyPortalItem.ts
@@ -68,6 +68,11 @@ export function buyEventShopItem({
       }
 
       stateCopy.balance = balance.sub(new Decimal(cost));
+      stateCopy.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        stateCopy.farmActivity,
+        new Decimal(cost),
+      );
     }
 
     getObjectEntries(items).forEach(([item, amount]) => {

--- a/src/features/game/events/landExpansion/buyPortalItem.ts
+++ b/src/features/game/events/landExpansion/buyPortalItem.ts
@@ -69,7 +69,7 @@ export function buyEventShopItem({
 
       stateCopy.balance = balance.sub(new Decimal(cost));
       stateCopy.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         stateCopy.farmActivity,
         new Decimal(cost),
       );

--- a/src/features/game/events/landExpansion/cancelBid.test.ts
+++ b/src/features/game/events/landExpansion/cancelBid.test.ts
@@ -61,10 +61,31 @@ describe("cancelBid", () => {
       state: {
         ...GAME_STATE,
         farmActivity: { "FLOWER Spent": 25 },
+        auctioneer: {
+          bid: {
+            ...GAME_STATE.auctioneer.bid!,
+            flowerSpentTracked: true,
+          },
+        },
       },
     });
 
     expect(state.farmActivity["FLOWER Spent"]).toEqual(15);
+  });
+
+  it("does not decrement FLOWER Spent when cancelling a legacy bid without the tracked marker", () => {
+    const state = cancelBid({
+      action: {
+        type: "bid.cancelled",
+        auctionId: "test-drop-1",
+      },
+      state: {
+        ...GAME_STATE,
+        farmActivity: { "FLOWER Spent": 25 },
+      },
+    });
+
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(25);
   });
 
   it("restores escrowed resources and clears the bid", () => {

--- a/src/features/game/events/landExpansion/cancelBid.test.ts
+++ b/src/features/game/events/landExpansion/cancelBid.test.ts
@@ -52,7 +52,7 @@ describe("cancelBid", () => {
     ).toThrow("Auction does not match active bid");
   });
 
-  it("decrements SFL Spent farm activity when cancelling a bid", () => {
+  it("decrements FLOWER Spent farm activity when cancelling a bid", () => {
     const state = cancelBid({
       action: {
         type: "bid.cancelled",
@@ -60,11 +60,11 @@ describe("cancelBid", () => {
       },
       state: {
         ...GAME_STATE,
-        farmActivity: { "SFL Spent": 25 },
+        farmActivity: { "FLOWER Spent": 25 },
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(15);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(15);
   });
 
   it("restores escrowed resources and clears the bid", () => {

--- a/src/features/game/events/landExpansion/cancelBid.test.ts
+++ b/src/features/game/events/landExpansion/cancelBid.test.ts
@@ -52,6 +52,21 @@ describe("cancelBid", () => {
     ).toThrow("Auction does not match active bid");
   });
 
+  it("decrements SFL Spent farm activity when cancelling a bid", () => {
+    const state = cancelBid({
+      action: {
+        type: "bid.cancelled",
+        auctionId: "test-drop-1",
+      },
+      state: {
+        ...GAME_STATE,
+        farmActivity: { "SFL Spent": 25 },
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(15);
+  });
+
   it("restores escrowed resources and clears the bid", () => {
     const state = cancelBid({
       action: {

--- a/src/features/game/events/landExpansion/cancelBid.ts
+++ b/src/features/game/events/landExpansion/cancelBid.ts
@@ -32,7 +32,7 @@ export function cancelBid({ state, action }: Options) {
     });
 
     game.balance = game.balance.add(bid.sfl);
-    if (bid.sfl > 0) {
+    if (bid.sfl > 0 && bid.flowerSpentTracked) {
       game.farmActivity = trackFarmActivity(
         "FLOWER Spent",
         game.farmActivity,

--- a/src/features/game/events/landExpansion/cancelBid.ts
+++ b/src/features/game/events/landExpansion/cancelBid.ts
@@ -34,7 +34,7 @@ export function cancelBid({ state, action }: Options) {
     game.balance = game.balance.add(bid.sfl);
     if (bid.sfl > 0) {
       game.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         game.farmActivity,
         new Decimal(-bid.sfl),
       );

--- a/src/features/game/events/landExpansion/cancelBid.ts
+++ b/src/features/game/events/landExpansion/cancelBid.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import type { GameState } from "features/game/types/game";
 import { getKeys } from "lib/object";
 import { produce } from "immer";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 
 export type CancelBidAction = {
   type: "bid.cancelled";
@@ -31,6 +32,13 @@ export function cancelBid({ state, action }: Options) {
     });
 
     game.balance = game.balance.add(bid.sfl);
+    if (bid.sfl > 0) {
+      game.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        game.farmActivity,
+        new Decimal(-bid.sfl),
+      );
+    }
 
     delete game.auctioneer.bid;
 

--- a/src/features/game/events/landExpansion/claimAchievement.test.ts
+++ b/src/features/game/events/landExpansion/claimAchievement.test.ts
@@ -65,6 +65,28 @@ describe("claim achievements", () => {
     expect(state.bumpkin?.achievements?.["Busy Bumpkin"]).toBe(1);
   });
 
+  it("claims High Roller by combining legacy SFL Spent and FLOWER Spent", () => {
+    const state = claimAchievement({
+      state: {
+        ...GAME_STATE,
+        farmActivity: {
+          "SFL Spent": 4000,
+          "FLOWER Spent": 3500,
+        },
+        bumpkin: {
+          ...INITIAL_BUMPKIN,
+          achievements: undefined,
+        },
+      },
+      action: {
+        type: "achievement.claimed",
+        achievement: "High Roller",
+      },
+    });
+
+    expect(state.bumpkin?.achievements?.["High Roller"]).toBe(1);
+  });
+
   it("claims busy bumpkin coin rewards", () => {
     const coins = 0;
     const experience = 250;

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.test.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.test.ts
@@ -374,6 +374,41 @@ describe("completeEventTask", () => {
     expect(state.balance).toEqual(new Decimal(1));
   });
 
+  it("tracks SFL Spent farm activity for sfl requirements", () => {
+    const state = completeSpecialEventTask({
+      createdAt: now,
+      action: {
+        type: "specialEvent.taskCompleted",
+        event: "Lunar New Year",
+        task: 1,
+      },
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(2),
+        specialEvents: {
+          history: {},
+          current: {
+            "Lunar New Year": {
+              isEligible: true,
+              requiresWallet: false,
+              text: "",
+              startAt: 0,
+              endAt: now + 1,
+              tasks: [
+                {
+                  reward: { wearables: {}, items: {}, sfl: 0, coins: 0 },
+                  requirements: { items: {}, sfl: 1 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(1);
+  });
+
   it("marks the task as completed", () => {
     const state = completeSpecialEventTask({
       createdAt: now,

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.test.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.test.ts
@@ -374,7 +374,7 @@ describe("completeEventTask", () => {
     expect(state.balance).toEqual(new Decimal(1));
   });
 
-  it("tracks SFL Spent farm activity for sfl requirements", () => {
+  it("tracks FLOWER Spent farm activity for sfl requirements", () => {
     const state = completeSpecialEventTask({
       createdAt: now,
       action: {
@@ -406,7 +406,7 @@ describe("completeEventTask", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(1);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(1);
   });
 
   it("marks the task as completed", () => {

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -3,6 +3,7 @@ import { getKeys } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
 import type { SpecialEventName } from "features/game/types/specialEvents";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
 export type CompleteSpecialEventTaskAction = {
@@ -66,6 +67,13 @@ export function completeSpecialEventTask({
     const balance = stateCopy.balance;
     if (balance.lt(sfl)) throw new Error("SFL requirement not met");
     stateCopy.balance = balance.minus(sfl);
+    if (sfl > 0) {
+      stateCopy.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        stateCopy.farmActivity,
+        new Decimal(sfl),
+      );
+    }
 
     stateCopy.inventory = getKeys(items).reduce((inventory, item) => {
       const inventoryAmount = inventory[item] ?? new Decimal(0);

--- a/src/features/game/events/landExpansion/completeSpecialEventTask.ts
+++ b/src/features/game/events/landExpansion/completeSpecialEventTask.ts
@@ -69,7 +69,7 @@ export function completeSpecialEventTask({
     stateCopy.balance = balance.minus(sfl);
     if (sfl > 0) {
       stateCopy.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         stateCopy.farmActivity,
         new Decimal(sfl),
       );

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.test.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.test.ts
@@ -27,7 +27,7 @@ describe("exchangeSFLtoCoins", () => {
     ).toThrow("Not enough SFL");
   });
 
-  it("tracks SFL Spent farm activity", () => {
+  it("tracks FLOWER Spent farm activity", () => {
     const state = exchangeSFLtoCoins({
       state: {
         ...TEST_FARM,
@@ -36,20 +36,20 @@ describe("exchangeSFLtoCoins", () => {
       action: { type: "sfl.exchanged", packageId: 2 },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(30);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(30);
   });
 
-  it("accumulates SFL Spent farm activity", () => {
+  it("accumulates FLOWER Spent farm activity", () => {
     const state = exchangeSFLtoCoins({
       state: {
         ...TEST_FARM,
         balance: new Decimal(1),
-        farmActivity: { "SFL Spent": 5 },
+        farmActivity: { "FLOWER Spent": 5 },
       },
       action: { type: "sfl.exchanged", packageId: 1 },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(6);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(6);
   });
 
   it("exchanges 1 sfl for 160 coins", () => {

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.test.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.test.ts
@@ -27,6 +27,31 @@ describe("exchangeSFLtoCoins", () => {
     ).toThrow("Not enough SFL");
   });
 
+  it("tracks SFL Spent farm activity", () => {
+    const state = exchangeSFLtoCoins({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(30),
+      },
+      action: { type: "sfl.exchanged", packageId: 2 },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(30);
+  });
+
+  it("accumulates SFL Spent farm activity", () => {
+    const state = exchangeSFLtoCoins({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(1),
+        farmActivity: { "SFL Spent": 5 },
+      },
+      action: { type: "sfl.exchanged", packageId: 1 },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(6);
+  });
+
   it("exchanges 1 sfl for 160 coins", () => {
     const state = exchangeSFLtoCoins({
       state: {

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
@@ -1,4 +1,6 @@
+import Decimal from "decimal.js-light";
 import type { GameState } from "features/game/types/game";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 import { produce } from "immer";
 
 type ExchangePackage = { sfl: number; coins: number };
@@ -48,6 +50,11 @@ export function exchangeSFLtoCoins({
 
     game.balance = balance.minus(sfl);
     game.coins += coins;
+    game.farmActivity = trackFarmActivity(
+      "SFL Spent",
+      game.farmActivity,
+      new Decimal(sfl),
+    );
 
     return game;
   });

--- a/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
+++ b/src/features/game/events/landExpansion/exchangeSFLtoCoins.ts
@@ -51,7 +51,7 @@ export function exchangeSFLtoCoins({
     game.balance = balance.minus(sfl);
     game.coins += coins;
     game.farmActivity = trackFarmActivity(
-      "SFL Spent",
+      "FLOWER Spent",
       game.farmActivity,
       new Decimal(sfl),
     );

--- a/src/features/game/events/landExpansion/joinFaction.test.ts
+++ b/src/features/game/events/landExpansion/joinFaction.test.ts
@@ -92,7 +92,7 @@ describe("joinFaction", () => {
     expect(state.balance).toEqual(new Decimal(90));
   });
 
-  it("tracks SFL Spent farm activity when joining", () => {
+  it("tracks FLOWER Spent farm activity when joining", () => {
     const state = joinFaction({
       state: {
         ...TEST_FARM,
@@ -105,7 +105,7 @@ describe("joinFaction", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(10);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(10);
   });
 
   it("throws an error if the player doesn't have enough SFL", () => {

--- a/src/features/game/events/landExpansion/joinFaction.test.ts
+++ b/src/features/game/events/landExpansion/joinFaction.test.ts
@@ -92,6 +92,22 @@ describe("joinFaction", () => {
     expect(state.balance).toEqual(new Decimal(90));
   });
 
+  it("tracks SFL Spent farm activity when joining", () => {
+    const state = joinFaction({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(100),
+      },
+      action: {
+        type: "faction.joined",
+        faction: "sunflorians",
+        sfl: 10,
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(10);
+  });
+
   it("throws an error if the player doesn't have enough SFL", () => {
     expect(() =>
       joinFaction({

--- a/src/features/game/events/landExpansion/joinFaction.ts
+++ b/src/features/game/events/landExpansion/joinFaction.ts
@@ -90,7 +90,7 @@ export function joinFaction({
     stateCopy.balance = state.balance.sub(action.sfl);
     if (action.sfl > 0) {
       stateCopy.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         stateCopy.farmActivity,
         new Decimal(action.sfl),
       );

--- a/src/features/game/events/landExpansion/joinFaction.ts
+++ b/src/features/game/events/landExpansion/joinFaction.ts
@@ -7,6 +7,7 @@ import type {
 } from "features/game/types/game";
 import { produce } from "immer";
 import { mfTrack } from "lib/moonforgeAnalytics";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 
 export const FACTIONS: FactionName[] = [
   "bumpkins",
@@ -87,6 +88,13 @@ export function joinFaction({
     }
 
     stateCopy.balance = state.balance.sub(action.sfl);
+    if (action.sfl > 0) {
+      stateCopy.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        stateCopy.farmActivity,
+        new Decimal(action.sfl),
+      );
+    }
 
     const banner = FACTION_BANNERS[action.faction];
 

--- a/src/features/game/events/landExpansion/refundBid.test.ts
+++ b/src/features/game/events/landExpansion/refundBid.test.ts
@@ -64,6 +64,31 @@ describe("refundBid", () => {
     expect(state.balance).toEqual(new Decimal(5));
   });
 
+  it("decrements SFL Spent farm activity when refunding sfl", () => {
+    const state = refundBid({
+      action: {
+        type: "bid.refunded",
+      },
+      state: {
+        ...TEST_FARM,
+        farmActivity: { "SFL Spent": 20 },
+        auctioneer: {
+          bid: {
+            collectible: "Beta Bear",
+            tickets: 3,
+            biddedAt: Date.now(),
+            ingredients: { Gold: 4 },
+            sfl: 5,
+            auctionId: "test-drop-1",
+            type: "collectible",
+          },
+        },
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(15);
+  });
+
   it("removes bid", () => {
     const state = refundBid({
       action: {

--- a/src/features/game/events/landExpansion/refundBid.test.ts
+++ b/src/features/game/events/landExpansion/refundBid.test.ts
@@ -64,14 +64,14 @@ describe("refundBid", () => {
     expect(state.balance).toEqual(new Decimal(5));
   });
 
-  it("decrements SFL Spent farm activity when refunding sfl", () => {
+  it("decrements FLOWER Spent farm activity when refunding sfl", () => {
     const state = refundBid({
       action: {
         type: "bid.refunded",
       },
       state: {
         ...TEST_FARM,
-        farmActivity: { "SFL Spent": 20 },
+        farmActivity: { "FLOWER Spent": 20 },
         auctioneer: {
           bid: {
             collectible: "Beta Bear",
@@ -86,7 +86,7 @@ describe("refundBid", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(15);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(15);
   });
 
   it("removes bid", () => {

--- a/src/features/game/events/landExpansion/refundBid.test.ts
+++ b/src/features/game/events/landExpansion/refundBid.test.ts
@@ -81,12 +81,37 @@ describe("refundBid", () => {
             sfl: 5,
             auctionId: "test-drop-1",
             type: "collectible",
+            flowerSpentTracked: true,
           },
         },
       },
     });
 
     expect(state.farmActivity["FLOWER Spent"]).toEqual(15);
+  });
+
+  it("does not write FLOWER Spent when refunding a legacy bid without the tracked marker", () => {
+    const state = refundBid({
+      action: {
+        type: "bid.refunded",
+      },
+      state: {
+        ...TEST_FARM,
+        auctioneer: {
+          bid: {
+            collectible: "Beta Bear",
+            tickets: 3,
+            biddedAt: Date.now(),
+            ingredients: { Gold: 4 },
+            sfl: 5,
+            auctionId: "test-drop-1",
+            type: "collectible",
+          },
+        },
+      },
+    });
+
+    expect(state.farmActivity["FLOWER Spent"]).toBeUndefined();
   });
 
   it("removes bid", () => {

--- a/src/features/game/events/landExpansion/refundBid.ts
+++ b/src/features/game/events/landExpansion/refundBid.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { getKeys } from "lib/object";
 import type { GameState } from "features/game/types/game";
 import { produce } from "immer";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 
 export type RefundBidAction = {
   type: "bid.refunded";
@@ -27,6 +28,13 @@ export function refundBid({ state }: Options) {
 
     // Add FLOWER back to balance
     game.balance = game.balance.add(bid.sfl);
+    if (bid.sfl > 0) {
+      game.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        game.farmActivity,
+        new Decimal(-bid.sfl),
+      );
+    }
 
     delete game.auctioneer.bid;
 

--- a/src/features/game/events/landExpansion/refundBid.ts
+++ b/src/features/game/events/landExpansion/refundBid.ts
@@ -28,7 +28,7 @@ export function refundBid({ state }: Options) {
 
     // Add FLOWER back to balance
     game.balance = game.balance.add(bid.sfl);
-    if (bid.sfl > 0) {
+    if (bid.sfl > 0 && bid.flowerSpentTracked) {
       game.farmActivity = trackFarmActivity(
         "FLOWER Spent",
         game.farmActivity,

--- a/src/features/game/events/landExpansion/refundBid.ts
+++ b/src/features/game/events/landExpansion/refundBid.ts
@@ -30,7 +30,7 @@ export function refundBid({ state }: Options) {
     game.balance = game.balance.add(bid.sfl);
     if (bid.sfl > 0) {
       game.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         game.farmActivity,
         new Decimal(-bid.sfl),
       );

--- a/src/features/game/events/minigames/purchaseMinigameItem.test.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.test.ts
@@ -172,7 +172,7 @@ describe("minigame.itemPurchased", () => {
     });
   });
 
-  it("tracks SFL Spent farm activity", () => {
+  it("tracks FLOWER Spent farm activity", () => {
     const state = purchaseMinigameItem({
       state: {
         ...TEST_FARM,
@@ -190,10 +190,10 @@ describe("minigame.itemPurchased", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toEqual(10);
+    expect(state.farmActivity["FLOWER Spent"]).toEqual(10);
   });
 
-  it("does not track SFL Spent when no sfl is spent", () => {
+  it("does not track FLOWER Spent when no sfl is spent", () => {
     const state = purchaseMinigameItem({
       state: {
         ...TEST_FARM,
@@ -212,7 +212,7 @@ describe("minigame.itemPurchased", () => {
       },
     });
 
-    expect(state.farmActivity["SFL Spent"]).toBeUndefined();
+    expect(state.farmActivity["FLOWER Spent"]).toBeUndefined();
   });
 
   it("stores multiple purchases", () => {

--- a/src/features/game/events/minigames/purchaseMinigameItem.test.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.test.ts
@@ -172,6 +172,49 @@ describe("minigame.itemPurchased", () => {
     });
   });
 
+  it("tracks SFL Spent farm activity", () => {
+    const state = purchaseMinigameItem({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(25),
+        minigames: {
+          prizes: {},
+          games: {},
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        type: "minigame.itemPurchased",
+        sfl: 10,
+        items: {},
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toEqual(10);
+  });
+
+  it("does not track SFL Spent when no sfl is spent", () => {
+    const state = purchaseMinigameItem({
+      state: {
+        ...TEST_FARM,
+        balance: new Decimal(25),
+        inventory: { Sunflower: new Decimal(5) },
+        minigames: {
+          prizes: {},
+          games: {},
+        },
+      },
+      action: {
+        id: "chicken-rescue",
+        type: "minigame.itemPurchased",
+        sfl: 0,
+        items: { Sunflower: 5 },
+      },
+    });
+
+    expect(state.farmActivity["SFL Spent"]).toBeUndefined();
+  });
+
   it("stores multiple purchases", () => {
     const state = purchaseMinigameItem({
       state: {

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -113,7 +113,7 @@ export function purchaseMinigameItem({
     game.balance = game.balance.sub(action.sfl);
     if (action.sfl > 0) {
       game.farmActivity = trackFarmActivity(
-        "SFL Spent",
+        "FLOWER Spent",
         game.farmActivity,
         new Decimal(action.sfl),
       );

--- a/src/features/game/events/minigames/purchaseMinigameItem.ts
+++ b/src/features/game/events/minigames/purchaseMinigameItem.ts
@@ -8,6 +8,7 @@ import {
   SUPPORTED_MINIGAMES,
 } from "features/game/types/minigames";
 import { COMMODITIES, type CommodityName } from "features/game/types/resources";
+import { trackFarmActivity } from "features/game/types/farmActivity";
 import { produce } from "immer";
 
 export type MinigameCurrency = CropName | PatchFruitName | CommodityName;
@@ -110,6 +111,13 @@ export function purchaseMinigameItem({
 
     // Burn the FLOWER
     game.balance = game.balance.sub(action.sfl);
+    if (action.sfl > 0) {
+      game.farmActivity = trackFarmActivity(
+        "SFL Spent",
+        game.farmActivity,
+        new Decimal(action.sfl),
+      );
+    }
 
     return game;
   });

--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -325,7 +325,8 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "Big Spender": {
     description: translate("bigSpender.description"),
     progress: (gameState: GameState) =>
-      gameState.farmActivity["SFL Spent"] || 0,
+      (gameState.farmActivity["SFL Spent"] || 0) +
+      (gameState.farmActivity["FLOWER Spent"] || 0),
     requirement: 10,
     coins: 20,
   },
@@ -341,7 +342,8 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   "High Roller": {
     description: translate("highRoller.description"),
     progress: (gameState: GameState) =>
-      gameState.farmActivity["SFL Spent"] || 0,
+      (gameState.farmActivity["SFL Spent"] || 0) +
+      (gameState.farmActivity["FLOWER Spent"] || 0),
     requirement: 7500,
     coins: 0,
     rewards: {

--- a/src/features/game/types/farmActivity.ts
+++ b/src/features/game/types/farmActivity.ts
@@ -221,6 +221,7 @@ export type FarmActivityName =
   | "Coins Spent"
   | "Coins Earned"
   | "SFL Spent"
+  | "FLOWER Spent"
   | "SFL Earned"
   | "Mutant Chicken Found"
   | "Building Constructed"

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -1208,6 +1208,9 @@ export type Bid = {
   ingredients: Partial<Record<InventoryItemName, number>>;
   biddedAt: number;
   tickets: number;
+  // Set when placing the bid incremented "FLOWER Spent" - bids placed
+  // before that tracking existed must not decrement it on cancel/refund
+  flowerSpentTracked?: boolean;
 } & (
   | {
       type: "collectible";


### PR DESCRIPTION
## Problem

The High Roller (7,500) and Big Spender (10) achievements read `farmActivity["SFL Spent"]`, but nothing has incremented that key since the SFL → Coins conversion (#3562, April 2024). Players' progress has been frozen ever since — anyone who hadn't already crossed the threshold can never earn these achievements, no matter how much FLOWER they spend.

## Changes

- Every game event that deducts FLOWER balance now tracks `farmActivity["FLOWER Spent"]`: `buyChapterItem`, `joinFaction`, `buyPortalItem`, `purchaseMinigameItem`, `completeSpecialEventTask`, `exchangeSFLtoCoins`. Amounts are the actual FLOWER paid (post VIP/SFL discounts), and zero-spend purchases don't write the key.
- `cancelBid` / `refundBid` decrement the counter so returned auction escrow doesn't count as spend (and bid/cancel loops can't farm it).
- High Roller and Big Spender progress is now `("SFL Spent" || 0) + ("FLOWER Spent" || 0)` — legacy pre-conversion totals still count, and the frozen `"SFL Spent"` key remains as historical data.

Mirrored in sunflower-land-api (same branch name), which also adds tracking for the server-driven spends: marketplace listing purchases, bulk resource buys, accepted offers, and auction `placeBid`.

## Testing

- TDD throughout: every new tracking call has a test that was watched failing first (asserting `farmActivity["FLOWER Spent"]` after the event), plus a `claimAchievement` test proving High Roller claims with combined legacy + new progress (4,000 + 3,500 vs the 7,500 requirement).
- Full suite green: 317 suites / 4,767 tests. `tsc --noEmit` and prettier clean.

## Out of scope / follow-ups

- Ledger backfill to credit spending from the April 2024 → now gap (per-farm aggregation of negative `changeset.balance` is feasible).
- `gems.traded` is not counted as FLOWER spend yet.
- `buyBiome` has a dead `coins` cost branch that deducts `balance` — looks like a latent bug, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q3rTRUcEo2nFckkxuJEzE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added game activity tracking for **FLOWER Spent** across purchases, faction fees, special event tasks, SFL exchanges, and minigame item buys.
  - Achievement progress for **Big Spender** and **High Roller** now counts both **SFL Spent** and **FLOWER Spent**.

- **Bug Fixes**
  - Bid cancellations and refunds now correctly adjust **FLOWER Spent** only when applicable (including support for legacy bids that weren’t previously tracked).
  - Purchase tracking updates only when FLOWER is actually spent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->