### PR TITLE
[FIX] Skip buy-all-seeds confirmation when Kuebiko makes seeds free

### DIFF
--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -590,7 +590,11 @@ export const SeasonalSeeds: React.FC = () => {
                 className="relative"
                 onClick={() => {
                   setBuyAllFailures([]);
-                  showConfirmBuyAllModal(true);
+                  if (isVIP && buyAllPlan.totalCost === 0) {
+                    buyAllSeeds();
+                  } else {
+                    showConfirmBuyAllModal(true);
+                  }
                 }}
               >
                 <img


### PR DESCRIPTION
## Problem

Player feedback: with Kuebiko built (seeds are free), clicking the regular \"Buy\" button already skips the confirmation dialog — but the \"Buy All\" button always opens a confirmation modal, even though there's nothing to confirm (total cost is 0).

## Cause

`SeasonalSeeds.tsx`'s single-seed buy button already has this exact skip logic:

\`\`\`tsx
onClick={() => {
  if (price > 0) {
    showConfirmBuyModal(true);
  } else {
    buy(bulkSeedBuyAmount);
  }
}}
\`\`\`

But the \"Buy All\" button unconditionally called `showConfirmBuyAllModal(true)`, ignoring `buyAllPlan.totalCost` (which is already correctly computed as `0` when Kuebiko is built — see `planSeedPurchases.test.ts`: \"is not price-limited by coins when the seed is free (e.g. Kuebiko built)\").

## Change

Mirror the existing skip pattern: if the player is VIP (required for Buy All regardless of cost) and `buyAllPlan.totalCost === 0`, purchase directly via `buyAllSeeds()` instead of opening the confirmation modal. The VIP gate is preserved so behavior for non-VIP players is unchanged.

## Validation

- `yarn tsc --noEmit`
- Pre-commit ESLint and Prettier hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VIP users can now immediately purchase all available seeds when the total cost is zero.
  * The purchase confirmation modal continues to appear when a cost is applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->