### PR TITLE
[CHORE] Move remove all button into landscaping removal mode

### DIFF
--- a/src/features/island/hud/LandscapingHud.tsx
+++ b/src/features/island/hud/LandscapingHud.tsx
@@ -269,7 +269,7 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
               top: `${PIXEL_SCALE * 31}px`,
             }}
           >
-            <RoundButton onClick={toggleRemovalMode}>
+            <RoundButton className="mb-3.5" onClick={toggleRemovalMode}>
               <img
                 src={SUNNYSIDE.icons.cancel}
                 className="absolute group-active:translate-y-[2px]"
@@ -277,6 +277,18 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
                   top: `${PIXEL_SCALE * 5.5}px`,
                   left: `${PIXEL_SCALE * 5.5}px`,
                   width: `${PIXEL_SCALE * 11}px`,
+                }}
+              />
+            </RoundButton>
+
+            <RoundButton onClick={removeAll}>
+              <img
+                src={cleanBroom}
+                className="absolute group-active:translate-y-[2px]"
+                style={{
+                  top: `${PIXEL_SCALE * 5}px`,
+                  left: `${PIXEL_SCALE * 5}px`,
+                  width: `${PIXEL_SCALE * 13}px`,
                 }}
               />
             </RoundButton>
@@ -368,18 +380,6 @@ const LandscapingHudComponent: React.FC<{ location: PlaceableLocation }> = ({
                   />
                 </>
               )}
-
-              <RoundButton className="mb-3.5" onClick={removeAll}>
-                <img
-                  src={cleanBroom}
-                  className="absolute group-active:translate-y-[2px]"
-                  style={{
-                    top: `${PIXEL_SCALE * 5}px`,
-                    left: `${PIXEL_SCALE * 5}px`,
-                    width: `${PIXEL_SCALE * 13}px`,
-                  }}
-                />
-              </RoundButton>
 
               {location === "farm" &&
                 hasFeatureAccess(gameState, "SAVED_LAYOUTS") && (


### PR DESCRIPTION
## What

Moves the broom (remove all) button out of the main landscaping button stack and into the removal mode HUD column.

- Previously: the broom sat alongside chest, shop, saved layouts and the shovel in the idle landscaping column, while removal mode showed only a cancel button.
- Now: entering removal mode shows the `Removal mode` label, the cancel button, and the broom directly beneath it.

`removeAll()` and the `RemoveAllConfirmation` modal are untouched — the modal renders outside the removal-mode block, so the confirm flow is unchanged.

## Testing

- `tsc --noEmit` passes
- Verified in the dev server: broom appears only in removal mode, remove-all confirmation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing around the removal-mode cancel button.
  * Moved the “remove all” option into removal mode, making it available only when actively removing landscaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->