### PR TITLE
[FEAT] Auction tiebreaker copy: ascension then level

### DIFF
--- a/src/features/retreat/components/auctioneer/TieBreaker.tsx
+++ b/src/features/retreat/components/auctioneer/TieBreaker.tsx
@@ -49,7 +49,7 @@ export const TieBreaker: React.FC<Props> = ({
         {`So close! You bid the exact same resources as the ${toOrdinalSuffix(
           results.supply,
         )} bid.`}{" "}
-        {t("tieBreaker.closeBid")}
+        {t("tieBreaker.ascensionRule")}
       </p>
       <p className="text-xs  mb-1 text-center px-2">
         {t("tieBreaker.betterLuck")}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4279,7 +4279,7 @@
   "swarming.tooLongToFarm": "Pay attention, you took too long to farm your crops!",
   "swarming.goblinsTakenOver": "The Goblins have taken over your farm. You must wait for them to leave",
   "tieBreaker.tiebreaker": "Tiebreaker",
-  "tieBreaker.ascensionRule": "A tie breaker is chosen by whichever Bumpkin has the higher Ascension, then level. Unfortunately you lost.",
+  "tieBreaker.ascensionRule": "A tie breaker is chosen by whichever Bumpkin has the higher Ascension, then level, then experience. Unfortunately you lost.",
   "tieBreaker.betterLuck": "Time to eat some more cakes! Better luck next time.",
   "tieBreaker.refund": "Refund resource",
   "time.millisecond.full": "millisecond",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4279,7 +4279,7 @@
   "swarming.tooLongToFarm": "Pay attention, you took too long to farm your crops!",
   "swarming.goblinsTakenOver": "The Goblins have taken over your farm. You must wait for them to leave",
   "tieBreaker.tiebreaker": "Tiebreaker",
-  "tieBreaker.closeBid": " A tie breaker is chosen by whichever Bumpkin has more experience. Unfortunately you lost.",
+  "tieBreaker.ascensionRule": "A tie breaker is chosen by whichever Bumpkin has the higher Ascension, then level. Unfortunately you lost.",
   "tieBreaker.betterLuck": "Time to eat some more cakes! Better luck next time.",
   "tieBreaker.refund": "Refund resource",
   "time.millisecond.full": "millisecond",


### PR DESCRIPTION
## Description

Companion to sunflower-land/sunflower-land-api#3525, which changes the auction tiebreak rule from raw Bumpkin experience to **ascension, then within-ascension level, then experience**.

The tiebreaker screen still told players ties are decided by experience — this updates the copy to match the new rule.

## Changes

- New dictionary key `tieBreaker.ascensionRule` ("A tie breaker is chosen by whichever Bumpkin has the higher Ascension, then level. Unfortunately you lost.") — added to `dictionary.json` only, per i18n rules
- Removed the stale `tieBreaker.closeBid` key (renamed rather than edited in place so the translation bot re-translates every locale instead of leaving stale foreign copies)
- `TieBreaker.tsx` uses the new key

No logic changes — winner selection happens entirely on the BE.

## Testing

- `tsc` clean (translation keys are typed from `dictionary.json`, so the rename is compiler-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tie-breaker instructions to accurately reflect the full decision order: higher Ascension first, then level (with the experience step remaining as described).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->