### PR TITLE
Fix Crafting Box Add/Remove/Instant buttons reflowing under the cursor

### DIFF
--- a/src/features/island/buildings/components/building/craftingBox/components/CraftButton.tsx
+++ b/src/features/island/buildings/components/building/craftingBox/components/CraftButton.tsx
@@ -82,60 +82,75 @@ export const CraftButton: React.FC<{
     isQueueFull || isCraftingBoxEmpty || !hasRequiredIngredients;
   const addToQueueHandler = onAddToQueue ?? handleCraft;
 
+  // Every branch below renders inside this same fixed-height, two-row slot
+  // stack. The exact button/label in each row can change (Add/Craft on top,
+  // Remove/Instant/Collect on bottom), but the row heights themselves never
+  // do — otherwise a quick second click lands on whatever button reflowed
+  // into the first click's position instead of the one the player saw.
+  const ROW_CLASS = "min-h-[46px] flex items-center justify-center w-full";
+
   if (isViewingQueuedRecipe && handleCancelQueuedItem) {
     return (
-      <div className="flex flex-col items-center justify-center gap-1 mt-2">
-        <Button
-          className="relative"
-          onClick={addToQueueHandler}
-          disabled={addToQueueDisabled}
-        >
-          <img
-            src={vipIcon}
-            alt="VIP"
-            className="absolute w-6 sm:w-4 -top-[1px] -right-[2px]"
-          />
-          {t("recipes.addToQueue")}
-        </Button>
-        <Button onClick={handleCancelQueuedItem}>{t("remove")}</Button>
+      <div className="flex flex-col items-center justify-center gap-1 mt-2 w-full">
+        <div className={ROW_CLASS}>
+          <Button
+            className="relative"
+            onClick={addToQueueHandler}
+            disabled={addToQueueDisabled}
+          >
+            <img
+              src={vipIcon}
+              alt="VIP"
+              className="absolute w-4 -top-[1px] -right-[2px]"
+            />
+            {t("recipes.addToQueue")}
+          </Button>
+        </div>
+        <div className={ROW_CLASS}>
+          <Button onClick={handleCancelQueuedItem}>{t("remove")}</Button>
+        </div>
       </div>
     );
   }
 
   if (isCrafting || isPending) {
     return (
-      <div className="flex flex-col items-center justify-center gap-1 mt-2">
-        <Button
-          className="relative"
-          onClick={addToQueueHandler}
-          disabled={addToQueueDisabled}
-        >
-          <img
-            src={vipIcon}
-            alt="VIP"
-            className="absolute w-4 -top-[1px] -right-[2px]"
-          />
-          {t("recipes.addToQueue")}
-        </Button>
-        {isViewingReadyItem && (
-          <Button onClick={handleCollect}>{t("collect")}</Button>
-        )}
-        {!isPreparingQueueSlot && !isViewingReadyItem && (
+      <div className="flex flex-col items-center justify-center gap-1 mt-2 w-full">
+        <div className={ROW_CLASS}>
           <Button
-            disabled={!payment.canAfford || isPending}
-            onClick={() => setShowConfirmation(true)}
+            className="relative"
+            onClick={addToQueueHandler}
+            disabled={addToQueueDisabled}
           >
-            <div className="flex items-center justify-center gap-1">
-              <img src={fastForward} className="h-5" />
-              {!payment.canPayWithCoins && (
-                <>
-                  <span className="text-sm flex items-center">{cost}</span>
-                  <img src={costIcon} className="h-5" />
-                </>
-              )}
-            </div>
+            <img
+              src={vipIcon}
+              alt="VIP"
+              className="absolute w-4 -top-[1px] -right-[2px]"
+            />
+            {t("recipes.addToQueue")}
           </Button>
-        )}
+        </div>
+        <div className={ROW_CLASS}>
+          {isViewingReadyItem && (
+            <Button onClick={handleCollect}>{t("collect")}</Button>
+          )}
+          {!isPreparingQueueSlot && !isViewingReadyItem && (
+            <Button
+              disabled={!payment.canAfford || isPending}
+              onClick={() => setShowConfirmation(true)}
+            >
+              <div className="flex items-center justify-center gap-1">
+                <img src={fastForward} className="h-5" />
+                {!payment.canPayWithCoins && (
+                  <>
+                    <span className="text-sm flex items-center">{cost}</span>
+                    <img src={costIcon} className="h-5" />
+                  </>
+                )}
+              </div>
+            </Button>
+          )}
+        </div>
         <ConfirmationModal
           show={showConfirmation}
           onHide={() => setShowConfirmation(false)}
@@ -156,21 +171,24 @@ export const CraftButton: React.FC<{
   }
 
   return (
-    <div className="flex flex-col items-center justify-center gap-1 mt-2">
-      <Button
-        className="mt-2"
-        onClick={handleCraft}
-        disabled={isCraftingBoxEmpty || !hasRequiredIngredients}
-      >
-        {t("craft")}
-      </Button>
-      <Button disabled>
-        <div className="flex items-center justify-center gap-1">
-          <img src={fastForward} className="h-5" />
-          <span className="text-sm flex items-center">{0}</span>
-          <img src={ITEM_DETAILS["Gem"].image} className="h-5" />
-        </div>
-      </Button>
+    <div className="flex flex-col items-center justify-center gap-1 mt-2 w-full">
+      <div className={ROW_CLASS}>
+        <Button
+          onClick={handleCraft}
+          disabled={isCraftingBoxEmpty || !hasRequiredIngredients}
+        >
+          {t("craft")}
+        </Button>
+      </div>
+      <div className={ROW_CLASS}>
+        <Button disabled>
+          <div className="flex items-center justify-center gap-1">
+            <img src={fastForward} className="h-5" />
+            <span className="text-sm flex items-center">{0}</span>
+            <img src={ITEM_DETAILS["Gem"].image} className="h-5" />
+          </div>
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes a reported UX bug in the Crafting Box:

> When adding an item to craft in Crafting Box, the UI rearranges such that most of the time the mouse is over the remove button. If you then click the Remove button, it rearranges again and your mouse is over the >> button. So the user wants to Add, Add, Add and instead gets Add, Cancel, Instant.

### Root cause

`CraftButton.tsx` renders a two-button, `flex-col` stack that switches between three states (preparing a slot, viewing a queued recipe, actively crafting). None of the three states pinned a row height, and the second row's content differs by state — plain text ("Remove") vs. an icon+cost row ("Instant Craft") vs. nothing at all. That let the stack's total height shift by a few pixels between renders, and a quick second click (aimed at where the previous button was) would land on whichever button reflowed into that spot instead.

A smaller, separate inconsistency compounded it: the "Add to Queue" button's VIP badge was `w-6 sm:w-4` in one state and `w-4` in another.

An active crafting-speed boost (e.g. Sol & Luna, Time Warp Totem) adds a second reflow risk on top: `CraftTimer` renders an extra strikethrough line (old time vs. boosted time) above the buttons whenever a boost is active, so that state was included in testing too.

### Fix

- Wraps each button in a `min-h-[46px]` row (sized to the button's actual rendered height — border + padding + text line height — not an arbitrary round number), so the stack's layout is identical across all three states.
- Unifies the VIP badge width on both "Add to Queue" instances.

### Status: ready — fully tested

Verified manually across multiple viewport sizes (desktop + mobile breakpoints) that:
- The button stack no longer reflows between Add → Queued → Idle/Crafting states — a same-position second click lands on the button the player actually saw, not one that shifted into place.
- Buttons no longer visually touch/overlap (an earlier `h-10` was shorter than the button's real rendered height and squeezed the gap — corrected to `min-h-[46px]`).
- Verified with an active time boost (Sol & Luna, +50% crafting speed) — the taller two-line `CraftTimer` above the buttons doesn't reintroduce the shift, since the button rows themselves are now independently pinned.

## Test plan

- [x] Add a recipe to the queue — confirm the button stack doesn't shift and a same-position second click doesn't land on Remove
- [x] Click Remove on a queued recipe — confirm the stack doesn't shift back into Instant Craft's position
- [x] Repeat with VIP access (multi-slot queue flow via "Add to Queue")
- [x] Repeat with an active crafting-speed boost (Sol & Luna) so CraftTimer renders its taller two-line boosted/base-time display above the buttons
- [x] Visual check across multiple screen sizes: confirm there's a visible gap between the two stacked buttons in every state (not touching) at each size
- [x] Confirm VIP badge renders identically in both places it appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crafting controls to maintain consistent vertical alignment across queued, crafting, pending, and idle states.
  * Standardized button and icon spacing for crafting actions.
  * Prevented layout shifts when instant-craft options are disabled or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->