### PR TITLE
[CHORE] Adjust trading limits for some smaller crops

### DIFF
--- a/src/features/game/actions/tradeLimits.ts
+++ b/src/features/game/actions/tradeLimits.ts
@@ -49,12 +49,12 @@ export type TradeResource = Extract<
 
 export const TRADE_LIMITS: Record<TradeResource, number> = {
   // Crops
-  Sunflower: 4000,
-  Potato: 3000,
-  Rhubarb: 2000,
-  Pumpkin: 2000,
-  Zucchini: 2000,
-  Carrot: 2000,
+  Sunflower: 10000,
+  Potato: 10000,
+  Rhubarb: 10000,
+  Pumpkin: 4000,
+  Zucchini: 4000,
+  Carrot: 4000,
   Yam: 2000,
   Cabbage: 2000,
   Broccoli: 2000,


### PR DESCRIPTION
The trading limit for some of these smaller crops have a max "stack" valued at less than 1 FLOWER.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased trading limits for Sunflower, Potato, and Rhubarb to 10,000 trades.
  * Increased trading limits for Pumpkin, Zucchini, and Carrot to 4,000 trades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->