### PR TITLE
[FEAT] Ascension Age VIP boost: -10% land expansion time

### DIFF
--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -36,9 +36,10 @@ import coinsIcon from "assets/icons/coins.webp";
 import { formatNumber } from "lib/utils/formatNumber";
 import {
   useExpansionCoinCostWithVip,
-  useExpansionSecondsWithVip,
   useVipAccess,
 } from "lib/utils/hooks/useVipAccess";
+import { useNow } from "lib/utils/hooks/useNow";
+import { hasVipExpansionSpeedBoost } from "features/game/lib/vipAccess";
 /**
  * The props for the component.
  * @param gameState The game state.
@@ -80,6 +81,7 @@ export const ExpansionRequirements: React.FC<Props> = ({
 }: Props) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
+  const now = useNow();
 
   // Compare the player's standing against the (ascension, level) requirement —
   // matching the `expandLand` gate.
@@ -102,12 +104,9 @@ export const ExpansionRequirements: React.FC<Props> = ({
     coins: effectiveCoinCost,
   };
 
-  // Ascension Age chapter perk: VIP holders build 10% faster.
-  const effectiveSeconds = useExpansionSecondsWithVip({
-    seconds: requirements.seconds,
-    game: state,
-  });
-  const showVipTimeBoost = effectiveSeconds < requirements.seconds;
+  // Ascension Age chapter perk: VIP holders build 10% faster. `requirements`
+  // already carries the shortened time — this only picks the timer's icon.
+  const showVipTimeBoost = hasVipExpansionSpeedBoost({ game: state, now });
 
   const onExpand = () => {
     gameService.send("land.expanded");
@@ -149,26 +148,17 @@ export const ExpansionRequirements: React.FC<Props> = ({
         </div>
       </InnerPanel>
       <InnerPanel className="relative flex flex-col mb-1">
-        <div className="p-1 flex justify-between items-center gap-1 mb-1">
+        <div className="p-1 flex justify-between items-center mb-1">
           <Label type={"default"} icon={SUNNYSIDE.icons.basket}>
             {t("requirements")}
           </Label>
-          <div className="flex items-center justify-end flex-wrap gap-x-1">
-            {showVipTimeBoost && (
-              <span className="line-through text-xxs whitespace-nowrap">
-                {secondsToString(requirements.seconds, { length: "short" })}
-              </span>
-            )}
-            <Label
-              type="info"
-              icon={SUNNYSIDE.icons.stopwatch}
-              secondaryIcon={
-                showVipTimeBoost ? vipIcon : SUNNYSIDE.icons.hammer
-              }
-            >
-              {secondsToString(effectiveSeconds, { length: "medium" })}
-            </Label>
-          </div>
+          <Label
+            type="info"
+            icon={SUNNYSIDE.icons.stopwatch}
+            secondaryIcon={showVipTimeBoost ? vipIcon : SUNNYSIDE.icons.hammer}
+          >
+            {secondsToString(requirements.seconds, { length: "medium" })}
+          </Label>
         </div>
 
         {!!requirements.coins && !showVipDiscount && (

--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -23,7 +23,6 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { ResizableBar } from "../ProgressBar";
 import { TimerDisplay } from "features/retreat/components/auctioneer/AuctionDetails";
-import { expansionRequirements } from "features/game/events/landExpansion/expandLand";
 import { Button } from "../Button";
 import { ITEM_DETAILS } from "features/game/types/images";
 import { useSpeedUpPayment } from "features/game/lib/useSpeedUpPayment";
@@ -37,6 +36,7 @@ import coinsIcon from "assets/icons/coins.webp";
 import { formatNumber } from "lib/utils/formatNumber";
 import {
   useExpansionCoinCostWithVip,
+  useExpansionSecondsWithVip,
   useVipAccess,
 } from "lib/utils/hooks/useVipAccess";
 /**
@@ -102,6 +102,13 @@ export const ExpansionRequirements: React.FC<Props> = ({
     coins: effectiveCoinCost,
   };
 
+  // Ascension Age chapter perk: VIP holders build 10% faster.
+  const effectiveSeconds = useExpansionSecondsWithVip({
+    seconds: requirements.seconds,
+    game: state,
+  });
+  const showVipTimeBoost = effectiveSeconds < requirements.seconds;
+
   const onExpand = () => {
     gameService.send("land.expanded");
     gameService.send("SAVE");
@@ -142,17 +149,26 @@ export const ExpansionRequirements: React.FC<Props> = ({
         </div>
       </InnerPanel>
       <InnerPanel className="relative flex flex-col mb-1">
-        <div className="p-1 flex justify-between items-center mb-1">
+        <div className="p-1 flex justify-between items-center gap-1 mb-1">
           <Label type={"default"} icon={SUNNYSIDE.icons.basket}>
             {t("requirements")}
           </Label>
-          <Label
-            type="info"
-            icon={SUNNYSIDE.icons.stopwatch}
-            secondaryIcon={SUNNYSIDE.icons.hammer}
-          >
-            {secondsToString(requirements.seconds, { length: "medium" })}
-          </Label>
+          <div className="flex items-center justify-end flex-wrap gap-x-1">
+            {showVipTimeBoost && (
+              <span className="line-through text-xxs whitespace-nowrap">
+                {secondsToString(requirements.seconds, { length: "short" })}
+              </span>
+            )}
+            <Label
+              type="info"
+              icon={SUNNYSIDE.icons.stopwatch}
+              secondaryIcon={
+                showVipTimeBoost ? vipIcon : SUNNYSIDE.icons.hammer
+              }
+            >
+              {secondsToString(effectiveSeconds, { length: "medium" })}
+            </Label>
+          </div>
         </div>
 
         {!!requirements.coins && !showVipDiscount && (
@@ -230,8 +246,13 @@ export const Expanding: React.FC<{
 }> = ({ state, onClose, onInstantExpanded, readyAt }) => {
   const { t } = useAppTranslation();
 
-  const { requirements } = expansionRequirements({ game: state });
-  const totalSeconds = requirements?.seconds ?? 0;
+  // Read the length of the build from the construction itself rather than
+  // re-deriving it — boosts (Ascension Monument, VIP speed) are baked into
+  // `readyAt` when the expansion starts and may no longer apply now.
+  const construction = state.expansionConstruction;
+  const totalSeconds = construction
+    ? (construction.readyAt - construction.createdAt) / 1000
+    : 0;
   const { totalSeconds: secondsTillReady, ...ready } = useCountdown(
     readyAt ?? 0,
   );

--- a/src/components/ui/layouts/ExpansionRequirements.tsx
+++ b/src/components/ui/layouts/ExpansionRequirements.tsx
@@ -5,19 +5,19 @@ import {
 } from "features/game/lib/level";
 import { getKeys } from "lib/object";
 import type {
+  BoostName,
   Bumpkin,
   GameState,
   ExpansionRequirements as IExpansionRequirements,
   Inventory,
 } from "features/game/types/game";
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { RequirementLabel } from "../RequirementsLabel";
 import { InlineDialogue } from "features/world/ui/TypingMessage";
 import { SUNNYSIDE } from "assets/sunnyside";
 
 import { Label } from "../Label";
 import { SquareIcon } from "../SquareIcon";
-import { secondsToString } from "lib/utils/time";
 import { InnerPanel } from "../Panel";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
@@ -38,8 +38,7 @@ import {
   useExpansionCoinCostWithVip,
   useVipAccess,
 } from "lib/utils/hooks/useVipAccess";
-import { useNow } from "lib/utils/hooks/useNow";
-import { hasVipExpansionSpeedBoost } from "features/game/lib/vipAccess";
+import { BoostsDisplay } from "./BoostsDisplay";
 /**
  * The props for the component.
  * @param gameState The game state.
@@ -53,6 +52,10 @@ interface Props {
   bumpkin: Bumpkin;
   details: DetailsProps;
   requirements: IExpansionRequirements;
+  /** Build time before any time boost — struck through when one applies. */
+  baseTimeSeconds: number;
+  /** Time boosts behind the shortened build, listed in the boosts popover. */
+  timeBoostsUsed: { name: BoostName; value: string }[];
   state: GameState;
   onClose: () => void;
 }
@@ -75,13 +78,15 @@ export const ExpansionRequirements: React.FC<Props> = ({
   bumpkin,
   details,
   requirements,
+  baseTimeSeconds,
+  timeBoostsUsed,
   coins,
   state,
   onClose,
 }: Props) => {
   const { t } = useAppTranslation();
   const { gameService } = useContext(Context);
-  const now = useNow();
+  const [showTimeBoosts, setShowTimeBoosts] = useState(false);
 
   // Compare the player's standing against the (ascension, level) requirement —
   // matching the `expandLand` gate.
@@ -104,9 +109,10 @@ export const ExpansionRequirements: React.FC<Props> = ({
     coins: effectiveCoinCost,
   };
 
-  // Ascension Age chapter perk: VIP holders build 10% faster. `requirements`
-  // already carries the shortened time — this only picks the timer's icon.
-  const showVipTimeBoost = hasVipExpansionSpeedBoost({ game: state, now });
+  // `requirements.seconds` already carries any shortening (Ascension Monument,
+  // VIP) — show it against the original, with the boosts behind the tap.
+  const isTimeBoosted =
+    timeBoostsUsed.length > 0 && requirements.seconds < baseTimeSeconds;
 
   const onExpand = () => {
     gameService.send("land.expanded");
@@ -152,13 +158,35 @@ export const ExpansionRequirements: React.FC<Props> = ({
           <Label type={"default"} icon={SUNNYSIDE.icons.basket}>
             {t("requirements")}
           </Label>
-          <Label
-            type="info"
-            icon={SUNNYSIDE.icons.stopwatch}
-            secondaryIcon={showVipTimeBoost ? vipIcon : SUNNYSIDE.icons.hammer}
+          <div
+            className={`flex flex-row items-center ${
+              isTimeBoosted ? "cursor-pointer" : ""
+            }`}
+            onClick={
+              isTimeBoosted
+                ? () => setShowTimeBoosts(!showTimeBoosts)
+                : undefined
+            }
           >
-            {secondsToString(requirements.seconds, { length: "medium" })}
-          </Label>
+            {isTimeBoosted && (
+              <RequirementLabel
+                type="time"
+                waitSeconds={requirements.seconds}
+                boosted
+              />
+            )}
+            <RequirementLabel
+              type="time"
+              waitSeconds={baseTimeSeconds}
+              strikethrough={isTimeBoosted}
+            />
+            <BoostsDisplay
+              boosts={timeBoostsUsed}
+              show={showTimeBoosts}
+              state={state}
+              onClick={() => setShowTimeBoosts(!showTimeBoosts)}
+            />
+          </div>
         </div>
 
         {!!requirements.coins && !showVipDiscount && (

--- a/src/features/game/components/modal/components/VIPItems.tsx
+++ b/src/features/game/components/modal/components/VIPItems.tsx
@@ -353,11 +353,11 @@ export const VIPItems: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
                     }
                   : undefined,
               },
-              ...(currentChapter === "Salt Awakening"
+              ...(currentChapter === "Ascension Age"
                 ? [
                     {
-                      text: t("vip.benefit.bonusSaltYield"),
-                      icon: ITEM_DETAILS["Salt"].image,
+                      text: t("vip.benefit.expansionSpeed"),
+                      icon: SUNNYSIDE.icons.stopwatch,
                     },
                   ]
                 : []),

--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -597,4 +597,24 @@ describe("Ascension Age VIP expansion time boost", () => {
       DURING + 124416 * 1000,
     );
   });
+
+  it("shortens the requirement itself, alongside the monument boost", () => {
+    const { requirements, boostsUsed } = expansionRequirements({
+      game: desertExpansionState(true, DURING),
+      now: DURING,
+    });
+
+    expect(requirements?.seconds).toEqual(BOOSTED_SECONDS);
+    expect(boostsUsed).toEqual([{ name: "VIP Access", value: "x0.9" }]);
+  });
+
+  it("leaves the requirement untouched when the perk does not apply", () => {
+    const { requirements, boostsUsed } = expansionRequirements({
+      game: desertExpansionState(false, DURING),
+      now: DURING,
+    });
+
+    expect(requirements?.seconds).toEqual(BASE_SECONDS);
+    expect(boostsUsed).toHaveLength(0);
+  });
 });

--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -598,23 +598,49 @@ describe("Ascension Age VIP expansion time boost", () => {
     );
   });
 
-  it("shortens the requirement itself, alongside the monument boost", () => {
-    const { requirements, boostsUsed } = expansionRequirements({
-      game: desertExpansionState(true, DURING),
-      now: DURING,
-    });
+  it("reports the original time and the boost behind it", () => {
+    const { requirements, baseTimeSeconds, timeBoostsUsed, boostsUsed } =
+      expansionRequirements({
+        game: desertExpansionState(true, DURING),
+        now: DURING,
+      });
 
     expect(requirements?.seconds).toEqual(BOOSTED_SECONDS);
+    expect(baseTimeSeconds).toEqual(BASE_SECONDS);
+    expect(timeBoostsUsed).toEqual([{ name: "VIP Access", value: "x0.9" }]);
     expect(boostsUsed).toEqual([{ name: "VIP Access", value: "x0.9" }]);
   });
 
-  it("leaves the requirement untouched when the perk does not apply", () => {
-    const { requirements, boostsUsed } = expansionRequirements({
-      game: desertExpansionState(false, DURING),
+  it("reports no time boost when the perk does not apply", () => {
+    const { requirements, baseTimeSeconds, timeBoostsUsed } =
+      expansionRequirements({
+        game: desertExpansionState(false, DURING),
+        now: DURING,
+      });
+
+    expect(requirements?.seconds).toEqual(BASE_SECONDS);
+    expect(baseTimeSeconds).toEqual(BASE_SECONDS);
+    expect(timeBoostsUsed).toHaveLength(0);
+  });
+
+  it("keeps resource boosts out of the time boost list", () => {
+    const base = desertExpansionState(true, DURING);
+    const { timeBoostsUsed, boostsUsed } = expansionRequirements({
+      game: {
+        ...base,
+        collectibles: {
+          "Grinx's Hammer": [
+            { coordinates: { x: 1, y: 1 }, createdAt: 0, id: "1", readyAt: 0 },
+          ],
+        },
+      },
       now: DURING,
     });
 
-    expect(requirements?.seconds).toEqual(BASE_SECONDS);
-    expect(boostsUsed).toHaveLength(0);
+    expect(timeBoostsUsed).toEqual([{ name: "VIP Access", value: "x0.9" }]);
+    expect(boostsUsed).toEqual([
+      { name: "Grinx's Hammer", value: "x0.5" },
+      { name: "VIP Access", value: "x0.9" },
+    ]);
   });
 });

--- a/src/features/game/events/landExpansion/expandLand.test.ts
+++ b/src/features/game/events/landExpansion/expandLand.test.ts
@@ -3,6 +3,7 @@ import { expandLand, expansionRequirements } from "./expandLand";
 import { ascensionBaseline } from "features/game/lib/level";
 import Decimal from "decimal.js-light";
 import { BB_TO_GEM_RATIO } from "features/game/types/game";
+import { CONFIG } from "lib/config";
 
 describe("expandLand", () => {
   it("does not allow expanding basic island past 9 (must upgrade)", () => {
@@ -455,5 +456,145 @@ describe("expansionRequirements", () => {
       Obsidian: 26,
     });
     expect(requirements?.seconds).toBe(84 * HOUR);
+  });
+});
+
+describe("Ascension Age VIP expansion time boost", () => {
+  // The boost window's testnet bypass would mask the pre-cutover behaviour
+  // (local .env runs jest on amoy), so exercise mainnet semantics here.
+  let previousNetwork: (typeof CONFIG)["NETWORK"];
+
+  beforeEach(() => {
+    previousNetwork = CONFIG.NETWORK;
+    CONFIG.NETWORK = "mainnet";
+  });
+
+  afterEach(() => {
+    CONFIG.NETWORK = previousNetwork;
+  });
+
+  // Desert expansion 21: 48 hours base build time.
+  const BASE_SECONDS = 48 * 60 * 60;
+  const BOOSTED_SECONDS = 155520; // 48h × 0.9 = 43.2h
+
+  // Golden timestamps for the boost window — if the dates in
+  // TIME_BASED_FEATURE_FLAG_WINDOWS.ASCENSION_AGE_VIP_EXPANSION move, these bite.
+  const BEFORE_START = new Date("2026-08-09T23:59:59Z").getTime();
+  const DURING = new Date("2026-08-10T00:00:01Z").getTime();
+  const AFTER_END = new Date("2026-11-02T00:00:01Z").getTime();
+
+  const desertExpansionState = (vip: boolean, now: number) => ({
+    ...TEST_FARM,
+    bumpkin: {
+      ...INITIAL_BUMPKIN,
+      experience: 1000000000,
+    },
+    inventory: {
+      "Basic Land": new Decimal(20),
+      Wood: new Decimal(550),
+      Stone: new Decimal(150),
+      Iron: new Decimal(30),
+      Gold: new Decimal(25),
+      Crimstone: new Decimal(45),
+      Oil: new Decimal(350),
+      Gem: new Decimal(4 * BB_TO_GEM_RATIO),
+    },
+    coins: 10000,
+    island: { type: "desert" as const },
+    ...(vip
+      ? {
+          vip: {
+            expiresAt: now + 86400000,
+            trialStartedAt: undefined,
+            bundles: [],
+          },
+        }
+      : {}),
+  });
+
+  it("shortens the build by 10% for VIP holders during the boost window", () => {
+    const state = expandLand({
+      action: { type: "land.expanded", farmId: 0 },
+      state: desertExpansionState(true, DURING),
+      createdAt: DURING,
+    });
+
+    expect(state.expansionConstruction?.readyAt).toEqual(
+      DURING + BOOSTED_SECONDS * 1000,
+    );
+    expect(state.boostsUsedAt?.["VIP Access"]).toEqual(DURING);
+  });
+
+  it("does not shorten the build for VIP holders before the boost starts", () => {
+    const state = expandLand({
+      action: { type: "land.expanded", farmId: 0 },
+      state: desertExpansionState(true, BEFORE_START),
+      createdAt: BEFORE_START,
+    });
+
+    expect(state.expansionConstruction?.readyAt).toEqual(
+      BEFORE_START + BASE_SECONDS * 1000,
+    );
+    expect(state.boostsUsedAt?.["VIP Access"]).toBeUndefined();
+  });
+
+  it("does not shorten the build for VIP holders once the chapter has ended", () => {
+    const state = expandLand({
+      action: { type: "land.expanded", farmId: 0 },
+      state: desertExpansionState(true, AFTER_END),
+      createdAt: AFTER_END,
+    });
+
+    expect(state.expansionConstruction?.readyAt).toEqual(
+      AFTER_END + BASE_SECONDS * 1000,
+    );
+  });
+
+  it("does not shorten the build for players without VIP", () => {
+    const state = expandLand({
+      action: { type: "land.expanded", farmId: 0 },
+      state: desertExpansionState(false, DURING),
+      createdAt: DURING,
+    });
+
+    expect(state.expansionConstruction?.readyAt).toEqual(
+      DURING + BASE_SECONDS * 1000,
+    );
+  });
+
+  it("stacks multiplicatively with the Ascension Monument boost", () => {
+    const base = desertExpansionState(true, DURING);
+    const state = expandLand({
+      action: { type: "land.expanded", farmId: 0 },
+      state: {
+        ...base,
+        inventory: {
+          ...base.inventory,
+          "Ascension Monument": new Decimal(1),
+        },
+        collectibles: {
+          "Ascension Monument": [
+            {
+              coordinates: { x: 1, y: 1 },
+              createdAt: 0,
+              id: "1",
+              readyAt: 0,
+            },
+          ],
+        },
+        socialFarming: {
+          ...base.socialFarming,
+          villageProjects: {
+            "Ascension Monument": { cheers: 1000000 },
+          },
+        },
+      },
+      createdAt: DURING,
+    });
+
+    // 48h × 0.8 (monument) × 0.9 (VIP) = 34.56h
+    expect(state.expansionConstruction?.readyAt).toEqual(
+      DURING + 124416 * 1000,
+    );
   });
 });

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -22,7 +22,7 @@ import { updateBoostUsed } from "features/game/types/updateBoostUsed";
 import {
   EXPANSION_VIP_TIME_MULTIPLIER,
   getExpansionCoinCostWithVip,
-  getExpansionSecondsWithVip,
+  hasVipExpansionSpeedBoost,
 } from "features/game/lib/vipAccess";
 
 export type ExpandLandAction = {
@@ -54,7 +54,10 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
 
     const bumpkin = game.bumpkin;
 
-    const { requirements, boostsUsed } = expansionRequirements({ game });
+    const { requirements, boostsUsed } = expansionRequirements({
+      game,
+      now: createdAt,
+    });
     if (!requirements) {
       throw new Error("No more land expansions available");
     }
@@ -111,24 +114,9 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
       game.inventory,
     );
 
-    // Ascension Age chapter perk: VIP holders build 10% faster. Kept out of
-    // `expansionRequirements` (like the VIP coin discount) so the UI can show
-    // the full requirement alongside the discounted one.
-    const effectiveSeconds = getExpansionSecondsWithVip({
-      seconds: requirements.seconds,
-      game,
-      now: createdAt,
-    });
-    if (effectiveSeconds < requirements.seconds) {
-      boostsUsed.push({
-        name: "VIP Access",
-        value: `x${EXPANSION_VIP_TIME_MULTIPLIER}`,
-      });
-    }
-
     game.expansionConstruction = {
       createdAt,
-      readyAt: createdAt + effectiveSeconds * 1000,
+      readyAt: createdAt + requirements.seconds * 1000,
     };
 
     // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#tutorial_complete
@@ -158,8 +146,10 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
 
 export const expansionRequirements = ({
   game,
+  now = Date.now(),
 }: {
   game: GameState;
+  now?: number;
 }): {
   requirements: Requirements | undefined;
   boostsUsed: { name: BoostName; value: string }[];
@@ -198,6 +188,15 @@ export const expansionRequirements = ({
   if (isMonumentActive({ game, monument: "Ascension Monument" })) {
     seconds *= 0.8;
     boostsUsed.push({ name: "Ascension Monument", value: "x0.8" });
+  }
+
+  // Ascension Age chapter perk: -10% expansion time for VIP holders
+  if (hasVipExpansionSpeedBoost({ game, now })) {
+    seconds = Math.round(seconds * EXPANSION_VIP_TIME_MULTIPLIER);
+    boostsUsed.push({
+      name: "VIP Access",
+      value: `x${EXPANSION_VIP_TIME_MULTIPLIER}`,
+    });
   }
 
   return { requirements: { ...requirements, resources, seconds }, boostsUsed };

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -19,7 +19,11 @@ import { ISLAND_MAX_EXPANSION } from "features/game/expansion/lib/expansionRequi
 import { produce } from "immer";
 import { trackFarmActivity } from "features/game/types/farmActivity";
 import { updateBoostUsed } from "features/game/types/updateBoostUsed";
-import { getExpansionCoinCostWithVip } from "features/game/lib/vipAccess";
+import {
+  EXPANSION_VIP_TIME_MULTIPLIER,
+  getExpansionCoinCostWithVip,
+  getExpansionSecondsWithVip,
+} from "features/game/lib/vipAccess";
 
 export type ExpandLandAction = {
   type: "land.expanded";
@@ -107,9 +111,24 @@ export function expandLand({ state, createdAt = Date.now() }: Options) {
       game.inventory,
     );
 
+    // Ascension Age chapter perk: VIP holders build 10% faster. Kept out of
+    // `expansionRequirements` (like the VIP coin discount) so the UI can show
+    // the full requirement alongside the discounted one.
+    const effectiveSeconds = getExpansionSecondsWithVip({
+      seconds: requirements.seconds,
+      game,
+      now: createdAt,
+    });
+    if (effectiveSeconds < requirements.seconds) {
+      boostsUsed.push({
+        name: "VIP Access",
+        value: `x${EXPANSION_VIP_TIME_MULTIPLIER}`,
+      });
+    }
+
     game.expansionConstruction = {
       createdAt,
-      readyAt: createdAt + requirements.seconds * 1000,
+      readyAt: createdAt + effectiveSeconds * 1000,
     };
 
     // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#tutorial_complete

--- a/src/features/game/events/landExpansion/expandLand.ts
+++ b/src/features/game/events/landExpansion/expandLand.ts
@@ -152,11 +152,16 @@ export const expansionRequirements = ({
   now?: number;
 }): {
   requirements: Requirements | undefined;
+  /** Build time before any time boost, for the struck-through original. */
+  baseTimeSeconds: number;
+  /** The subset of `boostsUsed` that shortened the build. */
+  timeBoostsUsed: { name: BoostName; value: string }[];
   boostsUsed: { name: BoostName; value: string }[];
 } => {
   const level = (game.inventory["Basic Land"]?.toNumber() ?? 0) + 1;
 
   const boostsUsed: { name: BoostName; value: string }[] = [];
+  const timeBoostsUsed: { name: BoostName; value: string }[] = [];
 
   const requirements = getExpansionRequirements({
     island: game.island.type,
@@ -165,7 +170,12 @@ export const expansionRequirements = ({
   });
 
   if (!requirements) {
-    return { requirements: undefined, boostsUsed };
+    return {
+      requirements: undefined,
+      baseTimeSeconds: 0,
+      timeBoostsUsed,
+      boostsUsed,
+    };
   }
 
   let resources = requirements.resources;
@@ -187,17 +197,24 @@ export const expansionRequirements = ({
   // -20% expansion time once the monument's cheers are complete
   if (isMonumentActive({ game, monument: "Ascension Monument" })) {
     seconds *= 0.8;
-    boostsUsed.push({ name: "Ascension Monument", value: "x0.8" });
+    timeBoostsUsed.push({ name: "Ascension Monument", value: "x0.8" });
   }
 
   // Ascension Age chapter perk: -10% expansion time for VIP holders
   if (hasVipExpansionSpeedBoost({ game, now })) {
     seconds = Math.round(seconds * EXPANSION_VIP_TIME_MULTIPLIER);
-    boostsUsed.push({
+    timeBoostsUsed.push({
       name: "VIP Access",
       value: `x${EXPANSION_VIP_TIME_MULTIPLIER}`,
     });
   }
 
-  return { requirements: { ...requirements, resources, seconds }, boostsUsed };
+  boostsUsed.push(...timeBoostsUsed);
+
+  return {
+    requirements: { ...requirements, resources, seconds },
+    baseTimeSeconds: requirements.seconds,
+    timeBoostsUsed,
+    boostsUsed,
+  };
 };

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -251,7 +251,8 @@ export const UpcomingExpansion: React.FC = () => {
 
   const state = gameState.context.state;
   const now = useNow();
-  const { requirements } = expansionRequirements({ game: state, now });
+  const { requirements, baseTimeSeconds, timeBoostsUsed } =
+    expansionRequirements({ game: state, now });
 
   const expansions =
     (gameState.context.state.inventory["Basic Land"]?.toNumber() ?? 3) + 1;
@@ -344,6 +345,8 @@ export const UpcomingExpansion: React.FC = () => {
             }}
             onClose={() => setShowBumpkinModal(false)}
             requirements={requirements as IExpansionRequirements}
+            baseTimeSeconds={baseTimeSeconds}
+            timeBoostsUsed={timeBoostsUsed}
           />
         </CloseButtonPanel>
       </Modal>

--- a/src/features/game/expansion/components/UpcomingExpansion.tsx
+++ b/src/features/game/expansion/components/UpcomingExpansion.tsx
@@ -250,7 +250,8 @@ export const UpcomingExpansion: React.FC = () => {
   const { openModal } = useContext(ModalContext);
 
   const state = gameState.context.state;
-  const { requirements } = expansionRequirements({ game: state });
+  const now = useNow();
+  const { requirements } = expansionRequirements({ game: state, now });
 
   const expansions =
     (gameState.context.state.inventory["Basic Land"]?.toNumber() ?? 3) + 1;

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js-light";
+import { hasTimeBasedFeatureAccess } from "lib/flags";
 import type { GameState, InventoryItemName } from "../types/game";
 
 export const VIP_TRIAL_PERIOD_MS = 1000 * 60 * 60 * 24 * 7;
@@ -78,4 +79,43 @@ export const getExpansionCoinCostWithVip = ({
   const discount20 = Math.floor(fullCost * EXPANSION_VIP_DISCOUNT_PERCENT);
   const discount = Math.max(EXPANSION_VIP_DISCOUNT_FIXED, discount20);
   return Math.max(0, fullCost - discount);
+};
+
+/** Ascension Age chapter perk: VIP holders expand 10% faster. */
+export const EXPANSION_VIP_TIME_MULTIPLIER = 0.9;
+
+/**
+ * Whether the Ascension Age VIP expansion-speed perk applies at `now` — the
+ * player holds VIP and the chapter's boost window is open.
+ */
+export const hasVipExpansionSpeedBoost = ({
+  game,
+  now,
+}: {
+  game: GameState;
+  now: number;
+}): boolean =>
+  hasVipAccess({ game, now }) &&
+  hasTimeBasedFeatureAccess({
+    featureName: "ASCENSION_AGE_VIP_EXPANSION",
+    game,
+    now,
+  });
+
+/**
+ * Expansion build time after the Ascension Age VIP speed perk. Returns the
+ * unboosted seconds when the perk does not apply.
+ */
+export const getExpansionSecondsWithVip = ({
+  seconds,
+  game,
+  now,
+}: {
+  seconds: number;
+  game: GameState;
+  now: number;
+}): number => {
+  if (!hasVipExpansionSpeedBoost({ game, now })) return seconds;
+
+  return Math.round(seconds * EXPANSION_VIP_TIME_MULTIPLIER);
 };

--- a/src/features/game/lib/vipAccess.ts
+++ b/src/features/game/lib/vipAccess.ts
@@ -101,21 +101,3 @@ export const hasVipExpansionSpeedBoost = ({
     game,
     now,
   });
-
-/**
- * Expansion build time after the Ascension Age VIP speed perk. Returns the
- * unboosted seconds when the perk does not apply.
- */
-export const getExpansionSecondsWithVip = ({
-  seconds,
-  game,
-  now,
-}: {
-  seconds: number;
-  game: GameState;
-  now: number;
-}): number => {
-  if (!hasVipExpansionSpeedBoost({ game, now })) return seconds;
-
-  return Math.round(seconds * EXPANSION_VIP_TIME_MULTIPLIER);
-};

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -95,6 +95,14 @@ export const TIME_BASED_FEATURE_FLAG_WINDOWS = {
     start: new Date("2026-09-07T00:00:00Z"),
     end: null,
   },
+  // Ascension Age chapter VIP perk: VIP holders expand their land 10% faster.
+  // Live from Mon 10th Aug 2026 (when the chapter's tasks begin) until the
+  // chapter ends — the end date must match CHAPTERS["Ascension Age"].endDate.
+  // Testnet bypasses the start date so testers can verify ahead of the cutover.
+  ASCENSION_AGE_VIP_EXPANSION: {
+    start: new Date("2026-08-10T00:00:00Z"),
+    end: new Date("2026-11-02T00:00:00Z"),
+  },
 } satisfies Record<string, TimeBasedFeatureWindow>;
 
 /** All time-based flags receive the full window; start-only helpers ignore `end`. */
@@ -115,6 +123,7 @@ export const TIME_BASED_FEATURE_FLAGS: Record<
   COLORS_2026_EVENT_FLAG: betaTimePeriodFeatureFlag,
   // Testnet-only bypass before the date (not beta), so live testers can reach A2.
   SPOOKY_ASCENSION: timePeriodFeatureFlag,
+  ASCENSION_AGE_VIP_EXPANSION: timePeriodFeatureFlag,
 };
 
 /**

--- a/src/lib/i18n/dictionaries/de.json
+++ b/src/lib/i18n/dictionaries/de.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 zufälliger Fisch auf {{reels}} -Walzen in dieser Besetzung",
   "fishing.shrimpOnesie.bonus": "Einteiler mit Garnelen + {{amount}}",
   "description.shrimpOnesie.boost": "+1 zufälliger Fisch auf jeder 15. Walze",
-  "vip.benefit.bonusSaltYield": "+2 Salz pro Rake während des Kapitels „Das Erwachen des Salzes“",
   "description.spaSheep.boost": "+5 Schaf-EP für Animal Affection Tools",
   "description.obsidianShrine.buff": "Ernten, pflanzen und düngen Sie Ihre Pflanzen, Ihr Obst und Ihr Gewächshaus in großen Mengen",
   "obsidianShrine.noEligiblePots": "Keine Gewächshaustöpfe zum Düngen",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5536,6 +5536,7 @@
   "vip.benefit.bonusDelivery": "Bonus Delivery & Chore Rewards",
   "vip.benefit.reputation": "{{points}} Reputation Points",
   "vip.benefit.bonusSaltYield": "+2 Salt per Rake during Salt Awakening Chapter",
+  "vip.benefit.expansionSpeed": "-10% Expansion time during Ascension Age Chapter (Starts on 10th August 2026 Midnight UTC)",
   "vip.savings.title": "VIP Savings",
   "vip.savings.description": "Track how much you've saved and earned with VIP perks.",
   "vip.savings.coinsSaved": "Coins Saved",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -5535,7 +5535,6 @@
   "vip.benefit.stellaDiscounts": "Stella FLOWER discounts (50%)",
   "vip.benefit.bonusDelivery": "Bonus Delivery & Chore Rewards",
   "vip.benefit.reputation": "{{points}} Reputation Points",
-  "vip.benefit.bonusSaltYield": "+2 Salt per Rake during Salt Awakening Chapter",
   "vip.benefit.expansionSpeed": "-10% Expansion time during Ascension Age Chapter (Starts on 10th August 2026 Midnight UTC)",
   "vip.savings.title": "VIP Savings",
   "vip.savings.description": "Track how much you've saved and earned with VIP perks.",

--- a/src/lib/i18n/dictionaries/en.json
+++ b/src/lib/i18n/dictionaries/en.json
@@ -5535,7 +5535,6 @@
   "vip.benefit.stellaDiscounts": "Stella FLOWER discounts (50%)",
   "vip.benefit.bonusDelivery": "Bonus Delivery & Chore Rewards",
   "vip.benefit.reputation": "{{points}} Reputation Points",
-  "vip.benefit.bonusSaltYield": "+2 Salt per Rake during Salt Awakening Chapter",
   "vip.savings.title": "VIP Savings",
   "vip.savings.description": "Track how much you've saved and earned with VIP perks.",
   "vip.savings.coinsSaved": "Coins Saved",

--- a/src/lib/i18n/dictionaries/es.json
+++ b/src/lib/i18n/dictionaries/es.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 pez aleatorio en los carretes de {{reels}} de este reparto",
   "fishing.shrimpOnesie.bonus": "Mono de camarones + {{amount}}",
   "description.shrimpOnesie.boost": "+1 pez aleatorio cada 15 carrete",
-  "vip.benefit.bonusSaltYield": "+2 de sal por rastrillo durante el capítulo El despertar de la sal",
   "description.spaSheep.boost": "+5 puntos de EXP para ovejas gracias a las herramientas de afecto animal",
   "description.obsidianShrine.buff": "Coseche, plante y fertilice a granel sus cultivos, frutas e invernaderos",
   "obsidianShrine.noEligiblePots": "No hay macetas de invernadero para fertilizar",

--- a/src/lib/i18n/dictionaries/fr.json
+++ b/src/lib/i18n/dictionaries/fr.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 poisson aléatoire sur les rouleaux {{reels}} dans ce casting",
   "fishing.shrimpOnesie.bonus": "Onesie aux crevettes + {{amount}}",
   "description.shrimpOnesie.boost": "+1 poisson aléatoire tous les 15 moulinets",
-  "vip.benefit.bonusSaltYield": "+2 points de sel par râteau pendant le chapitre Salt Awakening",
   "description.spaSheep.boost": "+5 points d'expérience pour les moutons grâce aux outils Animal Affection",
   "description.obsidianShrine.buff": "Récoltez, plantez et fertilisez en vrac vos cultures, vos fruits et vos serres",
   "obsidianShrine.noEligiblePots": "Pas de pots de serre à fertiliser",

--- a/src/lib/i18n/dictionaries/id.json
+++ b/src/lib/i18n/dictionaries/id.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 ikan acak pada gulungan {{reels}} dalam pemeran ini",
   "fishing.shrimpOnesie.bonus": "Onesie Udang + {{amount}}",
   "description.shrimpOnesie.boost": "+1 ikan acak setiap gulungan ke-15",
-  "vip.benefit.bonusSaltYield": "+2 Garam per Rake selama Bab Kebangkitan Garam",
   "description.spaSheep.boost": "+5 XP Domba dari alat Animal Affection",
   "description.obsidianShrine.buff": "Panen massal, tanam, dan pupuk tanaman, buah, dan rumah kaca Anda",
   "obsidianShrine.noEligiblePots": "Tidak ada pot rumah kaca untuk dipupuk",

--- a/src/lib/i18n/dictionaries/it.json
+++ b/src/lib/i18n/dictionaries/it.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 pesce a caso sui rulli {{reels}} in questo cast",
   "fishing.shrimpOnesie.bonus": "Tutina con gamberetti + {{amount}}",
   "description.shrimpOnesie.boost": "+1 pesce a caso ogni 15 rulli",
-  "vip.benefit.bonusSaltYield": "+2 sale per rake durante il capitolo Salt Awakening",
   "description.spaSheep.boost": "+5 Sheep XP dagli strumenti Animal Affection",
   "description.obsidianShrine.buff": "Raccogli, pianta e concima in massa le tue colture, la frutta e la serra",
   "obsidianShrine.noEligiblePots": "Nessun vaso da serra da concimare",

--- a/src/lib/i18n/dictionaries/ja.json
+++ b/src/lib/i18n/dictionaries/ja.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "このキャストの {{reels}} リールにランダムな魚+1匹",
   "fishing.shrimpOnesie.bonus": "シュリンプワンジー + [0@$]",
   "description.shrimpOnesie.boost": "15番目のリールごとに+1ランダムフィッシュ",
-  "vip.benefit.bonusSaltYield": "「塩の覚醒」チャプター中、レーキ1つにつき +2 塩",
   "description.spaSheep.boost": "アニマル・アフェクションツールから獲得する羊経験値+5",
   "description.obsidianShrine.buff": "作物、果物、温室の大量収穫、植え付け、施肥を行います",
   "obsidianShrine.noEligiblePots": "施肥する温室の鉢はありません",

--- a/src/lib/i18n/dictionaries/pt-BR.json
+++ b/src/lib/i18n/dictionaries/pt-BR.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 peixe aleatório em {{reels}} bobinas neste elenco",
   "fishing.shrimpOnesie.bonus": "Macacão de camarão + {{amount}}",
   "description.shrimpOnesie.boost": "+1 peixe aleatório a cada 15ª bobina",
-  "vip.benefit.bonusSaltYield": "+2 sal por ancinho durante o capítulo Salt Awakening",
   "description.spaSheep.boost": "+5 XP de ovelhas das ferramentas Animal Affection",
   "description.obsidianShrine.buff": "Colha a granel, plante e fertilize suas plantações, frutas e estufa",
   "obsidianShrine.noEligiblePots": "Sem vasos de estufa para fertilizar",

--- a/src/lib/i18n/dictionaries/ru.json
+++ b/src/lib/i18n/dictionaries/ru.json
@@ -7230,7 +7230,6 @@
   "fishing.shrimpOnesie.bulkReel": "+1 случайная рыба на {{reels}} забросах в этом мультизабросе",
   "fishing.shrimpOnesie.bonus": "Shrimp Onesie +{{amount}}",
   "description.shrimpOnesie.boost": "+1 случайная рыба на каждом 15-м забросе",
-  "vip.benefit.bonusSaltYield": "+2 соли за каждое использование граблей во время главы «Пробуждение соли».",
   "obsidianShrine.noEligiblePots": "Нет тепличных грядок для удобрения.",
   "description.saltDoll": "Приправлен щепоткой соли и большим количеством обаяния.",
   "description.jacuzziBear": "Нежится в солёных водах и наслаждается жизнью.",

--- a/src/lib/i18n/dictionaries/tr.json
+++ b/src/lib/i18n/dictionaries/tr.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "Bu oyuncu kadrosunda {{reels}} makaralarında +1 rastgele balık",
   "fishing.shrimpOnesie.bonus": "Karides Onesie + {{amount}}",
   "description.shrimpOnesie.boost": "Her 15. makarada +1 rastgele balık",
-  "vip.benefit.bonusSaltYield": "Tuz Uyanışı Bölümü sırasında Tırmık başına +2 Tuz",
   "description.spaSheep.boost": "Hayvan Sevgisi araçlarından +5 Koyun DP'si",
   "description.obsidianShrine.buff": "Mahsullerinizi, meyvelerinizi ve seralarınızı toplu olarak hasat edin, ekin ve gübreleyin",
   "obsidianShrine.noEligiblePots": "Gübrelenecek sera saksısı yok",

--- a/src/lib/i18n/dictionaries/zh-CN.json
+++ b/src/lib/i18n/dictionaries/zh-CN.json
@@ -7216,7 +7216,6 @@
   "fishing.shrimpOnesie.bulkReel": "在本次抛竿时，有 {{reels}} 次将获得 +1 条随机鱼类",
   "fishing.shrimpOnesie.bonus": "小虾连体衣 +{{amount}}",
   "description.shrimpOnesie.boost": "每抛竿 15 次，额外获得 1 条随机鱼类",
-  "vip.benefit.bonusSaltYield": "在“盐之觉醒”篇章期间，+2 盐产量",
   "description.spaSheep.boost": "使用亲昵动物工具时，绵羊经验值 +5",
   "description.obsidianShrine.buff": "批量对田坑、果坑和温室进行施肥与批量收获、种植田坑。",
   "obsidianShrine.noEligiblePots": "无可施肥的温室花盆",

--- a/src/lib/utils/hooks/useVipAccess.ts
+++ b/src/lib/utils/hooks/useVipAccess.ts
@@ -1,6 +1,7 @@
 import {
   VIP_TRIAL_PERIOD_MS,
   getExpansionCoinCostWithVip,
+  getExpansionSecondsWithVip,
   hasVipAccess,
 } from "features/game/lib/vipAccess";
 import type { GameState } from "features/game/types/game";
@@ -38,4 +39,25 @@ export const useExpansionCoinCostWithVip = ({
   const now = useNow({ live: true, autoEndAt });
 
   return getExpansionCoinCostWithVip({ coins, game, now });
+};
+
+/**
+ * Expansion build time in seconds after the Ascension Age VIP speed perk.
+ * Returns the unboosted seconds when the perk does not apply.
+ */
+export const useExpansionSecondsWithVip = ({
+  seconds,
+  game,
+}: {
+  seconds: number;
+  game: GameState;
+}): number => {
+  const autoEndAt = Math.max(
+    game.vip?.expiresAt ?? 0,
+    (game.vip?.trialStartedAt ?? 0) + VIP_TRIAL_PERIOD_MS,
+  );
+
+  const now = useNow({ live: true, autoEndAt });
+
+  return getExpansionSecondsWithVip({ seconds, game, now });
 };

--- a/src/lib/utils/hooks/useVipAccess.ts
+++ b/src/lib/utils/hooks/useVipAccess.ts
@@ -1,7 +1,6 @@
 import {
   VIP_TRIAL_PERIOD_MS,
   getExpansionCoinCostWithVip,
-  getExpansionSecondsWithVip,
   hasVipAccess,
 } from "features/game/lib/vipAccess";
 import type { GameState } from "features/game/types/game";
@@ -39,25 +38,4 @@ export const useExpansionCoinCostWithVip = ({
   const now = useNow({ live: true, autoEndAt });
 
   return getExpansionCoinCostWithVip({ coins, game, now });
-};
-
-/**
- * Expansion build time in seconds after the Ascension Age VIP speed perk.
- * Returns the unboosted seconds when the perk does not apply.
- */
-export const useExpansionSecondsWithVip = ({
-  seconds,
-  game,
-}: {
-  seconds: number;
-  game: GameState;
-}): number => {
-  const autoEndAt = Math.max(
-    game.vip?.expiresAt ?? 0,
-    (game.vip?.trialStartedAt ?? 0) + VIP_TRIAL_PERIOD_MS,
-  );
-
-  const now = useNow({ live: true, autoEndAt });
-
-  return getExpansionSecondsWithVip({ seconds, game, now });
 };


### PR DESCRIPTION
The Ascension Age chapter VIP perk: **VIP holders expand their land 10% faster**, live from **Mon 10th Aug 2026 00:00 UTC**.

BE PR: sunflower-land/sunflower-land-api#3537

## Flag

New time window `ASCENSION_AGE_VIP_EXPANSION` in `lib/flags.ts` — `2026-08-10T00:00:00Z` → `2026-11-02T00:00:00Z` (the chapter end). Testnet bypasses the start date so it can be verified ahead of the cutover.

## Behaviour

`seconds × 0.9`, applied in `expansionRequirements` right after the Ascension Monument’s `-20%` — one place for both time cuts, both reported in `boostsUsed` — and multiplicative with it (48h → 38.4h with the monument → 34.56h with both). Recorded as a `VIP Access` boost use. The gem/coin speed-up cost keys off `readyAt`, so it gets cheaper for VIP too.

## UI

- The requirements timer shows the boosted time with a lightning icon and the original struck through beside it, with a `BoostsDisplay` popover naming what shortened the build — the same treatment the lava pit and crafting panels use. `expansionRequirements` reports `baseTimeSeconds` and `timeBoostsUsed` for this; the time list excludes resource boosts like Grinx's Hammer. It also surfaces the Ascension Monument's `-20%`, which was applied but never shown before.
- The in-progress bar now derives its total from `readyAt - createdAt` on the construction record instead of re-deriving requirements, so it stays accurate if VIP lapses mid-build.
- The perk is listed in the VIP benefits panel for the whole chapter — from the chapter start, not just from the 10th — and the copy names the 10th August start date so it reads correctly in the days before the cutover. It takes over the chapter-gated slot the Salt Awakening `+2 Salt per Rake` entry held (that chapter ended on 3rd Aug), which leaves `vip.benefit.bonusSaltYield` unused.

<img width="520" height="493" alt="image" src="https://github.com/user-attachments/assets/e9ae50fa-8e78-4556-ac59-fc59f7cdaf2e" />
<img width="509" height="518" alt="image" src="https://github.com/user-attachments/assets/dacafe5e-5e36-44a3-81cd-9c869890d030" />


## Tests

5 new cases: during the window / before the start / after the chapter ends / non-VIP / stacking with the monument. Golden timestamps and durations, and they force `CONFIG.NETWORK = "mainnet"` because jest runs on amoy and the testnet bypass would otherwise mask the pre-cutover case. Mutation-checked both the multiplier and the start date — each flips the expected tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Ascension Age VIP time window (10 Aug–2 Nov 2026, UTC) that grants VIP holders a 10% land-expansion time reduction.
  - Expansion requirements now surface boosted-time details (including a boost breakdown) when the benefit applies.
  - Upcoming expansion UI now uses the current time when computing requirements.

- **Bug Fixes**
  - Expansion progress duration is now derived from the active construction timestamps, improving accuracy.

- **Localization**
  - Updated VIP benefit text to reflect the expansion-speed reduction instead of bonus salt yield.

- **Tests**
  - Added coverage for VIP time-boost behavior, stacking, and correct boost reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

