### PR TITLE
[Feat] Show animal production and boost breakdown

### DIFF
--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -58,11 +58,11 @@ const ProductionResource: React.FC<{
         alt={resource}
         className="w-5 mr-1"
       />
-      <span className="text-xs whitespace-nowrap">{resource}</span>
-      <span aria-hidden="true" className="mx-1 text-xs">
+      <span className="text-sm whitespace-nowrap">{resource}</span>
+      <span aria-hidden="true" className="mx-1 text-sm">
         ×
       </span>
-      <span className="text-xs whitespace-nowrap">{formatNumber(amount)}</span>
+      <span className="text-sm whitespace-nowrap">{formatNumber(amount)}</span>
       {hasBoosts && (
         <img
           src={SUNNYSIDE.icons.lightning}

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -242,6 +242,9 @@ export const SleepingAnimalModal = ({
               alt={t("sleepingAnimal.production")}
               className="w-6 mr-2 shrink-0"
             />
+            <span aria-hidden="true" className="mr-2 text-sm">
+              {":"}
+            </span>
             <div className="flex flex-nowrap items-center gap-x-3 whitespace-nowrap">
               {production.map(({ resource, amount, boostsUsed }) => (
                 <ProductionResource

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -240,7 +240,7 @@ export const SleepingAnimalModal = ({
             <img
               src={SUNNYSIDE.icons.basket}
               alt={t("sleepingAnimal.production")}
-              className="w-6 mr-2 shrink-0"
+              className="w-6 mr-0 shrink-0"
             />
             <span aria-hidden="true" className="mr-2 text-sm">
               {":"}

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -61,7 +61,7 @@ const ProductionResource: React.FC<{
       />
       <span className="text-sm whitespace-nowrap">{resource}</span>
       <span aria-hidden="true" className="mx-1 text-sm">
-        ×
+        {"×"}
       </span>
       <span className="text-sm whitespace-nowrap">{formatNumber(amount)}</span>
       {hasBoosts && (

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -59,7 +59,9 @@ const ProductionResource: React.FC<{
         className="w-5 mr-1"
       />
       <span className="text-xs whitespace-nowrap">{resource}</span>
-      <img src={SUNNYSIDE.icons.x} alt="times" className="w-3 mx-1" />
+      <span aria-hidden="true" className="mx-1 text-xs">
+        ×
+      </span>
       <span className="text-xs whitespace-nowrap">{formatNumber(amount)}</span>
       {hasBoosts && (
         <img

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -237,9 +237,11 @@ export const SleepingAnimalModal = ({
             className="flex text-sm p-1 items-center"
             aria-label={t("sleepingAnimal.production")}
           >
-            <span className="mr-2 whitespace-nowrap">
-              {t("sleepingAnimal.production")}
-            </span>
+            <img
+              src={SUNNYSIDE.icons.basket}
+              alt={t("sleepingAnimal.production")}
+              className="w-6 mr-2 shrink-0"
+            />
             <div className="flex flex-nowrap items-center gap-x-3 whitespace-nowrap">
               {production.map(({ resource, amount, boostsUsed }) => (
                 <ProductionResource

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -46,8 +46,9 @@ const ProductionResource: React.FC<{
   amount: number;
   boosts: { name: BoostName; value: string }[];
   state: GameState;
-}> = ({ resource, amount, boosts, state }) => {
-  const [showBoosts, setShowBoosts] = useState(false);
+  showBoosts: boolean;
+  onToggle: () => void;
+}> = ({ resource, amount, boosts, state, showBoosts, onToggle }) => {
   const anchorRef = useRef<HTMLButtonElement>(null);
   const hasBoosts = boosts.length > 0;
 
@@ -87,14 +88,14 @@ const ProductionResource: React.FC<{
       type="button"
       className="relative flex items-center py-0.5 cursor-pointer whitespace-nowrap"
       aria-expanded={showBoosts}
-      onClick={() => setShowBoosts((show) => !show)}
+      onClick={onToggle}
     >
       {content}
       <BoostsDisplay
         boosts={boosts}
         show={showBoosts}
         state={state}
-        onClick={() => setShowBoosts((show) => !show)}
+        onClick={onToggle}
         anchorRef={anchorRef}
         portalAlign="center"
       />
@@ -117,6 +118,8 @@ export const SleepingAnimalModal = ({
 }: Props) => {
   const { gameService } = useContext(Context);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [activeProductionResource, setActiveProductionResource] =
+    useState<AnimalResource | null>(null);
   const { t } = useAppTranslation();
   const { totalSeconds: secondsLeft } = useCountdown(awakeAt);
   const { totalSeconds: secondsUntilLove } = useCountdown(
@@ -241,6 +244,12 @@ export const SleepingAnimalModal = ({
                   amount={amount}
                   boosts={boostsUsed}
                   state={state}
+                  showBoosts={activeProductionResource === resource}
+                  onToggle={() =>
+                    setActiveProductionResource((active) =>
+                      active === resource ? null : resource,
+                    )
+                  }
                 />
               ))}
             </div>

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -240,7 +240,7 @@ export const SleepingAnimalModal = ({
             <img
               src={SUNNYSIDE.icons.basket}
               alt={t("sleepingAnimal.production")}
-              className="w-6 mr-0 shrink-0"
+              className="w-6 mr-1 shrink-0"
             />
             <span aria-hidden="true" className="mr-2 text-sm">
               {":"}

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -49,6 +49,7 @@ const ProductionResource: React.FC<{
   showBoosts: boolean;
   onToggle: () => void;
 }> = ({ resource, amount, boosts, state, showBoosts, onToggle }) => {
+  const { t } = useAppTranslation();
   const anchorRef = useRef<HTMLButtonElement>(null);
   const hasBoosts = boosts.length > 0;
 
@@ -67,7 +68,7 @@ const ProductionResource: React.FC<{
       {hasBoosts && (
         <img
           src={SUNNYSIDE.icons.lightning}
-          alt="Boosted"
+          alt={t("cropMachine.boosted")}
           className="w-3 ml-1"
         />
       )}

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 
 import { Box } from "components/ui/Box";
 import { Button } from "components/ui/Button";
@@ -12,13 +12,23 @@ import { InnerPanel } from "components/ui/Panel";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { Context } from "features/game/GameProvider";
 import { getAnimalToy } from "features/game/events/landExpansion/wakeUpAnimal";
-import type { Animal } from "features/game/types/game";
+import type {
+  Animal,
+  AnimalResource,
+  BoostName,
+  GameState,
+} from "features/game/types/game";
 import {
   getAnimalFavoriteFood,
   getAnimalLevel,
+  getResourceDropAmount,
   isMaxLevel as isMaxAnimalLevel,
 } from "features/game/lib/animals";
-import { ANIMAL_LEVELS, type AnimalLevel } from "features/game/types/animals";
+import {
+  ANIMAL_LEVELS,
+  ANIMAL_RESOURCE_DROP,
+  type AnimalLevel,
+} from "features/game/types/animals";
 import {
   getAnimalXP,
   getNextLoveAvailableAt,
@@ -28,6 +38,67 @@ import { useSelector } from "@xstate/react";
 import { SparkleBurst } from "features/farming/animals/components/MutantSparkles";
 import { useCountdown } from "lib/utils/hooks/useCountdown";
 import { isAnimalCoveredByGoldenAsset } from "features/game/events/landExpansion/feedAllAnimals";
+import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
+import { formatNumber } from "lib/utils/formatNumber";
+
+const ProductionResource: React.FC<{
+  resource: AnimalResource;
+  amount: number;
+  boosts: { name: BoostName; value: string }[];
+  state: GameState;
+}> = ({ resource, amount, boosts, state }) => {
+  const [showBoosts, setShowBoosts] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const hasBoosts = boosts.length > 0;
+
+  const content = (
+    <>
+      <img
+        src={ITEM_DETAILS[resource].image}
+        alt={resource}
+        className="w-5 mr-1"
+      />
+      <span className="text-xs whitespace-nowrap">{resource}</span>
+      <img src={SUNNYSIDE.icons.x} alt="times" className="w-3 mx-1" />
+      <span className="text-xs whitespace-nowrap">{formatNumber(amount)}</span>
+      {hasBoosts && (
+        <img
+          src={SUNNYSIDE.icons.lightning}
+          alt="Boosted"
+          className="w-3 ml-1"
+        />
+      )}
+    </>
+  );
+
+  if (!hasBoosts) {
+    return (
+      <div className="flex items-center py-0.5 whitespace-nowrap">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      ref={anchorRef}
+      type="button"
+      className="relative flex items-center py-0.5 cursor-pointer whitespace-nowrap"
+      aria-expanded={showBoosts}
+      onClick={() => setShowBoosts((show) => !show)}
+    >
+      {content}
+      <BoostsDisplay
+        boosts={boosts}
+        show={showBoosts}
+        state={state}
+        onClick={() => setShowBoosts((show) => !show)}
+        anchorRef={anchorRef}
+        portalAlign="center"
+      />
+    </button>
+  );
+};
 
 interface Props {
   onClose: () => void;
@@ -101,6 +172,24 @@ export const SleepingAnimalModal = ({
 
   const level = getAnimalLevel(animal.experience, animal.type);
   const isMaxLevel = isMaxAnimalLevel(animal.type, level);
+  const production = Object.entries(
+    ANIMAL_RESOURCE_DROP[animal.type][level],
+  ).map(([resource, baseAmount]) => {
+    const result = getResourceDropAmount({
+      game: state,
+      animalType: animal.type,
+      resource: resource as AnimalResource,
+      baseAmount: baseAmount.toNumber(),
+      multiplier: animal.multiplier ?? 0,
+      animal,
+    });
+
+    return {
+      resource: resource as AnimalResource,
+      baseAmount: baseAmount.toNumber(),
+      ...result,
+    };
+  });
 
   const xpToNext = isMaxLevel
     ? (() => {
@@ -137,6 +226,24 @@ export const SleepingAnimalModal = ({
             {`${t("wakesIn")} ${secondsToString(secondsLeft, { length: "medium" })}`}
           </span>
         </div>
+        {production.length > 0 && (
+          <div
+            className="flex text-sm p-1 items-center"
+            aria-label={t("sleepingAnimal.production")}
+          >
+            <div className="flex flex-nowrap items-center gap-x-3 whitespace-nowrap">
+              {production.map(({ resource, amount, boostsUsed }) => (
+                <ProductionResource
+                  key={resource}
+                  resource={resource}
+                  amount={amount}
+                  boosts={boostsUsed}
+                  state={state}
+                />
+              ))}
+            </div>
+          </div>
+        )}
         {/* XP progress */}
         <div className="flex text-sm p-1 items-center">
           <img src={SUNNYSIDE.icons.lightning} alt="XP" className="w-6 mr-2" />

--- a/src/features/barn/components/SleepingAnimalModal.tsx
+++ b/src/features/barn/components/SleepingAnimalModal.tsx
@@ -236,6 +236,9 @@ export const SleepingAnimalModal = ({
             className="flex text-sm p-1 items-center"
             aria-label={t("sleepingAnimal.production")}
           >
+            <span className="mr-2 whitespace-nowrap">
+              {t("sleepingAnimal.production")}
+            </span>
             <div className="flex flex-nowrap items-center gap-x-3 whitespace-nowrap">
               {production.map(({ resource, amount, boostsUsed }) => (
                 <ProductionResource

--- a/src/features/game/lib/animals.test.ts
+++ b/src/features/game/lib/animals.test.ts
@@ -239,6 +239,20 @@ describe("Animals skill ranks", () => {
     expect(amount).toEqual(1.58);
   });
 
+  it("attributes an animal critical drop multiplier to Buckaroo", () => {
+    const { amount, boostsUsed } = getResourceDropAmount({
+      game: withSkills({ Buckaroo: 1 }),
+      animalType: "Cow",
+      resource: "Milk",
+      baseAmount: 1,
+      multiplier: 2,
+      animal: { ...ANIMAL, type: "Cow" },
+    });
+
+    expect(amount).toEqual(2);
+    expect(boostsUsed).toContainEqual({ name: "Buckaroo", value: "x2" });
+  });
+
   describe("Featherweight", () => {
     it.each([
       [1, 0.35],

--- a/src/features/game/lib/animals.ts
+++ b/src/features/game/lib/animals.ts
@@ -527,7 +527,12 @@ export function getResourceDropAmount({
   if (budUsed)
     boostsUsed.push({ name: budUsed, value: `+${yieldBoost.toString()}` });
 
-  if (multiplier) amount = amount.mul(multiplier);
+  if (multiplier) {
+    amount = amount.mul(multiplier);
+    if (multiplier !== 1) {
+      boostsUsed.push({ name: "Buckaroo", value: `x${multiplier}` });
+    }
+  }
 
   if (animal.feedBuff?.name === "Salt Lick") {
     amount = amount.mul(1.05);

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -2056,6 +2056,7 @@ export type BoostName =
 
 export type SpecialBoostName =
   | `${SeasonalEventName}`
+  | "Buckaroo"
   | "Power hour"
   | "VIP Access"
   | "Faction Pet"

--- a/src/features/world/ui/AnimatedPanel.tsx
+++ b/src/features/world/ui/AnimatedPanel.tsx
@@ -23,7 +23,10 @@ export const AnimatedPanel: React.FC<PropsWithChildren<Props>> = ({
       {onBackdropClick && show && (
         <div
           className="fixed inset-0 z-30"
-          onClick={onBackdropClick}
+          onClick={(event) => {
+            event.stopPropagation();
+            onBackdropClick();
+          }}
           aria-hidden="true"
         />
       )}

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -6574,6 +6574,7 @@
   "sleepingAnimal.xp": "XP: {{experience}}",
   "sleepingAnimal.xpToNextLevel": "+{{xpToNext}} to Lvl {{level}}",
   "sleepingAnimal.xpToNextCycle": "+{{xpToNext}} XP to next cycle",
+  "sleepingAnimal.production": "Production:",
   "description.bonusBracelet.boost": "+1 Bracelet",
   "description.architectRuler.boost": "x0.75 Crafting Box Time",
   "description.reelmastersChair.boost": "+5 daily fishing reels",


### PR DESCRIPTION
<img width="503" height="457" alt="image" src="https://github.com/user-attachments/assets/1b1f0c3a-13b4-49bb-ad29-b026bf1463be" />

<img width="346" height="219" alt="image" src="https://github.com/user-attachments/assets/c07ad9ac-a3d5-45a7-a211-119948dbe0e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sleeping animals now show their expected production resources and quantities.
  * Production amounts reflect applicable animal bonuses.
  * Added an expandable view displaying production boosts, including Buckaroo effects.

* **Bug Fixes**
  * Animal resource drops now correctly record and display Buckaroo multiplier effects.

* **Tests**
  * Added coverage confirming Buckaroo doubles a cow’s Milk production and appears as the applied boost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->