### PR TITLE
[FIX] Preserve auction list scroll position

### DIFF
--- a/src/features/retreat/components/auctioneer/AuctionHistory.tsx
+++ b/src/features/retreat/components/auctioneer/AuctionHistory.tsx
@@ -17,6 +17,7 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { randomID } from "lib/utils/random";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useNow } from "lib/utils/hooks/useNow";
+import { useScrollRestoration } from "lib/utils/hooks/useScrollRestoration";
 
 const historyFetcher = async ([, token]: [string, string]): Promise<
   Auction[]
@@ -65,6 +66,8 @@ export const AuctionHistory: React.FC = () => {
   }>();
 
   const now = useNow();
+  const { scrollContainerRef, handleScroll } =
+    useScrollRestoration<HTMLDivElement>();
 
   const {
     data: auctions,
@@ -233,6 +236,8 @@ export const AuctionHistory: React.FC = () => {
     <div>
       <div className="p-2">
         <div
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
           className="max-h-52 overflow-y-auto scrollable pr-1"
           data-testid="auction-history-list"
         >

--- a/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
+++ b/src/features/retreat/components/auctioneer/AuctioneerContent.tsx
@@ -22,6 +22,7 @@ import { AuctionsComingSoon } from "./AuctionsComingSoon";
 import { GameWallet } from "features/wallet/Wallet";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { Loading } from "features/auth/components";
+import { useScrollRestoration } from "lib/utils/hooks/useScrollRestoration";
 
 interface Props {
   auctionService: MachineInterpreter;
@@ -37,6 +38,8 @@ export const AuctioneerContent: React.FC<Props> = ({
   const [auctioneerState, send] = useActor(auctionService);
 
   const [selectedAuctionId, setSelectedAuctionId] = useState<string>();
+  const { scrollContainerRef, handleScroll } =
+    useScrollRestoration<HTMLDivElement>();
 
   if (auctioneerState.matches("noAccess")) {
     return <AuctionsComingSoon />;
@@ -194,6 +197,8 @@ export const AuctioneerContent: React.FC<Props> = ({
       auctionService={auctionService}
       onSelect={(id) => setSelectedAuctionId(id)}
       game={gameState}
+      scrollContainerRef={scrollContainerRef}
+      onScroll={handleScroll}
     />
   );
 };

--- a/src/features/retreat/components/auctioneer/Auctions.tsx
+++ b/src/features/retreat/components/auctioneer/Auctions.tsx
@@ -21,11 +21,15 @@ interface Props {
   auctionService: MachineInterpreter;
   onSelect: (id: string) => void;
   game: GameState;
+  scrollContainerRef: React.RefCallback<HTMLDivElement>;
+  onScroll: React.UIEventHandler<HTMLDivElement>;
 }
 export const Auctions: React.FC<Props> = ({
   auctionService,
   onSelect,
   game,
+  scrollContainerRef,
+  onScroll,
 }) => {
   const [auctioneerState] = useActor(auctionService);
   const { t } = useAppTranslation();
@@ -39,6 +43,8 @@ export const Auctions: React.FC<Props> = ({
 
   return (
     <div
+      ref={scrollContainerRef}
+      onScroll={onScroll}
       style={{ maxHeight: "300px" }}
       className="overflow-y-auto scrollable flex flex-wrap pt-1.5 pr-0.5"
     >

--- a/src/lib/utils/hooks/useScrollRestoration.ts
+++ b/src/lib/utils/hooks/useScrollRestoration.ts
@@ -1,0 +1,17 @@
+import { type UIEvent, useCallback, useRef } from "react";
+
+export const useScrollRestoration = <T extends HTMLElement>() => {
+  const savedScrollTop = useRef(0);
+
+  const scrollContainerRef = useCallback((element: T | null) => {
+    if (!element) return;
+
+    element.scrollTop = savedScrollTop.current;
+  }, []);
+
+  const handleScroll = useCallback((event: UIEvent<T>) => {
+    savedScrollTop.current = event.currentTarget.scrollTop;
+  }, []);
+
+  return { scrollContainerRef, handleScroll };
+};


### PR DESCRIPTION
## Problem

Opening an auction or result replaces and unmounts its scrollable list. Returning to the list mounted a new container at the top, forcing players to find their previous place again.

The list now records its current `scrollTop` and restores it when the scroll container mounts again.

## What changed

- added a reusable scroll restoration hook for conditionally rendered scroll containers
- preserved the auction list position when returning from auction details
- applied the same behavior to the auction results list

<img width="445" height="329" alt="image" src="https://github.com/user-attachments/assets/2d91870d-c2e1-449e-9114-b7de4c784b79" />

## Player impact

Players return to the same place in the Auctions or Results list after viewing an item.

## Validation

- `yarn tsc --noEmit`
- targeted ESLint on the changed files
- Prettier check on the changed files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auction history and auction lists now restore their previous scroll position when revisited.
  * Scroll position is automatically saved as users browse auction content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->