### PR TITLE
[FEAT] Terms and conditions

### DIFF
--- a/src/features/game/events/index.ts
+++ b/src/features/game/events/index.ts
@@ -541,6 +541,10 @@ import {
   acknowledgeCalendarEvent,
   type AcknowledgeCalendarEventAction,
 } from "./landExpansion/acknowledgeCalendarEvent";
+import {
+  acknowledgeTcs,
+  type AcknowledgeTcsAction,
+} from "./landExpansion/acknowledgeTcs";
 
 import {
   collectLavaPit,
@@ -992,6 +996,7 @@ export type PlayingEvent =
   | RedeemTradeRewardsAction
   | DailyResetAction
   | AcknowledgeCalendarEventAction
+  | AcknowledgeTcsAction
   | CollectLavaPitAction
   | StartLavaPitAction
   | HarvestSaltAction
@@ -1298,6 +1303,7 @@ export const PLAYING_EVENTS: Handlers<PlayingEvent> = {
   "reward.redeemed": redeemTradeReward,
   "daily.reset": dailyReset,
   "calendarEvent.acknowledged": acknowledgeCalendarEvent,
+  "tcs.acknowledged": acknowledgeTcs,
   "lavaPit.collected": collectLavaPit,
   "lavaPit.started": startLavaPit,
   "salt.harvested": harvestSalt,

--- a/src/features/game/events/landExpansion/acknowledgeTcs.test.ts
+++ b/src/features/game/events/landExpansion/acknowledgeTcs.test.ts
@@ -1,0 +1,44 @@
+import { TEST_FARM } from "features/game/lib/constants";
+import {
+  TCS_ACKNOWLEDGEMENT_DURATION,
+  acknowledgeTcs,
+  hasAcknowledgedTcs,
+} from "./acknowledgeTcs";
+
+const NOW = new Date("2026-08-21T12:00:00.000Z").getTime();
+
+describe("acknowledgeTcs", () => {
+  it("stamps the acknowledgement time", () => {
+    const state = acknowledgeTcs({
+      state: TEST_FARM,
+      action: { type: "tcs.acknowledged" },
+      createdAt: NOW,
+    });
+
+    expect(state.tcsAcknowledged).toEqual(NOW);
+  });
+});
+
+describe("hasAcknowledgedTcs", () => {
+  it("returns false when the player has never acknowledged the terms", () => {
+    expect(hasAcknowledgedTcs({ game: TEST_FARM, now: NOW })).toBe(false);
+  });
+
+  it("returns false when the acknowledgement is older than 30 days", () => {
+    const game = {
+      ...TEST_FARM,
+      tcsAcknowledged: NOW - TCS_ACKNOWLEDGEMENT_DURATION - 1,
+    };
+
+    expect(hasAcknowledgedTcs({ game, now: NOW })).toBe(false);
+  });
+
+  it("returns true when the acknowledgement is within the last 30 days", () => {
+    const game = {
+      ...TEST_FARM,
+      tcsAcknowledged: NOW - TCS_ACKNOWLEDGEMENT_DURATION + 1,
+    };
+
+    expect(hasAcknowledgedTcs({ game, now: NOW })).toBe(true);
+  });
+});

--- a/src/features/game/events/landExpansion/acknowledgeTcs.ts
+++ b/src/features/game/events/landExpansion/acknowledgeTcs.ts
@@ -1,0 +1,49 @@
+import type { GameState } from "features/game/types/game";
+import { produce } from "immer";
+
+/**
+ * How long an acceptance of the Terms & Conditions stays valid for. Once the
+ * player's last acceptance is older than this they are asked to accept again.
+ */
+export const TCS_ACKNOWLEDGEMENT_DURATION = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Whether the player needs to (re-)accept the Terms & Conditions.
+ *
+ * True when they have never accepted them, or when their last acceptance has
+ * aged past {@link TCS_ACKNOWLEDGEMENT_DURATION}.
+ */
+export function hasAcknowledgedTcs({
+  game,
+  now = Date.now(),
+}: {
+  game: GameState;
+  now?: number;
+}): boolean {
+  const acknowledgedAt = game.tcsAcknowledged;
+
+  if (!acknowledgedAt) return false;
+
+  return acknowledgedAt > now - TCS_ACKNOWLEDGEMENT_DURATION;
+}
+
+export type AcknowledgeTcsAction = {
+  type: "tcs.acknowledged";
+};
+
+type Options = {
+  state: Readonly<GameState>;
+  action: AcknowledgeTcsAction;
+  createdAt?: number;
+};
+
+export function acknowledgeTcs({
+  state,
+  createdAt = Date.now(),
+}: Options): GameState {
+  return produce(state, (stateCopy) => {
+    stateCopy.tcsAcknowledged = createdAt;
+
+    return stateCopy;
+  });
+}

--- a/src/features/game/expansion/Game.tsx
+++ b/src/features/game/expansion/Game.tsx
@@ -90,6 +90,7 @@ import {
 import { LoveCharm } from "./components/LoveCharm";
 import { ClaimReferralRewards } from "./components/ClaimReferralRewards";
 import { ReferralsAnnouncement } from "./components/ReferralsAnnouncement";
+import { TermsAndConditions } from "./components/TermsAndConditions";
 import { SoftBan } from "features/retreat/components/personhood/SoftBan";
 import { RewardBox } from "features/rewardBoxes/RewardBox";
 import { SystemMessageWidget } from "features/announcements/SystemMessageWidget";
@@ -219,6 +220,7 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
   depositing: true,
   introduction: false,
   welcome: true,
+  termsAndConditions: true,
   vip: true,
   transacting: true,
   auctionResults: false,
@@ -250,6 +252,8 @@ const SHOW_MODAL: Record<StateValues, boolean> = {
 
 // State change selectors
 const isWelcome = (state: MachineState) => state.matches("welcome");
+const isTermsAndConditions = (state: MachineState) =>
+  state.matches("termsAndConditions");
 const isLoading = (state: MachineState) =>
   state.matches("loading") || state.matches("portalling");
 const isPortalling = (state: MachineState) => state.matches("portalling");
@@ -469,6 +473,7 @@ export const GameWrapper: React.FC<React.PropsWithChildren> = ({
 
   const loading = useSelector(gameService, isLoading);
   const welcome = useSelector(gameService, isWelcome);
+  const termsAndConditions = useSelector(gameService, isTermsAndConditions);
   const portalling = useSelector(gameService, isPortalling);
   const trading = useSelector(gameService, isTrading);
   const traded = useSelector(gameService, isTraded);
@@ -717,6 +722,7 @@ export const GameWrapper: React.FC<React.PropsWithChildren> = ({
             {dailyReward && <DailyRewardClaim showClose />}
             {transacting && <Transaction />}
             {welcome && <Welcome />}
+            {termsAndConditions && <TermsAndConditions />}
             {depositing && <Loading text={t("depositing")} />}
             {trading && <Loading text={t("trading")} />}
             {traded && <Traded />}

--- a/src/features/game/expansion/components/TermsAndConditions.tsx
+++ b/src/features/game/expansion/components/TermsAndConditions.tsx
@@ -1,0 +1,81 @@
+import React, { useContext, useState } from "react";
+
+import { Button } from "components/ui/Button";
+import { Checkbox } from "components/ui/Checkbox";
+import { Label } from "components/ui/Label";
+import { Context } from "features/game/GameProvider";
+import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
+import { SUNNYSIDE } from "assets/sunnyside";
+
+const TERMS_URL = "https://docs.sunflower-land.com/support/terms-of-service";
+
+/**
+ * Blocking Terms & Conditions gate.
+ *
+ * Shown by the `termsAndConditions` machine state whenever the player has never
+ * accepted the terms, or their last acceptance is over 30 days old. It is
+ * deliberately not closable - the only way out is to tick the box and continue,
+ * which stamps `tcsAcknowledged` on the game state.
+ */
+export const TermsAndConditions: React.FC = () => {
+  const { gameService } = useContext(Context);
+  const [accepted, setAccepted] = useState(false);
+
+  const acknowledge = () => {
+    gameService.send({ type: "tcs.acknowledged" });
+    gameService.send({ type: "ACKNOWLEDGE" });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="p-1">
+        <Label type="info" className="mb-2">
+          {`Rules`}
+        </Label>
+        <NoticeboardItems
+          items={[
+            {
+              text: `Sunflower Land is a game - not a financial product.`,
+              icon: SUNNYSIDE.icons.heart,
+            },
+            {
+              text: `1 account per player (no sharing)`,
+              icon: SUNNYSIDE.icons.player,
+            },
+            {
+              text: `Respect the rules - no botting/automation tools`,
+              icon: SUNNYSIDE.icons.search,
+            },
+          ]}
+        />
+        <div className="flex items-center gap-2 my-2">
+          <Checkbox
+            checked={accepted}
+            onChange={setAccepted}
+            aria-label="Accept the Terms and Conditions"
+          />
+          <p
+            className="text-xs cursor-pointer"
+            onClick={() => setAccepted(!accepted)}
+          >
+            {`I have read and agree to the `}
+            <a
+              href={TERMS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+              // Opening the terms shouldn't also tick the box
+              onClick={(e) => e.stopPropagation()}
+            >
+              {`Terms and Conditions`}
+            </a>
+            {`.`}
+          </p>
+        </div>
+      </div>
+      <Button disabled={!accepted} onClick={acknowledge}>
+        {`Continue`}
+      </Button>
+    </div>
+  );
+};

--- a/src/features/game/lib/gameMachine.ts
+++ b/src/features/game/lib/gameMachine.ts
@@ -114,6 +114,7 @@ import {
   getActiveCalendarEvent,
   type SeasonalEventName,
 } from "../types/calendar";
+import { hasAcknowledgedTcs } from "../events/landExpansion/acknowledgeTcs";
 import { getConnection, getChainId } from "@wagmi/core";
 import { config } from "features/wallet/WalletProvider";
 import { depositFlower } from "lib/blockchain/DepositFlower";
@@ -836,6 +837,7 @@ export type BlockchainState = {
     | "portalling"
     | "introduction"
     | "welcome"
+    | "termsAndConditions"
     | "investigating"
     | "gems"
     | "communityCoin"
@@ -1293,6 +1295,13 @@ export function startGame(authContext: AuthContext) {
         },
         notifying: {
           always: [
+            // The T&C gate must stay first - the player cannot see anything
+            // else until they have accepted the current terms.
+            {
+              target: "termsAndConditions",
+              cond: (context) =>
+                !hasAcknowledgedTcs({ game: context.state, now: Date.now() }),
+            },
             {
               target: "welcome",
               cond: (context) => {
@@ -2596,6 +2605,17 @@ export function startGame(authContext: AuthContext) {
         welcome: {
           on: {
             "bonus.claimed": (GAME_EVENT_HANDLERS as any)["bonus.claimed"],
+            ACKNOWLEDGE: {
+              target: "notifying",
+            },
+          },
+        },
+
+        termsAndConditions: {
+          on: {
+            "tcs.acknowledged": (GAME_EVENT_HANDLERS as any)[
+              "tcs.acknowledged"
+            ],
             ACKNOWLEDGE: {
               target: "notifying",
             },

--- a/src/features/game/lib/transforms.ts
+++ b/src/features/game/lib/transforms.ts
@@ -152,5 +152,6 @@ export function makeGame(farm: any): GameState {
     saltFarm: farm.saltFarm ?? { level: 0, nodes: {} },
     sculptures: farm.sculptures,
     layouts: farm.layouts,
+    tcsAcknowledged: farm.tcsAcknowledged,
   };
 }

--- a/src/features/game/types/game.ts
+++ b/src/features/game/types/game.ts
@@ -2165,6 +2165,16 @@ export interface GameState {
 
   verified?: boolean;
 
+  /**
+   * When the player last accepted the Terms & Conditions (epoch ms).
+   *
+   * Undefined for players who have never accepted them. Re-acceptance is
+   * forced once the acceptance is older than
+   * {@link TCS_ACKNOWLEDGEMENT_DURATION} - see the `termsAndConditions` state
+   * in `gameMachine`.
+   */
+  tcsAcknowledged?: number;
+
   gems: {
     history?: Record<string, { spent: number; coinsSpent?: number }>;
   };


### PR DESCRIPTION
# Pull request description

Clearer terms & conditions pop up for players with timestamping acknowledgement (not just on sign in acceptance)

<img width="469" height="251" alt="Screenshot 2026-08-21 at 9 18 31 am" src="https://github.com/user-attachments/assets/441c7b5d-1c3c-4ee2-907c-ba4ca3b342bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Terms & Conditions acceptance step before gameplay can continue.
  * Players can review the gameplay rules and terms-of-service link, then continue after checking the acceptance box.
  * Acceptance is recorded and remains valid for 30 days.

* **Bug Fixes**
  * Ensured games correctly recognize and enforce current Terms & Conditions acknowledgements.

* **Tests**
  * Added coverage for new, expired, and valid acknowledgements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->