### PR TITLE
[FIX] Show a clear notice when a pending transaction blocks marketplace claims

### DIFF
--- a/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
+++ b/src/features/game/expansion/components/MarketplaceSalesPopup.tsx
@@ -21,6 +21,7 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { isTradeResource } from "features/game/actions/tradeLimits";
 import { KNOWN_ITEMS } from "features/game/types";
 import { fallbackDisplayNameForMinigameCurrencyKey } from "features/marketplace/lib/minigameMarketplaceCopy";
+import { PendingTransactionClaimNotice } from "features/marketplace/components/PendingTransactionClaimNotice";
 
 /**
  * Display listings that have been fulfilled
@@ -31,12 +32,20 @@ export const MarketplaceSalesPopup: React.FC = () => {
 
   const { t } = useAppTranslation();
 
-  const { trades } = state.context.state;
+  const { trades, transaction } = state.context.state;
   const soldListingIds = getKeys(trades.listings ?? {}).filter(
     (id) => !!trades.listings?.[id].fulfilledAt,
   );
 
   if (soldListingIds.length === 0) return null;
+
+  if (transaction) {
+    return (
+      <PendingTransactionClaimNotice
+        onClose={() => gameService.send("CLOSE")}
+      />
+    );
+  }
 
   const claimAll = () => {
     gameService.send("purchase.claimed", {

--- a/src/features/marketplace/components/PendingTransactionClaimNotice.tsx
+++ b/src/features/marketplace/components/PendingTransactionClaimNotice.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import trade from "assets/icons/trade.png";
+import { Label } from "components/ui/Label";
+import { InlineDialogue } from "features/world/ui/TypingMessage";
+import { Button } from "components/ui/Button";
+import { useAppTranslation } from "lib/i18n/useAppTranslations";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Shown instead of the claim UI when the player has a pending withdrawal
+ * transaction, since claiming marketplace sales is blocked until that
+ * transaction is submitted or expires.
+ */
+export const PendingTransactionClaimNotice: React.FC<Props> = ({ onClose }) => {
+  const { t } = useAppTranslation();
+
+  return (
+    <div className="p-1">
+      <Label className="ml-2 mb-2 mt-1" type="danger" icon={trade}>
+        {t("marketplace.claimBlockedByTransaction.label")}
+      </Label>
+      <div className="mb-2 ml-1">
+        <InlineDialogue
+          message={t("marketplace.claimBlockedByTransaction.message")}
+        />
+      </div>
+      <Button onClick={onClose}>{t("gotIt")}</Button>
+    </div>
+  );
+};

--- a/src/features/marketplace/components/profile/ClaimPurchase.tsx
+++ b/src/features/marketplace/components/profile/ClaimPurchase.tsx
@@ -9,19 +9,31 @@ import { formatNumber } from "lib/utils/formatNumber";
 import { Button } from "components/ui/Button";
 import { NPC_WEARABLES } from "lib/npcs";
 import { Panel } from "components/ui/Panel";
+import { PendingTransactionClaimNotice } from "../PendingTransactionClaimNotice";
 
 interface ClaimPurchaseProps {
   sfl: number;
   onClaim: () => void;
   onClose: () => void;
+  hasPendingTransaction?: boolean;
 }
 
 export const ClaimPurchase: React.FC<ClaimPurchaseProps> = ({
   sfl,
   onClaim,
   onClose,
+  hasPendingTransaction,
 }) => {
   const { t } = useAppTranslation();
+
+  if (hasPendingTransaction) {
+    return (
+      <Panel bumpkinParts={NPC_WEARABLES["hammerin harry"]}>
+        <PendingTransactionClaimNotice onClose={onClose} />
+      </Panel>
+    );
+  }
+
   return (
     <Panel bumpkinParts={NPC_WEARABLES["hammerin harry"]}>
       <div className="p-1">

--- a/src/features/marketplace/components/profile/MyListings.tsx
+++ b/src/features/marketplace/components/profile/MyListings.tsx
@@ -148,6 +148,7 @@ export const MyListings: React.FC<Props> = ({ fullHeight = false }) => {
             sfl={listings[claimId as string].sfl}
             onClaim={claim}
             onClose={() => setClaimId(undefined)}
+            hasPendingTransaction={!!state.transaction}
           />
         )}
       </Modal>

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2860,7 +2860,7 @@
   "marketplace.youHaveHadSales": "Your item(s) sold while you were away!",
   "marketplace.offersWereAccepted": "One or more offers were accepted while you were away!",
   "marketplace.claimBlockedByTransaction.label": "Pending transaction",
-  "marketplace.claimBlockedByTransaction.message": "You have a withdrawal transaction waiting to be submitted. Please submit it (or let it expire) before claiming your marketplace sales.",
+  "marketplace.claimBlockedByTransaction.message": "You have a withdrawal transaction waiting to be submitted. Please submit it before you can claim your marketplace sales.",
   "marketplace.cancelListing": "Cancel Listing",
   "marketplace.bulkCancel": "Cancel all",
   "marketplace.bulkCancel.label": "Cancel {{type}}",

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -2859,6 +2859,8 @@
   "marketplace.congratulationsItemSold": "Congratulations, your item has sold!",
   "marketplace.youHaveHadSales": "Your item(s) sold while you were away!",
   "marketplace.offersWereAccepted": "One or more offers were accepted while you were away!",
+  "marketplace.claimBlockedByTransaction.label": "Pending transaction",
+  "marketplace.claimBlockedByTransaction.message": "You have a withdrawal transaction waiting to be submitted. Please submit it (or let it expire) before claiming your marketplace sales.",
   "marketplace.cancelListing": "Cancel Listing",
   "marketplace.bulkCancel": "Cancel all",
   "marketplace.bulkCancel.label": "Cancel {{type}}",


### PR DESCRIPTION
## Summary

Claiming a marketplace sale while a withdrawal transaction is still pending currently fails silently - the claim event handler throws internally with no feedback shown to the player. This adds a dedicated notice explaining that a pending transaction needs to be submitted first, shown wherever claiming can happen.

## Context / motivation

When a player has an unconfirmed/pending withdrawal transaction and tries to claim a sold marketplace listing, the claim is blocked but nothing tells the player why - the button just appears to do nothing. This adds a clear, specific message instead.

## How to test

1. Start a withdrawal (item/wearable/bud/pet/flower) but don't submit/confirm the transaction, so it stays pending.
2. While it's pending, have a marketplace listing that has already sold (fulfilledAt set, unclaimed).
3. Reload - the automatic "you had sales" popup should show the new pending-transaction notice instead of the claim UI.
4. Also check the Marketplace profile "My Listings" tab and click Claim on a sold item - same notice should appear instead of the claim confirmation.
5. Dismissing the notice ("Got it") returns to normal play without claiming; once the pending transaction clears, claiming works normally.

## Screenshots or screen recording
<img width="500" height="194" alt="image" src="https://github.com/user-attachments/assets/c485551e-aa09-4496-a041-eed957081080" />

N/A in this description - happy to attach one on request.

## Related issues

Related #

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [x] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added a translated notice for pending marketplace withdrawal transactions.
* Marketplace sales and purchase-claim screens now display the notice when claiming is unavailable.
* Added a “Got it” button to dismiss the notice.
* Pending transaction guidance is shown consistently across relevant marketplace areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->