### PR TITLE
[FEAT] Ascension Age marvel roles: Seahorse Dad marvel + map-piece odds rebalance

### DIFF
--- a/src/features/game/types/ascensionAge.test.ts
+++ b/src/features/game/types/ascensionAge.test.ts
@@ -14,7 +14,7 @@ describe("Ascension Age registration", () => {
   });
 
   it("maps the chapter to its marvel fish", () => {
-    expect(getChapterMarvelFish(IN_CHAPTER)).toEqual("Crocodile");
+    expect(getChapterMarvelFish(IN_CHAPTER)).toEqual("Seahorse Dad");
   });
 
   it("declares the chapter's mutant set", () => {

--- a/src/features/game/types/chapters.ts
+++ b/src/features/game/types/chapters.ts
@@ -241,8 +241,7 @@ export const CHAPTER_MARVEL_FISH: Record<ChapterName, ChapterFish> = {
   "Paw Prints": "Super Star",
   "Crabs and Traps": "Giant Isopod",
   "Salt Awakening": "Deep Sea Pig",
-  // TODO(Ascension Age): confirm which of the 3 chapter fish is the marvel
-  "Ascension Age": "Crocodile",
+  "Ascension Age": "Seahorse Dad",
 };
 
 export function getChapterMarvelFish(now: number): ChapterFish {

--- a/src/features/game/types/fishing.ts
+++ b/src/features/game/types/fishing.ts
@@ -779,8 +779,8 @@ export const MAP_PUZZLE_DIFFICULTY: Record<MarineMarvelName, number> = {
   "Deep Sea Slug": 4,
   "Crystal Shrimp": 3,
   Crocodile: 3,
-  "Dumbo Octopus": 4,
-  "Seahorse Dad": 3,
+  "Dumbo Octopus": 3,
+  "Seahorse Dad": 4,
 };
 
 export function getDailyFishingCount(state: GameState): number {
@@ -988,12 +988,12 @@ const CHAPTER_MAP_PIECE_TRIGGERS: Partial<
     Coelacanth: { marvel: "Deep Sea Pig", odds: 0.005 },
   },
   "Ascension Age": {
-    "Red Snapper": { marvel: "Crocodile", odds: 0.008 },
-    "Moray Eel": { marvel: "Crocodile", odds: 0.03 },
-    "Olive Flounder": { marvel: "Dumbo Octopus", odds: 0.001 },
-    Napoleanfish: { marvel: "Dumbo Octopus", odds: 0.01 },
-    Angelfish: { marvel: "Seahorse Dad", odds: 0.005 },
-    Porgy: { marvel: "Seahorse Dad", odds: 0.005 },
+    "Red Snapper": { marvel: "Crocodile", odds: 0.005 },
+    "Moray Eel": { marvel: "Crocodile", odds: 0.015 },
+    "Olive Flounder": { marvel: "Dumbo Octopus", odds: 0.005 },
+    Napoleanfish: { marvel: "Dumbo Octopus", odds: 0.005 },
+    Angelfish: { marvel: "Seahorse Dad", odds: 0.001 },
+    Porgy: { marvel: "Seahorse Dad", odds: 0.01 },
   },
 };
 

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -1714,6 +1714,14 @@ export const INVENTORY_RELEASES: InventoryReleases = {
   },
 
   // Ascension Age Collectibles
+  Crocodile: {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
+  "Dumbo Octopus": {
+    tradeAt: CHAPTERS["Ascension Age"].endDate,
+    withdrawAt: new Date("2026-11-30T00:00:00Z"),
+  },
   Astrolabe: {
     tradeAt: CHAPTERS["Ascension Age"].endDate,
     withdrawAt: new Date("2026-11-30T00:00:00Z"),


### PR DESCRIPTION
## What

Locks in the roles of the three Ascension Age marine marvels (resolves the `TODO(Ascension Age)` in `chapters.ts`):

| Marvel | Role | Tradable/Withdrawable |
|---|---|---|
| **Seahorse Dad** | Chapter marvel — the hard keepsake (Deep Sea Pig pattern) | ❌ No (deliberately no `INVENTORY_RELEASES` entry) |
| **Dumbo Octopus** | The boost collectible (buff lands in a follow-up) | ✅ After chapter end |
| **Crocodile** | Standard chapter fish | ✅ After chapter end |

## Map-piece odds changes

The scaffold odds mirrored Salt Awakening 1:1. This PR rebalances them so **Seahorse Dad is the rare one**:

| Trigger fish | Marvel | Before | After |
|---|---|---|---|
| Red Snapper | Crocodile | 0.008 | **0.005** |
| Moray Eel | Crocodile | 0.03 | **0.015** |
| Olive Flounder | Dumbo Octopus | 0.001 | **0.005** |
| Napoleanfish | Dumbo Octopus | 0.01 | **0.005** |
| Angelfish | Seahorse Dad | 0.005 | **0.001** |
| Porgy | Seahorse Dad | 0.005 | **0.01** |

Map puzzle difficulty swapped accordingly: Seahorse Dad 3→4, Dumbo Octopus 4→3.

## Other changes

- `CHAPTER_MARVEL_FISH["Ascension Age"]` = Seahorse Dad (codex highlight).
- `INVENTORY_RELEASES`: Crocodile + Dumbo Octopus tradeAt = chapter end, withdrawAt = 2026-11-30 (Salt convention). Seahorse Dad intentionally omitted.

## Verification

- `ascensionAge.test.ts` updated (red → green) — 52/52 passing.
- `tsc` clean.
- BE mirror: sunflower-land-api PR (odds + RELEASES; marvel-fish map and puzzle difficulty are FE-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Crocodile and Dumbo Octopus collectibles to the Ascension Age inventory release schedule.
* **Updates**
  * Updated the Ascension Age featured marvel fish to Seahorse Dad.
  * Adjusted puzzle difficulty ratings for Dumbo Octopus and Seahorse Dad.
  * Rebalanced Ascension Age fishing trigger odds across several fish encounters.
* **Bug Fixes**
  * Corrected the chapter-to-marvel-fish mapping for Ascension Age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->