### PR TITLE
[FIX] Keep village project help icon upright when flipped

### DIFF
--- a/src/features/island/collectibles/components/Project.tsx
+++ b/src/features/island/collectibles/components/Project.tsx
@@ -680,7 +680,7 @@ export const Project: React.FC<ProjectProps> = (input) => {
               }}
             >
               <div
-                className="relative mr-2"
+                className="monument-help-action relative mr-2"
                 style={{ width: `${PIXEL_SCALE * 20}px` }}
               >
                 <img className="w-full" src={SUNNYSIDE.icons.disc} />


### PR DESCRIPTION
## Problem

PR #7562 fixed the visitor help icon mirroring for `Monument.tsx`, but the identical bug still exists in `Project.tsx` — the component used by village projects (Big Apple, Big Orange, Big Banana, Cooking Pots). When one of these is flipped, its visitor help icon is mirrored along with the sprite, making the help affordance appear backwards.

This was flagged in [review on #7562](https://github.com/sunflower-land/sunflower-land/pull/7562#issuecomment) but wasn't addressed before merge:

> Both `Monument` and `Project` are placed via `CollectibleCollection.tsx`'s `COLLECTIBLE_COMPONENTS` map... `Project.tsx` has the identical help-icon structure... a flipped village project (e.g. a flipped Big Apple/Big Orange/Big Banana) would still show its help icon mirrored — same bug, uncovered path.

## Cause

Same root cause as #7562: collectibles with `flipped` use the global `.flipped img` rule (`scaleX(-1)`), which also applies to the visitor help icon nested inside `Project.tsx`.

## Change

Apply the existing `monument-help-action` class (added in #7562, with a matching `.flipped .monument-help-action img { transform: none; }` rule in `styles.css`) to the equivalent help-icon container in `Project.tsx`, so the fix covers village projects too.

## Validation

- `yarn tsc --noEmit`
- Pre-commit ESLint and Prettier hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visitor help-action indicator styling hook for improved visual targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->