### PR TITLE
[FIX] Scale daily chest rewards by ascended players' total level

### DIFF
--- a/src/features/game/lib/level.ts
+++ b/src/features/game/lib/level.ts
@@ -406,6 +406,9 @@ export const LEVEL_EXPERIENCE: Record<BumpkinLevel, number> = {
   200: 244_206_000,
 };
 
+/** Highest level in the `LEVEL_EXPERIENCE` table — the ceiling for table-keyed reward curves. */
+export const MAX_BUMPKIN_LEVEL: BumpkinLevel = 200;
+
 /** Pre-ascension level cap — levels above become ascension bands (see `getAscensionLevel`). */
 export const PRE_ASCENSION_MAX_LEVEL: BumpkinLevel = 150;
 

--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -104,3 +104,45 @@ describe("getRewardsForStreak — VIP banner perk chapter cutoff", () => {
     expect(defaultReward.items?.["Salt Awakening Banner"]).toBeUndefined();
   });
 });
+
+describe("getRewardsForStreak — ascension-aware reward scaling", () => {
+  // A1 L50 (ready to ascend) → total Bumpkin level 200, so the reward curve keys off
+  // 200 / 25 = 8. The bug scaled off the within-ascension level (50 → 50 / 25 = 2),
+  // handing an ascended player only 10 Axes / 10 Rods instead of 40.
+  const ascendedFarm: GameState = {
+    ...TEST_FARM,
+    bumpkin: { ...TEST_FARM.bumpkin, experience: 150_000_000 },
+    island: { ...TEST_FARM.island, ascensionLevel: 1 },
+    farmActivity: { ...TEST_FARM.farmActivity, "Daily Reward Collected": 100 },
+  };
+
+  it("scales the Tool Cache to the ascended player's total level, not their within-ascension level", () => {
+    const { rewards } = getRewardsForStreak({
+      game: ascendedFarm,
+      streak: 7, // 7 % 7 === 0 → weekly-day-1-tool-cache
+      currentDate: new Date(PAW_PRINTS_NOW).toISOString(),
+      now: PAW_PRINTS_NOW,
+    });
+
+    const toolCache = rewards.find((r) => r.id === "weekly-day-1-tool-cache")!;
+    expect(toolCache.items).toEqual({
+      Axe: 40,
+      Pickaxe: 16,
+      "Stone Pickaxe": 8,
+    });
+  });
+
+  it("scales the Angler Pack to the ascended player's total level, not their within-ascension level", () => {
+    const { rewards } = getRewardsForStreak({
+      game: ascendedFarm,
+      streak: 10, // 10 % 7 === 3 → weekly-day-4-angler-pack
+      currentDate: new Date(PAW_PRINTS_NOW).toISOString(),
+      now: PAW_PRINTS_NOW,
+    });
+
+    const anglerPack = rewards.find(
+      (r) => r.id === "weekly-day-4-angler-pack",
+    )!;
+    expect(anglerPack.items).toEqual({ Rod: 40, Earthworm: 24, Grub: 16 });
+  });
+});

--- a/src/features/game/types/dailyRewards.ts
+++ b/src/features/game/types/dailyRewards.ts
@@ -3,6 +3,8 @@ import type { BoostName, GameState, InventoryItemName } from "./game";
 import {
   getAscensionLevel,
   getExperienceToNextLevel,
+  getTotalBumpkinLevel,
+  MAX_BUMPKIN_LEVEL,
   meetsLevelRequirement,
 } from "../lib/level";
 import {
@@ -145,7 +147,17 @@ const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
     experience: game.bumpkin.experience ?? 0,
     ascensionLevel: game.island.ascensionLevel ?? 0,
   });
-  const level = ascension.level;
+  // Monotonic total level (ascension-aware) — the reward curve below is keyed to the
+  // historical 1..200 scale, so an ascended player must read as 150+, not their 1..50
+  // within-ascension level. Clamped at MAX_BUMPKIN_LEVEL to keep calculateXPPotion in domain.
+  // Mirror of the backend (`domain/game/types/dailyRewards.ts`).
+  const level = Math.min(
+    getTotalBumpkinLevel({
+      experience: game.bumpkin.experience ?? 0,
+      ascensionLevel: game.island.ascensionLevel ?? 0,
+    }),
+    MAX_BUMPKIN_LEVEL,
+  );
   const { experienceToNextLevel } = getExperienceToNextLevel(
     game.bumpkin?.experience ?? 0,
   );


### PR DESCRIPTION
The weekly daily-chest rewards scale item/coin/xp amounts by the player's level (level / 25). The frontend was reading `ascension.level` — the within-ascension level (0..50) — while the backend scales by the monotonic total level (150 + (A-1)*50 + L). An ascended player therefore saw far fewer items in the reward popup than they actually received on save (e.g. 10 Rods shown vs. 40 granted).

Mirror the backend: compute `level` from `getTotalBumpkinLevel`, clamped to MAX_BUMPKIN_LEVEL to keep calculateXPPotion in domain for A2+ players. Add the MAX_BUMPKIN_LEVEL constant to the frontend level lib, and a regression test covering Tool Cache / Angler Pack scaling for an ascended farm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Weekly daily rewards now scale correctly using the player’s total level across ascensions.
  - Reward scaling is capped at the maximum supported level to ensure consistent quantities for high-level players.

- **Tests**
  - Added coverage verifying ascension-aware scaling for Tool Cache and Angler Pack rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->