### PR TITLE
[FEAT] Megastore inventoryLimit prop to cap owned copies

### DIFF
--- a/src/features/game/events/landExpansion/buyChapterItem.test.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.test.ts
@@ -1185,5 +1185,89 @@ describe("buyChapterItem", () => {
         }),
       ).toThrow("Item not found in the chapter store");
     });
+
+    // These monuments carried over from previous chapters, so a chapter-scoped
+    // `limit` isn't enough — a player who already owns one (from any source)
+    // must not be able to buy another via the store.
+    describe("inventoryLimit", () => {
+      it("blocks buying the Cornucopia when the player already owns one", () => {
+        expect(() =>
+          buyChapterItem({
+            state: {
+              ...mockState,
+              inventory: {
+                "Shiny Feather": new Decimal(20000),
+                Cornucopia: new Decimal(1),
+              },
+            },
+            action: {
+              type: "chapterItem.bought",
+              name: "Cornucopia",
+              tier: "basic",
+            },
+            createdAt: ascensionAgeDate,
+          }),
+        ).toThrow("Inventory limit reached");
+      });
+
+      it("blocks buying the Teamwork Monument when the player already owns one", () => {
+        expect(() =>
+          buyChapterItem({
+            state: {
+              ...mockState,
+              inventory: {
+                "Shiny Feather": new Decimal(20000),
+                "Teamwork Monument": new Decimal(1),
+              },
+            },
+            action: {
+              type: "chapterItem.bought",
+              name: "Teamwork Monument",
+              tier: "basic",
+            },
+            createdAt: ascensionAgeDate,
+          }),
+        ).toThrow("Inventory limit reached");
+      });
+
+      it("blocks buying the Ascension Monument when the player already owns one", () => {
+        expect(() =>
+          buyChapterItem({
+            state: {
+              ...mockState,
+              inventory: {
+                "Shiny Feather": new Decimal(20000),
+                "Ascension Monument": new Decimal(1),
+              },
+            },
+            action: {
+              type: "chapterItem.bought",
+              name: "Ascension Monument",
+              tier: "basic",
+            },
+            createdAt: ascensionAgeDate,
+          }),
+        ).toThrow("Inventory limit reached");
+      });
+
+      it("allows buying the Cornucopia when the player does not own one", () => {
+        const result = buyChapterItem({
+          state: {
+            ...mockState,
+            inventory: {
+              "Shiny Feather": new Decimal(20000),
+            },
+          },
+          action: {
+            type: "chapterItem.bought",
+            name: "Cornucopia",
+            tier: "basic",
+          },
+          createdAt: ascensionAgeDate,
+        });
+
+        expect(result.inventory["Cornucopia"]).toEqual(new Decimal(1));
+      });
+    });
   });
 });

--- a/src/features/game/events/landExpansion/buyChapterItem.ts
+++ b/src/features/game/events/landExpansion/buyChapterItem.ts
@@ -60,6 +60,19 @@ function getItemName(item: ChapterStoreItem): ChapterTierItemName {
   return isCollectible(item) ? item.collectible : item.wearable;
 }
 
+// How many copies of a store item the player currently owns — collectibles are
+// counted from the inventory, wearables from the wardrobe. This is the basis
+// for `inventoryLimit`, which (unlike the chapter-scoped `limit`) caps total
+// ownership regardless of how or when the copies were acquired.
+export function getStoreItemOwnedCount(
+  game: GameState,
+  item: ChapterStoreItem,
+): number {
+  return isCollectible(item)
+    ? (game.inventory[item.collectible]?.toNumber() ?? 0)
+    : (game.wardrobe[item.wearable] ?? 0);
+}
+
 // Helper to create farm activity name from chapter item
 function toBoughtActivityName(
   itemName: ChapterTierItemName,
@@ -224,6 +237,15 @@ export function buyChapterItem({
       });
       if (chapterPurchaseCountBefore >= item.limit) {
         throw new Error("Purchase limit reached");
+      }
+    }
+
+    // Items with an explicit `inventoryLimit` cap how many copies a player may
+    // ever own. This blocks re-buying an item the player already holds — even
+    // one acquired in a previous chapter or from another source.
+    if (item.inventoryLimit !== undefined) {
+      if (getStoreItemOwnedCount(copy, item) >= item.inventoryLimit) {
+        throw new Error("Inventory limit reached");
       }
     }
 

--- a/src/features/game/types/megastore.ts
+++ b/src/features/game/types/megastore.ts
@@ -153,6 +153,12 @@ type SeasonalStoreBase = {
   cooldownMs?: number;
   // Maximum purchases of this item per chapter. Omit for unlimited.
   limit?: number;
+  // Maximum copies of this item a player may ever own (collectibles counted
+  // from inventory, wearables from wardrobe). Unlike the chapter-scoped
+  // `limit`, once the player holds this many the item can no longer be
+  // bought — even copies acquired in a previous chapter or from another
+  // source count. Omit for no ownership cap.
+  inventoryLimit?: number;
 };
 
 export type ChapterStoreWearable = SeasonalStoreBase & {
@@ -1267,16 +1273,19 @@ const ASCENSION_AGE_ITEMS: ChapterStore = {
       {
         collectible: "Ascension Monument",
         limit: 1,
+        inventoryLimit: 1,
         cost: { sfl: 0, items: { "Shiny Feather": 4000 } },
       },
       {
         collectible: "Cornucopia",
         limit: 1,
+        inventoryLimit: 1,
         cost: { sfl: 0, items: { "Shiny Feather": 9000 } },
       },
       {
         collectible: "Teamwork Monument",
         limit: 1,
+        inventoryLimit: 1,
         cost: { sfl: 0, items: { "Shiny Feather": 6000 } },
       },
       {

--- a/src/features/world/ui/megastore/chapter_store_components/ItemDetail.tsx
+++ b/src/features/world/ui/megastore/chapter_store_components/ItemDetail.tsx
@@ -33,6 +33,7 @@ import { SFLDiscount } from "features/game/lib/SFLDiscount";
 import {
   getChapterItemsCrafted,
   getChapterPurchaseCount,
+  getStoreItemOwnedCount,
   isKeyBoughtWithinChapter,
 } from "features/game/events/landExpansion/buyChapterItem";
 import {
@@ -143,6 +144,13 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
     now,
   });
 
+  // Items with an `inventoryLimit` can't be re-bought once the player owns that
+  // many copies — including copies from a previous chapter or other source.
+  const isInventoryLimitReached =
+    !!item &&
+    item.inventoryLimit !== undefined &&
+    getStoreItemOwnedCount(state, item) >= item.inventoryLimit;
+
   const description = getItemDescription(item);
   const { sfl = 0, coins: coinsCost = 0 } = item?.cost || {};
   const itemReq = item?.cost?.items;
@@ -182,6 +190,9 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
         return false;
       }
     }
+
+    // Items with an `inventoryLimit` can't be bought once already owned.
+    if (isInventoryLimitReached) return false;
 
     if (itemReq) {
       const hasRequirements = getKeys(itemReq).every((name) => {
@@ -306,6 +317,10 @@ export const ItemDetail: React.FC<ItemOverlayProps> = ({
               },
             ),
           })}
+        </Label>
+      ) : isInventoryLimitReached ? (
+        <Label type="danger" className="text-xxs">
+          {t("season.megastore.alreadyOwned")}
         </Label>
       ) : item?.limit === undefined ? null : (
         <Label

--- a/src/features/world/ui/megastore/chapter_store_components/ItemsList.tsx
+++ b/src/features/world/ui/megastore/chapter_store_components/ItemsList.tsx
@@ -41,6 +41,7 @@ import {
   getChapterItemsCrafted,
   getChapterPurchaseCount,
   getStore,
+  getStoreItemOwnedCount,
   isBoxBoughtWithinChapter,
   isKeyBoughtWithinChapter,
   isPetEggBoughtWithinChapter,
@@ -324,6 +325,16 @@ export const ItemsList: React.FC<Props> = ({
 
             const balanceOfItem = getBalanceOfItem(item);
 
+            // An item is "maxed" (shown with a confirm tick) when either the
+            // chapter purchase limit is hit, or the player already owns as many
+            // copies as the item's `inventoryLimit` allows.
+            const isChapterLimitReached =
+              item.limit !== undefined && balanceOfItem >= item.limit;
+            const isInventoryLimitReached =
+              item.inventoryLimit !== undefined &&
+              getStoreItemOwnedCount(state, item) >= item.inventoryLimit;
+            const isMaxed = isChapterLimitReached || isInventoryLimitReached;
+
             return (
               <div
                 id={`mega-store-item-${getItemName(item)}`}
@@ -350,11 +361,9 @@ export const ItemsList: React.FC<Props> = ({
                       />
                     )}
                     {/* Confirm Icon for non-key items */}
-                    {balanceOfItem > 0 &&
-                      !isItemKey &&
+                    {!isItemKey &&
                       !isItemFlowerBox &&
-                      item.limit !== undefined &&
-                      balanceOfItem >= item.limit &&
+                      isMaxed &&
                       (tier === "basic" ||
                         (tier === "rare" && isRareUnlocked) ||
                         (tier === "epic" && isEpicUnlocked) ||

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -4107,6 +4107,7 @@
   "season.megastore.discount": "Megastore FLOWER discount",
   "season.megastore.crafting.limit": "Limit: {{limit}}/1",
   "season.megastore.crafting.limit.max": "Limit: {{limit}}/{{max}}",
+  "season.megastore.alreadyOwned": "Already owned",
   "season.supporter.gift": "Supporter Gift",
   "season.free.season.passes": "Free Chapter Banners",
   "season.free.season.passes.description": "Receive banners for every Chapter",


### PR DESCRIPTION
## What
Adds an optional `inventoryLimit` prop to chapter store (megastore) items that caps how many copies a player may ever own — collectibles counted from inventory, wearables from wardrobe.

Unlike the existing chapter-scoped `limit` (which resets each chapter via `getChapterPurchaseCount`), `inventoryLimit` blocks re-buying an item the player **already holds**, even a copy acquired in a previous chapter or from another source.

## Why
Cornucopia and Teamwork Monument were sold in earlier chapters (Paw Prints / Better Together), so a player who already owned one could buy a duplicate when they reappeared in the Ascension Age store. Set `inventoryLimit: 1` on **Ascension Monument, Cornucopia and Teamwork Monument**.

## Changes
- `types/megastore.ts` — new `inventoryLimit?: number` on the store item base type.
- `buyChapterItem.ts` — exported `getStoreItemOwnedCount()` helper + a reducer check that throws `Inventory limit reached` before any resources are deducted.
- Set `inventoryLimit: 1` on the three Ascension Age monuments.
- `ItemDetail.tsx` — buy button disabled + an "Already owned" label (instead of a misleading `0/1`).
- `ItemsList.tsx` — grid confirm-tick now shows when either the chapter limit **or** the inventory limit is maxed.
- `dictionary.json` — `season.megastore.alreadyOwned` key.

Nothing is hardcoded to these three items — any future store entry just sets `inventoryLimit: n`.

## Tests
`buyChapterItem.test.ts` — new `inventoryLimit` describe block (blocks each of the 3 monuments when already owned + a positive control). Full suite green (49/49), `tsc` + lint clean.

## Paired BE PR
sunflower-land/sunflower-land-api#3535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ownership limits for select Ascension Age store items, including Cornucopia, Teamwork Monument, and Ascension Monument.
  * Limits now account for items already owned in inventory or equipped.
* **Bug Fixes**
  * Prevented purchases when an item’s total ownership limit is reached.
  * Store listings now correctly show items as unavailable when either purchase or ownership limits apply.
* **UI**
  * Added an “Already owned” label for items that cannot be purchased again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->