### PR TITLE
[FIX] Preserve marketplace return route

### DIFF
--- a/src/features/marketplace/Marketplace.tsx
+++ b/src/features/marketplace/Marketplace.tsx
@@ -1,5 +1,5 @@
 import { SUNNYSIDE } from "assets/sunnyside";
-import React, { useContext, useEffect, useCallback } from "react";
+import React, { useContext, useEffect, useCallback, useRef } from "react";
 import sflIcon from "assets/icons/flower_token.webp";
 import { MarketplaceNavigation } from "./components/home/MarketplaceHome";
 import { useLocation, useNavigate } from "react-router";
@@ -28,23 +28,27 @@ export const Marketplace: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useAppTranslation();
+  // Product navigation replaces location.state, so retain the state from when
+  // the marketplace was opened until it is closed.
+  const marketplaceNavigation = useRef(
+    getMarketplaceNavigationState(location.state),
+  );
 
   const handleClose = useCallback(() => {
-    const marketplaceNavigation = getMarketplaceNavigationState(location.state);
     const defaultRoute = location.pathname.includes("/world")
       ? "/world/plaza"
       : "/";
 
     const returnTo =
-      marketplaceNavigation?.returnTo ?? fromRoute ?? defaultRoute;
+      marketplaceNavigation.current?.returnTo ?? fromRoute ?? defaultRoute;
 
     navigate(returnTo, {
       replace: true,
-      state: marketplaceNavigation?.restore
-        ? { marketplaceRestore: marketplaceNavigation.restore }
+      state: marketplaceNavigation.current?.restore
+        ? { marketplaceRestore: marketplaceNavigation.current.restore }
         : undefined,
     });
-  }, [location.pathname, location.state, fromRoute, navigate]);
+  }, [location.pathname, fromRoute, navigate]);
 
   // exit marketplace if Escape key is pressed
   useEffect(() => {


### PR DESCRIPTION
# Pull request description

## Summary

[FIX] Preserve the original map when closing the marketplace after viewing an item. Players now return to the map where they opened the marketplace instead of being redirected to Plaza.

## Context / motivation

Opening an item performs an internal marketplace navigation that replaces the router state containing the original return route. Closing afterward falls back to `/world/plaza`.

This change retains the marketplace entry navigation state for the duration of the marketplace session.

## How to test

1. Open the game in any world map other than Plaza or the farm.
2. Open the marketplace using its HUD button.
3. Select any marketplace item.
4. Close the marketplace.
5. Confirm that the game returns to the map from step 1.
6. Repeat by opening the marketplace from the inventory and confirm the inventory return flow still works.

## Screenshots or screen recording

N/A

---

## Checklist

### PR and scope

- [x] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [x] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [x] Screenshots or recording are attached above
- [x] Copy and layout match existing patterns where relevant

### Code quality

- [x] I have performed a self-review of my own code
- [x] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [x] I have updated documentation if behaviour or public APIs changed
- [x] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [x] New and existing unit tests pass locally

### Dependencies and coordination

- [x] Any required changes in other repos (e.g. API) are merged or linked in the description
- [x] Any dependent packages or downstream modules are already published / coordinated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace navigation when opening and closing product pages.
  * Preserved the previous marketplace view and restored it correctly after returning from a product route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->