### PR TITLE
[FEAT] Show which boosts are giving chapter-ticket bonuses

### DIFF
--- a/src/features/game/events/landExpansion/completeNPCChore.ts
+++ b/src/features/game/events/landExpansion/completeNPCChore.ts
@@ -1,5 +1,9 @@
 import Decimal from "decimal.js-light";
-import type { GameState, InventoryItemName } from "features/game/types/game";
+import type {
+  BoostName,
+  GameState,
+  InventoryItemName,
+} from "features/game/types/game";
 import {
   getChoreProgress,
   NPC_CHORES,
@@ -151,7 +155,7 @@ export function completeNPCChore({
     // Mark chore as completed
     chore.completedAt = createdAt;
 
-    const items = generateChoreRewards({
+    const { items } = generateChoreRewards({
       game: draft,
       chore,
       now: new Date(createdAt),
@@ -236,17 +240,23 @@ export function generateChoreRewards({
   game: GameState;
   chore: NpcChore;
   now: Date;
-}) {
-  if (!chore) return {};
+}): {
+  items: Partial<Record<InventoryItemName, number>>;
+  boostsUsed: { name: BoostName; value: string }[];
+} {
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+
+  if (!chore) return { items: {}, boostsUsed };
 
   const items = Object.assign({}, chore.reward.items) ?? {};
 
   const ticket = getChapterTicket(now.getTime());
-  if (!items[ticket]) return items;
+  if (!items[ticket]) return { items, boostsUsed };
   let amount = items[ticket] ?? 0;
 
   if (hasVipAccess({ game, now: now.getTime() })) {
     amount += 2;
+    boostsUsed.push({ name: "VIP Access", value: "+2" });
   }
   const chapter = getCurrentChapter(now.getTime());
   const chapterBoost = CHAPTER_TICKET_BOOST_ITEMS[chapter];
@@ -255,15 +265,17 @@ export function generateChoreRewards({
     if (isCollectible(item)) {
       if (isCollectibleBuilt({ game, name: item })) {
         amount += 1;
+        boostsUsed.push({ name: item, value: "+1" });
       }
     } else {
       if (isWearableActive({ game, name: item })) {
         amount += 1;
+        boostsUsed.push({ name: item, value: "+1" });
       }
     }
   });
 
   items[ticket] = amount;
 
-  return items;
+  return { items, boostsUsed };
 }

--- a/src/features/game/events/landExpansion/sellBounty.ts
+++ b/src/features/game/events/landExpansion/sellBounty.ts
@@ -14,6 +14,7 @@ import {
   type FullMoonFruit,
 } from "features/game/types/fruits";
 import type {
+  BoostName,
   BountyRequest,
   DollBounty,
   ExoticBounty,
@@ -118,6 +119,45 @@ export function generateBountyTicket({
   });
 
   return amount;
+}
+
+/**
+ * Which chapter-ticket boosts are currently active for a bounty's ticket
+ * reward, for display only. Mirrors generateBountyTicket's boost logic
+ * without changing its return shape (17 call sites rely on it being a
+ * plain number).
+ */
+export function getBountyTicketBoosts({
+  game,
+  bounty,
+  now = Date.now(),
+}: {
+  game: GameState;
+  bounty: BountyRequest;
+  now?: number;
+}): { name: BoostName; value: string }[] {
+  const boostsUsed: { name: BoostName; value: string }[] = [];
+
+  if (!(bounty.items?.[getChapterTicket(now)] ?? 0)) {
+    return boostsUsed;
+  }
+
+  const chapter = getCurrentChapter(now);
+  const chapterBoost = CHAPTER_TICKET_BOOST_ITEMS[chapter];
+
+  Object.values(chapterBoost).forEach((item) => {
+    if (isCollectible(item)) {
+      if (isCollectibleBuilt({ game, name: item })) {
+        boostsUsed.push({ name: item, value: "+1" });
+      }
+    } else {
+      if (isWearableActive({ game, name: item })) {
+        boostsUsed.push({ name: item, value: "+1" });
+      }
+    }
+  });
+
+  return boostsUsed;
 }
 
 export function generateBountyCoins({

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -697,8 +697,27 @@ export const DeliveryOrders: React.FC<Props> = ({
                           className={classNames("relative", {
                             "cursor-pointer": ticketBoostsUsed.length > 0,
                           })}
+                          role={
+                            ticketBoostsUsed.length > 0 ? "button" : undefined
+                          }
+                          tabIndex={ticketBoostsUsed.length > 0 ? 0 : undefined}
+                          aria-expanded={
+                            ticketBoostsUsed.length > 0
+                              ? showTicketBoosts
+                              : undefined
+                          }
                           onClick={(e) => {
                             if (ticketBoostsUsed.length === 0) return;
+                            e.stopPropagation();
+                            setShowTicketBoosts((prev) => !prev);
+                          }}
+                          onKeyDown={(e) => {
+                            if (
+                              ticketBoostsUsed.length === 0 ||
+                              (e.key !== "Enter" && e.key !== " ")
+                            )
+                              return;
+                            e.preventDefault();
                             e.stopPropagation();
                             setShowTicketBoosts((prev) => !prev);
                           }}

--- a/src/features/island/delivery/components/Orders.tsx
+++ b/src/features/island/delivery/components/Orders.tsx
@@ -1,5 +1,5 @@
 import { SUNNYSIDE } from "assets/sunnyside";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import Decimal from "decimal.js-light";
 
@@ -72,6 +72,7 @@ import { LockedOrderCard } from "./LockedOrderCard";
 import { pixelVibrantBorderStyle } from "features/game/lib/style";
 import { getChapterTaskPoints } from "features/game/types/tracks";
 import { hasTimeBasedFeatureAccess } from "lib/flags";
+import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
 
 // Bumpkins
 export const BEACH_BUMPKINS: NPCName[] = [
@@ -137,6 +138,8 @@ export const DeliveryOrders: React.FC<Props> = ({
 
   const [showSkipDialog, setShowSkipDialog] = useState(false);
   const [isRevealing, setIsRevealing] = useState(false);
+  const [showTicketBoosts, setShowTicketBoosts] = useState(false);
+  const ticketBoostsAnchorRef = useRef<HTMLDivElement>(null);
 
   const now = useNow({ live: true });
   const chapterTicket = getChapterTicket(now);
@@ -274,11 +277,12 @@ export const DeliveryOrders: React.FC<Props> = ({
     )
     .find((npc) => isBelowLevel(NPC_DELIVERY_LEVELS[npc]));
 
-  const { amount: baseTickets } = generateDeliveryTickets({
-    game: state,
-    npc: previewOrder.from,
-    now,
-  });
+  const { amount: baseTickets, boostsUsed: ticketBoostsUsed } =
+    generateDeliveryTickets({
+      game: state,
+      npc: previewOrder.from,
+      now,
+    });
 
   // During ticket freeze (holiday), quest ticket deliveries are blocked.
   // Coin deliveries can still be completed but award 0 tickets.
@@ -688,17 +692,40 @@ export const DeliveryOrders: React.FC<Props> = ({
                         </Label>
                       )}
                       {(!!ticketDisplay || isFrozenQuestOrder) && (
-                        <Label
-                          type="warning"
-                          className="whitespace-nowrap"
-                          icon={ITEM_DETAILS[chapterTicket].image}
+                        <div
+                          ref={ticketBoostsAnchorRef}
+                          className={classNames("relative", {
+                            "cursor-pointer": ticketBoostsUsed.length > 0,
+                          })}
+                          onClick={(e) => {
+                            if (ticketBoostsUsed.length === 0) return;
+                            e.stopPropagation();
+                            setShowTicketBoosts((prev) => !prev);
+                          }}
                         >
-                          <span className={!isMobile ? "text-xxs" : ""}>
-                            {`${
-                              isFrozenQuestOrder ? baseTickets : ticketDisplay
-                            } ${chapterTicket}`}
-                          </span>
-                        </Label>
+                          <Label
+                            type="warning"
+                            className="whitespace-nowrap"
+                            icon={ITEM_DETAILS[chapterTicket].image}
+                          >
+                            <span className={!isMobile ? "text-xxs" : ""}>
+                              {`${
+                                isFrozenQuestOrder ? baseTickets : ticketDisplay
+                              } ${chapterTicket}`}
+                            </span>
+                          </Label>
+                          {ticketBoostsUsed.length > 0 && showTicketBoosts && (
+                            <BoostsDisplay
+                              boosts={ticketBoostsUsed}
+                              show={showTicketBoosts}
+                              state={state}
+                              onClick={() => setShowTicketBoosts(false)}
+                              anchorRef={ticketBoostsAnchorRef}
+                              portalAlign="right"
+                              portalPlacement="auto"
+                            />
+                          )}
+                        </div>
                       )}
                     </div>
                   </div>

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -433,8 +433,17 @@ export const ChoreRewardLabel: React.FC<{
       <div
         ref={boostsAnchorRef}
         className={classNames("relative", { "cursor-pointer": isBoosted })}
+        role={isBoosted ? "button" : undefined}
+        tabIndex={isBoosted ? 0 : undefined}
+        aria-expanded={isBoosted ? showBoosts : undefined}
         onClick={(e) => {
           if (!isBoosted) return;
+          e.stopPropagation();
+          setShowBoosts((prev) => !prev);
+        }}
+        onKeyDown={(e) => {
+          if (!isBoosted || (e.key !== "Enter" && e.key !== " ")) return;
+          e.preventDefault();
           e.stopPropagation();
           setShowBoosts((prev) => !prev);
         }}

--- a/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
+++ b/src/features/island/hud/components/codex/pages/ChoreBoard.tsx
@@ -13,7 +13,7 @@ import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { NPC_WEARABLES, type NPCName } from "lib/npcs";
 import { getImageUrl } from "lib/utils/getImageURLS";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 import chapterPoints from "assets/icons/red_medal_short.webp";
 
 import {
@@ -46,6 +46,7 @@ import { formatNumber } from "lib/utils/formatNumber";
 import { useNow } from "lib/utils/hooks/useNow";
 import { pixelVibrantBorderStyle } from "features/game/lib/style";
 import { getChapterTaskPoints } from "features/game/types/tracks";
+import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
 
 interface Props {
   state: GameState;
@@ -108,7 +109,7 @@ export const ChoreBoard: React.FC<Props> = ({ state }) => {
   const chapterTicket = getChapterTicket(now);
   const chapter = getCurrentChapter(now);
 
-  const rewards = generateChoreRewards({
+  const { items: rewards } = generateChoreRewards({
     game: state,
     chore: previewChore as NpcChore,
     now: new Date(),
@@ -417,16 +418,40 @@ export const ChoreRewardLabel: React.FC<{
 }> = ({ chore, state }) => {
   const now = useNow();
   const ticket = getChapterTicket(now);
+  const [showBoosts, setShowBoosts] = useState(false);
+  const boostsAnchorRef = useRef<HTMLDivElement>(null);
 
   if (chore.reward.items[ticket]) {
+    const { items, boostsUsed } = generateChoreRewards({
+      game: state,
+      chore,
+      now: new Date(),
+    });
+    const isBoosted = boostsUsed.length > 0;
+
     return (
-      <Label type={"warning"} icon={ITEM_DETAILS[ticket].image}>
-        {generateChoreRewards({
-          game: state,
-          chore,
-          now: new Date(),
-        })[ticket] ?? 0}
-      </Label>
+      <div
+        ref={boostsAnchorRef}
+        className={classNames("relative", { "cursor-pointer": isBoosted })}
+        onClick={(e) => {
+          if (!isBoosted) return;
+          e.stopPropagation();
+          setShowBoosts((prev) => !prev);
+        }}
+      >
+        <Label type={"warning"} icon={ITEM_DETAILS[ticket].image}>
+          {items[ticket] ?? 0}
+        </Label>
+        {isBoosted && showBoosts && (
+          <BoostsDisplay
+            boosts={boostsUsed}
+            show={showBoosts}
+            state={state}
+            onClick={() => setShowBoosts(false)}
+            anchorRef={boostsAnchorRef}
+          />
+        )}
+      </div>
     );
   }
 

--- a/src/features/world/ui/AnimatedPanel.tsx
+++ b/src/features/world/ui/AnimatedPanel.tsx
@@ -22,8 +22,19 @@ export const AnimatedPanel: React.FC<PropsWithChildren<Props>> = ({
     <>
       {onBackdropClick && show && (
         <div
-          className="fixed inset-0 z-30"
+          // onClick alone is unreliable on mobile Safari for a plain
+          // (non-button) div — taps outside the panel could be silently
+          // swallowed, leaving the trigger itself as the only way to
+          // close. onTouchEnd covers touch input directly; preventDefault
+          // stops it from also firing a synthetic click on whatever it
+          // lands on underneath.
+          className="fixed inset-0 z-30 cursor-pointer"
           onClick={(event) => {
+            event.stopPropagation();
+            onBackdropClick();
+          }}
+          onTouchEnd={(event) => {
+            event.preventDefault();
             event.stopPropagation();
             onBackdropClick();
           }}

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -249,8 +249,29 @@ const OrderCard: React.FC<{
                             className={classNames("flex items-center", {
                               "cursor-pointer": ticketBoostsUsed.length > 0,
                             })}
+                            role={
+                              ticketBoostsUsed.length > 0 ? "button" : undefined
+                            }
+                            tabIndex={
+                              ticketBoostsUsed.length > 0 ? 0 : undefined
+                            }
+                            aria-expanded={
+                              ticketBoostsUsed.length > 0
+                                ? showTicketBoosts
+                                : undefined
+                            }
                             onClick={(e) => {
                               if (ticketBoostsUsed.length === 0) return;
+                              e.stopPropagation();
+                              setShowTicketBoosts((prev) => !prev);
+                            }}
+                            onKeyDown={(e) => {
+                              if (
+                                ticketBoostsUsed.length === 0 ||
+                                (e.key !== "Enter" && e.key !== " ")
+                              )
+                                return;
+                              e.preventDefault();
                               e.stopPropagation();
                               setShowTicketBoosts((prev) => !prev);
                             }}

--- a/src/features/world/ui/deliveries/BumpkinDelivery.tsx
+++ b/src/features/world/ui/deliveries/BumpkinDelivery.tsx
@@ -58,6 +58,7 @@ import {
 import { getBumpkinHoliday } from "lib/utils/getSeasonWeek";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { formatNumber } from "lib/utils/formatNumber";
+import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
 import {
   getAscensionLevel,
   levelRequirementToTotal,
@@ -101,12 +102,15 @@ const OrderCard: React.FC<{
   const { t } = useAppTranslation();
   const { holiday } = getBumpkinHoliday({ now });
   const isHoliday = holiday === new Date(now).toISOString().split("T")[0];
+  const [showTicketBoosts, setShowTicketBoosts] = useState(false);
+  const ticketBoostsAnchorRef = useRef<HTMLDivElement>(null);
 
-  const { amount: baseTickets } = generateDeliveryTickets({
-    game,
-    npc: order.from,
-    now,
-  });
+  const { amount: baseTickets, boostsUsed: ticketBoostsUsed } =
+    generateDeliveryTickets({
+      game,
+      npc: order.from,
+      now,
+    });
   const tickets = isHoliday && !isTicketNPC(order.from) ? 0 : baseTickets;
   // Hide ticket count on frozen quest orders (holiday) to avoid mixed messaging
   const ticketDisplay =
@@ -240,7 +244,17 @@ const OrderCard: React.FC<{
                       )}
                       {!!ticketDisplay && (
                         <div className="flex items-center space-x-3 mr-1">
-                          <div className="flex items-center">
+                          <div
+                            ref={ticketBoostsAnchorRef}
+                            className={classNames("flex items-center", {
+                              "cursor-pointer": ticketBoostsUsed.length > 0,
+                            })}
+                            onClick={(e) => {
+                              if (ticketBoostsUsed.length === 0) return;
+                              e.stopPropagation();
+                              setShowTicketBoosts((prev) => !prev);
+                            }}
+                          >
                             <span className="text-xs mx-1">
                               {ticketDisplay}
                             </span>
@@ -248,6 +262,18 @@ const OrderCard: React.FC<{
                               src={ITEM_DETAILS[getChapterTicket(now)].image}
                               className="h-4 w-auto"
                             />
+                            {ticketBoostsUsed.length > 0 &&
+                              showTicketBoosts && (
+                                <BoostsDisplay
+                                  boosts={ticketBoostsUsed}
+                                  show={showTicketBoosts}
+                                  state={game}
+                                  onClick={() => setShowTicketBoosts(false)}
+                                  anchorRef={ticketBoostsAnchorRef}
+                                  portalAlign="right"
+                                  portalPlacement="auto"
+                                />
+                              )}
                           </div>
                         </div>
                       )}

--- a/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
+++ b/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useLayoutEffect, useMemo, useState } from "react";
+import React, {
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Label } from "components/ui/Label";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { secondsToString } from "lib/utils/time";
@@ -31,7 +37,9 @@ import {
   BOUNTY_CATEGORIES,
   canSellBounty,
   generateBountyTicket,
+  getBountyTicketBoosts,
 } from "features/game/events/landExpansion/sellBounty";
+import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
 import { Button } from "components/ui/Button";
 import confetti from "canvas-confetti";
 import flowerIcon from "assets/icons/flower_token.webp";
@@ -666,6 +674,9 @@ const Deal: React.FC<{
     game: state,
     bounty,
   });
+  const ticketBoostsUsed = getBountyTicketBoosts({ game: state, bounty, now });
+  const [showTicketBoosts, setShowTicketBoosts] = useState(false);
+  const ticketBoostsAnchorRef = useRef<HTMLDivElement>(null);
 
   return (
     <InnerPanel className="shadow">
@@ -720,9 +731,10 @@ const Deal: React.FC<{
                   />
                 </div>
                 {getKeys(bounty.items ?? {}).map((name) => {
-                  return (
+                  const isChapterTicket = name === getChapterTicket(now);
+
+                  const label = (
                     <Label
-                      key={`${name}-${bounty.id}-reward-label`}
                       type={isSold ? "success" : "warning"}
                       icon={ITEM_DETAILS[name].image}
                       secondaryIcon={
@@ -730,14 +742,47 @@ const Deal: React.FC<{
                       }
                     >
                       {`Reward: ${
-                        name !== getChapterTicket(now)
-                          ? bounty.items?.[name]
-                          : generateBountyTicket({
+                        isChapterTicket
+                          ? generateBountyTicket({
                               game: state,
                               bounty,
                             })
+                          : bounty.items?.[name]
                       } ${name}s`}
                     </Label>
+                  );
+
+                  if (!isChapterTicket || ticketBoostsUsed.length === 0) {
+                    return (
+                      <div key={`${name}-${bounty.id}-reward-label`}>
+                        {label}
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <div
+                      key={`${name}-${bounty.id}-reward-label`}
+                      ref={ticketBoostsAnchorRef}
+                      className="relative cursor-pointer"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowTicketBoosts((prev) => !prev);
+                      }}
+                    >
+                      {label}
+                      {showTicketBoosts && (
+                        <BoostsDisplay
+                          boosts={ticketBoostsUsed}
+                          show={showTicketBoosts}
+                          state={state}
+                          onClick={() => setShowTicketBoosts(false)}
+                          anchorRef={ticketBoostsAnchorRef}
+                          portalAlign="right"
+                          portalPlacement="auto"
+                        />
+                      )}
+                    </div>
                   );
                 })}
                 {!!tickets && (

--- a/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
+++ b/src/features/world/ui/flowerShop/MegaBountyBoard.tsx
@@ -673,6 +673,7 @@ const Deal: React.FC<{
   const tickets = generateBountyTicket({
     game: state,
     bounty,
+    now,
   });
   const ticketBoostsUsed = getBountyTicketBoosts({ game: state, bounty, now });
   const [showTicketBoosts, setShowTicketBoosts] = useState(false);
@@ -742,12 +743,7 @@ const Deal: React.FC<{
                       }
                     >
                       {`Reward: ${
-                        isChapterTicket
-                          ? generateBountyTicket({
-                              game: state,
-                              bounty,
-                            })
-                          : bounty.items?.[name]
+                        isChapterTicket ? tickets : bounty.items?.[name]
                       } ${name}s`}
                     </Label>
                   );
@@ -765,7 +761,16 @@ const Deal: React.FC<{
                       key={`${name}-${bounty.id}-reward-label`}
                       ref={ticketBoostsAnchorRef}
                       className="relative cursor-pointer"
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={showTicketBoosts}
                       onClick={(e) => {
+                        e.stopPropagation();
+                        setShowTicketBoosts((prev) => !prev);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key !== "Enter" && e.key !== " ") return;
+                        e.preventDefault();
                         e.stopPropagation();
                         setShowTicketBoosts((prev) => !prev);
                       }}


### PR DESCRIPTION

<img width="476" height="563" alt="image" src="https://github.com/user-attachments/assets/e61c5e1c-156f-49ff-a92d-281bee5b4e9b" />
<img width="838" height="526" alt="image" src="https://github.com/user-attachments/assets/85dbc7d0-595d-4a10-9e2d-4ce03d4d2389" />



## Summary
- Chapter-ticket rewards from deliveries, chores, and bounties can be boosted by VIP Access and seasonal wearables/collectibles (`CHAPTER_TICKET_BOOST_ITEMS`), but the boost breakdown was either silently discarded by the UI or never computed at all — players saw a higher ticket count with no way to see why.
- `generateDeliveryTickets` already returned `boostsUsed`; wired it into the two UI spots that were discarding it (`BumpkinDelivery.tsx`, `Orders.tsx`).
- `generateChoreRewards` didn't track boosts at all — extended it the same way (`{ items, boostsUsed }`), updating its two call sites (`completeNPCChore.ts`, `ChoreBoard.tsx`).
- `generateBountyTicket` has 17 call sites relying on its plain-number return, so rather than changing its signature, added a sibling `getBountyTicketBoosts` that mirrors its boost logic for display only (`sellBounty.ts`, `MegaBountyBoard.tsx`).
- All three surfaces wire into the existing `BoostsDisplay` popup via `anchorRef` — the portal-based positioning already used by `CraftingRequirements.tsx` — which also fixes the popup clipping/mispositioning inside scrollable Codex panels.
- `AnimatedPanel`'s backdrop only handled `onClick`, which mobile Safari can drop for a non-interactive `div` (only the trigger itself could close the popup on mobile). Added `onTouchEnd` + `cursor-pointer`, matching the pattern already used in `Modal.tsx`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] Full `jest` suite passes (328 suites, 4943 tests)
- [x] Verified locally: delivery ticket reward, chore ticket reward, and bounty ticket reward all show a clickable boost breakdown (VIP Access, seasonal wearables) when boosts are active, with no regression when there are none
- [x] Verified the popup no longer clips inside the Codex panel and closes on backdrop click on both desktop and mobile viewport emulation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added visibility into boosts applied to chore, delivery, bounty, and ticket rewards.
  * Reward indicators can be selected to open a details popover showing boost names and values.
  * Chapter-ticket boosts are now reflected across relevant reward displays.
  * Boost details can also be opened using keyboard controls for improved accessibility.

* **Bug Fixes**
  * Improved touch interactions when dismissing panels by tapping the backdrop.
  * Preserved existing reward amounts while displaying applied boost information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->