### PR TITLE
[FIX] Keep flower exchange labels readable on mobile

### DIFF
--- a/src/features/island/hud/components/SwapSFLForCoins.tsx
+++ b/src/features/island/hud/components/SwapSFLForCoins.tsx
@@ -94,7 +94,10 @@ export const SwapSFLForCoins: React.FC<{ onClose: () => void }> = ({
                       width: `calc(100% + ${PIXEL_SCALE * 6}px)`,
                     }}
                   >
-                    <span className="pl-1 sm:pl-0">{`${option.sfl} FLOWER`}</span>
+                    <span className="pl-1 sm:pl-0">
+                      {option.sfl}
+                      <span className="hidden sm:inline">{` FLOWER`}</span>
+                    </span>
                   </Label>
                 </ButtonPanel>
               );


### PR DESCRIPTION
# Pull request description

## Summary

Prevents FLOWER exchange package labels from wrapping on small mobile screens. Small screens now show only the numeric amount, while larger screens continue to show the full “1/30/200 FLOWER” label.

## Context / motivation

The package labels could wrap on narrow mobile layouts, making the exchange options difficult to read. This keeps the existing button dimensions and adapts only the label content at the small-screen breakpoint.

## How to test

1. Run `yarn dev`.
2. Open the FLOWER-to-coins exchange interface.
3. Use a narrow mobile viewport and confirm the package labels show only `1`, `30`, and `200`.
4. Use a viewport at the `sm` breakpoint or larger and confirm the labels show `1 FLOWER`, `30 FLOWER`, and `200 FLOWER`.
5. Confirm selecting and exchanging a package still works normally.

## Screenshots or screen recording

### Issue
<img width="390" height="844" alt="brave_Jud1rEwgSo" src="https://github.com/user-attachments/assets/121c28c5-9a88-4979-8ad9-94ceeae398e8" />

### Fix

<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/bcdb493a-5aa6-4b45-9d58-4a33b1c012de" />
 
 ### Desktop

<img width="2519" height="968" alt="image" src="https://github.com/user-attachments/assets/6624ef82-53f1-47f1-8d2e-6321a9cee342" />

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the SFL package cost display for responsive layouts.
  * The numeric amount remains visible on small screens, while the `FLOWER` label is shown on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->