### PR TITLE
[FEAT] Ascension Age megastore: Cornucopia + Teamwork Monument, and hourglass repricing

### DIFF
--- a/src/features/game/events/landExpansion/buyChapterItem.test.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.test.ts
@@ -1037,6 +1037,70 @@ describe("buyChapterItem", () => {
       expect(result.inventory["Shiny Feather"]).toEqual(new Decimal(1000));
     });
 
+    it("buys the Cornucopia with Shiny Feather and blocks a second purchase", () => {
+      const firstBuy = buyChapterItem({
+        state: {
+          ...mockState,
+          inventory: {
+            "Shiny Feather": new Decimal(20000),
+          },
+        },
+        action: {
+          type: "chapterItem.bought",
+          name: "Cornucopia",
+          tier: "basic",
+        },
+        createdAt: ascensionAgeDate,
+      });
+
+      expect(firstBuy.inventory["Cornucopia"]).toEqual(new Decimal(1));
+      expect(firstBuy.inventory["Shiny Feather"]).toEqual(new Decimal(11000));
+
+      expect(() =>
+        buyChapterItem({
+          state: firstBuy,
+          action: {
+            type: "chapterItem.bought",
+            name: "Cornucopia",
+            tier: "basic",
+          },
+          createdAt: ascensionAgeDate + 1000,
+        }),
+      ).toThrow("Purchase limit reached");
+    });
+
+    it("buys the Teamwork Monument with Shiny Feather and blocks a second purchase", () => {
+      const firstBuy = buyChapterItem({
+        state: {
+          ...mockState,
+          inventory: {
+            "Shiny Feather": new Decimal(10000),
+          },
+        },
+        action: {
+          type: "chapterItem.bought",
+          name: "Teamwork Monument",
+          tier: "basic",
+        },
+        createdAt: ascensionAgeDate,
+      });
+
+      expect(firstBuy.inventory["Teamwork Monument"]).toEqual(new Decimal(1));
+      expect(firstBuy.inventory["Shiny Feather"]).toEqual(new Decimal(4000));
+
+      expect(() =>
+        buyChapterItem({
+          state: firstBuy,
+          action: {
+            type: "chapterItem.bought",
+            name: "Teamwork Monument",
+            tier: "basic",
+          },
+          createdAt: ascensionAgeDate + 1000,
+        }),
+      ).toThrow("Purchase limit reached");
+    });
+
     it("buys the Moon Hair with Shiny Feather and blocks a second purchase", () => {
       const firstBuy = buyChapterItem({
         state: {

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -1270,6 +1270,16 @@ const ASCENSION_AGE_ITEMS: ChapterStore = {
         cost: { sfl: 0, items: { "Shiny Feather": 4000 } },
       },
       {
+        collectible: "Cornucopia",
+        limit: 1,
+        cost: { sfl: 0, items: { "Shiny Feather": 9000 } },
+      },
+      {
+        collectible: "Teamwork Monument",
+        limit: 1,
+        cost: { sfl: 0, items: { "Shiny Feather": 6000 } },
+      },
+      {
         collectible: "Otty the Otter",
         limit: 1,
         cost: { sfl: 0, items: { "Otter Pebble": 250 } },

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -1230,7 +1230,7 @@ const ASCENSION_AGE_ITEMS: ChapterStore = {
       },
       {
         collectible: "Ore Hourglass",
-        cost: { sfl: 0, items: { "Shiny Feather": 150 } },
+        cost: { sfl: 0, items: { "Shiny Feather": 400 } },
       },
       {
         collectible: "Timber Hourglass",
@@ -1242,7 +1242,7 @@ const ASCENSION_AGE_ITEMS: ChapterStore = {
       },
       {
         collectible: "Orchard Hourglass",
-        cost: { sfl: 0, items: { "Shiny Feather": 400 } },
+        cost: { sfl: 0, items: { "Shiny Feather": 200 } },
       },
       {
         collectible: "Fisher's Hourglass",


### PR DESCRIPTION
Two changes to the Ascension Age chapter store: two returning monuments added, and two hourglass prices put back to their Salt Awakening values.

## Monuments

Added at the prices agreed in Discord:

| Item | Price |
| --- | --- |
| Cornucopia | 9,000 Shiny Feather |
| Teamwork Monument | 6,000 Shiny Feather |

Both go in the `basic` tier of `ASCENSION_AGE_ITEMS`, next to the Ascension Monument, with `limit: 1` — the same limit they had in their original chapters. `limit` is per-chapter, so players who bought one in Paw Prints / Better Together can buy again this chapter.

### No other wiring needed

Both monuments shipped in earlier chapters, so images, sizes, buffs, `MEGASTORE_MONUMENTS` records, `REQUIRED_CHEERS` (Cornucopia 1000, Teamwork Monument 100) and withdrawables all already exist. Only the store listing was missing.

## Hourglass repricing

Ore and Orchard were carrying different numbers this chapter than they had in Salt Awakening. Restored:

| Hourglass | Before | After | Salt Awakening |
| --- | --- | --- | --- |
| Gourmet | 100 | 100 | 100 |
| Ore | 150 | **400** | 400 |
| Timber | 200 | 200 | 200 |
| Blossom | 200 | 200 | 150 |
| Orchard | 400 | **200** | 200 |
| Fisher's | 200 | 200 | — |
| Harvest | 200 | 200 | — |

Fisher's and Harvest are new this chapter and stay at 200. Blossom is left at 200 — it is the one deliberate difference from Salt Awakening's 150.

## Testing

A buy-and-block-second-purchase test per monument in `buyChapterItem.test.ts`. Written first and confirmed failing with `Item not found in the chapter store`, then passing. No test asserts on hourglass prices, so the repricing needed no test changes.

- `buyChapterItem.test.ts` 45/45
- all 16 `src/features/game/types/` suites (280 passing)
- `tsc --noEmit` and prettier clean

## Backend

Mirrored in sunflower-land/sunflower-land-api#3532. I diffed the full `ASCENSION_AGE_ITEMS` object across both repos afterwards — byte-identical.

## Note

`ITEM_DETAILS.Cornucopia.description` is `""` — pre-existing, unchanged by this PR, same as when it was live in Paw Prints. The detail panel still renders its two buff labels so it is not blank, but it has no prose where Teamwork Monument does. Happy to add a `dictionary.json` key in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cornucopia to the Ascension Age basic megastore for 9,000 Shiny Feathers.
  - Added Teamwork Monument to the Ascension Age basic megastore for 6,000 Shiny Feathers.
  - Both items can be purchased once per player, with additional purchase attempts rejected after the limit is reached.

- **Balance**
  - Ore Hourglass now costs 400 Shiny Feathers (was 150) and Orchard Hourglass now costs 200 (was 400).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
