### PR TITLE
[FIX] Keep monument help icon upright when flipped

### DIFF
--- a/src/features/island/collectibles/components/Monument.tsx
+++ b/src/features/island/collectibles/components/Monument.tsx
@@ -211,7 +211,7 @@ export const Monument: React.FC<MonumentProps> = (input) => {
                   }}
                 >
                   <div
-                    className="relative mr-2"
+                    className="monument-help-action relative mr-2"
                     style={{ width: `${PIXEL_SCALE * 20}px` }}
                   >
                     <img className="w-full" src={SUNNYSIDE.icons.disc} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -1677,6 +1677,11 @@ th {
   transform: scaleX(-1) translateX(50%);
 }
 
+/* Keep visitor action icons readable when their collectible is flipped. */
+.flipped .monument-help-action img {
+  transform: none;
+}
+
 /* Custom pixel art cursor (Sunnyside). While the mouse button is held
    anywhere on the page, html.custom-cursor:active swaps in a variant of the
    same art rotated 20deg counter-clockwise. Its hotspot (8 0) keeps the


### PR DESCRIPTION
## Problem

When a monument is flipped, the help action icon shown to a visiting player is also mirrored. This makes the help affordance appear backwards and is not part of the monument's intended visual flip behavior.

<img width="202" height="317" alt="image" src="https://github.com/user-attachments/assets/71406be2-1b0c-4cfb-932b-a6cfef1a14ea" />


## Cause

Collectibles with `flipped` use the global `.flipped img` rule, which applies `scaleX(-1)` to every image nested inside the collectible. The monument's visitor help icon is rendered inside that same subtree.

## Change

Keep the monument sprite mirrored while excluding the visitor help action icon from the collectible image-flip rule. The help icon remains readable in both monument orientations.

## Validation

- `yarn tsc --noEmit`
- `git diff --check`
- Pre-commit ESLint and Prettier hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the appearance and orientation of visitor action icons in monument interactions.
  * Prevented collectible-flipping effects from altering these icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->