### PR TITLE
[CHORE] Add Colors Event 2026 cosmetics to withdrawables

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -2038,6 +2038,22 @@ export const INVENTORY_RELEASES: InventoryReleases = {
     tradeAt: new Date("2026-08-20T00:00:00Z"),
     withdrawAt: new Date("2026-08-20T00:00:00Z"),
   },
+  "Fool's Gold": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Golden Slime Trophy": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Silver Slime Trophy": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Bronze Slime Trophy": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
 
   // Tutorial marketplace item
   "Stone Beetle": {

--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -804,6 +804,56 @@ export const WEARABLE_RELEASES: Partial<Record<BumpkinItem, Releases>> = {
     tradeAt: new Date("2026-04-17T00:00:00Z"),
     withdrawAt: new Date("2026-04-17T00:00:00Z"),
   },
+
+  // Colors Event 2026
+  "Rainbow Wings": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Butterfly Aura": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Slime Wall Background": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Green Slime Hair": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Blue Slime Shirt": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Slime Splattered Shirt": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Yellow Slime Puppet": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Blue Jelly Shoes": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Sad Slime Slippers": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Sad Slime Hat": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Sad Slime Pants": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Red Jelly Pants": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
 };
 
 type InventoryReleases = Partial<Record<InventoryItemName, Releases>>;
@@ -1937,6 +1987,56 @@ export const INVENTORY_RELEASES: InventoryReleases = {
   "The Sunflower Man Statue": {
     tradeAt: new Date("2026-04-17T00:00:00Z"),
     withdrawAt: new Date("2026-04-17T00:00:00Z"),
+  },
+
+  // Colors Event 2026
+  "Blue Paint Bucket": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Green Paint Bucket": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Purple Paint Bucket": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Yellow Paint Bucket": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Color Wheel": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Dhol Drum": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Mimic Slime Ball": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Mimic Winged Slime Ball": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Pork Jelly": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Rainbow Pork Jelly": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Slime Totem": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
+  },
+  "Giant Donut": {
+    tradeAt: new Date("2026-08-20T00:00:00Z"),
+    withdrawAt: new Date("2026-08-20T00:00:00Z"),
   },
 
   // Tutorial marketplace item


### PR DESCRIPTION
# Pull request description
Adds Color Event cosmetics to `withdrawables.ts`, making them available for trading and withdrawal starting August 20.

Replace the placeholders below. Delete sections that do not apply (e.g. no UI → remove Screenshots).

## Summary

What does this PR do in one short paragraph? Mention the user-facing outcome or the bug fixed.

## Context / motivation

Why is this change needed? Link to design docs, Slack threads, or prior discussion if helpful.

## How to test

Numbered steps a reviewer can follow. Include seed data, feature flags, or environment notes if needed.

1.
2.

## Screenshots or screen recording

Required for any visual or UX change. For pure logic/backend PRs, write "N/A" or delete this section.

## Related issues

Use one line per issue. Remove if none.

Fixes #
Related #

---

## Checklist

### PR and scope

- [ ] Title is clear and uses a prefix: `[FEAT]`, `[CHORE]`, or `[FIX]`
- [ ] I have read the contributing guidelines and agree to the T&Cs

### UI (if applicable)

- [ ] Screenshots or recording are attached above
- [ ] Copy and layout match existing patterns where relevant

### Code quality

- [ ] I have performed a self-review of my own code
- [ ] I have commented code only where it helps future readers (non-obvious logic, invariants, gotchas)
- [ ] I have updated documentation if behaviour or public APIs changed
- [ ] My changes do not introduce new warnings

### Tests

- [ ] I have added or updated tests that cover this change
- [ ] New and existing unit tests pass locally

### Dependencies and coordination

- [ ] Any required changes in other repos (e.g. API) are merged or linked in the description
- [ ] Any dependent packages or downstream modules are already published / coordinated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 12 wearable items and 15 inventory items for the Colors Event 2026.
  * Enabled trading and withdrawals for these items starting August 20, 2026.
  * The new releases expand the available event collection and can be managed through supported trading and withdrawal features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->