### PR TITLE
[CHORE] Hide unavailable chapter artefacts in Jafar shop

### DIFF
--- a/src/features/game/types/desert.test.ts
+++ b/src/features/game/types/desert.test.ts
@@ -1,0 +1,63 @@
+import Decimal from "decimal.js-light";
+import {
+  CHAPTER_ARTEFACT,
+  isChapterArtefact,
+  shouldHideChapterArtefact,
+} from "./desert";
+
+describe("isChapterArtefact", () => {
+  it.each([...new Set(Object.values(CHAPTER_ARTEFACT))])(
+    "identifies %s as a chapter artefact",
+    (name) => {
+      expect(isChapterArtefact(name)).toBe(true);
+    },
+  );
+
+  it("does not identify regular digging treasure as a chapter artefact", () => {
+    expect(isChapterArtefact("Coral")).toBe(false);
+  });
+});
+
+describe("shouldHideChapterArtefact", () => {
+  const currentChapterArtefact = "Otter Pebble";
+
+  it("hides an unowned artefact from a previous chapter", () => {
+    expect(
+      shouldHideChapterArtefact({
+        name: "Scarab",
+        currentChapterArtefact,
+        amount: new Decimal(0),
+      }),
+    ).toBe(true);
+  });
+
+  it("shows an owned artefact from a previous chapter", () => {
+    expect(
+      shouldHideChapterArtefact({
+        name: "Scarab",
+        currentChapterArtefact,
+        amount: new Decimal(1),
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the current chapter artefact when it is unowned", () => {
+    expect(
+      shouldHideChapterArtefact({
+        name: currentChapterArtefact,
+        currentChapterArtefact,
+        amount: new Decimal(0),
+      }),
+    ).toBe(false);
+  });
+
+  it("shows regular digging treasure when it is unowned", () => {
+    expect(
+      shouldHideChapterArtefact({
+        name: "Coral",
+        currentChapterArtefact,
+        amount: new Decimal(0),
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/game/types/desert.ts
+++ b/src/features/game/types/desert.ts
@@ -4,6 +4,7 @@ import { type ChapterName, getCurrentChapter } from "./chapters";
 import type { BeachBountyChapterArtefact } from "./treasure";
 import { isCollectibleBuilt } from "../lib/collectibleBuilt";
 import { isWearableActive } from "../lib/wearables";
+import type Decimal from "decimal.js-light";
 
 export const DESERT_GRID_HEIGHT = 10;
 export const DESERT_GRID_WIDTH = 10;
@@ -34,6 +35,30 @@ export const CHAPTER_ARTEFACT: Record<ChapterName, BeachBountyChapterArtefact> =
     "Salt Awakening": "Salt Dino Egg",
     "Ascension Age": "Otter Pebble",
   };
+
+const CHAPTER_ARTEFACTS = new Set<BeachBountyChapterArtefact>(
+  Object.values(CHAPTER_ARTEFACT),
+);
+
+export function isChapterArtefact(
+  name: InventoryItemName,
+): name is BeachBountyChapterArtefact {
+  return CHAPTER_ARTEFACTS.has(name as BeachBountyChapterArtefact);
+}
+
+export function shouldHideChapterArtefact({
+  name,
+  currentChapterArtefact,
+  amount,
+}: {
+  name: InventoryItemName;
+  currentChapterArtefact: BeachBountyChapterArtefact;
+  amount: Decimal;
+}) {
+  return (
+    isChapterArtefact(name) && name !== currentChapterArtefact && amount.lte(0)
+  );
+}
 
 export const DIGGING_FORMATIONS = {
   // Horizontal Zig Zag - X Coins

--- a/src/features/world/ui/beach/treasure_shop/TreasureShopSell.tsx
+++ b/src/features/world/ui/beach/treasure_shop/TreasureShopSell.tsx
@@ -17,7 +17,11 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import { ConfirmationModal } from "components/ui/ConfirmationModal";
 import { NPC_WEARABLES } from "lib/npcs";
 import { BulkSellModal } from "components/ui/BulkSellModal";
-import { CHAPTER_ARTEFACT } from "features/game/types/desert";
+import {
+  CHAPTER_ARTEFACT,
+  isChapterArtefact,
+  shouldHideChapterArtefact,
+} from "features/game/types/desert";
 import { getCurrentChapter } from "features/game/types/chapters";
 import { useNow } from "lib/utils/hooks/useNow";
 
@@ -26,29 +30,48 @@ export const TreasureShopSell: React.FC = () => {
   const now = useNow();
   const currentChapter = getCurrentChapter(now);
   const currentSeasonalArtefact = CHAPTER_ARTEFACT[currentChapter];
-  const beachBountyTreasure = getKeys(SELLABLE_TREASURES).sort(
+  const allBeachBountyTreasure = getKeys(SELLABLE_TREASURES).sort(
     (a, b) => SELLABLE_TREASURES[a].sellPrice - SELLABLE_TREASURES[b].sellPrice,
   );
-
-  const [selectedName, setSelectedName] = useState<BeachBountyTreasure>(
-    beachBountyTreasure[0],
-  );
-  const [confirmationModal, showConfirmationModal] = useState(false);
-  const [bulkSellModal, showBulkSellModal] = useState(false);
-  const [customAmount, setCustomAmount] = useState(new Decimal(0));
-
-  const selected = SELLABLE_TREASURES[selectedName];
   const { gameService } = useContext(Context);
   const [
     {
       context: { state },
     },
   ] = useActor(gameService);
+  const inventory = state.inventory;
+
+  const [selectedTreasure, setSelectedTreasure] = useState<BeachBountyTreasure>(
+    allBeachBountyTreasure[0],
+  );
+  const [chapterArtefactsVisibleAtOpen] = useState(
+    () =>
+      new Set<BeachBountyTreasure>(
+        allBeachBountyTreasure.filter(
+          (name) =>
+            isChapterArtefact(name) &&
+            (inventory[name]?.greaterThan(0) ?? false),
+        ),
+      ),
+  );
+  const [confirmationModal, showConfirmationModal] = useState(false);
+  const [bulkSellModal, showBulkSellModal] = useState(false);
+  const [customAmount, setCustomAmount] = useState(new Decimal(0));
 
   const divRef = useRef<HTMLDivElement>(null);
 
-  const inventory = state.inventory;
+  const beachBountyTreasure = allBeachBountyTreasure.filter(
+    (name) =>
+      chapterArtefactsVisibleAtOpen.has(name) ||
+      !shouldHideChapterArtefact({
+        name,
+        currentChapterArtefact: currentSeasonalArtefact,
+        amount: inventory[name] ?? new Decimal(0),
+      }),
+  );
+  const selectedName = selectedTreasure;
 
+  const selected = SELLABLE_TREASURES[selectedName];
   const { price } = getSellPrice(selected, state);
   const amount = inventory[selectedName] || new Decimal(0);
   const coinAmount = price * customAmount.toNumber();
@@ -131,7 +154,7 @@ export const TreasureShopSell: React.FC = () => {
               <Box
                 isSelected={selectedName === name}
                 key={name}
-                onClick={() => setSelectedName(name)}
+                onClick={() => setSelectedTreasure(name)}
                 image={ITEM_DETAILS[name].image}
                 count={inventory[name] || new Decimal(0)}
               />


### PR DESCRIPTION
## Problem

<img width="208" height="192" alt="image" src="https://github.com/user-attachments/assets/ec609169-137a-4a29-885a-a31a5b214f9b" />


## Summary

- hide unavailable chapter artefacts with a zero inventory balance from Jafar's Sell tab
- keep the current chapter artefact visible even when the player does not own it
- keep previous chapter artefacts visible when the player still has copies to sell

<img width="360" height="381" alt="image" src="https://github.com/user-attachments/assets/0b1868ae-08df-448c-b238-140acc993333" />


## Logic

A treasure is hidden only when all three conditions are true:

1. it is a chapter artefact derived from `CHAPTER_ARTEFACT`
2. it is not the current chapter artefact
3. its inventory amount is zero or lower

The Sell tab snapshots owned chapter artefacts when the window opens. If the player sells the final copy of one of those artefacts, its selected card remains visible with a zero balance until the window closes. This avoids moving the selection underneath the player's next click. The list is recalculated the next time the shop opens, so the depleted previous-chapter artefact is then hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treasure shops now prioritize relevant chapter artefacts based on the current chapter.
  * Previously owned chapter artefacts remain visible for selling.
  * Treasure selection is preserved while browsing sellable items.

* **Bug Fixes**
  * Prevented unavailable chapter artefacts with no inventory from appearing in treasure shops.
  * Improved treasure sorting and inventory handling for a smoother selling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->