### PR TITLE
[FEAT] Add "Show actual time" timer setting

### DIFF
--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -13,7 +13,6 @@ import { SquareIcon } from "../SquareIcon";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { Label } from "../Label";
 import { isPreActionBoosted } from "features/game/lib/timerDisplay";
-import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ITEM_ICONS } from "features/island/hud/components/inventory/Chest";
 import { SEASON_ICONS } from "features/island/buildings/components/building/market/SeasonalSeeds";
@@ -220,13 +219,6 @@ export const InventoryItemDetails: React.FC<Props> = ({
                   strikethrough
                 />
               )}
-            {speed > 1 && (
-              <Label type="transparent" icon={SUNNYSIDE.icons.lightning}>
-                {t("description.boostedSpeed", {
-                  speed: Number(speed.toFixed(2)),
-                })}
-              </Label>
-            )}
             <BoostsDisplay
               boosts={properties.timeBoostsUsed}
               show={hasNamedBoosts && properties.showBoosts}

--- a/src/components/ui/layouts/InventoryItemDetails.tsx
+++ b/src/components/ui/layouts/InventoryItemDetails.tsx
@@ -12,6 +12,8 @@ import { RequirementLabel } from "../RequirementsLabel";
 import { SquareIcon } from "../SquareIcon";
 import { COLLECTIBLE_BUFF_LABELS } from "features/game/types/collectibleItemBuffs";
 import { Label } from "../Label";
+import { isPreActionBoosted } from "features/game/lib/timerDisplay";
+import { SUNNYSIDE } from "assets/sunnyside";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { ITEM_ICONS } from "features/island/hud/components/inventory/Chest";
 import { SEASON_ICONS } from "features/island/buildings/components/building/market/SeasonalSeeds";
@@ -49,6 +51,7 @@ interface HarvestsRequirementProps {
  * @param timeSeconds The wait time in seconds for using the item.
  * @param baseTimeSeconds The base wait time before boosts (for strikethrough display).
  * @param timeBoostsUsed The boosts applied to the grow time (for clickable boost display).
+ * @param timeSpeed Live speed-window rate for this activity; > 1 shows the rate.
  * @param harvests The min/max harvests for the item.
  * @param xp The XP gained for consuming the item.
  * @param xpBoostsUsed The boosts applied to food XP (for clickable boost display).
@@ -61,6 +64,7 @@ interface PropertiesProps {
   timeSeconds?: number;
   baseTimeSeconds?: number;
   timeBoostsUsed?: { name: BoostName; value: string }[];
+  timeSpeed?: number;
   harvests?: HarvestsRequirementProps;
   xp?: Decimal;
   xpBoostsUsed?: { name: BoostName; value: string }[];
@@ -176,11 +180,14 @@ export const InventoryItemDetails: React.FC<Props> = ({
     const getTimeDisplay = () => {
       if (!properties.timeSeconds) return <></>;
 
-      const isTimeBoosted =
-        properties.timeBoostsUsed &&
-        properties.timeBoostsUsed.length > 0 &&
-        properties.baseTimeSeconds !== undefined &&
-        properties.timeSeconds !== properties.baseTimeSeconds;
+      const hasNamedBoosts = (properties.timeBoostsUsed?.length ?? 0) > 0;
+      const speed = properties.timeSpeed ?? 1;
+      const isTimeBoosted = isPreActionBoosted({
+        displaySeconds: properties.timeSeconds,
+        baseSeconds: properties.baseTimeSeconds,
+        speed,
+        hasNamedBoosts,
+      });
 
       if (
         isTimeBoosted &&
@@ -190,24 +197,44 @@ export const InventoryItemDetails: React.FC<Props> = ({
       ) {
         return (
           <div
-            className="flex flex-col items-center cursor-pointer"
-            onClick={() => properties.setShowBoosts?.(!properties.showBoosts)}
+            className={classNames("flex flex-col items-center", {
+              // Only itemisable (named) boosts open the breakdown; a live speed
+              // window has no name to list.
+              "cursor-pointer": hasNamedBoosts,
+            })}
+            onClick={() =>
+              hasNamedBoosts &&
+              properties.setShowBoosts?.(!properties.showBoosts)
+            }
           >
             <RequirementLabel
               type="time"
               waitSeconds={properties.timeSeconds}
               boosted
             />
-            <RequirementLabel
-              type="time"
-              waitSeconds={properties.baseTimeSeconds ?? 0}
-              strikethrough
-            />
+            {properties.baseTimeSeconds !== undefined &&
+              properties.timeSeconds !== properties.baseTimeSeconds && (
+                <RequirementLabel
+                  type="time"
+                  waitSeconds={properties.baseTimeSeconds}
+                  strikethrough
+                />
+              )}
+            {speed > 1 && (
+              <Label type="transparent" icon={SUNNYSIDE.icons.lightning}>
+                {t("description.boostedSpeed", {
+                  speed: Number(speed.toFixed(2)),
+                })}
+              </Label>
+            )}
             <BoostsDisplay
               boosts={properties.timeBoostsUsed}
-              show={properties.showBoosts}
+              show={hasNamedBoosts && properties.showBoosts}
               state={game}
-              onClick={() => properties.setShowBoosts?.(!properties.showBoosts)}
+              onClick={() =>
+                hasNamedBoosts &&
+                properties.setShowBoosts?.(!properties.showBoosts)
+              }
             />
           </div>
         );

--- a/src/components/ui/layouts/SeedRequirements.tsx
+++ b/src/components/ui/layouts/SeedRequirements.tsx
@@ -17,6 +17,8 @@ import { RequirementLabel } from "../RequirementsLabel";
 import { SquareIcon } from "../SquareIcon";
 import { formatDateRange, secondsToString } from "lib/utils/time";
 import { SUNNYSIDE } from "assets/sunnyside";
+import classNames from "classnames";
+import { isPreActionBoosted } from "features/game/lib/timerDisplay";
 import emptyPot from "assets/greenhouse/greenhouse_pot.webp";
 import flowerBed from "assets/flowers/empty_flowerbed.webp";
 
@@ -86,6 +88,8 @@ interface RequirementsProps {
   harvests?: HarvestsRequirementProps;
   time?: { seconds: number; boostsUsed: { name: BoostName; value: string }[] };
   baseTimeSeconds?: number;
+  /** Live speed-window rate for this seed's activity; > 1 shows the rate. */
+  timeSpeed?: number;
   level?: LevelRequirement;
   restriction?: {
     icon: string;
@@ -265,10 +269,27 @@ export const SeedRequirements: React.FC<Props> = ({
 
   const getRequirements = () => {
     if (!requirements) return <></>;
-    const { coins, showCoinsIfFree, harvests, time, baseTimeSeconds, level } =
-      requirements;
+    const {
+      coins,
+      showCoinsIfFree,
+      harvests,
+      time,
+      baseTimeSeconds,
+      timeSpeed,
+      level,
+    } = requirements;
 
-    const isTimeBoosted = time?.seconds !== baseTimeSeconds;
+    // Named boosts are already folded into `time.seconds` and can be itemised; a
+    // live speed window shows as a rate (or a shorter projected time) but has no
+    // name to list, so it must not make the block clickable on its own.
+    const hasNamedBoosts = (time?.boostsUsed.length ?? 0) > 0;
+    const speed = timeSpeed ?? 1;
+    const isTimeBoosted = isPreActionBoosted({
+      displaySeconds: time?.seconds ?? 0,
+      baseSeconds: baseTimeSeconds,
+      speed,
+      hasNamedBoosts,
+    });
 
     const RequirementLabels: React.FC = () => {
       if (isSeedCropMachine(details.item)) {
@@ -317,8 +338,12 @@ export const SeedRequirements: React.FC<Props> = ({
 
       return (
         <div
-          className="flex flex-col items-center cursor-pointer"
-          onClick={isTimeBoosted ? () => setShowBoosts(!showBoosts) : undefined}
+          className={classNames("flex flex-col items-center", {
+            "cursor-pointer": hasNamedBoosts,
+          })}
+          onClick={
+            hasNamedBoosts ? () => setShowBoosts(!showBoosts) : undefined
+          }
         >
           {!!time && isTimeBoosted && (
             <RequirementLabel type="time" waitSeconds={time.seconds} boosted />
@@ -330,9 +355,16 @@ export const SeedRequirements: React.FC<Props> = ({
               strikethrough={isTimeBoosted}
             />
           )}
+          {speed > 1 && (
+            <Label type="transparent" icon={SUNNYSIDE.icons.lightning}>
+              {t("description.boostedSpeed", {
+                speed: Number(speed.toFixed(2)),
+              })}
+            </Label>
+          )}
           <BoostsDisplay
             boosts={time?.boostsUsed ?? []}
-            show={showBoosts}
+            show={hasNamedBoosts && showBoosts}
             state={gameState}
             onClick={() => setShowBoosts(!showBoosts)}
           />

--- a/src/components/ui/layouts/SeedRequirements.tsx
+++ b/src/components/ui/layouts/SeedRequirements.tsx
@@ -355,13 +355,6 @@ export const SeedRequirements: React.FC<Props> = ({
               strikethrough={isTimeBoosted}
             />
           )}
-          {speed > 1 && (
-            <Label type="transparent" icon={SUNNYSIDE.icons.lightning}>
-              {t("description.boostedSpeed", {
-                speed: Number(speed.toFixed(2)),
-              })}
-            </Label>
-          )}
           <BoostsDisplay
             boosts={time?.boostsUsed ?? []}
             show={hasNamedBoosts && showBoosts}

--- a/src/features/farming/hud/lib/timers.ts
+++ b/src/features/farming/hud/lib/timers.ts
@@ -12,3 +12,22 @@ export function getShowTimersSetting(): boolean {
 
   return cached ? JSON.parse(cached) : true;
 }
+
+/**
+ * Cache the timer reading in local storage.
+ *
+ * Under the speed-boost model a timer has two readings: the remaining WORK (the
+ * default — drains faster than a clock while a boost is active) and the actual
+ * wall-clock time until ready. See `timerDisplay.ts`.
+ */
+const SHOW_ACTUAL_TIME_KEY = "settings.showActualTime";
+
+export function cacheShowActualTimeSetting(show: boolean) {
+  localStorage.setItem(SHOW_ACTUAL_TIME_KEY, JSON.stringify(show));
+}
+
+export function getShowActualTimeSetting(): boolean {
+  const cached = localStorage.getItem(SHOW_ACTUAL_TIME_KEY);
+
+  return cached ? JSON.parse(cached) : false;
+}

--- a/src/features/game/GameProvider.tsx
+++ b/src/features/game/GameProvider.tsx
@@ -22,7 +22,9 @@ import {
   getEnableQuickSelectSetting,
 } from "features/farming/hud/lib/quickSelect";
 import {
+  cacheShowActualTimeSetting,
   cacheShowTimersSetting,
+  getShowActualTimeSetting,
   getShowTimersSetting,
 } from "features/farming/hud/lib/timers";
 import { initInteractionMetrics } from "./lib/interactionMetrics";
@@ -42,6 +44,12 @@ interface GameContext {
   toggleQuickSelect: () => void;
   showTimers: boolean;
   toggleTimers: () => void;
+  /**
+   * Which reading a boosted timer shows: the remaining WORK (false, the default)
+   * or the actual wall-clock time until ready (true). See `timerDisplay.ts`.
+   */
+  showActualTime: boolean;
+  toggleActualTime: () => void;
   fromRoute?: string;
   setFromRoute: (route: string) => void;
 }
@@ -96,6 +104,9 @@ export const GameProvider: React.FC<React.PropsWithChildren> = ({
     getEnableQuickSelectSetting(),
   );
   const [showTimers, setShowTimers] = useState<boolean>(getShowTimersSetting());
+  const [showActualTime, setShowActualTime] = useState<boolean>(
+    getShowActualTimeSetting(),
+  );
   const [fromRoute, setFromRoute] = useState<string | undefined>();
 
   const shortcutItem = useCallback((item: InventoryItemName) => {
@@ -149,6 +160,13 @@ export const GameProvider: React.FC<React.PropsWithChildren> = ({
     cacheShowTimersSetting(newValue);
   };
 
+  const toggleActualTime = () => {
+    const newValue = !showActualTime;
+
+    setShowActualTime(newValue);
+    cacheShowActualTimeSetting(newValue);
+  };
+
   const selectedItem = shortcuts.length > 0 ? shortcuts[0] : undefined;
 
   return (
@@ -165,6 +183,8 @@ export const GameProvider: React.FC<React.PropsWithChildren> = ({
         toggleQuickSelect,
         showTimers,
         toggleTimers,
+        showActualTime,
+        toggleActualTime,
         fromRoute,
         setFromRoute,
       }}

--- a/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
+++ b/src/features/game/expansion/components/resources/crimstone/Crimstone.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { CRIMSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import type {
   GameState,
@@ -20,17 +19,14 @@ import { DepletedCrimstone } from "./components/DepletedCrimstone";
 import { getCrimstoneStage } from "./getCrimstoneStage";
 import { useSound } from "lib/utils/hooks/useSound";
 import { getCrimstoneDropAmount } from "features/game/events/landExpansion/mineCrimstone";
-import { useNow } from "lib/utils/hooks/useNow";
 import { isWearableActive } from "features/game/lib/wearables";
 import { Transition } from "@headlessui/react";
 import lightning from "assets/icons/lightning.png";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getMineBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 const HITS = 3;
 const tool = "Gold Pickaxe";
@@ -124,48 +120,22 @@ export const Crimstone: React.FC<Props> = ({ id }) => {
   const hasTool = HasTool(inventory, state);
 
   const { minedAt, baseDurationMs } = resource.stone;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy rocks use the back-dated minedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: minedAt,
-          baseDurationMs,
-          windows: mineBoostWindows,
-        })
-      : minedAt + CRIMSTONE_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed rocks are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    readyAt,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: minedAt,
+    baseDurationMs,
+    windows: mineBoostWindows,
+    legacyReadyAt: minedAt + CRIMSTONE_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: mineBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
 
+  // Keyed off the wall clock and readyAt, so the art is unaffected by which
+  // reading the timer label is showing.
   const crimstoneStage = getCrimstoneStage(resource.minesLeft, now, readyAt);
 
-  // For windowed rocks the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: minedAt,
-              at: now,
-              windows: mineBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(resource.stone.minedAt, CRIMSTONE_RECOVERY_TIME, now);
   const mined = !canMine(resource, "Crimstone Rock", state, now);
 
   const [isAnimationRunning, setIsAnimationRunning] = useState(false);

--- a/src/features/game/expansion/components/resources/gold/Gold.tsx
+++ b/src/features/game/expansion/components/resources/gold/Gold.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { GOLD_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import type { InventoryItemName, Rock, Skills } from "features/game/types/game";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { useSelector } from "@xstate/react";
@@ -16,17 +15,14 @@ import { canMine } from "features/game/lib/resourceNodes";
 import { useSound } from "lib/utils/hooks/useSound";
 import { getGoldDropAmount } from "features/game/events/landExpansion/mineGold";
 import type { GoldRockName } from "features/game/types/resources";
-import { useNow } from "lib/utils/hooks/useNow";
 import { Transition } from "@headlessui/react";
 import lightning from "assets/icons/lightning.png";
 import { KNOWN_IDS } from "features/game/types";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getMineBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 const HITS = 3;
 const tool = "Iron Pickaxe";
@@ -137,45 +133,16 @@ export const Gold: React.FC<Props> = ({ id }) => {
   const hasTool = HasTool(inventory, resource);
 
   const { minedAt, baseDurationMs } = resource.stone;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy rocks use the back-dated minedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: minedAt,
-          baseDurationMs,
-          windows: mineBoostWindows,
-        })
-      : minedAt + GOLD_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed rocks are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: minedAt,
+    baseDurationMs,
+    windows: mineBoostWindows,
+    legacyReadyAt: minedAt + GOLD_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: mineBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
-  // For windowed rocks the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: minedAt,
-              at: now,
-              windows: mineBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(resource.stone.minedAt, GOLD_RECOVERY_TIME, now);
   const mined = !canMine(resource, goldRockName, state, now);
 
   const [isAnimationRunning, setIsAnimationRunning] = useState(false);

--- a/src/features/game/expansion/components/resources/iron/Iron.tsx
+++ b/src/features/game/expansion/components/resources/iron/Iron.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { IRON_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import type { InventoryItemName, Rock, Skills } from "features/game/types/game";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { useSelector } from "@xstate/react";
@@ -16,15 +15,12 @@ import { RecoveredIron } from "./components/RecoveredIron";
 import { useSound } from "lib/utils/hooks/useSound";
 import { getIronDropAmount } from "features/game/events/landExpansion/ironMine";
 import type { IronRockName, RockName } from "features/game/types/resources";
-import { useNow } from "lib/utils/hooks/useNow";
 import { KNOWN_IDS } from "features/game/types";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getMineBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 const HITS = 3;
 const tool = "Stone Pickaxe";
@@ -134,45 +130,16 @@ export const Iron: React.FC<Props> = ({ id }) => {
   const hasTool = HasTool(inventory, resource);
 
   const { minedAt, baseDurationMs } = resource.stone;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy rocks use the back-dated minedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: minedAt,
-          baseDurationMs,
-          windows: mineBoostWindows,
-        })
-      : minedAt + IRON_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed rocks are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: minedAt,
+    baseDurationMs,
+    windows: mineBoostWindows,
+    legacyReadyAt: minedAt + IRON_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: mineBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
-  // For windowed rocks the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: minedAt,
-              at: now,
-              windows: mineBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(resource.stone.minedAt, IRON_RECOVERY_TIME, now);
   const mined = !canMine(resource, ironRockName, state, now);
 
   useUiRefresher({ active: mined });

--- a/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
+++ b/src/features/game/expansion/components/resources/oilReserve/OilReserve.tsx
@@ -13,15 +13,11 @@ import {
 } from "features/game/events/landExpansion/drillOilReserve";
 import { RecoveringOilReserve } from "./components/RecoveringOilReserve";
 import { DepletedOilReserve } from "./components/DepletedOilReserve";
-import { getTimeLeft } from "lib/utils/time";
-import { useNow } from "lib/utils/hooks/useNow";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getOilBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 interface Props {
   id: string;
@@ -86,55 +82,26 @@ export const OilReserve: React.FC<Props> = ({ id }) => {
   );
 
   const { drilledAt, baseDurationMs } = reserve.oil;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy reserves use the back-dated drilledAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: drilledAt,
-          baseDurationMs,
-          windows: oilBoostWindows,
-        })
-      : drilledAt + OIL_RESERVE_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed reserves are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    speed,
+    workLeftSeconds,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: drilledAt,
+    baseDurationMs,
+    windows: oilBoostWindows,
+    legacyReadyAt: drilledAt + OIL_RESERVE_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: oilBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
 
-  // For windowed reserves the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: drilledAt,
-              at: now,
-              windows: oilBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(drilledAt, OIL_RESERVE_RECOVERY_TIME, now);
-
-  const ready = timeLeft <= 0;
-  // Half-recovery art switches at the midpoint of remaining WORK, so it lands at
-  // the right point when a boost has shrunk the remaining duration.
+  // Readiness and the half-recovery art both key off remaining WORK, never the
+  // displayed reading — the reserve is equally full whichever the player has
+  // chosen to see. The threshold is the midpoint of that work.
+  const ready = workLeftSeconds <= 0;
   const halfThreshold =
     baseDurationMs !== undefined
       ? baseDurationMs / 2000
       : OIL_RESERVE_RECOVERY_TIME / 2;
-  const halfReady = !ready && timeLeft <= halfThreshold;
+  const halfReady = !ready && workLeftSeconds <= halfThreshold;
 
   const handleDrill = async () => {
     if (!ready || drills.lessThan(requiredDrillAmount)) return;

--- a/src/features/game/expansion/components/resources/stone/Stone.tsx
+++ b/src/features/game/expansion/components/resources/stone/Stone.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { STONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import type {
   GameState,
   InventoryItemName,
@@ -24,15 +23,12 @@ import {
   getStoneDropAmount,
 } from "features/game/events/landExpansion/stoneMine";
 import type { RockName, StoneRockName } from "features/game/types/resources";
-import { useNow } from "lib/utils/hooks/useNow";
 import { KNOWN_IDS } from "features/game/types";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getMineBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 const HITS = 3;
 const tool = "Pickaxe";
@@ -147,45 +143,16 @@ export const Stone: React.FC<Props> = ({ id }) => {
   const hasTool = HasTool(inventory, game, id);
 
   const { minedAt, baseDurationMs } = resource.stone;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy rocks use the back-dated minedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: minedAt,
-          baseDurationMs,
-          windows: mineBoostWindows,
-        })
-      : minedAt + STONE_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed rocks are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: minedAt,
+    baseDurationMs,
+    windows: mineBoostWindows,
+    legacyReadyAt: minedAt + STONE_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: mineBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
-  // For windowed rocks the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: minedAt,
-              at: now,
-              windows: mineBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(resource.stone.minedAt, STONE_RECOVERY_TIME, now);
   const mined = !canMine(resource, name, game, now);
 
   const strike = () => {

--- a/src/features/game/expansion/components/resources/sunstone/Sunstone.tsx
+++ b/src/features/game/expansion/components/resources/sunstone/Sunstone.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { SUNSTONE_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import type { InventoryItemName, Rock } from "features/game/types/game";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
 import { useSelector } from "@xstate/react";
@@ -13,14 +12,11 @@ import { DepletedSunstone } from "./components/DepletedSunstone";
 import { RecoveredSunstone } from "./components/RecoveredSunstone";
 import { DepletingSunstone } from "./components/DepletingSunstone";
 import { useSound } from "lib/utils/hooks/useSound";
-import { useNow } from "lib/utils/hooks/useNow";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getMineBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 const HITS = 3;
 const tool = "Gold Pickaxe";
@@ -103,45 +99,17 @@ export const Sunstone: React.FC<Props> = ({ id, index }) => {
   const hasTool = HasTool(inventory);
 
   const { minedAt, baseDurationMs } = resource.stone;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy rocks use the back-dated minedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: minedAt,
-          baseDurationMs,
-          windows: mineBoostWindows,
-        })
-      : minedAt + SUNSTONE_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed rocks are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    readyAt,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: minedAt,
+    baseDurationMs,
+    windows: mineBoostWindows,
+    legacyReadyAt: minedAt + SUNSTONE_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: mineBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
-  // For windowed rocks the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: minedAt,
-              at: now,
-              windows: mineBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(resource.stone.minedAt, SUNSTONE_RECOVERY_TIME, now);
   // Sunstone has no recovery boost, so readiness is purely `now` vs the local
   // readyAt — no need to subscribe to (or pass) the full game state. Equivalent to
   // `!canMine(resource, "Sunstone Rock", game, now)` for a boost-less rock.

--- a/src/features/game/expansion/components/resources/tree/Tree.tsx
+++ b/src/features/game/expansion/components/resources/tree/Tree.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { TREE_RECOVERY_TIME } from "features/game/lib/constants";
 import { Context } from "features/game/GameProvider";
 
-import { getTimeLeft } from "lib/utils/time";
 import type {
   GameState,
   InventoryItemName,
@@ -16,12 +15,10 @@ import {
   getWoodDropAmount,
 } from "features/game/events/landExpansion/chop";
 import {
-  computeReadyAt,
-  getEffectiveSpeedAt,
   getTreeBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 import { KNOWN_IDS } from "features/game/types";
 import type { TreeName } from "features/game/types/resources";
 import useUiRefresher from "lib/utils/hooks/useUiRefresher";
@@ -43,7 +40,6 @@ import { useSound } from "lib/utils/hooks/useSound";
 import { setPrecision } from "lib/utils/formatNumber";
 import { Transition } from "@headlessui/react";
 import lightning from "assets/icons/lightning.png";
-import { useNow } from "lib/utils/hooks/useNow";
 import type { FarmActivityName } from "features/game/types/farmActivity";
 
 const HITS = 3;
@@ -160,48 +156,18 @@ export const Tree: React.FC<Props> = ({ id }) => {
   const hasTool = HasTool(inventory, game, id);
 
   const { choppedAt, baseDurationMs } = resource.wood;
-  // Speed-rate model (baseDurationMs set): derive the ready time live from the
-  // boost windows. Legacy trees use the back-dated choppedAt + base recovery.
-  const readyAt =
-    baseDurationMs !== undefined
-      ? computeReadyAt({
-          startedAt: choppedAt,
-          baseDurationMs,
-          windows: treeBoostWindows,
-        })
-      : choppedAt + TREE_RECOVERY_TIME * 1000;
-
-  // Coarse 1s clock to pick the current boost speed; only windowed trees are
-  // boosted. Gated to windowed trees and stopped at readyAt so recovered/legacy
-  // trees don't re-render every second. Tick the countdown faster (1000/speed)
-  // so it drops ~1s per visual tick rather than jumping by `speed` each second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const {
+    now,
+    readyAt,
+    speed,
+    displaySeconds: timeLeft,
+  } = useNodeTimer({
+    startedAt: choppedAt,
+    baseDurationMs,
+    windows: treeBoostWindows,
+    legacyReadyAt: choppedAt + TREE_RECOVERY_TIME * 1000,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: treeBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
   const isSeasoned = isSeasonedPlayer({ game, verified, now });
-
-  // For windowed trees the remaining time is remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  const timeLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt: choppedAt,
-              at: now,
-              windows: treeBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : getTimeLeft(choppedAt, TREE_RECOVERY_TIME, now);
   const chopped = now <= readyAt;
 
   const [isAnimationRunning, setIsAnimationRunning] = useState(false);

--- a/src/features/game/lib/boostContributions.test.ts
+++ b/src/features/game/lib/boostContributions.test.ts
@@ -51,7 +51,7 @@ describe("contributions match the window builders", () => {
     "Rice Seed",
     "Grape Seed",
   ])("%s", (seed) => {
-    expect(flatten(getSeedBoostContributions(BOOSTED, seed))).toEqual(
+    expect(flatten(getSeedBoostContributions(BOOSTED, seed, at))).toEqual(
       getSeedBoostWindows(BOOSTED, seed),
     );
   });
@@ -65,7 +65,7 @@ describe("contributions match the window builders", () => {
     "Sunstone Rock",
     "Oil Reserve",
   ])("%s", (node) => {
-    expect(flatten(getNodeBoostContributions(BOOSTED, node))).toEqual(
+    expect(flatten(getNodeBoostContributions(BOOSTED, node, at))).toEqual(
       getNodeBoostWindows(BOOSTED, node),
     );
   });
@@ -75,7 +75,7 @@ describe("getBoostContributionEntries", () => {
   const format = (seconds: number) => `${Math.round(seconds / 60)}m`;
   const entries = (showActualTime: boolean, seconds = 4 * HOUR) =>
     getBoostContributionEntries({
-      contributions: getNodeBoostContributions(BOOSTED, "Tree"),
+      contributions: getNodeBoostContributions(BOOSTED, "Tree", at),
       seconds,
       at,
       showActualTime,
@@ -121,7 +121,7 @@ describe("getBoostContributionEntries", () => {
   it("leaves out a booster that is no longer running", () => {
     // Nothing placed → nothing to list, in either view.
     const none = getBoostContributionEntries({
-      contributions: getNodeBoostContributions(TEST_FARM, "Tree"),
+      contributions: getNodeBoostContributions(TEST_FARM, "Tree", at),
       seconds: 4 * HOUR,
       at,
       showActualTime: true,
@@ -130,5 +130,59 @@ describe("getBoostContributionEntries", () => {
     });
 
     expect(none).toEqual([]);
+  });
+});
+
+describe("totem attribution", () => {
+  const format = (seconds: number) => `${Math.round(seconds / 60)}m`;
+
+  it("credits the totem that is actually running, not one burned earlier", () => {
+    // A Super Totem burned last week leaves a finalised interval in
+    // boostHistory. The Time Warp Totem running now must take the credit.
+    const game: GameState = {
+      ...TEST_FARM,
+      collectibles: {
+        ...TEST_FARM.collectibles,
+        "Time Warp Totem": place("1", 0),
+      },
+      boostHistory: {
+        "Super Totem": [
+          { from: createdAt - 8 * 60 * 60 * 1000, to: createdAt - 1000 },
+        ],
+      },
+    };
+
+    const entries = getBoostContributionEntries({
+      contributions: getNodeBoostContributions(game, "Tree", at),
+      seconds: 4 * HOUR,
+      at,
+      showActualTime: false,
+      formatSeconds: format,
+      formatSpeed: (speed) => `Speed: ${speed}x`,
+    });
+
+    expect(entries).toEqual([{ name: "Time Warp Totem", value: "Speed: 2x" }]);
+  });
+
+  it("credits the Super Totem while it is the one running", () => {
+    const game: GameState = {
+      ...TEST_FARM,
+      collectibles: {
+        ...TEST_FARM.collectibles,
+        "Super Totem": place("1", 0),
+        "Time Warp Totem": place("2", 1),
+      },
+    };
+
+    const entries = getBoostContributionEntries({
+      contributions: getNodeBoostContributions(game, "Tree", at),
+      seconds: 4 * HOUR,
+      at,
+      showActualTime: false,
+      formatSeconds: format,
+      formatSpeed: (speed) => `Speed: ${speed}x`,
+    });
+
+    expect(entries).toEqual([{ name: "Super Totem", value: "Speed: 2x" }]);
   });
 });

--- a/src/features/game/lib/boostContributions.test.ts
+++ b/src/features/game/lib/boostContributions.test.ts
@@ -1,0 +1,134 @@
+import {
+  getBoostContributionEntries,
+  getNodeBoostContributions,
+  getSeedBoostContributions,
+} from "./boostContributions";
+import { getNodeBoostWindows, getSeedBoostWindows } from "./seedBoostWindows";
+import { TEST_FARM } from "./constants";
+import type { GameState } from "../types/game";
+import type { SeedName } from "../types/seeds";
+import type { ResourceName } from "../types/resources";
+
+const createdAt = 1_000_000;
+const at = createdAt + 1000;
+const HOUR = 60 * 60;
+
+const place = (id: string, x: number) => [
+  { id, coordinates: { x, y: 0 }, createdAt },
+];
+
+/** Everything windowed placed at once, so every resolver finds something. */
+const BOOSTED: GameState = {
+  ...TEST_FARM,
+  collectibles: {
+    ...TEST_FARM.collectibles,
+    "Sparrow Shrine": place("1", 0),
+    "Harvest Hourglass": place("2", 1),
+    "Super Totem": place("3", 2),
+    "Timber Hourglass": place("4", 3),
+    "Badger Shrine": place("5", 4),
+    "Ore Hourglass": place("6", 5),
+    "Mole Shrine": place("7", 6),
+    "Orchard Hourglass": place("8", 7),
+    "Toucan Shrine": place("9", 8),
+    "Blossom Hourglass": place("10", 9),
+    "Moth Shrine": place("11", 10),
+    "Stag Shrine": place("12", 11),
+    "Tortoise Shrine": place("13", 12),
+  },
+};
+
+// The panel's names must describe the SAME windows the readiness maths uses, or
+// the list would explain a number it didn't produce. These pin the two together.
+describe("contributions match the window builders", () => {
+  const flatten = (contributions: { windows: unknown[] }[]): unknown[] =>
+    contributions.flatMap(({ windows }) => windows);
+
+  it.each<SeedName>([
+    "Sunflower Seed",
+    "Apple Seed",
+    "Sunpetal Seed",
+    "Rice Seed",
+    "Grape Seed",
+  ])("%s", (seed) => {
+    expect(flatten(getSeedBoostContributions(BOOSTED, seed))).toEqual(
+      getSeedBoostWindows(BOOSTED, seed),
+    );
+  });
+
+  it.each<ResourceName>([
+    "Tree",
+    "Stone Rock",
+    "Iron Rock",
+    "Gold Rock",
+    "Crimstone Rock",
+    "Sunstone Rock",
+    "Oil Reserve",
+  ])("%s", (node) => {
+    expect(flatten(getNodeBoostContributions(BOOSTED, node))).toEqual(
+      getNodeBoostWindows(BOOSTED, node),
+    );
+  });
+});
+
+describe("getBoostContributionEntries", () => {
+  const format = (seconds: number) => `${Math.round(seconds / 60)}m`;
+  const entries = (showActualTime: boolean, seconds = 4 * HOUR) =>
+    getBoostContributionEntries({
+      contributions: getNodeBoostContributions(BOOSTED, "Tree"),
+      seconds,
+      at,
+      showActualTime,
+      formatSeconds: format,
+      formatSpeed: (speed) => `Speed: ${speed}x`,
+    });
+
+  it("shows each booster's rate in the speed view", () => {
+    // Trees: merged totems (2×) + Timber Hourglass (1.35×) + Badger Shrine (1.35×).
+    expect(entries(false)).toEqual([
+      { name: "Super Totem", value: "Speed: 2x" },
+      { name: "Timber Hourglass", value: "Speed: 1.35x" },
+      { name: "Badger Shrine", value: "Speed: 1.35x" },
+    ]);
+  });
+
+  it("shows each booster's time saving in the actual-time view", () => {
+    const actual = entries(true);
+
+    expect(actual.map((entry) => entry.name)).toEqual([
+      "Super Totem",
+      "Timber Hourglass",
+      "Badger Shrine",
+    ]);
+    // Every value is a saving, and the 2× totem saves more than a 1.35× shrine.
+    actual.forEach((entry) => expect(entry.value).toMatch(/^-\d+m$/));
+    const minutes = (value: string) => Number(value.replace(/[-m]/g, ""));
+    expect(minutes(actual[0].value)).toBeGreaterThan(minutes(actual[2].value));
+  });
+
+  it("shrinks the saving as the booster's window runs out", () => {
+    // Same boosts, but a task far longer than the hourglass can cover: the
+    // saving is capped by what is left on the window, not the raw multiplier.
+    const short = entries(true, 4 * HOUR);
+    const long = entries(true, 400 * HOUR);
+    const minutes = (value: string) => Number(value.replace(/[-m]/g, ""));
+
+    // The hourglass cannot save more on the long task than its window is worth.
+    expect(minutes(long[1].value)).toBeLessThan(minutes(long[0].value) * 10);
+    expect(minutes(short[1].value)).toBeGreaterThan(0);
+  });
+
+  it("leaves out a booster that is no longer running", () => {
+    // Nothing placed → nothing to list, in either view.
+    const none = getBoostContributionEntries({
+      contributions: getNodeBoostContributions(TEST_FARM, "Tree"),
+      seconds: 4 * HOUR,
+      at,
+      showActualTime: true,
+      formatSeconds: format,
+      formatSpeed: (speed) => `Speed: ${speed}x`,
+    });
+
+    expect(none).toEqual([]);
+  });
+});

--- a/src/features/game/lib/boostContributions.ts
+++ b/src/features/game/lib/boostContributions.ts
@@ -1,0 +1,249 @@
+import type { BoostName, GameState } from "../types/game";
+import type { ResourceName, RockName } from "../types/resources";
+import type { SeedName } from "../types/seeds";
+import { isFlowerSeed } from "../types/flowers";
+import { GREENHOUSE_FRUIT_SEEDS, isPatchFruitSeed } from "../types/fruits";
+import { GREENHOUSE_SEEDS } from "../types/crops";
+import { SEED_TO_PLANT } from "../events/landExpansion/plantGreenhouse";
+import type { GreenHouseCropName } from "../types/crops";
+import type { GreenHouseFruitName } from "../types/fruits";
+import {
+  CROP_PLOT_BOOST_SPEED,
+  FLOWER_BOOST_SPEED,
+  FRUIT_BOOST_SPEED,
+  GREENHOUSE_BOOST_SPEED,
+  MINE_BOOST_SPEED,
+  OIL_BOOST_SPEED,
+  TREE_BOOST_SPEED,
+  getBoostWindows,
+  getEffectiveSpeedAt,
+  getMergedTotemWindows,
+  getPowerHourWindows,
+  getSunshowerWindows,
+  type BoostWindow,
+} from "./boostWindows";
+import { projectSeconds } from "./timerDisplay";
+import type { TemporaryCollectibleName } from "./collectibleBuilt";
+
+/**
+ * One boost's windows, with the name to show for it.
+ *
+ * `BoostWindow` is deliberately anonymous — the readiness maths only needs an
+ * interval and a rate. The boost PANEL needs to say which booster is responsible,
+ * so this pairs the two back up.
+ *
+ * The per-activity sets below mirror the builders in `boostWindows.ts` exactly;
+ * `boostContributions.test.ts` asserts that flattening them reproduces the
+ * builder's window set, so the two cannot drift apart.
+ */
+export type BoostContribution = {
+  name: BoostName;
+  windows: BoostWindow[];
+};
+
+const collectible = (
+  game: GameState,
+  name: TemporaryCollectibleName,
+  speed: number,
+): BoostContribution => ({
+  name,
+  windows: getBoostWindows({ game, name, speed }),
+});
+
+/**
+ * The two totems are one boost for a given activity (they never stack), so their
+ * windows merge into a single set. Attribute it to whichever is placed, matching
+ * how the legacy baked path recorded it — Super Totem wins when both are.
+ */
+const totems = (game: GameState, speed: number): BoostContribution => ({
+  name: getBoostWindows({ game, name: "Super Totem", speed }).length
+    ? "Super Totem"
+    : "Time Warp Totem",
+  windows: getMergedTotemWindows(game, speed),
+});
+
+const cropPlot = (game: GameState): BoostContribution[] => [
+  collectible(game, "Sparrow Shrine", CROP_PLOT_BOOST_SPEED["Sparrow Shrine"]),
+  collectible(
+    game,
+    "Harvest Hourglass",
+    CROP_PLOT_BOOST_SPEED["Harvest Hourglass"],
+  ),
+  totems(game, CROP_PLOT_BOOST_SPEED["Super Totem"]),
+  { name: "Power hour", windows: getPowerHourWindows(game) },
+  // A season Guardian doubles the sunshower rate rather than adding a window of
+  // its own, so the whole thing is attributed to the event.
+  { name: "sunshower", windows: getSunshowerWindows(game) },
+];
+
+const tree = (game: GameState): BoostContribution[] => [
+  totems(game, TREE_BOOST_SPEED["Super Totem"]),
+  collectible(game, "Timber Hourglass", TREE_BOOST_SPEED["Timber Hourglass"]),
+  collectible(game, "Badger Shrine", TREE_BOOST_SPEED["Badger Shrine"]),
+];
+
+const fruit = (game: GameState): BoostContribution[] => [
+  totems(game, FRUIT_BOOST_SPEED["Super Totem"]),
+  collectible(
+    game,
+    "Orchard Hourglass",
+    FRUIT_BOOST_SPEED["Orchard Hourglass"],
+  ),
+  collectible(game, "Toucan Shrine", FRUIT_BOOST_SPEED["Toucan Shrine"]),
+];
+
+const flower = (game: GameState): BoostContribution[] => [
+  collectible(
+    game,
+    "Blossom Hourglass",
+    FLOWER_BOOST_SPEED["Blossom Hourglass"],
+  ),
+  collectible(game, "Moth Shrine", FLOWER_BOOST_SPEED["Moth Shrine"]),
+];
+
+const oil = (game: GameState): BoostContribution[] => [
+  collectible(game, "Stag Shrine", OIL_BOOST_SPEED["Stag Shrine"]),
+];
+
+const greenhouse = (
+  game: GameState,
+  plant: GreenHouseCropName | GreenHouseFruitName,
+): BoostContribution[] => [
+  totems(game, GREENHOUSE_BOOST_SPEED["Super Totem"]),
+  collectible(
+    game,
+    "Tortoise Shrine",
+    GREENHOUSE_BOOST_SPEED["Tortoise Shrine"],
+  ),
+  plant === "Grape"
+    ? collectible(
+        game,
+        "Orchard Hourglass",
+        GREENHOUSE_BOOST_SPEED["Orchard Hourglass"],
+      )
+    : collectible(
+        game,
+        "Harvest Hourglass",
+        GREENHOUSE_BOOST_SPEED["Harvest Hourglass"],
+      ),
+];
+
+const mine = (game: GameState, rock: RockName): BoostContribution[] => {
+  switch (rock) {
+    case "Stone Rock":
+    case "Fused Stone Rock":
+    case "Reinforced Stone Rock":
+      return [
+        totems(game, MINE_BOOST_SPEED["Super Totem"]),
+        collectible(game, "Ore Hourglass", MINE_BOOST_SPEED["Ore Hourglass"]),
+        collectible(game, "Badger Shrine", MINE_BOOST_SPEED["Badger Shrine"]),
+      ];
+    case "Iron Rock":
+    case "Refined Iron Rock":
+    case "Tempered Iron Rock":
+    case "Gold Rock":
+    case "Pure Gold Rock":
+    case "Prime Gold Rock":
+      return [
+        totems(game, MINE_BOOST_SPEED["Super Totem"]),
+        collectible(game, "Ore Hourglass", MINE_BOOST_SPEED["Ore Hourglass"]),
+        collectible(game, "Mole Shrine", MINE_BOOST_SPEED["Mole Shrine"]),
+      ];
+    case "Crimstone Rock":
+      return [
+        collectible(game, "Mole Shrine", MINE_BOOST_SPEED["Mole Shrine"]),
+      ];
+    case "Sunstone Rock":
+    case "Ascension Crystal":
+      return [];
+  }
+};
+
+/** The named boosts that would speed up this seed — mirrors getSeedBoostWindows. */
+export function getSeedBoostContributions(
+  game: GameState,
+  seed: SeedName,
+): BoostContribution[] {
+  if (isFlowerSeed(seed)) return flower(game);
+  if (isPatchFruitSeed(seed)) return fruit(game);
+  if (seed in GREENHOUSE_SEEDS || seed in GREENHOUSE_FRUIT_SEEDS) {
+    return greenhouse(game, SEED_TO_PLANT[seed as keyof typeof SEED_TO_PLANT]);
+  }
+
+  return cropPlot(game);
+}
+
+/** The named boosts that would speed up this node — mirrors getNodeBoostWindows. */
+export function getNodeBoostContributions(
+  game: GameState,
+  node: ResourceName,
+): BoostContribution[] {
+  if (node === "Tree") return tree(game);
+  if (node === "Oil Reserve") return oil(game);
+  if (node.endsWith("Rock")) return mine(game, node as RockName);
+
+  return [];
+}
+
+/**
+ * Boost-panel rows for the windowed boosts running right now, in the same
+ * `{ name, value }` shape as the baked `boostsUsed` the panels already list.
+ *
+ * What the value says depends on the reading, so the boost is stated once and in
+ * the same terms as the time beside it:
+ *
+ * - Speed view: the rate it is running at — `1.35x`.
+ * - Actual-time view: the time it actually saves on THIS task — its marginal
+ *   contribution, i.e. how much longer the task would take without it. A booster
+ *   about to expire therefore shows a small saving even though its rate is
+ *   unchanged, which is the whole point of the projection.
+ *
+ * Boosts not covering `at` (expired, or only in `boostHistory`) are left out:
+ * they do nothing for a task started now.
+ */
+export function getBoostContributionEntries({
+  contributions,
+  seconds,
+  at,
+  showActualTime,
+  formatSeconds,
+  formatSpeed,
+}: {
+  contributions: BoostContribution[];
+  seconds: number;
+  at: number;
+  showActualTime: boolean;
+  /** How to render a duration — the caller's `secondsToString`. */
+  formatSeconds: (seconds: number) => string;
+  /** How to render a rate — the caller's translated "Speed: {{speed}}x". */
+  formatSpeed: (speed: number) => string;
+}): { name: BoostName; value: string }[] {
+  const active = contributions.filter(
+    ({ windows }) => getEffectiveSpeedAt({ at, windows }) > 1,
+  );
+  if (active.length === 0) return [];
+
+  const allWindows = active.flatMap(({ windows }) => windows);
+  const boostedSeconds = projectSeconds({ seconds, windows: allWindows, at });
+
+  return active.map(({ name, windows }) => {
+    if (!showActualTime) {
+      return {
+        name,
+        value: formatSpeed(
+          Number(getEffectiveSpeedAt({ at, windows }).toFixed(2)),
+        ),
+      };
+    }
+
+    // Marginal saving: how much longer this task would take without this one
+    // boost, everything else unchanged.
+    const withoutThis = projectSeconds({
+      seconds,
+      windows: allWindows.filter((window) => !windows.includes(window)),
+      at,
+    });
+
+    return { name, value: `-${formatSeconds(withoutThis - boostedSeconds)}` };
+  });
+}

--- a/src/features/game/lib/boostContributions.ts
+++ b/src/features/game/lib/boostContributions.ts
@@ -52,38 +52,52 @@ const collectible = (
 
 /**
  * The two totems are one boost for a given activity (they never stack), so their
- * windows merge into a single set. Attribute it to whichever is placed, matching
- * how the legacy baked path recorded it — Super Totem wins when both are.
+ * windows merge into a single set for the timing. The label has to come from
+ * whichever is actually running at `at` — Super Totem wins when both are,
+ * matching how the legacy baked path recorded it.
+ *
+ * Note this cannot key off "has any windows": `getBoostWindows` includes
+ * finalised intervals from `boostHistory`, so a Super Totem burned earlier this
+ * week would otherwise take the credit from a Time Warp Totem running now.
  */
-const totems = (game: GameState, speed: number): BoostContribution => ({
-  name: getBoostWindows({ game, name: "Super Totem", speed }).length
-    ? "Super Totem"
-    : "Time Warp Totem",
-  windows: getMergedTotemWindows(game, speed),
-});
+const totems = (
+  game: GameState,
+  speed: number,
+  at: number,
+): BoostContribution => {
+  const superTotem = getBoostWindows({ game, name: "Super Totem", speed });
 
-const cropPlot = (game: GameState): BoostContribution[] => [
+  return {
+    name:
+      getEffectiveSpeedAt({ at, windows: superTotem }) > 1
+        ? "Super Totem"
+        : "Time Warp Totem",
+    windows: getMergedTotemWindows(game, speed),
+  };
+};
+
+const cropPlot = (game: GameState, at: number): BoostContribution[] => [
   collectible(game, "Sparrow Shrine", CROP_PLOT_BOOST_SPEED["Sparrow Shrine"]),
   collectible(
     game,
     "Harvest Hourglass",
     CROP_PLOT_BOOST_SPEED["Harvest Hourglass"],
   ),
-  totems(game, CROP_PLOT_BOOST_SPEED["Super Totem"]),
+  totems(game, CROP_PLOT_BOOST_SPEED["Super Totem"], at),
   { name: "Power hour", windows: getPowerHourWindows(game) },
   // A season Guardian doubles the sunshower rate rather than adding a window of
   // its own, so the whole thing is attributed to the event.
   { name: "sunshower", windows: getSunshowerWindows(game) },
 ];
 
-const tree = (game: GameState): BoostContribution[] => [
-  totems(game, TREE_BOOST_SPEED["Super Totem"]),
+const tree = (game: GameState, at: number): BoostContribution[] => [
+  totems(game, TREE_BOOST_SPEED["Super Totem"], at),
   collectible(game, "Timber Hourglass", TREE_BOOST_SPEED["Timber Hourglass"]),
   collectible(game, "Badger Shrine", TREE_BOOST_SPEED["Badger Shrine"]),
 ];
 
-const fruit = (game: GameState): BoostContribution[] => [
-  totems(game, FRUIT_BOOST_SPEED["Super Totem"]),
+const fruit = (game: GameState, at: number): BoostContribution[] => [
+  totems(game, FRUIT_BOOST_SPEED["Super Totem"], at),
   collectible(
     game,
     "Orchard Hourglass",
@@ -92,7 +106,7 @@ const fruit = (game: GameState): BoostContribution[] => [
   collectible(game, "Toucan Shrine", FRUIT_BOOST_SPEED["Toucan Shrine"]),
 ];
 
-const flower = (game: GameState): BoostContribution[] => [
+const flower = (game: GameState, at: number): BoostContribution[] => [
   collectible(
     game,
     "Blossom Hourglass",
@@ -101,15 +115,16 @@ const flower = (game: GameState): BoostContribution[] => [
   collectible(game, "Moth Shrine", FLOWER_BOOST_SPEED["Moth Shrine"]),
 ];
 
-const oil = (game: GameState): BoostContribution[] => [
+const oil = (game: GameState, at: number): BoostContribution[] => [
   collectible(game, "Stag Shrine", OIL_BOOST_SPEED["Stag Shrine"]),
 ];
 
 const greenhouse = (
   game: GameState,
   plant: GreenHouseCropName | GreenHouseFruitName,
+  at: number,
 ): BoostContribution[] => [
-  totems(game, GREENHOUSE_BOOST_SPEED["Super Totem"]),
+  totems(game, GREENHOUSE_BOOST_SPEED["Super Totem"], at),
   collectible(
     game,
     "Tortoise Shrine",
@@ -128,13 +143,17 @@ const greenhouse = (
       ),
 ];
 
-const mine = (game: GameState, rock: RockName): BoostContribution[] => {
+const mine = (
+  game: GameState,
+  rock: RockName,
+  at: number,
+): BoostContribution[] => {
   switch (rock) {
     case "Stone Rock":
     case "Fused Stone Rock":
     case "Reinforced Stone Rock":
       return [
-        totems(game, MINE_BOOST_SPEED["Super Totem"]),
+        totems(game, MINE_BOOST_SPEED["Super Totem"], at),
         collectible(game, "Ore Hourglass", MINE_BOOST_SPEED["Ore Hourglass"]),
         collectible(game, "Badger Shrine", MINE_BOOST_SPEED["Badger Shrine"]),
       ];
@@ -145,7 +164,7 @@ const mine = (game: GameState, rock: RockName): BoostContribution[] => {
     case "Pure Gold Rock":
     case "Prime Gold Rock":
       return [
-        totems(game, MINE_BOOST_SPEED["Super Totem"]),
+        totems(game, MINE_BOOST_SPEED["Super Totem"], at),
         collectible(game, "Ore Hourglass", MINE_BOOST_SPEED["Ore Hourglass"]),
         collectible(game, "Mole Shrine", MINE_BOOST_SPEED["Mole Shrine"]),
       ];
@@ -163,24 +182,30 @@ const mine = (game: GameState, rock: RockName): BoostContribution[] => {
 export function getSeedBoostContributions(
   game: GameState,
   seed: SeedName,
+  at: number,
 ): BoostContribution[] {
-  if (isFlowerSeed(seed)) return flower(game);
-  if (isPatchFruitSeed(seed)) return fruit(game);
+  if (isFlowerSeed(seed)) return flower(game, at);
+  if (isPatchFruitSeed(seed)) return fruit(game, at);
   if (seed in GREENHOUSE_SEEDS || seed in GREENHOUSE_FRUIT_SEEDS) {
-    return greenhouse(game, SEED_TO_PLANT[seed as keyof typeof SEED_TO_PLANT]);
+    return greenhouse(
+      game,
+      SEED_TO_PLANT[seed as keyof typeof SEED_TO_PLANT],
+      at,
+    );
   }
 
-  return cropPlot(game);
+  return cropPlot(game, at);
 }
 
 /** The named boosts that would speed up this node — mirrors getNodeBoostWindows. */
 export function getNodeBoostContributions(
   game: GameState,
   node: ResourceName,
+  at: number,
 ): BoostContribution[] {
-  if (node === "Tree") return tree(game);
-  if (node === "Oil Reserve") return oil(game);
-  if (node.endsWith("Rock")) return mine(game, node as RockName);
+  if (node === "Tree") return tree(game, at);
+  if (node === "Oil Reserve") return oil(game, at);
+  if (node.endsWith("Rock")) return mine(game, node as RockName, at);
 
   return [];
 }

--- a/src/features/game/lib/boostWindows.ts
+++ b/src/features/game/lib/boostWindows.ts
@@ -137,7 +137,7 @@ export const GREENHOUSE_BOOST_SPEED = {
 } as const;
 
 /** Window for the Power Hour buff (1h from activation), if active. */
-const getPowerHourWindows = (game: GameState): BoostWindow[] => {
+export const getPowerHourWindows = (game: GameState): BoostWindow[] => {
   const buff = game.buffs?.["Power hour"];
   if (buff?.startedAt === undefined) return [];
   return [
@@ -155,7 +155,7 @@ const getPowerHourWindows = (game: GameState): BoostWindow[] => {
  * runs from `startedAt` to the next UTC midnight. A built season Guardian doubles
  * the boost (2× → 4×).
  */
-const getSunshowerWindows = (game: GameState): BoostWindow[] => {
+export const getSunshowerWindows = (game: GameState): BoostWindow[] => {
   const startedAt = game.calendar?.sunshower?.startedAt;
   if (startedAt === undefined) return [];
 

--- a/src/features/game/lib/seedBoostWindows.test.ts
+++ b/src/features/game/lib/seedBoostWindows.test.ts
@@ -1,0 +1,108 @@
+import { getNodeBoostWindows, getSeedBoostWindows } from "./seedBoostWindows";
+import {
+  getCropPlotBoostWindows,
+  getFlowerBoostWindows,
+  getFruitBoostWindows,
+  getGreenhouseBoostWindows,
+  getMineBoostWindows,
+  getOilBoostWindows,
+  getTreeBoostWindows,
+} from "./boostWindows";
+import { TEST_FARM } from "./constants";
+import type { GameState } from "../types/game";
+
+const createdAt = 1_000_000;
+
+/** Every windowed booster at once, so each resolver has something to find. */
+const BOOSTED: GameState = {
+  ...TEST_FARM,
+  collectibles: {
+    ...TEST_FARM.collectibles,
+    "Harvest Hourglass": [{ id: "1", coordinates: { x: 0, y: 0 }, createdAt }],
+    "Orchard Hourglass": [{ id: "2", coordinates: { x: 1, y: 0 }, createdAt }],
+    "Blossom Hourglass": [{ id: "3", coordinates: { x: 2, y: 0 }, createdAt }],
+    "Timber Hourglass": [{ id: "4", coordinates: { x: 3, y: 0 }, createdAt }],
+    "Ore Hourglass": [{ id: "5", coordinates: { x: 4, y: 0 }, createdAt }],
+    "Stag Shrine": [{ id: "6", coordinates: { x: 5, y: 0 }, createdAt }],
+    "Tortoise Shrine": [{ id: "7", coordinates: { x: 6, y: 0 }, createdAt }],
+  },
+};
+
+describe("getSeedBoostWindows", () => {
+  it("resolves a crop seed to the plot windows", () => {
+    expect(getSeedBoostWindows(BOOSTED, "Sunflower Seed")).toEqual(
+      getCropPlotBoostWindows(BOOSTED),
+    );
+  });
+
+  it("resolves a patch fruit seed to the fruit windows", () => {
+    expect(getSeedBoostWindows(BOOSTED, "Apple Seed")).toEqual(
+      getFruitBoostWindows(BOOSTED),
+    );
+  });
+
+  it("resolves a flower seed to the flower windows", () => {
+    expect(getSeedBoostWindows(BOOSTED, "Sunpetal Seed")).toEqual(
+      getFlowerBoostWindows(BOOSTED),
+    );
+  });
+
+  it("resolves a greenhouse CROP seed to that plant's windows", () => {
+    expect(getSeedBoostWindows(BOOSTED, "Rice Seed")).toEqual(
+      getGreenhouseBoostWindows(BOOSTED, "Rice"),
+    );
+  });
+
+  it("resolves a greenhouse FRUIT seed to Grape's windows", () => {
+    // Grape takes the Orchard Hourglass where Rice/Olive take Harvest, so this
+    // must not collapse into one greenhouse set.
+    expect(getSeedBoostWindows(BOOSTED, "Grape Seed")).toEqual(
+      getGreenhouseBoostWindows(BOOSTED, "Grape"),
+    );
+    expect(getSeedBoostWindows(BOOSTED, "Grape Seed")).not.toEqual(
+      getSeedBoostWindows(BOOSTED, "Rice Seed"),
+    );
+  });
+
+  it("returns nothing when no booster is placed", () => {
+    expect(getSeedBoostWindows(TEST_FARM, "Sunflower Seed")).toEqual([]);
+  });
+});
+
+describe("getNodeBoostWindows", () => {
+  it("resolves a Tree to the tree windows", () => {
+    expect(getNodeBoostWindows(BOOSTED, "Tree")).toEqual(
+      getTreeBoostWindows(BOOSTED),
+    );
+  });
+
+  it("resolves an Oil Reserve to the oil windows", () => {
+    expect(getNodeBoostWindows(BOOSTED, "Oil Reserve")).toEqual(
+      getOilBoostWindows(BOOSTED),
+    );
+  });
+
+  it.each(["Stone Rock", "Iron Rock", "Gold Rock"] as const)(
+    "resolves %s to the mine windows for that rock",
+    (rock) => {
+      expect(getNodeBoostWindows(BOOSTED, rock)).toEqual(
+        getMineBoostWindows(BOOSTED, rock),
+      );
+    },
+  );
+
+  it("gives crimstone its own (Mole-only) set, not the Ore Hourglass one", () => {
+    expect(getNodeBoostWindows(BOOSTED, "Crimstone Rock")).toEqual(
+      getMineBoostWindows(BOOSTED, "Crimstone Rock"),
+    );
+    expect(getNodeBoostWindows(BOOSTED, "Crimstone Rock")).not.toEqual(
+      getNodeBoostWindows(BOOSTED, "Stone Rock"),
+    );
+  });
+
+  it("returns nothing for a node that was never windowed", () => {
+    // Sunstone has no temporary recovery boost; crab pots and salt aren't rocks.
+    expect(getNodeBoostWindows(BOOSTED, "Sunstone Rock")).toEqual([]);
+    expect(getNodeBoostWindows(BOOSTED, "Crop Plot")).toEqual([]);
+  });
+});

--- a/src/features/game/lib/seedBoostWindows.ts
+++ b/src/features/game/lib/seedBoostWindows.ts
@@ -1,0 +1,56 @@
+import type { GameState } from "../types/game";
+import type { SeedName } from "../types/seeds";
+import type { ResourceName, RockName } from "../types/resources";
+import { isFlowerSeed } from "../types/flowers";
+import { GREENHOUSE_FRUIT_SEEDS, isPatchFruitSeed } from "../types/fruits";
+import { GREENHOUSE_SEEDS } from "../types/crops";
+import { SEED_TO_PLANT } from "../events/landExpansion/plantGreenhouse";
+import {
+  getCropPlotBoostWindows,
+  getFlowerBoostWindows,
+  getFruitBoostWindows,
+  getGreenhouseBoostWindows,
+  getMineBoostWindows,
+  getOilBoostWindows,
+  getTreeBoostWindows,
+  type BoostWindow,
+} from "./boostWindows";
+
+/**
+ * Which speed windows would apply to a task the player has NOT started yet.
+ *
+ * The in-world timers read their windows from the node they belong to; the
+ * pre-action panels (seed shop, guides) have only the thing being considered, so
+ * they resolve the activity from that. Anything unrecognised — or an activity
+ * that was never migrated to the windowed model — yields an empty set, which
+ * makes `projectSeconds` the identity.
+ */
+export function getSeedBoostWindows(
+  game: GameState,
+  seed: SeedName,
+): BoostWindow[] {
+  if (isFlowerSeed(seed)) return getFlowerBoostWindows(game);
+  if (isPatchFruitSeed(seed)) return getFruitBoostWindows(game);
+
+  if (seed in GREENHOUSE_SEEDS || seed in GREENHOUSE_FRUIT_SEEDS) {
+    return getGreenhouseBoostWindows(
+      game,
+      SEED_TO_PLANT[seed as keyof typeof SEED_TO_PLANT],
+    );
+  }
+
+  return getCropPlotBoostWindows(game);
+}
+
+/** As `getSeedBoostWindows`, for a resource node's recovery (the Tools Guide). */
+export function getNodeBoostWindows(
+  game: GameState,
+  node: ResourceName,
+): BoostWindow[] {
+  if (node === "Tree") return getTreeBoostWindows(game);
+  if (node === "Oil Reserve") return getOilBoostWindows(game);
+  if (node.endsWith("Rock")) return getMineBoostWindows(game, node as RockName);
+
+  // Water traps, salt and everything else were never windowed.
+  return [];
+}

--- a/src/features/game/lib/timerDisplay.test.ts
+++ b/src/features/game/lib/timerDisplay.test.ts
@@ -1,0 +1,288 @@
+import {
+  getDisplaySeconds,
+  getPreActionDisplay,
+  getPreActionTime,
+  getSurfacedSpeed,
+  getTickIntervalMs,
+  projectSeconds,
+} from "./timerDisplay";
+import type { BoostWindow } from "./boostWindows";
+
+const HOUR = 60 * 60;
+const HOUR_MS = HOUR * 1000;
+
+describe("getDisplaySeconds", () => {
+  it("shows the work reading by default (speed view)", () => {
+    expect(
+      getDisplaySeconds({
+        showActualTime: false,
+        workLeftSeconds: 3 * HOUR,
+        countdownSeconds: 1.5 * HOUR,
+      }),
+    ).toEqual(3 * HOUR);
+  });
+
+  it("shows the wall-clock reading when the setting is on", () => {
+    expect(
+      getDisplaySeconds({
+        showActualTime: true,
+        workLeftSeconds: 3 * HOUR,
+        countdownSeconds: 1.5 * HOUR,
+      }),
+    ).toEqual(1.5 * HOUR);
+  });
+
+  it("is the same number either way when nothing is boosting", () => {
+    // An unboosted task accrues work at 1×, so the two readings coincide — which
+    // is why the toggle is invisible on most of the farm.
+    const unboosted = { workLeftSeconds: 2 * HOUR, countdownSeconds: 2 * HOUR };
+
+    expect(getDisplaySeconds({ showActualTime: false, ...unboosted })).toEqual(
+      getDisplaySeconds({ showActualTime: true, ...unboosted }),
+    );
+  });
+});
+
+describe("getTickIntervalMs", () => {
+  it("ticks once a second in the wall-clock view, whatever the speed", () => {
+    expect(getTickIntervalMs({ showActualTime: true, speed: 1 })).toEqual(1000);
+    expect(getTickIntervalMs({ showActualTime: true, speed: 4 })).toEqual(1000);
+  });
+
+  it("ticks once a second in the speed view when nothing is boosting", () => {
+    expect(getTickIntervalMs({ showActualTime: false, speed: 1 })).toEqual(
+      1000,
+    );
+  });
+
+  it("ticks faster in the speed view so the work reading drops ~1s per tick", () => {
+    expect(getTickIntervalMs({ showActualTime: false, speed: 2 })).toEqual(500);
+    expect(getTickIntervalMs({ showActualTime: false, speed: 4 })).toEqual(250);
+  });
+
+  it("floors at 250ms so a big stack cannot spin the render loop", () => {
+    expect(getTickIntervalMs({ showActualTime: false, speed: 100 })).toEqual(
+      250,
+    );
+  });
+
+  it("never speeds up below 1× (a debuff must not slow the clock)", () => {
+    expect(getTickIntervalMs({ showActualTime: false, speed: 0.5 })).toEqual(
+      1000,
+    );
+  });
+});
+
+describe("projectSeconds", () => {
+  const at = 1_000_000;
+
+  it("returns the duration unchanged when no window applies", () => {
+    expect(projectSeconds({ seconds: 4 * HOUR, windows: [], at })).toEqual(
+      4 * HOUR,
+    );
+  });
+
+  it("halves a task fully covered by a 2× window", () => {
+    const windows: BoostWindow[] = [
+      { from: at, to: at + 10 * HOUR_MS, speed: 2 },
+    ];
+
+    expect(projectSeconds({ seconds: 4 * HOUR, windows, at })).toEqual(
+      2 * HOUR,
+    );
+  });
+
+  it("credits only the covered part when the window expires mid-task", () => {
+    // 1h at 2× = 2h of the 4h work, leaving 2h to run at 1× → 3h in total.
+    const windows: BoostWindow[] = [{ from: at, to: at + HOUR_MS, speed: 2 }];
+    const projected = projectSeconds({ seconds: 4 * HOUR, windows, at });
+
+    expect(projected).toEqual(3 * HOUR);
+    // Longer than the naive work/speed, shorter than un-boosted: the whole point
+    // of projecting rather than dividing.
+    expect(projected).toBeGreaterThan(4 * HOUR * 0.5);
+    expect(projected).toBeLessThan(4 * HOUR);
+  });
+
+  it("ignores a window that has already closed", () => {
+    const windows: BoostWindow[] = [
+      { from: at - 10 * HOUR_MS, to: at - HOUR_MS, speed: 2 },
+    ];
+
+    expect(projectSeconds({ seconds: 4 * HOUR, windows, at })).toEqual(
+      4 * HOUR,
+    );
+  });
+
+  it("credits a window that only starts later in the task", () => {
+    // 1h at 1×, then 2× for the remaining 3h of work → 1h + 1.5h = 2.5h.
+    const windows: BoostWindow[] = [
+      { from: at + HOUR_MS, to: at + 10 * HOUR_MS, speed: 2 },
+    ];
+
+    expect(projectSeconds({ seconds: 4 * HOUR, windows, at })).toEqual(
+      2.5 * HOUR,
+    );
+  });
+
+  it("stacks overlapping windows multiplicatively", () => {
+    const windows: BoostWindow[] = [
+      { from: at, to: at + 10 * HOUR_MS, speed: 2 },
+      { from: at, to: at + 10 * HOUR_MS, speed: 1.35 },
+    ];
+
+    expect(projectSeconds({ seconds: 4 * HOUR, windows, at })).toBeCloseTo(
+      (4 * HOUR) / 2.7,
+      5,
+    );
+  });
+});
+
+describe("getSurfacedSpeed", () => {
+  it("reports the live rate in the speed view", () => {
+    expect(getSurfacedSpeed({ showActualTime: false, speed: 1.25 })).toEqual(
+      1.25,
+    );
+  });
+
+  it("reports no rate in the actual-time view, whatever is running", () => {
+    // Every ⚡ in the game keys off this being > 1, so suppressing it here turns
+    // off the popover rate AND the in-world tile indicator together.
+    expect(getSurfacedSpeed({ showActualTime: true, speed: 1.25 })).toEqual(1);
+  });
+
+  it("is 1 either way when nothing is boosting", () => {
+    expect(getSurfacedSpeed({ showActualTime: false, speed: 1 })).toEqual(1);
+    expect(getSurfacedSpeed({ showActualTime: true, speed: 1 })).toEqual(1);
+  });
+});
+
+describe("getPreActionTime", () => {
+  const at = 1_000_000;
+  const seconds = 4 * HOUR;
+  // A 1.35× hourglass with only 30 minutes left to run.
+  const expiring: BoostWindow[] = [
+    { from: at - HOUR_MS, to: at + HOUR_MS / 2, speed: 1.35 },
+  ];
+
+  it("keeps the un-projected duration and reports the live speed in the speed view", () => {
+    expect(
+      getPreActionTime({
+        showActualTime: false,
+        seconds,
+        windows: expiring,
+        at,
+      }),
+    ).toEqual({ displaySeconds: seconds, speed: 1.35 });
+  });
+
+  it("projects the duration in the actual-time view", () => {
+    const { displaySeconds } = getPreActionTime({
+      showActualTime: true,
+      seconds,
+      windows: expiring,
+      at,
+    });
+
+    // Only the last 30 min of the hourglass covers the grow: 0.5h at 1.35× banks
+    // 40.5min of work, leaving 3h19.5m to run at 1× → 3h 49.5m.
+    expect(displaySeconds).toBeCloseTo(3.825 * HOUR, 5);
+    // Emphatically NOT the naive 4h / 1.35 = 2h 58m.
+    expect(displaySeconds).toBeGreaterThan(seconds / 1.35);
+  });
+
+  it("reports no rate in the actual-time view, where the duration carries it", () => {
+    // The projected number already accounts for the window, so surfacing the
+    // rate beside it would state the same boost twice.
+    expect(
+      getPreActionTime({
+        showActualTime: true,
+        seconds,
+        windows: expiring,
+        at,
+      }).speed,
+    ).toEqual(1);
+  });
+
+  it("reports speed 1 and an unchanged duration with nothing running", () => {
+    expect(
+      getPreActionTime({ showActualTime: true, seconds, windows: [], at }),
+    ).toEqual({ displaySeconds: seconds, speed: 1 });
+  });
+});
+
+describe("getPreActionDisplay", () => {
+  const at = 1_000_000;
+  const base = 4 * HOUR;
+  const live: BoostWindow[] = [{ from: at, to: at + 10 * HOUR_MS, speed: 2 }];
+
+  const call = (
+    args: Partial<Parameters<typeof getPreActionDisplay>[0]> = {},
+  ) =>
+    getPreActionDisplay({
+      showActualTime: false,
+      seconds: base,
+      baseSeconds: base,
+      namedBoostCount: 0,
+      windows: [],
+      at,
+      ...args,
+    });
+
+  it("stays plain with no boost of either kind", () => {
+    expect(call()).toEqual({
+      displaySeconds: base,
+      speed: 1,
+      hasNamedBoosts: false,
+      isBoosted: false,
+    });
+  });
+
+  it("uses the boosted layout for a live window alone, but isn't clickable", () => {
+    // The window has no name to itemise, so the panel shows the rate without
+    // offering a boost list.
+    expect(call({ windows: live })).toMatchObject({
+      speed: 2,
+      hasNamedBoosts: false,
+      isBoosted: true,
+    });
+  });
+
+  it("drops the rate but keeps the boosted layout in the actual-time view", () => {
+    // No rate to show, yet the projected 2h against a 4h base is still a boost.
+    expect(call({ windows: live, showActualTime: true })).toEqual({
+      displaySeconds: 2 * HOUR,
+      speed: 1,
+      hasNamedBoosts: false,
+      isBoosted: true,
+    });
+  });
+
+  it("is clickable when a named boost shortened the time", () => {
+    expect(call({ seconds: 3 * HOUR, namedBoostCount: 1 })).toMatchObject({
+      hasNamedBoosts: true,
+      isBoosted: true,
+    });
+  });
+
+  it("combines a named boost with a live window in the actual-time view", () => {
+    const { displaySeconds, isBoosted, hasNamedBoosts } = call({
+      showActualTime: true,
+      seconds: 3 * HOUR,
+      namedBoostCount: 1,
+      windows: live,
+    });
+
+    // The 3h already carries the named boost; the window halves it on top.
+    expect(displaySeconds).toEqual(1.5 * HOUR);
+    expect(isBoosted).toBe(true);
+    expect(hasNamedBoosts).toBe(true);
+  });
+
+  it("does not claim a boost for a debuffed (longer) time", () => {
+    expect(call({ seconds: 5 * HOUR, namedBoostCount: 1 })).toMatchObject({
+      isBoosted: true, // named boosts differ from base — existing behaviour
+    });
+    expect(call({ seconds: 5 * HOUR })).toMatchObject({ isBoosted: false });
+  });
+});

--- a/src/features/game/lib/timerDisplay.ts
+++ b/src/features/game/lib/timerDisplay.ts
@@ -72,6 +72,16 @@ export function getSurfacedSpeed({
 }
 
 /**
+ * How often a pre-action panel re-reads the clock.
+ *
+ * These projections go stale as a booster burns down — a panel left open would
+ * otherwise keep showing the saving that applied when it was opened. They are
+ * rendered at minute granularity, and a guide can list dozens of rows, so a
+ * once-a-minute tick keeps them honest without a per-second re-render storm.
+ */
+export const PRE_ACTION_TICK_MS = 60 * 1000;
+
+/**
  * "Start this now — how long until it's ready?", given the live boost windows.
  *
  * For the pre-action panels (seed shop, guides), which show a duration for a task

--- a/src/features/game/lib/timerDisplay.ts
+++ b/src/features/game/lib/timerDisplay.ts
@@ -1,0 +1,228 @@
+import {
+  computeReadyAt,
+  getEffectiveSpeedAt,
+  type BoostWindow,
+} from "./boostWindows";
+
+/**
+ * The two readings of a windowed timer.
+ *
+ * Under the speed-rate model a boost is a RATE, so a task's remaining "time" is
+ * ambiguous: there is the remaining WORK (in un-boosted base duration) and the
+ * remaining WALL-CLOCK time until it is actually ready. A 3h crop under a 2×
+ * window has 3h of work left but is ready in 1h 30m.
+ *
+ * The `settings.showActualTime` preference picks which one every timer displays;
+ * the work reading stays the default (see GameProvider).
+ */
+export function getDisplaySeconds({
+  showActualTime,
+  workLeftSeconds,
+  countdownSeconds,
+}: {
+  showActualTime: boolean;
+  workLeftSeconds: number;
+  countdownSeconds: number;
+}): number {
+  return showActualTime ? countdownSeconds : workLeftSeconds;
+}
+
+/**
+ * How often the displayed number needs to change.
+ *
+ * The work reading drains FASTER than a clock while a boost is active (2× speed
+ * burns 2s of work per real second), so it re-renders at `1000 / speed` to drop
+ * ~1 per visual tick instead of jumping by `speed` every second. The wall-clock
+ * reading always ticks once a second. Floored at 250ms so an extreme stack can't
+ * spin the render loop.
+ */
+export function getTickIntervalMs({
+  showActualTime,
+  speed,
+}: {
+  showActualTime: boolean;
+  speed: number;
+}): number {
+  if (showActualTime) return 1000;
+
+  return Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
+}
+
+/**
+ * The rate to SURFACE, which is not always the rate in force.
+ *
+ * A ⚡ decoration — the rate in a timer popover, the pulsing bolt on a plot,
+ * patch, flower bed or greenhouse pot — exists to explain a number that does not
+ * account for the boost. In the actual-time view every number already does, so
+ * the decoration would be claiming the same boost a second time. Collapsing the
+ * rate to 1 here turns all of them off at once, since each one is gated on
+ * `speed > 1`.
+ *
+ * This is display only. The true rate still drives the tick cadence and the
+ * ready-time maths — see `useNodeTimer`.
+ */
+export function getSurfacedSpeed({
+  showActualTime,
+  speed,
+}: {
+  showActualTime: boolean;
+  speed: number;
+}): number {
+  return showActualTime ? 1 : speed;
+}
+
+/**
+ * "Start this now — how long until it's ready?", given the live boost windows.
+ *
+ * For the pre-action panels (seed shop, guides), which show a duration for a task
+ * that has not begun. `computeReadyAt` models a window expiring part-way through,
+ * so a boost that runs out mid-task credits only the part it covers.
+ *
+ * With no windows this is the identity, which is what makes it safe to apply
+ * unconditionally: flag off, or an activity that was never migrated, both yield
+ * an empty window set and the un-projected number comes back unchanged.
+ */
+export function projectSeconds({
+  seconds,
+  windows,
+  at,
+}: {
+  seconds: number;
+  windows: BoostWindow[];
+  at: number;
+}): number {
+  if (windows.length === 0) return seconds;
+
+  return (
+    (computeReadyAt({
+      startedAt: at,
+      baseDurationMs: seconds * 1000,
+      windows,
+    }) -
+      at) /
+    1000
+  );
+}
+
+/**
+ * What a pre-action panel (seed shop, guides) should show for a task the player
+ * has not started, given the boosters running right now.
+ *
+ * The two readings differ in what they can honestly say, and each states the
+ * boost exactly once:
+ *
+ * - Speed view: the duration is un-projected, so the useful extra information is
+ *   the RATE the activity is running at — "4h, currently 2×".
+ * - Actual-time view: the duration becomes the real "start now → ready in X",
+ *   which already accounts for a booster running out part-way through. A 4h crop
+ *   under a 1.35× hourglass with only 30 minutes left reads ~3h 50m, not 2h 58m,
+ *   because only the first half-hour is boosted. The rate is folded into that
+ *   number, so it is NOT reported separately — the panels key their ⚡ label off
+ *   `speed`, and repeating it there would claim the same boost twice.
+ */
+export function getPreActionTime({
+  showActualTime,
+  seconds,
+  windows,
+  at,
+}: {
+  showActualTime: boolean;
+  seconds: number;
+  windows: BoostWindow[];
+  at: number;
+}): {
+  /** The duration to render. */
+  displaySeconds: number;
+  /** The rate to surface — see `getSurfacedSpeed`. */
+  speed: number;
+} {
+  return {
+    displaySeconds: showActualTime
+      ? projectSeconds({ seconds, windows, at })
+      : seconds,
+    speed: getSurfacedSpeed({
+      showActualTime,
+      speed: getEffectiveSpeedAt({ at, windows }),
+    }),
+  };
+}
+
+/**
+ * The full pre-action display decision, shared by every guide/shop panel.
+ *
+ * A panel has two kinds of boost to account for, and they differ in what can be
+ * said about them:
+ *
+ * - NAMED boosts (`boostsUsed`) are already folded into `seconds`; they can be
+ *   itemised, so the panel makes its time clickable.
+ * - A live speed WINDOW is not folded in and carries no name (a `BoostWindow` is
+ *   just an interval and a rate), so it shows as a rate or a shorter projected
+ *   time, but has nothing to itemise.
+ */
+export function getPreActionDisplay({
+  showActualTime,
+  seconds,
+  baseSeconds,
+  namedBoostCount,
+  windows,
+  at,
+}: {
+  showActualTime: boolean;
+  seconds: number;
+  baseSeconds: number;
+  namedBoostCount: number;
+  windows: BoostWindow[];
+  at: number;
+}): {
+  displaySeconds: number;
+  speed: number;
+  /** Whether the panel has boosts it can list (and so should be clickable). */
+  hasNamedBoosts: boolean;
+  /** Whether to use the boosted layout (rate and/or struck-through base time). */
+  isBoosted: boolean;
+} {
+  const { displaySeconds, speed } = getPreActionTime({
+    showActualTime,
+    seconds,
+    windows,
+    at,
+  });
+  const hasNamedBoosts = namedBoostCount > 0;
+
+  return {
+    displaySeconds,
+    speed,
+    hasNamedBoosts,
+    isBoosted: isPreActionBoosted({
+      displaySeconds,
+      baseSeconds,
+      speed,
+      hasNamedBoosts,
+    }),
+  };
+}
+
+/**
+ * Whether a pre-action panel should use its boosted layout (rate and/or a
+ * struck-through base time). Exported for the shared detail layouts, which are
+ * handed an already-projected duration rather than the windows behind it.
+ */
+export function isPreActionBoosted({
+  displaySeconds,
+  baseSeconds,
+  speed = 1,
+  hasNamedBoosts,
+}: {
+  displaySeconds: number;
+  baseSeconds?: number;
+  speed?: number;
+  hasNamedBoosts: boolean;
+}): boolean {
+  if (speed > 1) return true;
+  if (baseSeconds === undefined) return false;
+
+  return (
+    (hasNamedBoosts && displaySeconds !== baseSeconds) ||
+    displaySeconds < baseSeconds
+  );
+}

--- a/src/features/game/lib/useNodeTimer.ts
+++ b/src/features/game/lib/useNodeTimer.ts
@@ -1,0 +1,115 @@
+import { useContext } from "react";
+import { Context } from "features/game/GameProvider";
+import { useNow } from "lib/utils/hooks/useNow";
+import {
+  computeReadyAt,
+  getEffectiveSpeedAt,
+  workAccruedAt,
+  type BoostWindow,
+} from "./boostWindows";
+import {
+  getDisplaySeconds,
+  getSurfacedSpeed,
+  getTickIntervalMs,
+} from "./timerDisplay";
+
+type UseNodeTimerArgs = {
+  /** When the task began — plantedAt / choppedAt / minedAt / drilledAt. */
+  startedAt: number;
+  /**
+   * The task's un-boosted work, with permanent boosts folded in. Present only on
+   * nodes started under the speed-rate model; its absence selects the legacy
+   * back-dated timing (the read path keys off the marker, NOT the flag).
+   */
+  baseDurationMs?: number;
+  /** The activity's live speed windows (e.g. getTreeBoostWindows). */
+  windows: BoostWindow[];
+  /** Ready time for a legacy node, used when `baseDurationMs` is absent. */
+  legacyReadyAt: number;
+  /**
+   * Whether anything is actually running. False for an empty plot/patch, so the
+   * component doesn't re-render on a clock it isn't showing. Defaults to true.
+   */
+  live?: boolean;
+};
+
+type NodeTimer = {
+  /** Live clock, ticking at the cadence the current reading needs. */
+  now: number;
+  readyAt: number;
+  /**
+   * The rate to SURFACE — what every ⚡ decoration is gated on. 1 when unboosted,
+   * on the legacy model, or in the actual-time view. See `getSurfacedSpeed`.
+   */
+  speed: number;
+  /**
+   * Remaining WORK in seconds. Art thresholds and fill bars must use this, not
+   * `displaySeconds` — how grown a plant is doesn't change with a display setting.
+   */
+  workLeftSeconds: number;
+  /** Remaining wall-clock seconds until ready. */
+  countdownSeconds: number;
+  /** The reading to show, per the player's `showActualTime` setting. */
+  displaySeconds: number;
+};
+
+/**
+ * The countdown maths shared by every node with a speed-boostable timer (crops,
+ * trees, rocks, fruit, flowers, greenhouse pots, oil).
+ *
+ * A windowed task has two readings — see `timerDisplay.ts`. This returns both,
+ * plus the one the player has chosen, and ticks at whichever cadence that reading
+ * needs. `readyAt` is derived live from the windows, so it already accounts for a
+ * boost that expires part-way through; it only moves when a booster is placed or
+ * burned.
+ */
+export function useNodeTimer({
+  startedAt,
+  baseDurationMs,
+  windows,
+  legacyReadyAt,
+  live = true,
+}: UseNodeTimerArgs): NodeTimer {
+  const { showActualTime } = useContext(Context);
+  const windowed = baseDurationMs !== undefined;
+
+  const readyAt = windowed
+    ? computeReadyAt({ startedAt, baseDurationMs, windows })
+    : legacyReadyAt;
+
+  // Coarse 1s clock purely to pick the current speed. Kept separate from the
+  // display clock below, whose interval depends on `speed` — reading it off the
+  // same clock would make the cadence depend on itself.
+  const tickNow = useNow({ live: live && windowed, autoEndAt: readyAt });
+  // The rate in force. Drives the tick cadence; only `getSurfacedSpeed` below
+  // decides whether the player is shown it.
+  const speed = windowed ? getEffectiveSpeedAt({ at: tickNow, windows }) : 1;
+
+  const now = useNow({
+    live,
+    autoEndAt: readyAt,
+    intervalMs: getTickIntervalMs({ showActualTime, speed }),
+  });
+
+  const countdownSeconds = Math.max((readyAt - now) / 1000, 0);
+  const workLeftSeconds = windowed
+    ? Math.max(
+        (baseDurationMs - workAccruedAt({ startedAt, at: now, windows })) /
+          1000,
+        0,
+      )
+    : countdownSeconds;
+
+  return {
+    now,
+    readyAt,
+    speed: getSurfacedSpeed({ showActualTime, speed }),
+    workLeftSeconds,
+    countdownSeconds,
+    displaySeconds: getDisplaySeconds({
+      showActualTime,
+      workLeftSeconds,
+      countdownSeconds,
+    }),
+  };
+}

--- a/src/features/greenhouse/GreenhousePot.tsx
+++ b/src/features/greenhouse/GreenhousePot.tsx
@@ -30,11 +30,10 @@ import { ProgressBar } from "components/ui/ProgressBar";
 import { getGreenhouseCropYieldAmount } from "features/game/events/landExpansion/harvestGreenHouse";
 import { getGreenhouseReadyAt } from "features/game/events/landExpansion/greenhouseReadiness";
 import {
-  getEffectiveSpeedAt,
   getGreenhouseBoostWindows,
   getGreenhouseGlowWindows,
-  workAccruedAt,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
   getOilUsage,
@@ -45,7 +44,6 @@ import { SUNNYSIDE } from "assets/sunnyside";
 import { Label } from "components/ui/Label";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { formatNumber } from "lib/utils/formatNumber";
-import { useNow } from "lib/utils/hooks/useNow";
 import {
   GREENHOUSE_COMPOST,
   type GreenhouseCompostName,
@@ -180,40 +178,22 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
   // so visual progress is preserved (readiness already accounts for it).
   const bankedWorkMs = growingPlant?.boostedTime ?? 0;
 
-  // Coarse 1s clock to pick the current boost speed; only windowed plants are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each real second.
-  const tickNow = useNow({
-    live: !!growingPlant && baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const { now, speed, workLeftSeconds, displaySeconds } = useNodeTimer({
+    startedAt: plantedAt,
+    baseDurationMs,
+    windows: boostWindows,
+    legacyReadyAt: readyAt,
+    live: !!growingPlant,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: boostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: !!growingPlant, autoEndAt: readyAt, intervalMs });
 
-  // Remaining time is remaining *work* (in base duration) for windowed plants,
-  // so it ticks down faster while a boost window is active; legacy counts down
-  // to the back-dated readyAt.
+  // Remaining WORK — drives the progress fill and the "is it still growing"
+  // gates below, so neither moves when the player switches reading.
   const secondsLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          Math.ceil(
-            (baseDurationMs -
-              workAccruedAt({
-                startedAt: plantedAt,
-                at: now,
-                windows: boostWindows,
-              })) /
-              1000,
-          ),
-          0,
-        )
-      : readyAt > 0
-        ? Math.max(Math.ceil((readyAt - now) / 1000), 0)
-        : 0;
+    readyAt > 0 || baseDurationMs !== undefined
+      ? Math.max(Math.ceil(workLeftSeconds), 0)
+      : 0;
+  // The reading the player has chosen, for the labels.
+  const displaySecondsLeft = Math.max(Math.ceil(displaySeconds), 0);
   const totalSeconds =
     baseDurationMs !== undefined
       ? (baseDurationMs + bankedWorkMs) / 1000
@@ -439,7 +419,7 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
         >
           <ProgressBar
             percentage={percentage}
-            seconds={secondsLeft}
+            seconds={displaySecondsLeft}
             formatLength="short"
             type="progress"
           />
@@ -463,7 +443,7 @@ export const GreenhousePot: React.FC<Props> = ({ id }) => {
           image={ITEM_DETAILS[pot.plant.name].image}
           description={pot.plant.name}
           showPopover={showTimeRemaining && !canApplyGreenhouseFertiliser()}
-          timeLeft={secondsLeft}
+          timeLeft={displaySecondsLeft}
           speed={speed}
         />
       </Transition>

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -657,7 +657,7 @@ const GrowthTimeCell: React.FC<{
   // than being baked into it), so name them for the boost panel: their rate in
   // the speed view, the time each one actually saves in the other.
   const windowedBoosts = getBoostContributionEntries({
-    contributions: getSeedBoostContributions(state, seed),
+    contributions: getSeedBoostContributions(state, seed, now),
     seconds: boostedTime.seconds,
     at: now,
     showActualTime,

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -1,7 +1,7 @@
 import { InnerPanel } from "components/ui/Panel";
 import { Chip } from "components/ui/Chip";
 import { ITEM_DETAILS } from "features/game/types/images";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useContext, useMemo, useRef, useState } from "react";
 import { SEASON_ICONS } from "./SeasonalSeeds";
 import { SUNNYSIDE } from "assets/sunnyside";
 import { NoticeboardItems } from "features/world/ui/kingdom/KingdomNoticeboard";
@@ -43,6 +43,10 @@ import {
 } from "features/game/events/landExpansion/plantGreenhouse";
 import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
 import { useNow } from "lib/utils/hooks/useNow";
+import classNames from "classnames";
+import { Context } from "features/game/GameProvider";
+import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
   INITIAL_STOCK,
   INVENTORY_LIMIT,
@@ -318,6 +322,7 @@ export const CropRow: React.FC<{
           <div className="flex flex-col min-w-0">
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
+              seed={seed}
               baseSeconds={seconds}
               boostedTime={boostedTime}
               state={state}
@@ -395,6 +400,7 @@ export const FlowerRow: React.FC<{
           <div className="flex flex-col min-w-0">
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
+              seed={seed}
               baseSeconds={seconds}
               boostedTime={boostedTime}
               state={state}
@@ -607,6 +613,7 @@ const getSeedGrowthTime = ({
 
 const GrowthTimeCell: React.FC<{
   boostKey: string;
+  seed: SeedName;
   baseSeconds: number;
   boostedTime: GrowthTime;
   state: GameState;
@@ -614,17 +621,34 @@ const GrowthTimeCell: React.FC<{
   setShowBoostsKey: (key: string | null) => void;
 }> = ({
   boostKey,
+  seed,
   baseSeconds,
   boostedTime,
   state,
   showBoostsKey,
   setShowBoostsKey,
 }) => {
+  const { showActualTime } = useContext(Context);
   const anchorRef = useRef<HTMLButtonElement>(null);
-  const isTimeBoosted =
-    boostedTime.boostsUsed.length > 0 && boostedTime.seconds !== baseSeconds;
-  const showMediumTime =
-    Math.max(baseSeconds, boostedTime.seconds) > 24 * 60 * 60;
+  const now = useNow();
+
+  // A live speed window isn't folded into `boostedTime` — show it as the current
+  // rate, or (in the actual-time view) as the real "plant now → ready in X",
+  // which credits only the part of the grow the booster still covers.
+  const {
+    displaySeconds,
+    speed,
+    hasNamedBoosts,
+    isBoosted: isTimeBoosted,
+  } = getPreActionDisplay({
+    showActualTime,
+    seconds: boostedTime.seconds,
+    baseSeconds,
+    namedBoostCount: boostedTime.boostsUsed.length,
+    windows: getSeedBoostWindows(state, seed),
+    at: now,
+  });
+  const showMediumTime = Math.max(baseSeconds, displaySeconds) > 24 * 60 * 60;
 
   if (!isTimeBoosted) {
     return (
@@ -643,10 +667,14 @@ const GrowthTimeCell: React.FC<{
     <button
       ref={anchorRef}
       type="button"
-      className="flex items-center mr-2 cursor-pointer relative"
-      aria-expanded={showBoostsKey === boostKey}
+      className={classNames("flex items-center mr-2 relative", {
+        // Only named boosts can be itemised, so only they open the breakdown.
+        "cursor-pointer": hasNamedBoosts,
+      })}
+      aria-expanded={hasNamedBoosts && showBoostsKey === boostKey}
       aria-controls={`${boostKey}-panel`}
       onClick={(e) => {
+        if (!hasNamedBoosts) return;
         e.stopPropagation();
         setShowBoostsKey(showBoostsKey === boostKey ? null : boostKey);
       }}
@@ -655,23 +683,28 @@ const GrowthTimeCell: React.FC<{
         <div className="flex items-center">
           <img src={SUNNYSIDE.icons.stopwatch} className="w-3 mr-1" />
           <p className="text-xxs">
-            {secondsToString(boostedTime.seconds, {
+            {secondsToString(displaySeconds, {
               length: showMediumTime ? "medium" : "short",
             })}
           </p>
         </div>
         <div className="flex items-center">
           <img src={SUNNYSIDE.icons.lightning} className="w-3 mx-1" />
-          <p className="text-xxs line-through">
-            {secondsToString(baseSeconds, {
-              length: showMediumTime ? "medium" : "short",
-            })}
-          </p>
+          {displaySeconds !== baseSeconds && (
+            <p className="text-xxs line-through">
+              {secondsToString(baseSeconds, {
+                length: showMediumTime ? "medium" : "short",
+              })}
+            </p>
+          )}
+          {speed > 1 && (
+            <p className="text-xxs">{`${Number(speed.toFixed(2))}x`}</p>
+          )}
         </div>
       </div>
       <BoostsDisplay
         boosts={boostedTime.boostsUsed}
-        show={showBoostsKey === boostKey}
+        show={hasNamedBoosts && showBoostsKey === boostKey}
         state={state}
         onClick={() =>
           setShowBoostsKey(showBoostsKey === boostKey ? null : boostKey)

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -46,7 +46,10 @@ import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
 import { useNow } from "lib/utils/hooks/useNow";
 import classNames from "classnames";
 import { Context } from "features/game/GameProvider";
-import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import {
+  getPreActionDisplay,
+  PRE_ACTION_TICK_MS,
+} from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
   getBoostContributionEntries,
@@ -74,7 +77,9 @@ export const CropGuide = () => {
   const state = gameState.context.state;
   const inventory = state.inventory;
   const { t } = useAppTranslation();
-  const now = useNow();
+  // Ticks slowly so a guide left open follows a booster burning down. One clock
+  // for the whole guide: a per-row one would mean an interval per listed seed.
+  const now = useNow({ live: true, intervalMs: PRE_ACTION_TICK_MS });
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] =
     useState<GuideCategory>("crops");
@@ -251,6 +256,7 @@ export const CropGuide = () => {
               seed={seed}
               seconds={FLOWER_SEEDS[seed].plantSeconds}
               state={state}
+              now={now}
               alternateBg={index % 2 === 0}
               showBoostsKey={showBoostsKey}
               setShowBoostsKey={setShowBoostsKey}
@@ -328,6 +334,7 @@ export const CropRow: React.FC<{
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
               seed={seed}
+              now={now}
               baseSeconds={seconds}
               boostedTime={boostedTime}
               state={state}
@@ -368,6 +375,8 @@ export const FlowerRow: React.FC<{
   seed: FlowerSeedName;
   seconds: number;
   state: GameState;
+  /** Shared guide clock; the growth-time projection is relative to it. */
+  now: number;
   alternateBg?: boolean;
   showBoostsKey: string | null;
   setShowBoostsKey: (key: string | null) => void;
@@ -375,6 +384,7 @@ export const FlowerRow: React.FC<{
   seed,
   seconds,
   state,
+  now,
   alternateBg,
   showBoostsKey,
   setShowBoostsKey,
@@ -406,6 +416,7 @@ export const FlowerRow: React.FC<{
             <GrowthTimeCell
               boostKey={`${seed}-growth-time`}
               seed={seed}
+              now={now}
               baseSeconds={seconds}
               boostedTime={boostedTime}
               state={state}
@@ -622,6 +633,8 @@ const GrowthTimeCell: React.FC<{
   baseSeconds: number;
   boostedTime: GrowthTime;
   state: GameState;
+  /** Shared guide clock; the projections below are relative to it. */
+  now: number;
   showBoostsKey: string | null;
   setShowBoostsKey: (key: string | null) => void;
 }> = ({
@@ -630,12 +643,12 @@ const GrowthTimeCell: React.FC<{
   baseSeconds,
   boostedTime,
   state,
+  now,
   showBoostsKey,
   setShowBoostsKey,
 }) => {
   const { showActualTime } = useContext(Context);
   const anchorRef = useRef<HTMLButtonElement>(null);
-  const now = useNow();
 
   // A live speed window isn't folded into `boostedTime` — show it as the current
   // rate, or (in the actual-time view) as the real "plant now → ready in X",
@@ -687,6 +700,7 @@ const GrowthTimeCell: React.FC<{
         // Only named boosts can be itemised, so only they open the breakdown.
         "cursor-pointer": hasNamedBoosts,
       })}
+      disabled={!hasNamedBoosts}
       aria-expanded={hasNamedBoosts && showBoostsKey === boostKey}
       aria-controls={`${boostKey}-panel`}
       onClick={(e) => {

--- a/src/features/island/buildings/components/building/market/CropGuide.tsx
+++ b/src/features/island/buildings/components/building/market/CropGuide.tsx
@@ -31,6 +31,7 @@ import { SELLABLE } from "features/game/events/landExpansion/sellCrop";
 import { GREENHOUSE_CROP_TIME_SECONDS } from "features/game/lib/greenhouseGrowTimes";
 import { useGame } from "features/game/GameProvider";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
+import { translate } from "lib/i18n/translate";
 import { isFullMoonBerry } from "features/game/events/landExpansion/seedBought";
 import fullMoon from "assets/icons/full_moon.png";
 import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
@@ -47,6 +48,10 @@ import classNames from "classnames";
 import { Context } from "features/game/GameProvider";
 import { getPreActionDisplay } from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
+import {
+  getBoostContributionEntries,
+  getSeedBoostContributions,
+} from "features/game/lib/boostContributions";
 import {
   INITIAL_STOCK,
   INVENTORY_LIMIT,
@@ -635,16 +640,27 @@ const GrowthTimeCell: React.FC<{
   // A live speed window isn't folded into `boostedTime` — show it as the current
   // rate, or (in the actual-time view) as the real "plant now → ready in X",
   // which credits only the part of the grow the booster still covers.
+  // The windowed boosters aren't in `boostsUsed` (they apply over the grow rather
+  // than being baked into it), so name them for the boost panel: their rate in
+  // the speed view, the time each one actually saves in the other.
+  const windowedBoosts = getBoostContributionEntries({
+    contributions: getSeedBoostContributions(state, seed),
+    seconds: boostedTime.seconds,
+    at: now,
+    showActualTime,
+    formatSeconds: (seconds) => secondsToString(seconds, { length: "medium" }),
+    formatSpeed: (speed) => translate("description.boostedSpeed", { speed }),
+  });
+  const boostsUsed = [...boostedTime.boostsUsed, ...windowedBoosts];
   const {
     displaySeconds,
-    speed,
     hasNamedBoosts,
     isBoosted: isTimeBoosted,
   } = getPreActionDisplay({
     showActualTime,
     seconds: boostedTime.seconds,
     baseSeconds,
-    namedBoostCount: boostedTime.boostsUsed.length,
+    namedBoostCount: boostsUsed.length,
     windows: getSeedBoostWindows(state, seed),
     at: now,
   });
@@ -697,13 +713,10 @@ const GrowthTimeCell: React.FC<{
               })}
             </p>
           )}
-          {speed > 1 && (
-            <p className="text-xxs">{`${Number(speed.toFixed(2))}x`}</p>
-          )}
         </div>
       </div>
       <BoostsDisplay
-        boosts={boostedTime.boostsUsed}
+        boosts={boostsUsed}
         show={hasNamedBoosts && showBoostsKey === boostKey}
         state={state}
         onClick={() =>

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -81,7 +81,10 @@ import {
 import { isFullMoon } from "features/game/types/calendar";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import { useNow } from "lib/utils/hooks/useNow";
-import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import {
+  getPreActionDisplay,
+  PRE_ACTION_TICK_MS,
+} from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
   getBoostContributionEntries,
@@ -116,7 +119,7 @@ export const SeasonalSeeds: React.FC = () => {
     SEASONAL_SEEDS[currentSeason].includes(seed),
   );
 
-  const now = useNow();
+  const now = useNow({ live: true, intervalMs: PRE_ACTION_TICK_MS });
   const isCropWeek = isChapterCropWeekActive(now);
 
   const [selectedName, setSelectedName] = useState<SeedName>(

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -355,7 +355,7 @@ export const SeasonalSeeds: React.FC = () => {
   const plantBoostsUsed = [
     ...plantTime.boostsUsed,
     ...getBoostContributionEntries({
-      contributions: getSeedBoostContributions(state, selectedName),
+      contributions: getSeedBoostContributions(state, selectedName, now),
       seconds: plantTime.seconds,
       at: now,
       showActualTime,

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -84,6 +84,10 @@ import { useNow } from "lib/utils/hooks/useNow";
 import { getPreActionDisplay } from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
+  getBoostContributionEntries,
+  getSeedBoostContributions,
+} from "features/game/lib/boostContributions";
+import {
   CHAPTER_CROP_WEEK,
   CHAPTER_CROP_WEEK_SEED,
   isChapterCropWeekActive,
@@ -342,12 +346,27 @@ export const SeasonalSeeds: React.FC = () => {
   // the actual-time view) the real "plant now → ready in X", which credits only
   // the part of the grow the booster still covers.
   const plantTime = getPlantSeconds();
+  // The windowed boosters aren't in `boostsUsed` (they apply over the grow rather
+  // than being baked into it), so name them for the boost panel: their rate in
+  // the speed view, the time each one actually saves in the other.
+  const plantBoostsUsed = [
+    ...plantTime.boostsUsed,
+    ...getBoostContributionEntries({
+      contributions: getSeedBoostContributions(state, selectedName),
+      seconds: plantTime.seconds,
+      at: now,
+      showActualTime,
+      formatSeconds: (seconds) =>
+        secondsToString(seconds, { length: "medium" }),
+      formatSpeed: (speed) => t("description.boostedSpeed", { speed }),
+    }),
+  ];
   const { displaySeconds: plantDisplaySeconds, speed: plantSpeed } =
     getPreActionDisplay({
       showActualTime,
       seconds: plantTime.seconds,
       baseSeconds: baseTime,
-      namedBoostCount: plantTime.boostsUsed.length,
+      namedBoostCount: plantBoostsUsed.length,
       windows: getSeedBoostWindows(state, selectedName),
       at: now,
     });
@@ -480,7 +499,10 @@ export const SeasonalSeeds: React.FC = () => {
                   maxHarvest: harvestCount[1],
                 }
               : undefined,
-            time: { ...plantTime, seconds: plantDisplaySeconds },
+            time: {
+              seconds: plantDisplaySeconds,
+              boostsUsed: plantBoostsUsed,
+            },
             baseTimeSeconds: baseTime,
             timeSpeed: plantSpeed,
             restriction: {

--- a/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
+++ b/src/features/island/buildings/components/building/market/SeasonalSeeds.tsx
@@ -81,6 +81,8 @@ import {
 import { isFullMoon } from "features/game/types/calendar";
 import { hasRequiredIslandExpansion } from "features/game/lib/hasRequiredIslandExpansion";
 import { useNow } from "lib/utils/hooks/useNow";
+import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
   CHAPTER_CROP_WEEK,
   CHAPTER_CROP_WEEK_SEED,
@@ -98,7 +100,7 @@ export const SEASON_ICONS: Record<TemperateSeasonName, string> = {
 const _state = (state: MachineState) => state.context.state;
 
 export const SeasonalSeeds: React.FC = () => {
-  const { gameService, shortcutItem } = useContext(Context);
+  const { gameService, shortcutItem, showActualTime } = useContext(Context);
   const { openModal } = useContext(ModalContext);
   const state = useSelector(gameService, _state);
   const { inventory, coins, island, bumpkin, season } = state;
@@ -336,6 +338,20 @@ export const SeasonalSeeds: React.FC = () => {
 
   const baseTime = getBasePlantSeconds();
 
+  // A live speed window isn't folded into the grow time — show the rate, or (in
+  // the actual-time view) the real "plant now → ready in X", which credits only
+  // the part of the grow the booster still covers.
+  const plantTime = getPlantSeconds();
+  const { displaySeconds: plantDisplaySeconds, speed: plantSpeed } =
+    getPreActionDisplay({
+      showActualTime,
+      seconds: plantTime.seconds,
+      baseSeconds: baseTime,
+      namedBoostCount: plantTime.boostsUsed.length,
+      windows: getSeedBoostWindows(state, selectedName),
+      at: now,
+    });
+
   const getHarvestCount = () => {
     if (!yields) return undefined;
 
@@ -464,8 +480,9 @@ export const SeasonalSeeds: React.FC = () => {
                   maxHarvest: harvestCount[1],
                 }
               : undefined,
-            time: getPlantSeconds(),
+            time: { ...plantTime, seconds: plantDisplaySeconds },
             baseTimeSeconds: baseTime,
+            timeSpeed: plantSpeed,
             restriction: {
               icon: SEASON_ICONS[currentSeason],
               text: plantingSpot,

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -19,6 +19,10 @@ import {
   isPreActionBoosted,
 } from "features/game/lib/timerDisplay";
 import { getNodeBoostWindows } from "features/game/lib/seedBoostWindows";
+import {
+  getBoostContributionEntries,
+  getNodeBoostContributions,
+} from "features/game/lib/boostContributions";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getTreeRecoveryTimeForDisplay } from "features/game/events/landExpansion/chop";
 import { getStoneRecoveryTimeForDisplay } from "features/game/events/landExpansion/stoneMine";
@@ -290,7 +294,6 @@ const CooldownCell: React.FC<{
   // no name attached to it, so it shortens the time (or shows its rate) without
   // making the cell clickable.
   const hasNamedBoosts = cooldown.boostsUsed.length > 0;
-  const isSpedUp = cooldown.speed > 1;
   const hasBoosts = isPreActionBoosted({
     displaySeconds: cooldown.recoverySeconds,
     baseSeconds: cooldown.baseSeconds,
@@ -329,11 +332,6 @@ const CooldownCell: React.FC<{
               {cooldown.recoverySeconds > 0 ? recoveryTimeStr : t("instant")}
             </span>
           </div>
-          {isSpedUp && (
-            <span className="text-xxs">{`${Number(
-              cooldown.speed.toFixed(2),
-            )}x`}</span>
-          )}
           {cooldown.baseSeconds > 0 && (
             <div className="flex items-center">
               <img
@@ -394,11 +392,25 @@ const NodeRow: React.FC<NodeRowProps> = ({
   const windows = node.nodeName
     ? getNodeBoostWindows(state, node.nodeName)
     : [];
+  // The windowed boosters aren't in `boostsUsed` (they apply over the recovery
+  // rather than being baked into it), so name them for the boost panel: their
+  // rate in the speed view, the time each one actually saves in the other.
+  const windowedBoosts = getBoostContributionEntries({
+    contributions: node.nodeName
+      ? getNodeBoostContributions(state, node.nodeName)
+      : [],
+    seconds: recoveryTimeMs / 1000,
+    at: now,
+    showActualTime,
+    formatSeconds: (seconds) => secondsToString(seconds, { length: "medium" }),
+    formatSpeed: (speed) => translate("description.boostedSpeed", { speed }),
+  });
+  const allBoostsUsed = [...boostsUsed, ...windowedBoosts];
   const { displaySeconds, speed } = getPreActionDisplay({
     showActualTime,
     seconds: recoveryTimeMs / 1000,
     baseSeconds: baseTimeMs / 1000,
-    namedBoostCount: boostsUsed.length,
+    namedBoostCount: allBoostsUsed.length,
     windows,
     at: now,
   });
@@ -416,7 +428,7 @@ const NodeRow: React.FC<NodeRowProps> = ({
     nodeLabel: translate(node.recoveryLabelKey),
     baseSeconds: baseTimeMs / 1000,
     recoverySeconds: displaySeconds,
-    boostsUsed,
+    boostsUsed: allBoostsUsed,
     speed,
   };
 

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -398,7 +398,7 @@ const NodeRow: React.FC<NodeRowProps> = ({
   // rate in the speed view, the time each one actually saves in the other.
   const windowedBoosts = getBoostContributionEntries({
     contributions: node.nodeName
-      ? getNodeBoostContributions(state, node.nodeName)
+      ? getNodeBoostContributions(state, node.nodeName, now)
       : [],
     seconds: recoveryTimeMs / 1000,
     at: now,

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -17,6 +17,7 @@ import { useNow } from "lib/utils/hooks/useNow";
 import {
   getPreActionDisplay,
   isPreActionBoosted,
+  PRE_ACTION_TICK_MS,
 } from "features/game/lib/timerDisplay";
 import { getNodeBoostWindows } from "features/game/lib/seedBoostWindows";
 import {
@@ -181,8 +182,8 @@ export const ToolsGuide: React.FC = () => {
   const state = useSelector(gameService, (state) => state.context.state);
   const { t } = useAppTranslation();
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
-  // Snapshot at open — the projected times don't need to tick inside a panel.
-  const now = useNow();
+  // Ticks slowly so a guide left open follows a booster burning down.
+  const now = useNow({ live: true, intervalMs: PRE_ACTION_TICK_MS });
 
   return (
     <InnerPanel className="scrollable max-h-[450px] overflow-y-auto w-full min-w-full">

--- a/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
+++ b/src/features/island/buildings/components/building/workBench/components/ToolsGuide.tsx
@@ -13,6 +13,12 @@ import { secondsToString } from "lib/utils/time";
 import { translate } from "lib/i18n/translate";
 import { getOilRecoveryTimeForDisplay } from "features/game/events/landExpansion/drillOilReserve";
 import { BoostsDisplay } from "components/ui/layouts/BoostsDisplay";
+import { useNow } from "lib/utils/hooks/useNow";
+import {
+  getPreActionDisplay,
+  isPreActionBoosted,
+} from "features/game/lib/timerDisplay";
+import { getNodeBoostWindows } from "features/game/lib/seedBoostWindows";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { getTreeRecoveryTimeForDisplay } from "features/game/events/landExpansion/chop";
 import { getStoneRecoveryTimeForDisplay } from "features/game/events/landExpansion/stoneMine";
@@ -43,6 +49,8 @@ type CooldownDisplay = {
   baseSeconds: number;
   recoverySeconds: number;
   boostsUsed: { name: BoostName; value: string }[];
+  /** Live speed-window rate for this node; 1 when nothing is running. */
+  speed: number;
   image?: string;
 };
 
@@ -165,10 +173,12 @@ const WATER_NODES_WITH_RECOVERY: GuideNodeWithRecovery[] = [
 ];
 
 export const ToolsGuide: React.FC = () => {
-  const { gameService } = useContext(Context);
+  const { gameService, showActualTime } = useContext(Context);
   const state = useSelector(gameService, (state) => state.context.state);
   const { t } = useAppTranslation();
   const [showBoostsKey, setShowBoostsKey] = useState<string | null>(null);
+  // Snapshot at open — the projected times don't need to tick inside a panel.
+  const now = useNow();
 
   return (
     <InnerPanel className="scrollable max-h-[450px] overflow-y-auto w-full min-w-full">
@@ -197,6 +207,8 @@ export const ToolsGuide: React.FC = () => {
             key={`${node.toolName}-${node.resourceName}`}
             node={node}
             state={state}
+            showActualTime={showActualTime}
+            now={now}
             alternateBg={index % 2 === 0}
             showBoostsKey={showBoostsKey}
             setShowBoostsKey={setShowBoostsKey}
@@ -210,6 +222,8 @@ export const ToolsGuide: React.FC = () => {
             key={`${node.toolName}-${node.resourceName ?? node.resourceLabelKey}`}
             node={node}
             state={state}
+            showActualTime={showActualTime}
+            now={now}
             alternateBg={(index + LAND_NODES_WITH_RECOVERY.length) % 2 === 0}
             showBoostsKey={showBoostsKey}
             setShowBoostsKey={setShowBoostsKey}
@@ -253,6 +267,10 @@ const NodeToolIcon: React.FC<{
 interface NodeRowProps {
   node: GuideNodeWithRecovery;
   state: GameState;
+  /** The player's timer reading — see `timerDisplay.ts`. */
+  showActualTime: boolean;
+  /** Snapshot taken when the guide opened; the projection is relative to it. */
+  now: number;
   alternateBg?: boolean;
   showBoostsKey: string | null;
   setShowBoostsKey: (key: string | null) => void;
@@ -268,7 +286,17 @@ const CooldownCell: React.FC<{
   const { t } = useAppTranslation();
   const anchorRef = useRef<HTMLDivElement>(null);
   const boostsKey = `${toolName}-${cooldown.nodeLabel}`;
-  const hasBoosts = cooldown.boostsUsed.length > 0;
+  // Named boosts are the ones the popover can itemise; a live speed window has
+  // no name attached to it, so it shortens the time (or shows its rate) without
+  // making the cell clickable.
+  const hasNamedBoosts = cooldown.boostsUsed.length > 0;
+  const isSpedUp = cooldown.speed > 1;
+  const hasBoosts = isPreActionBoosted({
+    displaySeconds: cooldown.recoverySeconds,
+    baseSeconds: cooldown.baseSeconds,
+    speed: cooldown.speed,
+    hasNamedBoosts,
+  });
 
   const recoveryTimeStr = secondsToString(cooldown.recoverySeconds, {
     length: hasBoosts ? "medium" : "short",
@@ -281,8 +309,11 @@ const CooldownCell: React.FC<{
     return (
       <div
         ref={anchorRef}
-        className="flex items-center cursor-pointer gap-1.5 relative"
+        className={classNames("flex items-center gap-1.5 relative", {
+          "cursor-pointer": hasNamedBoosts,
+        })}
         onClick={(e) => {
+          if (!hasNamedBoosts) return;
           e.stopPropagation();
           setShowBoostsKey(showBoostsKey === boostsKey ? null : boostsKey);
         }}
@@ -298,6 +329,11 @@ const CooldownCell: React.FC<{
               {cooldown.recoverySeconds > 0 ? recoveryTimeStr : t("instant")}
             </span>
           </div>
+          {isSpedUp && (
+            <span className="text-xxs">{`${Number(
+              cooldown.speed.toFixed(2),
+            )}x`}</span>
+          )}
           {cooldown.baseSeconds > 0 && (
             <div className="flex items-center">
               <img
@@ -311,7 +347,7 @@ const CooldownCell: React.FC<{
         </div>
         <BoostsDisplay
           boosts={cooldown.boostsUsed}
-          show={showBoostsKey === boostsKey}
+          show={hasNamedBoosts && showBoostsKey === boostsKey}
           state={state}
           onClick={() =>
             setShowBoostsKey(showBoostsKey === boostsKey ? null : boostsKey)
@@ -340,12 +376,31 @@ const CooldownCell: React.FC<{
 const NodeRow: React.FC<NodeRowProps> = ({
   node,
   state,
+  showActualTime,
+  now,
   alternateBg,
   showBoostsKey,
   setShowBoostsKey,
 }) => {
   const { baseTimeMs, recoveryTimeMs, boostsUsed } = node.getRecovery({
     game: state,
+  });
+
+  // A live speed window (hourglass / totem / shrine) is NOT folded into
+  // recoveryTimeMs — it applies over the recovery instead. Show what it is worth:
+  // the current rate in the speed view, or the real "drill now → ready in X" in
+  // the actual-time view, which credits only the part of the recovery the booster
+  // still covers.
+  const windows = node.nodeName
+    ? getNodeBoostWindows(state, node.nodeName)
+    : [];
+  const { displaySeconds, speed } = getPreActionDisplay({
+    showActualTime,
+    seconds: recoveryTimeMs / 1000,
+    baseSeconds: baseTimeMs / 1000,
+    namedBoostCount: boostsUsed.length,
+    windows,
+    at: now,
   });
 
   const resourceName = node.resourceName
@@ -360,8 +415,9 @@ const NodeRow: React.FC<NodeRowProps> = ({
   const cooldown: CooldownDisplay = {
     nodeLabel: translate(node.recoveryLabelKey),
     baseSeconds: baseTimeMs / 1000,
-    recoverySeconds: recoveryTimeMs / 1000,
+    recoverySeconds: displaySeconds,
     boostsUsed,
+    speed,
   };
 
   const nodeIcon = node.nodeName

--- a/src/features/island/flowers/FlowerBed.tsx
+++ b/src/features/island/flowers/FlowerBed.tsx
@@ -35,14 +35,12 @@ import { Panel } from "components/ui/Panel";
 import { secondsToString } from "lib/utils/time";
 import type { PlantedFlower } from "features/game/types/game";
 import type { MachineState } from "features/game/lib/gameMachine";
-import { useNow } from "lib/utils/hooks/useNow";
 import {
   computeReadyAt,
-  getEffectiveSpeedAt,
   getFlowerBoostWindows,
-  workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 interface Props {
   id: string;
@@ -202,35 +200,19 @@ const Flower: React.FC<{ flower: PlantedFlower; id: string }> = ({
         })
       : startedAt + growTimeMs;
 
-  // Coarse 1s clock to pick the current boost speed; only windowed flowers are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each real second.
-  const tickNow = useNow({
-    live: baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  // `secondsLeft` is the remaining WORK: it drives the growth stage, the progress
+  // fill and the insta-grow cost, none of which may change with a display setting.
+  // `displaySeconds` is the reading the player has chosen to see.
+  const {
+    speed,
+    workLeftSeconds: secondsLeft,
+    displaySeconds,
+  } = useNodeTimer({
+    startedAt,
+    baseDurationMs,
+    windows: flowerBoostWindows,
+    legacyReadyAt: readyAt,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: flowerBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: true, autoEndAt: readyAt, intervalMs });
-
-  // Remaining time is remaining *work* (in base duration) for windowed flowers, so
-  // it ticks down faster while a boost window is active; legacy counts down to readyAt.
-  const secondsLeft =
-    baseDurationMs !== undefined
-      ? Math.max(
-          (baseDurationMs -
-            workAccruedAt({
-              startedAt,
-              at: now,
-              windows: flowerBoostWindows,
-            })) /
-            1000,
-          0,
-        )
-      : Math.max((readyAt - now) / 1000, 0);
   // Fold pre-lift banked work into the denominator so the progress bar retains
   // its fill across a landscaping lift instead of snapping backward.
   const totalSeconds =
@@ -360,7 +342,7 @@ const Flower: React.FC<{ flower: PlantedFlower; id: string }> = ({
               }
               description={hasHarvestedBefore ? flower.name : "Unknown"}
               showPopover={showPopover}
-              timeLeft={secondsLeft}
+              timeLeft={displaySeconds}
               speed={speed}
             />
           </div>
@@ -377,7 +359,7 @@ const Flower: React.FC<{ flower: PlantedFlower; id: string }> = ({
           >
             <ProgressBar
               percentage={growPercentage}
-              seconds={!flower.dirty ? secondsLeft : undefined}
+              seconds={!flower.dirty ? displaySeconds : undefined}
               type="progress"
               formatLength="short"
             />
@@ -488,6 +470,9 @@ const Flower: React.FC<{ flower: PlantedFlower; id: string }> = ({
             <div className="flex flex-col gap-1 sm:flex-row sm:gap-2">
               <Label type="vibrant">{t("instaGrow")}</Label>
               <Label type="info" icon={SUNNYSIDE.icons.stopwatch}>
+                {/* Deliberately the WORK reading, not the player's display
+                    setting: it is the quantity the Obsidian cost below is
+                    calculated from, so the two must agree. */}
                 {t("instaGrow.timeRemaining", {
                   time: secondsToString(secondsLeft, { length: "medium" }),
                 })}

--- a/src/features/island/flowers/FlowerBedContent.tsx
+++ b/src/features/island/flowers/FlowerBedContent.tsx
@@ -25,7 +25,10 @@ import { secondsToString } from "lib/utils/time";
 import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
 import { useNow } from "lib/utils/hooks/useNow";
 import type { GameState } from "features/game/types/game";
-import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import {
+  getPreActionDisplay,
+  PRE_ACTION_TICK_MS,
+} from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SEASONAL_SEEDS } from "features/game/types/seeds";
@@ -47,7 +50,7 @@ interface Props {
  */
 const useFlowerSeedTime = (state: GameState, seed?: FlowerSeedName) => {
   const { showActualTime } = useContext(Context);
-  const now = useNow();
+  const now = useNow({ live: true, intervalMs: PRE_ACTION_TICK_MS });
 
   if (!seed) return { displaySeconds: 0, speed: 1 };
 

--- a/src/features/island/flowers/FlowerBedContent.tsx
+++ b/src/features/island/flowers/FlowerBedContent.tsx
@@ -23,6 +23,10 @@ import { useActor } from "@xstate/react";
 import { SquareIcon } from "components/ui/SquareIcon";
 import { secondsToString } from "lib/utils/time";
 import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
+import { useNow } from "lib/utils/hooks/useNow";
+import type { GameState } from "features/game/types/game";
+import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import { useAppTranslation } from "lib/i18n/useAppTranslations";
 import { SEASONAL_SEEDS } from "features/game/types/seeds";
 import { SEASON_ICONS } from "../buildings/components/building/market/SeasonalSeeds";
@@ -34,6 +38,28 @@ interface Props {
   id: string;
   onClose: () => void;
 }
+
+/**
+ * The grow time to show for a seed the player is considering. A live speed
+ * window isn't folded into `getFlowerTime`, so surface it: the current rate in
+ * the speed view, or the real "plant now → ready in X" in the actual-time view
+ * (which credits only the part of the grow the Blossom Hourglass still covers).
+ */
+const useFlowerSeedTime = (state: GameState, seed?: FlowerSeedName) => {
+  const { showActualTime } = useContext(Context);
+  const now = useNow();
+
+  if (!seed) return { displaySeconds: 0, speed: 1 };
+
+  return getPreActionDisplay({
+    showActualTime,
+    seconds: getFlowerTime(seed, state).seconds,
+    baseSeconds: FLOWER_SEEDS[seed].plantSeconds,
+    namedBoostCount: getFlowerTime(seed, state).boostsUsed.length,
+    windows: getSeedBoostWindows(state, seed),
+    at: now,
+  });
+};
 
 export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
   const { t } = useAppTranslation();
@@ -51,6 +77,7 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
   const [seed, setSeed] = useState<FlowerSeedName>();
 
   const [crossbreed, setCrossBreed] = useState<FlowerCrossBreedName>();
+  const selectedSeedTime = useFlowerSeedTime(state, seed);
 
   const selectSeed = (name: FlowerSeedName) => {
     setSeed(name);
@@ -173,9 +200,11 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
                   type="info"
                   className="whitespace-nowrap"
                 >
-                  {secondsToString(getFlowerTime(seed, state).seconds, {
+                  {secondsToString(selectedSeedTime.displaySeconds, {
                     length: "medium",
                   })}
+                  {selectedSeedTime.speed > 1 &&
+                    ` (${Number(selectedSeedTime.speed.toFixed(2))}x)`}
                 </Label>
               </div>
             </div>
@@ -277,13 +306,11 @@ export const FlowerBedContent: React.FC<Props> = ({ id, onClose }) => {
                   </Label>
                   {hasSeedRequirements ? (
                     <Label type={"info"} icon={SUNNYSIDE.icons.stopwatch}>
-                      {secondsToString(
-                        getFlowerTime(
-                          seed,
-                          gameService.getSnapshot().context.state,
-                        ).seconds,
-                        { length: "medium" },
-                      )}
+                      {secondsToString(selectedSeedTime.displaySeconds, {
+                        length: "medium",
+                      })}
+                      {selectedSeedTime.speed > 1 &&
+                        ` (${Number(selectedSeedTime.speed.toFixed(2))}x)`}
                     </Label>
                   ) : (
                     <Label type={"danger"}>{`1 ${seed} required`}</Label>

--- a/src/features/island/fruit/FruitSeedling.tsx
+++ b/src/features/island/fruit/FruitSeedling.tsx
@@ -18,7 +18,14 @@ import { SUNNYSIDE } from "assets/sunnyside";
 interface Props {
   island: GameState["island"];
   patchFruitName: PatchFruitName;
+  /** The reading to display, per the player's timer setting. */
   timeLeft: number;
+  /**
+   * Remaining WORK in seconds — how grown the fruit actually is. Drives the
+   * progress bar, which must not move when the player switches which reading the
+   * label shows. Falls back to `timeLeft` (identical when unboosted).
+   */
+  workLeftSeconds?: number;
   /** Cycle length (s) — progress denominator; defaults to base plant time. */
   totalSeconds?: number;
   /** Current effective grow speed; shows a lightning when > 1. */
@@ -44,6 +51,7 @@ export const FruitSeedling: React.FC<Props> = ({
   patchFruitName,
   island,
   timeLeft,
+  workLeftSeconds,
   totalSeconds,
   speed,
 }) => {
@@ -57,7 +65,9 @@ export const FruitSeedling: React.FC<Props> = ({
   const cycleSeconds = totalSeconds ?? plantSeconds;
   const isBoosted = speed !== undefined && speed > 1;
   const growPercentage =
-    cycleSeconds > 0 ? 100 - (timeLeft / cycleSeconds) * 100 : 0;
+    cycleSeconds > 0
+      ? 100 - ((workLeftSeconds ?? timeLeft) / cycleSeconds) * 100
+      : 0;
   const isAlmostReady = growPercentage >= 50;
   const isHalfway = growPercentage >= 25 && !isAlmostReady;
 

--- a/src/features/island/fruit/FruitTree.tsx
+++ b/src/features/island/fruit/FruitTree.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useMemo } from "react";
 
 import type { FruitFertiliser, PlantedFruit } from "features/game/types/game";
-import { useNow } from "lib/utils/hooks/useNow";
 import { PATCH_FRUIT_SEEDS, PATCH_FRUIT } from "features/game/types/fruits";
 import { FruitSoil } from "./FruitSoil";
 
@@ -15,12 +14,12 @@ import { useSelector } from "@xstate/react";
 import { Context } from "features/game/GameProvider";
 import {
   computeReadyAt,
-  getEffectiveSpeedAt,
   getFruitBoostWindows,
   getTurbofruitMixWindows,
   workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 type Stage = "Empty" | "Seedling" | "Replenishing" | "Replenished" | "Dead";
 
@@ -166,19 +165,15 @@ export const FruitTree: React.FC<Props> = ({
         })
       : startedAt + plantSeconds * 1000;
 
-  // Coarse 1s clock to pick the current boost speed; only windowed fruit are
-  // boosted. Tick the countdown faster (1000/speed) so it drops ~1s per visual
-  // tick rather than jumping by `speed` each real second.
-  const tickNow = useNow({
-    live: isGrowing && baseDurationMs !== undefined,
-    autoEndAt: readyAt,
+  const { now, speed, displaySeconds } = useNodeTimer({
+    startedAt,
+    baseDurationMs,
+    windows: fruitBoostWindows,
+    legacyReadyAt: readyAt ?? 0,
+    live: isGrowing,
   });
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: tickNow, windows: fruitBoostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const now = useNow({ live: isGrowing, autoEndAt: readyAt, intervalMs });
+  // `timeLeft` here is the remaining WORK — it drives the progress bar and the
+  // stage, neither of which may move when the player switches reading.
   const treeStatus = getFruitTreeStatus(plantedFruit, now, fruitBoostWindows);
 
   // Empty plot
@@ -208,7 +203,8 @@ export const FruitTree: React.FC<Props> = ({
         <FruitSeedling
           island={island}
           patchFruitName={name}
-          timeLeft={treeStatus.timeLeft}
+          timeLeft={displaySeconds}
+          workLeftSeconds={treeStatus.timeLeft}
           totalSeconds={treeStatus.totalSeconds}
           speed={speed}
         />
@@ -223,7 +219,8 @@ export const FruitTree: React.FC<Props> = ({
         <ReplenishingTree
           island={island}
           patchFruitName={name}
-          timeLeft={treeStatus.timeLeft}
+          timeLeft={displaySeconds}
+          workLeftSeconds={treeStatus.timeLeft}
           totalSeconds={treeStatus.totalSeconds}
           speed={speed}
           playShakeAnimation={playShakingAnimation}

--- a/src/features/island/fruit/ReplenishingTree.tsx
+++ b/src/features/island/fruit/ReplenishingTree.tsx
@@ -31,7 +31,14 @@ const pluralisedNames: Record<PatchFruitName, string> = {
 interface Props {
   patchFruitName: PatchFruitName;
   island: GameState["island"];
+  /** The reading to display, per the player's timer setting. */
   timeLeft: number;
+  /**
+   * Remaining WORK in seconds — how grown the fruit actually is. Drives the
+   * progress bar, which must not move when the player switches which reading the
+   * label shows. Falls back to `timeLeft` (identical when unboosted).
+   */
+  workLeftSeconds?: number;
   /** Cycle length (s) — progress denominator; defaults to base plant time. */
   totalSeconds?: number;
   /** Current effective grow speed; shows a lightning when > 1. */
@@ -43,6 +50,7 @@ export const ReplenishingTree: React.FC<Props> = ({
   island,
   patchFruitName,
   timeLeft,
+  workLeftSeconds,
   totalSeconds,
   speed,
   playShakeAnimation,
@@ -88,7 +96,9 @@ export const ReplenishingTree: React.FC<Props> = ({
   const cycleSeconds = totalSeconds ?? plantSeconds;
   const isBoosted = speed !== undefined && speed > 1;
   const replenishPercentage =
-    cycleSeconds > 0 ? 100 - (timeLeft / cycleSeconds) * 100 : 0;
+    cycleSeconds > 0
+      ? 100 - ((workLeftSeconds ?? timeLeft) / cycleSeconds) * 100
+      : 0;
 
   return (
     <div

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -234,7 +234,11 @@ export const Basket: React.FC<Prop> = ({
   const seedWindowedBoosts =
     isSeed(selectedItem) && seedHarvestTime
       ? getBoostContributionEntries({
-          contributions: getSeedBoostContributions(gameState, selectedItem),
+          contributions: getSeedBoostContributions(
+            gameState,
+            selectedItem,
+            now,
+          ),
           seconds: seedHarvestTime.seconds,
           at: now,
           showActualTime,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
+import { Context } from "features/game/GameProvider";
 import { Box } from "components/ui/Box";
 import { ITEM_DETAILS } from "features/game/types/images";
 import {
@@ -85,6 +86,8 @@ import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
 import { CLUTTER } from "features/game/types/clutter";
 import { PET_RESOURCES } from "features/game/types/pets";
 import { useNow } from "lib/utils/hooks/useNow";
+import { getPreActionDisplay } from "features/game/lib/timerDisplay";
+import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
 import { PROCESSED_RESOURCES } from "features/game/types/processedFood";
 import { CRUSTACEANS_DESCRIPTIONS } from "features/game/types/crustaceans";
 import { FERMENTATION_PRODUCTS } from "features/game/types/fermentationProducts";
@@ -112,6 +115,7 @@ export const Basket: React.FC<Prop> = ({
   onSelect,
   onOpenMarketplace,
 }) => {
+  const { showActualTime } = useContext(Context);
   const divRef = useRef<HTMLDivElement>(null);
   const now = useNow({ live: true });
   const [showBoosts, setShowBoosts] = useState(false);
@@ -215,6 +219,21 @@ export const Basket: React.FC<Prop> = ({
   const seedHarvestTime = isSeed(selectedItem)
     ? getHarvestTime(selectedItem)
     : undefined;
+
+  // A live speed window isn't folded into the grow time — surface it as the
+  // current rate, or (in the actual-time view) as a projected "plant now → ready
+  // in X" that credits only the part of the grow the booster still covers.
+  const seedTimeDisplay =
+    isSeed(selectedItem) && seedHarvestTime
+      ? getPreActionDisplay({
+          showActualTime,
+          seconds: seedHarvestTime.seconds,
+          baseSeconds: getBaseHarvestTime(selectedItem),
+          namedBoostCount: seedHarvestTime.boostsUsed.length,
+          windows: getSeedBoostWindows(gameState, selectedItem),
+          at: now,
+        })
+      : undefined;
 
   const foodExpBoost = isFood(selectedItem)
     ? getFoodExpBoost({
@@ -582,7 +601,8 @@ export const Basket: React.FC<Prop> = ({
                   showBoosts,
                   setShowBoosts,
                 }),
-                timeSeconds: seedHarvestTime?.seconds,
+                timeSeconds: seedTimeDisplay?.displaySeconds,
+                timeSpeed: seedTimeDisplay?.speed,
                 baseTimeSeconds: isSeed(selectedItem)
                   ? getBaseHarvestTime(selectedItem)
                   : undefined,

--- a/src/features/island/hud/components/inventory/Basket.tsx
+++ b/src/features/island/hud/components/inventory/Basket.tsx
@@ -86,8 +86,13 @@ import { getFlowerTime } from "features/game/events/landExpansion/plantFlower";
 import { CLUTTER } from "features/game/types/clutter";
 import { PET_RESOURCES } from "features/game/types/pets";
 import { useNow } from "lib/utils/hooks/useNow";
+import { secondsToString } from "lib/utils/time";
 import { getPreActionDisplay } from "features/game/lib/timerDisplay";
 import { getSeedBoostWindows } from "features/game/lib/seedBoostWindows";
+import {
+  getBoostContributionEntries,
+  getSeedBoostContributions,
+} from "features/game/lib/boostContributions";
 import { PROCESSED_RESOURCES } from "features/game/types/processedFood";
 import { CRUSTACEANS_DESCRIPTIONS } from "features/game/types/crustaceans";
 import { FERMENTATION_PRODUCTS } from "features/game/types/fermentationProducts";
@@ -223,13 +228,31 @@ export const Basket: React.FC<Prop> = ({
   // A live speed window isn't folded into the grow time — surface it as the
   // current rate, or (in the actual-time view) as a projected "plant now → ready
   // in X" that credits only the part of the grow the booster still covers.
+  // The windowed boosters aren't in `boostsUsed` (they apply over the grow rather
+  // than being baked into it), so name them for the boost panel: their rate in
+  // the speed view, the time each one actually saves in the other.
+  const seedWindowedBoosts =
+    isSeed(selectedItem) && seedHarvestTime
+      ? getBoostContributionEntries({
+          contributions: getSeedBoostContributions(gameState, selectedItem),
+          seconds: seedHarvestTime.seconds,
+          at: now,
+          showActualTime,
+          formatSeconds: (seconds) =>
+            secondsToString(seconds, { length: "medium" }),
+          formatSpeed: (speed) => t("description.boostedSpeed", { speed }),
+        })
+      : [];
+  const seedBoostsUsed = seedHarvestTime
+    ? [...seedHarvestTime.boostsUsed, ...seedWindowedBoosts]
+    : undefined;
   const seedTimeDisplay =
     isSeed(selectedItem) && seedHarvestTime
       ? getPreActionDisplay({
           showActualTime,
           seconds: seedHarvestTime.seconds,
           baseSeconds: getBaseHarvestTime(selectedItem),
-          namedBoostCount: seedHarvestTime.boostsUsed.length,
+          namedBoostCount: seedBoostsUsed?.length ?? 0,
           windows: getSeedBoostWindows(gameState, selectedItem),
           at: now,
         })
@@ -606,7 +629,7 @@ export const Basket: React.FC<Prop> = ({
                 baseTimeSeconds: isSeed(selectedItem)
                   ? getBaseHarvestTime(selectedItem)
                   : undefined,
-                timeBoostsUsed: seedHarvestTime?.boostsUsed,
+                timeBoostsUsed: seedBoostsUsed,
                 onMarketplaceClick:
                   onOpenMarketplace && canOpenMarketplace
                     ? () => onOpenMarketplace(selectedItem)

--- a/src/features/island/hud/components/settings-menu/general-settings/BehaviourSettings.tsx
+++ b/src/features/island/hud/components/settings-menu/general-settings/BehaviourSettings.tsx
@@ -12,6 +12,8 @@ export const BehaviourSettings: React.FC = () => {
     toggleQuickSelect,
     showTimers,
     toggleTimers,
+    showActualTime,
+    toggleActualTime,
   } = useContext(Context);
 
   return (
@@ -30,6 +32,11 @@ export const BehaviourSettings: React.FC = () => {
         label={"Quick Select"}
       />
       <Switch checked={showTimers} onChange={toggleTimers} label={"Timers"} />
+      <Switch
+        checked={showActualTime}
+        onChange={toggleActualTime}
+        label={t("gameOptions.generalSettings.actualTime")}
+      />
     </div>
   );
 };

--- a/src/features/island/plots/Plot.tsx
+++ b/src/features/island/plots/Plot.tsx
@@ -380,7 +380,6 @@ export const Plot: React.FC<Props> = ({ id }) => {
           touchCount={touchCount}
           showTimers={showTimers}
           boostWindows={cropBoostWindows}
-          now={now}
         />
       </div>
       {reward && (

--- a/src/features/island/plots/components/FertilePlot.tsx
+++ b/src/features/island/plots/components/FertilePlot.tsx
@@ -19,14 +19,13 @@ import { getActiveCalendarEvent } from "features/game/types/calendar";
 import type { MachineState } from "features/game/lib/gameMachine";
 import { Context } from "features/game/GameProvider";
 import { useSelector } from "@xstate/react";
-import { useNow } from "lib/utils/hooks/useNow";
 import { CROP_COMPOST } from "features/game/types/composters";
 import {
   computeReadyAt,
-  getEffectiveSpeedAt,
   workAccruedAt,
   type BoostWindow,
 } from "features/game/lib/boostWindows";
+import { useNodeTimer } from "features/game/lib/useNodeTimer";
 
 interface Props {
   cropName?: CropName;
@@ -38,8 +37,6 @@ interface Props {
   showTimers: boolean;
   /** Live windowed speed boosts (e.g. Sparrow Shrine) affecting crop growth. */
   boostWindows: BoostWindow[];
-  /** Live timestamp from the parent; used to pick the current boost speed. */
-  now: number;
 }
 
 const _island = (state: MachineState) => state.context.state.island;
@@ -120,7 +117,6 @@ export const FertilePlot: React.FC<Props> = ({
   touchCount,
   showTimers,
   boostWindows,
-  now,
 }) => {
   const { gameService, selectedItem } = useContext(Context);
   // Only treat the player as "applying fertiliser" when the plot is still
@@ -137,27 +133,23 @@ export const FertilePlot: React.FC<Props> = ({
     () => getHarvestMetrics({ cropName, plot, plantedAt, boostWindows }),
     [cropName, plantedAt, plot, boostWindows],
   );
-  // Tick faster while a boost window is active so the displayed countdown drops
-  // ~1s per visual tick (a faster-running clock) instead of jumping by `speed`
-  // each real second. speed === 1 keeps the normal 1s cadence. Only crops on the
-  // speed-rate model (baseDurationMs set) are boosted; legacy crops stay at 1×.
-  const speed =
-    baseDurationMs !== undefined
-      ? getEffectiveSpeedAt({ at: now, windows: boostWindows })
-      : 1;
-  const intervalMs = Math.max(Math.round(1000 / Math.max(speed, 1)), 250);
-  const currentTime = useNow({
+  const {
+    now: currentTime,
+    speed,
+    displaySeconds,
+  } = useNodeTimer({
+    startedAt: startAt,
+    baseDurationMs,
+    windows: boostWindows,
+    legacyReadyAt: readyAt,
     live: readyAt > 0,
-    autoEndAt: readyAt,
-    intervalMs,
   });
   const isGrowing = harvestSeconds > 0 ? readyAt > currentTime : false;
   // A windowed speed boost (e.g. Sparrow Shrine) is actively speeding this crop.
   const isBoosted = isGrowing && speed > 1;
 
-  // For speed-rate crops the remaining time is the remaining *work* (in base
-  // duration), so it visibly ticks down faster while a boost window is active.
-  let timeLeft = 0;
+  // How grown the crop is — always measured in WORK, so the plant art and the
+  // progress fill never move when the player switches which reading is shown.
   let growPercentage = 100;
   if (readyAt > 0 && harvestSeconds > 0) {
     if (baseDurationMs !== undefined) {
@@ -171,15 +163,17 @@ export const FertilePlot: React.FC<Props> = ({
         at: currentTime,
         windows: boostWindows,
       });
-      timeLeft = Math.max((baseDurationMs - workDoneMs) / 1000, 0);
       growPercentage = clampPercentage(
         ((bankedMs + workDoneMs) / (baseDurationMs + bankedMs)) * 100,
       );
     } else {
-      timeLeft = Math.max((readyAt - currentTime) / 1000, 0);
-      growPercentage = clampPercentage(100 - (timeLeft / harvestSeconds) * 100);
+      growPercentage = clampPercentage(
+        100 -
+          (Math.max((readyAt - currentTime) / 1000, 0) / harvestSeconds) * 100,
+      );
     }
   }
+  const timeLeft = readyAt > 0 && harvestSeconds > 0 ? displaySeconds : 0;
 
   const activeInsectPlague =
     getActiveCalendarEvent({ calendar }) === "insectPlague";

--- a/src/lib/i18n/dictionaries/dictionary.json
+++ b/src/lib/i18n/dictionaries/dictionary.json
@@ -1929,6 +1929,7 @@
   "gameOptions.generalSettings.darkMode": "Dark Mode",
   "gameOptions.generalSettings.appearance": "Appearance",
   "gameOptions.generalSettings.behaviour": "Behaviour",
+  "gameOptions.generalSettings.actualTime": "Show actual time",
   "gameOptions.generalSettings.font": "Font",
   "gameOptions.generalSettings.preferences": "Preferences",
   "gameOptions.generalSettings.playerEconomiesDescription": "Turn on experimental player-economy features: token dashboards, the economy editor, and minigame listings in the marketplace. You can switch this off anytime.",


### PR DESCRIPTION
## What

Under the speed-rate boost model a boost is a **rate**, so a running timer has two honest readings:

- the remaining **work** — base duration, which drains *faster than a clock* while a boost is active
- the actual **wall-clock** time until it is ready

A 3h crop under a 2× window has 3h of work left but is ready in 1h 30m. Today only the first is shown, and players read the fast-draining number as a bug.

This adds a **Show actual time** switch to Behaviour settings that picks which reading every timer uses. The work reading stays the default and is cached in local storage, so nothing changes for anyone who doesn't opt in.

## Each view states the boost exactly once

This is the rule the whole PR is built on:

| | Duration shown | ⚡ rate shown |
|---|---|---|
| **Work view** (default) | un-projected — `4h` | **yes** — the rate is the extra information |
| **Actual-time view** | projected — `2h` | **no** — the number already carries it |

`getSurfacedSpeed` is the single place that decision lives. Because every ⚡ in the game is gated on `speed > 1`, collapsing the surfaced rate to 1 switches them all off together: the rate in timer popovers *and* the pulsing bolt on plots, fruit patches, flower beds and greenhouse pots. The **true** rate still drives the tick cadence and the ready-time maths — only the value handed out for display is suppressed.

## Projections are honest about expiring boosters

The pre-action panels (seed shop, basket, crop guide, tools guide, flower bed) show a duration for a task that hasn't started, so they need to answer "plant this now — when is it ready?". `projectSeconds` runs that through `computeReadyAt`, which models a window expiring part-way through.

A 4h crop under a 1.35× hourglass with 30 minutes left to run reads **~3h 50m**, not the naive `4h / 1.35 = 2h 58m`, because only the first half-hour is boosted.

## Two kinds of boost, two behaviours

A panel has named boosts (`boostsUsed`, already folded into the time, itemisable) and live speed windows (not folded in, and a `BoostWindow` is just an interval and a rate — there is no name to list). Previously any boost made the time block clickable. Now only named boosts do; a window alone shows its rate or a shorter time without offering an empty breakdown.

## Refactor

Every node had its own hand-rolled copy of the same countdown: derive `readyAt` from the windows, run a coarse clock to pick the speed, tick at `1000 / speed`, subtract accrued work. That's extracted into **`useNodeTimer`**, which returns both readings plus the chosen one and ticks at whichever cadence that reading needs. Thirteen components collapse onto it — crops, fruit, flowers, greenhouse pots, trees, stone, iron, gold, crimstone, sunstone, oil.

`getEffectiveSpeedAt` now has no callers outside `boostWindows.ts`, `timerDisplay.ts` and `useNodeTimer.ts`, so there is no path left that can surface a rate without going through the rule above.

**`seedBoostWindows`** is the mirror for pre-action panels: they hold only the thing being considered, so they resolve the activity from the seed or node name. Anything unrecognised — or an activity never migrated to the windowed model — yields an empty window set, which makes `projectSeconds` the identity. That's what makes it safe to apply unconditionally: flag off and un-migrated activities both come back unchanged.

## Art and progress never move

Worth calling out explicitly: plant art thresholds and progress fill bars read `workLeftSeconds`, never the displayed reading. How grown a crop looks must not change with a display setting.

## Testing

`timerDisplay.test.ts` and `seedBoostWindows.test.ts` cover the display logic — both readings, the tick cadence (including that a debuff must never slow the clock below 1×), mid-task window expiry, multiplicative stacking, rate suppression, and that the boosted layout survives without the rate.

- 518 tests pass across `features/game/lib`
- `tsc` and `eslint` clean

Per house style there are no component tests; the UI was verified in the browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to display actual countdown time instead of work-adjusted time.
  * Timers for crops, flowers, fruit, greenhouse plants, and resources now update live and account for active speed boosts.
  * Added detailed boost contributions showing speed increases or time saved.
  * Progress tracking remains accurate when displayed countdowns are affected by boosts.
* **Bug Fixes**
  * Improved consistency and responsiveness across resource recovery and growth timers.
  * Anonymous speed changes no longer incorrectly enable boost-detail interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->