### PR TITLE
[FIX] Allow placing items on top of Salt Rug

### DIFF
--- a/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.test.ts
@@ -177,6 +177,37 @@ describe("detectCollisions", () => {
     expect(hasCollision).toBe(true);
   });
 
+  it("allows placing an item on top of a Salt Rug", () => {
+    const state: GameState = cloneDeep(TEST_FARM);
+    state.collectibles = {
+      "Salt Rug": [
+        {
+          id: "123",
+          coordinates: {
+            x: 1,
+            y: 1,
+          },
+          readyAt: 0,
+          createdAt: 0,
+        },
+      ],
+    };
+
+    const hasCollision = detectCollision({
+      state,
+      position: {
+        x: 1,
+        y: 1,
+        height: 1,
+        width: 1,
+      },
+      location: "farm",
+      name: "Abandoned Bear",
+    });
+
+    expect(hasCollision).toBe(false);
+  });
+
   it("returns true if a collision is detected with a bud", () => {
     const state: GameState = cloneDeep(TEST_FARM);
     state.buds = {

--- a/src/features/game/expansion/placeable/lib/collisionDetection.ts
+++ b/src/features/game/expansion/placeable/lib/collisionDetection.ts
@@ -423,6 +423,7 @@ export const NON_COLLIDING_OBJECTS: InventoryItemName[] = [
   "Green Field Rug",
   "Fancy Rug",
   "Gaucho Rug",
+  "Salt Rug",
   "Sunflorian Faction Rug",
   "Bumpkin Faction Rug",
   "Goblin Faction Rug",


### PR DESCRIPTION
## Summary
- Fixes Salt Rug not behaving like other rugs during placement - items could not be placed on top of it, unlike every other rug (Chess Rug, Christmas Rug, Gaucho Rug, etc.).
- Root cause: `NON_COLLIDING_OBJECTS` in `src/features/game/expansion/placeable/lib/collisionDetection.ts` is the single list that lets rugs/tiles act as a non-blocking floor layer other items can be placed over. Salt Rug was simply missing from it, so it was treated as a regular blocking collectible instead.
- This list is shared by every placement surface (farm, home, interior, level_one, pet house), so the one-line fix covers all of them.

## Test plan
- [x] Added a regression test (`allows placing an item on top of a Salt Rug`) that places a Salt Rug and asserts another item can be placed on the same tile
- [x] Verified the test fails without the fix (reproduces the reported bug) and passes with it
- [x] Full `collisionDetection.test.ts` suite passing (123 tests)
- [x] `tsc --noEmit` and lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Items can now be placed on top of Salt Rug collectibles without triggering a collision.
* **Tests**
  * Added coverage to verify valid placement over Salt Rugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->