### PR TITLE
[FIX] Preserve local Pet House/project help progress after visit effects

### DIFF
--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -84,6 +84,7 @@ import {
 } from "../actions/sellMarketResource";
 import { setCachedMarketPrices } from "features/world/ui/market/lib/marketCache";
 import { OFFLINE_FARM } from "./landData";
+import { mergeLocalVisitProgress } from "./mergeLocalVisitProgress";
 import { isValidRedirect } from "features/portal/lib/portalUtil";
 import {
   type Effect,
@@ -755,7 +756,10 @@ const VISIT_EFFECT_STATES = Object.values(STATE_MACHINE_VISIT_EFFECTS).reduce(
           const { visitedFarmState, ...rest } = data;
 
           return {
-            state: makeGame(visitedFarmState),
+            state: mergeLocalVisitProgress(
+              makeGame(visitedFarmState),
+              context.state,
+            ),
             data: rest,
             visitorState: gameState,
           };

--- a/src/features/game/lib/mergeLocalVisitProgress.test.ts
+++ b/src/features/game/lib/mergeLocalVisitProgress.test.ts
@@ -1,0 +1,150 @@
+import { INITIAL_FARM } from "./constants";
+import type { GameState } from "../types/game";
+import type { PetName } from "../types/pets";
+import { mergeLocalVisitProgress } from "./mergeLocalVisitProgress";
+
+const basePet = {
+  experience: 0,
+  energy: 0,
+  pettedAt: 0,
+  requests: { food: [], fedAt: 0 },
+};
+
+describe("mergeLocalVisitProgress", () => {
+  it("carries over a pet's local visitedAt when the fresh snapshot has none", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" as PetName, visitedAt: 123 },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" as PetName },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(merged.pets?.common?.Barkley?.visitedAt).toEqual(123);
+  });
+
+  it("does not overwrite a fresh visitedAt with an older/missing local one", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" as PetName },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" as PetName, visitedAt: 456 },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(merged.pets?.common?.Barkley?.visitedAt).toEqual(456);
+  });
+
+  it("carries over NFT pet visitedAt", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        nfts: {
+          1: {
+            ...basePet,
+            id: 1,
+            name: "Pet #1",
+            coordinates: { x: 0, y: 0 },
+            location: "petHouse",
+            visitedAt: 789,
+          },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        nfts: {
+          1: {
+            ...basePet,
+            id: 1,
+            name: "Pet #1",
+            coordinates: { x: 0, y: 0 },
+            location: "petHouse",
+          },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(merged.pets?.nfts?.[1]?.visitedAt).toEqual(789);
+  });
+
+  it("carries over a village project's local helpedAt", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      socialFarming: {
+        ...INITIAL_FARM.socialFarming,
+        villageProjects: {
+          "Farmer's Monument": { cheers: 3, helpedAt: 111 },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      socialFarming: {
+        ...INITIAL_FARM.socialFarming,
+        villageProjects: {
+          "Farmer's Monument": { cheers: 2 },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(
+      merged.socialFarming.villageProjects["Farmer's Monument"]?.helpedAt,
+    ).toEqual(111);
+    // Fresh cheers count (from server) is preserved, not overwritten.
+    expect(
+      merged.socialFarming.villageProjects["Farmer's Monument"]?.cheers,
+    ).toEqual(2);
+  });
+
+  it("leaves pets untouched when there is no local progress to merge", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      pets: { common: {} },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          Barkley: { ...basePet, name: "Barkley" as PetName },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(merged.pets?.common?.Barkley?.visitedAt).toBeUndefined();
+  });
+});

--- a/src/features/game/lib/mergeLocalVisitProgress.test.ts
+++ b/src/features/game/lib/mergeLocalVisitProgress.test.ts
@@ -35,7 +35,7 @@ describe("mergeLocalVisitProgress", () => {
     expect(merged.pets?.common?.Barkley?.visitedAt).toEqual(123);
   });
 
-  it("does not overwrite a fresh visitedAt with an older/missing local one", () => {
+  it("does not overwrite a fresh visitedAt with a missing local one", () => {
     const localState: GameState = {
       ...INITIAL_FARM,
       pets: {
@@ -57,6 +57,33 @@ describe("mergeLocalVisitProgress", () => {
     const merged = mergeLocalVisitProgress(freshState, localState);
 
     expect(merged.pets?.common?.Barkley?.visitedAt).toEqual(456);
+  });
+
+  it("does not regress a fresher server visitedAt with an older local one", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          // Stale local progress from before the visitor's session started.
+          Barkley: { ...basePet, name: "Barkley" as PetName, visitedAt: 100 },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      pets: {
+        common: {
+          // Server has a newer help record (e.g. help recorded through
+          // another client) than the local one.
+          Barkley: { ...basePet, name: "Barkley" as PetName, visitedAt: 999 },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(merged.pets?.common?.Barkley?.visitedAt).toEqual(999);
   });
 
   it("carries over NFT pet visitedAt", () => {
@@ -126,6 +153,34 @@ describe("mergeLocalVisitProgress", () => {
     expect(
       merged.socialFarming.villageProjects["Farmer's Monument"]?.cheers,
     ).toEqual(2);
+  });
+
+  it("does not regress a fresher server helpedAt with an older local one", () => {
+    const localState: GameState = {
+      ...INITIAL_FARM,
+      socialFarming: {
+        ...INITIAL_FARM.socialFarming,
+        villageProjects: {
+          "Farmer's Monument": { cheers: 1, helpedAt: 100 },
+        },
+      },
+    };
+
+    const freshState: GameState = {
+      ...INITIAL_FARM,
+      socialFarming: {
+        ...INITIAL_FARM.socialFarming,
+        villageProjects: {
+          "Farmer's Monument": { cheers: 4, helpedAt: 999 },
+        },
+      },
+    };
+
+    const merged = mergeLocalVisitProgress(freshState, localState);
+
+    expect(
+      merged.socialFarming.villageProjects["Farmer's Monument"]?.helpedAt,
+    ).toEqual(999);
   });
 
   it("leaves pets untouched when there is no local progress to merge", () => {

--- a/src/features/game/lib/mergeLocalVisitProgress.ts
+++ b/src/features/game/lib/mergeLocalVisitProgress.ts
@@ -16,6 +16,21 @@ import type { GameState } from "../types/game";
  * of the Pet House help, so its "needs help" badge reappears and clicking
  * it again re-attempts to help instead of entering.
  */
+/**
+ * Returns whichever timestamp is later, treating a missing one as "never".
+ * Keeping the later value (rather than always preferring local) means a
+ * fresher server-side update - e.g. help recorded through another client -
+ * is never regressed by an older local timestamp.
+ */
+function latestTimestamp(
+  a: number | undefined,
+  b: number | undefined,
+): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
 export function mergeLocalVisitProgress(
   freshState: GameState,
   localState: GameState,
@@ -24,9 +39,10 @@ export function mergeLocalVisitProgress(
   getKeys(localState.pets?.common ?? {}).forEach((name) => {
     const freshPet = mergedCommonPets[name];
     const localVisitedAt = localState.pets?.common?.[name]?.visitedAt;
+    const merged = latestTimestamp(freshPet?.visitedAt, localVisitedAt);
 
-    if (freshPet && localVisitedAt) {
-      mergedCommonPets[name] = { ...freshPet, visitedAt: localVisitedAt };
+    if (freshPet && merged !== undefined) {
+      mergedCommonPets[name] = { ...freshPet, visitedAt: merged };
     }
   });
 
@@ -34,9 +50,10 @@ export function mergeLocalVisitProgress(
   getKeys(localState.pets?.nfts ?? {}).forEach((id) => {
     const freshPet = mergedNftPets[id];
     const localVisitedAt = localState.pets?.nfts?.[id]?.visitedAt;
+    const merged = latestTimestamp(freshPet?.visitedAt, localVisitedAt);
 
-    if (freshPet && localVisitedAt) {
-      mergedNftPets[id] = { ...freshPet, visitedAt: localVisitedAt };
+    if (freshPet && merged !== undefined) {
+      mergedNftPets[id] = { ...freshPet, visitedAt: merged };
     }
   });
 
@@ -45,11 +62,12 @@ export function mergeLocalVisitProgress(
     const freshProject = mergedVillageProjects[name];
     const localHelpedAt =
       localState.socialFarming.villageProjects[name]?.helpedAt;
+    const merged = latestTimestamp(freshProject?.helpedAt, localHelpedAt);
 
-    if (freshProject && localHelpedAt) {
+    if (freshProject && merged !== undefined) {
       mergedVillageProjects[name] = {
         ...freshProject,
-        helpedAt: localHelpedAt,
+        helpedAt: merged,
       };
     }
   });

--- a/src/features/game/lib/mergeLocalVisitProgress.ts
+++ b/src/features/game/lib/mergeLocalVisitProgress.ts
@@ -1,0 +1,65 @@
+import { getKeys } from "lib/object";
+import type { GameState } from "../types/game";
+
+/**
+ * LOCAL_VISITING_EVENTS (e.g. pet.helpAllPetsInHouse, project.helped)
+ * mutate the visited farm's state on the client only - they're deliberately
+ * excluded from `context.actions` so they never reach the backend (see the
+ * actions filter in playingEventHandler in gameMachine.ts).
+ *
+ * When a visit *effect* (farm.helped/farm.cheered) later completes, the
+ * backend returns its own fresh snapshot of the visited farm and that
+ * fully replaces `context.state`. Without this merge, that overwrite wipes
+ * out any local-only help progress made just before the effect fired -
+ * e.g. a visitor helps the Pet House, then closes the "Helped" popup
+ * (which fires the farm.helped effect); the fresh snapshot has no record
+ * of the Pet House help, so its "needs help" badge reappears and clicking
+ * it again re-attempts to help instead of entering.
+ */
+export function mergeLocalVisitProgress(
+  freshState: GameState,
+  localState: GameState,
+): GameState {
+  const mergedCommonPets = { ...freshState.pets?.common };
+  getKeys(localState.pets?.common ?? {}).forEach((name) => {
+    const freshPet = mergedCommonPets[name];
+    const localVisitedAt = localState.pets?.common?.[name]?.visitedAt;
+
+    if (freshPet && localVisitedAt) {
+      mergedCommonPets[name] = { ...freshPet, visitedAt: localVisitedAt };
+    }
+  });
+
+  const mergedNftPets = { ...freshState.pets?.nfts };
+  getKeys(localState.pets?.nfts ?? {}).forEach((id) => {
+    const freshPet = mergedNftPets[id];
+    const localVisitedAt = localState.pets?.nfts?.[id]?.visitedAt;
+
+    if (freshPet && localVisitedAt) {
+      mergedNftPets[id] = { ...freshPet, visitedAt: localVisitedAt };
+    }
+  });
+
+  const mergedVillageProjects = { ...freshState.socialFarming.villageProjects };
+  getKeys(localState.socialFarming.villageProjects).forEach((name) => {
+    const freshProject = mergedVillageProjects[name];
+    const localHelpedAt =
+      localState.socialFarming.villageProjects[name]?.helpedAt;
+
+    if (freshProject && localHelpedAt) {
+      mergedVillageProjects[name] = {
+        ...freshProject,
+        helpedAt: localHelpedAt,
+      };
+    }
+  });
+
+  return {
+    ...freshState,
+    pets: { ...freshState.pets, common: mergedCommonPets, nfts: mergedNftPets },
+    socialFarming: {
+      ...freshState.socialFarming,
+      villageProjects: mergedVillageProjects,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes a bug where a visitor who fully helped a farm (including its Pet House) would see the Pet House "needs help" badge reappear and get stuck re-attempting to help instead of being able to enter.
- Root cause: `pet.helpAllPetsInHouse` and `project.helped` are local-only events - they mutate the visited farm's state on the client but are deliberately excluded from the actions sent to the backend. When a visit effect (`farm.helped`/`farm.cheered`) later completes, the backend's fresh snapshot of the visited farm has no record of that local progress and was overwriting `context.state` wholesale, wiping it out.
- `mergeLocalVisitProgress` (new, `src/features/game/lib/mergeLocalVisitProgress.ts`) carries the locally-known pet `visitedAt` and village project `helpedAt` over onto the fresh snapshot before it replaces the visited farm's state, applied at the one place in `gameMachine.ts` where that replacement happens.

## Test plan
- [x] Unit tests added for `mergeLocalVisitProgress` covering common pets, NFT pets, village projects, and the no-local-progress case - all passing
- [x] Full regression pass on related suites (`helpAllPetsInHouse`, `collectGarbage`, `monuments`, `petHouse`) - all passing
- [x] Manually verified end-to-end with a local mock visit: helped the Pet House, closed the "Helped" popup (triggering the real `farm.helped` effect flow with a simulated fresh server snapshot), confirmed the badge did not reappear and the next click entered the Pet House directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved local pet visit progress when refreshing farm data after visiting.
  * Kept village project help timestamps while retaining the latest server-provided progress.
  * Preserved NFT pet visit timestamps and other updated game data during refreshes.
  * Ensured missing local progress does not overwrite fresh server data.

* **Tests**
  * Added coverage for pet visits, NFT pets, village project help, timestamp precedence, and missing local progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->