### PR TITLE
[FIX] Clarify that switching networks won't lift a withdrawal hold

### DIFF
--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6867,7 +6867,7 @@
   "withdraw.flower.transaction": "A transaction must be completed on {{chain}} to complete the withdrawal.",
   "withdraw.duplicate.title": "Shared Network Detected",
   "withdraw.duplicate.description": "We have noticed another withdrawal happening from the same internet connection. To keep the game fair and protect the economy, we allow only one withdrawal at a time.",
-  "withdraw.duplicate.waitMessage": "If you're on a public or shared network, you may need to wait—that's expected. Public or shared networks may require a short wait due to overuse. Very busy networks may require up to 2 weeks depending on usage. This safeguard applies automatically and isn't a strike or warning.",
+  "withdraw.duplicate.waitMessage": "This hold is on your account, not your device or network - switching to a different network or device will not lift it. It needs to run its course, which can take up to 14 days depending on usage. This is applied automatically and isn't a strike or warning against your account.",
   "select.network": "Select Network",
   "switching.network": "Switching Network...",
   "marketplace.tradesCleared": "Trades removed",


### PR DESCRIPTION
## Summary

Players who see the "Shared Network Detected" withdrawal message often try switching to a different network or device to resolve it, which doesn't help since the hold is on the account, not the connection. This updates the message copy to say that directly, instead of implying the network itself is fixable/diagnosable by the player.

## Context / motivation

Support sees repeated cases of players changing networks after hitting this message, expecting it to help. It doesn't, and they end up waiting the same duration regardless - the copy change sets the right expectation up front (wait it out, up to 14 days) so players aren't wasting time on ineffective workarounds.

## How to test

1. Open `src/features/auth/components/DuplicateWithdraw.tsx` and confirm it renders `withdraw.duplicate.waitMessage`.
2. Confirm the updated copy in `src/lib/i18n/dictionaries/dictionary.json` reads correctly (no logic changes, copy only).

## Screenshots or screen recording

N/A - text-only copy change, no layout/behaviour change.

## Related issues

Related #

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### Code quality

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

### Tests

- [x] New and existing unit tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the withdrawal hold message to explain that it applies to the account, may last up to 14 days, and is an automatic safeguard rather than a warning or penalty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->