### PR TITLE
[FEAT] Group Letter Tiles into their own Chest category

### DIFF
--- a/src/features/game/types/decorations.ts
+++ b/src/features/game/types/decorations.ts
@@ -856,6 +856,63 @@ export const DECORATION_TEMPLATES = {
 
 export type TemplateDecorationName = keyof typeof DECORATION_TEMPLATES;
 
+export type LetterTileName =
+  | "Letter A Tile"
+  | "Letter B Tile"
+  | "Letter C Tile"
+  | "Letter D Tile"
+  | "Letter E Tile"
+  | "Letter F Tile"
+  | "Letter G Tile"
+  | "Letter H Tile"
+  | "Letter I Tile"
+  | "Letter J Tile"
+  | "Letter K Tile"
+  | "Letter L Tile"
+  | "Letter M Tile"
+  | "Letter N Tile"
+  | "Letter O Tile"
+  | "Letter P Tile"
+  | "Letter Q Tile"
+  | "Letter R Tile"
+  | "Letter S Tile"
+  | "Letter T Tile"
+  | "Letter U Tile"
+  | "Letter V Tile"
+  | "Letter W Tile"
+  | "Letter X Tile"
+  | "Letter Y Tile"
+  | "Letter Z Tile";
+
+export const LETTER_TILES: Record<LetterTileName, object> = {
+  "Letter A Tile": {},
+  "Letter B Tile": {},
+  "Letter C Tile": {},
+  "Letter D Tile": {},
+  "Letter E Tile": {},
+  "Letter F Tile": {},
+  "Letter G Tile": {},
+  "Letter H Tile": {},
+  "Letter I Tile": {},
+  "Letter J Tile": {},
+  "Letter K Tile": {},
+  "Letter L Tile": {},
+  "Letter M Tile": {},
+  "Letter N Tile": {},
+  "Letter O Tile": {},
+  "Letter P Tile": {},
+  "Letter Q Tile": {},
+  "Letter R Tile": {},
+  "Letter S Tile": {},
+  "Letter T Tile": {},
+  "Letter U Tile": {},
+  "Letter V Tile": {},
+  "Letter W Tile": {},
+  "Letter X Tile": {},
+  "Letter Y Tile": {},
+  "Letter Z Tile": {},
+};
+
 export type DecorationName =
   | DollName
   | AchievementDecorationName

--- a/src/features/island/hud/components/inventory/utils/chestCategories.test.ts
+++ b/src/features/island/hud/components/inventory/utils/chestCategories.test.ts
@@ -44,4 +44,26 @@ describe("getChestCategories", () => {
 
     expect(temporaryBoosts?.items).toEqual([]);
   });
+
+  it("groups letter tiles into their own category", () => {
+    const categories = getChestCategories(state, [
+      "Letter A Tile",
+      "Letter F Tile",
+      "Letter M Tile",
+      "Basic Scarecrow",
+    ]);
+
+    const letterTiles = categories.find((c) => c.id === "letterTiles");
+    const decorations = categories.find((c) => c.id === "decorations");
+
+    expect(letterTiles?.items).toEqual(
+      expect.arrayContaining([
+        "Letter A Tile",
+        "Letter F Tile",
+        "Letter M Tile",
+      ]),
+    );
+    expect(letterTiles?.items).toHaveLength(3);
+    expect(decorations?.items).not.toContain("Letter A Tile");
+  });
 });

--- a/src/features/island/hud/components/inventory/utils/chestCategories.ts
+++ b/src/features/island/hud/components/inventory/utils/chestCategories.ts
@@ -8,6 +8,7 @@ import { BANNERS } from "features/game/types/banners";
 import { BED_FARMHAND_COUNT } from "features/game/types/beds";
 import { WEATHER_SHOP_ITEM_COSTS } from "features/game/types/calendar";
 import { DOLLS } from "features/game/lib/crafting";
+import { LETTER_TILES } from "features/game/types/decorations";
 import { PET_TYPES } from "features/game/types/pets";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -36,6 +37,7 @@ const CHEST_CATEGORIES_META = [
   { id: "villageProjects", icon: ITEM_DETAILS["Big Orange"].image },
   { id: "dolls", icon: ITEM_DETAILS["Doll"].image },
   { id: "flowers", icon: ITEM_DETAILS["Prism Petal"].image },
+  { id: "letterTiles", icon: ITEM_DETAILS["Letter A Tile"].image },
   { id: "decorations", icon: ITEM_DETAILS["Basic Bear"].image },
 ] as const satisfies readonly { id: TranslationKeys; icon: string }[];
 
@@ -91,6 +93,7 @@ export const getChestCategories = (
   );
   const dolls = collectibleNames.filter((name) => name in DOLLS);
   const pets = collectibleNames.filter((name) => name in PET_TYPES);
+  const letterTiles = collectibleNames.filter((name) => name in LETTER_TILES);
 
   // Sets for O(1) lookups when computing the catch-all categories below.
   const resourcesSet = new Set(resources);
@@ -103,6 +106,7 @@ export const getChestCategories = (
   const flowersSet = new Set<CollectibleName>(flowers);
   const dollsSet = new Set(dolls);
   const petsSet = new Set(pets);
+  const letterTilesSet = new Set(letterTiles);
 
   // Totems, hourglasses and shrines expire and need re-triggering - split
   // them out from the "always on" boosts (EXPIRY_COOLDOWNS is the ground
@@ -116,7 +120,8 @@ export const getChestCategories = (
         !monumentsSet.has(name) &&
         !villageProjectsSet.has(name) &&
         !bedsSet.has(name) &&
-        !flowersSet.has(name),
+        !flowersSet.has(name) &&
+        !letterTilesSet.has(name),
     );
 
   const temporaryBoostsSet = new Set(temporaryBoosts);
@@ -131,7 +136,8 @@ export const getChestCategories = (
         !villageProjectsSet.has(name) &&
         !bedsSet.has(name) &&
         !flowersSet.has(name) &&
-        !temporaryBoostsSet.has(name),
+        !temporaryBoostsSet.has(name) &&
+        !letterTilesSet.has(name),
     );
 
   const boostsSet = new Set(boosts);
@@ -149,7 +155,8 @@ export const getChestCategories = (
       !dollsSet.has(name) &&
       !petsSet.has(name) &&
       !flowersSet.has(name) &&
-      !villageProjectsSet.has(name),
+      !villageProjectsSet.has(name) &&
+      !letterTilesSet.has(name),
   );
 
   const itemsById: Record<ChestCategoryId, CollectibleName[]> = {
@@ -165,6 +172,7 @@ export const getChestCategories = (
     villageProjects,
     dolls,
     flowers,
+    letterTiles,
     decorations,
   };
 

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -81,6 +81,7 @@
   "following": "Following",
   "you": "You",
   "dolls": "Dolls",
+  "letterTiles": "Letter Tiles",
   "noActivity": "No activity yet.",
   "myProfile": "My profile",
   "stream": "Stream",


### PR DESCRIPTION
## Summary

The 26 Letter Tiles (`Letter A Tile` through `Letter Z Tile`, used to spell decorative words like FARM) had no dedicated grouping in `getChestCategories`, so they fell into the catch-all "decorations" category alongside every other unclassified collectible — making them hard to find in a Chest full of decorations once a player owns several tiles.
<img width="922" height="564" alt="image" src="https://github.com/user-attachments/assets/b6539215-1bf8-4cbf-88c2-d3d237394350" />

## Changes

- Added a `LetterTileName` type and `LETTER_TILES` lookup object (`Record<LetterTileName, object>`, the same pattern already used for `DOLLS`/`PET_TYPES`/etc.) in `decorations.ts`.
- Added a new `letterTiles` category in `chestCategories.ts`, following the exact same pattern as the other dedicated categories (dolls, banners, weatherItems, ...):
  - Filtered out of `temporaryBoosts`, `boosts`, and the catch-all `decorations` category so tiles aren't double-counted.
  - Own icon (reusing the `Letter A Tile` artwork already in `ITEM_DETAILS`).
  - New `letterTiles` translation key ("Letter Tiles"), added to `dictionary.json` only, per this repo's i18n pipeline (`en.json` and the other 10 locales are regenerated from it by `_scripts/translate.ts`).

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors.
- [x] Added a test asserting letter tiles are grouped into their own category and excluded from `decorations`, following the existing test style in `chestCategories.test.ts`. All 4 tests pass.
- [x] Full test suite (`yarn test`): 318/318 suites passing.
- [x] Manually verified in the running app: with a mock inventory containing a few letter tiles plus an unrelated boosted decoration, the Chest now shows a separate "Letter Tiles" category and the tiles no longer appear under "Decorations".