### PR TITLE
[FIX] Fix interior projects

### DIFF
--- a/src/features/game/types/monuments.test.ts
+++ b/src/features/game/types/monuments.test.ts
@@ -1,0 +1,188 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import type { GameState } from "./game";
+import { getHelpRequired } from "./monuments";
+
+const GAME_STATE: GameState = {
+  ...TEST_FARM,
+  socialFarming: {
+    ...TEST_FARM.socialFarming,
+    villageProjects: {
+      "Basic Cooking Pot": { cheers: 0 },
+    },
+  },
+};
+
+describe("getHelpRequired", () => {
+  it("counts a project placed on the land", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...GAME_STATE,
+        collectibles: {
+          "Basic Cooking Pot": [
+            {
+              id: "1",
+              createdAt: 0,
+              readyAt: 0,
+              coordinates: { x: 0, y: 0 },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.farm.projects).toEqual(["Basic Cooking Pot"]);
+  });
+
+  it("counts a project placed in the legacy home", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...GAME_STATE,
+        home: {
+          collectibles: {
+            "Basic Cooking Pot": [
+              {
+                id: "1",
+                createdAt: 0,
+                readyAt: 0,
+                coordinates: { x: 0, y: 0 },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.home.projects).toEqual(["Basic Cooking Pot"]);
+  });
+
+  it("counts a project placed on the interior ground floor", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...GAME_STATE,
+        interior: {
+          ground: {
+            collectibles: {
+              "Basic Cooking Pot": [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.home.projects).toEqual(["Basic Cooking Pot"]);
+  });
+
+  it("counts a project placed on the interior level one floor", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...GAME_STATE,
+        interior: {
+          ground: { collectibles: {} },
+          level_one: {
+            collectibles: {
+              "Basic Cooking Pot": [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.home.projects).toEqual(["Basic Cooking Pot"]);
+  });
+
+  it("does not count a project that is in the interior but not placed", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...GAME_STATE,
+        interior: {
+          ground: {
+            collectibles: {
+              "Basic Cooking Pot": [{ id: "1", createdAt: 0, readyAt: 0 }],
+            },
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(0);
+  });
+
+  it("counts a pet placed on the interior ground floor", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...TEST_FARM,
+        pets: {
+          common: {
+            Barkley: {
+              name: "Barkley",
+              experience: 0,
+              energy: 0,
+              requests: { food: [], fedAt: 0 },
+              pettedAt: 0,
+            },
+          },
+        },
+        interior: {
+          ground: {
+            collectibles: {
+              Barkley: [
+                {
+                  id: "1",
+                  createdAt: 0,
+                  readyAt: 0,
+                  coordinates: { x: 0, y: 0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.home.pets).toEqual(["Barkley"]);
+  });
+
+  it("counts a pet NFT living on an interior floor", () => {
+    const helpRequired = getHelpRequired({
+      game: {
+        ...TEST_FARM,
+        pets: {
+          nfts: {
+            1: {
+              id: 1,
+              name: "Pet #1",
+              location: "level_one",
+              coordinates: { x: 0, y: 0 },
+              experience: 0,
+              energy: 0,
+              requests: { food: [], fedAt: 0 },
+              pettedAt: 0,
+            },
+          },
+        },
+      },
+    });
+
+    expect(helpRequired.totalCount).toEqual(1);
+    expect(helpRequired.tasks.home.pets).toEqual(["Pet #1"]);
+  });
+});

--- a/src/features/game/types/monuments.ts
+++ b/src/features/game/types/monuments.ts
@@ -288,8 +288,31 @@ export function isHelpComplete({ game }: { game: GameState }) {
 export function getHelpRequired({ game }: { game: GameState }) {
   const villageProjects = game.socialFarming.villageProjects;
   const collectibles = game.collectibles;
-  const homeCollectibles = game.home.collectibles;
   const petHouseCollectibles = game.petHouse?.pets ?? {};
+
+  /**
+   * Every placement surface that sits *inside* the player's house: the legacy
+   * `home` room plus the two interior floors that replaced it. They all report
+   * into the same `home` bucket, which is what the house building badge and the
+   * VisitorGuide read — as far as a visitor is concerned it is one building.
+   *
+   * Without the interior floors here, a project or pet that has been imported
+   * out of the old home is invisible to the whole help system: it isn't counted
+   * on the house, `isHelpComplete` returns true without it, and the visitor is
+   * never sent inside to help with it.
+   */
+  const insideHouse = [
+    game.home.collectibles,
+    game.interior?.ground.collectibles,
+    game.interior?.level_one?.collectibles,
+  ];
+
+  const isPlacedInsideHouse = (name: MonumentName | PetName) =>
+    insideHouse.some((c) => !!c?.[name]?.some((item) => !!item.coordinates));
+
+  /** Pet NFTs carry their surface on the item rather than in a keyed bucket. */
+  const HOUSE_LOCATIONS = ["home", "interior", "level_one"];
+
   const clutterLocations = game.socialFarming.clutter?.locations;
   const pets = game.pets;
   const isPetHousePlaced = !!game.buildings["Pet House"]?.some(
@@ -322,9 +345,7 @@ export function getHelpRequired({ game }: { game: GameState }) {
       const isProjectPlacedOnLand = !!collectibles[monument]?.some(
         (item) => !!item.coordinates,
       );
-      const isProjectPlacedInHome = !!homeCollectibles[monument]?.some(
-        (item) => !!item.coordinates,
-      );
+      const isProjectPlacedInHome = isPlacedInsideHouse(monument);
 
       if (isProjectPlacedOnLand) {
         acc.pendingLandProjects = [...acc.pendingLandProjects, monument];
@@ -362,9 +383,7 @@ export function getHelpRequired({ game }: { game: GameState }) {
       const isPetPlacedOnLand = !!collectibles[name]?.some(
         (item) => !!item.coordinates,
       );
-      const isPetPlacedOnHome = !!homeCollectibles[name]?.some(
-        (item) => !!item.coordinates,
-      );
+      const isPetPlacedOnHome = isPlacedInsideHouse(name);
       const isPetPlacedOnPetHouse = !!petHouseCollectibles[name]?.some(
         (item) => !!item.coordinates,
       );
@@ -417,7 +436,7 @@ export function getHelpRequired({ game }: { game: GameState }) {
           return acc;
         }
 
-        if (pet.location === "home") {
+        if (HOUSE_LOCATIONS.includes(pet.location ?? "")) {
           acc.pendingHomeNftPets = [...acc.pendingHomeNftPets, pet.name];
 
           return acc;

--- a/src/features/interior/Interior.tsx
+++ b/src/features/interior/Interior.tsx
@@ -39,6 +39,10 @@ import { ZoomContext } from "components/ZoomProvider";
 import { useVisiting } from "lib/utils/visitUtils";
 import { VisitingHud } from "features/island/hud/VisitingHud";
 import { getInteriorExitRoute, getInteriorRoute } from "./lib/interiorRoutes";
+import { PlayerModal } from "features/social/PlayerModal";
+import { Context as AuthContext } from "features/auth/lib/Provider";
+import type { AuthMachineState } from "features/auth/lib/authMachine";
+import { hasFeatureAccess } from "lib/flags";
 
 const _landscaping = (state: MachineState) => state.matches("landscaping");
 const _bumpkin = (state: MachineState) => state.context.state.bumpkin;
@@ -49,6 +53,7 @@ const _hasInteriorAccess = (state: MachineState) =>
   !!state.context.state.settings.interiorsEnabled;
 const _expansion = (state: MachineState) =>
   state.context.state.interior.expansion;
+const _token = (state: AuthMachineState) => state.context.user.rawToken ?? "";
 
 const _interiorCollectibles = (state: MachineState) => {
   // Only the ground level is rendered for now. When additional levels are
@@ -97,6 +102,7 @@ const _interiorFarmHands = (state: MachineState) => {
  */
 export const Interior: React.FC = () => {
   const { gameService } = useContext(Context);
+  const { authService } = useContext(AuthContext);
   const { scale } = useContext(ZoomContext);
   const [params] = useSearchParams();
   const [scrollIntoView] = useScrollIntoView();
@@ -110,6 +116,20 @@ export const Interior: React.FC = () => {
   const island = useSelector(gameService, _island);
   const hasAccess = useSelector(gameService, _hasInteriorAccess);
   const expansion = useSelector(gameService, _expansion);
+  const token = useSelector(authService, _token);
+
+  // The world feed (rendered by both HUDs) opens the player modal, so the modal
+  // has to be mounted on this surface too — same as /home and the other farm
+  // interiors. While visiting, `farmId` is the visited farm, so the logged-in
+  // player is `visitorId`.
+  const { visitorId, farmId, visitorState, state } =
+    gameService.getSnapshot().context;
+  const loggedInFarmId = visitorId ?? farmId;
+  const hasAirdropAccess = hasFeatureAccess(
+    visitorState ?? state,
+    "AIRDROP_PLAYER",
+  );
+
   // Center the canvas in the viewport on mount. GenesisBlock sits at the
   // canvas centre — same anchor MapPlacement uses to render placed items
   // and Placeable uses for its drag-coord origin.
@@ -428,6 +448,12 @@ export const Interior: React.FC = () => {
       {!landscaping && !isVisiting && <Hud isFarming location="interior" />}
       {landscaping && <LandscapingHud location="interior" />}
       {isVisiting && <VisitingHud />}
+
+      <PlayerModal
+        loggedInFarmId={loggedInFarmId}
+        token={token}
+        hasAirdropAccess={hasAirdropAccess}
+      />
     </>
   );
 };

--- a/src/features/interior/LevelOne.tsx
+++ b/src/features/interior/LevelOne.tsx
@@ -39,6 +39,10 @@ import { ZoomContext } from "components/ZoomProvider";
 import { useVisiting } from "lib/utils/visitUtils";
 import { VisitingHud } from "features/island/hud/VisitingHud";
 import { getInteriorExitRoute, getInteriorRoute } from "./lib/interiorRoutes";
+import { PlayerModal } from "features/social/PlayerModal";
+import { Context as AuthContext } from "features/auth/lib/Provider";
+import type { AuthMachineState } from "features/auth/lib/authMachine";
+import { hasFeatureAccess } from "lib/flags";
 
 const _landscaping = (state: MachineState) => state.matches("landscaping");
 const _bumpkin = (state: MachineState) => state.context.state.bumpkin;
@@ -50,6 +54,7 @@ const _expansion = (state: MachineState) =>
   state.context.state.interior.expansion;
 const _hasInteriorAccess = (state: MachineState) =>
   !!state.context.state.settings.interiorsEnabled;
+const _token = (state: AuthMachineState) => state.context.user.rawToken ?? "";
 
 const EMPTY_COLLECTIBLES: Collectibles = {};
 
@@ -118,6 +123,7 @@ const UPGRADE_POSITIONS: Partial<
  */
 export const LevelOne: React.FC = () => {
   const { gameService } = useContext(Context);
+  const { authService } = useContext(AuthContext);
   const { scale } = useContext(ZoomContext);
   const [params] = useSearchParams();
   const navigate = useNavigate();
@@ -132,6 +138,17 @@ export const LevelOne: React.FC = () => {
   const expansion = useSelector(gameService, _expansion);
   const hasAccess = useSelector(gameService, _hasInteriorAccess);
   const levelOneFarmHands = useSelector(gameService, _levelOneFarmHands);
+  const token = useSelector(authService, _token);
+
+  // See Interior.tsx — the world feed opens the player modal, so it has to be
+  // mounted here too.
+  const { visitorId, farmId, visitorState, state } =
+    gameService.getSnapshot().context;
+  const loggedInFarmId = visitorId ?? farmId;
+  const hasAirdropAccess = hasFeatureAccess(
+    visitorState ?? state,
+    "AIRDROP_PLAYER",
+  );
   const { collectibles, positions: levelOnePositions } = useSelector(
     gameService,
     _levelOneCollectibles,
@@ -450,6 +467,12 @@ export const LevelOne: React.FC = () => {
       {!landscaping && !isVisiting && <Hud isFarming location="level_one" />}
       {landscaping && <LandscapingHud location="level_one" />}
       {isVisiting && <VisitingHud />}
+
+      <PlayerModal
+        loggedInFarmId={loggedInFarmId}
+        token={token}
+        hasAirdropAccess={hasAirdropAccess}
+      />
     </>
   );
 };

--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -82,6 +82,7 @@ import { CloseButtonPanel } from "features/game/components/CloseablePanel";
 import { FarmHelped } from "features/island/hud/components/FarmHelped";
 import { getPartialInstantGrowPrice } from "features/game/events/landExpansion/instaGrowProject";
 import { getKeys } from "lib/object";
+import { getCollectiblesAcrossLocations } from "features/game/lib/getCollectiblesAcrossLocations";
 import { RequirementLabel } from "components/ui/RequirementsLabel";
 import { EffectSuccess } from "features/game/expansion/components/effects/EffectSuccess";
 
@@ -494,14 +495,24 @@ const _cheers = (project: MonumentName) => (state: MachineState) => {
   );
 };
 
+/**
+ * A placed monument with no village project behind it — either never started,
+ * or already completed and cashed in. It renders the "start project" flow
+ * instead of a progress bar, and visitors must not be able to cheer it.
+ *
+ * Placement is checked across *all* surfaces (farm, home and both interior
+ * floors). Missing the interior floors here left a pot moved inside looking
+ * like a live project stuck at 0%: the owner got the progress modal rather than
+ * the start prompt, and a visitor's cheer threw "Project not found".
+ */
 const _isInactive = (project: MonumentName) => (state: MachineState) => {
   const gameState = state.context.state;
-  const isPlaced =
-    gameState.collectibles[project]?.some((c) => !!c.coordinates) ||
-    gameState.home.collectibles[project]?.some((c) => !!c.coordinates);
+  const isPlaced = getCollectiblesAcrossLocations(gameState, project).some(
+    (c) => !!c.coordinates,
+  );
   const hasVillageProject =
     !!gameState.socialFarming.villageProjects?.[project];
-  return !!isPlaced && !hasVillageProject;
+  return isPlaced && !hasVillageProject;
 };
 
 const _cheersAvailable = (state: MachineState) => {

--- a/src/features/island/hud/VisitingHud.tsx
+++ b/src/features/island/hud/VisitingHud.tsx
@@ -13,7 +13,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { RoundButton } from "components/ui/RoundButton";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { HudContainer } from "components/ui/HudContainer";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import type { MachineState } from "features/game/lib/gameMachine";
 import { NPCIcon } from "../bumpkin/components/NPC";
 import { Label } from "components/ui/Label";
@@ -22,6 +22,9 @@ import socialPointsIcon from "assets/icons/social_score.webp";
 import loadingIcon from "assets/icons/timer.gif";
 import saveIcon from "assets/icons/save.webp";
 import choreIcon from "assets/icons/chores.webp";
+import farmIcon from "assets/icons/farm.webp";
+import { getInteriorExitRoute } from "features/interior/lib/interiorRoutes";
+import { useVisiting } from "lib/utils/visitUtils";
 import { VisitorGuide } from "./components/VisitorGuide";
 import { Modal } from "components/ui/Modal";
 import { CloseButtonPanel } from "features/game/components/CloseablePanel";
@@ -33,6 +36,28 @@ import { Feed } from "features/social/Feed";
 import { WorldFeedButton } from "features/social/components/WorldFeedButton";
 import classNames from "classnames";
 import { isMobile } from "mobile-device-detect";
+
+/**
+ * `fromRoute` is wherever the player was standing when they started the visit.
+ * Most of those are fine to return to, but the farm-interior surfaces are not:
+ * they render the *current* farm, so dropping back onto one after the visit has
+ * ended leaves the player standing inside a room they never asked to be in.
+ * Send them to their own land instead. `visit` is here for the visit-to-visit
+ * hop, which must not chain back into the farm they just left.
+ *
+ * The last two are the new interior floors — `/interior` and `/level_one`,
+ * which replaced `/home` for players on the interiors experiment.
+ */
+const ENDS_ON_OWN_FARM = [
+  "visit",
+  "home",
+  "barn",
+  "hen-house",
+  "greenhouse",
+  "pet-house",
+  "interior",
+  "level_one",
+];
 
 const _socialPoints = (state: MachineState) => {
   return state.context.state.socialFarming?.points ?? 0;
@@ -77,20 +102,23 @@ export const VisitingHud: React.FC = () => {
 
   const { t } = useAppTranslation();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { visitedFarmId } = useVisiting();
+
+  /**
+   * The interior floors have no in-world exit button of their own — on the
+   * owner's farm the only way out is the Hud travel button, and the Hud is
+   * swapped for this component while visiting. Without this the sole way out of
+   * someone else's house is to end the visit entirely.
+   */
+  const isInsideVisitedHouse = /\/(interior|level_one)\/?$/.test(pathname);
 
   const handleEndVisit = () => {
     gameService.send("END_VISIT");
 
-    const target =
-      fromRoute &&
-      !fromRoute.includes("visit") &&
-      !fromRoute.includes("home") &&
-      !fromRoute.includes("barn") &&
-      !fromRoute.includes("hen-house") &&
-      !fromRoute.includes("greenhouse") &&
-      !fromRoute.includes("pet-house")
-        ? fromRoute
-        : "/";
+    const target = ENDS_ON_OWN_FARM.some((route) => fromRoute?.includes(route))
+      ? "/"
+      : (fromRoute ?? "/");
 
     navigate(target, { replace: true });
   };
@@ -237,6 +265,26 @@ export const VisitingHud: React.FC = () => {
         )}
       >
         <WorldFeedButton showFeed={showFeed} setShowFeed={setShowFeed} />
+        {isInsideVisitedHouse && (
+          <RoundButton
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              navigate(getInteriorExitRoute({ visitedFarmId }));
+            }}
+          >
+            <img
+              src={farmIcon}
+              alt="Back to farm"
+              className="absolute group-active:translate-y-[2px]"
+              style={{
+                width: `${PIXEL_SCALE * 12}px`,
+                left: `${PIXEL_SCALE * 5}px`,
+                top: `${PIXEL_SCALE * 4}px`,
+              }}
+            />
+          </RoundButton>
+        )}
         <RoundButton
           onClick={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
# Pull request description

Fixes a range of bugs with helping projects inside of the interior + general interior visiting issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added player access controls and modal interactions within interior and level-one farm areas.
  - Added navigation to the visited farm’s interior exit when ending a visit.
  - Improved inactive project detection across farms, homes, and interior floors.

- **Bug Fixes**
  - Help requests now correctly categorize projects and pets located throughout home and interior areas, including NFT pets.

- **Tests**
  - Added coverage for help-request totals and task categorization across supported locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->