### PR TITLE
[Chore] Hide Animal Tool requests for golden assets

### DIFF
--- a/src/features/barn/components/Cow.tsx
+++ b/src/features/barn/components/Cow.tsx
@@ -44,7 +44,7 @@ import {
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { isAnimalFeedable } from "features/game/events/landExpansion/buyAnimal";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 import { isWearableActive } from "features/game/lib/wearables";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
@@ -229,9 +229,9 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
     animal: cow,
   });
 
-  const hasGoldenCow = isCollectibleBuilt({
-    name: "Golden Cow",
-    game,
+  const hasGoldenCow = isAnimalCoveredByGoldenAsset({
+    state: game,
+    animalType: "Cow",
   });
 
   const hasOracleSyringeEquipped = isWearableActive({
@@ -395,7 +395,12 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) return onLoveClick();
+    if (needsLove) {
+      if (!hasGoldenCow) return onLoveClick();
+
+      handleShowDetails();
+      return;
+    }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
 
@@ -520,7 +525,7 @@ export const Cow: React.FC<{ id: string; disabled: boolean }> = ({
     return favFood;
   };
   const showRequestBubble =
-    sick || needsLove || (idle && !isLocked && !showDrops);
+    sick || (needsLove && !hasGoldenCow) || (idle && !isLocked && !showDrops);
 
   if (cowMachineState === "initial") return null;
 

--- a/src/features/barn/components/Sheep.tsx
+++ b/src/features/barn/components/Sheep.tsx
@@ -44,7 +44,7 @@ import {
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { isAnimalFeedable } from "features/game/events/landExpansion/buyAnimal";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 import { isWearableActive } from "features/game/lib/wearables";
 import { Modal } from "components/ui/Modal";
 import { SleepingAnimalModal } from "./SleepingAnimalModal";
@@ -115,9 +115,9 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
     animal: sheep,
   });
 
-  const hasGoldenSheep = isCollectibleBuilt({
-    name: "Golden Sheep",
-    game,
+  const hasGoldenSheep = isAnimalCoveredByGoldenAsset({
+    state: game,
+    animalType: "Sheep",
   });
 
   const hasOracleSyringeEquipped = isWearableActive({
@@ -362,7 +362,12 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) return onLoveClick();
+    if (needsLove) {
+      if (!hasGoldenSheep) return onLoveClick();
+
+      handleShowDetails();
+      return;
+    }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
 
@@ -487,7 +492,7 @@ export const Sheep: React.FC<{ id: string; disabled: boolean }> = ({
     return favFood;
   };
   const showRequestBubble =
-    sick || needsLove || (idle && !isLocked && !showDrops);
+    sick || (needsLove && !hasGoldenSheep) || (idle && !isLocked && !showDrops);
 
   if (sheepState === "initial") return null;
 

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -27,6 +27,7 @@ import { getCountAndType } from "features/island/hud/components/inventory/utils/
 import { useSelector } from "@xstate/react";
 import glow from "public/world/glow.png";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 
 interface Props {
   onClose: () => void;
@@ -51,6 +52,10 @@ export const SleepingAnimalModal = ({
 
   const toy = getAnimalToy({ animal });
   const state = useSelector(gameService, (state) => state.context.state);
+  const isCoveredByGoldenAsset = isAnimalCoveredByGoldenAsset({
+    state,
+    animalType: animal.type,
+  });
 
   const { count } = getCountAndType(state, toy);
 
@@ -163,32 +168,34 @@ export const SleepingAnimalModal = ({
             </span>
           </div>
         </div>
-        <div className="flex text-sm p-1 items-center">
-          <img
-            src={ITEM_DETAILS[animal.item].image}
-            alt="Sleep"
-            className="w-6 mr-2"
-          />
-          <div className="w-full">
-            <div className="flex items-center justify-between w-full">
-              <p className="text-sm font-secondary">{`${animal.item} (+${animalXP}XP)`}</p>
-              {!hasTool && (
-                <Label type="danger" className="text-xxs">
-                  {t("sleepingAnimal.missing")}
-                </Label>
-              )}
+        {!isCoveredByGoldenAsset && (
+          <div className="flex text-sm p-1 items-center">
+            <img
+              src={ITEM_DETAILS[animal.item].image}
+              alt="Sleep"
+              className="w-6 mr-2"
+            />
+            <div className="w-full">
+              <div className="flex items-center justify-between w-full">
+                <p className="text-sm font-secondary">{`${animal.item} (+${animalXP}XP)`}</p>
+                {!hasTool && (
+                  <Label type="danger" className="text-xxs">
+                    {t("sleepingAnimal.missing")}
+                  </Label>
+                )}
+              </div>
+              <span className="text-xs -top-0.5 relative">
+                {secondsUntilLove > 0
+                  ? t("pets.nextRequestsIn", {
+                      time: secondsToString(secondsUntilLove, {
+                        length: "medium",
+                      }),
+                    })
+                  : t("ready")}
+              </span>
             </div>
-            <span className="text-xs -top-0.5 relative">
-              {secondsUntilLove > 0
-                ? t("pets.nextRequestsIn", {
-                    time: secondsToString(secondsUntilLove, {
-                      length: "medium",
-                    }),
-                  })
-                : t("ready")}
-            </span>
           </div>
-        </div>
+        )}
 
         {mutantName && (
           <div className="flex p-1 items-center w-[330px]">

--- a/src/features/game/events/landExpansion/feedAllAnimals.test.ts
+++ b/src/features/game/events/landExpansion/feedAllAnimals.test.ts
@@ -5,6 +5,7 @@ import {
   feedAllAnimals,
   getCoveredAnimalTypes,
   getFeedAllTargets,
+  isAnimalCoveredByGoldenAsset,
 } from "./feedAllAnimals";
 
 const now = Date.now();
@@ -65,6 +66,31 @@ const withOracleSyringe = (state: GameState): GameState => ({
     ...state.bumpkin,
     equipped: { ...state.bumpkin.equipped, wings: "Oracle Syringe" },
   },
+});
+
+describe("isAnimalCoveredByGoldenAsset", () => {
+  it("matches an active golden asset to its animal type", () => {
+    const state = withGoldenCow(GAME_STATE);
+
+    expect(isAnimalCoveredByGoldenAsset({ state, animalType: "Cow" })).toBe(
+      true,
+    );
+    expect(isAnimalCoveredByGoldenAsset({ state, animalType: "Sheep" })).toBe(
+      false,
+    );
+  });
+
+  it("does not cover an animal when the golden asset is owned but not placed", () => {
+    const state: GameState = {
+      ...GAME_STATE,
+      inventory: { ...GAME_STATE.inventory, "Gold Egg": new Decimal(1) },
+      collectibles: {},
+    };
+
+    expect(isAnimalCoveredByGoldenAsset({ state, animalType: "Chicken" })).toBe(
+      false,
+    );
+  });
 });
 
 describe("getCoveredAnimalTypes", () => {

--- a/src/features/game/events/landExpansion/feedAllAnimals.ts
+++ b/src/features/game/events/landExpansion/feedAllAnimals.ts
@@ -19,6 +19,19 @@ export const GOLDEN_ANIMAL_ASSETS: Record<AnimalType, CollectibleName> = {
   Sheep: "Golden Sheep",
 };
 
+export function isAnimalCoveredByGoldenAsset({
+  state,
+  animalType,
+}: {
+  state: GameState;
+  animalType: AnimalType;
+}): boolean {
+  return isCollectibleBuilt({
+    name: GOLDEN_ANIMAL_ASSETS[animalType],
+    game: state,
+  });
+}
+
 export function getCoveredAnimalTypes({
   state,
   building,
@@ -29,7 +42,7 @@ export function getCoveredAnimalTypes({
   return getKeys(ANIMALS).filter(
     (type) =>
       ANIMALS[type].buildingRequired === building &&
-      isCollectibleBuilt({ name: GOLDEN_ANIMAL_ASSETS[type], game: state }),
+      isAnimalCoveredByGoldenAsset({ state, animalType: type }),
   );
 }
 

--- a/src/features/henHouse/Chicken.tsx
+++ b/src/features/henHouse/Chicken.tsx
@@ -43,7 +43,7 @@ import {
 } from "features/game/events/landExpansion/feedAnimal";
 import { getAnimalXP } from "features/game/events/landExpansion/loveAnimal";
 import { isAnimalFeedable } from "features/game/events/landExpansion/buyAnimal";
-import { isCollectibleBuilt } from "features/game/lib/collectibleBuilt";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 import { MutantAnimalModal } from "features/farming/animals/components/MutantAnimalModal";
 import { isWearableActive } from "features/game/lib/wearables";
 import { Modal } from "components/ui/Modal";
@@ -248,9 +248,9 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
     animal: chicken,
   });
 
-  const hasGoldEgg = isCollectibleBuilt({
-    name: "Gold Egg",
-    game,
+  const hasGoldEgg = isAnimalCoveredByGoldenAsset({
+    state: game,
+    animalType: "Chicken",
   });
 
   const hasOracleSyringeEquipped = isWearableActive({
@@ -414,7 +414,12 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
 
     if (sick) return onSickClick();
 
-    if (needsLove) return onLoveClick();
+    if (needsLove) {
+      if (!hasGoldEgg) return onLoveClick();
+
+      handleShowDetails();
+      return;
+    }
 
     const hasBuffSelected = selectedItem && isAnimalFeedBuffItem(selectedItem);
 
@@ -539,7 +544,7 @@ export const Chicken: React.FC<{ id: string; disabled: boolean }> = ({
     return favFood;
   };
   const showRequestBubble =
-    sick || needsLove || (idle && !isLocked && !showDrops);
+    sick || (needsLove && !hasGoldEgg) || (idle && !isLocked && !showDrops);
 
   if (chickenMachineState === "initial") return null;
 

--- a/src/features/island/buildings/components/building/barn/Barn.tsx
+++ b/src/features/island/buildings/components/building/barn/Barn.tsx
@@ -15,6 +15,7 @@ import { getCurrentBiome } from "features/island/biomes/biomes";
 import type { LandBiomeName } from "features/island/biomes/biomes";
 import { isAnimalReadyForLove } from "features/game/events/landExpansion/loveAnimal";
 import { getOverCapacityAnimalIds } from "features/game/events/landExpansion/buyAnimal";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 import classNames from "classnames";
 import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
@@ -239,6 +240,7 @@ const _hasSickAnimals = (state: MachineState) => {
 };
 
 const _barnAnimals = (state: MachineState) => state.context.state.barn.animals;
+const _game = (state: MachineState) => state.context.state;
 
 const _barnLevel = (state: MachineState) => {
   return state.context.state.barn.level;
@@ -254,14 +256,19 @@ export const Barn: React.FC<BuildingProps> = ({ isBuilt, island, season }) => {
 
   const hasHungryAnimals = useSelector(gameService, _hasHungryAnimals);
   const barnAnimals = useSelector(gameService, _barnAnimals);
+  const game = useSelector(gameService, _game);
   const hasSickAnimals = useSelector(gameService, _hasSickAnimals);
 
   // useNow drives a tick every second so the alert flips on as soon as
   // the love window opens — the underlying gate values only change on
   // game-state events, which wouldn't fire when crossing the time gate.
   const now = useNow({ live: true });
-  const animalsNeedLove = Object.values(barnAnimals).some((animal) =>
-    isAnimalReadyForLove(animal, now),
+  const animalsNeedLove = Object.values(barnAnimals).some(
+    (animal) =>
+      !isAnimalCoveredByGoldenAsset({
+        state: game,
+        animalType: animal.type,
+      }) && isAnimalReadyForLove(animal, now),
   );
   const handleClick = () => {
     if (isBuilt) {

--- a/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
+++ b/src/features/island/buildings/components/building/henHouse/HenHouse.tsx
@@ -13,6 +13,7 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { useNow } from "lib/utils/hooks/useNow";
 import { isAnimalReadyForLove } from "features/game/events/landExpansion/loveAnimal";
 import { getOverCapacityAnimalIds } from "features/game/events/landExpansion/buyAnimal";
+import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
 import classNames from "classnames";
 import { saveIslandScrollPosition } from "features/game/expansion/lib/islandScroll";
 
@@ -33,6 +34,7 @@ const _hasSickChickens = (state: MachineState) => {
 
 const _henHouseAnimals = (state: MachineState) =>
   state.context.state.henHouse.animals;
+const _game = (state: MachineState) => state.context.state;
 
 const _buildingLevel = (state: MachineState) =>
   state.context.state.henHouse.level;
@@ -44,14 +46,19 @@ export const ChickenHouse: React.FC<BuildingProps> = ({ isBuilt, season }) => {
   const hasHungryChickens = useSelector(gameService, _hasHungryChickens);
   const hasSickChickens = useSelector(gameService, _hasSickChickens);
   const henHouseAnimals = useSelector(gameService, _henHouseAnimals);
+  const game = useSelector(gameService, _game);
   const buildingLevel = useSelector(gameService, _buildingLevel);
 
   // useNow drives a tick every second so the alert flips on as soon as
   // the love window opens — the underlying gate values only change on
   // game-state events, which wouldn't fire when crossing the time gate.
   const now = useNow({ live: true });
-  const chickensNeedLove = Object.values(henHouseAnimals).some((animal) =>
-    isAnimalReadyForLove(animal, now),
+  const chickensNeedLove = Object.values(henHouseAnimals).some(
+    (animal) =>
+      !isAnimalCoveredByGoldenAsset({
+        state: game,
+        animalType: animal.type,
+      }) && isAnimalReadyForLove(animal, now),
   );
 
   const { play: barnAudio } = useSound("barn");


### PR DESCRIPTION
# Pull request description

## Summary

Stops sleeping animals covered by an active golden asset from surfacing Animal Tool requests. The UI now reuses the golden coverage introduced in #7469, hides covered love requests across the animal interior, building alerts, and sleeping-animal details, and prevents covered animals from consuming a tool when clicked.

## Context / motivation

PR #7469 added one-click feed-all for active golden asset holders, but sleeping animals are intentionally skipped by that action. Animal Tool requests are derived independently by the local animal state machine from `asleepAt`, `lovedAt`, and `awakeAt`, so covered animals could still enter `needsLove` and distract players even though the next golden feed advances them without normal food.

This change introduces a shared `isAnimalCoveredByGoldenAsset` selector based on the existing `GOLDEN_ANIMAL_ASSETS` mapping and applies it to every Animal Tool request surface:

- Chicken, Cow, and Sheep request bubbles
- Barn and Hen House exterior love alerts
- the Animal Tool row in the sleeping-animal modal
- click handling while a covered animal is in `needsLove`

Coverage remains species-specific. A Golden Cow suppresses Cow requests but not Sheep requests, and vice versa. The asset must be active and placed; owning it in inventory is not enough, matching #7469.

The underlying `animalMachine`, `animal.loved` event, feed-all event, and backend contract are unchanged.

## How to test

1. Place a Gold Egg and put a sleeping Chicken into its Animal Tool request window. Confirm the Chicken shows no tool bubble, the Hen House shows no love alert, and the sleeping-animal modal has no Animal Tool row.
2. Click that covered Chicken and confirm the sleeping-animal details open without consuming a Petting Hand, Brush, or Music Box.
3. In a Barn containing Cows and Sheep, place only a Golden Cow. Confirm Cow love requests are hidden while Sheep requests remain visible.
4. Replace the Golden Cow with a Golden Sheep and confirm the inverse behavior.
5. Place both Barn golden assets and confirm all Barn Animal Tool requests are hidden.
6. Remove or unplace a golden asset and confirm the relevant requests return. Confirm an owned-but-unplaced asset does not suppress requests.
7. Confirm the existing Feed All button still feeds, cures, and claims the same eligible awake animals as before.

Automated checks:

- `yarn test src/features/game/events/landExpansion/feedAllAnimals.test.ts --runInBand` — 29 tests passed
- `yarn tsc --noEmit`
- ESLint on all eight changed files
- Prettier on all eight changed files
- `git diff --check`

## Screenshots or screen recording

<img width="664" height="572" alt="image" src="https://github.com/user-attachments/assets/de6c5601-95c9-44dd-b582-51435450f364" />

## Related issues

Related #7469

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Golden-asset animals are handled consistently across barns and hen houses.
  * Clicking a covered animal that needs love opens its details instead of triggering the love action.
  * Love request bubbles and building alerts are hidden for covered animals.
  * Sleeping-animal details no longer show love-item information when covered by a golden asset.

* **Tests**
  * Added coverage for matching, mismatched, and unplaced golden assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->