### PR TITLE
[FIX] Keep minigame loader stable until iframe loads

### DIFF
--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -1,5 +1,11 @@
 import { createPortal } from "react-dom";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useActor } from "@xstate/react";
 
 import * as AuthProvider from "features/auth/lib/Provider";
@@ -24,6 +30,8 @@ import { ITEM_DETAILS } from "features/game/types/images";
 import sflIcon from "assets/icons/flower_token.webp";
 import { type IPortalDonation, PortalDonation } from "./PortalDonation";
 import { getCachedFont } from "lib/utils/fonts";
+
+const PORTAL_LOAD_TIMEOUT_MS = 30_000;
 
 type PortalPurchase = {
   sfl: number;
@@ -183,62 +191,83 @@ export const Portal: React.FC<Props> = ({
     };
   }, [portalName, playUrl, iframeBaseUrl, loadAttempt]);
 
-  // Function to handle messages from the iframe
-  const handleMessage = (event: any) => {
-    if (event.data?.event === "closePortal") {
-      // Close the modal when the message is received
-      setLoading(false);
-      setUrl("");
-      onClose();
-    }
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      const iframeWindow = iframeRef.current?.contentWindow;
+      const iframeOrigin = url
+        ? new URL(url, window.location.origin).origin
+        : undefined;
 
-    if (event.data?.event === "claimPrize") {
-      // Close the modal when the message is received
-      setLoading(false);
-      setIsComplete(true);
-      return;
-    }
+      if (
+        !iframeWindow ||
+        !iframeOrigin ||
+        event.source !== iframeWindow ||
+        event.origin !== iframeOrigin
+      ) {
+        return;
+      }
 
-    if (event.data.event === "purchase") {
-      // Purchase the item
-      setPurchase(event.data);
-      return;
-    }
+      const eventName = event.data?.event;
 
-    if (event.data.event === "donated") {
-      setDonation(event.data);
-      return;
-    }
+      if (eventName === "closePortal") {
+        setLoading(false);
+        setUrl("");
+        onClose();
+      }
 
-    if (event.data.event === "attemptStarted") {
-      // Start the minigame attempt
-      gameService.send("minigame.attemptStarted", {
-        id: portalName,
-      });
-      gameService.send("SAVE");
-      return;
-    }
+      if (eventName === "claimPrize") {
+        setLoading(false);
+        setIsComplete(true);
+        return;
+      }
 
-    if (event.data.event === "scoreSubmitted") {
-      // Submit the minigame score
-      gameService.send("minigame.scoreSubmitted", {
-        score: event.data.score,
-        id: portalName,
-      });
-      gameService.send("SAVE");
-      return;
-    }
-  };
+      if (eventName === "purchase") {
+        setPurchase(event.data);
+        return;
+      }
+
+      if (eventName === "donated") {
+        setDonation(event.data);
+        return;
+      }
+
+      if (eventName === "attemptStarted") {
+        gameService.send("minigame.attemptStarted", {
+          id: portalName,
+        });
+        gameService.send("SAVE");
+        return;
+      }
+
+      if (eventName === "scoreSubmitted") {
+        gameService.send("minigame.scoreSubmitted", {
+          score: event.data.score,
+          id: portalName,
+        });
+        gameService.send("SAVE");
+      }
+    },
+    [gameService, onClose, portalName, url],
+  );
 
   useEffect(() => {
-    // Add event listener to listen for messages from any origin
     window.addEventListener("message", handleMessage);
 
     return () => {
-      // Remove the event listener when the component is unmounted
       window.removeEventListener("message", handleMessage);
     };
-  }, []);
+  }, [handleMessage]);
+
+  useEffect(() => {
+    if (!url || !loading) return;
+
+    const timeout = window.setTimeout(() => {
+      setLoading(false);
+      setLoadFailed(true);
+    }, PORTAL_LOAD_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [loading, url]);
 
   const confirmPurchase = () => {
     gameService.send("minigame.itemPurchased", {
@@ -320,10 +349,6 @@ export const Portal: React.FC<Props> = ({
               ref={iframeRef} // Set ref to the iframe
               title={portalName}
               onLoad={() => setLoading(false)}
-              onError={() => {
-                setLoading(false);
-                setLoadFailed(true);
-              }}
             />
           </div>,
           document.body,

--- a/src/features/world/ui/portals/Portal.tsx
+++ b/src/features/world/ui/portals/Portal.tsx
@@ -100,6 +100,8 @@ export const Portal: React.FC<Props> = ({
   const [url, setUrl] = useState<string>();
 
   const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
   const [isComplete, setIsComplete] = useState(false);
   const [purchase, setPurchase] = useState<PortalPurchase | undefined>(
     undefined,
@@ -125,46 +127,61 @@ export const Portal: React.FC<Props> = ({
   }, [rawToken, farmId]);
 
   useEffect(() => {
+    let cancelled = false;
+
     const load = async () => {
       setLoading(true);
+      setLoadFailed(false);
+      setUrl(undefined);
 
-      let token = "";
-      if (CONFIG.API_URL) {
-        const { token: portalToken } = await portal({
-          portalId: portalName,
-          token: rawTokenRef.current as string,
-          farmId: farmIdRef.current,
-        });
-        token = portalToken;
+      try {
+        let token = "";
+        if (CONFIG.API_URL) {
+          const { token: portalToken } = await portal({
+            portalId: portalName,
+            token: rawTokenRef.current as string,
+            farmId: farmIdRef.current,
+          });
+          token = portalToken;
+        }
+
+        const baseUrl = resolveMinigameIframeBaseUrl(
+          portalName,
+          playUrl,
+          iframeBaseUrl,
+        );
+
+        const language = localStorage.getItem("language") || "en";
+        const font = getCachedFont();
+
+        const params = new URLSearchParams();
+        params.set("jwt", token);
+        params.set("network", CONFIG.NETWORK);
+        params.set("language", language);
+        params.set("font", font);
+        if (CONFIG.API_URL) {
+          params.set("apiUrl", CONFIG.API_URL);
+        }
+
+        const nextUrl = `${baseUrl}?${params.toString()}`;
+
+        if (!cancelled) {
+          setUrl(nextUrl);
+        }
+      } catch {
+        if (!cancelled) {
+          setLoading(false);
+          setLoadFailed(true);
+        }
       }
-
-      const baseUrl = resolveMinigameIframeBaseUrl(
-        portalName,
-        playUrl,
-        iframeBaseUrl,
-      );
-
-      const language = localStorage.getItem("language") || "en";
-      const font = getCachedFont();
-
-      const params = new URLSearchParams();
-      params.set("jwt", token);
-      params.set("network", CONFIG.NETWORK);
-      params.set("language", language);
-      params.set("font", font);
-      if (CONFIG.API_URL) {
-        params.set("apiUrl", CONFIG.API_URL);
-      }
-
-      const nextUrl = `${baseUrl}?${params.toString()}`;
-
-      setUrl(nextUrl);
-
-      setLoading(false);
     };
 
     load();
-  }, [portalName, playUrl, iframeBaseUrl]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [portalName, playUrl, iframeBaseUrl, loadAttempt]);
 
   // Function to handle messages from the iframe
   const handleMessage = (event: any) => {
@@ -253,10 +270,6 @@ export const Portal: React.FC<Props> = ({
     onClose();
   };
 
-  if (loading) {
-    return <Loading />;
-  }
-
   if (isComplete) {
     const prize = gameState.context.state.minigames.prizes[portalName];
 
@@ -276,22 +289,45 @@ export const Portal: React.FC<Props> = ({
     );
   }
 
+  if (loadFailed) {
+    return (
+      <div className="flex min-h-[48px] items-center gap-2 p-1 pr-12">
+        <Label type="danger">{t("error")}</Label>
+        <Button onClick={() => setLoadAttempt((attempt) => attempt + 1)}>
+          {t("retry")}
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <>
-      {createPortal(
-        <div
-          data-html2canvas-ignore="true"
-          aria-label="Hud"
-          className="fixed inset-0 z-50"
-        >
-          <iframe
-            src={url}
-            className="w-full h-full absolute z-10"
-            ref={iframeRef} // Set ref to the iframe
-          />
-        </div>,
-        document.body,
+      {loading && (
+        <div className="flex min-h-[48px] items-center pr-12">
+          <Loading />
+        </div>
       )}
+      {url &&
+        createPortal(
+          <div
+            data-html2canvas-ignore="true"
+            aria-label="Hud"
+            className={`fixed inset-0 z-50 ${loading ? "invisible" : ""}`}
+          >
+            <iframe
+              src={url}
+              className="w-full h-full absolute z-10"
+              ref={iframeRef} // Set ref to the iframe
+              title={portalName}
+              onLoad={() => setLoading(false)}
+              onError={() => {
+                setLoading(false);
+                setLoadFailed(true);
+              }}
+            />
+          </div>,
+          document.body,
+        )}
       {purchase &&
         createPortal(
           <div


### PR DESCRIPTION
## Problem

<img width="656" height="294" alt="image" src="https://github.com/user-attachments/assets/5b639885-3101-4071-9125-ba825d502d38" />

## Summary

- keep the existing minigame loading panel visible while the iframe loads in the background
- reveal the iframe only after its `load` event, preventing the empty collapsed modal frame
- reserve enough loading-panel space for the close button
- show a retry action when portal authentication or iframe loading fails
- accept portal messages only from the current iframe window and expected origin
- fail a loading attempt after 30 seconds so retry remains available

## User impact

Players now see a stable loading panel with an accessible close button until the selected minigame is ready. The transition no longer flashes a compressed empty panel before the iframe renders.

## Validation

- `yarn eslint --quiet src/features/world/ui/portals/Portal.tsx`
- `yarn tsc --noEmit`
- `git diff --cached --check`

## Notes

- The change is shared by all minigames using `Portal`.
- The deployed minigames do not currently emit a render-ready message, so `iframe.onload` remains the supported success signal. Waiting for a new readiness event in this PR would prevent current games from opening.
- DevStand was not started because visual preview was not requested for this implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved portal loading reliability and error handling.
  - Added automatic timeout detection for stalled loads.
  - Added a retry option when loading fails.
  - Prevented cancelled or outdated requests from affecting the active portal.
  - Improved security and reliability of iframe communication.

- **UI Improvements**
  - Portal displays clear loading, error, retry, completion, and content states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->