### PR TITLE
[FIX] Load chapter artefact textures from ITEM_DETAILS

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -11,6 +11,7 @@ import { getUTCDateString } from "lib/utils/time";
 import type { BumpkinContainer } from "../containers/BumpkinContainer";
 import { getKeys } from "lib/object";
 import {
+  CHAPTER_ARTEFACT,
   DESERT_GRID_HEIGHT,
   DESERT_GRID_WIDTH,
   getArtefactsFound,
@@ -18,6 +19,7 @@ import {
   hasClaimedReward,
   secondsTillDesertStorm,
 } from "features/game/types/desert";
+import { ITEM_DETAILS } from "features/game/types/images";
 import { ProgressBarContainer } from "../containers/ProgressBarContainer";
 import { npcModalManager } from "../ui/NPCModals";
 import { hasReadDesertNotice as hasReadDesertNotice } from "../ui/beach/DesertNoticeboard";
@@ -150,15 +152,16 @@ export class BeachScene extends BaseScene {
     this.load.image("cockle_shell", "world/cockle_shell.webp");
     this.load.image("hieroglyph", "world/hieroglyph.webp");
     this.load.image("vase", "world/vase.webp");
-    this.load.image("scarab", "world/scarab.webp");
-    this.load.image("cow_skull", "world/cow_skull.webp");
-    this.load.image("ancient_clock", "world/ancient_clock.png");
-    this.load.image("broken_pillar", "world/broken_pillar.webp");
-    this.load.image("coprolite", "world/coprolite.webp");
-    this.load.image("moon_crystal", "world/moon_crystal.webp");
     this.load.image("sand", "world/sand.webp");
-    this.load.image("ammonite_shell", "world/ammonite_shell.webp");
-    this.load.image("salt_dino_egg", "world/salt_dino_egg.webp");
+
+    // Chapter artefacts - derived from CHAPTER_ARTEFACT so that adding a
+    // chapter does not require uploading a copy of its artefact to public/
+    new Set(Object.values(CHAPTER_ARTEFACT)).forEach((artefact) =>
+      this.load.image(
+        convertToSnakeCase(artefact),
+        ITEM_DETAILS[artefact].image,
+      ),
+    );
 
     this.load.image("shovel_select", "world/shovel_select_new.webp");
     this.load.image("confirm_select", "world/select_confirm_new.webp");


### PR DESCRIPTION
The beach dig site preloaded one hardcoded `world/<artefact>.webp` per chapter. Each of those files is a **byte-identical duplicate** of an asset already bundled in `src/assets`, so every new chapter needed its artefact uploaded to `public/` a second time:

```
public/world/scarab.webp         == src/assets/resources/scarab.webp
public/world/moon_crystal.webp   == src/assets/icons/moon_crystal.webp
public/world/salt_dino_egg.webp  == src/assets/icons/salt_dino_egg.webp   (all 8 identical)
```

## Change

Derive the set from `CHAPTER_ARTEFACT` and load each artefact's bundled `ITEM_DETAILS` image — the same way `Preloader` already loads the Love Charm icon:

```ts
new Set(Object.values(CHAPTER_ARTEFACT)).forEach((artefact) =>
  this.load.image(convertToSnakeCase(artefact), ITEM_DETAILS[artefact].image),
);
```

Adding a chapter now means one line in `CHAPTER_ARTEFACT` — which `tsc` already forces, since it is a `Record<ChapterName, …>` — and no asset upload.

## Fixes a live missing texture

`CHAPTER_ARTEFACT["Ascension Age"] = "Otter Pebble"`, but there is no `public/world/otter_pebble.webp` and there was no preload line for it, so dug Otter Pebbles rendered as a missing-texture box. `ITEM_DETAILS["Otter Pebble"].image` already exists, so the loop picks it up.

## Notes

- Texture keys are unchanged — both the loader and `populateDugItems` run the item name through the same `convertToSnakeCase`.
- `sand` stays on `world/sand.webp`; it is a regular beach treasure, not a chapter artefact.
- 7 of the 8 artefacts resolve to the exact file their `public/world/` twin duplicated. Cow Skull is the one substitution: the preload used `world/cow_skull.webp`, `ITEM_DETAILS` uses `assets/resources/cow_skull.png`. Both are lossless 14×10 of the same art, so it renders identically.
- Side benefit: bundled assets get content-hashed URLs, so the art can no longer drift between the dig site and the rest of the UI.

## Follow-up (not in this PR)

Nine files under `public/world/` are now unreferenced anywhere in `src/` or `public/` — the 8 artefacts plus an already-orphaned `cow_skull.png`. Happy to delete them in a separate PR.

## Testing

- `npx tsc --noEmit` clean
- `npx eslint --quiet` clean on the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated beach scene asset loading to support chapter-specific artefacts dynamically.
  * Ensured unique artefact images are loaded using their configured item details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->