### PR TITLE
[FEAT] Make Treasure Shop accessible in the digging area

### DIFF
--- a/src/features/world/scenes/BeachScene.ts
+++ b/src/features/world/scenes/BeachScene.ts
@@ -85,6 +85,7 @@ export class BeachScene extends BaseScene {
   digSoundsCooldown = false;
   sandHole?: Phaser.GameObjects.Image;
   digbyAlertSprite: Phaser.GameObjects.Sprite | undefined;
+  treasureShopIcon?: Phaser.GameObjects.Sprite | undefined;
 
   constructor() {
     super({ name: "beach", map: { json: mapJSON } });
@@ -280,23 +281,8 @@ export class BeachScene extends BaseScene {
       hank.play("hank_anim", true);
     }
 
-    const treasureShop = this.add.sprite(464, 194, "treasure_shop");
-    this.physics.world.enable(treasureShop);
-    this.colliders?.add(treasureShop);
-    this.triggerColliders?.add(treasureShop);
-    (treasureShop.body as Phaser.Physics.Arcade.Body)
-      .setSize(69, 50)
-      .setOffset(0, 0)
-      .setImmovable(true)
-      .setCollideWorldBounds(true);
-    this.add.sprite(464, 174, "shop_icon");
-    treasureShop.setInteractive({ cursor: "pointer" }).on("pointerdown", () => {
-      if (this.checkDistanceToSprite(treasureShop, 75)) {
-        npcModalManager.open("jafar");
-      } else {
-        this.currentPlayer?.speak(translateForBubble("base.iam.far.away"));
-      }
-    });
+    // Main treasure shop
+    this.treasureShop(464, 194, "treasure_shop", true, 1);
 
     const beachBud2 = this.add.sprite(348, 397, "beach_bud_2");
     // turtle.setScale(-1, 1);
@@ -430,6 +416,37 @@ export class BeachScene extends BaseScene {
     this.currentSelectedItem = this.selectedItem;
 
     this.setupPopups();
+  }
+
+  private treasureShop(
+    x: number,
+    y: number,
+    icon: string,
+    physics: boolean,
+    scale: number,
+  ) {
+    const treasureShop = this.add.sprite(x, y, icon);
+    treasureShop.setScale(scale);
+    if (physics) {
+      this.physics.world.enable(treasureShop);
+      this.colliders?.add(treasureShop);
+      this.triggerColliders?.add(treasureShop);
+      (treasureShop.body as Phaser.Physics.Arcade.Body)
+        .setSize(69, 50)
+        .setOffset(0, 0)
+        .setImmovable(true)
+        .setCollideWorldBounds(true);
+    }
+    this.add.sprite(464, 174, "shop_icon");
+    treasureShop.setInteractive({ cursor: "pointer" }).on("pointerdown", () => {
+      if (this.checkDistanceToSprite(treasureShop, 75)) {
+        npcModalManager.open("jafar");
+      } else {
+        this.currentPlayer?.speak(translateForBubble("base.iam.far.away"));
+      }
+    });
+
+    return treasureShop;
   }
 
   setupPopups = () => {
@@ -821,6 +838,7 @@ export class BeachScene extends BaseScene {
       (this.selectedItem === "Sand Drill" && sandDrillsCount > 0) ||
       (this.selectedItem === "Sand Shovel" && sandShovelsCount > 0) ||
       this.isAncientShovelActive;
+    this.hideTreasureShopIcon();
 
     if (!hasTool || !this.hasDigsLeft) {
       if (!hasDugHere) {
@@ -1375,6 +1393,15 @@ export class BeachScene extends BaseScene {
   public handleDigbyWarnings = () => {
     if (!this.currentPlayer) return;
 
+    const body = this.currentPlayer.body as
+      | Phaser.Physics.Arcade.Body
+      | undefined;
+    const isMoving = !!body && (body.velocity.x !== 0 || body.velocity.y !== 0);
+
+    if (isMoving) {
+      this.hideTreasureShopIcon();
+    }
+
     if (this.percentageTreasuresFound >= 100 && !this.hasClaimedStreakReward) {
       if (this.alreadyNotifiedOfClaim) return;
 
@@ -1405,7 +1432,12 @@ export class BeachScene extends BaseScene {
       !this.isAncientShovelActive
     ) {
       this.npcs.digby?.speak(translateForBubble("digby.noShovels"));
-
+      if (!isMoving) {
+        this.showTreasureShopIcon(
+          this.currentPlayer.x,
+          this.currentPlayer.y - 18,
+        );
+      }
       return;
     }
 
@@ -1414,6 +1446,29 @@ export class BeachScene extends BaseScene {
 
       return;
     }
+  };
+
+  private showTreasureShopIcon = (x: number, y: number) => {
+    const roundedX = Math.round(x);
+    const roundedY = Math.round(y);
+
+    if (!this.treasureShopIcon) {
+      this.treasureShopIcon = this.treasureShop(
+        roundedX,
+        roundedY,
+        "shop_icon",
+        false,
+        0.7,
+      );
+    } else {
+      this.treasureShopIcon.setPosition(roundedX, roundedY);
+      this.treasureShopIcon.setVisible(true);
+    }
+  };
+
+  private hideTreasureShopIcon = () => {
+    this.treasureShopIcon?.destroy();
+    this.treasureShopIcon = undefined;
   };
 
   public handleActionSFX = () => {
@@ -1672,6 +1727,7 @@ export class BeachScene extends BaseScene {
       // this.noToolHoverBox?.setVisible(false);
       this.alreadyWarnedOfNoDigs = false;
       this.alreadyNotifiedOfClaim = false;
+      this.hideTreasureShopIcon();
       super.update();
     }
 


### PR DESCRIPTION
# Pull request description
Makes the Treasure Shop accessible directly from the digging area when the player runs out of Sand Shovels.

Replace the placeholders below. Delete sections that do not apply (e.g. no UI → remove Screenshots).

## Summary
Makes the Treasure Shop accessible from the digging area when the player runs out of Sand Shovels. The shop icon appears above the player when they stop moving.

What does this PR do in one short paragraph? Mention the user-facing outcome or the bug fixed.

## Context / motivation
Players can now access the Treasure Shop without needing to leave the digging area when they don't have the required digging tool.

Why is this change needed? Link to design docs, Slack threads, or prior discussion if helpful.

## How to test

Numbered steps a reviewer can follow. Include seed data, feature flags, or environment notes if needed.

1. Enter the digging area.
2. Run out of Sand Shovels.
3. Verify that the Treasure Shop icon appears above the player when stop moving.
4. Click the icon and verify that the Treasure Shop opens.
5. Move the player or leave the digging area and verify that the shop icon disappears.

## Screenshots or screen recording

https://github.com/user-attachments/assets/86bc82f0-7ea2-48d2-9259-be71239106d8

Required for any visual or UX change. For pure logic/backend PRs, write "N/A" or delete this section.

## Related issues
N/A

Use one line per issue. Remove if none.

Fixes #
Related #

---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual treasure-shop indicator near the player when shovels are unavailable.
  * The indicator appears only in the appropriate digging area and remains hidden during movement or when digging is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->