### PR TITLE
[FIX] Ascension-aware daily chest XP and uncapped item scaling

### DIFF
--- a/src/features/game/types/dailyRewards.test.ts
+++ b/src/features/game/types/dailyRewards.test.ts
@@ -145,4 +145,100 @@ describe("getRewardsForStreak — ascension-aware reward scaling", () => {
     )!;
     expect(anglerPack.items).toEqual({ Rod: 40, Earthworm: 24, Grub: 16 });
   });
+
+  // A2 L50 → total Bumpkin level 250, which must scale past the historical 200 cap:
+  // the bug clamped every ascended player to 200, so A2 L50 got the same items as A1 L50.
+  const ascendedFarmA2: GameState = {
+    ...TEST_FARM,
+    bumpkin: { ...TEST_FARM.bumpkin, experience: 220_000_000 },
+    island: { ...TEST_FARM.island, ascensionLevel: 2 },
+    farmActivity: { ...TEST_FARM.farmActivity, "Daily Reward Collected": 100 },
+  };
+
+  it("scales items past the level-200 cap for higher ascensions (A2 L50 > A1 L50)", () => {
+    const rewardsFor = (game: GameState, streak: number) =>
+      getRewardsForStreak({
+        game,
+        streak,
+        currentDate: new Date(PAW_PRINTS_NOW).toISOString(),
+        now: PAW_PRINTS_NOW,
+      }).rewards;
+
+    // Tool Cache: 250 / 25 = 10 → 5×/2×/1× × 10.
+    const toolCache = rewardsFor(ascendedFarmA2, 7).find(
+      (r) => r.id === "weekly-day-1-tool-cache",
+    )!;
+    expect(toolCache.items).toEqual({
+      Axe: 50,
+      Pickaxe: 20,
+      "Stone Pickaxe": 10,
+    });
+
+    // Angler Pack: 5×/3×/2× × 10.
+    const anglerPack = rewardsFor(ascendedFarmA2, 10).find(
+      (r) => r.id === "weekly-day-4-angler-pack",
+    )!;
+    expect(anglerPack.items).toEqual({ Rod: 50, Earthworm: 30, Grub: 20 });
+
+    // Coin Stash: 500 × (250 / 25) = 5000 (A1 L50 gives 4000).
+    const coinStash = rewardsFor(ascendedFarmA2, 12).find(
+      (r) => r.id === "weekly-day-6-coin-stash",
+    )!;
+    expect(coinStash.coins).toBe(5000);
+  });
+});
+
+describe("getRewardsForStreak — Growth Feast XP scaling", () => {
+  // streak % 7 === 4 → weekly-day-5-growth-feast; Daily Reward Collected > 6 skips onboarding.
+  const growthFeastFor = (game: GameState) =>
+    getRewardsForStreak({
+      game,
+      streak: 11,
+      currentDate: new Date(PAW_PRINTS_NOW).toISOString(),
+      now: PAW_PRINTS_NOW,
+    }).rewards.find((r) => r.id === "weekly-day-5-growth-feast")!;
+
+  const farmAt = (experience: number, ascensionLevel: number): GameState => ({
+    ...TEST_FARM,
+    bumpkin: { ...TEST_FARM.bumpkin, experience },
+    island: { ...TEST_FARM.island, ascensionLevel },
+    farmActivity: { ...TEST_FARM.farmActivity, "Daily Reward Collected": 100 },
+  });
+
+  it("scales an ascended player's XP linearly with total Bumpkin level", () => {
+    // A1 L50 → total level 200 → 1000 × 200.
+    expect(growthFeastFor(farmAt(150_000_000, 1)).xp).toBe(200_000);
+  });
+
+  it("grants a higher ascension strictly more XP (A2 L50 !== A1 L50)", () => {
+    const a1 = growthFeastFor(farmAt(150_000_000, 1)).xp!; // total 200 → 200,000
+    const a2 = growthFeastFor(farmAt(220_000_000, 2)).xp!; // total 250 → 250,000
+    expect(a2).toBe(250_000);
+    expect(a2).toBeGreaterThan(a1);
+  });
+
+  it("bumps (does not drop) XP the moment a maxed player ascends", () => {
+    // Non-ascended at the level-150 cap vs. their first ascended level.
+    const preAscension = growthFeastFor(farmAt(94_333_905, 0)).xp!;
+    const firstAscended = growthFeastFor(farmAt(94_333_905 + 1, 1)).xp!; // A1 L1 → 151
+    expect(firstAscended).toBe(151_000);
+    expect(firstAscended).toBeGreaterThanOrEqual(preAscension);
+  });
+
+  it("keeps the historical fraction-of-next-level curve for non-ascended players", () => {
+    // A mid-level, non-ascended player is untouched by the ascension branch: their
+    // reward is a small fraction of a level, not the linear 1000 × level.
+    const midLevelExperience = 1_000_000; // level 50
+    const xp = growthFeastFor(farmAt(midLevelExperience, 0)).xp!;
+    expect(xp).toBeGreaterThan(0);
+    expect(xp).toBeLessThan(51 * 1000); // well under the linear 1000 × level rate
+  });
+
+  it("holds the non-ascended display and grant in sync (frontend cap === backend cap)", () => {
+    // A non-ascended player parked at the level cap must read the same XP the server
+    // grants — the legacy mismatch came from the frontend capping at 150 while the
+    // backend walked the 151-200 table. Both now cap at the pre-ascension max.
+    const xp = growthFeastFor(farmAt(94_333_905, 0)).xp!;
+    expect(xp).toBe(103_768);
+  });
 });

--- a/src/features/game/types/dailyRewards.ts
+++ b/src/features/game/types/dailyRewards.ts
@@ -125,6 +125,13 @@ const POTION_XP_CURVE_TUNING = 1.5;
 const LN_200 = Math.log(200);
 
 /**
+ * Day-5 (Growth Feast) XP for ascended players, granted per total Bumpkin level.
+ * Linear (not band-XP-scaled) so the reward stays ascension-aware and monotonic
+ * without compounding — see `WEEKLY_REWARDS` for why the legacy curve can't be used.
+ */
+const DAILY_XP_PER_TOTAL_LEVEL = 1000;
+
+/**
  * Calculates:
  * L3 + 0.42 * ((ln(200) - ln(value)) / ln(200)) ^ L2
  */
@@ -143,21 +150,23 @@ export function calculateXPPotion(
 const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
   game: GameState,
 ) => {
+  const ascensionLevel = game.island.ascensionLevel ?? 0;
   const ascension = getAscensionLevel({
     experience: game.bumpkin.experience ?? 0,
-    ascensionLevel: game.island.ascensionLevel ?? 0,
+    ascensionLevel,
   });
-  // Monotonic total level (ascension-aware) — the reward curve below is keyed to the
-  // historical 1..200 scale, so an ascended player must read as 150+, not their 1..50
-  // within-ascension level. Clamped at MAX_BUMPKIN_LEVEL to keep calculateXPPotion in domain.
+  // Monotonic total level (ascension-aware): 1..150 pre-ascension, then +50 per band
+  // (A1 L1 → 151, A1 L50 → 200, A2 L50 → 250, …). Uncapped — every scaled reward (tools,
+  // coins) must keep growing with ascension, so A2 L50 reads 250, not a 200-clamped 200.
   // Mirror of the backend (`domain/game/types/dailyRewards.ts`).
-  const level = Math.min(
-    getTotalBumpkinLevel({
-      experience: game.bumpkin.experience ?? 0,
-      ascensionLevel: game.island.ascensionLevel ?? 0,
-    }),
-    MAX_BUMPKIN_LEVEL,
-  );
+  const totalLevel = getTotalBumpkinLevel({
+    experience: game.bumpkin.experience ?? 0,
+    ascensionLevel,
+  });
+  // `calculateXPPotion` is only defined on the historical 1..200 domain (its ln term goes
+  // negative past 200). Non-ascended players never exceed 150, so this clamp is just a
+  // safety net for that one call — item/coin scaling reads the uncapped `totalLevel`.
+  const potionLevel = Math.min(totalLevel, MAX_BUMPKIN_LEVEL);
   const { experienceToNextLevel } = getExperienceToNextLevel(
     game.bumpkin?.experience ?? 0,
   );
@@ -167,7 +176,17 @@ const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
     return Math.max(1, Math.floor(base * baseMultiplier));
   };
 
-  const day2Xp = calculateXPPotion(level, experienceToNextLevel);
+  // Day-5 (Growth Feast) XP. Pre-ascension keeps the historical fraction-of-next-level
+  // curve. Once ascended, that curve is unusable: `getExperienceToNextLevel` caps at
+  // level 150 (a flat 2,290,000) and `calculateXPPotion`'s percentage pins to its 0.04
+  // floor once total level clamps at 200 — so every ascended player got an identical,
+  // ascension-blind 91,600 (A1 L50 == A2 L50). Instead scale linearly off the monotonic
+  // total level: ascension-aware, a bump (not a drop) at the ascension boundary, and a
+  // low linear — not band-XP-exponential — curve so this one chest can't compound XP.
+  const day2Xp =
+    ascensionLevel >= 1
+      ? DAILY_XP_PER_TOTAL_LEVEL * totalLevel
+      : calculateXPPotion(potionLevel, experienceToNextLevel);
 
   const loveBox = (() => {
     if (meetsLevelRequirement(ascension, { ascension: 0, level: 101 })) {
@@ -185,9 +204,9 @@ const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
       id: "weekly-day-1-tool-cache",
       label: "Tool Cache",
       items: {
-        Axe: scaleAmount(5, level / 25),
-        Pickaxe: scaleAmount(2, level / 25),
-        "Stone Pickaxe": scaleAmount(1, level / 25),
+        Axe: scaleAmount(5, totalLevel / 25),
+        Pickaxe: scaleAmount(2, totalLevel / 25),
+        "Stone Pickaxe": scaleAmount(1, totalLevel / 25),
       },
     },
     {
@@ -206,9 +225,9 @@ const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
       id: "weekly-day-4-angler-pack",
       label: "Angler Pack",
       items: {
-        Rod: scaleAmount(5, Math.max(1, Math.floor(level / 25))),
-        Earthworm: scaleAmount(3, Math.max(1, Math.floor(level / 25))),
-        Grub: scaleAmount(2, Math.max(1, Math.floor(level / 25))),
+        Rod: scaleAmount(5, Math.max(1, Math.floor(totalLevel / 25))),
+        Earthworm: scaleAmount(3, Math.max(1, Math.floor(totalLevel / 25))),
+        Grub: scaleAmount(2, Math.max(1, Math.floor(totalLevel / 25))),
       },
     },
     {
@@ -219,7 +238,7 @@ const WEEKLY_REWARDS: (game: GameState) => DailyRewardDefinition[] = (
     {
       id: "weekly-day-6-coin-stash",
       label: "Coin Stash",
-      coins: Math.floor(500 * (level / 25)),
+      coins: Math.floor(500 * (totalLevel / 25)),
     },
     {
       id: "weekly-mega-box",


### PR DESCRIPTION
Two ascension bugs in the weekly daily-chest rewards:

1. Day-5 "Growth Feast" XP was identical for every ascended player (A1 L50 == A2 L50, a flat 91,600 on the frontend). `calculateXPPotion` pins to its 0.04 floor once the total level clamps at 200, and `getExperienceToNextLevel` caps at level 150 (a constant 2,290,000), so the reward was ascension-blind and mismatched the backend grant. Ascended players now get a linear `1000 x totalLevel` — ascension-aware, monotonic, a bump (not a drop) at the ascension boundary, and low/linear so this chest can't compound XP. Non-ascended players keep the historical fraction-of-next-level curve.

2. Tool Cache / Angler Pack / Coin Stash scaling was clamped at total level 200, so every ascended player past A1 L50 got frozen amounts (A2 L50 handed the same 40 Axes / 4000 coins as A1 L50). Item/coin/love-box scaling now reads the uncapped total level (A2 L50 -> 250, A3 L50 -> 300, ...). The 200 clamp is kept only as a domain guard for the non-ascended calculateXPPotion.

Mirror of the backend (`domain/game/types/dailyRewards.ts`). Adds regression tests for the linear XP curve, A2 > A1 scaling, the ascension-boundary bump, non-ascended curve preservation, and past-200 item scaling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily rewards now continue scaling beyond level 200 for ascended players.
  * Growth Feast XP increases with total level and ascension progress.
  * Tool Cache, Angler Pack, and Coin Stash rewards now reflect uncapped progression.

* **Bug Fixes**
  * Prevented XP reductions when reaching the first ascension.
  * Preserved the existing reward curve for players who have not ascended.
  * Improved consistency between displayed Growth Feast XP and the amount granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->