### PR TITLE
[FIX] Auto place bug

### DIFF
--- a/src/features/game/events/landExpansion/importHomeItems.test.ts
+++ b/src/features/game/events/landExpansion/importHomeItems.test.ts
@@ -279,7 +279,10 @@ describe("tryApplyImportStep", () => {
         height: 1,
       },
       location: "interior" as const,
-      coordinates: { x: 0, y: 0 },
+      // (-5, -5) → layout tile (7, 7). TEST_FARM is a basic island, whose tent
+      // interior only spans tiles x 3-8, y 2-7, so the placement has to land on
+      // a real floor tile or the reducer collides — same as the API's.
+      coordinates: { x: -5, y: -5 },
     };
 
     const result = tryApplyImportStep(state, placement);

--- a/src/features/game/events/landExpansion/importHomeItems.ts
+++ b/src/features/game/events/landExpansion/importHomeItems.ts
@@ -401,6 +401,15 @@ export function getHomeRemovalEvents(state: GameState): PlacementEvent[] {
  * event and hoping the place succeeds, we run both reducers up front and only
  * commit when the place actually lands, so an item is never dug up into the
  * inventory and stranded there.
+ *
+ * It only works because the place reducers reject everything the API's do —
+ * collision included. The plan is computed once at the start of the migration
+ * but applied over several seconds and across autosaves, so a spot that was
+ * free at planning time can be taken by the time we get to it. Catching that
+ * here costs the player one item (reported as "could not be moved", and picked
+ * up by re-running the import); missing it costs them the whole save, because
+ * the API reduces the batch as a unit and one "Building collides" rejects every
+ * event in it.
  */
 export function tryApplyImportStep(
   state: GameState,

--- a/src/features/game/events/landExpansion/placeCollectible.test.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.test.ts
@@ -74,6 +74,10 @@ describe("Place Collectible", () => {
           "Brazilian Flag": new Decimal(1),
         },
         collectibles: {},
+        // (0, 0) is a crop plot on INITIAL_FARM. The reducer now runs the same
+        // collision check as the API, so clear the land the placement needs.
+        crops: {},
+        buildings: {},
       },
       action: {
         id: "123",
@@ -94,6 +98,7 @@ describe("Place Collectible", () => {
     const state = placeCollectible({
       state: {
         ...GAME_STATE,
+        buildings: {},
         inventory: {
           Scarecrow: new Decimal(2),
         },
@@ -101,7 +106,7 @@ describe("Place Collectible", () => {
           Scarecrow: [
             {
               id: "123",
-              coordinates: { x: 1, y: 1 },
+              coordinates: { x: -1, y: -1 },
             },
           ],
         },
@@ -112,8 +117,8 @@ describe("Place Collectible", () => {
         type: "collectible.placed",
         name: "Scarecrow",
         coordinates: {
-          x: 0,
-          y: 0,
+          x: 1,
+          y: 1,
         },
         location: "farm",
       },
@@ -122,11 +127,11 @@ describe("Place Collectible", () => {
     expect(state.collectibles["Scarecrow"]).toHaveLength(2);
     expect(state.collectibles["Scarecrow"]?.[0]).toEqual({
       id: expect.any(String),
-      coordinates: { x: 1, y: 1 },
+      coordinates: { x: -1, y: -1 },
     });
     expect(state.collectibles["Scarecrow"]?.[1]).toEqual({
       id: expect.any(String),
-      coordinates: { x: 0, y: 0 },
+      coordinates: { x: 1, y: 1 },
     });
   });
 
@@ -141,6 +146,7 @@ describe("Place Collectible", () => {
         buildings: {},
         trees: {},
         stones: {},
+        crops: {},
       },
       action: {
         id: "123",
@@ -171,6 +177,7 @@ describe("Place Collectible", () => {
         buildings: {},
         trees: {},
         stones: {},
+        crops: {},
         socialFarming: {
           ...GAME_STATE.socialFarming,
           completedProjects: ["Big Orange"],
@@ -206,6 +213,7 @@ describe("Place Collectible", () => {
           // consumed, so restarting it must go through `project.started`
           "Basic Cooking Pot": [{ id: "123", removedAt: dateNow }],
         },
+        crops: {},
       },
       action: {
         id: "123",
@@ -234,6 +242,7 @@ describe("Place Collectible", () => {
           "Basic Cooking Pot": new Decimal(1),
         },
         collectibles: {},
+        crops: {},
         home: {
           ...GAME_STATE.home,
           collectibles: {
@@ -586,6 +595,14 @@ describe("Place Collectible", () => {
       const state = placeCollectible({
         state: {
           ...GAME_STATE,
+          buildings: {},
+          trees: {},
+          stones: {},
+          iron: {},
+          gold: {},
+          crops: {},
+          fruitPatches: {},
+          collectibles: {},
           inventory: {
             Flicker: new Decimal(1),
           },
@@ -598,7 +615,7 @@ describe("Place Collectible", () => {
           id: "3",
           type: "collectible.placed",
           name: "Flicker",
-          coordinates: { x: 10, y: 10 },
+          coordinates: { x: 2, y: 2 }, // Use empty farm coordinates
           location: "farm",
         },
         createdAt: dateNow,
@@ -624,8 +641,10 @@ describe("Place Collectible", () => {
           id: "ground-1",
           type: "collectible.placed",
           name: "Abandoned Bear",
-          // (-7, -3) → layout tile (5, 9) — valid wood-floor tile on basic.
-          coordinates: { x: -7, y: -3 },
+          // (-5, -5) → layout tile (7, 7) — a valid wood-floor tile on the
+          // basic island layout (the default for TEST_FARM). The basic tent
+          // only spans tiles x 3-8, y 2-7.
+          coordinates: { x: -5, y: -5 },
           location: "interior",
         },
       });
@@ -633,7 +652,7 @@ describe("Place Collectible", () => {
       expect(state.interior.ground.collectibles["Abandoned Bear"]).toEqual([
         {
           id: "ground-1",
-          coordinates: { x: -7, y: -3 },
+          coordinates: { x: -5, y: -5 },
         },
       ]);
     });

--- a/src/features/game/events/landExpansion/placeCollectible.ts
+++ b/src/features/game/events/landExpansion/placeCollectible.ts
@@ -27,6 +27,7 @@ import { COMPETITION_POINTS } from "features/game/types/competitions";
 import { populateSaltFarm } from "features/game/types/salt";
 import { refreshBasicScarecrowTimeAOE } from "features/game/lib/aoe";
 import { getCollectiblesAcrossLocations } from "features/game/lib/getCollectiblesAcrossLocations";
+import { detectCollision } from "features/game/expansion/placeable/lib/collisionDetection";
 
 export type PlaceCollectibleAction = {
   type: "collectible.placed";
@@ -151,9 +152,36 @@ export function placeCollectible({
     }
 
     // For level_one, the floor must already be unlocked (player has bought the
-    // first interior.upgrade) before any placement is allowed.
+    // first interior.upgrade) before any placement is allowed. Run this before
+    // collision detection so the user gets a meaningful error instead of a
+    // generic "collides" message (collision returns true when level_one is
+    // missing because it can't validate a floor that doesn't exist).
     if (action.location === "level_one" && !stateCopy.interior.level_one) {
       throw new Error("Level one floor has not been unlocked");
+    }
+
+    // Mirrors the same check in the API's placeCollectible reducer. The UI
+    // placement flows already block a colliding drop before dispatching, so
+    // this is a no-op for them — it exists so that callers which reduce
+    // speculatively (the home import's `tryApplyImportStep`) find out here
+    // rather than having the server reject the whole save batch. Keep the two
+    // implementations in lockstep: anything accepted here and rejected there
+    // fails at save time with "Building collides".
+    const dimensions = COLLECTIBLES_DIMENSIONS[collectible];
+    const collides = detectCollision({
+      state,
+      position: {
+        x: action.coordinates.x,
+        y: action.coordinates.y,
+        height: dimensions.height,
+        width: dimensions.width,
+      },
+      name: collectible,
+      location: action.location,
+    });
+
+    if (collides) {
+      throw new Error("Building collides");
     }
 
     // Search for existing collectible in current location


### PR DESCRIPTION
# Pull request description

This PR makes the front-end collision detection in sync with how the backend handles it. We had a few cases where the API was throwing a Building Collides.

At least now, only the collectible/item in question will fail to place, instead of everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented collectible placement on coordinates already occupied by another building.
  * Preserved clear validation messages for locked floor levels.
  * Updated placement and import scenarios to use valid, unoccupied locations.
* **Documentation**
  * Clarified how stale plans, autosaves, and placement failures are handled during home-item imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->