### PR TITLE
[FEAT] Buy max Sand Shovel / Sand Drill at Jafar's shop

### DIFF
--- a/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
@@ -12,7 +12,10 @@ import { SplitScreenView } from "components/ui/SplitScreenView";
 import Decimal from "decimal.js-light";
 import { Context } from "features/game/GameProvider";
 import { getKeys, getObjectEntries } from "lib/object";
-import { ITEM_DETAILS } from "features/game/types/images";
+import {
+  ITEM_DETAILS,
+  getTranslatedItemName,
+} from "features/game/types/images";
 import {
   TREASURE_TOOLS,
   type TreasureToolName,
@@ -175,7 +178,7 @@ const ToolContent: React.FC<ToolContentProps> = ({ selectedName }) => {
                 className="h-8 mr-2"
               />
               <span className="text-sm">
-                {maxAffordableAmount} {selectedName}
+                {maxAffordableAmount} {getTranslatedItemName(selectedName)}
               </span>
             </div>
             <div className="flex flex-wrap justify-center items-center gap-2 mb-3">

--- a/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopBuy.tsx
@@ -44,6 +44,10 @@ import { isMobile } from "mobile-device-detect";
 import { Restock } from "features/island/buildings/components/building/market/restock/Restock";
 import { useNow } from "lib/utils/hooks/useNow";
 import type { MachineState } from "features/game/lib/gameMachine";
+import { computeAffordableAmount } from "features/island/buildings/components/building/workBench/lib/planToolPurchases";
+import { Modal } from "components/ui/Modal";
+import { CloseButtonPanel } from "features/game/components/CloseablePanel";
+import { formatNumber } from "lib/utils/formatNumber";
 
 interface ToolContentProps {
   selectedName: TreasureToolName;
@@ -56,6 +60,7 @@ const ToolContent: React.FC<ToolContentProps> = ({ selectedName }) => {
   const { gameService, shortcutItem } = useContext(Context);
 
   const state = useSelector(gameService, _state);
+  const [showMaxConfirm, setShowMaxConfirm] = useState(false);
 
   const stock = state.stock[selectedName] || new Decimal(0);
   const selected = TREASURE_TOOLS[selectedName];
@@ -74,6 +79,16 @@ const ToolContent: React.FC<ToolContentProps> = ({ selectedName }) => {
       ingredients?.mul(amount).greaterThan(inventory[name] || 0),
     );
 
+  const stockAmount = stock.toDecimalPlaces(0, Decimal.ROUND_DOWN).toNumber();
+
+  const maxAffordableAmount = computeAffordableAmount(
+    stockAmount,
+    price,
+    state.coins,
+    selectedIngredients,
+    (name) => inventory[name] ?? new Decimal(0),
+  );
+
   const craft = (event: SyntheticEvent, amount: number) => {
     event.stopPropagation();
     gameService.send("tool.crafted", {
@@ -84,43 +99,124 @@ const ToolContent: React.FC<ToolContentProps> = ({ selectedName }) => {
     shortcutItem(selectedName);
   };
 
+  const confirmBuyMax = () => {
+    gameService.send("tool.crafted", {
+      tool: selectedName,
+      amount: maxAffordableAmount,
+    });
+
+    shortcutItem(selectedName);
+    setShowMaxConfirm(false);
+  };
+
   return (
-    <CraftingRequirements
-      gameState={state}
-      stock={stock}
-      details={{ item: selectedName }}
-      requirements={{
-        coins: price,
-        resources: selectedIngredients,
-      }}
-      actionView={
-        <>
-          {stock.equals(0) ? (
-            <Restock npc={"jafar"} />
-          ) : (
-            <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col w-full">
-              <Button
-                disabled={lessFunds() || lessIngredients() || stock.lessThan(1)}
-                onClick={(e) => craft(e, 1)}
-              >
-                {t("craft")} {"1"}
-              </Button>
-              {bulkToolCraftAmount > 1 && (
-                <Button
-                  disabled={
-                    lessFunds(bulkToolCraftAmount) ||
-                    lessIngredients(bulkToolCraftAmount)
-                  }
-                  onClick={(e) => craft(e, bulkToolCraftAmount)}
-                >
-                  {t("craft")} {bulkToolCraftAmount}
-                </Button>
+    <>
+      <CraftingRequirements
+        gameState={state}
+        stock={stock}
+        details={{ item: selectedName }}
+        requirements={{
+          coins: price,
+          resources: selectedIngredients,
+        }}
+        actionView={
+          <>
+            {stock.equals(0) ? (
+              <Restock npc={"jafar"} />
+            ) : (
+              <div className="flex flex-col space-y-1 w-full">
+                <div className="flex space-x-1 sm:space-x-0 sm:space-y-1 sm:flex-col">
+                  <Button
+                    disabled={
+                      lessFunds() || lessIngredients() || stock.lessThan(1)
+                    }
+                    onClick={(e) => craft(e, 1)}
+                  >
+                    {t("craft")} {"1"}
+                  </Button>
+                  {bulkToolCraftAmount > 1 && (
+                    <Button
+                      disabled={
+                        lessFunds(bulkToolCraftAmount) ||
+                        lessIngredients(bulkToolCraftAmount)
+                      }
+                      onClick={(e) => craft(e, bulkToolCraftAmount)}
+                    >
+                      {t("craft")} {bulkToolCraftAmount}
+                    </Button>
+                  )}
+                </div>
+                {stockAmount > bulkToolCraftAmount && (
+                  <Button
+                    disabled={maxAffordableAmount <= 0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowMaxConfirm(true);
+                    }}
+                  >
+                    {t("craft")}{" "}
+                    {`${maxAffordableAmount > 0 ? maxAffordableAmount : stockAmount}`}
+                  </Button>
+                )}
+              </div>
+            )}
+          </>
+        }
+      />
+      <Modal show={showMaxConfirm} onHide={() => setShowMaxConfirm(false)}>
+        <CloseButtonPanel onClose={() => setShowMaxConfirm(false)}>
+          <div className="flex flex-col items-center p-1">
+            <p className="text-sm mb-2 text-center">
+              {t("marketplace.areYouSureBulkBuy")}
+            </p>
+            <div className="flex items-center mb-3">
+              <img
+                src={ITEM_DETAILS[selectedName].image}
+                className="h-8 mr-2"
+              />
+              <span className="text-sm">
+                {maxAffordableAmount} {selectedName}
+              </span>
+            </div>
+            <div className="flex flex-wrap justify-center items-center gap-2 mb-3">
+              <div className="flex items-center">
+                <img src={SUNNYSIDE.ui.coins} className="h-6 mr-1" />
+                <span className="text-xs">
+                  {formatNumber(price * maxAffordableAmount)}
+                </span>
+              </div>
+              {getObjectEntries(selectedIngredients).map(
+                ([ingredientName, ingredientAmount]) =>
+                  ingredientAmount && (
+                    <div key={ingredientName} className="flex items-center">
+                      <img
+                        src={ITEM_DETAILS[ingredientName].image}
+                        className="h-6 mr-1"
+                      />
+                      <span className="text-xs">
+                        {formatNumber(
+                          ingredientAmount.mul(maxAffordableAmount),
+                        )}
+                      </span>
+                    </div>
+                  ),
               )}
             </div>
-          )}
-        </>
-      }
-    />
+            <div className="flex w-full space-x-1">
+              <Button onClick={() => setShowMaxConfirm(false)}>
+                {t("cancel")}
+              </Button>
+              <Button
+                disabled={maxAffordableAmount <= 0}
+                onClick={confirmBuyMax}
+              >
+                {t("confirm")}
+              </Button>
+            </div>
+          </div>
+        </CloseButtonPanel>
+      </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- Adds a "Craft (N)" button to the treasure tool shop (Sand Shovel / Sand Drill) that buys the maximum amount affordable by coins, ingredients, and remaining stock — previously bulk purchases were capped at a flat 10 regardless of what the player could actually afford.
- Shows a confirmation modal before the purchase, listing the total coin and resource cost.
- The button stays visible (disabled, showing remaining stock) once stock outpaces what's affordable, instead of disappearing.

## Test plan
- [ ] Open Jafar's shop with enough coins/resources for >10 Sand Shovel — confirm "Craft (N)" shows the real affordable max, not a hardcoded number
- [ ] Confirm modal shows correct coin + resource totals for the chosen amount
- [ ] Buy the max amount, confirm inventory/coins/resources update correctly
- [ ] Deplete a required ingredient (e.g. Wood) so max affordable drops to 0 — confirm button stays visible but disabled, showing remaining stock
- [ ] Repeat for Sand Drill
- [ ] Verify existing "Craft 1" and "Craft 10" buttons still behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a bulk-buy option for tools, allowing players to purchase the maximum affordable quantity based on available stock, coins, and ingredients.
  - Added a confirmation modal that displays the selected quantity and required resources before purchase.
  - Players can confirm the purchase directly from the modal, which closes after completion.
  - Existing single-item and fixed-quantity purchase options remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->