### PR TITLE
[FEAT] Market guide improvements

### DIFF
--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -250,33 +250,37 @@ export const CropRow: React.FC<{
       }`}
     >
       <div className="flex items-center flex-1 min-w-0">
-        <div className="flex items-center w-24 sm:w-32 mr-2 shrink-0">
+        <div className="flex items-center min-w-24 max-w-32 sm:min-w-32 sm:max-w-40 mr-4 shrink-0">
           <img src={ITEM_DETAILS[crop].image} className="w-6 h-auto mr-2" />
           <div className="flex-1 min-w-0">
-            <p className="text-xs">{crop}</p>
+            <p className="text-xs break-words" title={crop}>
+              {crop}
+            </p>
             <p className="text-xxs">{t(getCropCategory(crop))}</p>
           </div>
         </div>
-        <div className="flex flex-col min-w-0">
-          <GrowthTimeCell
-            boostKey={`${seed}-growth-time`}
-            baseSeconds={seconds}
-            boostedTime={boostedTime}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:gap-x-2">
+          <div className="flex flex-col min-w-0">
+            <GrowthTimeCell
+              boostKey={`${seed}-growth-time`}
+              baseSeconds={seconds}
+              boostedTime={boostedTime}
+              state={state}
+              showBoostsKey={showBoostsKey}
+              setShowBoostsKey={setShowBoostsKey}
+            />
+            <div className="flex items-center">
+              <img src={SUNNYSIDE.ui.coins} className="w-3 mr-1" />
+              <p className="text-xxs">{coins.toLocaleString()}</p>
+            </div>
+          </div>
+          <SeedCapacityLimits
+            seed={seed}
             state={state}
             showBoostsKey={showBoostsKey}
             setShowBoostsKey={setShowBoostsKey}
           />
-          <div className="flex items-center">
-            <img src={SUNNYSIDE.ui.coins} className="w-3 mr-1" />
-            <p className="text-xxs">{coins.toLocaleString()}</p>
-          </div>
         </div>
-        <SeedCapacityLimits
-          seed={seed}
-          state={state}
-          showBoostsKey={showBoostsKey}
-          setShowBoostsKey={setShowBoostsKey}
-        />
       </div>
 
       <div className="flex items-center shrink-0">
@@ -322,29 +326,33 @@ export const FlowerRow: React.FC<{
       }`}
     >
       <div className="flex items-center flex-1 min-w-0">
-        <div className="flex items-center w-24 sm:w-32 mr-2 shrink-0">
+        <div className="flex items-center min-w-24 max-w-32 sm:min-w-32 sm:max-w-40 mr-4 shrink-0">
           <img src={ITEM_DETAILS[seed].image} className="w-6 h-auto mr-2" />
           <div className="flex-1 min-w-0">
-            <p className="text-xs">{seed}</p>
+            <p className="text-xs break-words" title={seed}>
+              {seed}
+            </p>
             <p className="text-xxs">{`Flower`}</p>
           </div>
         </div>
-        <div className="flex flex-col min-w-0">
-          <GrowthTimeCell
-            boostKey={`${seed}-growth-time`}
-            baseSeconds={seconds}
-            boostedTime={boostedTime}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:gap-x-2">
+          <div className="flex flex-col min-w-0">
+            <GrowthTimeCell
+              boostKey={`${seed}-growth-time`}
+              baseSeconds={seconds}
+              boostedTime={boostedTime}
+              state={state}
+              showBoostsKey={showBoostsKey}
+              setShowBoostsKey={setShowBoostsKey}
+            />
+          </div>
+          <SeedCapacityLimits
+            seed={seed}
             state={state}
             showBoostsKey={showBoostsKey}
             setShowBoostsKey={setShowBoostsKey}
           />
         </div>
-        <SeedCapacityLimits
-          seed={seed}
-          state={state}
-          showBoostsKey={showBoostsKey}
-          setShowBoostsKey={setShowBoostsKey}
-        />
       </div>
 
       <div className="flex items-center shrink-0">
@@ -387,7 +395,7 @@ const SeedCapacityLimits: React.FC<{
   }
 
   return (
-    <div className="flex flex-col gap-1 ml-2">
+    <div className="flex flex-col gap-1 sm:ml-2">
       <CapacityLimit
         seed={seed}
         baseAmount={baseInventoryLimit.toString()}
@@ -449,9 +457,9 @@ const CapacityLimit: React.FC<{
         setShowBoostsKey(showBoostsKey === boostKey ? null : boostKey);
       }}
     >
-      <img src={SUNNYSIDE.icons.lightning} className="w-3 mr-1" />
       <CapacityAmount amount={amount} icon={icon} />
-      <p className="text-xxs line-through ml-1">{baseAmount}</p>
+      <img src={SUNNYSIDE.icons.lightning} className="w-3 mx-1" />
+      <p className="text-xxs line-through">{baseAmount}</p>
       <BoostsDisplay
         boosts={boosts}
         show={showBoostsKey === boostKey}
@@ -587,9 +595,9 @@ const GrowthTimeCell: React.FC<{
         setShowBoostsKey(showBoostsKey === boostKey ? null : boostKey);
       }}
     >
-      <div className="flex flex-wrap items-center gap-x-2">
+      <div className="flex items-center">
         <div className="flex items-center">
-          <img src={SUNNYSIDE.icons.lightning} className="w-3 mr-1" />
+          <img src={SUNNYSIDE.icons.stopwatch} className="w-3 mr-1" />
           <p className="text-xxs">
             {secondsToString(boostedTime.seconds, {
               length: showMediumTime ? "medium" : "short",
@@ -597,7 +605,7 @@ const GrowthTimeCell: React.FC<{
           </p>
         </div>
         <div className="flex items-center">
-          <img src={SUNNYSIDE.icons.stopwatch} className="w-3 mr-1" />
+          <img src={SUNNYSIDE.icons.lightning} className="w-3 mx-1" />
           <p className="text-xxs line-through">
             {secondsToString(baseSeconds, {
               length: showMediumTime ? "medium" : "short",

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -66,7 +66,10 @@ export const CropGuide = () => {
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
 
   return (
-    <InnerPanel className="scrollable max-h-[360px] overflow-y-scroll overflow-x-hidden">
+    <InnerPanel
+      className="scrollable max-h-[360px] overflow-y-scroll overflow-x-hidden"
+      onClick={() => setShowBoostsKey(null)}
+    >
       <div className="p-1">
         <NoticeboardItems
           items={[

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -1,4 +1,5 @@
 import { InnerPanel } from "components/ui/Panel";
+import { Chip } from "components/ui/Chip";
 import { ITEM_DETAILS } from "features/game/types/images";
 import React, { useMemo, useRef, useState } from "react";
 import { SEASON_ICONS } from "./SeasonalSeeds";
@@ -57,6 +58,8 @@ type GrowthTime = {
   boostsUsed: { name: BoostName; value: string }[];
 };
 
+type GuideCategory = "crops" | "fruits" | "greenhouse" | "flowers" | "exotics";
+
 export const CropGuide = () => {
   const { gameState } = useGame();
   const state = gameState.context.state;
@@ -64,6 +67,40 @@ export const CropGuide = () => {
   const { t } = useAppTranslation();
   const now = useNow();
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] =
+    useState<GuideCategory>("crops");
+
+  const categories: {
+    id: GuideCategory;
+    label: string;
+    icon: string;
+  }[] = [
+    {
+      id: "crops",
+      label: t("cropGuide.crops"),
+      icon: ITEM_DETAILS.Sunflower.image,
+    },
+    {
+      id: "fruits",
+      label: t("cropGuide.fruits"),
+      icon: ITEM_DETAILS.Apple.image,
+    },
+    {
+      id: "greenhouse",
+      label: t("cropGuide.greenhouse"),
+      icon: ITEM_DETAILS.Olive.image,
+    },
+    {
+      id: "flowers",
+      label: t("cropGuide.flower"),
+      icon: ITEM_DETAILS["Sunpetal Seed"].image,
+    },
+    {
+      id: "exotics",
+      label: t("cropGuide.exotics"),
+      icon: ITEM_DETAILS["Giant Apple"].image,
+    },
+  ];
 
   return (
     <InnerPanel
@@ -97,72 +134,30 @@ export const CropGuide = () => {
           ]}
         />
       </div>
-      <Label type="default" className="mb-2">
-        {t("cropGuide.crops")}
-      </Label>
-      {getKeys({ ...CROP_SEEDS }).map((seed, index) => {
-        const crop = CROP_SEEDS[seed].yield as CropName;
-        return (
-          <CropRow
-            key={seed}
-            crop={crop}
-            seed={seed}
-            seconds={CROPS[crop].harvestSeconds}
-            coins={CROPS[crop].sellPrice}
-            state={state}
-            now={now}
-            alternateBg={index % 2 === 0}
-            showBoostsKey={showBoostsKey}
-            setShowBoostsKey={setShowBoostsKey}
-          />
-        );
-      })}
-      <div className="flex my-2 items-center">
-        <Label type="default" className="mr-2">
-          {t("cropGuide.fruits")}
-        </Label>
-        {!inventory["Fruit Patch"] && (
-          <Label type="danger">{t("cropGuide.fruitPatchRequired")}</Label>
-        )}
+      <div className="mb-2 flex flex-wrap justify-center gap-2 px-1">
+        {categories.map((category) => (
+          <Chip
+            key={category.id}
+            onClick={() => setSelectedCategory(category.id)}
+            selected={selectedCategory === category.id}
+            icon={category.icon}
+            className="shrink-0 whitespace-nowrap"
+          >
+            {category.label}
+          </Chip>
+        ))}
       </div>
 
-      <p className="text-xs ml-2 mb-2">{t("cropGuide.fruit.description")}</p>
-      {getKeys({ ...PATCH_FRUIT_SEEDS }).map((seed, index) => {
-        const crop = PATCH_FRUIT_SEEDS[seed].yield;
-        return (
-          <CropRow
-            key={seed}
-            seed={seed}
-            crop={crop}
-            seconds={PATCH_FRUIT_SEEDS[seed].plantSeconds}
-            coins={PATCH_FRUIT[crop].sellPrice}
-            state={state}
-            now={now}
-            alternateBg={index % 2 === 0}
-            showBoostsKey={showBoostsKey}
-            setShowBoostsKey={setShowBoostsKey}
-          />
-        );
-      })}
-      <div className="flex my-2 items-center">
-        <Label type="default" className="mr-2">
-          {t("cropGuide.greenhouse")}
-        </Label>
-        {!inventory.Greenhouse && (
-          <Label type="danger">{t("cropGuide.greenhouseRequired")}</Label>
-        )}
-      </div>
-      {getKeys({ ...GREENHOUSE_FRUIT_SEEDS, ...GREENHOUSE_SEEDS }).map(
-        (seed, index) => {
-          const crop = { ...GREENHOUSE_FRUIT_SEEDS, ...GREENHOUSE_SEEDS }[seed]
-            .yield as GreenHouseCropName;
+      {selectedCategory === "crops" &&
+        getKeys({ ...CROP_SEEDS }).map((seed, index) => {
+          const crop = CROP_SEEDS[seed].yield as CropName;
           return (
             <CropRow
               key={seed}
               crop={crop}
               seed={seed}
-              seconds={GREENHOUSE_CROP_TIME_SECONDS[crop]}
-              coins={SELLABLE[crop].sellPrice}
+              seconds={CROPS[crop].harvestSeconds}
+              coins={CROPS[crop].sellPrice}
               state={state}
               now={now}
               alternateBg={index % 2 === 0}
@@ -170,48 +165,105 @@ export const CropGuide = () => {
               setShowBoostsKey={setShowBoostsKey}
             />
           );
-        },
+        })}
+      {selectedCategory === "fruits" && (
+        <>
+          {!inventory["Fruit Patch"] && (
+            <Label type="danger" className="mb-2">
+              {t("cropGuide.fruitPatchRequired")}
+            </Label>
+          )}
+          <p className="ml-2 mb-2 text-xs">
+            {t("cropGuide.fruit.description")}
+          </p>
+          {getKeys({ ...PATCH_FRUIT_SEEDS }).map((seed, index) => {
+            const crop = PATCH_FRUIT_SEEDS[seed].yield;
+            return (
+              <CropRow
+                key={seed}
+                seed={seed}
+                crop={crop}
+                seconds={PATCH_FRUIT_SEEDS[seed].plantSeconds}
+                coins={PATCH_FRUIT[crop].sellPrice}
+                state={state}
+                now={now}
+                alternateBg={index % 2 === 0}
+                showBoostsKey={showBoostsKey}
+                setShowBoostsKey={setShowBoostsKey}
+              />
+            );
+          })}
+        </>
       )}
-
-      <div className="flex my-2 items-center">
-        <Label type="default" className="mr-2">
-          {t("cropGuide.flower")}
-        </Label>
-        {!inventory["Flower Bed"] && (
-          <Label type="danger">{t("cropGuide.flowerbedRequired")}</Label>
-        )}
-      </div>
-      <p className="text-xs ml-2 mb-2">{t("cropGuide.flower.description")}</p>
-      {getKeys({ ...FLOWER_SEEDS }).map((seed, index) => {
-        return (
-          <FlowerRow
-            key={seed}
-            seed={seed}
-            seconds={FLOWER_SEEDS[seed].plantSeconds}
-            state={state}
-            alternateBg={index % 2 === 0}
-            showBoostsKey={showBoostsKey}
-            setShowBoostsKey={setShowBoostsKey}
-          />
-        );
-      })}
-
-      <Label type="default" className="my-2">
-        {t("cropGuide.exotics")}
-      </Label>
-      <p className="text-xs ml-2 mb-2">
-        {t("cropGuide.discoverExoticsDuringSpecialEvents")}
-      </p>
-      {getKeys({ ...EXOTIC_CROPS }).map((crop, index) => {
-        return (
-          <ExoticRow
-            key={crop}
-            crop={crop}
-            coins={EXOTIC_CROPS[crop].sellPrice}
-            alternateBg={index % 2 === 0}
-          />
-        );
-      })}
+      {selectedCategory === "greenhouse" && (
+        <>
+          {!inventory.Greenhouse && (
+            <Label type="danger" className="mb-2">
+              {t("cropGuide.greenhouseRequired")}
+            </Label>
+          )}
+          {getKeys({ ...GREENHOUSE_FRUIT_SEEDS, ...GREENHOUSE_SEEDS }).map(
+            (seed, index) => {
+              const crop = {
+                ...GREENHOUSE_FRUIT_SEEDS,
+                ...GREENHOUSE_SEEDS,
+              }[seed].yield as GreenHouseCropName;
+              return (
+                <CropRow
+                  key={seed}
+                  crop={crop}
+                  seed={seed}
+                  seconds={GREENHOUSE_CROP_TIME_SECONDS[crop]}
+                  coins={SELLABLE[crop].sellPrice}
+                  state={state}
+                  now={now}
+                  alternateBg={index % 2 === 0}
+                  showBoostsKey={showBoostsKey}
+                  setShowBoostsKey={setShowBoostsKey}
+                />
+              );
+            },
+          )}
+        </>
+      )}
+      {selectedCategory === "flowers" && (
+        <>
+          {!inventory["Flower Bed"] && (
+            <Label type="danger" className="mb-2">
+              {t("cropGuide.flowerbedRequired")}
+            </Label>
+          )}
+          <p className="ml-2 mb-2 text-xs">
+            {t("cropGuide.flower.description")}
+          </p>
+          {getKeys({ ...FLOWER_SEEDS }).map((seed, index) => (
+            <FlowerRow
+              key={seed}
+              seed={seed}
+              seconds={FLOWER_SEEDS[seed].plantSeconds}
+              state={state}
+              alternateBg={index % 2 === 0}
+              showBoostsKey={showBoostsKey}
+              setShowBoostsKey={setShowBoostsKey}
+            />
+          ))}
+        </>
+      )}
+      {selectedCategory === "exotics" && (
+        <>
+          <p className="ml-2 mb-2 text-xs">
+            {t("cropGuide.discoverExoticsDuringSpecialEvents")}
+          </p>
+          {getKeys({ ...EXOTIC_CROPS }).map((crop, index) => (
+            <ExoticRow
+              key={crop}
+              crop={crop}
+              coins={EXOTIC_CROPS[crop].sellPrice}
+              alternateBg={index % 2 === 0}
+            />
+          ))}
+        </>
+      )}
     </InnerPanel>
   );
 };
@@ -262,7 +314,7 @@ export const CropRow: React.FC<{
             <p className="text-xxs">{t(getCropCategory(crop))}</p>
           </div>
         </div>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:gap-x-2">
+        <div className="flex flex-col">
           <div className="flex flex-col min-w-0">
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
@@ -338,7 +390,7 @@ export const FlowerRow: React.FC<{
             <p className="text-xxs">{`Flower`}</p>
           </div>
         </div>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:gap-x-2">
+        <div className="flex flex-col">
           <div className="flex flex-col min-w-0">
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
@@ -398,7 +450,7 @@ const SeedCapacityLimits: React.FC<{
   }
 
   return (
-    <div className="flex flex-col gap-1 sm:ml-2">
+    <div className="flex flex-col gap-1">
       <CapacityLimit
         seed={seed}
         baseAmount={baseInventoryLimit.toString()}

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -372,6 +372,7 @@ export const FlowerRow: React.FC<{
   const seasons = getKeys(SEASONAL_SEEDS).filter((season) =>
     SEASONAL_SEEDS[season].includes(seed as SeedName),
   );
+  const { t } = useAppTranslation();
   const boostedTime = useMemo(() => getFlowerTime(seed, state), [seed, state]);
 
   return (
@@ -387,7 +388,7 @@ export const FlowerRow: React.FC<{
             <p className="text-xs break-words" title={seed}>
               {seed}
             </p>
-            <p className="text-xxs">{`Flower`}</p>
+            <p className="text-xxs">{t("crops.flower")}</p>
           </div>
         </div>
         <div className="flex flex-col">

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -66,7 +66,7 @@ export const CropGuide = () => {
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
 
   return (
-    <InnerPanel className="scrollable max-h-[300px] overflow-y-scroll overflow-x-hidden">
+    <InnerPanel className="scrollable max-h-[360px] overflow-y-scroll overflow-x-hidden">
       <div className="p-1">
         <NoticeboardItems
           items={[


### PR DESCRIPTION
# Pull request description

## Summary

Adds category filters to the Market guide, allowing players to switch between crops, fruits, greenhouse items, flowers, and exotics. It also stacks the time, coins, inventory, and restock indicators vertically, increases the guide’s visible height, and fixes boost tooltips so they close when clicking elsewhere in the guide.

## Context / motivation

The latest update added maximum inventory and restock limits, which made the guide’s item indicators too text-heavy and caused overlapping content—especially on mobile and smaller screens. Increasing the guide height also provides more space to browse items comfortably.

The boost tooltip previously remained open when clicking elsewhere in the guide, which made the interaction feel unintuitive.

Additionally, the game is gaining a wider variety of items, and guide lists are becoming longer. If this filtered guide layout is well received, I plan to apply it to other guides to improve navigation and reduce visual density.

## How to test

1. Open the Market and select the **Guide** tab.
2. Select each filter: Crops, Fruits, Greenhouse, Flowers, and Exotics.
3. Confirm that only items from the selected category are displayed.
4. Verify on desktop and mobile that time, coins, inventory, and restock indicators are stacked vertically.
5. Open a boost tooltip, then click elsewhere in the guide to confirm it closes.

## Screenshots or screen recording

https://github.com/user-attachments/assets/451ece5b-2c93-4d21-9eea-96588136eb7c

---
## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category filters to the Crop Guide for crops, fruits, greenhouse crops, flowers, and exotic plants.
  * Each category now displays its own descriptions and building requirements.
  * Improved responsive layouts for crop and flower listings.
  * Updated capacity and growth-time indicators for clearer presentation.

* **Bug Fixes**
  * Improved panel sizing and click behavior.
  * Boost popovers now clear when clicking within the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->