### PR TITLE
[FEAT] Make SWAMP_ASCENSION + ASCENSION_SKILLS time-based flags

### DIFF
--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -39,7 +39,7 @@ import {
   useExpansionCoinCostWithVip,
   useVipAccess,
 } from "lib/utils/hooks/useVipAccess";
-import { hasFeatureAccess } from "lib/flags";
+import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
 /**
  * The props for the component.
  * @param gameState The game state.
@@ -237,9 +237,13 @@ export const Expanding: React.FC<{
     readyAt ?? 0,
   );
 
+  const hasSwampAscensionAccess = useTimeBasedFeatureAccess({
+    featureName: "SWAMP_ASCENSION",
+    game: state,
+  });
   const hasAccess = !hasRequiredIslandExpansion(
     state.island.type,
-    hasFeatureAccess(state, "SWAMP_ASCENSION") ? "swamp" : "desert",
+    hasSwampAscensionAccess ? "swamp" : "desert",
   );
 
   const payment = useSpeedUpPayment({ readyAt, game: state });

--- a/src/features/bumpkins/components/AchievementDetails.tsx
+++ b/src/features/bumpkins/components/AchievementDetails.tsx
@@ -11,6 +11,8 @@ import { Button } from "components/ui/Button";
 import type { GameState } from "features/game/types/game";
 import { InnerPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { setImageWidth } from "lib/images";
@@ -36,7 +38,12 @@ export const AchievementDetails: React.FC<Props> = ({
   state,
 }) => {
   const achievement = ACHIEVEMENTS()[name];
-  const progress = achievement.progress(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const progress = achievement.progress(state, now);
   const isComplete = progress >= achievement.requirement;
 
   const bumpkinAchievements = state.bumpkin?.achievements || {};

--- a/src/features/bumpkins/components/AchievementDetails.tsx
+++ b/src/features/bumpkins/components/AchievementDetails.tsx
@@ -11,8 +11,6 @@ import { Button } from "components/ui/Button";
 import type { GameState } from "features/game/types/game";
 import { InnerPanel } from "components/ui/Panel";
 import { ITEM_DETAILS } from "features/game/types/images";
-import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
-import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { setImageWidth } from "lib/images";
@@ -29,6 +27,7 @@ interface Props {
   name: AchievementName;
   state: GameState;
   readonly: boolean;
+  now: number;
 }
 
 export const AchievementDetails: React.FC<Props> = ({
@@ -36,13 +35,9 @@ export const AchievementDetails: React.FC<Props> = ({
   onClaim,
   name,
   state,
+  now,
 }) => {
   const achievement = ACHIEVEMENTS()[name];
-  const now = useNow({
-    live: true,
-    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
-    intervalMs: 60 * 1000,
-  });
   const progress = achievement.progress(state, now);
   const isComplete = progress >= achievement.requirement;
 

--- a/src/features/bumpkins/components/Achievements.tsx
+++ b/src/features/bumpkins/components/Achievements.tsx
@@ -6,6 +6,8 @@ import {
   type AchievementName,
   ACHIEVEMENTS,
 } from "features/game/types/achievements";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { ITEM_DETAILS } from "features/game/types/images";
 import classNames from "classnames";
@@ -27,7 +29,7 @@ interface Props {
   readonly: boolean;
 }
 
-const getDefaultSelectedAchievement = (state: GameState) => {
+const getDefaultSelectedAchievement = (state: GameState, now: number) => {
   const achievements = ACHIEVEMENTS();
   const bumpkinAchievements = state.bumpkin?.achievements || {};
   const achievementKeys = getKeys(achievements).filter((achievement) => {
@@ -37,7 +39,7 @@ const getDefaultSelectedAchievement = (state: GameState) => {
 
   const firstUnclaimedAchievementName = achievementKeys.find((name) => {
     const achievement = achievements[name];
-    const progress = achievement.progress(state);
+    const progress = achievement.progress(state, now);
     const isComplete = progress >= achievement.requirement;
     const isAlreadyClaimed = !!bumpkinAchievements[name];
 
@@ -54,8 +56,13 @@ export const Achievements: React.FC<Props> = ({ onBack, readonly }) => {
       context: { state },
     },
   ] = useActor(gameService);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
   const [selected, setSelected] = useState<AchievementName>(
-    getDefaultSelectedAchievement(state),
+    getDefaultSelectedAchievement(state, now),
   );
 
   const achievements = ACHIEVEMENTS();
@@ -94,7 +101,7 @@ export const Achievements: React.FC<Props> = ({ onBack, readonly }) => {
             .map((name) => {
               const achievement = achievements[name];
 
-              const progress = achievement.progress(state);
+              const progress = achievement.progress(state, now);
               const isComplete = progress >= achievement.requirement;
 
               const bumpkinAchievements = state.bumpkin?.achievements || {};

--- a/src/features/bumpkins/components/Achievements.tsx
+++ b/src/features/bumpkins/components/Achievements.tsx
@@ -86,6 +86,7 @@ export const Achievements: React.FC<Props> = ({ onBack, readonly }) => {
           onClaim={claim}
           state={state}
           readonly={readonly}
+          now={now}
         />
       </div>
       <div className="w-full mt-2">

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -49,6 +49,7 @@ import {
 import { getSkillCooldown } from "features/game/events/landExpansion/skillUsed";
 import { getAvailableBumpkinSkillPoints } from "features/game/events/landExpansion/choseSkill";
 import { useNow } from "lib/utils/hooks/useNow";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 
 export type ViewState =
   | "home"
@@ -133,7 +134,12 @@ export const BumpkinModal: React.FC<Props> = ({
   const { openModal } = useContext(ModalContext);
   const experience = useSelector(gameService, _experience);
   const ascensionLevel = gameState.island.ascensionLevel ?? 0;
-  const maxBumpkinLevel = getMaxBumpkinLevel(gameState);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const maxBumpkinLevel = getMaxBumpkinLevel(gameState, now);
   const isAscended = ascensionLevel >= 1;
   const ascension = getAscensionLevel({
     experience,
@@ -156,7 +162,6 @@ export const BumpkinModal: React.FC<Props> = ({
     return stored && valid.includes(stored) ? stored : initialTab;
   });
   const { t } = useAppTranslation();
-  const now = useNow();
 
   useEffect(() => {
     if (!readonly) {
@@ -204,7 +209,7 @@ export const BumpkinModal: React.FC<Props> = ({
   >(undefined);
 
   const availableFood = getAvailableFood(inventory);
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(gameState);
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(gameState, now);
 
   if (view === "achievements") {
     return (

--- a/src/features/bumpkins/components/BumpkinModal.tsx
+++ b/src/features/bumpkins/components/BumpkinModal.tsx
@@ -134,12 +134,17 @@ export const BumpkinModal: React.FC<Props> = ({
   const { openModal } = useContext(ModalContext);
   const experience = useSelector(gameService, _experience);
   const ascensionLevel = gameState.island.ascensionLevel ?? 0;
-  const now = useNow({
+  // Mount snapshot, as before — drives the power-skill cooldown readiness check.
+  const now = useNow();
+  // Separate bounded clock for the flag-derived values, so the level cap and
+  // skill-point count flip when the window opens without pinning the cooldown
+  // clock to that window.
+  const featureNow = useNow({
     live: true,
     autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
     intervalMs: 60 * 1000,
   });
-  const maxBumpkinLevel = getMaxBumpkinLevel(gameState, now);
+  const maxBumpkinLevel = getMaxBumpkinLevel(gameState, featureNow);
   const isAscended = ascensionLevel >= 1;
   const ascension = getAscensionLevel({
     experience,
@@ -209,7 +214,10 @@ export const BumpkinModal: React.FC<Props> = ({
   >(undefined);
 
   const availableFood = getAvailableFood(inventory);
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(gameState, now);
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(
+    gameState,
+    featureNow,
+  );
 
   if (view === "achievements") {
     return (

--- a/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
+++ b/src/features/bumpkins/components/revamp/SkillCategoryList.tsx
@@ -8,6 +8,8 @@ import {
 
 import { Modal } from "components/ui/Modal";
 import { Label } from "components/ui/Label";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
@@ -60,7 +62,12 @@ export const SkillCategoryList: React.FC<{
     useState(false);
 
   const { bumpkin, inventory } = state;
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(state, now);
   const { previousFreeSkillResetAt = 0, paidSkillResets = 0, skills } = bumpkin;
 
   const hasSkills = getKeys(skills).length > 0;

--- a/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
+++ b/src/features/bumpkins/components/revamp/SkillPathDetails.tsx
@@ -35,7 +35,9 @@ import {
   SKILL_POINTS_PER_TIER,
 } from "features/game/events/landExpansion/choseSkill";
 import { gameAnalytics } from "lib/gameAnalytics";
-import { hasFeatureAccess } from "lib/flags";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
+import { useNow } from "lib/utils/hooks/useNow";
 import Decimal from "decimal.js-light";
 
 // Icon imports
@@ -194,7 +196,12 @@ export const SkillPathDetails: React.FC<Props> = ({
   });
   const { buff, debuff } = boosts;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(state, now);
   const { availableTier, totalUsedSkillPoints } = getUnlockedTierForTree(
     tree,
     bumpkin,
@@ -217,7 +224,10 @@ export const SkillPathDetails: React.FC<Props> = ({
 
   // The three panel modes. Upgrades only exist behind ASCENSION_SKILLS, so
   // non-Crops trees and flag-off players resolve to Locked -> Maxed (no ranks).
-  const upgradesEnabled = hasFeatureAccess(state, "ASCENSION_SKILLS");
+  const upgradesEnabled = useTimeBasedFeatureAccess({
+    featureName: "ASCENSION_SKILLS",
+    game: state,
+  });
   const canUpgradeHere = upgradesEnabled && !!upgrade;
   const isLocked = !hasSelectedSkill;
   const isUpgradable =
@@ -654,12 +664,7 @@ export const SkillPathDetails: React.FC<Props> = ({
                             overlayIcon={
                               <img
                                 src={
-                                  isSkillMaxed ||
-                                  (!hasFeatureAccess(
-                                    state,
-                                    "ASCENSION_SKILLS",
-                                  ) &&
-                                    hasSkill)
+                                  isSkillMaxed || (!upgradesEnabled && hasSkill)
                                     ? SUNNYSIDE.icons.confirm
                                     : !tierUnlocked
                                       ? SUNNYSIDE.icons.lock

--- a/src/features/game/components/DailyReward.tsx
+++ b/src/features/game/components/DailyReward.tsx
@@ -188,7 +188,7 @@ export const DailyRewardClaim: React.FC<{ showClose?: boolean }> = ({
     const level = getTotalBumpkinLevel({
       experience: bumpkinExperience,
       ascensionLevel: gameState.island.ascensionLevel ?? 0,
-      maxLevel: getMaxBumpkinLevel(gameState),
+      maxLevel: getMaxBumpkinLevel(gameState, now),
     });
     const vipGiftItem = hasVip ? getVipDailyBonusItem(level) : null;
     if (vipGiftItem) {

--- a/src/features/game/events/landExpansion/choseSkill.test.ts
+++ b/src/features/game/events/landExpansion/choseSkill.test.ts
@@ -209,124 +209,151 @@ describe("choseSkill", () => {
 
   describe("getAvailableBumpkinSkillPoints", () => {
     it("makes sure level 1 bumpkin with no skills has 1 skill point", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[1],
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[1],
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(1);
     });
 
     it("makes sure level 10 bumpkin with no skills has 10 skill points", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[10],
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[10],
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(10);
     });
 
     it("makes sure level 5 bumpkins with one tier 1 skills has 4 skill points", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[5],
-          skills: { "Young Farmer": 1 },
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[5],
+            skills: { "Young Farmer": 1 },
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(4);
     });
 
     it("makes sure level 5 bumpkins with one tier 2 skills has 3 skill points", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[5],
-          skills: { "Strong Roots": 1 },
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[5],
+            skills: { "Strong Roots": 1 },
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(3);
     });
 
     it("makes sure level 5 bumpkins with one tier 3 skills has 2 skill points", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[5],
-          skills: { "Instant Growth": 1 },
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[5],
+            skills: { "Instant Growth": 1 },
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(2);
     });
 
     it("makes sure level 10 bumpkins with one skill of each tier has 5 skill points", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[10],
-          skills: {
-            "Young Farmer": 1,
-            "Strong Roots": 1,
-            "Instant Growth": 1,
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[10],
+            skills: {
+              "Young Farmer": 1,
+              "Strong Roots": 1,
+              "Instant Growth": 1,
+            },
           },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(4);
     });
 
     it("grants 150 skill points at the pre-ascension cap (level 150)", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[150],
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[150],
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(150);
     });
 
     it("grants 150 + within-ascension level skill points (A1 L1 → 151)", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        island: { type: "swamp", ascensionLevel: 1 },
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: ascensionBaseline(1),
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          island: { type: "swamp", ascensionLevel: 1 },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: ascensionBaseline(1),
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(151);
     });
 
     it("grants 200 skill points at A1 L50 (band complete)", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        island: { type: "swamp", ascensionLevel: 1 },
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: ascensionBaseline(2),
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          island: { type: "swamp", ascensionLevel: 1 },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: ascensionBaseline(2),
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(200);
     });
@@ -335,29 +362,35 @@ describe("choseSkill", () => {
       let experience = ascensionBaseline(2);
       for (let n = 1; n < 25; n++) experience += levelXp(2, n);
 
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        island: { type: "swamp", ascensionLevel: 2 },
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience,
-          skills: {},
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          island: { type: "swamp", ascensionLevel: 2 },
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience,
+            skills: {},
+          },
         },
-      });
+        dateNow,
+      );
 
       expect(result).toBe(225);
     });
 
     it("subtracts skill points spent on rank upgrades", () => {
-      const result = getAvailableBumpkinSkillPoints({
-        ...TEST_FARM,
-        bumpkin: {
-          ...INITIAL_BUMPKIN,
-          experience: LEVEL_EXPERIENCE[10],
-          // Green Thumb (tier 1) at rank 3: base 1 + upgrades 1 * 2 = 3 used.
-          skills: { "Green Thumb": 3 },
+      const result = getAvailableBumpkinSkillPoints(
+        {
+          ...TEST_FARM,
+          bumpkin: {
+            ...INITIAL_BUMPKIN,
+            experience: LEVEL_EXPERIENCE[10],
+            // Green Thumb (tier 1) at rank 3: base 1 + upgrades 1 * 2 = 3 used.
+            skills: { "Green Thumb": 3 },
+          },
         },
-      });
+        dateNow,
+      );
 
       // Level 10 earns 10 points; 3 spent => 7 available.
       expect(result).toBe(7);

--- a/src/features/game/events/landExpansion/choseSkill.ts
+++ b/src/features/game/events/landExpansion/choseSkill.ts
@@ -26,7 +26,10 @@ type Options = {
   createdAt?: number;
 };
 
-export const getAvailableBumpkinSkillPoints = (game?: GameState) => {
+export const getAvailableBumpkinSkillPoints = (
+  game: GameState | undefined,
+  now: number,
+) => {
   const bumpkin = game?.bumpkin;
   if (!bumpkin) return 0;
 
@@ -34,7 +37,7 @@ export const getAvailableBumpkinSkillPoints = (game?: GameState) => {
   const earnedSkillPoints = getTotalBumpkinLevel({
     experience: bumpkin.experience,
     ascensionLevel: game.island.ascensionLevel ?? 0,
-    maxLevel: getMaxBumpkinLevel(game),
+    maxLevel: getMaxBumpkinLevel(game, now),
   });
   const skillsClaimed = Object.keys(bumpkin.skills) as BumpkinRevampSkillName[];
 
@@ -171,7 +174,10 @@ export function choseSkill({ state, action, createdAt = Date.now() }: Options) {
       BUMPKIN_REVAMP_SKILL_TREE[action.skill];
     const bumpkinHasSkill = bumpkin.skills[action.skill];
 
-    const availableSkillPoints = getAvailableBumpkinSkillPoints(stateCopy);
+    const availableSkillPoints = getAvailableBumpkinSkillPoints(
+      stateCopy,
+      createdAt,
+    );
     const { availableTier } = getUnlockedTierForTree(tree, bumpkin);
 
     if (!hasRequiredIslandExpansion(island.type, requirements.island)) {

--- a/src/features/game/events/landExpansion/claimAchievement.ts
+++ b/src/features/game/events/landExpansion/claimAchievement.ts
@@ -18,9 +18,14 @@ export type ClaimAchievementAction = {
 type Options = {
   state: Readonly<GameState>;
   action: ClaimAchievementAction;
+  createdAt?: number;
 };
 
-export function claimAchievement({ state, action }: Options): GameState {
+export function claimAchievement({
+  state,
+  action,
+  createdAt = Date.now(),
+}: Options): GameState {
   return produce(state, (stateCopy) => {
     const bumpkin = stateCopy.bumpkin;
     const achievement = ACHIEVEMENTS()[action.achievement];
@@ -33,7 +38,7 @@ export function claimAchievement({ state, action }: Options): GameState {
       throw new Error(translate("claimAchievement.alreadyHave"));
     }
 
-    if (achievement.progress(stateCopy) < achievement.requirement) {
+    if (achievement.progress(stateCopy, createdAt) < achievement.requirement) {
       throw new Error(translate("claimAchievement.requirementsNotMet"));
     }
 

--- a/src/features/game/events/landExpansion/claimDailyReward.ts
+++ b/src/features/game/events/landExpansion/claimDailyReward.ts
@@ -151,7 +151,7 @@ export function claimDailyReward({
       const level = getTotalBumpkinLevel({
         experience: game.bumpkin.experience ?? 0,
         ascensionLevel: game.island.ascensionLevel ?? 0,
-        maxLevel: getMaxBumpkinLevel(game),
+        maxLevel: getMaxBumpkinLevel(game, createdAt),
       });
       const vipBonusItem = getVipDailyBonusItem(level);
       if (vipBonusItem) {

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -6,7 +6,7 @@ import {
 import { getKeys } from "lib/object";
 import type { BoostName, GameState } from "features/game/types/game";
 import { ASCENSION_ISLANDS } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { onboardingAnalytics } from "lib/onboardingAnalytics";
 import { mfTrack } from "lib/moonforgeAnalytics";
 
@@ -47,7 +47,11 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
     // ascension island while the flag was on if it is later turned off.
     if (
       (ASCENSION_ISLANDS as readonly string[]).includes(game.island.type) &&
-      !hasFeatureAccess(game, "SWAMP_ASCENSION")
+      !hasTimeBasedFeatureAccess({
+        featureName: "SWAMP_ASCENSION",
+        game,
+        now: createdAt,
+      })
     ) {
       throw new Error("Swamp ascension is not yet available");
     }
@@ -66,7 +70,7 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
       throw new Error("No more land expansions available");
     }
 
-    const land = getLand({ game });
+    const land = getLand({ game, now: createdAt });
     if (!land) {
       throw new Error("Land Does Not Exists");
     }

--- a/src/features/game/events/landExpansion/revealLand.ts
+++ b/src/features/game/events/landExpansion/revealLand.ts
@@ -11,7 +11,7 @@ import {
   SUNSTONE_MINES,
 } from "features/game/types/expansions";
 import type { Airdrop, GameState } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 import { getKeys } from "lib/object";
 import { pickEmptyPosition } from "features/game/expansion/placeable/lib/collisionDetection";
@@ -72,7 +72,7 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
     // 10-23, spring 17-20). A pending construction for one of those rows would
     // surface here — not expected, as those were UI-capped (basic 9 / spring 16)
     // long ago and constructions are short-lived.
-    const land = getLand({ game });
+    const land = getLand({ game, now: createdAt });
     if (!land) {
       throw new Error("Land Does Not Exists");
     }
@@ -211,7 +211,11 @@ export function revealLand({ state, createdAt = Date.now() }: Options) {
     // Gated by the feature flag so the forward grant can never run while the
     // ascension system is disabled (the back-pay reconciliation is gated too).
     if (
-      hasFeatureAccess(game, "SWAMP_ASCENSION") &&
+      hasTimeBasedFeatureAccess({
+        featureName: "SWAMP_ASCENSION",
+        game,
+        now: createdAt,
+      }) &&
       land.ascensionCrystals?.length
     ) {
       game.ascensionCrystals = game.ascensionCrystals ?? {};
@@ -583,6 +587,7 @@ export function getRewards({
   const missingNodes = getMissingResources({
     game,
     expansion: expansions.toNumber(),
+    now: createdAt,
   });
 
   const hasMissing = getKeys(missingNodes).some(

--- a/src/features/game/events/landExpansion/speedUpExpansion.test.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.test.ts
@@ -2,6 +2,7 @@ import { INITIAL_FARM } from "features/game/lib/constants";
 import { speedUpExpansion } from "./speedUpExpansion";
 import Decimal from "decimal.js-light";
 import { CONFIG } from "lib/config";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 
 describe("instantExpand", () => {
   it("requires expansion is in progress", () => {
@@ -115,9 +116,12 @@ describe("instantExpand", () => {
   });
 
   describe("when SWAMP_ASCENSION is off (mainnet)", () => {
-    // The flag is on by default in tests (amoy), so force mainnet to exercise
-    // the flag-off threshold ("desert"): desert and every island beyond it
+    // SWAMP_ASCENSION is a time-based flag: beta/testnet OR past its window
+    // start. Force mainnet AND evaluate before the window opens to exercise the
+    // flag-off threshold ("desert"): desert and every island beyond it
     // (volcano, swamp) are blocked from speeding up.
+    const beforeWindow =
+      TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime() - 1;
     let previousNetwork: (typeof CONFIG)["NETWORK"];
     beforeEach(() => {
       previousNetwork = CONFIG.NETWORK;
@@ -139,9 +143,10 @@ describe("instantExpand", () => {
             },
             expansionConstruction: {
               createdAt: 0,
-              readyAt: Date.now() + 1000,
+              readyAt: beforeWindow + 1000,
             },
           },
+          createdAt: beforeWindow,
         }),
       ).toThrow("You can't speed up the expansion on this island");
     });
@@ -158,9 +163,10 @@ describe("instantExpand", () => {
             },
             expansionConstruction: {
               createdAt: 0,
-              readyAt: Date.now() + 1000,
+              readyAt: beforeWindow + 1000,
             },
           },
+          createdAt: beforeWindow,
         }),
       ).toThrow("You can't speed up the expansion on this island");
     });

--- a/src/features/game/events/landExpansion/speedUpExpansion.ts
+++ b/src/features/game/events/landExpansion/speedUpExpansion.ts
@@ -8,7 +8,7 @@ import {
 } from "features/game/lib/getInstantGems";
 import Decimal from "decimal.js-light";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 
 export type InstantExpand = {
   type: "expansion.spedUp";
@@ -46,7 +46,13 @@ export function speedUpExpansion({
     if (
       hasRequiredIslandExpansion(
         game.island.type,
-        hasFeatureAccess(game, "SWAMP_ASCENSION") ? "swamp" : "desert",
+        hasTimeBasedFeatureAccess({
+          featureName: "SWAMP_ASCENSION",
+          game,
+          now: createdAt,
+        })
+          ? "swamp"
+          : "desert",
       )
     ) {
       throw new Error("You can't speed up the expansion on this island");

--- a/src/features/game/events/landExpansion/upgradeFarm.test.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.test.ts
@@ -2236,6 +2236,7 @@ describe("upgradeFarm", () => {
     });
 
     const land = getLand({
+      now: Date.now(),
       game: {
         ...upgradedState,
         inventory: {
@@ -2278,6 +2279,7 @@ describe("upgradeFarm", () => {
     expect(upgradedState.inventory["Sacred Tree"]).toEqual(new Decimal(1));
 
     const land = getLand({
+      now: Date.now(),
       game: {
         ...upgradedState,
         inventory: {
@@ -2346,6 +2348,7 @@ describe("upgradeFarm", () => {
     });
 
     const land = getLand({
+      now: Date.now(),
       game: {
         ...upgradedState,
         inventory: {
@@ -2414,6 +2417,7 @@ describe("upgradeFarm", () => {
     });
 
     const land = getLand({
+      now: Date.now(),
       game: {
         ...upgradedState,
         inventory: {
@@ -2482,6 +2486,7 @@ describe("upgradeFarm", () => {
     });
 
     const land = getLand({
+      now: Date.now(),
       game: {
         ...upgradedState,
         inventory: {

--- a/src/features/game/events/landExpansion/upgradeFarm.ts
+++ b/src/features/game/events/landExpansion/upgradeFarm.ts
@@ -14,7 +14,7 @@ import type {
   TemperateSeasonName,
 } from "features/game/types/game";
 import { ASCENSION_ISLANDS } from "features/game/types/game";
-import { hasFeatureAccess, hasTimeBasedFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { getAscensionLevel, getMaxBumpkinLevel } from "features/game/lib/level";
 import {
   getTotalBaseResourceEquivalents,
@@ -1269,7 +1269,13 @@ function transitionToIsland({
     game.layouts = [...(game.layouts ?? []), ascensionLayout];
   }
 
-  if (hasFeatureAccess(game, "SWAMP_ASCENSION")) {
+  if (
+    hasTimeBasedFeatureAccess({
+      featureName: "SWAMP_ASCENSION",
+      game,
+      now: createdAt,
+    })
+  ) {
     // Every island upgrade (basic + ascension) reconciles the player's resources
     // against the new island's floor via the shared `getMissingResources`
     // back-pay (same as revealLand's: per-tier/forging-safe, depletion-aware) and
@@ -1280,6 +1286,7 @@ function transitionToIsland({
     const bundle = getMissingResources({
       game,
       expansion: game.inventory["Basic Land"]?.toNumber() ?? 0,
+      now: createdAt,
     });
     if (getObjectEntries(bundle).length > 0) {
       game.airdrops = [
@@ -1336,7 +1343,14 @@ export function upgrade({ state, createdAt = Date.now(), farmId }: Options) {
     upcoming.upgrade,
   );
 
-  if (targetIsAscension && !hasFeatureAccess(game, "SWAMP_ASCENSION")) {
+  if (
+    targetIsAscension &&
+    !hasTimeBasedFeatureAccess({
+      featureName: "SWAMP_ASCENSION",
+      game,
+      now: createdAt,
+    })
+  ) {
     throw new Error("Swamp ascension is not yet available");
   }
 
@@ -1364,7 +1378,7 @@ export function upgrade({ state, createdAt = Date.now(), farmId }: Options) {
     !getAscensionLevel({
       experience: game.bumpkin.experience ?? 0,
       ascensionLevel: game.island.ascensionLevel ?? 0,
-      maxLevel: getMaxBumpkinLevel(game),
+      maxLevel: getMaxBumpkinLevel(game, createdAt),
     }).isReadyToAscend
   ) {
     throw new Error("Player has not met the level requirements");

--- a/src/features/game/events/landExpansion/upgradeSkill.test.ts
+++ b/src/features/game/events/landExpansion/upgradeSkill.test.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js-light";
 import { TEST_FARM, INITIAL_BUMPKIN } from "features/game/lib/constants";
 import { LEVEL_EXPERIENCE } from "features/game/lib/level";
 import { CONFIG } from "lib/config";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 import { upgradeSkill } from "./upgradeSkill";
 import { getAvailableBumpkinSkillPoints } from "./choseSkill";
 import { getSkillCooldown } from "./skillUsed";
@@ -62,7 +63,7 @@ describe("upgradeSkill", () => {
         skills: { ...CROPS_TIER_3 },
       },
     };
-    const before = getAvailableBumpkinSkillPoints(state);
+    const before = getAvailableBumpkinSkillPoints(state, dateNow);
 
     const result = upgradeSkill({
       state,
@@ -73,7 +74,7 @@ describe("upgradeSkill", () => {
     expect(result.bumpkin?.skills["Strong Roots"]).toEqual(2);
     expect(result.inventory["Ascension Shard"]).toEqual(new Decimal(3));
     // Tier 2 rank-up costs 3 skill points.
-    expect(getAvailableBumpkinSkillPoints(result)).toEqual(before - 3);
+    expect(getAvailableBumpkinSkillPoints(result, dateNow)).toEqual(before - 3);
   });
 
   it("spends a tier-scaled cost for a tier 3 skill (3 shards, 6 skill points)", () => {
@@ -90,7 +91,7 @@ describe("upgradeSkill", () => {
         skills: { ...CROPS_TIER_3, "Acre Farm": 1 },
       },
     };
-    const before = getAvailableBumpkinSkillPoints(state);
+    const before = getAvailableBumpkinSkillPoints(state, dateNow);
 
     const result = upgradeSkill({
       state,
@@ -101,7 +102,7 @@ describe("upgradeSkill", () => {
     expect(result.bumpkin?.skills["Acre Farm"]).toEqual(2);
     expect(result.inventory["Ascension Shard"]).toEqual(new Decimal(2));
     // Tier 3 rank-up costs 6 skill points.
-    expect(getAvailableBumpkinSkillPoints(result)).toEqual(before - 6);
+    expect(getAvailableBumpkinSkillPoints(result, dateNow)).toEqual(before - 6);
   });
 
   it("upgrades a rank 2 skill to rank 3 and keeps point accounting aligned", () => {
@@ -118,7 +119,7 @@ describe("upgradeSkill", () => {
         skills: { ...CROPS_TIER_3, "Green Thumb": 2 },
       },
     };
-    const before = getAvailableBumpkinSkillPoints(state);
+    const before = getAvailableBumpkinSkillPoints(state, dateNow);
 
     const result = upgradeSkill({
       state,
@@ -129,7 +130,7 @@ describe("upgradeSkill", () => {
     expect(result.bumpkin?.skills["Green Thumb"]).toEqual(3);
     expect(result.inventory["Ascension Shard"]).toEqual(new Decimal(4));
     // Tier 1 rank-up costs 1 skill point; available drops by exactly that.
-    expect(getAvailableBumpkinSkillPoints(result)).toEqual(before - 1);
+    expect(getAvailableBumpkinSkillPoints(result, dateNow)).toEqual(before - 1);
   });
 
   it("throws when the tree tier is not unlocked", () => {
@@ -370,8 +371,11 @@ describe("upgradeSkill", () => {
   });
 
   describe("when ASCENSION_SKILLS is off (mainnet)", () => {
-    // The flag is on by default in tests (amoy), so force mainnet to exercise
-    // the flag-off path.
+    // ASCENSION_SKILLS is a time-based flag: beta/testnet OR past its window
+    // start. Force mainnet AND evaluate before the window opens so this stays
+    // the flag-off path once the window start date passes.
+    const beforeWindow =
+      TIME_BASED_FEATURE_FLAG_WINDOWS.ASCENSION_SKILLS.start.getTime() - 1;
     let previousNetwork: (typeof CONFIG)["NETWORK"];
     beforeEach(() => {
       previousNetwork = CONFIG.NETWORK;
@@ -397,7 +401,7 @@ describe("upgradeSkill", () => {
             },
           },
           action: { type: "skill.upgraded", skill: "Green Thumb" },
-          createdAt: dateNow,
+          createdAt: beforeWindow,
         }),
       ).toThrow("Skill upgrades are not available");
     });

--- a/src/features/game/events/landExpansion/upgradeSkill.ts
+++ b/src/features/game/events/landExpansion/upgradeSkill.ts
@@ -8,7 +8,7 @@ import {
   getSkillUpgradeTierRequirement,
 } from "features/game/types/bumpkinSkills";
 import type { GameState } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import {
   getAvailableBumpkinSkillPoints,
   getUnlockedTierForTree,
@@ -38,7 +38,13 @@ export function upgradeSkill({
       throw new Error("You do not have a Bumpkin!");
     }
 
-    if (!hasFeatureAccess(game, "ASCENSION_SKILLS")) {
+    if (
+      !hasTimeBasedFeatureAccess({
+        featureName: "ASCENSION_SKILLS",
+        game,
+        now: createdAt,
+      })
+    ) {
       throw new Error("Skill upgrades are not available");
     }
 
@@ -82,7 +88,7 @@ export function upgradeSkill({
 
     const cost = getSkillUpgradeCost(skillData.requirements.tier);
 
-    if (getAvailableBumpkinSkillPoints(game) < cost.points) {
+    if (getAvailableBumpkinSkillPoints(game, createdAt) < cost.points) {
       throw new Error("You do not have enough skill points");
     }
 

--- a/src/features/game/expansion/components/IslandUpgrader.tsx
+++ b/src/features/game/expansion/components/IslandUpgrader.tsx
@@ -22,6 +22,7 @@ import {
   ASCENSION_BUMPKIN_LEVEL,
 } from "features/game/events/landExpansion/upgradeFarm";
 import { useTimeBasedFeatureAccess } from "lib/utils/hooks/useTimeBasedFeatureAccess";
+import { useNow } from "lib/utils/hooks/useNow";
 import {
   getAscensionLevel,
   getMaxBumpkinLevel,
@@ -33,7 +34,7 @@ import { createPortal } from "react-dom";
 import confetti from "canvas-confetti";
 import type { AscensionIslandType, IslandType } from "features/game/types/game";
 import { ASCENSION_ISLANDS, getIslandName } from "features/game/types/game";
-import { hasFeatureAccess, TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 import { Section, useScrollIntoView } from "lib/utils/hooks/useScrollIntoView";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Transition } from "@headlessui/react";
@@ -124,6 +125,15 @@ const IslandUpgraderModal: React.FC<{
     featureName: "SPOOKY_ASCENSION",
     game: gameState.context.state,
   });
+  const hasSwampAscensionAccess = useTimeBasedFeatureAccess({
+    featureName: "SWAMP_ASCENSION",
+    game: gameState.context.state,
+  });
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
   // Match the reducer's authoritative A1→A2 condition (ascensionLevel === 1) so
   // the button can't enable an upgrade the server rejects, or vice versa.
   const isNextAscensionLocked =
@@ -162,7 +172,7 @@ const IslandUpgraderModal: React.FC<{
       // Mirror the server gate: the pre-ascension cap drops to 150 under
       // SWAMP_ASCENSION, so without this a maxed level-150 player would be
       // measured against the legacy 200 cap and never show as ready.
-      maxLevel: getMaxBumpkinLevel(gameState.context.state),
+      maxLevel: getMaxBumpkinLevel(gameState.context.state, now),
     }).isReadyToAscend;
 
   if (showConfirmation) {
@@ -213,9 +223,7 @@ const IslandUpgraderModal: React.FC<{
     return getKeys(temporaryCollectibles).length > 0;
   };
 
-  const flagAllows =
-    !isAscensionUpgrade ||
-    hasFeatureAccess(gameState.context.state, "SWAMP_ASCENSION");
+  const flagAllows = !isAscensionUpgrade || hasSwampAscensionAccess;
   const hasUpgrade = isLandUpgradable(island.type) && flagAllows;
 
   // Ascension upgrades carry their (level-scaled) cost in getAscensionUpgradeCost,

--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js-light";
 import type { GameState } from "features/game/types/game";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import { translate } from "lib/i18n/translate";
 
 export type BumpkinLevel =
@@ -419,8 +419,11 @@ export const PRE_ASCENSION_MAX_LEVEL: BumpkinLevel = 150;
  * pass this as the `maxLevel` arg to `getBumpkinLevel`/`isMaxLevel`/`getExperienceToNextLevel`
  * at ascension-aware call sites. Flag-off keeps the legacy 200 cap.
  */
-export const getMaxBumpkinLevel = (game: GameState): BumpkinLevel =>
-  hasFeatureAccess(game, "SWAMP_ASCENSION")
+export const getMaxBumpkinLevel = (
+  game: GameState,
+  now: number,
+): BumpkinLevel =>
+  hasTimeBasedFeatureAccess({ featureName: "SWAMP_ASCENSION", game, now })
     ? PRE_ASCENSION_MAX_LEVEL
     : MAX_BUMPKIN_LEVEL;
 

--- a/src/features/game/types/achievements.ts
+++ b/src/features/game/types/achievements.ts
@@ -65,7 +65,7 @@ export type AchievementName =
 export type Achievement = {
   description: string;
   introduction?: string[];
-  progress: (game: GameState) => number;
+  progress: (game: GameState, now: number) => number;
   requirement: number;
   coins: number;
   rewards?: Inventory;
@@ -226,11 +226,11 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   // Cooking
   "Busy Bumpkin": {
     description: translate("busyBumpkin.description"),
-    progress: (gameState: GameState) =>
+    progress: (gameState: GameState, now: number) =>
       getTotalBumpkinLevel({
         experience: gameState.bumpkin.experience || 0,
         ascensionLevel: gameState.island.ascensionLevel ?? 0,
-        maxLevel: getMaxBumpkinLevel(gameState),
+        maxLevel: getMaxBumpkinLevel(gameState, now),
       }),
     requirement: 2,
     coins: 10,
@@ -278,11 +278,11 @@ export const ACHIEVEMENTS: () => Record<AchievementName, Achievement> = () => ({
   },
   "Brilliant Bumpkin": {
     description: translate("brilliantBumpkin.description"),
-    progress: (gameState: GameState) =>
+    progress: (gameState: GameState, now: number) =>
       getTotalBumpkinLevel({
         experience: gameState.bumpkin.experience || 0,
         ascensionLevel: gameState.island.ascensionLevel ?? 0,
-        maxLevel: getMaxBumpkinLevel(gameState),
+        maxLevel: getMaxBumpkinLevel(gameState, now),
       }),
     requirement: 20,
     coins: 0,

--- a/src/features/game/types/dailyRewards.ts
+++ b/src/features/game/types/dailyRewards.ts
@@ -285,8 +285,8 @@ export function getWeeklyReward({
   game: GameState;
   streak: number;
 }): DailyRewardDefinition {
-  const index = streak % WEEKLY_REWARDS(game).length;
-  return WEEKLY_REWARDS(game)[index];
+  const rewards = WEEKLY_REWARDS(game);
+  return rewards[streak % rewards.length];
 }
 
 export function getMilestoneRewards({

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -11,9 +11,12 @@ import {
 import { upgradeRock } from "../events/landExpansion/upgradeRock";
 import { SWAMP_BASE_NODES } from "../expansion/lib/ascension";
 
+const now = Date.now();
+
 describe("getLand", () => {
   it("returns a basic land", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -28,6 +31,7 @@ describe("getLand", () => {
 
   it("returns a spring land", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: {
@@ -45,6 +49,7 @@ describe("getLand", () => {
 
   it("does not return resources if player already has expected resources", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: {
@@ -74,6 +79,7 @@ describe("getLand", () => {
 
   it("only returns spring resources if they previously had basic resources", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: {
@@ -105,6 +111,7 @@ describe("getLand", () => {
   // Flower bed and honey temp disabled
   it.skip("returns spring resources if they had bought resource nodes", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: {
@@ -196,6 +203,7 @@ describe("getExpectedResources", () => {
     });
 
     const resources = getExpectedResources({
+      now,
       game: {
         ...farm,
         inventory: {
@@ -214,6 +222,7 @@ describe("getExpectedResources", () => {
 
   it("returns the correct resources when upgrading from L2 -> L3", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -239,6 +248,7 @@ describe("getExpectedResources", () => {
 
   it("returns 20 when on spring expansion 16 (18 trees) and have purchased 2 trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -259,6 +269,7 @@ describe("getExpectedResources", () => {
 
   it("returns 16 when on spring expansion 16 (18 trees) and have purchased 2 trees, and upgraded 1 ancient tree", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -280,6 +291,7 @@ describe("getExpectedResources", () => {
 
   it("returns 4 when on spring expansion 16 (18 trees) and have purchased 2 trees, and upgraded 1 sacred tree and 4 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -302,6 +314,7 @@ describe("getExpectedResources", () => {
 
   it("returns 0 when on spring expansion 16 (18 trees) and have purchased 2 trees, and upgraded 1 sacred tree and 5 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -324,6 +337,7 @@ describe("getExpectedResources", () => {
 
   it("returns 0 when on spring expansion 16 (18 trees) and have purchased 2 trees, and upgraded 1 sacred tree and 5 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -346,6 +360,7 @@ describe("getExpectedResources", () => {
 
   it("returns 5 ancient trees when on spring expansion 16 (18 trees) and upgraded 5 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -367,6 +382,7 @@ describe("getExpectedResources", () => {
 
   it("returns 1 ancient tree when on spring expansion 16 (18 trees) and upgraded 1 sacred tree and 5 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -389,6 +405,7 @@ describe("getExpectedResources", () => {
 
   it("returns 1 sacred tree when on spring expansion 16 (18 trees) and upgraded 1 sacred tree and 5 ancient trees", () => {
     const resources = getExpectedResources({
+      now,
       game: {
         ...TEST_FARM,
         inventory: {
@@ -558,6 +575,7 @@ describe("getExpansionRequirements", () => {
 describe("getLand (ascension path)", () => {
   it("returns a non-null layout for a swamp island with ascensionLevel 1", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: { type: "swamp", ascensionLevel: 1 },
@@ -575,6 +593,7 @@ describe("getLand (ascension path)", () => {
     // Even a known static island type is overridden by ascensionLevel > 0,
     // because the ascension check comes after and always wins.
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: { type: "swamp", ascensionLevel: 2 },
@@ -590,6 +609,7 @@ describe("getLand (ascension path)", () => {
 
   it("places the dripped Crop Plot dealt to expansion 32", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         island: { type: "swamp", ascensionLevel: 1 },
@@ -608,6 +628,7 @@ describe("getLand (ascension path)", () => {
 
   it("returns null when island type is unknown (no branch matches) and ascensionLevel is absent", () => {
     const land = getLand({
+      now,
       game: {
         ...TEST_FARM,
         // Swamp with no ascensionLevel: none of the static branches match and

--- a/src/features/game/types/expansions.test.ts
+++ b/src/features/game/types/expansions.test.ts
@@ -11,7 +11,9 @@ import {
 import { upgradeRock } from "../events/landExpansion/upgradeRock";
 import { SWAMP_BASE_NODES } from "../expansion/lib/ascension";
 
-const now = Date.now();
+// Fixed, pre-window instant: these cases cover the legacy (SWAMP_ASCENSION off)
+// layouts, so pin the clock rather than letting it drift past the window start.
+const now = new Date("2026-07-01T00:00:00Z").getTime();
 
 describe("getLand", () => {
   it("returns a basic land", () => {

--- a/src/features/game/types/expansions.ts
+++ b/src/features/game/types/expansions.ts
@@ -13,7 +13,7 @@ import {
   getExpectedAscensionCrystals,
 } from "../expansion/lib/ascension";
 import { getKeys } from "lib/object";
-import { hasFeatureAccess } from "lib/flags";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import type { LevelRequirement } from "features/game/lib/level";
 import {
   ADVANCED_RESOURCES,
@@ -72,9 +72,11 @@ const isAdvancedResource = (
 export function getExpectedResources({
   game,
   expansion,
+  now,
 }: {
   game: GameState;
   expansion: number;
+  now: number;
 }): Record<ResourceName, number> {
   const baseNodes = getExpansionNodes({
     island: game.island.type,
@@ -126,10 +128,11 @@ export function getExpectedResources({
   // and only when the ascension feature is live. Override the base (0) with the
   // cumulative expected so revealLand's missing-node airdrop can back-pay legacy
   // players who progressed before the feature shipped.
-  expectedResources["Ascension Crystal"] = hasFeatureAccess(
+  expectedResources["Ascension Crystal"] = hasTimeBasedFeatureAccess({
+    featureName: "SWAMP_ASCENSION",
     game,
-    "SWAMP_ASCENSION",
-  )
+    now,
+  })
     ? getExpectedAscensionCrystals({
         islandType: game.island.type,
         ascensionLevel: game.island.ascensionLevel ?? 0,
@@ -166,11 +169,13 @@ export const SUNSTONE_MINES = 10;
 export function getMissingResources({
   game,
   expansion,
+  now,
 }: {
   game: GameState;
   expansion: number;
+  now: number;
 }): Partial<Record<ResourceName, number>> {
-  const expected = getExpectedResources({ game, expansion });
+  const expected = getExpectedResources({ game, expansion, now });
 
   // Items already promised by an un-collected missing-resources airdrop are not
   // yet in inventory; counting them as still-missing would duplicate the grant
@@ -226,7 +231,13 @@ export function getMissingResources({
  * @param game - The current game state
  * @returns The next land expansion layout with resource placements capped by available resources, or `null` if no layout exists for the computed expansion
  */
-export function getLand({ game }: { game: GameState }): Layout | null {
+export function getLand({
+  game,
+  now,
+}: {
+  game: GameState;
+  now: number;
+}): Layout | null {
   const expansion = (game.inventory["Basic Land"]?.toNumber() ?? 0) + 1;
 
   let land: Layout | null = null;
@@ -261,6 +272,7 @@ export function getLand({ game }: { game: GameState }): Layout | null {
   const expectedResources = getExpectedResources({
     game,
     expansion,
+    now,
   });
 
   const totalTrees = game.inventory.Tree?.toNumber() ?? 0;

--- a/src/features/helios/components/hayseedHank/components/Guide.tsx
+++ b/src/features/helios/components/hayseedHank/components/Guide.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from "react";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { ButtonPanel, OuterPanel } from "components/ui/Panel";
 import { ACHIEVEMENTS } from "features/game/types/achievements";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { Context } from "features/game/GameProvider";
 import { useActor } from "@xstate/react";
@@ -20,6 +22,11 @@ export const Guide: React.FC<Props> = ({ selected, onSelect }) => {
   const { t } = useAppTranslation();
 
   const state = gameState.context.state;
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
 
   return (
     <div className="h-full pt-1.5 pr-0.5">
@@ -98,7 +105,7 @@ export const Guide: React.FC<Props> = ({ selected, onSelect }) => {
                     <div className="flex items-center">
                       {achievements.map((name) => {
                         const achievement = ACHIEVEMENTS()[name];
-                        const progress = achievement.progress(state);
+                        const progress = achievement.progress(state, now);
                         const isComplete = progress >= achievement.requirement;
 
                         if (isComplete) {

--- a/src/features/helios/components/hayseedHank/components/Guide.tsx
+++ b/src/features/helios/components/hayseedHank/components/Guide.tsx
@@ -60,7 +60,7 @@ export const Guide: React.FC<Props> = ({ selected, onSelect }) => {
 
           {GUIDE_PATHS[selected].achievements.map((name) => (
             <OuterPanel className="mt-2 !p-1" key={name}>
-              <GuideTask state={state} task={name} />
+              <GuideTask state={state} task={name} now={now} />
             </OuterPanel>
           ))}
         </div>

--- a/src/features/helios/components/hayseedHank/components/Task.tsx
+++ b/src/features/helios/components/hayseedHank/components/Task.tsx
@@ -7,6 +7,8 @@ import { formatNumber } from "lib/utils/formatNumber";
 import React, { useContext } from "react";
 import { GUIDE_PATHS, type GuidePath } from "../lib/guide";
 import type { GameState } from "features/game/types/game";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { useActor } from "@xstate/react";
@@ -30,7 +32,12 @@ export const GuideTask: React.FC<GuideTaskProps> = ({
 }) => {
   const { t } = useAppTranslation();
   const achievement = ACHIEVEMENTS()[task];
-  const progress = achievement.progress(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const progress = achievement.progress(state, now);
 
   const progressPercentage =
     Math.min(1, progress / achievement.requirement) * 100;

--- a/src/features/helios/components/hayseedHank/components/Task.tsx
+++ b/src/features/helios/components/hayseedHank/components/Task.tsx
@@ -11,9 +11,8 @@ import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
 import { useNow } from "lib/utils/hooks/useNow";
 import { getKeys } from "lib/object";
 import { SUNNYSIDE } from "assets/sunnyside";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
-import { useAppTranslation } from "lib/i18n/useAppTranslations";
 
 interface Props {
   onOpenGuide: (guide: GuidePath) => void;
@@ -24,19 +23,15 @@ interface GuideTaskProps {
   state: GameState;
   task: AchievementName;
   onNeedHelp?: (guide: GuidePath) => void;
+  now: number;
 }
 export const GuideTask: React.FC<GuideTaskProps> = ({
   state,
   task,
   onNeedHelp,
+  now,
 }) => {
-  const { t } = useAppTranslation();
   const achievement = ACHIEVEMENTS()[task];
-  const now = useNow({
-    live: true,
-    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
-    intervalMs: 60 * 1000,
-  });
   const progress = achievement.progress(state, now);
 
   const progressPercentage =
@@ -95,11 +90,15 @@ export const GuideTask: React.FC<GuideTaskProps> = ({
     </>
   );
 };
+
 export const Task: React.FC<Props> = ({ onOpenGuide, task }) => {
   const { gameService } = useContext(Context);
-  const [gameState] = useActor(gameService);
-
-  const state = gameState.context.state;
+  const state = useSelector(gameService, (state) => state.context.state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
 
   if (!task) {
     return (
@@ -115,6 +114,7 @@ export const Task: React.FC<Props> = ({ onOpenGuide, task }) => {
         state={state}
         task={task}
         onNeedHelp={(guide) => onOpenGuide(guide)}
+        now={now}
       />
     </div>
   );

--- a/src/features/island/bumpkin/components/Feed.tsx
+++ b/src/features/island/bumpkin/components/Feed.tsx
@@ -91,7 +91,7 @@ export const Feed: React.FC<Props> = ({
 
     const ascensionLevel = game.island.ascensionLevel ?? 0;
     const previousExperience = bumpkin?.experience ?? 0;
-    const maxLevel = getMaxBumpkinLevel(game);
+    const maxLevel = getMaxBumpkinLevel(game, now);
     // Track the total level (across ascension bands) so milestones still fire
     // correctly if a feed ever crosses an ascension boundary.
     let previousLevel: number = getTotalBumpkinLevel({

--- a/src/features/island/bumpkin/lib/skillPointStorage.ts
+++ b/src/features/island/bumpkin/lib/skillPointStorage.ts
@@ -13,11 +13,14 @@ export function getAcknowledgedSkillPointsForBumpkin(id: number) {
   return getAcknowledgedSkillPoints()[id] ?? 0;
 }
 
-export function hasUnacknowledgedSkillPoints(game?: GameState) {
+export function hasUnacknowledgedSkillPoints(
+  game: GameState | undefined,
+  now: number,
+) {
   const bumpkin = game?.bumpkin;
   if (!bumpkin) return false;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(game);
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(game, now);
   const acknowledgedSkillPoints = getAcknowledgedSkillPointsForBumpkin(
     bumpkin.id,
   );
@@ -25,11 +28,14 @@ export function hasUnacknowledgedSkillPoints(game?: GameState) {
   return availableSkillPoints > Number(acknowledgedSkillPoints);
 }
 
-export function acknowledgeSkillPoints(game?: GameState) {
+export function acknowledgeSkillPoints(
+  game: GameState | undefined,
+  now: number,
+) {
   const bumpkin = game?.bumpkin;
   if (!bumpkin) return;
 
-  const availableSkillPoints = getAvailableBumpkinSkillPoints(game);
+  const availableSkillPoints = getAvailableBumpkinSkillPoints(game, now);
   const currentAcknowledgedSkillPoints = getAcknowledgedSkillPoints();
 
   const newValue = {

--- a/src/features/island/hud/components/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/BumpkinProfile.tsx
@@ -14,6 +14,8 @@ import {
   acknowledgeSkillPoints,
   hasUnacknowledgedSkillPoints,
 } from "features/island/bumpkin/lib/skillPointStorage";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import Spritesheet, {
   type SpriteSheetInstance,
 } from "components/animation/SpriteAnimator";
@@ -225,13 +227,18 @@ export const BumpkinProfile: React.FC = () => {
 
   const experience = state.bumpkin?.experience ?? 0;
   const ascensionLevel = state.island.ascensionLevel ?? 0;
-  const maxLevel = getMaxBumpkinLevel(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const maxLevel = getMaxBumpkinLevel(state, now);
   const level = getAscensionLevel({
     experience,
     ascensionLevel,
     maxLevel,
   }).level;
-  const showSkillPointAlert = hasUnacknowledgedSkillPoints(state);
+  const showSkillPointAlert = hasUnacknowledgedSkillPoints(state, now);
 
   useEffect(() => {
     goToProgress();
@@ -243,7 +250,7 @@ export const BumpkinProfile: React.FC = () => {
     setViewSkillsTab(showSkillPointAlert);
     setShowModal(true);
     if (showSkillPointAlert) {
-      acknowledgeSkillPoints(state);
+      acknowledgeSkillPoints(state, now);
     }
   };
 

--- a/src/features/island/hud/components/bumpkinProfile/BumpkinProfile.tsx
+++ b/src/features/island/hud/components/bumpkinProfile/BumpkinProfile.tsx
@@ -14,6 +14,8 @@ import {
   acknowledgeSkillPoints,
   hasUnacknowledgedSkillPoints,
 } from "features/island/bumpkin/lib/skillPointStorage";
+import { TIME_BASED_FEATURE_FLAG_WINDOWS } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import Spritesheet, {
   type SpriteSheetInstance,
 } from "components/animation/SpriteAnimator";
@@ -225,13 +227,18 @@ export const BumpkinProfile: React.FC = () => {
 
   const experience = state.bumpkin?.experience ?? 0;
   const ascensionLevel = state.island.ascensionLevel ?? 0;
-  const maxLevel = getMaxBumpkinLevel(state);
+  const now = useNow({
+    live: true,
+    autoEndAt: TIME_BASED_FEATURE_FLAG_WINDOWS.SWAMP_ASCENSION.start.getTime(),
+    intervalMs: 60 * 1000,
+  });
+  const maxLevel = getMaxBumpkinLevel(state, now);
   const level = getAscensionLevel({
     experience,
     ascensionLevel,
     maxLevel,
   }).level;
-  const showSkillPointAlert = hasUnacknowledgedSkillPoints(state);
+  const showSkillPointAlert = hasUnacknowledgedSkillPoints(state, now);
 
   useEffect(() => {
     goToProgress();
@@ -243,7 +250,7 @@ export const BumpkinProfile: React.FC = () => {
     setViewSkillsTab(showSkillPointAlert);
     setShowModal(true);
     if (showSkillPointAlert) {
-      acknowledgeSkillPoints(state);
+      acknowledgeSkillPoints(state, now);
     }
   };
 

--- a/src/features/world/ui/yakkamon/Yakkamon.tsx
+++ b/src/features/world/ui/yakkamon/Yakkamon.tsx
@@ -18,6 +18,7 @@ import {
   getTotalBumpkinLevel,
 } from "features/game/lib/level";
 import { hasFeatureAccess } from "lib/flags";
+import { useNow } from "lib/utils/hooks/useNow";
 import { SUNNYSIDE } from "assets/sunnyside";
 import lockIcon from "assets/icons/lock.png";
 
@@ -56,12 +57,12 @@ export const Yakkamon: React.FC<Props> = ({ onClose }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
 
-  const now = Date.now();
+  const now = useNow({ live: true, intervalMs: 60 * 1000 });
 
   const level = getTotalBumpkinLevel({
     experience: state.bumpkin?.experience ?? 0,
     ascensionLevel: state.island.ascensionLevel ?? 0,
-    maxLevel: getMaxBumpkinLevel(state),
+    maxLevel: getMaxBumpkinLevel(state, now),
   });
 
   const isBetaTester = hasFeatureAccess(state, "YAKKAMON_BETA_ACCESS");

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -95,6 +95,14 @@ export const TIME_BASED_FEATURE_FLAG_WINDOWS = {
     start: new Date("2026-09-07T00:00:00Z"),
     end: null,
   },
+  ASCENSION_SKILLS: {
+    start: new Date("2026-08-03T00:00:00Z"),
+    end: null,
+  },
+  SWAMP_ASCENSION: {
+    start: new Date("2026-08-03T00:00:00Z"),
+    end: null,
+  },
 } satisfies Record<string, TimeBasedFeatureWindow>;
 
 /** All time-based flags receive the full window; start-only helpers ignore `end`. */
@@ -113,6 +121,8 @@ export const TIME_BASED_FEATURE_FLAGS: Record<
   APRIL_FOOLS_EVENT_FLAG: betaTimePeriodFeatureFlag,
   RONIN_WAYPOINT_DEPRECATION: timePeriodFeatureFlag,
   COLORS_2026_EVENT_FLAG: betaTimePeriodFeatureFlag,
+  ASCENSION_SKILLS: betaTimePeriodFeatureFlag,
+  SWAMP_ASCENSION: betaTimePeriodFeatureFlag,
   // Testnet-only bypass before the date (not beta), so live testers can reach A2.
   SPOOKY_ASCENSION: timePeriodFeatureFlag,
 };
@@ -183,18 +193,9 @@ const FEATURE_FLAGS = {
   // baseDurationMs + true plantedAt model; when off, boosts stay discount-at-start.
   SPEED_BOOSTS: usernameFeatureFlag,
 
-  SWAMP_ASCENSION: betaFeatureFlag,
-
   // Bulk Mixer tab in the feeder machine: mix the missing feed for every
   // waiting animal at once. Beta-pass / testnet only until it ships.
   BULK_MIXER: betaFeatureFlag,
-
-  // Per-rank skill upgrades (spend Ascension Shards + skill points to rank up a
-  // skill). Kept on its own flag so the upgrade UI + `skill.upgraded` event can
-  // be toggled independently of the rest of the ascension system (islands,
-  // expansion, level bands). Skill *effects* still apply off the stored rank
-  // regardless of this flag; only purchasing new ranks is gated here.
-  ASCENSION_SKILLS: betaFeatureFlag,
 
   // Beta testers can grab a Yakkamon pre-registration code before the level
   // tiers open to everyone else. The server enforces the same rule.


### PR DESCRIPTION
Mirrors the api ([sunflower-land-api PR](https://github.com/sunflower-land/sunflower-land-api/pull/3531)): `SWAMP_ASCENSION` and `ASCENSION_SKILLS` move out of `FEATURE_FLAGS` into `TIME_BASED_FEATURE_FLAG_WINDOWS`.

```ts
ASCENSION_SKILLS: { start: new Date("2026-08-03T00:00:00Z"), end: null },
SWAMP_ASCENSION:  { start: new Date("2026-08-03T00:00:00Z"), end: null },
```

Both use `betaTimePeriodFeatureFlag`, so beta-pass / testnet players keep early access and everyone else picks the feature up when the window opens — no follow-up deploy needed to flip them on.

## Call sites

Nothing still reads these two flags through `hasFeatureAccess`:

- **React components** use `useTimeBasedFeatureAccess` — `IslandUpgrader`, `SkillPathDetails`, `ExpansionRequirements`.
- **Event reducers** thread their own `createdAt` into `hasTimeBasedFeatureAccess` — `expandLand`, `revealLand`, `upgradeFarm`, `upgradeSkill`, `speedUpExpansion`, `choseSkill`, `claimDailyReward`, `claimAchievement`. Access is evaluated at the instant the action claims to have happened, matching the server.

## Why so many files

The flags are mostly read *indirectly*, so the shared helpers needed an explicit `now`:

| helper | reads |
|---|---|
| `getMaxBumpkinLevel` | `SWAMP_ASCENSION` (150 vs 200 cap) |
| `getExpectedResources` / `getMissingResources` / `getLand` | `SWAMP_ASCENSION` (Ascension Crystal grant) |
| `getAvailableBumpkinSkillPoints`, `hasUnacknowledgedSkillPoints`, `acknowledgeSkillPoints` | via `getMaxBumpkinLevel` |
| `Achievement.progress` | via `getMaxBumpkinLevel` |

Components feeding those helpers use `useNow` (live, `autoEndAt` at the window start, 1-min tick) so the level cap and skill-point counts flip on their own instead of waiting for an unrelated re-render. `Yakkamon.tsx`'s raw `Date.now()` is swapped for `useNow` for the same reason (per CLAUDE.md).

## Test time-bombs

Making a flag time-based means any test asserting the **flag-off** path with a `Date.now()` timestamp silently starts passing the gate on 3 Aug. I ran the full suite against a backdated window to find them; three were pinned to `window.start - 1`:

- `speedUpExpansion.test.ts` ×2 (desert / volcano mainnet blocks)
- `upgradeSkill.test.ts` (`ASCENSION_SKILLS is off (mainnet)`)

## Verification

- `tsc --noEmit` clean
- `yarn test`: **318/318** suites, 4787 passed
- Full suite re-run against a simulated post-window clock: also green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-based access for Swamp Ascension and Ascension Skills.
  * Land expansion, upgrades, skill points, rewards, and level limits now reflect feature availability at the relevant time.
  * Bumpkin profiles, achievements, skill displays, and Yakkamon access refresh automatically as timed features become available.

* **Bug Fixes**
  * Improved consistency of achievement progress, rewards, resource requirements, and expansion checks around feature launch windows.

* **Tests**
  * Expanded coverage for timed feature access and time-dependent progression calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->